### PR TITLE
Eliminate IProfiler::_maxCount

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8023,11 +8023,6 @@ TR::CompilationInfoPerThreadBase::compile(
    try
       {
       InterruptibleOperation compilingMethodBody(*this);
-#if defined(J9VM_INTERP_PROFILING_BYTECODES)
-      TR_IProfiler *profiler = vm.getIProfiler();
-      if (profiler)
-         profiler->resetProfiler();
-#endif
 
       TR::IlGeneratorMethodDetails & details = _methodBeingCompiled->getMethodDetails();
       J9Method *method = details.getMethod();

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -579,7 +579,7 @@ TR_IProfiler::allocate(J9JITConfig *jitConfig)
 
 TR_IProfiler::TR_IProfiler(J9JITConfig *jitConfig)
    : _isIProfilingEnabled(true),
-     _valueProfileMethod(NULL), _maxCount(DEFAULT_PROFILING_COUNT), _lightHashTableMonitor(0), _allowedToGiveInlinedInformation(true),
+     _valueProfileMethod(NULL), _lightHashTableMonitor(0), _allowedToGiveInlinedInformation(true),
      _globalAllocationCount (0), _maxCallFrequency(0), _iprofilerThread(0), _iprofilerOSThread(NULL),
      _workingBufferTail(NULL), _numOutstandingBuffers(0), _numRequests(1), _numRequestsSkipped(0),
      _numRequestsHandedToIProfilerThread(0), _iprofilerThreadExitFlag(0), _iprofilerMonitor(NULL),
@@ -2060,14 +2060,6 @@ TR_IProfiler::getProfilingData(TR_OpaqueMethodBlock *method, uint32_t byteCodeIn
    return 0;
    }
 
-int32_t
-TR_IProfiler::getMaxCount(bool isAOT)
-   {
-   if (!isIProfilingEnabled())
-      return 0;
-
-   return _maxCount;
-   }
 
 int32_t
 TR_IProfiler::getSwitchCountForValue (TR::Node *node, int32_t value, TR::Compilation *comp)
@@ -2313,7 +2305,6 @@ TR_IProfiler::setBlockAndEdgeFrequencies(TR::CFG *cfg, TR::Compilation *comp)
       return;
 
    cfg->propagateFrequencyInfoFromExternalProfiler(this);
-   _maxCount = cfg->getMaxFrequency();
 
    static bool traceIProfiling = ((debug("traceIProfiling") != NULL));
    if (traceIProfiling)
@@ -2331,11 +2322,6 @@ TR_IProfiler::setBlockAndEdgeFrequencies(TR::CFG *cfg, TR::Compilation *comp)
       }
    }
 
-void
-TR_IProfiler::resetProfiler()
-   {
-   _maxCount = DEFAULT_PROFILING_COUNT;
-   }
 
 J9Class *
 TR_IProfiler::getInterfaceClass(J9Method *aMethod, TR::Compilation *comp)

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -480,7 +480,6 @@ public:
    void shutdown();
    void outputStats();
    void dumpIPBCDataCallGraph(J9VMThread* currentThread);
-   void resetProfiler();
    void startIProfilerThread(J9JavaVM *javaVM);
    void deallocateIProfilerBuffers();
    void stopIProfilerThread();
@@ -573,7 +572,6 @@ private:
    virtual void setBlockAndEdgeFrequencies( TR::CFG *cfg, TR::Compilation *comp);
    virtual bool hasSameBytecodeInfo(TR_ByteCodeInfo & persistentByteCodeInfo, TR_ByteCodeInfo & currentByteCodeInfo, TR::Compilation *comp);
    virtual void getBranchCounters (TR::Node *node, TR::TreeTop *fallThroughTree, int32_t *taken, int32_t *notTaken, TR::Compilation *comp);
-   int32_t getMaxCount(bool isAOT);
    virtual int32_t getSwitchCountForValue (TR::Node *node, int32_t value, TR::Compilation *comp);
    virtual int32_t getSumSwitchCount (TR::Node *node, TR::Compilation *comp);
    virtual int32_t getFlatSwitchProfileCounts (TR::Node *node, TR::Compilation *comp);


### PR DESCRIPTION
IProfiler::_maxCount is a value set by the optimizer when it calls
"setBlockAndEdgeFrequencies" and is reset at the beginning of a
compilation. The problem is that this value is shared by all compilation
threads so one thread could be setting it to some value while another
thread could be resetting it. The good news is that _maxCount appears
to be unused so it can be deleted.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>