### PR TITLE
Override OMR's supportsMergingGuards routine

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -298,6 +298,13 @@ J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const boo
    prevBlock->append(TR::TreeTop::create(comp, ifacmpeqNode));
    }
 
+bool J9::CodeGenerator::supportsMergingGuards()
+   {
+   return self()->getSupportsVirtualGuardNOPing() &&
+          self()->comp()->performVirtualGuardNOPing() &&
+          self()->allowGuardMerging();
+   }
+
 void
 J9::CodeGenerator::lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt)
    {

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -125,6 +125,8 @@ public:
    */
    bool willGenerateNOPForVirtualGuard(TR::Node* node);
 
+   bool supportsMergingGuards();
+
    void zeroOutAutoOnEdge(TR::SymbolReference * liveAutoSym, TR::Block *block, TR::Block *succBlock, TR::list<TR::Block*> *newBlocks, TR_ScratchList<TR::Node> *fsdStores);
 
    TR::Linkage *createLinkageForCompilation();


### PR DESCRIPTION
This commit overrides OMR's supportsMergingGuards routine in order to extend its functionality for remote compilations.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>