### PR TITLE
Define new ILGen optimization to induce OSR for unresolved value types

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1401,7 +1401,8 @@ J9::Compilation::pendingPushLivenessDuringIlgen()
 bool
 J9::Compilation::isOSRAllowedForOperationsRequiringRecompilation()
    {
-   return self()->getOption(TR_EnableOSR) && (self()->getOSRMode() == TR::voluntaryOSR)
+   return !self()->isDisabled(OMR::handleRecompilationOps)
+          && self()->getOption(TR_EnableOSR) && (self()->getOSRMode() == TR::voluntaryOSR)
           && self()->supportsInduceOSR() && self()->allowRecompilation()
           && !self()->isPeekingMethod() && self()->isOSRTransitionTarget(TR::postExecutionOSR);
    }

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1399,6 +1399,14 @@ J9::Compilation::pendingPushLivenessDuringIlgen()
    }
 
 bool
+J9::Compilation::isOSRAllowedForOperationsRequiringRecompilation()
+   {
+   return self()->getOption(TR_EnableOSR) && (self()->getOSRMode() == TR::voluntaryOSR)
+          && self()->supportsInduceOSR() && self()->allowRecompilation()
+          && !self()->isPeekingMethod() && self()->isOSRTransitionTarget(TR::postExecutionOSR);
+   }
+
+bool
 J9::Compilation::supportsQuadOptimization()
    {
    if (self()->isDLT() || self()->getOption(TR_FullSpeedDebug))

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -173,6 +173,13 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool pendingPushLivenessDuringIlgen();
 
+   /**
+    * Check whether OSR can be induced and recompilation requested
+    * for operations for which the JIT does not yet have enough
+    * information to generate correct code.
+    */
+   bool isOSRAllowedForOperationsRequiringRecompilation();
+
    TR::list<TR_ExternalValueProfileInfo*> &getExternalVPInfos() { return _externalVPInfoList; }
 
    TR_ValueProfileInfoManager *getValueProfileInfoManager()             { return _vpInfoManager;}

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -138,7 +138,7 @@ private:
    TR::Node *    genInvokeDirect(TR::SymbolReference *symRef){ return genInvoke(symRef, NULL); }
    TR::Node *    genInvokeWithVFTChild(TR::SymbolReference *);
    TR::Node *    getReceiverFor(TR::SymbolReference *);
-   void          prepareUnresolvedValueTypeOSRPoint();
+   void          prepareUnresolvedValueTypeOSRPoint(const char *bytecodeName, const char* refType);
    void          stashArgumentsForOSR(TR_J9ByteCode byteCode);
    /** \brief
     *    Tell if the current bytecode is at start of a basic block

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -132,11 +132,13 @@ private:
 
    bool         runMacro(TR::SymbolReference *);
    bool         runFEMacro(TR::SymbolReference *);
+
    TR::Node *    genInvoke(TR::SymbolReference *, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver = NULL);
 
    TR::Node *    genInvokeDirect(TR::SymbolReference *symRef){ return genInvoke(symRef, NULL); }
    TR::Node *    genInvokeWithVFTChild(TR::SymbolReference *);
    TR::Node *    getReceiverFor(TR::SymbolReference *);
+   void          prepareUnresolvedValueTypeOSRPoint();
    void          stashArgumentsForOSR(TR_J9ByteCode byteCode);
    /** \brief
     *    Tell if the current bytecode is at start of a basic block
@@ -234,7 +236,7 @@ private:
    void         genMonitorExit(bool);
    TR_OpaqueClassBlock *loadValueClass(int32_t classCpIndex);
    void         genDefaultValue(uint16_t classCpIndex);
-   void         genDefaultValue(TR_OpaqueClassBlock *valueTypeClass);
+   void         genDefaultValue(TR::SymbolReference *valueClassSymRef);
    void         genWithField(uint16_t fieldCpIndex);
    void         genWithField(TR::SymbolReference *, TR_OpaqueClassBlock *);
    void         genFlattenableWithField(uint16_t, TR_OpaqueClassBlock *);

--- a/runtime/compiler/optimizer/HandleRecompilationOps.cpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.cpp
@@ -20,12 +20,235 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <stdint.h>
+#include "env/FrontEnd.hpp"
+#include "env/j9method.h"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/CfgEdge.hpp"
 #include "optimizer/HandleRecompilationOps.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
 
 int32_t
 TR_HandleRecompilationOps::perform()
    {
+   _enableTransform = true;
+
+   if (trace())
+      {
+      traceMsg(comp(), "Entering HandleRecompilationOps\n");
+      }
+
+   // The following series of tests check whether voluntary OSR is allowed and that recompilation is allowed.
+   // If not, _enableTransform is set to false, but the optimizer still checks for situations in which it
+   // would like to induce OSR.  If any of those situations are encountered with _enableTransform set to
+   // false, the compilation will abort, as correct code generation for those situations requires OSR to be
+   // induced.
+   //
+   if (comp()->getOption(TR_DisableOSR))
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Disabling Handle Recompilation Operations as OSR is disabled\n");
+         }
+
+      _enableTransform = false;
+      }
+
+   if (comp()->getHCRMode() != TR::osr)
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Disabling Handle Recompilation Operations as HCR mode is not OSR\n");
+         }
+
+      _enableTransform = false;
+      }
+
+   if (comp()->getOSRMode() == TR::involuntaryOSR)
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Disabling Handle Recompilation Operations as OSR mode is involuntary\n");
+         }
+
+      _enableTransform = false;
+      }
+
+   if (!comp()->supportsInduceOSR())
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Disabling Handle Recompilation Operations as induceOSR is not supported\n");
+         }
+
+      _enableTransform = false;
+      }
+
+   if (!comp()->allowRecompilation())
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Disabling Handle Recompilation Operations as recompilation is not permitted\n");
+         }
+
+      _enableTransform = false;
+      }
+
+   for (TR::TreeTop *tt = comp()->getStartTree(); tt != NULL; tt = tt->getNextTreeTop())
+      {
+      TR::Node *node = tt->getNode();
+      visitNode(tt, node);
+      }
+
+   if (_enableTransform && trace())
+     {
+     traceMsg(comp(), "Exiting HandleRecompilationOps\n");
+     }
+
    return 0;
+   }
+
+bool
+TR_HandleRecompilationOps::resolveCHKGuardsValueTypeOperation(TR::TreeTop *currTree, TR::Node *node)
+   {
+   TR::Node *resolveChild = node->getFirstChild();
+
+   if (resolveChild->getOpCodeValue() == TR::loadaddr)
+      {
+      // Check whether the ResolveCHK guards a loadaddr that is used in newvalue
+      // operation.
+      //
+      TR::SymbolReference *loadAddrSymRef = resolveChild->getSymbolReference();
+
+      if (loadAddrSymRef->isUnresolved())
+         {
+         for (TR::TreeTop *nextTree = currTree->getNextTreeTop();
+              nextTree != NULL && nextTree->getNode()->getOpCodeValue() != TR::BBEnd;
+              nextTree = nextTree->getNextTreeTop())
+            {
+            TR::Node *nextNode = nextTree->getNode();
+            if (nextNode->getOpCode().isTreeTop() && nextNode->getNumChildren() > 0)
+               {
+               nextNode = nextNode->getFirstChild();
+               }
+
+            if (nextNode->getOpCodeValue() == TR::newvalue)
+               {
+               TR::Node *classAddr = nextNode->getFirstChild();
+
+               if (classAddr == resolveChild
+                   || (classAddr->getOpCodeValue() == TR::loadaddr
+                       && classAddr->getSymbolReference() == loadAddrSymRef))
+                  {
+                  return true;
+                  }
+               }
+            }
+         }
+      }
+   else if (resolveChild->getOpCode().isLoadVarOrStore() && resolveChild->getOpCode().isIndirect())
+      {
+      // Check whether the ResolveCHK guards a load or store operation on a field that is a Q type (value type)
+      //
+      TR::SymbolReference *symRef = resolveChild->getSymbolReference();
+
+      if (symRef->getCPIndex() != -1 && static_cast<TR_ResolvedJ9Method*>(_methodSymbol->getResolvedMethod())->isFieldQType(symRef->getCPIndex()))
+         {
+         return true;
+         }
+      }
+
+   return false;
+   }
+
+void
+TR_HandleRecompilationOps::visitNode(TR::TreeTop *currTree, TR::Node *node)
+   {
+   TR::ILOpCode opcode = node->getOpCode();
+
+   // Is this a ResolveCHK or ResolveAndNULLCHK that guards a value type operation?
+   //
+   if (opcode.isResolveCheck() && resolveCHKGuardsValueTypeOperation(currTree, node))
+      {
+      // We couldn't have found a value type operation if value types are not enabled.
+      // The matching performed by resolveCHKGuardsValueTypeOperation must be in error if
+      // value types are not enabled.
+      //
+      TR_ASSERT_FATAL(TR::Compiler->om.areValueTypesEnabled(), "TR_HandleRecompilationOps thought node n%dn [%p] was part of a value types operation, but value types are not enabled.\n", node->getGlobalIndex(), node);
+
+      if (_enableTransform
+          && performTransformation(comp(), "%sInserting induceOSR call after ResolveCHK node n%dn [%p]\n", optDetailString(), node->getGlobalIndex(), node))
+         {
+         TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(node->getByteCodeInfo().getCallerIndex(), _methodSymbol);
+
+         if (comp()->getOption(TR_TraceILGen))
+            {
+            traceMsg(comp(), "Preparing to generate induceOSR for value type operation guarded by node n%dn [%p]\n", node->getGlobalIndex(), node);
+            }
+
+         TR::Node *branchNode = TR::Node::create(node, TR::Goto, 0);
+         TR::TreeTop *branchTT = TR::TreeTop::create(comp(), branchNode);
+         TR::TreeTop *lastTT = NULL;
+
+         // Clean up trees following the point at which the branch to the induceOSR will be inserted,
+         // as they will not be executed
+         //
+         TR::TreeTop *cleanupTT = currTree->getNextTreeTop();
+         while (cleanupTT)
+            {
+            TR::Node *cleanupNode = cleanupTT->getNode();
+            if (((cleanupNode->getOpCodeValue() == TR::athrow)
+                 && cleanupNode->throwInsertedByOSR())
+                || (cleanupNode->getOpCodeValue() == TR::BBEnd))
+               {
+               break;
+               }
+
+            TR::TreeTop *nextTT = cleanupTT->getNextTreeTop();
+            currTree->join(nextTT);
+            cleanupNode->recursivelyDecReferenceCount();
+            cleanupTT = nextTT;
+            }
+
+         TR_ASSERT_FATAL(_methodSymbol->induceOSRAfterAndRecompile(currTree, node->getByteCodeInfo(), branchTT, false, 0, &lastTT), "Unable to generate induce OSR");
+         node->setSymbolReference(getSymRefTab()->findOrCreateResolveCheckSymbolRef(_methodSymbol));
+         }
+      else
+         {
+         // The optimization has been disabled either explicitly or because OSR is disabled or recompilation
+         // is not allowed.  Emit a static debug counter to track the failure and abort the compilation,
+         // as correct code generation will not be possible.
+         //
+         if (comp()->getOption(TR_TraceILGen))
+            {
+            traceMsg(comp(), "   Encountered ResolveCHK or ResolveAndNULLCHK node n%dn [%p], but cannot induce OSR.  Aborting compilation\n", node->getGlobalIndex(), node);
+            }
+
+         TR_ByteCodeInfo nodeBCI = node->getByteCodeInfo();
+
+         if (nodeBCI.getCallerIndex() == -1)
+            {
+            TR::DebugCounter::incStaticDebugCounter(comp(),
+               TR::DebugCounter::debugCounterName(comp(), "handleRecompilationOps.abort/(%s)/bc=%d",
+                                                  comp()->signature(), nodeBCI.getByteCodeIndex()));
+            }
+         else
+            {
+            TR::DebugCounter::incStaticDebugCounter(comp(),
+               TR::DebugCounter::debugCounterName(comp(), "handleRecompilationOps.abort/(%s)/bc=%d/root=(%s)",
+                                                  comp()->getInlinedResolvedMethod(nodeBCI.getCallerIndex())->signature(trMemory()),
+                                                  nodeBCI.getByteCodeIndex(), comp()->signature()));
+            }
+
+         comp()->failCompilation<TR::UnsupportedValueTypeOperation>("TR_HandleRecompilationOps encountered ResolveCHK or ResolveAndNULLCHK in node n%dn [%p] guarding value type operation, but transformation is not enabled", node->getGlobalIndex(), node);
+         }
+      }
    }
 
 const char *

--- a/runtime/compiler/optimizer/HandleRecompilationOps.cpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.cpp
@@ -189,6 +189,16 @@ TR_HandleRecompilationOps::visitTree(TR::TreeTop *currTree)
             cleanupTT = nextTT;
             }
 
+         TR::Block *currBlock = currTree->getEnclosingBlock();
+         TR::CFG *cfg = comp()->getFlowGraph();
+
+         // Inserting an unconditional branch at the end of the current block,
+         // so existing successors should be removed from the CFG
+         for (auto nextEdge = currBlock->getSuccessors().begin(); nextEdge != currBlock->getSuccessors().end();)
+            {
+            cfg->removeEdge(*(nextEdge++));
+            }
+
          if (!_methodSymbol->induceOSRAfterAndRecompile(currTree, node->getByteCodeInfo(), branchTT, false, 0, &lastTT))
             {
             if (trace())

--- a/runtime/compiler/optimizer/HandleRecompilationOps.hpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.hpp
@@ -24,19 +24,41 @@
 #define HANDLERECOMPILATINOOPS_INCL
 
 #include <stdint.h>
+#include "infra/Cfg.hpp"
+#include "infra/CfgEdge.hpp"
+#include "infra/CfgNode.hpp"
 #include "optimizer/Optimization.hpp"
 #include "optimizer/OptimizationManager.hpp"
 
+/**
+ * The \c TR_HandleRecompilationOps optimization is an IL generation
+ * optimization whose purpose is to detect situations in which IL generation
+ * is unable to generate trees that correctly represent the semantics of
+ * a particular operation.  In such cases, the optimization will generate an
+ * OSR requesting recompilation.  This relies on voluntary OSR and
+ * recompilation both being enabled, as well as being possible at the point
+ * in the trees where the operation under consideration was encountered.
+ * If the optimization is unable to induce OSR at that point, it will abort
+ * the compilation.
+ *
+ * The optimization is currently needed for some value type operations
+ * involving unresolved types or unresolved fields whose types are of value
+ * types.
+ */
 class TR_HandleRecompilationOps : public TR::Optimization
    {
    private:
 
    TR::ResolvedMethodSymbol *_methodSymbol;
+   bool _enableTransform;
 
    TR_HandleRecompilationOps(TR::OptimizationManager *manager) : TR::Optimization(manager)
       {
       _methodSymbol = comp()->getOwningMethodSymbol(comp()->getCurrentMethod());
       }
+
+   bool resolveCHKGuardsValueTypeOperation(TR::TreeTop *currTree, TR::Node *node);
+   void visitNode(TR::TreeTop *currTree, TR::Node *node);
 
    public:
 

--- a/runtime/compiler/optimizer/HandleRecompilationOps.hpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.hpp
@@ -58,7 +58,7 @@ class TR_HandleRecompilationOps : public TR::Optimization
       }
 
    bool resolveCHKGuardsValueTypeOperation(TR::TreeTop *currTree, TR::Node *node);
-   void visitNode(TR::TreeTop *currTree, TR::Node *node);
+   bool visitTree(TR::TreeTop *currTree);
 
    public:
 


### PR DESCRIPTION
Define an OpenJ9-specific optimization, `HandleRecompilationOps`, that looks for `ResolveCHK` operations that are applied to fields of value type or that are applied to a `loadaddr` on a value type class that is being applied to a `newvalue` operation.  As the JIT is not able to generate code that performs the required operations on such unresolved types, it
instead will attempt to induce a recompilation request, triggering OSR.  If that's not possible, it will abort the compilation.

This pull request depends upon [OpenJ9 pull request #11020](https://github.com/eclipse/openj9/pull/11020) and [OMR pull request #5631](https://github.com/eclipse/omr/pull/5631).

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>