### PR TITLE
Reduce scratchSpaceFactorWhenJSR292Workload to 1 in Xtune:virtualized

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1303,6 +1303,7 @@ J9::Options::fePreProcess(void * base)
       if (vm->runtimeFlags & J9_RUNTIME_TUNE_VIRTUALIZED)
          {
          _aggressivenessLevel = TR::Options::AGGRESSIVE_AOT;
+         _scratchSpaceFactorWhenJSR292Workload = 1;
          }
       if (_aggressivenessLevel == -1) // not yet set
          {


### PR DESCRIPTION
This change is motivated by the goal to keep the peak footprint low
when running in virtualized/cloud environments.
The user still has the possibility to change the option to any
desired value with -Xjit:scratchSpaceFactorWhenJSR292Workload=<n>

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>