### PR TITLE
WIP: AArch64: Enable a test with balanced GC

### DIFF
--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -181,8 +181,6 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<!-- aarch64 JIT lacks the support for -Xgcpolicy:balanced -->
-		<platformRequirements>^arch.aarch64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
This commit enables a test with balanced GC for AArch64.
It was disabled by #8569.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>