### PR TITLE
 Update Q Type support throughout VM

### DIFF
--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -1065,11 +1065,14 @@ ClassFileWriter::computeArgsCount(U_16 methodRefIndex)
 			while ((index < count) && ('[' == sig[index])) {
 				index += 1;
 			}
-			if ('L' != sig[index]) {
+			if (J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(sig[index])) {
 				break;
 			}
 			/* fall through */
 		case 'L':
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 			index += 1;
 			while ((index < count) && (';' != sig[index])) {
 				index += 1;

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1820,13 +1820,37 @@ ROMClassWriter::writeNativeSignature(Cursor *cursor, U_8 *methodDescriptor, U_8 
 {
 	/* mapping characters A..Z */
 	static const U_8 nativeArgCharConversion[] = {
-			0,			PARAM_BYTE,		PARAM_CHAR,		PARAM_DOUBLE,
-			0,			PARAM_FLOAT,	0,				0,
-			PARAM_INT,	PARAM_LONG,		0,				PARAM_OBJECT,
-			0,			0,				0,				0,
-			0,			0,				PARAM_SHORT,	0,
-			0,			PARAM_VOID,		0,				0,
-			0,			PARAM_BOOLEAN};
+			0,             /* A */
+			PARAM_BYTE,    /* B */
+			PARAM_CHAR,    /* C */
+			PARAM_DOUBLE,  /* D */
+			0,             /* E */
+			PARAM_FLOAT,   /* F */
+			0,             /* G */
+			0,             /* H */
+			PARAM_INT,     /* I */
+			PARAM_LONG,    /* J */
+			0,             /* K */
+			PARAM_OBJECT,  /* L */
+			0,             /* M */
+			0,             /* N */
+			0,             /* O */
+			0,             /* P */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			PARAM_OBJECT,  /* Q */
+#else
+			0,             /* Q */
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+			0,             /* R */
+			PARAM_SHORT,   /* S */
+			0,             /* T */
+			0,             /* U */
+			PARAM_VOID,    /* V */
+			0,             /* W */
+			0,             /* X */
+			0,             /* Y */
+			PARAM_BOOLEAN  /* Z */
+	};
 
 	UDATA index = 1;
 
@@ -1855,7 +1879,7 @@ ROMClassWriter::writeNativeSignature(Cursor *cursor, U_8 *methodDescriptor, U_8 
 		} else {
 			cursor->writeU8(nativeArgCharConversion[methodDescriptor[index] - 'A'], Cursor::GENERIC);
 		}
-		if ('L' == methodDescriptor[index]) {
+		if (J9_IS_OBJECT_OR_VALUETYPE(methodDescriptor[index])) {
 			while (';' != methodDescriptor[index]) {
 				++index;
 			}

--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -1148,6 +1148,8 @@ printMethod (J9BytecodeVerificationData * verifyData)
 			printf( "long");
 			break;
 
+		case 'Q':
+			printf( "flattenable "); /* fallthrough*/
 		case 'L':
 			i++;
 			while(string[i] != ';')
@@ -1204,6 +1206,8 @@ printMethod (J9BytecodeVerificationData * verifyData)
 				printf( "long");
 				break;
 		
+			case 'Q':
+				printf("flattenable "); /* fallthrough*/
 			case 'L':
 				i++;
 				while(string[i] != ';')

--- a/runtime/bcverify/clconstraints.c
+++ b/runtime/bcverify/clconstraints.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,15 +85,15 @@ j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoa
 
 	omrthread_monitor_enter(javaVM->classTableMutex);
 	for (;;) {
-		/* find a 'L', indicating the beginning of a class name */
-		while (index  < length && J9UTF8_DATA(sig1)[index] != 'L') {
+		/* find an 'L' or 'Q', indicating the beginning of a class name */
+		while ((index  < length) && J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(J9UTF8_DATA(sig1)[index])) {
 			index++;
 		}
 		if (index >= length) {
 			break;
 		}
 
-		/* skip the 'L'; */
+		/* skip the 'L' or 'Q'; */
 		index++;
 
 		/* find the ';' marking the end of the class name */

--- a/runtime/bcverify/j9bcverify.tdf
+++ b/runtime/bcverify/j9bcverify.tdf
@@ -187,3 +187,5 @@ TraceException=Trc_RTV_j9rtv_verifyArguments_OutOfMemoryException Overhead=1 Lev
 TraceException=Trc_RTV_j9rtv_verifyArguments_InaccessibleClass Overhead=1 Level=1 Template="j9rtv_verifyArguments - %.*s %.*s%.*s - Inaccessible class"
 
 TraceException=Trc_RTV_j9rtv_verifyBytecodes_Unreachable Overhead=1 Level=1 Template="j9rtv_verifyBytecodes - %.*s %.*s%.*s Unreachable error %i occurred"
+
+TraceAssert=Assert_RTV_qTypeStackObjectUnimplemented Overhead=1 Level=1 NoEnv Assert="(0 /* Q type stack mapping unimplemented */)"

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -2547,11 +2547,11 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 		}
 
 		/* Object or array */
-		if ((*signature == 'L') || arity) {
+		if (J9_IS_OBJECT_OR_VALUETYPE(*signature) || arity) {
 			IDATA reasonCode = 0;
 
 			/* Object array */
-			if (*signature == 'L') {
+			if (J9_IS_OBJECT_OR_VALUETYPE(*signature)) {
 				signature++;
 				string = signature;	/* remember the start of the string */
 				while (*signature++ != ';');

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -812,7 +812,7 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			break;
 
 		case CFR_BC_areturn:
-			if ((sigChar != 'L') && (sigChar != '[')) {
+			if (J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(sigChar) && ('[' != sigChar)) {
 				/* fail, modify the bytecode to be incompatible in the second pass of verification */
 				if (sigChar != 'V') {
 					*(bcIndex - 1) = CFR_BC_return;
@@ -1647,6 +1647,9 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 
 				switch (utf8->bytes[arity]) {
 				case 'L':		/* object array */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 					if (utf8->bytes[--end] != ';') {
 						errorType = J9NLS_CFR_ERR_BAD_CLASS_NAME__ID;
 						goto _formatError;

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -278,7 +278,16 @@ buildStackFromMethodSignature( J9BytecodeVerificationData *verifyData, UDATA **s
 			arity++;
 		}
 
-		if (args[i] == 'L') {
+		if (J9_IS_OBJECT_OR_VALUETYPE(args[i])) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (args[i] == 'Q') {
+				/* There is no way to differentiate a Q and L type object once added
+				 * to the verifier's stack map. Until this is fixed, error
+				 * when a Q type would be added to the stack map.
+				 */
+				Assert_RTV_qTypeStackObjectUnimplemented();
+			}
+#endif
 			U_8 *string;
 			U_16 length = 0;
 
@@ -647,7 +656,16 @@ static UDATA *
 pushType(J9BytecodeVerificationData *verifyData, U_8 * signature, UDATA * stackTop)
 {
 	if (*signature != 'V') {
-		if ((*signature == '[') || (*signature == 'L')) {
+		if (('[' == *signature) || J9_IS_OBJECT_OR_VALUETYPE(*signature)) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (*signature == 'Q') {
+				/* There is no way to differentiate a Q and L type object once added
+				 * to the verifier's stack map. Until this is fixed, error
+				 * when a Q type would be added to the stack map.
+				 */
+				Assert_RTV_qTypeStackObjectUnimplemented();
+			}
+#endif
 			PUSH(parseObjectOrArrayName(verifyData, signature));
 		} else {
 			UDATA baseType = (UDATA) argTypeCharConversion[*signature - 'A'];
@@ -1126,7 +1144,16 @@ parseObjectOrArrayName(J9BytecodeVerificationData *verifyData, U_8 *signature)
 		signature++;
 	}
 	arity = (UDATA) (signature - string);
-	if (*signature == 'L') {
+	if (J9_IS_OBJECT_OR_VALUETYPE(*signature)) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (*signature == 'Q') {
+			/* There is no way to differentiate a Q and L type object once added
+			* to the verifier's stack map. Until this is fixed, error
+			* when a Q type would be added to the stack map.
+			*/
+				Assert_RTV_qTypeStackObjectUnimplemented();
+		}
+#endif
 		U_16 length = 0;
 		UDATA classIndex = 0;
 

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -1042,6 +1042,8 @@ static void printMethod(J9CfrClassFile* classfile, J9CfrMethod* method)
 			j9tty_printf( PORTLIB, "long");
 			break;
 
+		case 'Q':
+			j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 		case 'L':
 			i++;
 			while(string[i] != ';')
@@ -1098,6 +1100,8 @@ static void printMethod(J9CfrClassFile* classfile, J9CfrMethod* method)
 				j9tty_printf( PORTLIB, "long");
 				break;
 
+			case 'Q':
+				j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 			case 'L':
 				i++;
 				while(string[i] != ';')
@@ -1214,6 +1218,8 @@ static void printField(J9CfrClassFile* classfile, J9CfrField* field)
 			j9tty_printf( PORTLIB, "long");
 			break;
 
+		case 'Q':
+			j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 		case 'L':
 			i++;
 			while(string[i] != ';')
@@ -1308,6 +1314,8 @@ static void printDisassembledMethod(J9CfrClassFile* classfile, J9CfrMethod* meth
 			j9tty_printf( PORTLIB, "long");
 			break;
 
+		case 'Q':
+			j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 		case 'L':
 			i++;
 			while(string[i] != ';')
@@ -1364,6 +1372,8 @@ static void printDisassembledMethod(J9CfrClassFile* classfile, J9CfrMethod* meth
 				j9tty_printf( PORTLIB, "long");
 				break;
 
+			case 'Q':
+				j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 			case 'L':
 				i++;
 				while(string[i] != ';')
@@ -4371,6 +4381,8 @@ static void sun_formatField(J9CfrClassFile* classfile, J9CfrField* field, char *
 						}
 						switch(string[j++])
 						{
+							case 'Q':
+								j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 							case 'L':
 								while((ch2 = string[j++]) != ';')
 								{
@@ -4618,6 +4630,8 @@ static void sun_formatMethod(J9CfrClassFile* classfile, J9CfrMethod* method, cha
 						}
 						switch(string[j++])
 						{
+							case 'Q':
+								j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 							case 'L':
 								while((ch2 = string[j++]) != ';')
 								{
@@ -4683,6 +4697,8 @@ static void sun_formatMethod(J9CfrClassFile* classfile, J9CfrMethod* method, cha
 							}
 							switch(string[j++])
 							{
+								case 'Q':
+									j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 								case 'L':
 									while((ch2 = string[j++]) != ';')
 									{
@@ -5136,6 +5152,8 @@ static void j9_formatField(J9ROMClass* romClass, J9ROMFieldShape* field, char *f
 						}
 						switch(string[j++])
 						{
+							case 'Q':
+								j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 							case 'L':
 								while((ch2 = string[j++]) != ';')
 								{
@@ -5408,6 +5426,8 @@ static void j9_formatMethod(J9ROMClass* romClass, J9ROMMethod* method, char *for
 						}
 						switch(string[j++])
 						{
+							case 'Q':
+								j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 							case 'L':
 								while((ch2 = string[j++]) != ';')
 								{
@@ -5474,6 +5494,8 @@ static void j9_formatMethod(J9ROMClass* romClass, J9ROMMethod* method, char *for
 							}
 							switch(string[j++])
 							{
+								case 'Q':
+									j9tty_printf( PORTLIB, "flattenable "); /* fallthrough */
 								case 'L':
 									while((ch2 = string[j++]) != ';')
 									{

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -345,7 +345,7 @@ accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA
 			sigOffset += 1;
 		}
 	
-		if ('L' == lookupSigData[sigOffset]) {
+		if (J9_IS_OBJECT_OR_VALUETYPE(lookupSigData[sigOffset])) {
 			BOOLEAN isVirtual = (0 == (((J9ROMFieldShape*)romField)->modifiers & J9_JAVA_STATIC));
 			j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, methodType);
 			U_32 numParameters = J9INDEXABLEOBJECT_SIZE(currentThread, argsArray);
@@ -433,7 +433,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 			endIndex = index;
 
 			/* If this entry is a class type, we need to do a classloader check on it */
-			if ('L' == lookupSigData[index]) {
+			if (J9_IS_OBJECT_OR_VALUETYPE(lookupSigData[index])) {
 				index += 1;
 
 				clazz = J9JAVAARRAYOFOBJECT_LOAD(currentThread, argsArray, i);
@@ -462,7 +462,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 		while ('[' == lookupSigData[index]) {
 			index += 1;
 		}
-		if('L' == lookupSigData[index]) {
+		if(J9_IS_OBJECT_OR_VALUETYPE(lookupSigData[index])) {
 			J9Class *returnRamClass = NULL;
 			/* Grab the MethodType returnType */
 			clazz = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, methodType);

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -326,6 +326,9 @@ Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass
 				utfData[arity] = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(leafComponentType->arrayClass->romClass))[1];
 			} else {
 				/* The / to . conversion is done later, so just copy the RAW class name here */
+				/* TODO: ValueTypes Once there are more specs for Java API Q types, this will need to be updated.
+				 * See https://github.com/eclipse/openj9/issues/4083
+				 */
 				utfData[arity] = 'L';
 				memcpy(utfData + arity + 1, J9UTF8_DATA(leafName), J9UTF8_LENGTH(leafName));
 				utfData[utfLength - 1] = ';';

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -50,7 +50,7 @@ accessCheckFieldType(J9VMThread *currentThread, J9Class* lookupClass, J9Class* t
 	if (NULL != verifyData) {
 		U_8 *lookupSigData = J9UTF8_DATA(lookupSig);
 		/* Only check reference types (not primitive types) */
-		if ('L' == *lookupSigData) {
+		if (J9_IS_OBJECT_OR_VALUETYPE(*lookupSigData)) {
 			J9ClassLoader *lookupClassloader = lookupClass->classLoader;
 			J9ClassLoader *typeClassloader = type->classLoader;
 			if (typeClassloader != lookupClassloader) {

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -231,11 +231,14 @@ computeArgCount(J9ROMMethod *method)
 			while ((index < count) && ('[' == bytes[index])) {
 				index += 1;
 			}
-			if ('L' != bytes[index]) {
+			if (J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(bytes[index])) {
 				break;
 			}
 			/* fall through */
 		case 'L':
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 			index += 1;
 			while ((index < count) && (';' != bytes[index])) {
 				index += 1;
@@ -454,6 +457,9 @@ classForSignature(struct J9VMThread *vmThread, U_8 **sigDataPtr, struct J9ClassL
 	/* Non-array case */
 	switch (c) {
 	case 'L': {
+		/* TODO: ValueTypes Once it is known if Q and L types share a ramClass, revisit this.
+		* See https://github.com/eclipse/openj9/issues/4083
+		*/
 		/* object case */
 		U_8 *tempData = sigData;
 		UDATA length = 0;
@@ -522,7 +528,7 @@ getArgCountFromSignature(J9UTF8* signature)
 			i++;
 		}
 		/* skip class name */
-		if ('L' == sigData[i]) {
+		if (J9_IS_OBJECT_OR_VALUETYPE(sigData[i])) {
 			while (';' != sigData[i]) {
 				i++;
 			}

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -323,8 +323,12 @@ static const struct { \
 /* Macros for ValueTypes */
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 #define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsValueType)
+#define J9_IS_OBJECT_OR_VALUETYPE(sigChar) (('L' == (sigChar)) || ('Q' == (sigChar)))
+#define J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(sigChar) (('L' != (sigChar)) && ('Q' != (sigChar)))
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
+#define J9_IS_OBJECT_OR_VALUETYPE(sigChar) ('L' == (sigChar))
+#define J9_IS_NOT_OBJECT_AND_NOT_VALUETYPE(sigChar) ('L' != (sigChar))
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #if defined(OPENJ9_BUILD)

--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -488,11 +488,14 @@ traceMethodArguments(J9VMThread* thr, J9UTF8* signature, UDATA* arg0EA, char* bu
 		switch (*sigChar) {
 		case '[':
 		case 'L':
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 			traceMethodArgObject(thr, arg0EA--, cursor, endOfBuf - cursor);
 			while (*sigChar == '[') {
 				sigChar++;
 			}
-			if (*sigChar == 'L' ) {
+			if (J9_IS_OBJECT_OR_VALUETYPE(*sigChar)) {
 				while (*sigChar != ';') {
 					sigChar++;
 				}
@@ -567,6 +570,9 @@ traceMethodReturnVal(J9VMThread* thr, J9UTF8* signature, void* returnValuePtr, c
 	switch (*(++sigChar)) {
 	case '[':
 	case 'L':
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 		traceMethodArgObject(thr, returnValuePtr, cursor, endOfBuf - cursor);
 		break;
 	case 'J':

--- a/runtime/stackmap/stackmap.c
+++ b/runtime/stackmap/stackmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -436,7 +436,10 @@ mapStack(UDATA *scratch, UDATA totalStack, U_8 * map, J9ROMClass * romClass, J9R
 					J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMFIELDREF_NAMEANDSIGNATURE
 													((J9ROMFieldRef *) (&(pool[index]))));
 				signature = (U_8) J9UTF8_DATA(utf8Signature)[0];
-				if ((signature == 'L') || (signature == '[')) {
+				if (J9_IS_OBJECT_OR_VALUETYPE(signature) || ('[' == signature)) {
+					/* Once flattenable Q Tpes are implemented, this will need to be revisited.
+					 * See https://github.com/eclipse/openj9/issues/4083.
+					 */
 					PUSH(OBJ);
 				} else {
 					PUSH(INT);

--- a/runtime/util/argbits.c
+++ b/runtime/util/argbits.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,12 +40,12 @@ argBitsFromSignature(U_8 * signature, U_32 * resultArrayBase, UDATA resultArrayS
 	
 	/* Parse the signature inside the ()'s */
 	while (*(++signature) != ')') {
-		if ((*signature == '[') || (*signature == 'L')) {
+		if (('[' == *signature) || J9_IS_OBJECT_OR_VALUETYPE(*signature)) {
 			*resultArrayBase |= argBit;
 			while (*signature == '[') {
 				signature++;
 			}
-			if (*signature == 'L' ) {
+			if (J9_IS_OBJECT_OR_VALUETYPE(*signature)) {
 				while (*signature != ';') {
 					signature++;
 				}

--- a/runtime/util/argcount.c
+++ b/runtime/util/argcount.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,13 +26,39 @@
 
 /* include '[' for arrays (character after 'Z') */
 const U_8 argCountCharConversion[] = {
-0,	1,	1,	2,
-0,	1,	0,	0,
-1,	2,	0,	1,
-0,	0,	0,	0,
-0,	0,	1,	0, 
-0,	0,	0,	0,
-0,	1,	1,	0}; 
+	0,  /* A */
+	1,  /* B */
+	1,  /* C */
+	2,  /* D */
+	0,  /* E */
+	1,  /* F */
+	0,  /* G */
+	0,  /* H */
+	1,  /* I */
+	2,  /* J */
+	0,  /* K */
+	1,  /* L */
+	0,  /* M */
+	0,  /* N */
+	0,  /* O */
+	0,  /* P */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	1,  /* Q */
+#else
+	0,  /* Q */
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+	0,  /* R */
+	1,  /* S */
+	0,  /* T */
+	0,  /* U */
+	0,  /* V */
+	0,  /* W */
+	0,  /* X */
+	0,  /* Y */
+	1,  /* Z */
+	1,  /* [ */
+	0   /* \ */
+}; 
 
 
 

--- a/runtime/util/sendslot.c
+++ b/runtime/util/sendslot.c
@@ -37,11 +37,7 @@ getSendSlotsFromSignature(const U_8* signature)
 		case '[':
 			/* skip all '['s */
 			for (i++; signature[i] == '['; i++);
-			if ((signature[i] == 'L')
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-				|| (signature[i] == 'Q')
-#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
-			) {
+			if (J9_IS_OBJECT_OR_VALUETYPE(signature[i])) {
 				/* FALL THRU */
 			} else {
 				sendArgs++;

--- a/runtime/verutil/sigverify.c
+++ b/runtime/verutil/sigverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,10 +195,10 @@ checkSignatureInlined (U_8* signatureBytes, UDATA signatureLength, UDATA *curren
 		}
 	}
 
-	if (*cursor == 'L') {
+	if (J9_IS_OBJECT_OR_VALUETYPE(*cursor)) {
 		IDATA bytesConsumed = 0;
 
-		cursor += 1; /* skip the 'L' */
+		cursor += 1; /* skip the 'L' or 'Q'*/
 		bytesConsumed = verifyIdentifierUtf8Impl(cursor, signatureEnd, TRUE);
 
 		/* Identifier must end in a semicolon */

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -108,9 +108,9 @@ internalFindArrayClass(J9VMThread* vmThread, J9Module *j9module, UDATA arity, U_
 		/* the first level of arity is already present in the array class */
 		arity -= 1;
 
-	} else if (firstChar == 'L' && lastChar == ';') {
-
-		name += arity + 1; /* 1 for 'L' */
+	} else if ((';' == lastChar) && J9_IS_OBJECT_OR_VALUETYPE(firstChar)) {
+		/* TODO: ValueTypes This must be revisisted for flattenable arrays. See https://github.com/eclipse/openj9/issues/1389 */
+		name += arity + 1; /* 1 for 'L' or 'Q' */
 		length -= arity + 2; /* 2 for 'L and ';' */
 
 		arrayClass = internalFindClassInModule(vmThread, j9module, name, length, classLoader, options);

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -468,8 +468,12 @@ UDATA JNICALL   pushArguments(J9VMThread *vmThread, J9Method* method, void *args
 				while ('[' == *sigChar) {
 					sigChar += 1;
 				}
-				skipSignature = ('L' == *sigChar++);
-			case 'L': /* FALLTHROUGH */
+				skipSignature = (J9_IS_OBJECT_OR_VALUETYPE(*sigChar));
+				sigChar += 1; /* FALLTHROUGH */
+			case 'L':
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			case 'Q':
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 				/* skip the rest of the signature */
 				if (skipSignature) {
 					while (';' != *sigChar) {
@@ -520,7 +524,7 @@ UDATA JNICALL   pushArguments(J9VMThread *vmThread, J9Method* method, void *args
 				break;
 			case ')':
 				vmThread->sp = sp;
-				return (*sigChar == 'L' || *sigChar == '[') ? J9_SSF_RETURNS_OBJECT : 0;
+				return (J9_IS_OBJECT_OR_VALUETYPE(*sigChar) || ('[' == *sigChar)) ? J9_SSF_RETURNS_OBJECT : 0;
 		}
 	}
 }

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -217,7 +217,7 @@ findFieldSignatureClass(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA field
 	if ('[' == J9UTF8_DATA(signature)[0]) {
 		resolvedClass = internalFindClassUTF8(vmStruct, J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	} else {
-		Assert_VM_true('L' == J9UTF8_DATA(signature)[0]);
+		Assert_VM_true(J9_IS_OBJECT_OR_VALUETYPE(J9UTF8_DATA(signature)[0]));
 		/* skip fieldSignature's L and ; to have only CLASSNAME required for internalFindClassUTF8 */
 		resolvedClass = internalFindClassUTF8(vmStruct, &J9UTF8_DATA(signature)[1], J9UTF8_LENGTH(signature)-2, classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	}


### PR DESCRIPTION
Where appropriate, add support for Q types.
Previously, many locations check for L types, either through character comparisons or through an ascii character map.
Q types have been added to these checks when appropriate, so that they will be treated like objects as opposed to causing crashes or unexpected behavior.

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>
