### PR TITLE
Add unit test for simplifyBoundCheckWithThrowException

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -506,6 +506,31 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>BNDCHKSimplifyTest</testCaseName>
+		<variations>
+			<variation>-Xjit:count=100,limit={*checkIndex*},optLevel=scorching,disableAsyncCompilation</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	BNDCHKSimplifyTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<aot>nonapplicable</aot>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 	<!-- jit.test.hw tests start here -->
 	<test>
 		<testCaseName>jit_hw</testCaseName>

--- a/test/functional/JIT_Test/src/jit/test/tr/BNDCHKSimplify/BNDCHKSimplifyTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/BNDCHKSimplify/BNDCHKSimplifyTest.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.tr.BNDCHKSimplify;
+
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+
+@Test(groups = { "level.sanity","component.jit" })
+public class BNDCHKSimplifyTest{
+	int limit;
+	int dummy;
+	public int checkIndexV1(int index) {
+		if (index < 0 || index >= limit)
+			throw new IndexOutOfBoundsException();
+		return index;
+	}
+
+	public int checkIndexV2(int index) {
+		if (index >= 0 && index < limit)
+			return index;
+		throw new NullPointerException();
+	}
+
+	public int checkIndexV3(int index) {
+		if (index < 0)
+			throw new IllegalStateException();
+		if (index >= limit)
+			throw new IllegalArgumentException();
+		return index;
+	}
+
+	public int checkIndexV4(int index) {
+		if (index < 0 || index >= limit)
+			throw new StringIndexOutOfBoundsException();
+		dummy += index;
+		return index;
+	}
+
+	void setLimit(int limit) {
+		this.limit = limit;
+		this.dummy = 0;
+	}
+
+	@Test
+	public void whenBoundsAreInRangeThenReturnWithoutAssert(){
+		for (int i = 0; i < 20; ++i){
+			BNDCHKSimplifyTest obj = new BNDCHKSimplifyTest();
+			obj.setLimit(10);
+			for (int j=0; j < 10; ++j) {
+				obj.checkIndexV1(j);
+				obj.checkIndexV2(j);
+				obj.checkIndexV3(j);
+				obj.checkIndexV4(j);
+			}
+		}
+		int maxIndex = 10000;
+		BNDCHKSimplifyTest objUnderTest = new BNDCHKSimplifyTest();
+		objUnderTest.setLimit(maxIndex);
+		for(int i = 0; i < maxIndex; ++i) {
+			int actualIdx = objUnderTest.checkIndexV1(i);
+			AssertJUnit.assertEquals("Mismatched index value", i, actualIdx);
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		for(int i = 0; i < maxIndex; ++i) {
+			int actualIdx = objUnderTest.checkIndexV2(i);
+			AssertJUnit.assertEquals("Mismatched index value", i, actualIdx);
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		for(int i = 0; i < maxIndex; ++i) {
+			int actualIdx = objUnderTest.checkIndexV3(i);
+			AssertJUnit.assertEquals("Mismatched index value", i, actualIdx);
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		for(int i = 0; i < maxIndex; ++i) {
+			int actualIdx = objUnderTest.checkIndexV4(i);
+			AssertJUnit.assertEquals("Mismatched index value", i, actualIdx);
+		}
+	}
+
+
+	@Test
+	public void whenBoundsAreOutOfRangeThenThrowCorrectException(){
+		for (int i = 0; i < 20; ++i){
+			BNDCHKSimplifyTest obj = new BNDCHKSimplifyTest();
+			obj.setLimit(10);
+			for (int j=0; j < 10; ++j) {
+				obj.checkIndexV1(j);
+				obj.checkIndexV2(j);
+				obj.checkIndexV3(j);
+				obj.checkIndexV4(j);
+			}
+		}
+		int maxIndex = 10000;
+		BNDCHKSimplifyTest objUnderTest = new BNDCHKSimplifyTest();
+		objUnderTest.setLimit(maxIndex);
+		try {
+			int actualIdx = objUnderTest.checkIndexV1(maxIndex + 1);
+			AssertJUnit.fail("failed to throw correct exception");
+		} catch (IndexOutOfBoundsException outOfBound) {
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		try {
+			int actualIdx = objUnderTest.checkIndexV2(maxIndex + 1);
+			AssertJUnit.fail("failed to throw correct exception");
+		}catch(NullPointerException outOfBound) {
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		try {
+			int actualIdx = objUnderTest.checkIndexV3(-1);
+			AssertJUnit.fail("failed to throw correct exception");
+		} catch (IllegalStateException outOfBound) {
+		}
+		try {
+			int actualIdx = objUnderTest.checkIndexV3(maxIndex + 1);
+			AssertJUnit.fail("failed to throw correct exception");
+		} catch (IllegalArgumentException outOfBound) {
+		}
+
+		objUnderTest.setLimit(maxIndex);
+		try {
+			int actualIdx = objUnderTest.checkIndexV4(maxIndex + 1);
+			AssertJUnit.fail("failed to throw correct exception");
+		} catch (StringIndexOutOfBoundsException outOfBound) {
+		}
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -450,6 +450,11 @@
 	   <class name="jit.test.tr.SIMDOpts.SIMDOptTest" />
 	 </classes>
   </test>
+  <test name="BNDCHKSimplifyTest">
+	 <classes>
+	   <class name="jit.test.tr.BNDCHKSimplify.BNDCHKSimplifyTest" />
+	 </classes>
+  </test>
 	<test name="StringPeepholeTest">
     <classes>
       <class name="jit.test.tr.stringPeephole.BigDecimalToStringTest" />


### PR DESCRIPTION
Similar pattern to BNDCHK but with different exception is simplified by
simplifyBoundCheckWithThrowException. This commit adds some test
cases for positive and negative situation for the simplifier.

Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>