### PR TITLE
Ensure stdout and stderr from child process are fully read

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -1369,8 +1369,11 @@ public class VmArgumentTests {
 			stdoutReader.start();
 			stderrReader.start();
 			int rc = p.waitFor();
+			/* Ensure the ProcessStreamReaders finish reading their respective streams. */
+			stdoutReader.join(10000);
+			stderrReader.join(10000);
+			ArrayList<String> outputLines = stdoutReader.getOutputLines();
 			if (0 != rc) {
-				ArrayList<String> outputLines = stdoutReader.getOutputLines();
 				logger.debug("---------------------------------\nstdout");
 				dumpStrings(outputLines);
 				ArrayList<String> errLines = stderrReader.getOutputLines();
@@ -1379,7 +1382,6 @@ public class VmArgumentTests {
 				fail("Target process failed");
 
 			}
-			ArrayList<String> outputLines = stdoutReader.getOutputLines();
 			Iterator<String> olIterator = outputLines.iterator();
 			String l = "";
 			while (olIterator.hasNext() && isNotTag(l)) {


### PR DESCRIPTION
ProcessStreamReader threads may still be running when the main thread reads
from the buffer, causing a ConcurrentModificationException.
See https://github.com/eclipse/openj9/issues/708

Closes: #708

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>