### PR TITLE
Stop-gap DDR fix for JIT metadata offsets

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -89,7 +89,7 @@ import static com.ibm.j9ddr.vm29.structure.MethodMetaDataConstants.INTERNAL_PTR_
 /**
  * Stack walker for processing JIT frames. Don't call directly - go through
  * com.ibm.j9ddr.vm.j9.stackwalker.StackWalker
- * 
+ *
  * @author andhall
  *
  */
@@ -100,19 +100,19 @@ public class JITStackWalker
 	{
 		return getImpl().jitWalkStackFrames(walkState);
 	}
-	
+
 	static void jitPrintRegisterMapArray(WalkState walkState, String description) throws CorruptDataException
 	{
 		getImpl().jitPrintRegisterMapArray(walkState,description);
 	}
-	
+
 	static J9JITExceptionTablePointer jitGetExceptionTableFromPC(J9VMThreadPointer walkThread, U8Pointer pc) throws CorruptDataException
 	{
 		return getImpl().jitGetExceptionTableFromPC(walkThread, pc);
 	}
-	
+
 	private static IJITStackWalker impl;
-	
+
 	private static final AlgorithmPicker<IJITStackWalker> picker = new AlgorithmPicker<IJITStackWalker>(AlgorithmVersion.JIT_STACK_WALKER_VERSION){
 
 		@Override
@@ -122,7 +122,7 @@ public class JITStackWalker
 			toReturn.add(new JITStackWalker_29_V0());
 			return toReturn;
 		}};
-	
+
 	private static IJITStackWalker getImpl()
 	{
 		if (impl == null) {
@@ -130,13 +130,13 @@ public class JITStackWalker
 		}
 		return impl;
 	}
-	
+
 	private static interface IJITStackWalker extends IAlgorithm
 	{
 		public FrameCallbackResult jitWalkStackFrames(WalkState walkState) throws CorruptDataException;
 
 		public void jitPrintRegisterMapArray(WalkState walkState, String description) throws CorruptDataException;
-		
+
 		public J9JITExceptionTablePointer jitGetExceptionTableFromPC(J9VMThreadPointer walkThread, U8Pointer pc) throws CorruptDataException;
 	}
 
@@ -144,8 +144,8 @@ public class JITStackWalker
 	 * JIT Stack Walker for Java 5 SR11
 	 * @author andhall
 	 */
-	
-	
+
+
 	/**
 	 * JIT Stack Walker for 2.6 circa early 2010
 	 * @author andhall
@@ -155,7 +155,7 @@ public class JITStackWalker
 		protected JITStackWalker_29_V0() {
 			super(90, 0);
 		}
-		
+
 		private static U8Pointer MASK_PC(AbstractPointer ptr)
 		{
 			if (J9BuildFlags.arch_s390 && !J9BuildFlags.env_data64) {
@@ -164,7 +164,7 @@ public class JITStackWalker
 				return U8Pointer.cast(ptr);
 			}
 		}
-		
+
 		/* Used differently to macro it's based on. Argument is pcExpressionEA NOT pcExpression */
 		private static void UPDATE_PC_FROM(WalkState walkState, PointerPointer pcExpressionEA) throws CorruptDataException
 		{
@@ -175,13 +175,13 @@ public class JITStackWalker
 				walkState.pc = MASK_PC(pcExpressionEA.at(0));
 			}
 		}
-		
+
 
 		private static void SET_A0_CP_METHOD(WalkState walkState) throws CorruptDataException
-		{			
+		{
 			walkState.arg0EA = UDATAPointer.cast(U8Pointer.cast(walkState.bp.add(walkState.jitInfo.slots())).add(J9JITFrame.SIZEOF).sub(UDATA.SIZEOF));
-			walkState.method = walkState.jitInfo.ramMethod();
-			walkState.constantPool = walkState.jitInfo.constantPool();
+			walkState.method = J9MethodPointer.cast(walkState.jitInfo.ramMethodOffset());
+			walkState.constantPool = J9ConstantPoolPointer.cast(walkState.jitInfo.constantPoolOffset());
 			walkState.argCount = new UDATA(walkState.jitInfo.slots());
 		}
 
@@ -198,24 +198,24 @@ public class JITStackWalker
 			if ( (rc = walkTransitionFrame(walkState)) != FrameCallbackResult.KEEP_ITERATING) {
 				return rc;
 			}
-			
+
 			walkState.frameFlags = new UDATA(0);
-			
+
 			while ( (walkState.jitInfo = jitGetExceptionTable(walkState)).notNull() ) {
 				walkState.bp = walkState.unwindSP.add(getJitTotalFrameSize(walkState.jitInfo));
-				
+
 				/* Point walkState->sp to the last outgoing argument */
 				if (J9SW_NEEDS_JIT_2_INTERP_CALLEE_ARG_POP) {
 					walkState.sp = walkState.unwindSP.sub(walkState.argCount);
 				} else {
 					walkState.sp = walkState.unwindSP;
 				}
-				
+
 				walkState.outgoingArgCount = walkState.argCount;
-				
+
 				if (((walkState.flags & J9_STACKWALK_SKIP_INLINES) == 0) && getJitInlinedCallInfo(walkState.jitInfo).notNull()) {
 					jitGetMapsFromPC(walkState.walkThread.javaVM(), walkState.jitInfo, UDATA.cast(walkState.pc), maps);
-					if (maps.inlineMap.notNull()) {  
+					if (maps.inlineMap.notNull()) {
 						VoidPointer inlinedCallSite = getFirstInlinedCallSite(walkState.jitInfo, VoidPointer.cast(maps.inlineMap));
 						walkState.arg0EA = UDATAPointer.NULL;
 						if (inlinedCallSite.notNull()) {
@@ -223,16 +223,16 @@ public class JITStackWalker
 							walkState.arg0EA = UDATAPointer.NULL;
 							do {
 								J9MethodPointer inlinedMethod = J9MethodPointer.cast(getInlinedMethod(inlinedCallSite));
-								
+
 								walkState.method = inlinedMethod;
 								walkState.constantPool = ConstantPoolHelpers.J9_CP_FROM_METHOD(walkState.method);
 								walkState.bytecodePCOffset = U8Pointer.cast(getCurrentByteCodeIndexAndIsSameReceiver(walkState.jitInfo, VoidPointer.cast(maps.inlineMap), inlinedCallSite, null));
 								jitPrintFrameType(walkState, "JIT inline");
-								
+
 								if ((rc = walkFrame(walkState)) != FrameCallbackResult.KEEP_ITERATING) {
 									return rc;
 								}
-								
+
 								inlinedCallSite = getNextInlinedCallSite(walkState.jitInfo, inlinedCallSite);
 							} while(--walkState.inlineDepth > 0);
 						}
@@ -240,7 +240,7 @@ public class JITStackWalker
 				} else if ((walkState.flags & J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET) != 0) {
 					jitGetMapsFromPC(walkState.walkThread.javaVM(), walkState.jitInfo, UDATA.cast(walkState.pc),maps);
 				}
-				
+
 				SET_A0_CP_METHOD(walkState);
 				if ((walkState.flags & J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET) != 0) {
 					walkState.bytecodePCOffset = (maps.inlineMap.isNull()) ? U8Pointer.cast(-1) : U8Pointer.cast(getCurrentByteCodeIndexAndIsSameReceiver(walkState.jitInfo, VoidPointer.cast(maps.inlineMap), VoidPointer.NULL, null));
@@ -251,7 +251,7 @@ public class JITStackWalker
 				if ((walkState.flags & J9_STACKWALK_ITERATE_METHOD_CLASS_SLOTS) != 0) {
 					markClassesInInlineRanges(walkState.jitInfo, walkState);
 				}
-				
+
 				if ((walkState.flags & J9_STACKWALK_ITERATE_O_SLOTS) != 0) {
 					try {
 						jitWalkFrame(walkState, true, VoidPointer.cast(maps.stackMap));
@@ -270,12 +270,12 @@ public class JITStackWalker
 						jitAddSpilledRegisters(walkState, VoidPointer.cast(maps.stackMap));
 					} catch (CorruptDataException ex) {
 						handleOSlotsCorruption(walkState, "JITStackWalker_29_V0", "jitWalkStackFrames", ex);
-					}						
+					}
 				}
 
 				UNWIND_TO_NEXT_FRAME(walkState);
 			}
-			
+
 			/* JIT pair with no mapping indicates a bytecoded frame */
 			failedPC = walkState.pc;
 			returnTable = PointerPointer.cast(walkState.walkThread.javaVM().jitConfig().i2jReturnTable());
@@ -293,11 +293,11 @@ public class JITStackWalker
 			returnSP = walkState.i2jState.returnSP();
 			walkState.previousFrameFlags = new UDATA(0);
 			walkState.walkSP = returnSP.untag(3L);
-			swPrintf(walkState, 2, "I2J values: PC = {0}, A0 = {1}, walkSP = {2}, literals = {3}, JIT PC = {4}, pcAddress = {5}, decomp = {6}", 
+			swPrintf(walkState, 2, "I2J values: PC = {0}, A0 = {1}, walkSP = {2}, literals = {3}, JIT PC = {4}, pcAddress = {5}, decomp = {6}",
 					walkState.pc.getHexAddress(),
-					walkState.arg0EA.getHexAddress(), 
-					walkState.walkSP.getHexAddress(), 
-					walkState.literals.getHexAddress(), 
+					walkState.arg0EA.getHexAddress(),
+					walkState.walkSP.getHexAddress(),
+					walkState.literals.getHexAddress(),
 					failedPC.getHexAddress(), J9BuildFlags.jit_fullSpeedDebug ? walkState.pcAddress.getHexAddress() : "0",
 					J9BuildFlags.jit_fullSpeedDebug ? walkState.decompilationStack.getHexAddress() : "0");
 
@@ -311,7 +311,7 @@ public class JITStackWalker
 			if (! J9BuildFlags.jit_fullSpeedDebug) {
 				return jitGetExceptionTableFromPC(walkState.walkThread, walkState.pc);
 			}
-			
+
 			J9JITDecompilationInfoPointer stack;
 			J9JITExceptionTablePointer result = jitGetExceptionTableFromPC(walkState.walkThread, walkState.pc);
 
@@ -321,10 +321,10 @@ public class JITStackWalker
 			/* Check to see if the PC is a decompilation return point and if so, use the real PC for finding the metaData */
 
 			if (walkState.decompilationStack != null && walkState.decompilationStack.notNull()) {
-				swPrintf(walkState, 3, "(ws pcaddr = {0}, dc tos = {1}, pcaddr = {2}, pc = {3})", 
-						walkState.pcAddress.getHexAddress(), 
-						walkState.decompilationStack.getHexAddress(), 
-						walkState.decompilationStack.pcAddress().getHexAddress(), 
+				swPrintf(walkState, 3, "(ws pcaddr = {0}, dc tos = {1}, pcaddr = {2}, pc = {3})",
+						walkState.pcAddress.getHexAddress(),
+						walkState.decompilationStack.getHexAddress(),
+						walkState.decompilationStack.pcAddress().getHexAddress(),
 						walkState.decompilationStack.pc().getHexAddress());
 				if (walkState.pcAddress.eq(walkState.decompilationStack.pcAddress())) {
 					walkState.pc = walkState.decompilationStack.pc();
@@ -351,11 +351,11 @@ public class JITStackWalker
 				J9VMThreadPointer walkThread, U8Pointer pc) throws CorruptDataException
 		{
 			J9JITConfigPointer jitConfig = walkThread.javaVM().jitConfig();
-			
+
 			if (jitConfig.isNull()) {
 				return J9JITExceptionTablePointer.NULL;
 			}
-			
+
 			return jit_artifact_search(jitConfig.translationArtifacts(), UDATA.cast(MASK_PC(pc)));
 		}
 
@@ -365,25 +365,25 @@ public class JITStackWalker
 		UDATA floatRegistersRemaining;
 		UDATAPointer pendingSendScanCursor;
 		int charIndex;
-		
+
 		private void jitWalkResolveMethodFrame(WalkState walkState) throws CorruptDataException
 		{
 			boolean walkStackedReceiver;
 			J9UTF8Pointer signature;
 			UDATA pendingSendSlots;
 			char sigChar;
-			
+
 			//Init shared data
 			stackSpillCount = null;
 			stackSpillCursor = null;
 			floatRegistersRemaining = new UDATA(0);
-			
+
 			if (J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT_DEFINED) {
 				floatRegistersRemaining = new UDATA(J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT);
 			}
-			
+
 			UDATA resolveFrameType = walkState.frameFlags.bitAnd(J9_STACK_FLAGS_JIT_FRAME_SUB_TYPE_MASK);
-			
+
 			walkState.slotType = (int) J9_STACKWALK_SLOT_TYPE_INTERNAL;
 			walkState.slotIndex = -1;
 
@@ -391,7 +391,7 @@ public class JITStackWalker
 				J9ROMMethodPointer romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(J9MethodPointer.cast(JIT_RESOLVE_PARM(walkState,1)));
 
 				signature = J9ROMMETHOD_SIGNATURE(romMethod);
-				
+
 				pendingSendSlots = new UDATA(J9_ARG_COUNT_FROM_ROM_METHOD(romMethod)); /* receiver is already included in this arg count */
 				walkStackedReceiver = romMethod.modifiers().anyBitsIn(J9AccStatic);
 				if (J9SW_ARGUMENT_REGISTER_COUNT_DEFINED) {
@@ -465,7 +465,7 @@ public class JITStackWalker
 						}
 					}
 				}
-				
+
 				walkState.unwindSP = walkState.unwindSP.add(getJitVirtualMethodResolvePushes());
 			} else if (resolveFrameType.eq(J9_STACK_FLAGS_JIT_INDUCE_OSR_RESOLVE)) {
 				throw new CorruptDataException("Induced OSR resolve not handled yet");
@@ -516,11 +516,11 @@ public class JITStackWalker
 				signature = romMethodRef.nameAndSignature().signature();
 				pendingSendSlots = getSendSlotsFromSignature(signature).add(walkStackedReceiver ? 1 : 0);
 			}
-			
+
 			if ((walkState.flags & J9_STACKWALK_ITERATE_O_SLOTS) != 0) {
 				try {
 					pendingSendScanCursor = walkState.unwindSP.add(pendingSendSlots).sub(1);
-	
+
 					swPrintf(walkState, 3, "\tPending send scan cursor initialized to {0}", pendingSendScanCursor.getHexAddress());
 					if (walkStackedReceiver) {
 						if (J9SW_ARGUMENT_REGISTER_COUNT_DEFINED && ! stackSpillCount.eq(0)) {
@@ -546,14 +546,14 @@ public class JITStackWalker
 						}
 						pendingSendScanCursor = pendingSendScanCursor.sub(1);
 					}
-	
+
 					swPrintf(walkState, 3, "\tMethod signature: {0}", J9UTF8Helper.stringValue(signature));
-	
+
 					charIndex = 1; /* skip the opening ( */
 					String signatureString = J9UTF8Helper.stringValue(signature);
-					
+
 					while ((sigChar = jitNextSigChar(signatureString)) != ')') {
-						
+
 						switch (sigChar) {
 							case 'L':
 								if (J9SW_ARGUMENT_REGISTER_COUNT_DEFINED && ! stackSpillCount.eq(0) ) {
@@ -576,7 +576,7 @@ public class JITStackWalker
 										}
 								}
 								break;
-	
+
 							case 'D':
 								if (J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT_DEFINED) {
 									jitWalkResolveMethodFrame_walkD(walkState);
@@ -585,7 +585,7 @@ public class JITStackWalker
 									jitWalkResolveMethodFrame_walkJ(walkState);
 								}
 								break;
-	
+
 			 	 			case 'F':
 			 	 				if (J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT_DEFINED) {
 									jitWalkResolveMethodFrame_walkF(walkState);
@@ -594,11 +594,11 @@ public class JITStackWalker
 			 	 					jitWalkResolveMethodFrame_walkI(walkState);
 			 	 				}
 								break;
-	
+
 							case 'J':
 								jitWalkResolveMethodFrame_walkJ(walkState);
 								break;
-							
+
 							case 'I':
 							default:
 								jitWalkResolveMethodFrame_walkI(walkState);
@@ -610,7 +610,7 @@ public class JITStackWalker
 					handleOSlotsCorruption(walkState, "JITStackWalker_29_V0", "jitWalkResolveMethodFrame", ex);
 				}
 			}
-			
+
 			if (J9SW_NEEDS_JIT_2_INTERP_CALLEE_ARG_POP) {
 				walkState.unwindSP = walkState.unwindSP.add(pendingSendSlots);
 			}
@@ -620,7 +620,7 @@ public class JITStackWalker
 		private char jitNextSigChar(String signatureString) throws CorruptDataException
 		{
 			char utfChar = signatureString.charAt(charIndex++);
-			
+
 			switch (utfChar) {
 			case '[':
 				do {
@@ -686,7 +686,7 @@ public class JITStackWalker
 				}
 			}
 		}
-		
+
 		private void jitWalkResolveMethodFrame_walkF(WalkState walkState) throws CorruptDataException
 		{
 			if (! floatRegistersRemaining.eq(0)) {
@@ -713,7 +713,7 @@ public class JITStackWalker
 				}
 			}
 		}
-		
+
 		private void jitWalkResolveMethodFrame_walkJ(WalkState walkState) throws CorruptDataException
 		{
 			/* Longs always take 2 stack slots */
@@ -768,7 +768,7 @@ public class JITStackWalker
 				}
 			}
 		}
-		
+
 		private void jitWalkResolveMethodFrame_walkD(WalkState walkState) throws CorruptDataException
 		{
 
@@ -805,7 +805,7 @@ public class JITStackWalker
 			}
 		}
 
-		
+
 		private FrameCallbackResult walkTransitionFrame(WalkState walkState) throws CorruptDataException
 		{
 			if ((walkState.flags & J9_STACKWALK_START_AT_JIT_FRAME) != 0) {
@@ -820,9 +820,9 @@ public class JITStackWalker
 			if (walkState.frameFlags.anyBitsIn(J9_STACK_FLAGS_JIT_RESOLVE_FRAME)) {
 				J9SFJITResolveFramePointer resolveFrame = J9SFJITResolveFramePointer.cast(U8Pointer.cast(walkState.bp).sub(com.ibm.j9ddr.vm29.structure.J9SFJITResolveFrame.SIZEOF).add(UDATA.SIZEOF));
 				UDATA resolveFrameType = walkState.frameFlags.bitAnd(J9_STACK_FLAGS_JIT_FRAME_SUB_TYPE_MASK);
-				
+
 				//Using if rather than switch because you can only switch on int constants
-				
+
 				if (resolveFrameType.eq(J9_STACK_FLAGS_JIT_GENERIC_RESOLVE)) swPrintf(walkState, 3, "\tGeneric resolve");
 				else if (resolveFrameType.eq(J9_STACK_FLAGS_JIT_STACK_OVERFLOW_RESOLVE_FRAME)) swPrintf(walkState, 3, "\tStack overflow resolve");
 				else if (resolveFrameType.eq(J9_STACK_FLAGS_JIT_DATA_RESOLVE)) swPrintf(walkState, 3, "\tData resolve");
@@ -901,7 +901,7 @@ public class JITStackWalker
 						} catch (CorruptDataException ex) {
 							handleOSlotsCorruption(walkState, "JITStackWalker_29_V0", "walkTransitionFrame", ex);
 						}
-					
+
 						if ((walkState.flags & J9_STACKWALK_ITERATE_HIDDEN_JIT_FRAMES) != 0) {
 							FrameCallbackResult rc;
 
@@ -918,7 +918,7 @@ public class JITStackWalker
 						UNWIND_TO_NEXT_FRAME(walkState);
 					}
 				}
-			} else if (walkState.frameFlags.anyBitsIn(J9_STACK_FLAGS_JIT_JNI_CALL_OUT_FRAME)) {	
+			} else if (walkState.frameFlags.anyBitsIn(J9_STACK_FLAGS_JIT_JNI_CALL_OUT_FRAME)) {
 				J9SFNativeMethodFramePointer nativeMethodFrame = J9SFNativeMethodFramePointer.cast(walkState.bp.subOffset(J9SFNativeMethodFrame.SIZEOF).addOffset(UDATA.SIZEOF));
 
 				UPDATE_PC_FROM(walkState, nativeMethodFrame.savedCPEA());
@@ -926,7 +926,7 @@ public class JITStackWalker
 					if (walkState.frameFlags.anyBitsIn(J9_SSF_JNI_REFS_REDIRECTED) && (walkState.flags & J9_STACKWALK_ITERATE_O_SLOTS) != 0) {
 						try {
 							UDATAPointer currentBP = walkState.bp;
-	
+
 							walkState.jitInfo = jitGetExceptionTable(walkState);
 							walkState.unwindSP = UDATAPointer.cast(nativeMethodFrame.savedPC()).add(1);
 							walkState.bp = walkState.unwindSP.add(getJitTotalFrameSize(walkState.jitInfo));
@@ -944,14 +944,14 @@ public class JITStackWalker
 				UDATA callInFrameType = walkState.frameFlags.bitAnd(J9_STACK_FLAGS_JIT_FRAME_SUB_TYPE_MASK);
 				if (callInFrameType.eq(J9_STACK_FLAGS_JIT_CALL_IN_TYPE_J2_I)) {
 					J9SFJ2IFramePointer j2iFrame = J9SFJ2IFramePointer.cast(walkState.bp.subOffset(J9SFJ2IFrame.SIZEOF).addOffset(UDATA.SIZEOF));
-	
+
 					walkState.i2jState = J9I2JStatePointer.cast(j2iFrame.i2jStateEA());
 					walkState.j2iFrame = j2iFrame.previousJ2iFrame();
-	
+
 					if ((walkState.flags & J9_STACKWALK_MAINTAIN_REGISTER_MAP) != 0) {
 						jitAddSpilledRegistersForJ2I(walkState);
 					}
-	
+
 					walkState.unwindSP = j2iFrame.taggedReturnSP().untag(3L);
 					UPDATE_PC_FROM(walkState, j2iFrame.returnAddressEA());
 				}
@@ -972,7 +972,7 @@ public class JITStackWalker
 
 			return FrameCallbackResult.KEEP_ITERATING;
 		}
-		
+
 		private void jitAddSpilledRegistersForResolve(WalkState walkState) throws CorruptDataException
 		{
 			try {
@@ -995,7 +995,7 @@ public class JITStackWalker
 		{
 			UDATAPointer slotCursor = walkState.walkedEntryLocalStorage.jitGlobalStorageBase();
 			int i;
-		
+
 			for (i = 0; i < J9SW_JIT_CALLEE_PRESERVED_SIZE; ++i) {
 				int regNumber = jitCalleeSavedRegisterList[i];
 
@@ -1005,36 +1005,36 @@ public class JITStackWalker
 			jitPrintRegisterMapArray(walkState, "INL");
 		}
 
-		
+
 		private void jitAddSpilledRegistersForJ2I(WalkState walkState) throws CorruptDataException
 		{
 			J9SFJ2IFramePointer j2iFrame = J9SFJ2IFramePointer.cast(walkState.bp.subOffset(J9SFJ2IFrame.SIZEOF).addOffset(UDATA.SIZEOF));
 			UDATAPointer slotCursor = UDATAPointer.cast(j2iFrame.previousJ2iFrameEA()).add(1);
 			int i;
-		 
+
 			for (i = 0; i < J9SW_JIT_CALLEE_PRESERVED_SIZE; ++i) {
 				int regNumber = jitCalleeSavedRegisterList[i];
-				
+
 				walkState.registerEAs[regNumber] = slotCursor;
 				slotCursor = slotCursor.add(1);
 			}
-		
+
 			jitPrintRegisterMapArray(walkState, "J2I");
 		}
 
-		
+
 		public void jitPrintRegisterMapArray(WalkState walkState, String description) throws CorruptDataException
 		{
 			for (int i = 0; i < J9SW_POTENTIAL_SAVED_REGISTERS; ++i) {
 				UDATAPointer registerSaveAddress = walkState.registerEAs[i];
 
 				if (!registerSaveAddress.eq(UDATAPointer.NULL)) {
-					swPrintf(walkState, 3, "\tJIT-{0}-RegisterMap[{1}] = {2} ({3})", description, 
+					swPrintf(walkState, 3, "\tJIT-{0}-RegisterMap[{1}] = {2} ({3})", description,
 						registerSaveAddress.getHexAddress(), registerSaveAddress.at(0), jitRegisterNames[i]);
 				}
 			}
 		}
-		
+
 		private void CLEAR_LOCAL_REGISTER_MAP_ENTRIES(WalkState walkState)
 		{
 			int clearRegNum;
@@ -1053,7 +1053,7 @@ public class JITStackWalker
 				walkState.unwindSP = UDATAPointer.cast(J9JITFramePointer.cast(walkState.bp).add(1));
 				COMMON_UNWIND_TO_NEXT_FRAME(walkState);
 			}
-			
+
 		}
 
 		private void COMMON_UNWIND_TO_NEXT_FRAME(WalkState walkState) throws CorruptDataException
@@ -1083,7 +1083,7 @@ public class JITStackWalker
 			swPrintf(walkState, 2, "\tstackMap={0}, slots={1} parmBaseOffset={2}, parmSlots={3}, localBaseOffset={4}",
 							stackMap.getHexAddress(), walkState.jitInfo.slots(), gcStackAtlas.parmBaseOffset(), gcStackAtlas.numberOfParmSlots(), gcStackAtlas.localBaseOffset());
 
-			objectArgScanCursor = getObjectArgScanCursor(walkState); 
+			objectArgScanCursor = getObjectArgScanCursor(walkState);
 			jitBitsRemaining = new UDATA(0);
 			mapBytesRemaining = new UDATA(getJitNumberOfMapBytes(gcStackAtlas));
 
@@ -1122,57 +1122,57 @@ public class JITStackWalker
 			}
 
 		}
-		
+
 		// Shared data for walkJITFrameSlots
 		// Passed by reference in native implementation
-		
+
 		private U8 jitDescriptionBits;
 		private U8 stackAllocMapBits;
 		private U8Pointer jitDescriptionCursor;
 		private U8Pointer stackAllocMapCursor;
 		private UDATA jitBitsRemaining;
 		private UDATA mapBytesRemaining;
-		
+
 		private void walkJITFrameSlots(WalkState walkState, UDATAPointer scanCursor, UDATA slotsRemaining, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas, String slotDescription) throws CorruptDataException
 		{
-			/* GC stack atlas passed in to this function is NULL when this method 
-			   is called for parameters in the frame; when this method is called for 
-			   autos in the frame, the actual stack atlas is passed in. This 
+			/* GC stack atlas passed in to this function is NULL when this method
+			   is called for parameters in the frame; when this method is called for
+			   autos in the frame, the actual stack atlas is passed in. This
 			   works because no internal pointers/pinning arrays can be parameters.
-			   We must avoid doing internal pointer fixup twice for a 
-			   given stack frame as this method is called twice for each 
-			   stack frame (once for parms and once for autos). 
-			
-			   If internal pointer map exists in the atlas it means there are internal pointer 
+			   We must avoid doing internal pointer fixup twice for a
+			   given stack frame as this method is called twice for each
+			   stack frame (once for parms and once for autos).
+
+			   If internal pointer map exists in the atlas it means there are internal pointer
 			   regs/autos in this method.
 			*/
 
-			if (gcStackAtlas.notNull() && getJitInternalPointerMap(gcStackAtlas).notNull()) 
+			if (gcStackAtlas.notNull() && getJitInternalPointerMap(gcStackAtlas).notNull())
 			{
 				walkJITFrameSlotsForInternalPointers(walkState, jitDescriptionCursor, scanCursor, stackMap, gcStackAtlas);
 			}
-			
-			while (! slotsRemaining.eq(0)) 
+
+			while (! slotsRemaining.eq(0))
 			{
-				if (jitBitsRemaining.eq(0)) 
+				if (jitBitsRemaining.eq(0))
 				{
 					if (! mapBytesRemaining.eq(0)) {
 						jitDescriptionBits = getNextDescriptionBit(jitDescriptionCursor);
-						//We have to move jitDescriptionCursor on ourselves, DDR getNextDescriptionBits doesn't do it for us  
+						//We have to move jitDescriptionCursor on ourselves, DDR getNextDescriptionBits doesn't do it for us
 						jitDescriptionCursor = jitDescriptionCursor.add(1);
-						
+
 						if (stackAllocMapCursor.notNull()) {
 							stackAllocMapBits = getNextDescriptionBit(stackAllocMapCursor);
 							stackAllocMapCursor = stackAllocMapCursor.add(1);
 						}
-						
+
 						mapBytesRemaining = mapBytesRemaining.sub(1);
 					} else {
 						jitDescriptionBits = new U8(0);
 					}
 					jitBitsRemaining = new UDATA(8);
 				}
-				
+
 				if (jitDescriptionBits.anyBitsIn(1)) {
 					String indexedTag = String.format("O-Slot: %s%d", slotDescription, slotsRemaining.sub(1).intValue());
 					WALK_NAMED_O_SLOT(walkState,PointerPointer.cast(scanCursor), indexedTag);
@@ -1191,7 +1191,7 @@ public class JITStackWalker
 				slotsRemaining = slotsRemaining.sub(1);
 			}
 		}
-		
+
 		/* This function is invoked for each stack allocated object. Unless a specific callback
 		 * has been provided for stack allocated objects it creates synthetic slots for the object's
 		 * fields and reports them using WALK_O_SLOT()
@@ -1202,14 +1202,14 @@ public class JITStackWalker
 //			if (J9_STACKWALK_INCLUDE_ARRAYLET_LEAVES == (walkState.flags & J9_STACKWALK_INCLUDE_ARRAYLET_LEAVES)) {
 //				iterateObjectSlotsFlags = iterateObjectSlotsFlags.bitOr(j9mm_iterator_flag_include_arraylet_leaves);
 //			}
-			
+
 			swPrintf(walkState, 4, "\t\tSA-Obj[{0}]", Long.toHexString(object.getAddress()));
-			
+
 			GCObjectIterator it = GCObjectIterator.fromJ9Object(object, false);
-			
+
 			while (it.hasNext()) {
 				ObjectReferencePointer slot = ObjectReferencePointer.cast(it.nextAddress());
-				
+
 				swPrintf(walkState, 4, "\t\t\tF-Slot[{0}] = {1}", slot.getHexAddress(), slot.at(0).getHexAddress());
 
 				if (walkState.callBacks != null) {
@@ -1217,17 +1217,17 @@ public class JITStackWalker
 				}
 
 			}
-			
+
 		}
-		
-		
+
+
 		private static void jitPrintFrameType(WalkState walkState, String frameType) throws CorruptDataException
 		{
-			swPrintf(walkState, 2, "{0} frame: bp = {1}, pc = {2}, unwindSP = {3}, cp = {4}, arg0EA = {5}, jitInfo = {6}", frameType, 
-					walkState.bp.getHexAddress(), 
-					walkState.pc.getHexAddress(), 
-					walkState.unwindSP.getHexAddress(), 
-					walkState.constantPool.getHexAddress(), 
+			swPrintf(walkState, 2, "{0} frame: bp = {1}, pc = {2}, unwindSP = {3}, cp = {4}, arg0EA = {5}, jitInfo = {6}", frameType,
+					walkState.bp.getHexAddress(),
+					walkState.pc.getHexAddress(),
+					walkState.unwindSP.getHexAddress(),
+					walkState.constantPool.getHexAddress(),
 					walkState.arg0EA.getHexAddress(), walkState.jitInfo.getHexAddress());
 			try {
 				swPrintMethod(walkState);
@@ -1235,20 +1235,20 @@ public class JITStackWalker
 				handleOSlotsCorruption(walkState, "JITStackWalker_29_V0", "jitWalkStackFrames", ex);
 			}
 
-			swPrintf(walkState, 3, "\tBytecode index = {0}, inlineDepth = {1}, PC offset = {2}", UDATA.cast(walkState.bytecodePCOffset).longValue(), walkState.inlineDepth, 
+			swPrintf(walkState, 3, "\tBytecode index = {0}, inlineDepth = {1}, PC offset = {2}", UDATA.cast(walkState.bytecodePCOffset).longValue(), walkState.inlineDepth,
 					walkState.pc.sub(UDATA.cast(walkState.method.extra())).getHexAddress());
 		}
-		
-		
+
+
 		private void jitWalkRegisterMap(WalkState walkState, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException
 		{
 			UDATA registerMap = new UDATA(getJitRegisterMap(walkState.jitInfo, stackMap).bitAnd(J9SW_REGISTER_MAP_MASK));
 
 			swPrintf(walkState, 200, "\tIn jitWalkRegisterMap. stackMap={0}, gcStackAtlas={1}", Long.toHexString(stackMap.getAddress()), Long.toHexString(gcStackAtlas.getAddress()));
-			
+
 			swPrintf(walkState, 3, "\tJIT-RegisterMap = {0}", registerMap);
 
-			if (gcStackAtlas.internalPointerMap().notNull()) {
+			if (VoidPointer.cast(gcStackAtlas.internalPointerMapOffset()).notNull()) {
 				registerMap = registerMap.bitAnd(new UDATA(INTERNAL_PTR_REG_MASK).bitNot());
 			}
 
@@ -1271,13 +1271,13 @@ public class JITStackWalker
 
 						J9ObjectPointer oldObject = targetObject.isNull() ? J9ObjectPointer.NULL : J9ObjectPointer.cast(targetObject.at(0));
 						J9ObjectPointer newObject;
-						swPrintf(walkState, 4, "\t\tJIT-RegisterMap-O-Slot[{0}] = {1} ({2})", 
-								targetObject.getHexAddress(), 
+						swPrintf(walkState, 4, "\t\tJIT-RegisterMap-O-Slot[{0}] = {1} ({2})",
+								targetObject.getHexAddress(),
 								oldObject.getHexAddress(), jitRegisterNames[mapCursor]);
 						walkState.callBacks.objectSlotWalkFunction(walkState.walkThread, walkState, targetObject, VoidPointer.cast(targetObject));
-		
+
 						newObject = targetObject.isNull() ? J9ObjectPointer.NULL : J9ObjectPointer.cast(targetObject.at(0));
-		
+
 						if (! oldObject.eq(newObject)) {
 							swPrintf(walkState, 4, "\t\t\t-> {0}\n", newObject);
 						}
@@ -1285,7 +1285,7 @@ public class JITStackWalker
 						UDATAPointer targetSlot = walkState.registerEAs[mapCursor];
 
 						if (targetSlot.notNull()) {
-							swPrintf(walkState, 5, "\t\tJIT-RegisterMap-I-Slot[{0}] = {1} ({2})", 
+							swPrintf(walkState, 5, "\t\tJIT-RegisterMap-I-Slot[{0}] = {1} ({2})",
 									targetSlot.getHexAddress(), targetSlot.at(0), jitRegisterNames[mapCursor]);
 						}
 					}
@@ -1293,7 +1293,7 @@ public class JITStackWalker
 					++(walkState.slotIndex);
 					--count;
 					registerMap = registerMap.rightShift(1);
-					
+
 					if (J9SW_REGISTER_MAP_WALK_REGISTERS_LOW_TO_HIGH) {
 						++mapCursor;
 					} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -67,173 +67,173 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 
 /**
  * Java-equivalent of MethodMetaData.c.
- * 
+ *
  * Encapsulates the JIT-specific information required for stack walking.
- * 
+ *
  * Note that in the C, there's typedef J9JITExceptionTablePointer J9TR_MethodMetaData. That alias isn't
  * represented in the Java.
- * 
+ *
  * @author andhall
  *
  */
 public class MethodMetaData
 {
 	public static final long REGISTER_MAP_VALUE_FOR_GAP = 0xFADECAFE;
-	
+
 	public static final long BYTE_CODE_INFO_VALUE_FOR_GAP = 0x0;
-	
+
 	public static I16 getJitTotalFrameSize(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitTotalFrameSize(md);
 	}
-	
+
 	public static VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitInlinedCallInfo(md);
 	}
-	
+
 	public static void jitAddSpilledRegistersForDataResolve(WalkState walkState) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegistersForDataResolve(walkState);
 	}
-	
+
 	public static UDATA getJitDataResolvePushes() throws CorruptDataException
 	{
 		return getImpl().getJitDataResolvePushes();
 	}
-	
+
 	public static VoidPointer getStackMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC) throws CorruptDataException
 	{
 		return getImpl().getStackMapFromJitPC(javaVM,methodMetaData,jitPC);
 	}
-	
+
 	public static J9JITStackAtlasPointer getJitGCStackAtlas(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitGCStackAtlas(md);
 	}
-	
+
 	public static VoidPointer getFirstInlinedCallSite(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getFirstInlinedCallSite(methodMetaData,stackMap);
 	}
-	
+
 	public static UDATA getJitInlineDepthFromCallSite(J9JITExceptionTablePointer methodMetaData, VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getJitInlineDepthFromCallSite(methodMetaData,inlinedCallSite);
 	}
-	
+
 	public static boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().hasMoreInlinedMethods(inlinedCallSite);
 	}
-	
+
 	public static VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getInlinedMethod(inlinedCallSite);
 	}
-	
+
 	public static UDATA getCurrentByteCodeIndexAndIsSameReceiver(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer currentInlinedCallSite, boolean[] isSameReceiver) throws CorruptDataException
 	{
 		return getImpl().getCurrentByteCodeIndexAndIsSameReceiver(methodMetaData, stackMap, currentInlinedCallSite, isSameReceiver);
 	}
-	
+
 	public static void jitAddSpilledRegisters(WalkState walkState) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegisters(walkState);
 	}
-	
+
 	public static void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegisters(walkState, stackMap);
 	}
-	
+
 	public static UDATAPointer getObjectArgScanCursor(WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getObjectArgScanCursor(walkState);
 	}
-	
+
 	public static U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getJitDescriptionCursor(stackMap, walkState);
 	}
-	
+
 	public static U16 getJitNumberOfMapBytes(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitNumberOfMapBytes(sa);
 	}
-	
+
 	public static U32 getJitRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getJitRegisterMap(methodMetaData,stackMap);
 	}
-	
+
 	public static U8Pointer getNextDescriptionCursor(J9JITExceptionTablePointer metadata, VoidPointer stackMap, U8Pointer jitDescriptionCursor) throws CorruptDataException
 	{
 		return getImpl().getNextDescriptionCursor(metadata,stackMap,jitDescriptionCursor);
 	}
-	
+
 	public static U16 getJitNumberOfParmSlots(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitNumberOfParmSlots(sa);
 	}
-	
+
 	public static U8Pointer getJitInternalPointerMap(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitInternalPointerMap(sa);
 	}
-	
+
 	public static void walkJITFrameSlotsForInternalPointers(WalkState walkState,  U8Pointer jitDescriptionCursor, UDATAPointer scanCursor, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException
 	{
 		getImpl().walkJITFrameSlotsForInternalPointers(walkState,jitDescriptionCursor,scanCursor,stackMap,gcStackAtlas);
 	}
-	
+
 	public static VoidPointer getNextInlinedCallSite(
 			J9JITExceptionTablePointer methodMetaData,
 			VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getNextInlinedCallSite(methodMetaData,inlinedCallSite);
 	}
-	
+
 	public static U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException
 	{
 		return getImpl().getNextDescriptionBit(jitDescriptionCursor);
 	}
-	
+
 	public static UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getObjectTempScanCursor(walkState);
 	}
-	
+
 	public static int getJitRecompilationResolvePushes()
 	{
 		return getImpl().getJitRecompilationResolvePushes();
 	}
-	
+
 	public static int getJitVirtualMethodResolvePushes()
 	{
 		return getImpl().getJitVirtualMethodResolvePushes();
 	}
-	
+
 	public static int getJitStaticMethodResolvePushes()
 	{
 		return getImpl().getJitStaticMethodResolvePushes();
 	}
-	
+
 	public static VoidPointer getStackAllocMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC, VoidPointer curStackMap) throws CorruptDataException
 	{
 		return getImpl().getStackAllocMapFromJitPC(javaVM, methodMetaData, jitPC, curStackMap);
 	}
-	
+
 	public static U8Pointer getJitStackSlots(J9JITExceptionTablePointer metaData,  VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getJitStackSlots(metaData, stackMap);
 	}
-	
+
 	public static void markClassesInInlineRanges(J9JITExceptionTablePointer metaData, WalkState walkState) throws CorruptDataException
 	{
 		getImpl().markClassesInInlineRanges(metaData, walkState);
 	}
-	
+
 	/**
 	 * Class used to pass maps by reference to jitGetMapsFromPC.
 	 *
@@ -243,16 +243,16 @@ public class MethodMetaData
 		public PointerPointer stackMap = PointerPointer.NULL;
 		public PointerPointer inlineMap = PointerPointer.NULL;
 	}
-	
+
 	public static void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 			J9JITExceptionTablePointer methodMetaData, UDATA jitPC, JITMaps maps) throws CorruptDataException
 	{
 		getImpl().jitGetMapsFromPC(javaVM, methodMetaData, jitPC, maps);
 	}
 
-	
+
 	private static MethodMetaDataImpl impl;
-	
+
 	private static final AlgorithmPicker<MethodMetaDataImpl> picker = new AlgorithmPicker<MethodMetaDataImpl>(AlgorithmVersion.METHOD_META_DATA_VERSION){
 
 		@Override
@@ -262,7 +262,7 @@ public class MethodMetaData
 			toReturn.add(new MethodMetaData_29_V0());
 			return toReturn;
 		}};
-	
+
 	private static MethodMetaDataImpl getImpl()
 	{
 		if (impl == null) {
@@ -270,12 +270,12 @@ public class MethodMetaData
 		}
 		return impl;
 	}
-	
+
 	/* In Java 8 builds, the (interim) compiler gets confused if IAlgorithm is not fully qualified. */
 	private static interface MethodMetaDataImpl extends com.ibm.j9ddr.vm29.j9.IAlgorithm
 	{
 		public UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException;
-		
+
 		public int getJitStaticMethodResolvePushes();
 
 		public int getJitVirtualMethodResolvePushes();
@@ -283,7 +283,7 @@ public class MethodMetaData
 		public int getJitRecompilationResolvePushes();
 
 		public U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException;
-		
+
 		public void walkJITFrameSlotsForInternalPointers(WalkState walkState,U8Pointer jitDescriptionCursor, UDATAPointer scanCursor,VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException;
 
 		public U8Pointer getJitInternalPointerMap(J9JITStackAtlasPointer sa) throws CorruptDataException;
@@ -306,7 +306,7 @@ public class MethodMetaData
 				boolean[] isSameReceiver) throws CorruptDataException;
 
 		public boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException;
-		
+
 		public VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException;
 
 		public UDATA getJitInlineDepthFromCallSite(
@@ -315,7 +315,7 @@ public class MethodMetaData
 
 		public VoidPointer getFirstInlinedCallSite(
 				J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public VoidPointer getNextInlinedCallSite(J9JITExceptionTablePointer methodMetaData,VoidPointer inlinedCallSite) throws CorruptDataException;
 
 		public J9JITStackAtlasPointer getJitGCStackAtlas(
@@ -329,20 +329,20 @@ public class MethodMetaData
 		public void jitAddSpilledRegistersForDataResolve(WalkState walkState) throws CorruptDataException;
 
 		public VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md) throws CorruptDataException;
-		
+
 		public void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC, JITMaps maps) throws CorruptDataException;
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState) throws CorruptDataException;
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException;
-		
+
 		public VoidPointer getStackAllocMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC, VoidPointer curStackMap) throws CorruptDataException;
-		
+
 		public U8Pointer getJitStackSlots(J9JITExceptionTablePointer metaData,  VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public void markClassesInInlineRanges(J9JITExceptionTablePointer metaData, WalkState walkState) throws CorruptDataException;
 	}
 
@@ -355,17 +355,17 @@ public class MethodMetaData
 		protected MethodMetaData_29_V0() {
 			super(90,0);
 		}
-		
+
 		public I16 getJitTotalFrameSize(J9JITExceptionTablePointer md)
 				throws CorruptDataException
 		{
 			return new I16(md.totalFrameSize());
 		}
-		
+
 		public VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md)
 				throws CorruptDataException
 		{
-			return md.inlinedCalls();
+			return VoidPointer.cast(md.inlinedCallsOffset());
 		}
 
 		public void jitAddSpilledRegistersForDataResolve(WalkState walkState)
@@ -373,8 +373,8 @@ public class MethodMetaData
 		{
 			UDATAPointer slotCursor = walkState.unwindSP.add(getJitSlotsBeforeSavesInDataResolve());
 			int mapCursor = 0;
-			
-			for (int i = 0; i < J9SW_POTENTIAL_SAVED_REGISTERS; ++i) 
+
+			for (int i = 0; i < J9SW_POTENTIAL_SAVED_REGISTERS; ++i)
 			{
 				walkState.registerEAs[mapCursor++] = slotCursor;
 				slotCursor = slotCursor.add(1);
@@ -383,9 +383,9 @@ public class MethodMetaData
 			swPrintf(walkState, 2, "\t{0} slots skipped before scalar registers", getJitSlotsBeforeSavesInDataResolve());
 			jitPrintRegisterMapArray(walkState, "DataResolve");
 		}
-		
+
 		/* Number of slots of data pushed after the integer registers during data resolves */
-		
+
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
 			if (J9BuildFlags.arch_x86) {
@@ -419,7 +419,7 @@ public class MethodMetaData
 		{
 			throw new UnsupportedOperationException("Not implemented at 2.6");
 		}
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException
 		{
 			UDATA savedGPRs = new UDATA(0), saveOffset = new UDATA(0), lowestRegister = new UDATA(0);
@@ -431,7 +431,7 @@ public class MethodMetaData
 
 			if (J9BuildFlags.arch_x86) {
 				UDATA prologuePushes = new UDATA(getJitProloguePushes(walkState.jitInfo));
-				U8 i = new U8(1); 
+				U8 i = new U8(1);
 
 				if (! prologuePushes.eq(0)) {
 					saveCursor = walkState.bp.sub(  new UDATA(getJitScalarTempSlots(walkState.jitInfo)).add(new UDATA(getJitObjectTempSlots(walkState.jitInfo)).add(prologuePushes)) );
@@ -453,9 +453,9 @@ public class MethodMetaData
 			} else if (J9BuildFlags.arch_power || TRBuildFlags.host_MIPS) {
 				if (J9BuildFlags.arch_power) {
 					/*
-					 * see PPCLinkage for a description of the RSD 
-					 * the save offset is located from bits 18-32 
-					 * so first mask it off to get the bit vector 
+					 * see PPCLinkage for a description of the RSD
+					 * the save offset is located from bits 18-32
+					 * so first mask it off to get the bit vector
 					 * corresponding to the saved GPRS
 					 */
 					savedGPRs = registerSaveDescription.bitAnd(new UDATA(0x1FFFFL));
@@ -472,7 +472,7 @@ public class MethodMetaData
 				if (J9BuildFlags.arch_power) {
 					mapCursor += lowestRegister.intValue(); /* access gpr15 in the vm register state */
 					U8 i = new U8(lowestRegister.add(1));
-					do 
+					do
 					{
 						if (savedGPRs.anyBitsIn(1)) {
 							walkState.registerEAs[mapCursor] = saveCursor;
@@ -534,7 +534,7 @@ public class MethodMetaData
 
 			jitPrintRegisterMapArray(walkState, "Frame");
 		}
-		
+
 		private U8Pointer GET_REGISTER_SAVE_DESCRIPTION_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
 			return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF);
@@ -542,19 +542,19 @@ public class MethodMetaData
 
 		public U16 getJitProloguePushes(J9JITExceptionTablePointer md) throws CorruptDataException
 		{
-			return md.prologuePushes(); 
+			return md.prologuePushes();
 		}
-		
+
 		public I16 getJitScalarTempSlots(J9JITExceptionTablePointer md) throws CorruptDataException
 		{
-			return md.scalarTempSlots(); 
+			return md.scalarTempSlots();
 		}
 
 		public I16 getJitObjectTempSlots(J9JITExceptionTablePointer md) throws CorruptDataException
-		{ 
-			return md.objectTempSlots(); 
+		{
+			return md.objectTempSlots();
 		}
-		
+
 		public UDATA getJitDataResolvePushes() throws CorruptDataException {
 			if (J9BuildFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
@@ -610,7 +610,7 @@ public class MethodMetaData
 				return new UDATA(32);
 			} else if (TRBuildFlags.host_SH4) {
 				/* SH4 data resolve shape
-				   16 integer registers 
+				   16 integer registers
 				*/
 				return new UDATA(16);
 			} else {
@@ -622,39 +622,39 @@ public class MethodMetaData
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC) throws CorruptDataException
 		{
 			JITMaps maps = new JITMaps();
-			
+
 			jitGetMapsFromPC(javaVM, methodMetaData, jitPC, maps);
 			return VoidPointer.cast(maps.stackMap);
 		}
 
 		public J9JITStackAtlasPointer getJitGCStackAtlas(J9JITExceptionTablePointer md) throws CorruptDataException
 		{
-			return J9JITStackAtlasPointer.cast(md.gcStackAtlas());
+			return J9JITStackAtlasPointer.cast(md.gcStackAtlasOffset());
 		}
-		
+
 		public void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC,
 				JITMaps maps) throws CorruptDataException
 		{
 			MapIterator i = new MapIterator();
-			
+
 			/* We subtract one from the jitPC as jitPCs that come in are always pointing at the beginning of the next instruction
 			 * (ie: the return address from the child call).  In the case of trap handlers, the GP handler has already bumped the PC
 			 * forward by one, expecting this -1 to happen.
 			 */
 			UDATA offsetPC = jitPC.sub(methodMetaData.startPC()).sub(1);
-			
-			boolean fourByteOffsets = HAS_FOUR_BYTE_OFFSET(methodMetaData); 
-			
+
+			boolean fourByteOffsets = HAS_FOUR_BYTE_OFFSET(methodMetaData);
+
 			maps.stackMap = PointerPointer.NULL;
 			maps.inlineMap = PointerPointer.NULL;
-			
-			if (methodMetaData.gcStackAtlas().isNull()) { 
+
+			if (J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlasOffset()).isNull()) {
 				return;
 			}
 
 			initializeIterator(i, methodMetaData);
-			
+
 			findMapsAtPC(i, offsetPC, maps, fourByteOffsets);
 		}
 
@@ -708,7 +708,7 @@ public class MethodMetaData
 
 			return i._currentMap;
 		}
-		
+
 		private static UDATA GET_LOW_PC_OFFSET_VALUE(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException
 		{
 			Scalar returnValue = null;
@@ -717,31 +717,31 @@ public class MethodMetaData
 			} else {
 				returnValue = U16Pointer.cast(ADDRESS_OF_LOW_PC_OFFSET_IN_STACK_MAP(fourByteOffset,stackMap)).at(0);
 			}
-			
+
 			return new UDATA(returnValue);
 		}
-		
+
 		private static U32 GET_SIZEOF_BYTECODEINFO_MAP(boolean fourByteOffset)
 		{
 			return new U32(U32.SIZEOF).add(SIZEOF_MAP_OFFSET(fourByteOffset));
 		}
-		
+
 		private static U8Pointer ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset));
 		}
-		
+
 		private static U8Pointer ADDRESS_OF_LOW_PC_OFFSET_IN_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap;
 		}
-		
+
 		@SuppressWarnings("unused")
 		private static U8Pointer ADDRESS_OF_REGISTERMAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(2 * U32.SIZEOF);
 		}
-		
+
 		private static boolean RANGE_NEEDS_FOUR_BYTE_OFFSET(Scalar s)
 		{
 			//#define RANGE_NEEDS_FOUR_BYTE_OFFSET(r)   (((r) >= (USHRT_MAX   )) ? 1 : 0)
@@ -752,38 +752,38 @@ public class MethodMetaData
 		{
 			if (AlgorithmVersion.getVersionOf(AlgorithmVersion.FOUR_BYTE_OFFSETS_VERSION).getAlgorithmVersion() > 0) {
 				if (md.flags().anyBitsIn(JIT_METADATA_FLAGS_USED_FOR_SIZE)) {
-					return (md.flags().anyBitsIn(JIT_METADATA_GC_MAP_32_BIT_OFFSETS));	
+					return (md.flags().anyBitsIn(JIT_METADATA_GC_MAP_32_BIT_OFFSETS));
 				}
 			}
 			return RANGE_NEEDS_FOUR_BYTE_OFFSET(md.endPC().sub(md.startPC()));
 		}
-		
+
 		private static U32 SIZEOF_MAP_OFFSET(boolean fourByteOffset)
 		{
 			return (alignStackMaps || fourByteOffset) ? new U32(4) : new U32(2);
 		}
-		
-		private static boolean IS_BYTECODEINFO_MAP(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException 
+
+		private static boolean IS_BYTECODEINFO_MAP(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException
 		{
 			return ! TR_ByteCodeInfoPointer.cast(ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(fourByteOffset, stackMap))._doNotProfile().eq(0);
 		}
-		
+
 		//#define GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap) ((U_8 *)stackMap + SIZEOF_MAP_OFFSET(fourByteOffset) + 2*sizeof(U_32))
 		private static U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(2 * U32.SIZEOF));
 		}
-		
+
 		/* Note: this differs from the native version in that nextStackMap is returned - not passed by reference */
 		private static U8Pointer GET_NEXT_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap, J9JITStackAtlasPointer atlas) throws CorruptDataException
 		{
 			U8Pointer nextStackMap = stackMap;
-			
+
 			if (IS_BYTECODEINFO_MAP(fourByteOffset, stackMap)) {
 				nextStackMap = nextStackMap.add(GET_SIZEOF_BYTECODEINFO_MAP(fourByteOffset));
 			} else {
 				nextStackMap = GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap);
-				if ( U32Pointer.cast(nextStackMap).at(0).anyBitsIn(INTERNAL_PTR_REG_MASK) && atlas.internalPointerMap().notNull() ) {
+				if ( U32Pointer.cast(nextStackMap).at(0).anyBitsIn(INTERNAL_PTR_REG_MASK) && VoidPointer.cast(atlas.internalPointerMapOffset()).notNull() ) {
 					nextStackMap = nextStackMap.add(nextStackMap.add(4).at(0).add(1));
 				}
 				nextStackMap = nextStackMap.add(3).add(atlas.numberOfMapBytes());
@@ -792,15 +792,15 @@ public class MethodMetaData
 				}
 				nextStackMap = nextStackMap.add(1);
 			}
-			
+
 			return nextStackMap;
 		}
-		
+
 		private void initializeIterator(MapIterator i,
 				J9JITExceptionTablePointer methodMetaData) throws CorruptDataException
 		{
 			i._methodMetaData = methodMetaData;
-			i._stackAtlas = J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlas());
+			i._stackAtlas = J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlasOffset());
 			i._currentStackMap = U8Pointer.NULL;
 			i._currentInlineMap = U8Pointer.NULL;
 			i._nextMap = getFirstStackMap(i._stackAtlas);
@@ -824,7 +824,7 @@ public class MethodMetaData
 		{
 			return VoidPointer.cast(U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)));
 		}
-		
+
 		private VoidPointer getFirstInlinedCallSiteWithByteCodeInfo(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer byteCodeInfo) throws CorruptDataException
 		{
 			if (byteCodeInfo.isNull()) {
@@ -837,13 +837,13 @@ public class MethodMetaData
 
 			return getNotUnloadedInlinedCallSiteArrayElement(methodMetaData, cix);
 		}
-		
+
 
 		private U32 sizeOfInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData) throws CorruptDataException
 		{
-			return new U32(TR_InlinedCallSite.SIZEOF).add(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlas()).numberOfMapBytes());
+			return new U32(TR_InlinedCallSite.SIZEOF).add(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlasOffset()).numberOfMapBytes());
 		}
-		
+
 		private U8Pointer getInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, I32 cix) throws CorruptDataException
 		{
 			U8Pointer inlinedCallSiteArray = U8Pointer.cast(getJitInlinedCallInfo(methodMetaData));
@@ -858,7 +858,7 @@ public class MethodMetaData
 		{
 			return UDATA.cast(method).bitNot().eq(0); /* d142150: check for method==-1 in a way that works on ZOS */
 		}
-		
+
 		private  VoidPointer getNotUnloadedInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, I32 cix) throws CorruptDataException
 		{
 			VoidPointer inlinedCallSite = VoidPointer.cast(getInlinedCallSiteArrayElement(methodMetaData, cix));
@@ -890,29 +890,29 @@ public class MethodMetaData
 			if (hasMoreInlinedMethods(inlinedCallSite)) {
 				return getNotUnloadedInlinedCallSiteArrayElement(methodMetaData, new I32(getByteCodeInfo(inlinedCallSite)._callerIndex()));
 			}
-			return VoidPointer.NULL; 
+			return VoidPointer.NULL;
 		}
-		
+
 		public boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			TR_ByteCodeInfoPointer byteCodeInfo = getByteCodeInfo(inlinedCallSite);
 			return ! byteCodeInfo._callerIndex().lt(new I32(0));
 		}
-		
+
 		private static TR_ByteCodeInfoPointer getByteCodeInfo(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			return TR_ByteCodeInfoPointer.cast(TR_InlinedCallSitePointer.cast(inlinedCallSite)._byteCodeInfoEA());
 		}
-		
+
 		public VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			return TR_InlinedCallSitePointer.cast(inlinedCallSite)._methodInfo();
 		}
-		
+
 		public UDATA getCurrentByteCodeIndexAndIsSameReceiver(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer currentInlinedCallSite, boolean[] isSameReceiver) throws CorruptDataException
 		{
 			TR_ByteCodeInfoPointer byteCodeInfo = TR_ByteCodeInfoPointer.cast(getByteCodeInfoFromStackMap(methodMetaData, stackMap));
-			
+
 			if (currentInlinedCallSite.notNull()) {
 				VoidPointer inlinedCallSite = getFirstInlinedCallSiteWithByteCodeInfo(methodMetaData, stackMap, VoidPointer.cast(byteCodeInfo));
 				if (! inlinedCallSite.eq(currentInlinedCallSite))
@@ -939,7 +939,7 @@ public class MethodMetaData
 
 			if (isSameReceiver != null) {
 				isSameReceiver[0] = ! byteCodeInfo._isSameReceiver().eq(0);
-			}	
+			}
 			return new UDATA(byteCodeInfo._byteCodeIndex());
 		}
 
@@ -948,14 +948,14 @@ public class MethodMetaData
 		{
 			return VoidPointer.cast(ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(HAS_FOUR_BYTE_OFFSET(methodMetaData), U8Pointer.cast(stackMap)));
 		}
-		
+
 		public UDATAPointer getObjectArgScanCursor(WalkState walkState) throws CorruptDataException
 		{
-			return UDATAPointer.cast(U8Pointer.cast(walkState.bp).addOffset(J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlas()).parmBaseOffset()));
+			return UDATAPointer.cast(U8Pointer.cast(walkState.bp).addOffset(J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlasOffset()).parmBaseOffset()));
 		}
-		
+
 		public U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException
-		{ 
+		{
 			/* deprecated */
 			return U8Pointer.NULL;
 		}
@@ -968,8 +968,8 @@ public class MethodMetaData
 		public U32 getJitRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 		{
 			return U32Pointer.cast(GET_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(methodMetaData), stackMap)).at(0);
-		}		
-		
+		}
+
 		public U8Pointer getNextDescriptionCursor(J9JITExceptionTablePointer metadata, VoidPointer stackMap, U8Pointer jitDescriptionCursor) throws CorruptDataException
 		{
 			throw new UnsupportedOperationException("Not implemented at 2.6");
@@ -977,26 +977,26 @@ public class MethodMetaData
 
 		public U8Pointer getJitInternalPointerMap(J9JITStackAtlasPointer sa) throws CorruptDataException
 		{
-			return sa.internalPointerMap();
+			return U8Pointer.cast(sa.internalPointerMapOffset());
 		}
-		
+
 		public U16 getJitNumberOfParmSlots(J9JITStackAtlasPointer sa) throws CorruptDataException
 		{
 			return sa.numberOfParmSlots();
 		}
-		
+
 		/* Note - unlike the native version of this function, we don't mutate the jitDescriptionCursor */
 		public U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException
 		{
 			return jitDescriptionCursor.at(0);
 		}
-		
+
 		public UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException
 		{
 			//return (UDATA *) (((U_8 *) walkState->bp) + ((J9JITStackAtlas *)walkState->jitInfo->gcStackAtlas)->localBaseOffset);
-			return walkState.bp.addOffset( J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlas()).localBaseOffset() );
+			return walkState.bp.addOffset( J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlasOffset()).localBaseOffset() );
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed register arguments for recompilation resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1034,7 +1034,7 @@ public class MethodMetaData
 				1:		r2 (arg register)
 				2:		r1 (arg register)
 				3:		??							<== unwindSP points here
-				4:		??											
+				4:		??
 				5:		??
 				6:		64 bytes FP register saves
 				7:		temp1
@@ -1079,7 +1079,7 @@ public class MethodMetaData
 				return 0;
 			}
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed register arguments for virtual/interface method resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1121,7 +1121,7 @@ public class MethodMetaData
 				1: saved r6
 				2: saved r5
 				3: saved r4
-				4: return address                <== unwindSP points here    
+				4: return address                <== unwindSP points here
 				5: saved resolved data
 				6: <last argument to method>     <== unwindSP should point here
 				*/
@@ -1130,7 +1130,7 @@ public class MethodMetaData
 				return 0;
 			}
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed resolve arguments for static/special method resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1166,7 +1166,7 @@ public class MethodMetaData
 			UDATA registerMap;
 			U8 numInternalPtrMapBytes, numDistinctPinningArrays, i;
 			UDATA parmStackMap;
-			VoidPointer internalPointerMap = VoidPointer.cast(gcStackAtlas.internalPointerMap());
+			VoidPointer internalPointerMap = VoidPointer.cast(gcStackAtlas.internalPointerMapOffset());
 			U8Pointer tempJitDescriptionCursor = U8Pointer.cast(internalPointerMap);
 			I16 indexOfFirstInternalPtr;
 			I16 offsetOfFirstInternalPtr;
@@ -1204,7 +1204,7 @@ public class MethodMetaData
 			indexOfFirstInternalPtr = new I16(U16Pointer.cast(tempJitDescriptionCursor).at(0));
 
 			swPrintf(walkState, 6, "Address {0}", tempJitDescriptionCursor.getHexAddress());
-			
+
 			tempJitDescriptionCursor = tempJitDescriptionCursor.add(2);
 
 			swPrintf(walkState, 6,"Index of first internal ptr {0}", indexOfFirstInternalPtr);
@@ -1242,20 +1242,20 @@ public class MethodMetaData
 				IDATA displacement = new IDATA(0);
 
 
-				swPrintf(walkState, 6, "Before object slot walk &address : {0} address : {1} bp {2} offset of first internal ptr {3}", 
-						currPinningArrayCursor.getHexAddress(), 
-						oldPinningArrayAddress.getHexAddress(), 
-						walkState.bp.getHexAddress(), 
+				swPrintf(walkState, 6, "Before object slot walk &address : {0} address : {1} bp {2} offset of first internal ptr {3}",
+						currPinningArrayCursor.getHexAddress(),
+						oldPinningArrayAddress.getHexAddress(),
+						walkState.bp.getHexAddress(),
 						offsetOfFirstInternalPtr);
 				walkState.callBacks.objectSlotWalkFunction(walkState.walkThread, walkState, currPinningArrayCursor, VoidPointer.cast(currPinningArrayCursor));
 				newPinningArrayAddress = J9ObjectPointer.cast( currPinningArrayCursor.at(0) );
 				displacement = new IDATA( UDATA.cast(newPinningArrayAddress).sub(UDATA.cast(oldPinningArrayAddress)));
 				walkState.slotIndex++;
 
-				swPrintf(walkState, 6, "After object slot walk for pinning array with &address : {0} old address {1} new address {2} displacement {3}", 
-						currPinningArrayCursor.getHexAddress(), 
-						oldPinningArrayAddress.getHexAddress(), 
-						newPinningArrayAddress.getHexAddress(), 
+				swPrintf(walkState, 6, "After object slot walk for pinning array with &address : {0} old address {1} new address {2} displacement {3}",
+						currPinningArrayCursor.getHexAddress(),
+						oldPinningArrayAddress.getHexAddress(),
+						newPinningArrayAddress.getHexAddress(),
 						displacement);
 
 
@@ -1272,13 +1272,13 @@ public class MethodMetaData
 					{
 						U8 internalPtrAuto = tempJitDescriptionCursor.at(0);
 						tempJitDescriptionCursor = tempJitDescriptionCursor.add(1);
-						
+
 						PointerPointer currInternalPtrCursor = PointerPointer.cast(walkState.bp.addOffset(offsetOfFirstInternalPtr.add( internalPtrAuto.intValue() * UDATA.SIZEOF )));
 
-						swPrintf(walkState, 6, "For pinning array {0} internal pointer auto {1} old address {2} displacement {3}", 
-								currPinningArrayIndex, 
-								internalPtrAuto, 
-								currInternalPtrCursor.at(0).getHexAddress(), 
+						swPrintf(walkState, 6, "For pinning array {0} internal pointer auto {1} old address {2} displacement {3}",
+								currPinningArrayIndex,
+								internalPtrAuto,
+								currInternalPtrCursor.at(0).getHexAddress(),
 								displacement);
 
 						/*
@@ -1305,11 +1305,11 @@ public class MethodMetaData
 						U8 k;
 
 						registerMap = registerMap.bitAnd(J9SW_REGISTER_MAP_MASK);
-						
+
 
 						swPrintf(walkState, 6, "\tJIT-RegisterMap = {0}", registerMap);
 						tempJitDescriptionCursorForRegs = U8Pointer.cast(stackMap);
-					
+
 						/* Skip the register map and register save description word */
 						tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(8);
 
@@ -1337,7 +1337,7 @@ public class MethodMetaData
 							if (currPinningArrayIndexForRegister.eq(currPinningArrayIndex))
 							{
 								int mapCursor;
-								
+
 								if (J9SW_REGISTER_MAP_WALK_REGISTERS_LOW_TO_HIGH) {
 									mapCursor = 0;
 								} else {
@@ -1395,31 +1395,31 @@ public class MethodMetaData
 		{
 			VoidPointer stackMap;
 			PointerPointer stackAllocMap;
-			
-			if (methodMetaData.gcStackAtlas().isNull()) {
+
+			if (J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlasOffset()).isNull()) {
 				return VoidPointer.NULL;
 			}
-			
+
 			if (curStackMap.notNull()) {
 				stackMap = curStackMap;
 			} else {
 				stackMap = getStackMapFromJitPC(javaVM, methodMetaData, jitPC);
 			}
-			
-			stackAllocMap = PointerPointer.cast(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlas()).stackAllocMap());
-			
+
+			stackAllocMap = PointerPointer.cast(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlasOffset()).stackAllocMapOffset());
+
 			if (stackAllocMap.notNull()) {
 				UDATA returnValue;
-				
+
 				if (UDATAPointer.cast(stackAllocMap.at(0)).eq(stackMap)) {
 					return VoidPointer.NULL;
 				}
-				
+
 				returnValue = UDATA.cast(stackAllocMap).add(UDATA.SIZEOF);
-				
+
 				return VoidPointer.cast(returnValue);
 			}
-			
+
 			return VoidPointer.NULL;
 		}
 
@@ -1427,17 +1427,17 @@ public class MethodMetaData
 				VoidPointer stackMap) throws CorruptDataException
 		{
 			U8Pointer cursor = GET_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(metaData), stackMap);
-			
+
 			if ( U32Pointer.cast(cursor).at(0).anyBitsIn(INTERNAL_PTR_REG_MASK) && getJitInternalPointerMap(getJitGCStackAtlas(metaData)).notNull() ) {
 				cursor = cursor.add( cursor.add(4).at(0).add(1));
 			}
-			
+
 			cursor = cursor.add(4);
-			
+
 			return cursor;
 		}
-		
-		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap) 
+
+		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
 			return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 2));
 		}
@@ -1446,15 +1446,15 @@ public class MethodMetaData
 		{
 			U32 sizeOfInlinedCallSites, numInlinedCallSites = new U32(0);
 
-			if (methodMetaData.inlinedCalls().notNull())
+			if (VoidPointer.cast(methodMetaData.inlinedCallsOffset()).notNull())
 			{
-				sizeOfInlinedCallSites = new U32(UDATA.cast(methodMetaData.gcStackAtlas()).sub(UDATA.cast(methodMetaData.inlinedCalls())));
+				sizeOfInlinedCallSites = new U32(methodMetaData.gcStackAtlasOffset().sub(methodMetaData.inlinedCallsOffset()));
 
 				numInlinedCallSites = new U32(sizeOfInlinedCallSites.longValue() / sizeOfInlinedCallSiteArrayElement(methodMetaData).longValue());
 			}
 			return numInlinedCallSites;
 		}
-		
+
 		private U8Pointer getInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, int cix) throws CorruptDataException
 		{
 			U8Pointer inlinedCallSiteArray = U8Pointer.cast(getJitInlinedCallInfo(methodMetaData));
@@ -1464,7 +1464,7 @@ public class MethodMetaData
 
 			return U8Pointer.NULL;
 		}
-		
+
 		private boolean isPatchedValue(J9MethodPointer m)
 		{
 			if ((J9BuildFlags.arch_power && m.anyBitsIn(0x1)) || UDATA.cast(m).bitNot().eq(0)) {
@@ -1474,21 +1474,21 @@ public class MethodMetaData
 			return false;
 		}
 
-		
+
 		public void markClassesInInlineRanges(J9JITExceptionTablePointer methodMetaData, WalkState walkState)
 				throws CorruptDataException
 		{
 			J9MethodPointer savedMethod = walkState.method;
 			J9ConstantPoolPointer savedCP = walkState.constantPool;
-			
+
 			U32 numCallSites = getNumInlinedCallSites(methodMetaData);
-			
+
 			int i = 0;
 			for (i=0; i<numCallSites.intValue(); i++)
 			{
 				U8Pointer inlinedCallSite = getInlinedCallSiteArrayElement(methodMetaData, i);
 				J9MethodPointer inlinedMethod = J9MethodPointer.cast(getInlinedMethod(VoidPointer.cast(inlinedCallSite)));
-				
+
 				if (!isPatchedValue(inlinedMethod))
 				{
 					walkState.method = inlinedMethod;
@@ -1501,7 +1501,7 @@ public class MethodMetaData
 			walkState.constantPool = savedCP;
 
 		}
-		
+
 	}
 
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/JitMetadataFromPcCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/JitMetadataFromPcCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,21 +30,25 @@ import com.ibm.j9ddr.tools.ddrinteractive.Context;
 import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
 import com.ibm.j9ddr.vm29.j9.DataType;
 import com.ibm.j9ddr.vm29.j9.JITLook;
+import com.ibm.j9ddr.vm29.pointer.VoidPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ConstantPoolPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JITExceptionTablePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9MethodPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9MethodHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class JitMetadataFromPcCommand extends Command 
+public class JitMetadataFromPcCommand extends Command
 {
 	public JitMetadataFromPcCommand()
 	{
 		addCommand("jitmetadatafrompc", "<pc>", "Show jit method metadata for PC");
 	}
-	
-	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException
 	{
 		try {
 			UDATA searchValue = new UDATA(Long.decode(args[0]));
@@ -60,15 +64,15 @@ public class JitMetadataFromPcCommand extends Command
 
 	}
 
-	void dbgext_j9jitexceptiontable(PrintStream out, J9JITExceptionTablePointer parm) throws CorruptDataException 
+	void dbgext_j9jitexceptiontable(PrintStream out, J9JITExceptionTablePointer parm) throws CorruptDataException
 	{
 		/* print individual fields */
 		CommandUtils.dbgPrint(out, "J9JITExceptionTable at %s {\n", parm.getHexAddress());
-		CommandUtils.dbgPrint(out, "    struct J9UTF8* className = !j9utf8 %s   // %s\n", parm.className().getHexAddress(), parm.className().isNull() ? "NULL" : J9UTF8Helper.stringValue(parm.className()));
-		CommandUtils.dbgPrint(out, "    struct J9UTF8* methodName = !j9utf8 %s   // %s\n", parm.methodName().getHexAddress(), parm.methodName().isNull() ? "NULL" : J9UTF8Helper.stringValue(parm.methodName()));
-		CommandUtils.dbgPrint(out, "    struct J9UTF8* methodSignature = !j9utf8 %s   // %s\n", parm.methodSignature().getHexAddress(), parm.methodSignature().isNull() ? "NULL" :J9UTF8Helper.stringValue(parm.methodSignature()));
-		CommandUtils.dbgPrint(out, "    struct J9ConstantPool* constantPool = !j9constantpool %s \n", parm.constantPool().getHexAddress());
-		CommandUtils.dbgPrint(out, "    struct J9Method* ramMethod = !j9method %s   // %s\n", parm.ramMethod().getHexAddress(), J9MethodHelper.getName(parm.ramMethod()));
+		CommandUtils.dbgPrint(out, "    struct J9UTF8* className = !j9utf8 %s   // %s\n", J9UTF8Pointer.cast(parm.classNameOffset()).getHexAddress(), J9UTF8Pointer.cast(parm.classNameOffset()).isNull() ? "NULL" : J9UTF8Helper.stringValue(J9UTF8Pointer.cast(parm.classNameOffset())));
+		CommandUtils.dbgPrint(out, "    struct J9UTF8* methodName = !j9utf8 %s   // %s\n", J9UTF8Pointer.cast(parm.methodNameOffset()).getHexAddress(), J9UTF8Pointer.cast(parm.methodNameOffset()).isNull() ? "NULL" : J9UTF8Helper.stringValue(J9UTF8Pointer.cast(parm.methodNameOffset())));
+		CommandUtils.dbgPrint(out, "    struct J9UTF8* methodSignature = !j9utf8 %s   // %s\n", J9UTF8Pointer.cast(parm.methodSignatureOffset()).getHexAddress(), J9UTF8Pointer.cast(parm.methodSignatureOffset()).isNull() ? "NULL" :J9UTF8Helper.stringValue(J9UTF8Pointer.cast(parm.methodSignatureOffset())));
+		CommandUtils.dbgPrint(out, "    struct J9ConstantPool* constantPool = !j9constantpool %s \n", J9ConstantPoolPointer.cast(parm.constantPoolOffset()).getHexAddress());
+		CommandUtils.dbgPrint(out, "    struct J9Method* ramMethod = !j9method %s   // %s\n", J9MethodPointer.cast(parm.ramMethodOffset()).getHexAddress(), J9MethodHelper.getName(J9MethodPointer.cast(parm.ramMethodOffset())));
 		CommandUtils.dbgPrint(out, "    UDATA parm.startPC = %s;\n", parm.startPC().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.endWarmPC = %s;\n", parm.endWarmPC().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.startColdPC = %s;\n", parm.startColdPC().getHexValue());
@@ -82,19 +86,19 @@ public class JitMetadataFromPcCommand extends Command
 		CommandUtils.dbgPrint(out, "    U_16 parm.numExcptionRanges = %s;\n", parm.numExcptionRanges().getHexValue());
 		CommandUtils.dbgPrint(out, "    I_32 parm.size = %s;\n", parm.size().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.registerSaveDescription = %s;\n", parm.registerSaveDescription().getHexValue());
-		CommandUtils.dbgPrint(out, "    void* gcStackAtlas = !void %s \n", parm.gcStackAtlas().getHexAddress());
-		CommandUtils.dbgPrint(out, "    void* inlinedCalls = !void %s \n", parm.inlinedCalls().getHexAddress());
+		CommandUtils.dbgPrint(out, "    void* gcStackAtlas = !void %s \n", VoidPointer.cast(parm.gcStackAtlasOffset()).getHexAddress());
+		CommandUtils.dbgPrint(out, "    void* inlinedCalls = !void %s \n", VoidPointer.cast(parm.inlinedCallsOffset()).getHexAddress());
 		CommandUtils.dbgPrint(out, "    void* bodyInfo = !void %s \n", parm.bodyInfo().getHexAddress());
-		CommandUtils.dbgPrint(out, "    struct J9JITExceptionTable* nextMethod = !j9jitexceptiontable %s \n", parm.nextMethod().getHexAddress());
-		CommandUtils.dbgPrint(out, "    struct J9JITExceptionTable* prevMethod = !j9jitexceptiontable %s \n", parm.prevMethod().getHexAddress());
+		CommandUtils.dbgPrint(out, "    struct J9JITExceptionTable* nextMethod = !j9jitexceptiontable %s \n", J9JITExceptionTablePointer.cast(parm.nextMethodOffset()).getHexAddress());
+		CommandUtils.dbgPrint(out, "    struct J9JITExceptionTable* prevMethod = !j9jitexceptiontable %s \n", J9JITExceptionTablePointer.cast(parm.prevMethodOffset()).getHexAddress());
 		CommandUtils.dbgPrint(out, "    void* debugSlot1 = !void %s \n", parm.debugSlot1().getHexAddress());
 		CommandUtils.dbgPrint(out, "    void* debugSlot2 = !void %s \n", parm.debugSlot2().getHexAddress());
-		CommandUtils.dbgPrint(out, "    void* osrInfo = !void %s \n", parm.osrInfo().getHexAddress());
+		CommandUtils.dbgPrint(out, "    void* osrInfo = !void %s \n", VoidPointer.cast(parm.osrInfoOffset()).getHexAddress());
 		CommandUtils.dbgPrint(out, "    void* runtimeAssumptionList = !void %s \n", parm.runtimeAssumptionList().getHexAddress());
 		CommandUtils.dbgPrint(out, "    I_32 parm.hotness = %s;\n", parm.hotness().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.codeCacheAlloc = %s;\n", parm.codeCacheAlloc().getHexValue());
-		CommandUtils.dbgPrint(out, "    void* gpuCode = !void %s \n", parm.gpuCode().getHexAddress());
-		CommandUtils.dbgPrint(out, "    void* riData = !void %s \n", parm.riData().getHexAddress());
+		CommandUtils.dbgPrint(out, "    void* gpuCode = !void %s \n", VoidPointer.cast(parm.gpuCodeOffset()).getHexAddress());
+		CommandUtils.dbgPrint(out, "    void* riData = !void %s \n", VoidPointer.cast(parm.riDataOffset()).getHexAddress());
 		CommandUtils.dbgPrint(out, "}\n");
 	}
 }


### PR DESCRIPTION
This patch modifies DDR to deal with offset fields in the JIT metadata that were formerly represented by pointers. This fix breaks DDR's backward compatibility with the older JIT metadata shape and is temporary until the backward compatible solution is ready.

Fixes #10586