### PR TITLE
Map -XX:[+-]DisableExplicitGC to OpenJ9-equivalent

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -462,6 +462,8 @@ enum INIT_STAGE {
 #define MAPOPT_XSHARE_AUTO "-Xshare:auto"
 #define MAPOPT_XSHARECLASSES_UTILITIES "-Xshareclasses:utilities"
 #define MAPOPT_XSHARECLASSES_NONFATAL "-Xshareclasses:nonfatal"
+#define MAPOPT_XXDISABLEEXPLICITGC "-XX:+DisableExplicitGC"
+#define MAPOPT_XXENABLEEXPLICITGC "-XX:-DisableExplicitGC"
 
 #define VMOPT_XXDUMPLOADEDCLASSLIST "-XX:DumpLoadedClassList"
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3752,6 +3752,14 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XSHARE_AUTO, MAPOPT_XSHARECLASSES_NONFATAL, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
+	/* Map -XX:+DisableExplicitGC to -Xdisableexplicitgc */
+	if (registerCmdLineMapping(vm, MAPOPT_XXDISABLEEXPLICITGC, "-Xdisableexplicitgc", EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
+	/* Map -XX:+EnableExplicitGC to -Xenableexplicitgc */
+	if (registerCmdLineMapping(vm, MAPOPT_XXENABLEEXPLICITGC, "-Xenableexplicitgc", EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This helps end users get equivalent behaviour without requiring them to modify commandlines.

-XX:+DisableExplicitGC -> -Xdisableexplicitgc
-XX:-DisableExplicitGC -> -Xenableexplicitgc

Issue #1370

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>