### PR TITLE
Avoid crash on uninitialized String

### DIFF
--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -1774,15 +1774,14 @@ wrap_stringPrimitiveCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData)
 	j9object_t bytes = J9VMJAVALANGSTRING_VALUE(iteratorData->currentThread, iteratorData->object);
 	UDATA offset = 0;
 
-	/* Get the Unicode string data */
-
-	stringLength = J9VMJAVALANGSTRING_LENGTH(iteratorData->currentThread, iteratorData->object);
-	
 	/* Ignore uninitialized string */
 	if (NULL == bytes) {
 		return JVMTI_ITERATION_CONTINUE;
 	}
 
+	/* Get the Unicode string data */
+
+	stringLength = J9VMJAVALANGSTRING_LENGTH(iteratorData->currentThread, iteratorData->object);
 	stringValue = j9mem_allocate_memory(stringLength * sizeof(jchar), J9MEM_CATEGORY_JVMTI);
 	if (NULL == stringValue) {
 		JVMTI_HEAP_ERROR(JVMTI_ERROR_OUT_OF_MEMORY);


### PR DESCRIPTION
JVMTI heap iterator is using J9VMJAVALANGSTRING_LENGTH on an
uninitialized String object, which causes a crash due to the macro
attempting to determine the size of the underlying data array (which is
NULL). Move the length fetch after the uninitialized check.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>