### PR TITLE
Added aarch to pipeline platforms

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -45,6 +45,12 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - Linux on ppc64le
         - Spec: ppc64le_linux
         - Shortname: plinux
+    - Linux on aarch64
+        - Spec: aarch64_linux
+        - Shortname: alinux64
+    - Linux on aarch64 largeheap/non-compressed references
+        - Spec: aarch64_linux_xl
+        - Shortname: alinux64xl or alinux64largeheap
     - AIX on ppc64
         - Spec: ppc64_aix
         - Shortname: aix

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -39,7 +39,9 @@
  *              win_x86 (Java 8 support only),
  *              zos_390-64_cmprssptrs (Java 11 support only),
  *              osx_x86-64 (Java 8 and Java 11 support only),
- *              osx_x86-64_cmprssptrs (Java 8 and Java 11 support only)
+ *              osx_x86-64_cmprssptrs (Java 8 and Java 11 support only),
+ *              aarch64_linux (Java 11 support only),
+ *              aarch64_linux_xl (Java 11 support only)
  *   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse/openj9.git (default)
  *   OPENJ9_BRANCH: String - the OpenJ9 branch to clone from: e.g. master (default)
  *   OPENJ9_SHA: String - the last commit SHA of the OpenJ9 repository
@@ -88,7 +90,9 @@ SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
          'x86-64_mac'     : CURRENT_RELEASES,
          'x86-32_windows' : ['8'],
          'x86-64_windows' : CURRENT_RELEASES,
-         'x86-64_windows_xl' : CURRENT_RELEASES]
+         'x86-64_windows_xl' : CURRENT_RELEASES,
+         'aarch64_linux' : ['11'],
+         'aarch64_linux_xl' : ['11']]
 
 // SHORT_NAMES is used for PullRequest triggers
 // TODO Combine SHORT_NAMES and SPECS
@@ -107,7 +111,10 @@ SHORT_NAMES = ['all' : ['ppc64le_linux','s390x_linux','x86-64_linux','x86-64_lin
             'winxl' : ['x86-64_windows_xl'],
             'osx' : ['x86-64_mac'],
             'osxlargeheap' : ['x86-64_mac_xl'],
-            'osxxl' : ['x86-64_mac_xl']]
+            'osxxl' : ['x86-64_mac_xl'],
+            'alinux64' : ['aarch64_linux'],
+            'alinux64xl' : ['aarch64_linux_xl'],
+            'alinux64largeheap' : ['aarch64_linux_xl']]
 
 // Initialize all PARAMETERS (params) to Groovy Variables even if they are not passed
 echo "Initialize all PARAMETERS..."

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -425,6 +425,34 @@ x86-64_linux_xl:
     13:
       ? special.system
 #========================================#
+# Linux Aarch 64bits Large Heap
+#========================================#
+aarch64_linux_xl:
+  boot_jdk:
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+  release:
+    11: 'linux-aarch64-normal-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  extra_configure_options:
+    11: '--with-noncompressedrefs'
+  node_labels:
+    build:
+      11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
+#========================================#
+# Linux Aarch 64bits Compressed Pointers
+#========================================#
+aarch64_linux:
+  boot_jdk:
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+  release:
+    11: 'linux-aarch64-normal-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  node_labels:
+    build:
+      11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
+#========================================#
 # Windows x86 64bits Compressed Pointers
 #========================================#
 x86-64_windows:


### PR DESCRIPTION
Updated Pipeline-Build-Test-All.groovy to include Aarch64 as a platform.
Also updated defaults.yml to include variables for Aarch64. Currently
Aarch64 is only able to compile JDK11, and is unable to compile tests.
The only Aarch64 machine currently setup is running cent7.

Signed-off-by: Colton Mills <millscolt3@gmail.com>