### PR TITLE
Remove definition of deprecated IL const Opcodes

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -571,9 +571,6 @@ static const char * nvvmOpCodeNames[] =
 /*
  *END OF OPCODES REQUIRED BY OMR
  */
-   NULL,          // TR::iuconst
-   NULL,          // TR::luconst
-   NULL,          // TR::buconst
    "load",          // TR::iuload
    "load",          // TR::luload
    "load",          // TR::buload
@@ -610,7 +607,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::luRegLoad
    NULL,          // TR::iuRegStore
    NULL,          // TR::luRegStore
-   NULL,          // TR::cconst
 
    "load",        // TR::cload
    "load",        // TR::cloadi


### PR DESCRIPTION
Remove any definitions of const ILopcodes, namely TR::buconst, TR::iuconst, TR::luconst, TR::cconst

_Note that this PR needs to be merged simultaneously with https://github.com/eclipse/omr/pull/5023_
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>