### PR TITLE
WIP: Reduce number of VM_getResolvedVirtualMethod messages

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3090,6 +3090,11 @@ ClientSessionData::ClassInfo::freeClassInfo()
       _staticAttributesCacheAOT->~TR_FieldAttributesCache();
       jitPersistentFree(_staticAttributesCacheAOT);
       }
+   if (_virtualMethodCache)
+      {
+      _virtualMethodCache->~PersistentUnorderedMap<int32_t, TR_OpaqueMethodBlock *>();
+      jitPersistentFree(_virtualMethodCache);
+      }
    }
 
 ClientSessionData::VMInfo *
@@ -3351,6 +3356,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct._staticAttributesCache = NULL;
    classInfoStruct._fieldAttributesCacheAOT = NULL;
    classInfoStruct._staticAttributesCacheAOT = NULL;
+   classInfoStruct._virtualMethodCache = NULL;
 
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -70,6 +70,7 @@ class ClientSessionData
       TR_FieldAttributesCache *_staticAttributesCache;
       TR_FieldAttributesCache *_fieldAttributesCacheAOT;
       TR_FieldAttributesCache *_staticAttributesCacheAOT;
+      PersistentUnorderedMap<int32_t, TR_OpaqueMethodBlock *> *_virtualMethodCache;
       };
 
    struct J9MethodInfo


### PR DESCRIPTION
To reduce the frequency of VM_getResolvedVirtualMethod
messages this commit adds a per-session cache that will store
<virtualCallSelector --> j9method mappings>. There will be one cache
for each j9class, but these caches are created on demand.

[skip ci]

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>