### PR TITLE
Serialize runtime assumptions

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -92,6 +92,7 @@
 #include "env/VMJ9.h"
 #include "env/annotations/AnnotationBase.hpp"
 #include "runtime/MethodMetaData.h"
+#include "runtime/RuntimeAssumptions.hpp"
 #include "env/J9JitMemory.hpp"
 #include "env/J9SegmentCache.hpp"
 #include "env/SystemSegmentProvider.hpp"
@@ -9328,6 +9329,13 @@ TR::CompilationInfoPerThreadBase::compile(
                   );
                }
             compiler->failCompilation<J9::MetaDataCreationFailure>("Metadata creation failure");
+            }
+
+         if (compiler->getGenerateReadOnlyCode())
+            {
+            TR::SentinelRuntimeAssumption *sentinel = *reinterpret_cast<TR::SentinelRuntimeAssumption **>(compiler->getMetadataAssumptionList());
+            TR_ASSERT_FATAL(sentinel, "sentinel can't be NULL\n");
+            sentinel->setOwningMetadata(metaData);
             }
 
          if (TR::Options::getVerboseOption(TR_VerboseCompilationDispatch))

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -103,6 +103,31 @@ TR_PatchJNICallSite::serialize(uint8_t *cursor, uint8_t *owningMetadata)
    memcpy(cursor, &serializedData, sizeof(SerializedData));
    }
 
+void
+TR_PatchJNICallSite::deserialize(TR_FrontEnd *fe, TR_PersistentMemory *pm, uint8_t *cursor, uint32_t numAssumptions)
+   {
+   for (uint32_t i = 0; i < numAssumptions; i++)
+      {
+      SerializedData *serializedData = (SerializedData *)cursor;
+      J9JITExceptionTable *owningMetadata = (J9JITExceptionTable *)serializedData->_owningMetadata;
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+         {
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
+                                        "\tDeserializing RuntimeAssumptionOnRegisterNative: "
+                                        "_key=%p, _pc=%p, owningMetadata=%p",
+                                        serializedData->_key,
+                                        serializedData->_pc,
+                                        owningMetadata);
+         }
+
+      TR_PatchJNICallSite::make(fe, pm, serializedData->_key,serializedData->_pc,
+                                (OMR::RuntimeAssumption **)&owningMetadata->runtimeAssumptionList);
+
+      cursor += sizeof(SerializedData);
+      }
+   }
+
 TR_PatchNOPedGuardSiteOnClassExtend *TR_PatchNOPedGuardSiteOnClassExtend::make(
    TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel)
    {

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -84,6 +84,25 @@ TR_PatchJNICallSite::dumpInfo()
    TR_VerboseLog::write(" pc=%p", _pc );
    }
 
+void
+TR_PatchJNICallSite::serialize(uint8_t *cursor, uint8_t *owningMetadata)
+   {
+   // TODO: All of this data should be converted into position independent offsets
+   SerializedData serializedData = { getKey(), _pc , owningMetadata };
+
+   if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+      {
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
+                                     "\tSerializing RuntimeAssumptionOnRegisterNative: "
+                                     "_key=%p, _pc=%p, owningMetadata=%p",
+                                     serializedData._key,
+                                     serializedData._pc,
+                                     owningMetadata);
+      }
+
+   memcpy(cursor, &serializedData, sizeof(SerializedData));
+   }
+
 TR_PatchNOPedGuardSiteOnClassExtend *TR_PatchNOPedGuardSiteOnClassExtend::make(
    TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel)
    {

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -249,6 +249,18 @@ class TR_PatchJNICallSite : public OMR::ValueModifyRuntimeAssumption
     */
    virtual uint32_t size() { return sizeof(SerializedData); }
 
+   /**
+    * @brief Deserializes the assumption
+    *
+    * @param[in] fe - TR_Frontend
+    * @param[in] pm - TR_PersistentMemory
+    * @param[in] cursor - pointer to the start of the section of the serialized assumptions for this kind
+    * @param[in] numAssumptions - number of assumptions in the section
+    *
+    * This method goes through the buffer and calls make to add assumptions to the RAT
+    */
+   static void deserialize(TR_FrontEnd *fe, TR_PersistentMemory * pm, uint8_t *cursor, uint32_t numAssumptions);
+
    virtual void compensate(TR_FrontEnd *vm, bool isSMP, void *newAddress);
    virtual bool equals(OMR::RuntimeAssumption &other)
          {

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -236,6 +236,19 @@ class TR_PatchJNICallSite : public OMR::ValueModifyRuntimeAssumption
 
    virtual void dumpInfo();
 
+   /**
+    * @brief Serializes the assumption
+    * @param[in] cursor - pointer to where the assumption should be serialized
+    * @param[in] owningMetadata - pointer to the metadata that this assumption belongs to
+    */
+   virtual void serialize(uint8_t *cursor, uint8_t *owningMetadata);
+
+   /**
+    * @brief Returns the size of the serialized data
+    * @return size of the serialized data
+    */
+   virtual uint32_t size() { return sizeof(SerializedData); }
+
    virtual void compensate(TR_FrontEnd *vm, bool isSMP, void *newAddress);
    virtual bool equals(OMR::RuntimeAssumption &other)
          {
@@ -251,6 +264,13 @@ class TR_PatchJNICallSite : public OMR::ValueModifyRuntimeAssumption
 
    private:
    uint8_t *_pc;
+
+   struct SerializedData
+      {
+      uintptr_t _key;
+      uint8_t * _pc;
+      uint8_t * _owningMetadata;
+      };
    };
 
 class TR_PreXRecompile : public OMR::LocationRedirectRuntimeAssumption

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -25,6 +25,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "j9.h"
 #include "env/jittypes.h"
 
 class TR_FrontEnd;
@@ -135,7 +136,36 @@ class TR_RuntimeAssumptionTable
 
    uint32_t getTotalSizeOfAssumptionsToBeSerialized() { return _totalSizeOfAssumptionsToBeSerialized; }
 
+   /**
+    * @brief Allocates a buffer and serializes Runtime Assumptions
+    *
+    * This method goes through all the runtime assumptions in the RAT that are NOT marked for detach
+    * and calls the assumption's serialize method.
+    *
+    * It also maintains an Atlas that is placed at the start of the
+    * buffer which holds the number of assumptions per kind as well as the size of the section of the
+    * buffer used for each assumption kind.
+    *
+    * @param[in] jitConfig pointer to the J9JITConfig
+    *
+    * @return Buffer containing serialized assumptions
+    */
+   uint8_t *serialize(J9JITConfig *jitConfig);
+
    private:
+
+   struct AssumptionCountAndSize
+      {
+      uint32_t _count;
+      uint32_t _size;
+      };
+
+   struct SerializedDataAtlas
+      {
+      uint32_t _size;
+      AssumptionCountAndSize _numAssumptionsPerKind[LastAssumptionKind];
+      };
+
    friend class OMR::RuntimeAssumption;
    void addAssumption(OMR::RuntimeAssumption *a, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel);
    int32_t reclaimAssumptions(void *md, OMR::RuntimeAssumption **hashTable, OMR::RuntimeAssumption **possiblyRelevantHashTable);

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -133,6 +133,8 @@ class TR_RuntimeAssumptionTable
     */
    static bool assumptionCanBeSerialized(TR_RuntimeAssumptionKind kind);
 
+   uint32_t getTotalSizeOfAssumptionsToBeSerialized() { return _totalSizeOfAssumptionsToBeSerialized; }
+
    private:
    friend class OMR::RuntimeAssumption;
    void addAssumption(OMR::RuntimeAssumption *a, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel);
@@ -144,6 +146,8 @@ class TR_RuntimeAssumptionTable
    uint32_t _marked;                            // Counts the number of assumptions waiting to be removed
    int32_t assumptionCount[LastAssumptionKind]; // this never gets decremented
    int32_t reclaimedAssumptionCount[LastAssumptionKind];
+
+   uint32_t _totalSizeOfAssumptionsToBeSerialized;
    };
 
 #endif // RUNTIMEASSUMPTIONTABLE_HPP

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -30,6 +30,7 @@
 
 class TR_FrontEnd;
 class TR_OpaqueClassBlock;
+class TR_PersistentMemory;
 namespace OMR { class RuntimeAssumption; }
 
 // Note !!!: routine findAssumptionHashTable() assumes that the types of
@@ -151,6 +152,19 @@ class TR_RuntimeAssumptionTable
     * @return Buffer containing serialized assumptions
     */
    uint8_t *serialize(J9JITConfig *jitConfig);
+
+   /**
+    * @brief Deserializes assumptions from a buffer
+    *
+    * @param[in] fe - TR_Frontend
+    * @param[in] pm - TR_PersistentMemory
+    * @param[in] buffer - pointer to the buffer containing the serialized runtime assumptions
+    * @param[in] kind - Used to only deserialize a specific assumption kind; the default is LastAssumptionKind which means all assumptions
+    *
+    * This method goes through the buffer and calls the static deserialize method on each valid assumption
+    * kind, passing in a pointer to the start of the section for that kind.
+    */
+   void deserialize(TR_FrontEnd *fe, TR_PersistentMemory *pm, uint8_t *buffer, TR_RuntimeAssumptionKind kind = LastAssumptionKind);
 
    private:
 

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -124,6 +124,15 @@ class TR_RuntimeAssumptionTable
 
    int32_t countRatAssumptions();
 
+   /**
+    * @brief Helper to query whether serializing an assumption kind is supported.
+    *
+    * @param[in] kind - TR_RuntimeAssumptionKind
+    *
+    * @return true if assumption can be serialized, false otherwise
+    */
+   static bool assumptionCanBeSerialized(TR_RuntimeAssumptionKind kind);
+
    private:
    friend class OMR::RuntimeAssumption;
    void addAssumption(OMR::RuntimeAssumption *a, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel);

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -580,7 +580,22 @@ int32_t TR_RuntimeAssumptionTable::countRatAssumptions()
    return count;
    }
 
+bool
+TR_RuntimeAssumptionTable::assumptionCanBeSerialized(TR_RuntimeAssumptionKind kind)
+   {
+   bool canBeSerialized;
 
+   switch (kind)
+      {
+      default:
+         {
+         canBeSerialized = false;
+         break;
+         }
+      }
+
+   return canBeSerialized;
+   }
 
 
 void TR_RuntimeAssumptionTable::reclaimAssumptions(void *md, bool reclaimPrePrologueAssumptions)

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -299,9 +299,30 @@ class TR_UnloadedClassPicSite : public OMR::ValueModifyRuntimeAssumption
 
    virtual void dumpInfo();
 
+   /**
+    * @brief Serializes the assumption
+    * @param[in] cursor - pointer to where the assumption should be serialized
+    * @param[in] owningMetadata - pointer to the metadata that this assumption belongs to
+    */
+   virtual void serialize(uint8_t *cursor, uint8_t *owningMetadata);
+
+   /**
+    * @brief Returns the size of the serialized data
+    * @return size of the serialized data
+    */
+   virtual uint32_t size() { return sizeof(SerializedData); }
+
    private:
    uint8_t    *_picLocation;
    uint32_t    _size;
+
+   struct SerializedData
+      {
+      uint32_t   _size;
+      uintptr_t  _key;
+      uint8_t *  _picLocation;
+      uint8_t *  _owningMetadata;
+      };
    };
 
 #ifdef J9VM_OPT_JITSERVER

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -312,6 +312,18 @@ class TR_UnloadedClassPicSite : public OMR::ValueModifyRuntimeAssumption
     */
    virtual uint32_t size() { return sizeof(SerializedData); }
 
+   /**
+    * @brief Deserializes the assumption
+    *
+    * @param[in] fe - TR_Frontend
+    * @param[in] pm - TR_PersistentMemory
+    * @param[in] cursor - pointer to the start of the section of the serialized assumptions for this kind
+    * @param[in] numAssumptions - number of assumptions in the section
+    *
+    * This method goes through the buffer and calls make to add assumptions to the RAT
+    */
+   static void deserialize(TR_FrontEnd *fe, TR_PersistentMemory * pm, uint8_t *cursor, uint32_t numAssumptions);
+
    private:
    uint8_t    *_picLocation;
    uint32_t    _size;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3917,6 +3917,7 @@ typedef struct J9JITConfig {
 	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);
 	uint64_t clientUID;
 #endif /* J9VM_OPT_JITSERVER */
+	void* serializedRuntimeAssumptions;
 } J9JITConfig;
 
 #define J9JIT_GROW_CACHES  0x100000


### PR DESCRIPTION
# Overview
Depends on https://github.com/eclipse/omr/pull/5649

This PR adds the infrastructure to serialize/deserialize runtime assumptions. It is a port of some of the code in the `snapshot` branch.

# Design
This is the general design:

`TR_RuntimeAssumptionTable::serialize` is used to serialize runtime assumptions into a buffer. It should be called in `JitShutdown`.
`TR_RuntimeAssumptionTable::deserialize` is used to deserialize runtime assumptions from a buffer. It should be called either sometime before any of the hooks have run, or lazily as the hooks are run.

## Buffer Layout
The buffer is structured in the following way:
```
SerializedDataAtlas
Serialized assumptions for kind 1
Serialized assumptions for kind 2
...
Serialized assumptions for kind n
```
`SerializedDataAtlas` is a table of contents, defined in two new structs in `TR_RuntimeAssumptionTable`:
```
struct AssumptionCountAndSize
      {
      uint32_t _count;
      uint32_t _size;
      };

   struct SerializedDataAtlas
      {
      uint32_t _size;
      AssumptionCountAndSize _numAssumptionsPerKind[LastAssumptionKind];
      };
```
Therefore, `SerializedDataAtlas` contains the size the size of the entire buffer, as well as the number of assumptions serialized + the size of the serialized data for each runtime assumption kind. `TR_RuntimeAssumptionTable::deserialize` can use this data to deserialize the assumptions.

## Serialization
The way `TR_RuntimeAssumptionTable::serialize` serializes the assumptions is:

1. Loop through the runtime assumption kinds
2. Go through all the assumptions for that kind
3. Call the virtual method serialize on the assumption

The owning metadata is the `J9JITexceptionTable` which holds a pointer to the sentinel runtime assumption that is part of the circular linked list of assumptions that belong to a particular JIT'd body. We need to store the owning metadata so that when we add the assumption to the RAT in the restore run, we can also enqueue it into the circular linked list of assumptions for the same JIT'd body.

## Deserialization
The way `TR_RuntimeAssumptionTable::deserialize` works is by looping through all the runtime assumption kinds. For each kind (that's supported), it calls the appropriate static method `deserialize`. The reason `deserialize` is static rather than virtual is because the constructors of the runtime assumptions are protected; therefore, we can't initialize a dummy instance to call a hypothetical virtual `deserialize`.

Therefore, `deserialize` takes a pointer to the start of the section that contains the deserialized assumptions for that kind as well as the number of assumptions in that section. It then loops through the section and calls make to create the runtime assumptions and add it to the RAT.

`TR_RuntimeAssumptionTable::deserialize` also takes an optional parameter `kind`, which can be used to only create assumptions of a specific kind (rather than all kinds).