### PR TITLE
Creating Kubernetes / OpenShift deployment with Helm Chart

### DIFF
--- a/deploy/openj9-chart/.helmignore
+++ b/deploy/openj9-chart/.helmignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/deploy/openj9-chart/Chart.yaml
+++ b/deploy/openj9-chart/Chart.yaml
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+apiVersion: v1
+name: openj9-chart
+version: 0.1.0
+kubeVersion: ">=1.11.0"
+description: OpenJ9 helm chart
+keywords:
+  - amd64
+  - ppc64le
+  - RHOCP
+  - runtime
+  - OpenJ9
+sources:
+  - https://github.com/eclipse/openj9
+icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/deploy/openj9-chart/LICENSE
+++ b/deploy/openj9-chart/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/deploy/openj9-chart/README.md
+++ b/deploy/openj9-chart/README.md
@@ -1,0 +1,106 @@
+# OpenJ9 Helm Chart
+
+## Introduction
+
+Eclipse OpenJ9 is an independent implementation of a Java Virtual Machine.
+
+The OpenJ9 Chart allows you to deploy and manage java applications running on OpenJ9 into OKD or OpenShift clusters. You can also perform Day-2 operations such as rolling update your application, enabling JITServer technology for continued performance enhancements or gathering JVM dumps using the operator.
+
+## Resources Required
+
+### System
+
+* CPU Requested : 1 CPU
+* Memory Requested : 256 MB
+
+### Storage
+
+* Currently no storage or volume needed.
+
+## Chart Details
+
+* Install one `deployment` running AdoptOpenJDK OpenJ9 image
+* Install one `service` that is JITServer technology enabled by default
+
+## Prerequisites
+
+### Red Hat OpenShift SecurityContextConstraints Requirements
+
+This chart does not require SecurityContextConstraints to be bound to the target namespace prior to installation.
+
+### PodSecurityPolicy Requirements
+
+This chart does not require PodSecurityPolicy to be bound to the target namespace prior to installation.
+
+### PodDisruptionBudgets Requirement
+
+This chart does not require PodDisruptionBudgets to be bound to the target namespace prior to installation.
+
+## Installing the Chart
+
+``` bash
+helm install example-openj9 PATH_TO_OPENJ9_CHART
+```
+
+This chart installs OpenJ9 instance for Java 11 on x86 platform by default. If you would like to use OpenJ9 chart on other platform and different Java version, please override keyword `arch` or `image` with `--set` option.
+
+## Verifying the Chart
+
+``` bash
+helm test example-openj9
+helm status example-openj9
+```
+
+## Uninstalling the Chart
+
+``` bash
+helm delete example-openj9
+```
+
+## Getting started with OpenJ9 JITServer Technology
+
+JITServer technology can be used for any Java application running on OpenJ9. Please make sure that JITServer image runs the same build version of JDK as your application image.
+
+``` bash
+helm install example-openj9 PATH_TO_OPENJ9_CHART
+```
+
+Once JITServer is deployed, you can enable JITServer by adding the following JVM option to your Java application.
+
+You may change `<servicename>` and `<serverport>` by editing `values.yaml`. Look for service name with `kubectl get service`, `<serverport>` is set to `38400` by default.
+
+``` bash
+OPENJ9_JAVA_OPTIONS = -XX:+UseJITServer -XX:JITServerAddress=<servicename> -XX:JITServerPort=<serverport>
+```
+
+See the [JITServer quick start guide](doc/enabling-jitserver.adoc) for more information on how to enable JITServer technology with Open Liberty WebServer as an example java application.
+
+### Configuration
+
+| Qualifier      | Parameter                               | Definition                                                                  | Allowed Value                                             |
+|----------------|-----------------------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------------|
+|fullnameOverride|                                         |Name of service, deployment, replicaset, should be unique inside cluster     |                                                           |
+|arch            |                                         |CPU architecture preference                                                  |`amd64` or `ppc64le`                                       |
+|image           |repository                               |Image repository                                                             |Defaults to `docker.io/adoptopenjdk`                       |
+|                |tag                                      |Image tag                                                                    |Defaults to `openj9`                                       |
+|                |pullPolicy                               |Image Pull Policy                                                            |`Always`, `Never`, or `IfNotPresent`. Defaults to Always   |
+|container       |command                                  |Container start command / entrypoint, override existing entrypoint if present|Defaults to `jitserver`                                    |
+|                |OPENJ9_JAVA_OPTIONS                      |Options passed into OpenJ9 JVM                                               |                                                           |
+|                |limits.memory                            |Maximum memory allocated for container                                       |Defaults to `8 Gi`                                         |
+|                |limits.cpu                               |Maximum CPU allocated for container                                          |Defaults to `8`                                            |
+|                |requests.memory                          |Minimum memory allocated for container                                       |Defaults to `256 Mi`                                       |
+|                |requests.cpu                             |Minimum CPU allocated for container                                          |Defaults to `1`                                            |
+|service         |port                                     |Port number that java acceleration listens to                                |Defaults to `38400`                                        |
+|replicaCount    |                                         |Number of replica to be deployed                                             |Defaults to `1`                                            |
+
+## Documentation
+
+* OpenJ9 website: https://www.eclipse.org/openj9/index.html
+* OpenJ9 JITServer technology: https://www.eclipse.org/openj9/docs/jitserver/
+* OpenJ9 repository: https://github.com/eclipse/openj9
+* OpenJ9 docs: https://github.com/eclipse/openj9-docs
+
+## Limitations
+
+* Deploys on x86 (amd64) and power (ppcle) architecture only, it is intended to support other architectures in future releases.
+* Supports Java 8, Java 11 and the current Java release only, it is intended to support other java versions in future releases.

--- a/deploy/openj9-chart/templates/NOTES.txt
+++ b/deploy/openj9-chart/templates/NOTES.txt
@@ -1,0 +1,15 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+To learn more about OpenJ9, please visit:
+
+  * OpenJ9 website: https://www.eclipse.org/openj9/index.html
+  * OpenJ9 JITServer technology: https://www.eclipse.org/openj9/docs/jitserver/
+  * OpenJ9 repository: https://github.com/eclipse/openj9
+  * OpenJ9 docs: https://github.com/eclipse/openj9-docs

--- a/deploy/openj9-chart/templates/_helpers.tpl
+++ b/deploy/openj9-chart/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openj9-chart.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openj9-chart.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- printf "%s-%s" .Values.fullnameOverride .Values.arch | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- printf "%s-%s" .Release.Name .Values.arch | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s-%s" .Release.Name $name .Values.arch | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openj9-chart.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/openj9-chart/templates/deployment.yaml
+++ b/deploy/openj9-chart/templates/deployment.yaml
@@ -1,0 +1,80 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openj9-chart.fullname" . }}
+  labels:
+    helm.sh/chart: {{ template "openj9-chart.chart" . }}
+    app.kubernetes.io/name: {{ template "openj9-chart.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ template "openj9-chart.name" . }}
+    app.kubernetes.io/part-of: {{ template "openj9-chart.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "openj9-chart.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/version: "1.0.0"
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: {{ template "openj9-chart.chart" . }}
+        app.kubernetes.io/name: {{ template "openj9-chart.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: openj9
+        app.kubernetes.io/part-of: openj9
+    spec:
+      containers:
+        - name: {{ template "openj9-chart.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{ .Values.container.command }}
+          env:
+          - name: OPENJ9_JAVA_OPTIONS
+            value: {{ .Values.container.OPENJ9_JAVA_OPTIONS }}
+          ports:
+            - containerPort: 38400
+              protocol: TCP
+          resources:
+            limits:
+              memory: {{ .Values.container.limits.memory }}
+              cpu: {{ .Values.container.limits.cpu }}
+            requests:
+              memory: {{ .Values.container.requests.memory }}
+              cpu: {{ .Values.container.requests.cpu }}
+      affinity: 
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions: 
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - {{ .Values.arch }}
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/deploy/openj9-chart/templates/service.yaml
+++ b/deploy/openj9-chart/templates/service.yaml
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "openj9-chart.fullname" . }}
+  labels:
+    helm.sh/chart: {{ template "openj9-chart.chart" . }}
+    app.kubernetes.io/name: {{ template "openj9-chart.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ template "openj9-chart.name" . }}
+    app.kubernetes.io/part-of: {{ template "openj9-chart.name" . }}
+spec:
+  selector:
+    app: {{ template "openj9-chart.name" . }}
+  ports:
+    - name: {{ template "openj9-chart.fullname" . }}
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 38400
+  type: ClusterIP

--- a/deploy/openj9-chart/templates/tests/test_openj9.yaml
+++ b/deploy/openj9-chart/templates/tests/test_openj9.yaml
@@ -1,0 +1,52 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "openj9-chart.fullname" . }}-test"
+  annotations:
+    "helm.sh/hook": test-success
+  labels:
+    helm.sh/chart: {{ template "openj9-chart.chart" . }}
+    app.kubernetes.io/name: {{ template "openj9-chart.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ template "openj9-chart.name" . }}
+    app.kubernetes.io/part-of: {{ template "openj9-chart.name" . }}
+spec: 
+  containers:
+  - name: {{ template "openj9-chart.fullname" . }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command: ["java"]
+    args: ["-version"]
+    resources:
+      limits:
+        memory: {{ .Values.container.limits.memory }}
+        cpu: {{ .Values.container.limits.cpu }}
+      requests:
+        memory: {{ .Values.container.requests.memory }}
+        cpu: {{ .Values.container.requests.cpu }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions: 
+          - key: beta.kubernetes.io/arch
+            operator: In
+            values:
+            - amd64
+  restartPolicy: Never

--- a/deploy/openj9-chart/values.yaml
+++ b/deploy/openj9-chart/values.yaml
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+fullnameOverride: []
+
+arch: amd64
+
+image:
+  repository: docker.io/adoptopenjdk
+  tag: 11-jdk-openj9
+  pullPolicy: Always
+
+container:
+  command: ["jitserver"]
+  OPENJ9_JAVA_OPTIONS: ""
+  limits:
+    memory: 8Gi
+    cpu: 8
+  requests:
+    memory: 256Mi
+    cpu: 1
+
+service:
+  port: 38400
+
+replicaCount: 1


### PR DESCRIPTION
As a continuous part of the discussed in #9443, we would like to provide a deployment method for running OpenJ9 on Kubernetes / OpenShift. This PR introduces the OpenJ9 helm chart. 

Some testing information will be provided shortly later. More testing discussion can be found #10510. 

Reference: https://github.com/eclipse/openj9/issues/9443
FYI: @raguks @mpirvu @DanHeidinga 

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>