### PR TITLE
Remove defineClass() in DefineAnonClass in Jsr335 test

### DIFF
--- a/test/functional/Jsr335/src/org/openj9/test/jsr335/defineAnonClass/DefineAnonClass.java
+++ b/test/functional/Jsr335/src/org/openj9/test/jsr335/defineAnonClass/DefineAnonClass.java
@@ -65,14 +65,6 @@ public class DefineAnonClass {
 		return unsafe.defineAnonymousClass(hostClass, bytes, cpPatches);
 	}
 
-
-	static public Class<?> defineClass(String className, String byteCodePath, ClassLoader loader, ProtectionDomain pD) throws Throwable {
-		byte[] bytes = getClassBytes(byteCodePath);
-
-		Class<?> newClass = unsafe.defineClass(className, bytes, 0, bytes.length, loader, pD);
-		return newClass;
-	}
-
 	static public byte[] getClassBytes(String fileName) {
 		String classFile = fileName.replace(".", "/")+ ".class";
 		InputStream classStream = null;


### PR DESCRIPTION
The test does not use defineClass() method and
sun.misc.Unsafe.defineClass is removed in JDK11. In order to be able
to compile using JDK11, the defineClass() is removed

Issue: #2071
[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>