### PR TITLE
WIP: Reuse free memory from GMP in PGC

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -187,6 +187,7 @@ public:
 	double maxRAMPercent; /**< Value of -XX:MaxRAMPercentage specified by the user */
 	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
 
+	bool tarokEnableRecoverRegionLargestFreeMemory; /**< Enable recovering region largest free memory during post sweep of GMP, this flag is only available if tarokEnableRecoverRegionTailsAfterSweep == true */
 protected:
 private:
 protected:
@@ -317,6 +318,7 @@ public:
 #endif
 		, maxRAMPercent(0.0) /* this would get overwritten by user specified value */
 		, initialRAMPercent(0.0) /* this would get overwritten by user specified value */
+		, tarokEnableRecoverRegionLargestFreeMemory(false)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -358,6 +358,14 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->tarokEnableExpensiveAssertions = false;
 			continue;
 		}
+		if (try_scan(&scan_start, "tarokEnableAllocationPointerAssertion")) {
+			extensions->tarokEnableAllocationPointerAssertion = true;
+			continue;
+		}
+		if (try_scan(&scan_start, "tarokDisableAllocationPointerAssertion")) {
+			extensions->tarokEnableAllocationPointerAssertion = false;
+			continue;
+		}
 		if (try_scan(&scan_start, "tarokTgcEnableRememberedSetDuplicateDetection")) {
 			extensions->tarokTgcEnableRememberedSetDuplicateDetection = true;
 			continue;
@@ -629,6 +637,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 
 			continue;
 		}
+		if (try_scan(&scan_start, "tarokEnableRecoverRegionTailsAfterSweep")) {
+			extensions->tarokEnableRecoverRegionTailsAfterSweep = true;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "tarokEnableRecoverRegionLargestFreeMemory")) {
+			extensions->tarokEnableRecoverRegionLargestFreeMemory = true;
+			continue;
+		}
+
 #endif /* defined (J9VM_GC_VLHGC) */
 
 		if(try_scan(&scan_start, "packetListLockSplit=")) {

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -278,6 +278,12 @@ MM_CopyForwardScheme::initialize(MM_EnvironmentVLHGC *env)
 		if(!_reservedRegionList[index]._tailCandidatesLock.initialize(env, &_extensions->lnrlOptions, "MM_CopyForwardScheme:_reservedRegionList[]._tailCandidatesLock")) {
 			return false;
 		}
+		_reservedRegionList[index]._largestFreeMemoryCandidates = NULL;
+		_reservedRegionList[index]._largestFreeMemoryCandidateCount = 0;
+		if(!_reservedRegionList[index]._largestFreeMemoryCandidatesLock.initialize(env, &_extensions->lnrlOptions, "MM_CopyForwardScheme:_reservedRegionList[]._largestFreeMemoryCandidatesLock")) {
+			return false;
+		}
+
 	}
 
 	/* Set the min/max sizes for copy scan cache allocation when allocating a general purpose area (does not include non-standard sized objects) */
@@ -332,6 +338,7 @@ MM_CopyForwardScheme::tearDown(MM_EnvironmentVLHGC *env)
 				_reservedRegionList[index]._sublists[sublistIndex]._lock.tearDown();
 			}
 			_reservedRegionList[index]._tailCandidatesLock.tearDown();
+			_reservedRegionList[index]._largestFreeMemoryCandidatesLock.tearDown();
 		}
 		env->getForge()->free(_reservedRegionList);
 		_reservedRegionList = NULL;
@@ -440,6 +447,8 @@ MM_CopyForwardScheme::preProcessRegions(MM_EnvironmentVLHGC *env)
 
 	while(NULL != (region = regionIterator.nextRegion())) {
 		region->_copyForwardData._survivorBase = NULL;
+		region->_copyForwardData._survivorLow = NULL;
+		region->_copyForwardData._survivorHigh = NULL;
 
 		if(region->containsObjects()) {
 			region->_copyForwardData._initialLiveSet = true;
@@ -498,7 +507,7 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 			} else {
 				static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats._nonEdenEvacuateRegionCount += 1;
 			}
-		} else if (region->isSurvivorRegion() && !region->isTailFilledSurvivorRegion()) {
+		} else if (region->isSurvivorRegion() && !region->isTailFilledSurvivorRegion() && !region->isLargestFreeMemoryFilledSurvivorRegion()) {
 			/* check Eden Survivor Regions */
 			if (0 == region->getLogicalAge()) {
 				static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats._edenSurvivorRegionCount += 1;
@@ -514,18 +523,23 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 			Assert_MM_false(region->_markData._shouldMark);
 			Assert_MM_false(region->_reclaimData._shouldReclaim);
 
-			/* we do not count tails, only regions that we acquired as free */
+			/* we do not count tails and free memory in exist regions, only regions that we acquired as free */
 			if (region->getLowAddress() == region->_copyForwardData._survivorBase) {
 				survivorSetRegionCount += 1;
 			}
 			/* store back the remaining memory in the pool as free memory */
 			UDATA remainingBytes = pool->getAllocatableBytes();
-
+			UDATA holeCount = (0 == remainingBytes) ? 0 : 1;
+			UDATA largestFreeEntrySize = remainingBytes;
+			if (region->isLargestFreeMemoryFilledSurvivorRegion()) {
+				remainingBytes += pool->getAllocatableBytes4Collector();
+				largestFreeEntrySize = OMR_MAX( largestFreeEntrySize,  pool->getAllocatableBytes4Collector());
+				holeCount += 1;
+			}
 			region->_sweepData._alreadySwept = true;
 			pool->setFreeMemorySize(pool->getActualFreeMemorySize() + remainingBytes);
-			UDATA holeCount = (0 == remainingBytes) ? 0 : 1;
-			pool->setFreeEntryCount(holeCount);
-			pool->setLargestFreeEntry(remainingBytes);
+			pool->setFreeEntryCount(pool->getActualFreeEntryCount() + holeCount);
+			pool->setLargestFreeEntry(largestFreeEntrySize);
 			Assert_MM_true(pool->getActualFreeMemorySize() >= pool->getAllocatableBytes());
 			Assert_MM_true(pool->getActualFreeMemorySize() <= region->getSize());
 			if (pool->getActualFreeMemorySize() == region->getSize()) {
@@ -544,6 +558,8 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 		region->_copyForwardData._initialLiveSet = false;
 		region->_copyForwardData._requiresPhantomReferenceProcessing = false;
 		region->_copyForwardData._survivorBase = NULL;
+		region->_copyForwardData._survivorLow = NULL;
+		region->_copyForwardData._survivorHigh = NULL;
 
 		if (region->_copyForwardData._evacuateSet) {
 			Assert_MM_true(region->_sweepData._alreadySwept);
@@ -623,7 +639,8 @@ MM_CopyForwardScheme::isObjectInSurvivorMemory(J9Object *objectPtr)
 		MM_HeapRegionDescriptorVLHGC *region = NULL;
 		region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(objectPtr);
 		Assert_MM_true(region->_copyForwardData._initialLiveSet || (!region->_markData._shouldMark && !region->_copyForwardData._initialLiveSet));
-		result = region->isSurvivorRegion() && (objectPtr >= region->_copyForwardData._survivorBase);
+		result = region->isSurvivorRegion() && (((NULL != region->_copyForwardData._survivorBase) && (objectPtr >= region->_copyForwardData._survivorBase)) ||
+												((NULL != region->_copyForwardData._survivorLow) && (region->_copyForwardData._survivorLow <= objectPtr) && (objectPtr<region->_copyForwardData._survivorHigh)));
 	}
 	return result;
 }
@@ -636,7 +653,7 @@ MM_CopyForwardScheme::isObjectInNurseryMemory(J9Object *objectPtr)
 	if(NULL != objectPtr) {
 		MM_HeapRegionDescriptorVLHGC *region = NULL;
 		region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(objectPtr);
-		result = region->_markData._shouldMark || (region->isSurvivorRegion() && (objectPtr >= region->_copyForwardData._survivorBase));
+		result = region->_markData._shouldMark || isObjectInSurvivorMemory(objectPtr);
 	}
 	return result;
 }
@@ -745,10 +762,16 @@ MM_CopyForwardScheme::clearReservedRegionLists(MM_EnvironmentVLHGC *env)
 			Assert_MM_true(NULL != _reservedRegionList[index]._tailCandidates);
 		}
 		
+		if (0 == _reservedRegionList[index]._largestFreeMemoryCandidateCount) {
+			Assert_MM_true(NULL == _reservedRegionList[index]._largestFreeMemoryCandidates);
+		} else {
+			Assert_MM_true(NULL != _reservedRegionList[index]._largestFreeMemoryCandidates);
+		}
+
 		for (UDATA sublistIndex = 0; sublistIndex < _reservedRegionList[index]._sublistCount; sublistIndex++) {
 			MM_ReservedRegionListHeader::Sublist *regionList = &_reservedRegionList[index]._sublists[sublistIndex];
 			MM_HeapRegionDescriptorVLHGC *region = regionList->_head;
-	
+
 			while(NULL != region) {
 				MM_HeapRegionDescriptorVLHGC *next = region->_copyForwardData._nextRegion;
 				releaseRegion(env, regionList, region);
@@ -768,6 +791,8 @@ MM_CopyForwardScheme::clearReservedRegionLists(MM_EnvironmentVLHGC *env)
 		_reservedRegionList[index]._evacuateRegionCount = 0;
 		_reservedRegionList[index]._tailCandidates = NULL;
 		_reservedRegionList[index]._tailCandidateCount = 0;
+		_reservedRegionList[index]._largestFreeMemoryCandidates = NULL;
+		_reservedRegionList[index]._largestFreeMemoryCandidateCount = 0;
 	}
 	
 	Trc_MM_CopyForwardScheme_clearReservedRegionLists_Exit(env->getLanguageVMThread());
@@ -890,9 +915,49 @@ MM_CopyForwardScheme::reserveMemoryForObject(MM_EnvironmentVLHGC *env, UDATA com
 		result = memoryPool->collectorAllocate(env, &allocDescription, false);
 		region = region->_copyForwardData._nextRegion;
 	}
-
 	/* 
-	 * 2. attempt to acquire a region from the tail candidates list 
+	 * 2.1 attempt to acquire a region from the largest freememory candidates list
+	 */
+	if ((NULL == result) && (NULL != _reservedRegionList[compactGroup]._largestFreeMemoryCandidates)) {
+		_reservedRegionList[compactGroup]._largestFreeMemoryCandidatesLock.acquire();
+		region = _reservedRegionList[compactGroup]._largestFreeMemoryCandidates;
+		MM_HeapRegionDescriptorVLHGC *resultRegion = NULL;
+		MM_MemoryPoolBumpPointer *memoryPool = NULL;
+		while ((NULL == result) && (NULL != region)) {
+			memoryPool = (MM_MemoryPoolBumpPointer*)region->getMemoryPool();
+			Assert_MM_true(NULL != memoryPool);
+
+			/* make sure that we can't be copying objects into the area covered by a card which is meant to describe objects which were already in the region */
+			UDATA lostToAlignment = alignMemoryPool4Collector(env, memoryPool);
+			env->_copyForwardCompactGroups[compactGroup]._discardedBytes += lostToAlignment;
+
+			result = memoryPool->collectorAllocate(env, &allocDescription, false);
+			resultRegion = region;
+			region = region->_copyForwardData._nextRegion;
+		}
+		if (NULL != result) {
+			/* remove this region from the common largest freememory candidates list and add it to our own sublist */
+			Assert_MM_true(NULL != resultRegion);
+			Assert_MM_true(NULL != memoryPool);
+			void *baseAddr =memoryPool->getAllocationPointer();
+			void *lowAddr = memoryPool->getAllocationPointer4Collector();
+			void *highAddr = memoryPool->getAlloctionTop4Collector();
+			if ((UDATA) result > (UDATA) highAddr) {
+				baseAddr = result;
+			} else {
+				lowAddr = result;
+			}
+			if (baseAddr == resultRegion->getHighAddress()) {
+				baseAddr = NULL;
+			}
+			removeCandidate(env, _reservedRegionList[compactGroup]._largestFreeMemoryCandidates, _reservedRegionList[compactGroup]._largestFreeMemoryCandidateCount, resultRegion);
+			insertRegionIntoLockedList(env, regionList, resultRegion);
+			convertCandidateToSurvivorRegion(env, resultRegion, baseAddr, lowAddr, highAddr);
+		}
+		_reservedRegionList[compactGroup]._largestFreeMemoryCandidatesLock.release();
+	}
+	/*
+	 * 2.2 attempt to acquire a region from the tail candidates list
 	 */
 	if ((NULL == result) && (NULL != _reservedRegionList[compactGroup]._tailCandidates)) {
 		_reservedRegionList[compactGroup]._tailCandidatesLock.acquire();
@@ -913,9 +978,9 @@ MM_CopyForwardScheme::reserveMemoryForObject(MM_EnvironmentVLHGC *env, UDATA com
 		if (NULL != result) {
 			/* remove this region from the common tail candidates list and add it to our own sublist */
 			Assert_MM_true(NULL != resultRegion);
-			removeTailCandidate(env, &_reservedRegionList[compactGroup], resultRegion);
+			removeCandidate(env, _reservedRegionList[compactGroup]._tailCandidates, _reservedRegionList[compactGroup]._tailCandidateCount, resultRegion);
 			insertRegionIntoLockedList(env, regionList, resultRegion);
-			convertTailCandidateToSurvivorRegion(env, resultRegion, result);
+			convertCandidateToSurvivorRegion(env, resultRegion, result, NULL, NULL);
 		}
 		_reservedRegionList[compactGroup]._tailCandidatesLock.release();
 	}
@@ -992,7 +1057,49 @@ MM_CopyForwardScheme::reserveMemoryForCache(MM_EnvironmentVLHGC *env, UDATA comp
 	}
 
 	/* 
-	 * 2. attempt to acquire a region from the tail candidates list 
+	 * 2.1 attempt to acquire a region from the largest freememory candidates list
+	 */
+	if ((!result) && (NULL != _reservedRegionList[compactGroup]._largestFreeMemoryCandidates)) {
+		_reservedRegionList[compactGroup]._largestFreeMemoryCandidatesLock.acquire();
+		region = _reservedRegionList[compactGroup]._largestFreeMemoryCandidates;
+		if (NULL != region) {
+			MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer*)region->getMemoryPool();
+			Assert_MM_true(NULL != memoryPool);
+
+			/* make sure that we can't be copying objects into the area covered by a card which is meant to describe objects which were already in the region */
+			UDATA lostToAlignment = alignMemoryPool4Collector(env, memoryPool);
+			env->_copyForwardCompactGroups[compactGroup]._discardedBytes += lostToAlignment;
+
+			void *tlhBase = NULL;
+			void *tlhTop = NULL;
+			result = (NULL != memoryPool->collectorAllocateTLH(env, &allocDescription, maxCacheSize, tlhBase, tlhTop, false));
+			/* this region was a tail candidate so it must have had room for at least a minimal TLH */
+			Assert_MM_true(result);
+			*addrBase = tlhBase;
+			*addrTop = tlhTop;
+
+			void *baseAddr =memoryPool->getAllocationPointer();
+			void *lowAddr = memoryPool->getAllocationPointer4Collector();
+			void *highAddr = memoryPool->getAlloctionTop4Collector();
+			if ((UDATA) tlhBase > (UDATA) highAddr) {
+				baseAddr = tlhBase;
+			} else {
+				lowAddr = tlhBase;
+			}
+			if (baseAddr == region->getHighAddress()) {
+				baseAddr = NULL;
+			}
+
+			/* remove this region from the common tail candidates list and add it to our own sublist */
+			removeCandidate(env, _reservedRegionList[compactGroup]._largestFreeMemoryCandidates, _reservedRegionList[compactGroup]._largestFreeMemoryCandidateCount, region);
+
+			insertRegionIntoLockedList(env, regionList, region);
+			convertCandidateToSurvivorRegion(env, region, baseAddr, lowAddr, highAddr);
+		}
+		_reservedRegionList[compactGroup]._largestFreeMemoryCandidatesLock.release();
+	}
+	/*
+	 * 2.2 attempt to acquire a region from the tail candidates list
 	 */
 	if ((!result) && (NULL != _reservedRegionList[compactGroup]._tailCandidates)) {
 		_reservedRegionList[compactGroup]._tailCandidatesLock.acquire();
@@ -1013,9 +1120,9 @@ MM_CopyForwardScheme::reserveMemoryForCache(MM_EnvironmentVLHGC *env, UDATA comp
 			*addrBase = tlhBase;
 			*addrTop = tlhTop;
 			/* remove this region from the common tail candidates list and add it to our own sublist */
-			removeTailCandidate(env, &_reservedRegionList[compactGroup], region);
+			removeCandidate(env, _reservedRegionList[compactGroup]._tailCandidates, _reservedRegionList[compactGroup]._tailCandidateCount, region);
 			insertRegionIntoLockedList(env, regionList, region);
-			convertTailCandidateToSurvivorRegion(env, region, tlhBase);
+			convertCandidateToSurvivorRegion(env, region, tlhBase, NULL, NULL);
 		}
 		_reservedRegionList[compactGroup]._tailCandidatesLock.release();
 	}
@@ -3170,9 +3277,6 @@ MM_CopyForwardScheme::incrementalScanCacheBySlot(MM_EnvironmentVLHGC *env)
 void
 MM_CopyForwardScheme::cleanRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, U_8 flagToClean)
 {
-	/* At this point, no copying should happen, so that reservingContext is irrelevant */
-	MM_AllocationContextTarok *reservingContext = _commonContext;
-
 	Assert_MM_true(region->containsObjects());
 	/* do we need to clean this region? */
 	U_8 flags = region->_markData._overflowFlags;
@@ -3184,16 +3288,19 @@ MM_CopyForwardScheme::cleanRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescrip
 		/* Force our write of the overflow flags from our cache and ensure that we have no stale mark map data before we walk */
 		MM_AtomicOperations::sync();
 		UDATA *heapBase = (UDATA *)region->getLowAddress();
-		/* If it is tail filled region scan only survivor portion of the region */
+		UDATA *heapTop = (UDATA *)region->getHighAddress();
+		/* If it is tail filled region or largest free memory filled region, scan only survivor portions of the region, otherwise scan whole region */
+		if ((UDATA *)region->_copyForwardData._survivorLow > heapBase) {
+			heapBase = (UDATA *)region->_copyForwardData._survivorLow;
+			heapTop = (UDATA *)region->_copyForwardData._survivorHigh;
+			cleanInRange(env, heapBase, heapTop);
+		}
 		if ((UDATA *)region->_copyForwardData._survivorBase > heapBase) {
 			heapBase = (UDATA *)region->_copyForwardData._survivorBase;
+			heapTop = (UDATA *)region->getHighAddress();
 		}
-		UDATA *heapTop = (UDATA *)region->getHighAddress();
-		MM_HeapMapIterator objectIterator = MM_HeapMapIterator(MM_GCExtensions::getExtensions(env), env->_cycleState->_markMap, heapBase, heapTop);
-
-		J9Object *object = NULL;
-		while (NULL != (object = objectIterator.nextObject())) {
-			scanObject(env, reservingContext, object, SCAN_REASON_OVERFLOWED_REGION);
+		if ((UDATA *)region->getHighAddress() == heapTop) {
+			cleanInRange(env, heapBase, heapTop);
 		}
 	}
 }
@@ -4022,6 +4129,37 @@ MM_CopyForwardScheme::alignMemoryPool(MM_EnvironmentVLHGC *env, MM_MemoryPoolBum
 	return lostToAlignment;
 }
 
+UDATA
+MM_CopyForwardScheme::alignMemoryPool4Collector(MM_EnvironmentVLHGC *env, MM_MemoryPoolBumpPointer *pool)
+{
+	/* make sure that we can't be copying objects into the area covered by a card which is meant to describe objects which were already in the region */
+	UDATA recordedActualFree = pool->getActualFreeMemorySize();
+	UDATA initialAllocatableBytes = pool->getAllocatableBytes();
+	UDATA allocatableBytes4Collector = pool->getAllocatableBytes4Collector();
+
+	Assert_MM_true(recordedActualFree >= (initialAllocatableBytes + allocatableBytes4Collector));
+	UDATA previousFree = recordedActualFree - initialAllocatableBytes - allocatableBytes4Collector;
+	Assert_MM_true(previousFree < _regionManager->getRegionSize());
+	UDATA lostToAlignment = 0;
+	if (0 != allocatableBytes4Collector) {
+		void *newStartFreeEntry = pool->alignWithCard((void *)  pool->getAllocationPointer4Collector(), false, CARD_SIZE);
+		void *newEndFreeEntry = pool->alignWithCard((void *)  pool->getAlloctionTop4Collector(), true, CARD_SIZE);
+		UDATA newAllocatableBytes = (UDATA)newEndFreeEntry - (UDATA)newStartFreeEntry;
+		Assert_MM_true(newAllocatableBytes >= pool->getMinimumFreeEntrySize());
+		Assert_MM_true(newAllocatableBytes <= allocatableBytes4Collector);
+		pool->setAllocationPointer4Collector(env, newStartFreeEntry, newEndFreeEntry);
+		lostToAlignment += allocatableBytes4Collector - newAllocatableBytes;
+	}
+	if (0 != initialAllocatableBytes) {
+		pool->alignAllocationPointer(CARD_SIZE);
+		UDATA newAllocatableBytes = pool->getAllocatableBytes();
+		Assert_MM_true(newAllocatableBytes >= pool->getMinimumFreeEntrySize());
+		Assert_MM_true(newAllocatableBytes <= initialAllocatableBytes);
+		lostToAlignment += initialAllocatableBytes - newAllocatableBytes;
+	}
+	return lostToAlignment;
+}
+
 void
 MM_CopyForwardScheme::workThreadGarbageCollect(MM_EnvironmentVLHGC *env)
 {
@@ -4045,13 +4183,29 @@ MM_CopyForwardScheme::workThreadGarbageCollect(MM_EnvironmentVLHGC *env)
 					MM_MemoryPoolBumpPointer *pool = (MM_MemoryPoolBumpPointer *)region->getMemoryPool();
 					/* only add regions with pools which could possibly satisfy a TLH allocation */
 					UDATA initialAllocatableBytes = pool->getAllocatableBytes();
+					UDATA allocatableBytes4Collector = pool->getAllocatableBytes4Collector();
 					UDATA minimumEntrySize = pool->getMinimumFreeEntrySize();
-					if (initialAllocatableBytes >= (minimumEntrySize + CARD_SIZE - 1)) {
+					if ((NULL != pool->getAllocationPointer4Collector()) && (allocatableBytes4Collector >= (minimumEntrySize + CARD_SIZE - 1))) {
+						/* insert the region into largestFreeMemoryCandidates List */
+						Assert_MM_false(region->isSurvivorRegion());
+						Assert_MM_true(NULL == region->_copyForwardData._survivorLow);
+						Assert_MM_true(NULL == region->_copyForwardData._survivorBase);
+						insertCandidate(env, _reservedRegionList[compactGroup]._largestFreeMemoryCandidates, _reservedRegionList[compactGroup]._largestFreeMemoryCandidateCount, region);
+						if ((initialAllocatableBytes != 0) && (initialAllocatableBytes < (minimumEntrySize + CARD_SIZE - 1))) {
+							/* clear the tail */
+							pool->setAllocationPointer(env,region->getHighAddress());
+						}
+					} else if (initialAllocatableBytes >= (minimumEntrySize + CARD_SIZE - 1)) {
+						/* insert the region into tailCandidates List */
 						Assert_MM_true(pool->getActualFreeMemorySize() >= initialAllocatableBytes);
 						Assert_MM_true(pool->getActualFreeMemorySize() < region->getSize());
 						Assert_MM_false(region->isSurvivorRegion());
 						Assert_MM_true(NULL == region->_copyForwardData._survivorBase);
-						insertTailCandidate(env, &_reservedRegionList[compactGroup], region);
+						insertCandidate(env, _reservedRegionList[compactGroup]._tailCandidates, _reservedRegionList[compactGroup]._tailCandidateCount, region);
+						if (0 != allocatableBytes4Collector) {
+							pool->setAllocationPointer4Collector(env, NULL, NULL);
+							pool->setLargestFreeEntry(initialAllocatableBytes);
+						}
 					}
 				}
 			}
@@ -4288,13 +4442,15 @@ MM_CopyForwardScheme::verifyDumpObjectDetails(MM_EnvironmentVLHGC *env, const ch
 				region->getRegionProperties()
 				);
 
-		j9tty_printf(PORTLIB, "\t\tbitSet:%c externalBitSet:%c shouldMark:%c initialLiveSet:%c survivorSet:%c survivorBase:%p age:%zu\n",
+		j9tty_printf(PORTLIB, "\t\tbitSet:%c externalBitSet:%c shouldMark:%c initialLiveSet:%c survivorSet:%c survivorBase:%p, survivorLow:%p, survivorHigh:%p  age:%zu\n",
 				_markMap->isBitSet(object) ? 'Y' : 'N',
 				(NULL == env->_cycleState->_externalCycleState) ? 'N' : (env->_cycleState->_externalCycleState->_markMap->isBitSet(object) ? 'Y' : 'N'),
 				region->_markData._shouldMark ? 'Y' : 'N',
 				region->_copyForwardData._initialLiveSet ? 'Y' : 'N',
 				region->isSurvivorRegion() ? 'Y' : 'N',
 				region->_copyForwardData._survivorBase,
+				region->_copyForwardData._survivorLow,
+				region->_copyForwardData._survivorHigh,
 				region->getLogicalAge()
 		);
 	}
@@ -4440,40 +4596,36 @@ MM_CopyForwardScheme::verifyCopyForwardResult(MM_EnvironmentVLHGC *env)
 		} else {
 			if(region->containsObjects()) {
 				if(region->isSurvivorRegion()) {
-
-					void *endOfAllocatedObjects = ((MM_MemoryPoolBumpPointer*)region->getMemoryPool())->getAllocationPointer();
-					MM_HeapMapIterator mapIterator(_extensions, _markMap, (UDATA *)region->_copyForwardData._survivorBase, (UDATA *)endOfAllocatedObjects, false);
-					GC_ObjectHeapIteratorAddressOrderedList heapChunkIterator(_extensions, (J9Object *)region->_copyForwardData._survivorBase, (J9Object *)endOfAllocatedObjects, false);
-					J9Object *objectPtr = NULL;
-
-					while(NULL != (objectPtr = heapChunkIterator.nextObject())) {
-						J9Object *mapObjectPtr = mapIterator.nextObject();
-
-						if(objectPtr != mapObjectPtr) {
-							PORT_ACCESS_FROM_ENVIRONMENT(env);
-							j9tty_printf(PORTLIB, "ChunkIterator and mapIterator did not match up during walk of survivor space! ChunkSlot %p MapSlot %p\n", objectPtr, mapObjectPtr);
-							Assert_MM_unreachable();
-							break;
-						}
-						verifyObject(env, objectPtr);
+					UDATA *lowAddress = NULL;
+					UDATA *highAddress = NULL;
+					if (NULL != region->_copyForwardData._survivorLow) {
+						lowAddress = (UDATA *)region->_copyForwardData._survivorLow;
+						highAddress = (UDATA *)region->_copyForwardData._survivorHigh;
+						verifyChunkSlotsAndMapSlotsInRange(env, lowAddress, highAddress);
 					}
-					if(NULL != mapIterator.nextObject()) {
-						PORT_ACCESS_FROM_ENVIRONMENT(env);
-						j9tty_printf(PORTLIB, "Survivor space mapIterator did not end when the chunkIterator did!\n");
-						Assert_MM_unreachable();
+					if(NULL != region->_copyForwardData._survivorBase) {
+						lowAddress = (UDATA *)region->_copyForwardData._survivorBase;
+						highAddress = (UDATA *)((MM_MemoryPoolBumpPointer*)region->getMemoryPool())->getAllocationPointer();
+						verifyChunkSlotsAndMapSlotsInRange(env, lowAddress, highAddress);
 					}
 				}
 
 				if(region->_copyForwardData._initialLiveSet) {
-					UDATA *highAddress = (UDATA *)region->getHighAddress();
+					UDATA *lowAddress = (UDATA *)region->getLowAddress();
+					UDATA *highAddress = NULL;
+					if (NULL != region->_copyForwardData._survivorLow) {
+						highAddress = (UDATA *) region->_copyForwardData._survivorLow;
+
+						verifyObjectInRange(env, lowAddress, highAddress);
+
+						lowAddress = (UDATA *) region->_copyForwardData._survivorHigh;
+					}
+
+					highAddress = (UDATA *)region->getHighAddress();
 					if(NULL != region->_copyForwardData._survivorBase) {
 						highAddress = (UDATA *)region->_copyForwardData._survivorBase;
 					}
-					MM_HeapMapIterator iterator(_extensions, _markMap, (UDATA *)region->getLowAddress(), highAddress, false);
-					J9Object *objectPtr = NULL;
-					while (NULL != (objectPtr = (iterator.nextObject()))) {
-						verifyObject(env, objectPtr);
-					}
+					verifyObjectInRange(env, lowAddress, highAddress);
 				}
 			}
 		}
@@ -4786,13 +4938,11 @@ MM_CopyForwardScheme::verifyExternalState(MM_EnvironmentVLHGC *env)
 				}
 			} else if (region->isSurvivorRegion()) {
 				/* Survivor space - check that anything marked in the GMP map is also marked in the PGC map */
-				MM_HeapMapIterator mapIterator(_extensions, externalMarkMap, (UDATA *)region->_copyForwardData._survivorBase, (UDATA *)region->getHighAddress(), false);
-				J9Object *objectPtr = NULL;
-
-				while(NULL != (objectPtr = mapIterator.nextObject())) {
-					Assert_MM_true(_markMap->isBitSet(objectPtr));
-					Assert_MM_true(objectPtr >= region->getLowAddress());
-					Assert_MM_true(objectPtr < region->getHighAddress());
+				if (region->isLargestFreeMemoryFilledSurvivorRegion()) {
+					checkConsistencyGMPMapAndPGCMap(env, region, (UDATA *)region->_copyForwardData._survivorLow, (UDATA *)region->_copyForwardData._survivorHigh);
+				}
+				if (NULL != region->_copyForwardData._survivorBase) {
+					checkConsistencyGMPMapAndPGCMap(env, region, (UDATA *)region->_copyForwardData._survivorBase, (UDATA *)region->getHighAddress());
 				}
 			}
 		}
@@ -4830,7 +4980,7 @@ MM_CopyForwardScheme::verifyIsPointerInSurvivor(MM_EnvironmentVLHGC *env, J9Obje
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->physicalTableDescriptorForAddress(object);
 
-	return region->isSurvivorRegion() && (object >= region->_copyForwardData._survivorBase);
+	return region->isSurvivorRegion() && (((NULL != region->_copyForwardData._survivorBase) && (object >= region->_copyForwardData._survivorBase)) || ((NULL != region->_copyForwardData._survivorLow) && (object >= region->_copyForwardData._survivorLow) && (object < region->_copyForwardData._survivorHigh)));
 }
 
 bool
@@ -4845,6 +4995,67 @@ MM_CopyForwardScheme::verifyIsPointerInEvacute(MM_EnvironmentVLHGC *env, J9Objec
 	return region->_markData._shouldMark;
 }
 
+void
+MM_CopyForwardScheme::verifyObjectInRange(MM_EnvironmentVLHGC *env, UDATA *lowAddress, UDATA *highAddress)
+{
+	MM_HeapMapIterator iterator(_extensions, _markMap, lowAddress, highAddress, false);
+	J9Object *objectPtr = NULL;
+	while (NULL != (objectPtr = (iterator.nextObject()))) {
+		verifyObject(env, objectPtr);
+	}
+}
+
+void
+MM_CopyForwardScheme::verifyChunkSlotsAndMapSlotsInRange(MM_EnvironmentVLHGC *env, UDATA *lowAddress, UDATA *highAddress)
+{
+	MM_HeapMapIterator mapIterator(_extensions, _markMap, lowAddress, highAddress, false);
+	GC_ObjectHeapIteratorAddressOrderedList heapChunkIterator(_extensions, (J9Object *)lowAddress, (J9Object *)highAddress, false);
+	J9Object *objectPtr = NULL;
+
+	while(NULL != (objectPtr = heapChunkIterator.nextObject())) {
+		J9Object *mapObjectPtr = mapIterator.nextObject();
+
+		if(objectPtr != mapObjectPtr) {
+			PORT_ACCESS_FROM_ENVIRONMENT(env);
+			j9tty_printf(PORTLIB, "ChunkIterator and mapIterator did not match up during walk of survivor space! ChunkSlot %p MapSlot %p\n", objectPtr, mapObjectPtr);
+			Assert_MM_unreachable();
+			break;
+		}
+		verifyObject(env, objectPtr);
+	}
+	if(NULL != mapIterator.nextObject()) {
+		PORT_ACCESS_FROM_ENVIRONMENT(env);
+		j9tty_printf(PORTLIB, "Survivor space mapIterator did not end when the chunkIterator did!\n");
+		Assert_MM_unreachable();
+	}
+}
+
+void
+MM_CopyForwardScheme::cleanInRange(MM_EnvironmentVLHGC *env, UDATA *lowAddress, UDATA *highAddress)
+{
+	/* At this point, no copying should happen, so that reservingContext is irrelevant */
+	MM_AllocationContextTarok *reservingContext = _commonContext;
+	MM_HeapMapIterator objectIterator = MM_HeapMapIterator(MM_GCExtensions::getExtensions(env), env->_cycleState->_markMap, lowAddress, highAddress);
+
+	J9Object *object = NULL;
+	while (NULL != (object = objectIterator.nextObject())) {
+		scanObject(env, reservingContext, object, SCAN_REASON_OVERFLOWED_REGION);
+	}
+}
+
+void
+MM_CopyForwardScheme::checkConsistencyGMPMapAndPGCMap(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, UDATA *lowAddress, UDATA *highAddress)
+{
+	MM_MarkMap *externalMarkMap = env->_cycleState->_externalCycleState->_markMap;
+	MM_HeapMapIterator mapIterator(_extensions, externalMarkMap, lowAddress, highAddress, false);
+	J9Object *objectPtr = NULL;
+
+	while(NULL != (objectPtr = mapIterator.nextObject())) {
+		Assert_MM_true(_markMap->isBitSet(objectPtr));
+		Assert_MM_true(objectPtr >= region->getLowAddress());
+		Assert_MM_true(objectPtr < region->getHighAddress());
+	}
+}
 
 
 void
@@ -5235,16 +5446,16 @@ MM_CopyForwardScheme::scanFinalizableList(MM_EnvironmentVLHGC *env, j9object_t h
 }
 #endif /* J9VM_GC_FINALIZATION */
 
-void 
-MM_CopyForwardScheme::removeTailCandidate(MM_EnvironmentVLHGC* env, MM_ReservedRegionListHeader* regionList, MM_HeapRegionDescriptorVLHGC *tailRegion)
+void
+MM_CopyForwardScheme::removeCandidate(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *&cadidatesListHead, UDATA &cadidatesCount,  MM_HeapRegionDescriptorVLHGC *region)
 {
-	Assert_MM_true(NULL != regionList->_tailCandidates);
-	Assert_MM_true(0 < regionList->_tailCandidateCount);
+	Assert_MM_true(NULL != cadidatesListHead);
+	Assert_MM_true(0 < cadidatesCount);
 
-	regionList->_tailCandidateCount -= 1;
+	cadidatesCount -= 1;
 
-	MM_HeapRegionDescriptorVLHGC *next = tailRegion->_copyForwardData._nextRegion;
-	MM_HeapRegionDescriptorVLHGC *previous = tailRegion->_copyForwardData._previousRegion;
+	MM_HeapRegionDescriptorVLHGC *next = region->_copyForwardData._nextRegion;
+	MM_HeapRegionDescriptorVLHGC *previous = region->_copyForwardData._previousRegion;
 	if (NULL != next) {
 		next->_copyForwardData._previousRegion = previous;
 	}
@@ -5252,42 +5463,42 @@ MM_CopyForwardScheme::removeTailCandidate(MM_EnvironmentVLHGC* env, MM_ReservedR
 		previous->_copyForwardData._nextRegion = next;
 		Assert_MM_true(previous != previous->_copyForwardData._nextRegion);
 	} else {
-		Assert_MM_true(tailRegion == regionList->_tailCandidates);
-		regionList->_tailCandidates = next;
+		Assert_MM_true(region == cadidatesListHead);
+		cadidatesListHead = next;
 	}
 }
 
 void
-MM_CopyForwardScheme::insertTailCandidate(MM_EnvironmentVLHGC* env, MM_ReservedRegionListHeader* regionList, MM_HeapRegionDescriptorVLHGC *tailRegion)
+MM_CopyForwardScheme::insertCandidate(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *&cadidatesListHead, UDATA &cadidatesCount,  MM_HeapRegionDescriptorVLHGC *region)
 {
-	tailRegion->_copyForwardData._nextRegion = regionList->_tailCandidates;
-	tailRegion->_copyForwardData._previousRegion = NULL;
-	if(NULL != regionList->_tailCandidates) {
-		regionList->_tailCandidates->_copyForwardData._previousRegion = tailRegion;
+	region->_copyForwardData._nextRegion = cadidatesListHead;
+	region->_copyForwardData._previousRegion = NULL;
+	if(NULL != cadidatesListHead) {
+		cadidatesListHead->_copyForwardData._previousRegion = region;
 	}
-	regionList->_tailCandidates = tailRegion;
-	regionList->_tailCandidateCount += 1;
+	cadidatesListHead = region;
+	cadidatesCount += 1;
 }
 
 void
-MM_CopyForwardScheme::convertTailCandidateToSurvivorRegion(MM_EnvironmentVLHGC* env, MM_HeapRegionDescriptorVLHGC *region, void* survivorBase)
+MM_CopyForwardScheme::convertCandidateToSurvivorRegion(MM_EnvironmentVLHGC* env, MM_HeapRegionDescriptorVLHGC *region, void* survivorBase, void* survivorLow, void* survivorHigh)
 {
-	Trc_MM_CopyForwardScheme_convertTailCandidateToSurvivorRegion_Entry(env->getLanguageVMThread(), region, survivorBase);
+	Trc_MM_CopyForwardScheme_convertCandidateToSurvivorRegion_Entry(env->getLanguageVMThread(), region, survivorBase, survivorLow, survivorHigh);
+
 	Assert_MM_true(NULL != region);
 	Assert_MM_true(MM_HeapRegionDescriptor::BUMP_ALLOCATED_MARKED == region->getRegionType());
 	Assert_MM_false(region->isSurvivorRegion());
-	Assert_MM_true(region->isAddressInRegion(survivorBase));
+	Assert_MM_true(((NULL == survivorLow) || region->isAddressInRegion(survivorLow)) && ((NULL == survivorBase) || region->isAddressInRegion(survivorBase)));
 
-	setRegionAsSurvivor(env, region, survivorBase);
+	setRegionAsSurvivor(env, region, survivorBase, survivorLow, survivorHigh);
 
 	/* TODO: Remembering does not really have to be done under a lock, but dual (prev, current) list implementation indirectly forces us to do it this way. */
 	rememberAndResetReferenceLists(env, region);
-
-	Trc_MM_CopyForwardScheme_convertTailCandidateToSurvivorRegion_Exit(env->getLanguageVMThread());
+	Trc_MM_CopyForwardScheme_convertCandidateToSurvivorRegion_Exit(env->getLanguageVMThread());
 }
 
 void
-MM_CopyForwardScheme::setRegionAsSurvivor(MM_EnvironmentVLHGC* env, MM_HeapRegionDescriptorVLHGC *region, void* survivorBase)
+MM_CopyForwardScheme::setRegionAsSurvivor(MM_EnvironmentVLHGC* env, MM_HeapRegionDescriptorVLHGC *region, void *survivorBase, void *survivorLow, void *survivorHigh)
 {
 	MM_MemoryPoolBumpPointer *memoryPool =  (MM_MemoryPoolBumpPointer *)region->getMemoryPool();
 	UDATA freeMemorySize = memoryPool->getActualFreeMemorySize();
@@ -5308,12 +5519,24 @@ MM_CopyForwardScheme::setRegionAsSurvivor(MM_EnvironmentVLHGC* env, MM_HeapRegio
 	}
 
 	/* update the pool so it only knows about the free memory occurring before survivor base.  We will add whatever we don't use at the end of the copy-forward */
-	UDATA survivorSize = (UDATA)region->getHighAddress() - (UDATA)survivorBase;
+	region->_copyForwardData._survivorBase = survivorBase;
+	region->_copyForwardData._survivorLow =  survivorLow;
+	region->_copyForwardData._survivorHigh = survivorHigh;
+	UDATA survivorSize = 0;
+	UDATA survivorCount = 0;
+	if (NULL != survivorBase) {
+		survivorSize += (UDATA)region->getHighAddress() - (UDATA)survivorBase;
+		survivorCount += 1;
+	}
+	if (NULL != survivorLow) {
+		Assert_MM_true(survivorHigh > survivorLow);
+		survivorSize += (UDATA)survivorHigh - (UDATA)survivorLow;
+		survivorCount += 1;
+	}
 	Assert_MM_true(freeMemorySize >= survivorSize);
 	memoryPool->setFreeMemorySize(freeMemorySize - survivorSize);
-
+	memoryPool->setFreeEntryCount(memoryPool->getActualFreeEntryCount() - survivorCount);
 	Assert_MM_false(region->_copyForwardData._requiresPhantomReferenceProcessing);
-	region->_copyForwardData._survivorBase = survivorBase;
 }
 
 void

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,6 +81,9 @@ MM_HeapRegionDescriptorVLHGC::initialize(MM_EnvironmentBase *env, MM_HeapRegionM
 	_copyForwardData._evacuateSet = false;
 	_copyForwardData._requiresPhantomReferenceProcessing = false;
 	_copyForwardData._survivorBase = NULL;
+	_copyForwardData._survivorLow = NULL;
+	_copyForwardData._survivorHigh = NULL;
+
 	_copyForwardData._nextRegion = NULL;
 	_copyForwardData._previousRegion = NULL;
 

--- a/runtime/gc_vlhgc/ReclaimDelegate.cpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.cpp
@@ -193,7 +193,7 @@ MM_ReclaimDelegate::tagRegionsBeforeCompactWithWorkGoal(MM_EnvironmentVLHGC *env
 	UDATA regionCount = 0;
 
 	deriveCompactScore(env);
-	
+
 	if (!isCopyForward) {
 		/* Everything already Marked should be Compacted */
 		regionCount += tagRegionsBeforeCompact(env, skippedRegionCountRequiringSweep);
@@ -474,6 +474,10 @@ done:
 void
 MM_ReclaimDelegate::runGlobalSweepBeforePGC(MM_EnvironmentVLHGC *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *activeSubSpace, MM_GCCode gcCode)
 {
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	if (extensions->tarokEnableRecoverRegionTailsAfterSweep) {
+		_sweepScheme->setNoCompactionAfterSweep(true);
+	}
 	performAtomicSweep(env, allocDescription, activeSubSpace, gcCode);
 	
 	/* Now that dark matter and free bytes data have been updated in all memoryPools, we want to rebuild the _regionsSortedByEmptinessArray table */

--- a/runtime/gc_vlhgc/SweepPoolManagerVLHGC.cpp
+++ b/runtime/gc_vlhgc/SweepPoolManagerVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -129,8 +129,10 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 		/* This trumps any checks on the trailing free space of the previous chunk */
 		previousFreeEntrySize += leadingFreeEntrySize;
 		sweepState->_sweepFreeBytes += leadingFreeEntrySize;
-		sweepState->_largestFreeEntry = OMR_MAX(previousFreeEntrySize, sweepState->_largestFreeEntry);
-
+		if (previousFreeEntrySize > sweepState->_largestFreeEntry) {
+			sweepState->_largestFreeEntry = previousFreeEntrySize;
+			sweepState->_previousLargestFreeEntry = previousFreeEntry;
+		}
 		/* Consume the leading entry */
 		leadingFreeEntry = NULL;
 	}
@@ -146,14 +148,23 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 			if(memoryPool->canMemoryBeConnectedToPool(env, previousConnectChunk->trailingFreeCandidate, jointFreeSize)) {
 
 				/* Free list candidate has been found - attach it to the free list */
+
+				memoryPool->connectOuterMemoryToPool(env,
+						previousFreeEntry,
+						previousFreeEntrySize,
+						previousConnectChunk->trailingFreeCandidate);
+
 				previousFreeEntry = (MM_HeapLinkedFreeHeader *)previousConnectChunk->trailingFreeCandidate;
 				previousFreeEntrySize = jointFreeSize;
 			
 				/* Maintain the free bytes/holes count in the allocate profile for expansion/contraction purposes */
-				if(0 != jointFreeSize) {
-					sweepState->_sweepFreeBytes += jointFreeSize;
+				if(0 != previousFreeEntrySize) {
+					sweepState->_sweepFreeBytes += previousFreeEntrySize;
 					sweepState->_sweepFreeHoles += 1;
-					sweepState->_largestFreeEntry = OMR_MAX(jointFreeSize, sweepState->_largestFreeEntry);
+					if (previousFreeEntrySize > sweepState->_largestFreeEntry) {
+						sweepState->_largestFreeEntry = previousFreeEntrySize;
+						sweepState->_previousLargestFreeEntry = previousFreeEntry;
+					}
 				}
 			}
 
@@ -161,14 +172,23 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 			leadingFreeEntry = NULL;
 		} else {
 			if(memoryPool->canMemoryBeConnectedToPool(env, previousConnectChunk->trailingFreeCandidate, previousConnectChunk->trailingFreeCandidateSize)) {
+
+				memoryPool->connectOuterMemoryToPool(env,
+						previousFreeEntry,
+						previousFreeEntrySize,
+						previousConnectChunk->trailingFreeCandidate);
+
 				previousFreeEntry = (MM_HeapLinkedFreeHeader *)previousConnectChunk->trailingFreeCandidate;
 				previousFreeEntrySize = previousConnectChunk->trailingFreeCandidateSize;
 			
 				/* Maintain the free bytes/holes count in the allocate profile for expansion/contraction purposes */
-				if(0 != previousConnectChunk->trailingFreeCandidateSize) {
-					sweepState->_sweepFreeBytes += previousConnectChunk->trailingFreeCandidateSize;
+				if (0 != previousFreeEntrySize) {
+					sweepState->_sweepFreeBytes += previousFreeEntrySize;
 					sweepState->_sweepFreeHoles += 1;
-					sweepState->_largestFreeEntry = OMR_MAX(previousConnectChunk->trailingFreeCandidateSize, sweepState->_largestFreeEntry);
+					if (previousFreeEntrySize > sweepState->_largestFreeEntry) {
+						sweepState->_largestFreeEntry = previousFreeEntrySize;
+						sweepState->_previousLargestFreeEntry = previousFreeEntry;
+					}
 				}
 			}
 		}
@@ -190,17 +210,24 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 		if(NULL != leadingFreeEntry) { 
 			if(memoryPool->canMemoryBeConnectedToPool(env, leadingFreeEntry, leadingFreeEntrySize)) {
 				
-				Assert_MM_true(previousFreeEntry < leadingFreeEntry);
 				Assert_MM_true(previousFreeEntry <= leadingFreeEntry);
+
+				memoryPool->connectOuterMemoryToPool(env,
+						previousFreeEntry,
+						previousFreeEntrySize,
+						leadingFreeEntry);
 
 				previousFreeEntry = leadingFreeEntry;
 				previousFreeEntrySize = leadingFreeEntrySize;
 					
 				/* Maintain the free bytes/holes count in the allocate profile for expansion/contraction purposes */
-				if(0 != leadingFreeEntrySize) {
-					sweepState->_sweepFreeBytes += leadingFreeEntrySize;
+				if(0 != previousFreeEntrySize) {
+					sweepState->_sweepFreeBytes += previousFreeEntrySize;
 					sweepState->_sweepFreeHoles += 1;
-					sweepState->_largestFreeEntry = OMR_MAX(leadingFreeEntrySize, sweepState->_largestFreeEntry);
+					if (previousFreeEntrySize > sweepState->_largestFreeEntry) {
+						sweepState->_largestFreeEntry = previousFreeEntrySize;
+						sweepState->_previousLargestFreeEntry = previousFreeEntry;
+					}
 				}
 			}	
 		}	
@@ -212,7 +239,12 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 	 */
 	if(chunk->freeListHead) {
 		Assert_MM_true(previousFreeEntry < chunk->freeListHead);
-		
+
+		memoryPool->connectOuterMemoryToPool(env,
+				previousFreeEntry,
+				previousFreeEntrySize,
+				chunk->freeListHead);
+
 		/* If there is a head, there is a tail - update the previous free entry */
 		previousFreeEntry = chunk->freeListTail;
 		previousFreeEntrySize = chunk->freeListTailSize;
@@ -224,7 +256,7 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 		}
 
 		/* Adjusted the largest free entry found for the sweep state */
-		sweepState->_largestFreeEntry = OMR_MAX(chunk->_largestFreeEntry, sweepState->_largestFreeEntry);
+//		sweepState->_largestFreeEntry = OMR_MAX(chunk->_largestFreeEntry, sweepState->_largestFreeEntry);
 	}
 
 	/* Update the allocate profile with the previous free entry and previous chunk */
@@ -239,38 +271,59 @@ MM_SweepPoolManagerVLHGC::connectChunk(MM_EnvironmentBase *env, MM_ParallelSweep
 }
 
 void
-MM_SweepPoolManagerVLHGC::flushFinalChunk(MM_EnvironmentBase *envModron, MM_MemoryPool *memoryPool)
+MM_SweepPoolManagerVLHGC::flushFinalChunk(MM_EnvironmentBase *envModron, MM_MemoryPool *memoryPoolBase)
 {
-	MM_SweepPoolState *sweepState = getPoolState(memoryPool);
+	MM_SweepPoolState *sweepState = getPoolState(memoryPoolBase);
 
 	/* If the last chunk had trailing free space, try and add it to the free list */
 	if((sweepState->_connectPreviousChunk != NULL) && (sweepState->_connectPreviousChunk->trailingFreeCandidateSize > 0)) {
 		/* Check if the entry is a candidate */
-		if (((MM_MemoryPoolBumpPointer *)memoryPool)->canMemoryBeConnectedToPool(envModron, sweepState->_connectPreviousChunk->trailingFreeCandidate, sweepState->_connectPreviousChunk->trailingFreeCandidateSize)) {
+		MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer *)memoryPoolBase;
+		if (!memoryPool->canMemoryBeConnectedToPool(envModron, sweepState->_connectPreviousChunk->trailingFreeCandidate, sweepState->_connectPreviousChunk->trailingFreeCandidateSize)) {
+		} else {
+			/* It is - fold it into the free list */
+			memoryPool->connectOuterMemoryToPool(envModron,
+					sweepState->_connectPreviousFreeEntry,
+					sweepState->_connectPreviousFreeEntrySize,
+					sweepState->_connectPreviousChunk->trailingFreeCandidate);
+
 			sweepState->_connectPreviousFreeEntry = (MM_HeapLinkedFreeHeader *)sweepState->_connectPreviousChunk->trailingFreeCandidate;
 			sweepState->_connectPreviousFreeEntrySize = sweepState->_connectPreviousChunk->trailingFreeCandidateSize;
 			Assert_MM_true(sweepState->_connectPreviousFreeEntry != sweepState->_connectPreviousChunk->leadingFreeCandidate);
 	
 			sweepState->_sweepFreeBytes += sweepState->_connectPreviousChunk->trailingFreeCandidateSize;
 			sweepState->_sweepFreeHoles += 1;
-			sweepState->_largestFreeEntry = OMR_MAX(sweepState->_connectPreviousChunk->trailingFreeCandidateSize, sweepState->_largestFreeEntry);
+			if (sweepState->_connectPreviousChunk->trailingFreeCandidateSize > sweepState->_largestFreeEntry) {
+				sweepState->_largestFreeEntry = sweepState->_connectPreviousChunk->trailingFreeCandidateSize;
+				sweepState->_previousLargestFreeEntry = sweepState->_connectPreviousFreeEntry;
+			}
 		}
 	}
 }
 
 void
-MM_SweepPoolManagerVLHGC::connectFinalChunk(MM_EnvironmentBase *envModron,MM_MemoryPool *memoryPool)
+MM_SweepPoolManagerVLHGC::connectFinalChunk(MM_EnvironmentBase *envModron,MM_MemoryPool *memoryPoolBase)
 {
 	/* Update pool free memory statistics since they are required to identify free regions to recycle */
-	MM_SweepPoolState *sweepState = getPoolState(memoryPool);
+	MM_SweepPoolState *sweepState = getPoolState(memoryPoolBase);
+	MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer *)memoryPoolBase;
+
+	if(sweepState->_connectPreviousFreeEntry) {
+
+		memoryPool->connectFinalMemoryToPool(envModron,
+				sweepState->_connectPreviousFreeEntry,
+				sweepState->_connectPreviousFreeEntrySize);
+	}
+
 	memoryPool->setFreeMemorySize(sweepState->_sweepFreeBytes);
 	memoryPool->setFreeEntryCount(sweepState->_sweepFreeHoles);
 	memoryPool->setLargestFreeEntry(sweepState->_largestFreeEntry);
-	MM_MemoryPoolBumpPointer *bpPool = (MM_MemoryPoolBumpPointer *)memoryPool;
-	UDATA actualFreeMemory = bpPool->getActualFreeMemorySize();
-	UDATA allocatableBytes = bpPool->getAllocatableBytes();
+	memoryPool->setLargestFreeEntryAddr((void *) sweepState->_previousLargestFreeEntry);
+
+	UDATA actualFreeMemory = memoryPool->getActualFreeMemorySize();
+	UDATA allocatableBytes = memoryPool->getAllocatableBytes();
 	if (0 == actualFreeMemory) {
-		Assert_MM_true(allocatableBytes < bpPool->getMinimumFreeEntrySize());
+		Assert_MM_true(allocatableBytes < memoryPool->getMinimumFreeEntrySize());
 	} else {
 		Assert_MM_true(allocatableBytes <= actualFreeMemory);
 	}
@@ -314,8 +367,8 @@ MM_SweepPoolManagerVLHGC::addFreeMemory(MM_EnvironmentBase *env, MM_ParallelSwee
 		Assert_MM_true(objectSizeDelta <= freeSizeInBytes);
 		freeSizeInBytes -= objectSizeDelta;
 		address = (UDATA *) (((UDATA)address) + objectSizeDelta);
-
-		if (((MM_MemoryPoolBumpPointer *)sweepChunk->memoryPool)->canMemoryBeConnectedToPool(env, address, freeSizeInBytes)) {
+		MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer *)sweepChunk->memoryPool;
+		if (memoryPool->connectInnerMemoryToPool(env, address, freeSizeInBytes, sweepChunk->freeListTail)) {
 			/* If the hole is first in this chunk, make it the header */
 			if(NULL == sweepChunk->freeListTail) {
 				sweepChunk->freeListHead = (MM_HeapLinkedFreeHeader *)address;
@@ -323,10 +376,14 @@ MM_SweepPoolManagerVLHGC::addFreeMemory(MM_EnvironmentBase *env, MM_ParallelSwee
 			}
 
 			/* Maintain the free bytes/holes count in the chunk for heap expansion/contraction purposes (will be gathered up in the allocate profile) */
-			if(0 != freeSizeInBytes) {
+			if (0 != freeSizeInBytes) {
 				sweepChunk->freeBytes += freeSizeInBytes;
 				sweepChunk->freeHoles += 1;
-				sweepChunk->_largestFreeEntry = OMR_MAX(sweepChunk->_largestFreeEntry , freeSizeInBytes);
+				MM_SweepPoolState *sweepState = getPoolState(memoryPool);
+				if (freeSizeInBytes > sweepState->_largestFreeEntry) {
+					sweepState->_largestFreeEntry = freeSizeInBytes;
+					sweepState->_previousLargestFreeEntry = sweepChunk->freeListHead;
+				}
 			}
 
 			sweepChunk->freeListTail = (MM_HeapLinkedFreeHeader *)address;


### PR DESCRIPTION
Step1: Recover Region tails during post-sweep of GMP and Reuse them during PGC
	Recover tail point to the last freespace which connect to region top,
	can be reused as survivor or tenure space during copyforward.
	the first sweep after GMP does reset all of region tails.
	recover region tails during post-sweep could reduce copyforward
	abort cases.

	- New XXgc:tarokEnableRecoverRegionTailsAfterSweep option for enabling
	region tail recovery(default == false).
	- New XXgc:tarokEnableAllocationPointerAssertion option for enabling
	recovered tail verification(default == false).
	- Maintain free list during sweep for MemoryPoolBumpPointer.
	- Maintain last free entry during sweep for MemoryPoolBumpPointer.
	- Rcover region tail from last free entry.
	- Verify recovered region tail via reverse searching markmap
	- Align recovered tail with the card and clear card for the tail.

Step2:Reuse the largest free memory from GMP in PGC
        The largest free space inside region(if it is not tail) can be used during 
        collector allocation. the free list has been created during the sweep after GMP, 
        but in order to keep collector allocation simple and efficient, only region tail
	and the largest free space would be used during collector allocation.

	- New XXggc:tarokEnableRecoverRegionLargestFreeMemory option for
	 enabling region largest free memory recovery(default == false).
	 the option would be ignored if tarokEnableRecoverRegionTailsAfterSweep
	 is disabled.
	- Maintain largest free entryt sweep for MemoryPoolBumpPointer.
	- Align the largest free memory with the card and clear card for the free spaces.
	- Reuse the regions with the largest free memory first, then try
	to reuse the regions with free tail only before using free regions.
	- Still using region base lock for the allocation synchronization,
	for the region with both largest free memory and region tail, only
	can be used by one thread at the same time.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>

depends on https://github.com/eclipse/omr/pull/4284
depends on https://github.com/eclipse/openj9/pull/8804
depends on https://github.com/eclipse/omr/pull/5514