### PR TITLE
Support OSX dylib syntax

### DIFF
--- a/runtime/jsigWrapper/jsig.c
+++ b/runtime/jsigWrapper/jsig.c
@@ -74,7 +74,13 @@ getFunction(void **tableAddress, char *name)
 		void *handle = dlopen("libomrsig.so", RTLD_LAZY);
 		*tableAddress = dlsym(handle, name);
 #else /* defined(WIN32) */
-		void *handle = dlopen("libomrsig.so", RTLD_GLOBAL | RTLD_LAZY);
+		/* Note: this needs to be ifdef'd this way for zOS to compile as it redefines dlopen */
+		void *handle = 
+#if defined(OSX)
+			dlopen("libomrsig.dylib", RTLD_GLOBAL | RTLD_LAZY);
+#else /* OSX */
+			dlopen("libomrsig.so", RTLD_GLOBAL | RTLD_LAZY);
+#endif /*OSX */
 		*tableAddress = dlsym(handle, name);
 #endif /* defined(WIN32) */
 	}


### PR DESCRIPTION
The code needs to be ifdefed this way due to zOS and the
way it has macroized dlopen

The code needs to be ifdefed this way due to zOS and the
way it has macroized dlopen.  Otherwise, the zOS compile
will fail

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>