### PR TITLE
Remove any definitions to deprecated Add/Sub ILOpcode

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -583,14 +583,6 @@ static const char * nvvmOpCodeNames[] =
    "store",          // TR::iustorei
    "store",          // TR::lustorei
    "store",          // TR::bustorei
-   "add",         // TR::iuadd
-   "add",         // TR::luadd
-   "add",         // TR::buadd
-   "sub",         // TR::iusub
-   "sub",         // TR::lusub
-   "sub",         // TR::busub
-   "sub",         // TR::iuneg
-   "sub",         // TR::luneg
    "fptoui",      // TR::f2iu
    "fptoui",      // TR::f2lu
    "fptoui",      // TR::f2bu
@@ -637,15 +629,11 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::calli
    NULL,          // TR::fence
    NULL,          // TR::luaddh
-   "add",        // TR::cadd
 
   "getelementptr",          // TR::aiadd
-  "getelementptr",          // TR::aiuadd
   "getelementptr",          // TR::aladd
-  "getelementptr",          // TR::aluadd
 
    NULL,          // TR::lusubh
-   "sub",         // TR::csub
 
    NULL,          // TR::imulh, implemented but this table value is unused
    NULL,          // TR::iumulh, implemented but this table value is unused


### PR DESCRIPTION
Clean up remnants of the following unsigned ILOpcodes from OpenJ9:

- `aiuadd`, `aluadd`, `buadd`, `busub`, `cadd`, `csub`, `iuadd`, `iuneg`, `iusub`, `luadd`, `luneg`, `lusub`

The above ILOpcodes will be completely removed from OpenJ9 after this PR.

_Note that this PR needs to be merged with eclipse/omr#5245 simultaneously._

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>