### PR TITLE
Replaced current socket code with omrsock API

### DIFF
--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -27,10 +27,10 @@ namespace JITServer
 int ServerStream::_numConnectionsOpened = 0;
 int ServerStream::_numConnectionsClosed = 0;
 
-ServerStream::ServerStream(int connfd, BIO *ssl)
+ServerStream::ServerStream(omrsock_socket_t socket, BIO *ssl)
    : CommunicationStream()
    {
-   initStream(connfd, ssl);
+   initStream(socket, ssl);
    _numConnectionsOpened++;
    _pClientSessionData = NULL;
    }

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -67,11 +67,11 @@ public:
    /**
       @brief Constructor of ServerStream class
 
-      @param connfd socket descriptor for the communication channel
+      @param socket Pointer to omrsock socket structure for the communication channel
       @param ssl  BIO for the SSL enabled stream
-      @param timeout timeout value (ms) to be set for connfd
+      @param timeout timeout value (ms) to be set for socket structure
    */
-   explicit ServerStream(int connfd, BIO *ssl);
+   explicit ServerStream(omrsock_socket_t socket, BIO *ssl);
    virtual ~ServerStream()
       {
       _numConnectionsClosed++;

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -20,26 +20,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <arpa/inet.h>
 #include <chrono>
 #include <fcntl.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>	/* for TCP_NODELAY option */
 #include <openssl/err.h>
-#include <poll.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/un.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h> /// gethostname, read, write
 #include "control/CompilationRuntime.hpp"
 #include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
 #include "net/CommunicationStream.hpp"
 #include "net/LoadSSLLibs.hpp"
 #include "net/ServerStream.hpp"
+#include "omrportsocktypes.h"
 #include "runtime/CompileService.hpp"
 #include "runtime/Listener.hpp"
 
@@ -135,13 +126,13 @@ createSSLContext(TR::PersistentInfo *info)
    }
 
 static bool
-handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMsg)
+handleOpenSSLConnectionError(omrsock_socket_t socket, SSL *&ssl, BIO *&bio, const char *errMsg)
    {
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
        TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "%s: errno=%d", errMsg, errno);
    (*OERR_print_errors_fp)(stderr);
-
-   close(connfd);
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   omrsock_close(&socket);
    if (bio)
       {
       (*OBIO_free_all)(bio);
@@ -156,30 +147,32 @@ handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMs
    }
 
 static bool
-acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
+acceptOpenSSLConnection(SSL_CTX *sslCtx, omrsock_socket_t socket, BIO *&bio)
    {
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+
    SSL *ssl = (*OSSL_new)(sslCtx);
    if (!ssl)
-      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error creating SSL connection");
+      return handleOpenSSLConnectionError(socket, ssl, bio, "Error creating SSL connection");
 
    (*OSSL_set_accept_state)(ssl);
 
-   if ((*OSSL_set_fd)(ssl, connfd) != 1)
-      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting SSL file descriptor");
+   if ((*OSSL_set_fd)(ssl, omrsock_socket_getfd(socket)) != 1)
+      return handleOpenSSLConnectionError(socket, ssl, bio, "Error setting SSL file descriptor");
 
    if ((*OSSL_accept)(ssl) <= 0)
-      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error accepting SSL connection");
+      return handleOpenSSLConnectionError(socket, ssl, bio, "Error accepting SSL connection");
 
    bio = (*OBIO_new_ssl)(sslCtx, false);
    if (!bio)
-      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error creating new BIO");
+      return handleOpenSSLConnectionError(socket, ssl, bio, "Error creating new BIO");
 
    if ((*OBIO_ctrl)(bio, BIO_C_SET_SSL, true, (char *)ssl) != 1) // BIO_set_ssl(bio, ssl, true)
-      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting BIO SSL");
+      return handleOpenSSLConnectionError(socket, ssl, bio, "Error setting BIO SSL");
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
-                                                     connfd, (*OSSL_get_version)(ssl), (*OSSL_get_cipher)(ssl));
+                                                     omrsock_socket_getfd(socket), (*OSSL_get_version)(ssl), (*OSSL_get_cipher)(ssl));
    return true;
    }
 
@@ -199,69 +192,69 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
       JITServer::CommunicationStream::initSSL();
       sslCtx = createSSLContext(info);
       }
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
 
    uint32_t port = info->getJITServerPort();
    uint32_t timeoutMs = info->getSocketTimeout();
-   struct pollfd pfd = {0};
-   int sockfd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-   if (sockfd < 0)
+   OMRPollFd pfd;
+
+   omrsock_socket_t socket = NULL;
+   if (omrsock_socket(&socket, OMRSOCK_AF_INET, OMRSOCK_STREAM | OMRSOCK_O_NONBLOCK, OMRSOCK_IPPROTO_DEFAULT) < 0)
       {
-      perror("can't open server socket");
+      perror("can't open server socket using omrsock api");
       exit(1);
       }
 
    // see `man 7 socket` for option explanations
    int flag = true;
-   if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (void *)&flag, sizeof(flag)) < 0)
+   if (omrsock_setsockopt_int(socket, OMRSOCK_SOL_SOCKET, OMRSOCK_SO_REUSEADDR, &flag) < 0)
       {
       perror("Can't set SO_REUSEADDR");
       exit(-1);
       }
-   if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void *)&flag, sizeof(flag)) < 0)
+   if (omrsock_setsockopt_int(socket, OMRSOCK_SOL_SOCKET, OMRSOCK_SO_KEEPALIVE, &flag) < 0)
       {
       perror("Can't set SO_KEEPALIVE");
       exit(-1);
       }
 
-   struct sockaddr_in serv_addr;
-   memset((char *)&serv_addr, 0, sizeof(serv_addr));
-   serv_addr.sin_family = AF_INET;
-   serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-   serv_addr.sin_port = htons(port);
+	OMRSockAddrStorage sockAddr;
+	uint8_t addr[4];
+	unsigned int inaddrAny = omrsock_htonl(OMRSOCK_INADDR_ANY);
+	memcpy(addr, &inaddrAny, 4);
+   omrsock_sockaddr_init(&sockAddr, OMRSOCK_AF_INET, addr, omrsock_htons(port));
 
-   if (bind(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+   if (omrsock_bind(socket, &sockAddr) < 0)
       {
       perror("can't bind server address");
       exit(1);
       }
-   if (listen(sockfd, SOMAXCONN) < 0)
+   if (omrsock_listen(socket, OMRSOCK_MAXCONN) < 0)
       {
       perror("listen failed");
       exit(1);
       }
 
-   pfd.fd = sockfd;
-   pfd.events = POLLIN;
+   omrsock_pollfd_init(&pfd, socket, OMRSOCK_POLLIN);
 
    while (!getListenerThreadExitFlag())
       {
       int32_t rc = 0;
-      struct sockaddr_in cli_addr;
-      socklen_t clilen = sizeof(cli_addr);
-      int connfd = -1;
+      OMRSockAddrStorage cli_addr;
+      omrsock_socket_t cli_socket = NULL;
 
-      rc = poll(&pfd, 1, OPENJ9_LISTENER_POLL_TIMEOUT);
+      rc = omrsock_poll(&pfd, 1, OPENJ9_LISTENER_POLL_TIMEOUT);
       if (getListenerThreadExitFlag()) // if we are exiting, no need to check poll() status
          {
          break;
          }
-      else if (0 == rc) // poll() timed out and no fd is ready
+      else if (0 == rc) // omrsock_poll() timed out and no fd is ready
          {
          continue;
          }
       else if (rc < 0)
          {
-         if (errno == EINTR)
+         if (omrerror_last_error_number() == OMRPORT_ERROR_FILE_OPFAILED) //TODO: After openj9-omr merge change to: if (OMRPORT_ERROR_SOCKET_INTERRUPTED == rc)
             {
             continue;
             }
@@ -271,47 +264,54 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
             exit(1);
             }
          }
-      else if (pfd.revents != POLLIN)
+      else
          {
-         fprintf(stderr, "Unexpected event occurred during poll for new connection: revents=%d\n", pfd.revents);
-         exit(1);
+         omrsock_socket_t rSocket;
+         int16_t revents = 0;
+         omrsock_get_pollfd_info(&pfd, &rSocket, &revents);
+         if (revents != OMRSOCK_POLLIN)
+            {
+            fprintf(stderr, "Unexpected event occurred during poll for new connection: revents=%d\n", revents);
+            exit(1);
+            }
          }
       do
          {
          /* at this stage we should have a valid request for new connection */
-         connfd = accept(sockfd, (struct sockaddr *)&cli_addr, &clilen);
-         if (connfd < 0)
+         rc = omrsock_accept(socket, &cli_addr, &cli_socket);
+         if (rc < 0)
             {
-            if ((EAGAIN != errno) && (EWOULDBLOCK != errno))
+            if (OMRPORT_ERROR_SOCKET_WOULDBLOCK != rc)
                {
                if (TR::Options::getVerboseOption(TR_VerboseJITServer))
                   {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d", errno);
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d", rc);
                   }
                }
             }
          else
             {
-            struct timeval timeoutMsForConnection = {(timeoutMs / 1000), ((timeoutMs % 1000) * 1000)};
-            if (setsockopt(connfd, SOL_SOCKET, SO_RCVTIMEO, (void *)&timeoutMsForConnection, sizeof(timeoutMsForConnection)) < 0)
+            OMRTimeval timeoutMsForConnection;
+            omrsock_timeval_init(&timeoutMsForConnection, timeoutMs / 1000, (timeoutMs % 1000) * 1000);
+            if (omrsock_setsockopt_timeval(socket, OMRSOCK_SOL_SOCKET, OMRSOCK_SO_RCVTIMEO, &timeoutMsForConnection) < 0)
                {
                perror("Can't set option SO_RCVTIMEO on connfd socket");
                exit(-1);
                }
-            if (setsockopt(connfd, SOL_SOCKET, SO_SNDTIMEO, (void *)&timeoutMsForConnection, sizeof(timeoutMsForConnection)) < 0)
+            if (omrsock_setsockopt_timeval(socket, OMRSOCK_SOL_SOCKET, OMRSOCK_SO_SNDTIMEO, &timeoutMsForConnection) < 0)
                {
                perror("Can't set option SO_SNDTIMEO on connfd socket");
                exit(-1);
                }
 
             BIO *bio = NULL;
-            if (sslCtx && !acceptOpenSSLConnection(sslCtx, connfd, bio))
+            if (sslCtx && !acceptOpenSSLConnection(sslCtx, cli_socket, bio))
                continue;
 
-            JITServer::ServerStream *stream = new (PERSISTENT_NEW) JITServer::ServerStream(connfd, bio);
+            JITServer::ServerStream *stream = new (PERSISTENT_NEW) JITServer::ServerStream(cli_socket, bio);
             compiler->compile(stream);
             }
-         } while ((-1 != connfd) && !getListenerThreadExitFlag());
+         } while ((0 == rc) && !getListenerThreadExitFlag());
       }
 
    // The following piece of code will be executed only if the server shuts down properly
@@ -320,6 +320,7 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
       (*OSSL_CTX_free)(sslCtx);
       (*OEVP_cleanup)();
       }
+   omrsock_close(&socket);
    }
 
 TR_Listener * TR_Listener::allocate()


### PR DESCRIPTION
Replace socket code for JitServer communication with omrsock API code

- Replaced networking include files with omrsock omrportsocktypes.h include file
- Replace all socket function calls with omrsock API calls
- Replace sockaddr_in with OMRAddrInfo and use getaddrinfo
- Replace all connfd with pointer to OMRSocket structure called socket.
- Replace all access to connfd needed for SSL with omrsock_socket_getfd.
- Replace all constants with omrsock constants.

Issue: #4102

Signed-off-by: Haley Cao <haleycao88@hotmail.com>