### PR TITLE
Correct the support statement for xgc:concurrentScavenge, by removing…

### DIFF
--- a/doc/release-notes/0.11/0.11.md
+++ b/doc/release-notes/0.11/0.11.md
@@ -83,8 +83,8 @@ The following table covers notable changes in v0.11.0. Further information about
 </tr>
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3054">#3054</a></td>
-<td valign="top">Concurrent scavenge mode is now available on x86</td>
-<td valign="top">OpenJDK8 and later (x86-64: Linux and Windows only)</td>
+<td valign="top">Concurrent scavenge mode is now available on Linux x86</td>
+<td valign="top">OpenJDK8 and later (x86-64: Linux only)</td>
 <td valign="top">When this mode is enabled, (`-Xgc:concurrentScavenge`) the VM attempts to reduce GC pause-times for response-time sensitive, large heap applications. This mode is available only on compressed references builds. Attempting to use this option on a non-compressed references build results in an *unrecognized option* error message. </td>
 </tr>
 


### PR DESCRIPTION
… Windows

This commit fixes the release notes for this issue: https://github.com/eclipse/openj9-docs/issues/126#issuecomment-433213295

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>