### PR TITLE
Option to sort Tail Candidate List by free size

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -638,6 +638,14 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->tarokEnableCopyForwardHybrid = false;
 			continue;
 		}
+		if (try_scan(&scan_start, "tarokSortTailCandidateAscending")) {
+			extensions->tarokTailCandidateListSortOrder = MM_GCExtensionsBase::SORT_ORDER_ASCENDING;
+			continue;
+		}
+		if (try_scan(&scan_start, "tarokSortTailCandidateDescending")) {
+			extensions->tarokTailCandidateListSortOrder = MM_GCExtensionsBase::SORT_ORDER_DESCENDING;
+			continue;
+		}
 
 #endif /* defined (J9VM_GC_VLHGC) */
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -515,6 +515,17 @@ private:
 	void insertTailCandidate(MM_EnvironmentVLHGC* env, MM_ReservedRegionListHeader* regionList, MM_HeapRegionDescriptorVLHGC *tailRegion);
 
 	/**
+	 * Insert the specified tail candidate into the tail candidate list and sort the list by tail size ascending order.
+	 * The implementation assumes that the calling thread can modify
+	 * regionList without locking it so the callsite either needs to have locked the list or be single-threaded.
+	 * @param env[in] The GC thread
+	 * @param regionList[in] The region list to which tailRegion should be added as a a tail candidate
+	 * @param tailRegion[in] The region to add
+	 * @param isAscending
+	 */
+	void insertAndSortTailCandidate(MM_EnvironmentVLHGC* env, MM_ReservedRegionListHeader* regionList, MM_HeapRegionDescriptorVLHGC* tailRegion, bool isAscending);
+
+	/**
 	 * Remove the specified tail candidate from the tail candidate list.  The implementation assumes that the calling thread can modify 
 	 * regionList without locking it so the callsite either needs to have locked the list or be single-threaded.
 	 * @param env[in] The GC thread


### PR DESCRIPTION
	tail candidate list is created for reusing free space of survivor
	regions and tenure regions. sort the list Ascending or Descending
	might help reduce fragmentation or increasing Cache locality.

	- new XXgc:tarokSortTailCandidateAscending,
XXgc:tarokSortTailCandidateDescending option
	- base on the value of tarokTailCandidateListSortOrder
	sort tail candidate list by free size.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>

depends on eclipse/omr#4283
