### PR TITLE
Reserve the region from CollectionSet

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -639,6 +639,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "tarokReserveRegionsFromCollectionSet=mostAllocatable")) {
+			extensions->tarokReserveRegionsFromCollectionSet = MM_GCExtensionsBase::RESERVE_REGIONS_MOST_ALLOCATABLE;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "tarokReserveRegionsFromCollectionSet=mostFree")) {
+			extensions->tarokReserveRegionsFromCollectionSet = MM_GCExtensionsBase::RESERVE_REGIONS_MOST_FREE;
+			continue;
+		}
+
 #endif /* defined (J9VM_GC_VLHGC) */
 
 		if(try_scan(&scan_start, "packetListLockSplit=")) {

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -56,6 +56,9 @@ MM_ProjectedSurvivalCollectionSetDelegate::MM_ProjectedSurvivalCollectionSetDele
 	, _setSelectionDataTable(NULL)
 	, _dynamicSelectionList(NULL)
 	, _dynamicSelectionRegionList(NULL)
+	, _reservedFromCollectionSet(NULL)
+	, _reservedFromCollectionSetMostFree(NULL)
+	, _projectedLiveBytes(NULL)
 {
 	_typeId = __FUNCTION__;
 }
@@ -88,6 +91,19 @@ MM_ProjectedSurvivalCollectionSetDelegate::initialize(MM_EnvironmentVLHGC *env)
 		if(NULL == _dynamicSelectionRegionList) {
 			goto error_no_memory;
 		}
+
+		_reservedFromCollectionSet = (MM_HeapRegionDescriptorVLHGC **)env->getForge()->allocate(sizeof(MM_HeapRegionDescriptorVLHGC *) * setSelectionEntryCount, MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+		if(NULL == _reservedFromCollectionSet) {
+			goto error_no_memory;
+		}
+		_reservedFromCollectionSetMostFree = (MM_HeapRegionDescriptorVLHGC **)env->getForge()->allocate(sizeof(MM_HeapRegionDescriptorVLHGC *) * setSelectionEntryCount, MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+		if(NULL == _reservedFromCollectionSetMostFree) {
+			goto error_no_memory;
+		}
+		_projectedLiveBytes = (UDATA*) env->getForge()->allocate(sizeof(UDATA) * setSelectionEntryCount, MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+		if(NULL == _projectedLiveBytes) {
+			goto error_no_memory;
+		}
 	}
 
 	return true;
@@ -112,6 +128,20 @@ MM_ProjectedSurvivalCollectionSetDelegate::tearDown(MM_EnvironmentVLHGC *env)
 	if(NULL != _dynamicSelectionRegionList) {
 		env->getForge()->free(_dynamicSelectionRegionList);
 		_dynamicSelectionRegionList = NULL;
+	}
+
+	if(NULL != _reservedFromCollectionSet) {
+		env->getForge()->free(_reservedFromCollectionSet);
+		_reservedFromCollectionSet = NULL;
+	}
+
+	if(NULL != _reservedFromCollectionSetMostFree) {
+		env->getForge()->free(_reservedFromCollectionSetMostFree);
+		_reservedFromCollectionSetMostFree = NULL;
+	}
+	if(NULL != _projectedLiveBytes) {
+		env->getForge()->free(_projectedLiveBytes);
+		_projectedLiveBytes = NULL;
 	}
 }
 
@@ -180,8 +210,10 @@ MM_ProjectedSurvivalCollectionSetDelegate::createNurseryCollectionSet(MM_Environ
 				if(MM_CompactGroupManager::isRegionInNursery(env, region)) {
 					/* on collection phase, mark all non-overflowed regions and those that RSCL is not being rebuilt */
 					/* sweep/compact flags are set in ReclaimDelegate */
-					selectRegion(env, region);
-					nurseryRegionCount += 1;
+					if (!isInReserveList(env, region)) {
+						selectRegion(env, region);
+						nurseryRegionCount += 1;
+					}
 				} else {
 					Assert_MM_true(!region->isEden());
 				}
@@ -237,9 +269,10 @@ MM_ProjectedSurvivalCollectionSetDelegate::selectRegionsForBudget(MM_Environment
 		regionSelectionIndex += regionSelectionIncrement;
 		if(regionSelectionIndex >= regionSelectionThreshold) {
 			/* The region is to be selected as part of the dynamic set */
-			selectRegion(env, regionSelectionPtr);
-			ageGroupBudgetRemaining -= 1;
-
+			if (!isInReserveList(env, regionSelectionPtr)) {
+				selectRegion(env, regionSelectionPtr);
+				ageGroupBudgetRemaining -= 1;
+			}
 		}
 		regionSelectionIndex %= regionSelectionThreshold;
 
@@ -300,9 +333,11 @@ MM_ProjectedSurvivalCollectionSetDelegate::createRateOfReturnCollectionSet(MM_En
 		double projectedReclaimableBytesFraction = (double)projectedReclaimableBytes / (double)regionSize;
 
 		if (projectedReclaimableBytesFraction > _extensions->tarokCopyForwardFragmentationTarget) {
-			selectRegion(env, region);
-			_setSelectionDataTable[compactGroup]._dynamicSelectionThisCycle = true;
-			regionBudget -= 1;
+			if (!isInReserveList(env, region)) {
+				selectRegion(env, region);
+				_setSelectionDataTable[compactGroup]._dynamicSelectionThisCycle = true;
+				regionBudget -= 1;
+			}
 		} else {
 			/* Since _dynamicSelectionRegionList is sorted by projectedReclaimableBytes, they'll be no more regions to select so break */
 			break;
@@ -398,12 +433,127 @@ MM_ProjectedSurvivalCollectionSetDelegate::createCoreSamplingCollectionSet(MM_En
 	);
 }
 
+bool
+MM_ProjectedSurvivalCollectionSetDelegate::isInReserveList(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region)
+{
+	bool ret = false;
+	UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
+	switch (_extensions->tarokReserveRegionsFromCollectionSet)
+	{
+	case MM_GCExtensionsBase::RESERVE_REGIONS_MOST_ALLOCATABLE :
+		ret = (region == _reservedFromCollectionSet[compactGroup]);
+		break;
+	case MM_GCExtensionsBase::RESERVE_REGIONS_MOST_FREE :
+		ret = (region == _reservedFromCollectionSetMostFree[compactGroup]);
+		break;
+	case MM_GCExtensionsBase::RESERVE_REGIONS_NO :
+		ret = false;
+		break;
+	default :
+		Assert_MM_unreachable();
+		break;
+	}
+	return ret;
+}
+
+/**
+ * Prepare the reserve region list, which contains the non-eden most free region per compact group, try to exclude those regions from copyforward collection set,
+ * they are good candidate for survivor region rather than collection set to avoid abort cases.
+ */
+void
+MM_ProjectedSurvivalCollectionSetDelegate::prepareReserveList(MM_EnvironmentVLHGC *env)
+{
+	MM_HeapRegionManager *regionManager = _extensions->heapRegionManager;
+	UDATA regionSize = _regionManager->getRegionSize();
+
+	GC_HeapRegionIteratorVLHGC regionIterator(regionManager);
+	MM_HeapRegionDescriptorVLHGC *region = NULL;
+
+	while (NULL != (region = regionIterator.nextRegion())) {
+		if (region->containsObjects() && region->getRememberedSetCardList()->isAccurate()) {
+			UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
+			_projectedLiveBytes[compactGroup] += region->_projectedLiveBytes;
+			if (!region->isEden()) {
+				UDATA freeMemory = ((MM_MemoryPoolBumpPointer *)region->getMemoryPool())->getAllocatableBytes();
+				if ((10 < (100 * freeMemory)/regionSize) && ((NULL == _reservedFromCollectionSet[compactGroup]) ||
+					(freeMemory > ((MM_MemoryPoolBumpPointer *)_reservedFromCollectionSet[compactGroup]->getMemoryPool())->getAllocatableBytes()))) {
+					_reservedFromCollectionSet[compactGroup] = region;
+				}
+				UDATA mostFreeMemory = ((MM_MemoryPoolBumpPointer *)region->getMemoryPool())->getFreeMemoryAndDarkMatterBytes();
+				if ((10 < (100 * mostFreeMemory)/regionSize) && ((NULL == _reservedFromCollectionSetMostFree[compactGroup]) ||
+					(mostFreeMemory > ((MM_MemoryPoolBumpPointer *)_reservedFromCollectionSetMostFree[compactGroup]->getMemoryPool())->getFreeMemoryAndDarkMatterBytes()))) {
+					_reservedFromCollectionSetMostFree[compactGroup] = region;
+				}
+			}
+		}
+	}
+
+	UDATA compactGroupMaxCount = MM_CompactGroupManager::getCompactGroupMaxCount(env);
+	UDATA reservedSize = 0;
+	/* check if we would like reserved a survivor region for the age group to reduce to use the free region for copyforward */
+	for (UDATA idx =0; idx<compactGroupMaxCount; idx++) {
+		region = _reservedFromCollectionSet[idx];
+		if (NULL != region) {
+			reservedSize = ((MM_MemoryPoolBumpPointer *)region->getMemoryPool())->getAllocatableBytes() + region->_projectedLiveBytes;
+			if ( (reservedSize < _projectedLiveBytes[idx]) && (MM_Math::roundToCeiling(regionSize, _projectedLiveBytes[idx]) <= MM_Math::roundToCeiling(regionSize, _projectedLiveBytes[idx] - reservedSize))) {
+				/* if reserved "the most allocatable region" would not save any free region for copyforward, cancel the reservation */
+				_reservedFromCollectionSet[idx] = NULL;
+			}
+		}
+
+		region = _reservedFromCollectionSetMostFree[idx];
+		if (NULL != region) {
+			reservedSize = ((MM_MemoryPoolBumpPointer *)region->getMemoryPool())->getFreeMemoryAndDarkMatterBytes() + region->_projectedLiveBytes;
+			if ( (reservedSize < _projectedLiveBytes[idx]) && (MM_Math::roundToCeiling(regionSize, _projectedLiveBytes[idx]) <= MM_Math::roundToCeiling(regionSize, _projectedLiveBytes[idx] - reservedSize))) {
+				/* if reserved "the most free region" would not save any free region for copyforward, cancel the reservation */
+				_reservedFromCollectionSetMostFree[idx] = NULL;
+			}
+		}
+	}
+/*
+	PORT_ACCESS_FROM_ENVIRONMENT(env);
+	j9tty_printf(PORTLIB, "MM_ProjectedSurvivalCollectionSetDelegate::prepareReserveList\n");
+
+	MM_MemoryPoolBumpPointer * memoryPool = NULL;
+	j9tty_printf(PORTLIB, "the most Allocatable list: ");
+	for (UDATA idx =0; idx<compactGroupMaxCount; idx++) {
+		region = _reservedFromCollectionSet[idx];
+
+		if (NULL != region) {
+			memoryPool = (MM_MemoryPoolBumpPointer *)region->getMemoryPool();
+			j9tty_printf(PORTLIB, " compactGroup=%zu, id=%zu, allocable=%zu, ", idx, _regionManager->mapDescriptorToRegionTableIndex(region), memoryPool->getAllocatableBytes());
+		}
+	}
+	j9tty_printf(PORTLIB, "\nthe most Free list: ");
+	for (UDATA idx =0; idx<compactGroupMaxCount; idx++) {
+		region = _reservedFromCollectionSetMostFree[idx];
+		if (NULL != region) {
+			memoryPool = (MM_MemoryPoolBumpPointer *)region->getMemoryPool();
+			j9tty_printf(PORTLIB, " compactGroup=%zu, id=%zu, free=%zu, ", idx, _regionManager->mapDescriptorToRegionTableIndex(region), memoryPool->getFreeMemoryAndDarkMatterBytes());
+		}
+	}
+	j9tty_printf(PORTLIB, "\n projectedLiveBytes :");
+	for (UDATA idx =0; idx<compactGroupMaxCount; idx++) {
+		j9tty_printf(PORTLIB, " compactGroup=%zu, bytes=%zu, ", idx, _projectedLiveBytes[idx]);
+	}
+
+	j9tty_printf(PORTLIB, "\n");
+*/
+}
+
 void
 MM_ProjectedSurvivalCollectionSetDelegate::createRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env)
 {
 	Assert_MM_true(MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
 
 	bool dynamicCollectionSet = _extensions->tarokEnableDynamicCollectionSetSelection;
+
+	memset((void *)_reservedFromCollectionSet, 0, sizeof(MM_HeapRegionDescriptorVLHGC *) * MM_CompactGroupManager::getCompactGroupMaxCount(env));
+	memset((void *)_reservedFromCollectionSetMostFree, 0, sizeof(MM_HeapRegionDescriptorVLHGC *) * MM_CompactGroupManager::getCompactGroupMaxCount(env));
+	memset((void *) _projectedLiveBytes, 0, sizeof(UDATA) * MM_CompactGroupManager::getCompactGroupMaxCount(env));
+	if (env->_cycleState->_shouldRunCopyForward) {
+		prepareReserveList(env);
+	}
 
 	/* If dynamic collection sets are enabled, reset all related data structures that are used for selection */
 	if(dynamicCollectionSet) {

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.hpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.hpp
@@ -132,6 +132,9 @@ private:
 	SetSelectionData **_dynamicSelectionList;  /**< Pointer table used for sorting or iterating over candidate dynamic selection elements */
 
 	MM_HeapRegionDescriptorVLHGC **_dynamicSelectionRegionList;  /**< Pointer table used for sorting or iterating over regions */
+	MM_HeapRegionDescriptorVLHGC **_reservedFromCollectionSet; /**< Pointer table used for regions could be excluded from collection set per age */
+	MM_HeapRegionDescriptorVLHGC **_reservedFromCollectionSetMostFree; /**< Pointer table used for regions could be excluded from collection set per age */
+	UDATA *_projectedLiveBytes; /**< projected total live bytes per age */
 
 protected:
 public:
@@ -207,6 +210,10 @@ private:
 	 * @param[in] element2 second element to compare
 	 */
 	static int compareCoreSampleScoreFunc(const void *element1, const void *element2);
+	
+	void prepareReserveList(MM_EnvironmentVLHGC *env);
+	bool isInReserveList(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region);
+
 protected:
 public:
 	/**


### PR DESCRIPTION
	for Balanced Partial Garbage Collection, all of eden regions(
	age0 and age1) and partial of survivor regions would be selected
	as collection set, some of those regions have a large freespace,
	which could be used as survivor region .perpare reserve list
	("most freespace" for each age region) during pre-collection,
	keep them as candidate of the survivors in order to avoid
	potential copyforward abort case.

	- new XXgc:tarokReserveRegionsFromCollectionSet=mostAllocatable
	option for reserving biggest tail region for each age
	- new XXgc:tarokReserveRegionsFromCollectionSet=mostFree
	option for reserving most freespace region for each age
	- prepare reserve list before creating collection set
	- check if "reserve" region could potentially save any free region
	during copyforward base on projected live data, if not, do not
	reserve the region.
	- do not include the region for collection set, if the region is
	in reserved list.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>

depends on eclipse/omr#4286