### PR TITLE
Fix crash in JVMTI GetJNIFunctionTable

### DIFF
--- a/runtime/jvmti/jvmtiJNIFunctionInterception.c
+++ b/runtime/jvmti/jvmtiJNIFunctionInterception.c
@@ -111,7 +111,7 @@ jvmtiGetJNIFunctionTable(jvmtiEnv* env,
 		/* Get the JVMTI mutex to ensure this operation is atomic with SetJNIFunctionTable */
 
 		omrthread_monitor_enter(jvmtiData->mutex);
-		memcpy(*function_table, vm->jniFunctionTable, sizeof(jniNativeInterface));
+		memcpy(rv_function_table, vm->jniFunctionTable, sizeof(jniNativeInterface));
 		omrthread_monitor_exit(jvmtiData->mutex);
 	}
 


### PR DESCRIPTION
Error introduced in #3492

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>