### PR TITLE
Add valgrind support

### DIFF
--- a/buildspecs/core.feature
+++ b/buildspecs/core.feature
@@ -131,6 +131,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="opt_phpSupport" value="false"/>
 		<flag id="opt_romImageSupport" value="true"/>
 		<flag id="opt_useOmrDdr" value="false"/>
+		<flag id="opt_valgrindSupport" value="false"/>
 		<flag id="opt_veeSupport" value="false"/>
 		<flag id="opt_vmLocalStorage" value="true"/>
 		<flag id="prof_countArgsTemps" value="false"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -2132,6 +2132,10 @@ Only available on zOS</description>
 		<description>Use the ddrgen tool from OMR in support of DDR.</description>
 		<ifRemoved>If DDR support is enabled, the legacy tools will be used instead.</ifRemoved>
 	</flag>
+	<flag id="opt_valgrindSupport">
+		<description>Enable linking with Valgrind Memcheck APIs.</description>
+		<ifRemoved>Skip linking with Valgrind Memcheck APIs.</ifRemoved>
+	</flag>
 	<flag id="opt_veeSupport">
 		<description>Support for multiple Virtual Execution Environments.</description>
 		<ifRemoved>No support for multiple languages</ifRemoved>

--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,6 +73,11 @@ public:
 	VMINLINE j9object_t
 	inlineAllocateObject(J9VMThread *currentThread, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true)
 	{
+#if defined(J9VM_OPT_VALGRIND_SUPPORT)
+		/* Failing inline allocation here will make openj9 allocate object using OMR where valgrind is linked. */
+		return NULL;
+#endif /* J9VM_OPT_VALGRIND_SUPPORT */
+
 		j9object_t instance = NULL;
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP) || defined(J9VM_GC_SEGREGATED_HEAP)
 		/* Calculate the size of the object */
@@ -155,6 +160,11 @@ public:
 	VMINLINE j9object_t
 	inlineAllocateIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
 	{
+#if defined(J9VM_OPT_VALGRIND_SUPPORT)
+		/* Failing inline allocation here will make openj9 allocate object using OMR where valgrind is linked. */
+		return NULL;
+#endif /* J9VM_OPT_VALGRIND_SUPPORT */
+
 		j9object_t instance = NULL;
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP) || defined(J9VM_GC_SEGREGATED_HEAP)

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1181,6 +1181,9 @@ initBackTrace(J9JavaVM *vm)
 	
 	/* Use a local heap so the memory used for the backtrace is freed automatically. */
 	heap = j9heap_create(backingStore, sizeof(backingStore), 0);
+
+	//initialize threadInfo.context for an if condition (omrintrospect_backtrace_thread_raw) called in code below
+	threadInfo.context = NULL;
 	if( j9introspect_backtrace_thread(&threadInfo, heap, NULL) != 0 ) {
 		j9introspect_backtrace_symbols(&threadInfo, heap);
 	}

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1392,6 +1392,7 @@ allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
 		stack->size = stackSize;
 		stack->previous = previousStack;
 		stack->firstReferenceFrame = 0;
+		memset((void*) ( (uintptr_t) stack + sizeof(J9JavaStack)), 0, mallocSize - sizeof(J9JavaStack));
 
 
 		/* If this is a profiling VM, or verbose:stack is enabled, paint the stack with a distinctive pattern so we can


### PR DESCRIPTION
#### Changes

With these changes Openj9 runs cleanly on valgrind using interpretor (`-Djava.compiler=NONE` or `-Xint`. This goes alongside: https://github.com/eclipse/omr/pull/1759

1. Added `opt_valgrindSupport(J9VM_OPT_VALGRIND_SUPPORT)` option.
2. When J9VM_OPT_VALGRIND_SUPPORT is enabled inline allocation is skipped to fall back to omr.
3. Fixed 2 valgrind warnings in runtime/rasdump/dmpsup.c and runtime/vm/vmthread.c

#### Questions:

1. How can I set option in OpenJ9 and OMR from OpenJDK without altering openJDK code? I did some changes [here](https://github.com/ibmruntimes/openj9-openjdk-jdk9/compare/openj9...Varun-garg:openj9). Do I have to request for these changes to OpenJDK community?

2. I want to know [default initialization](https://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.12.5) is happening and if it is happening during runtime. If it is happening during runtime, Valgrind could know that and user would be wanned of it. Example
```java
class Z {
    static int peek() { return j; }
    static int i = peek();
    static int j = 1;
}
class Test {
    public static void main(String[] args) {
        System.out.println(Z.i);
    }
}
````
This gives output as `0` instead of `1`.  User can be warned of this if valgrind is informed.

Signed-off-by: Varun Garg <varun.10@live.com>