### PR TITLE
Modify SCC test to make it compatible with JITServer

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
@@ -110,7 +110,7 @@
 	</test>
 	
 	<test id="Test 3-a: Add ROMClasses, AOT methods and JITHints into the cache" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,verboseAOT,verboseJITDATA,addtestjithints -Xaot:forceAot,count=1 -Xjit:disableAsyncCompilation -version</command>
+		<command>$JAVA_EXE$ $currentMode$,verboseAOT,verboseJITDATA,addtestjithints -Xaot:forceAot,count=1 -Xjit:disableAsyncCompilation,memExpensiveCompThreshold=65536 -version</command>
 		
 		<output type="required" caseSensitive="yes" regex="no">Stored AOT code for ROMMethod</output>
 		<output type="required" caseSensitive="yes" regex="no">Stored JITHINT attached data</output>


### PR DESCRIPTION
`testSCCMLSoftmx_1` from `extended.functional` currently
fails in JITServer mode, because it expects to find SCC hints
produced due to compilation exceeding an expensive memory
compilation threshold. That does not happen for a remote compilation,
because it uses very little memory on the client.
Make the test pass by manually setting the threshold to a small value
that will definitely be exceeded by a remote compilation.