### PR TITLE
Recognize fma method on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -384,12 +384,20 @@ J9::X86::CodeGenerator::enableAESInHardwareTransformations()
 bool
 J9::X86::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
    {
-   switch (method)
+   if (method == TR::java_lang_Object_clone)
       {
-      case TR::java_lang_Object_clone:
+      return true; 
+      }
+
+   if (self()->getX86ProcessorInfo().supportsFMA())
+      {
+      if (method == TR::java_lang_Math_fma_D       ||
+          method == TR::java_lang_StrictMath_fma_D ||
+          method == TR::java_lang_Math_fma_F       ||
+          method == TR::java_lang_StrictMath_fma_F)
+         {
          return true;
-      default:
-         return false;
+         }
       }
    }
 


### PR DESCRIPTION
Recognize `Math.fma` methods on X86 and use Instruction Opcode: `vfmadd231ss`/`vfmadd231sd` to generate a customized sequence of any calls to the Math.fma() method.

*Note that this PR requires support from OMR https://github.com/eclipse/omr/pull/4831*

Issue:#7474
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com