### PR TITLE
[WIP] Removing GCC from the x86/ub16 container on Jenkins

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     ant \
@@ -49,11 +48,6 @@ RUN apt-get update \
     cpio \
     curl \
     file \
-    g++-4.8 \
-    g++-7 \
-    gcc-4.8 \
-    gcc-7 \
-    gdb \
     git \
     git-core \
     libasound2-dev \
@@ -85,13 +79,6 @@ RUN apt-get update \
 
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
-
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \


### PR DESCRIPTION
I want to see if we can still test the jdks tests without gcc

[skip ci]

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>