### PR TITLE
Add Fences after Volatile Field Stores

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1674,6 +1674,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_S390jitResolveVirtualMethod,                    (void *) jitResolveVirtualMethod,                        TR_Helper);
    SET(TR_S390jitResolveSpecialMethod,                    (void *) jitResolveSpecialMethod,                        TR_Helper);
    SET(TR_S390jitResolveStaticMethod,                     (void *) jitResolveStaticMethod,                         TR_Helper);
+   SET(TR_S390jitResolvedFieldIsVolatile,                 (void *) jitResolvedFieldIsVolatile,                     TR_Helper);
 
    SET(TR_S390interpreterStaticSpecialCallGlue,       (void *) _interpreterStaticSpecialCallGlue,TR_Helper);
    SET(TR_S390nativeStaticHelper,                     (void *) _nativeStaticHelper,              TR_Helper);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -6329,6 +6329,44 @@ J9::Z::TreeEvaluator::ardbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return resultReg;
    }
 
+static void
+xstoreVolatileHelper(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   if (node->getSymbolReference()->isUnresolved())
+      {
+      TR::Instruction* cursor = cg->getAppendInstruction();
+      while (cursor != NULL)
+         {
+         if (cursor->getOpCodeValue() == TR::InstOpCode::BRCL)
+            {
+            TR::S390RILInstruction* brclInst = reinterpret_cast<TR::S390RILInstruction*>(cursor);
+            if (brclInst->getTargetSnippet() != NULL && brclInst->getTargetSnippet()->getKind() == TR::Snippet::IsUnresolvedData)
+               {
+               TR::UnresolvedDataSnippet* uds = reinterpret_cast<TR::UnresolvedDataSnippet*>(brclInst->getTargetSnippet());
+               if (uds->getDataSymbolReference() == node->getSymbolReference())
+                  {
+                  // For unresolved symrefs we emit a NOP of the same size as a store fence (BCR 14,0). The unresolved helper call
+                  // will take care of patching the NOP into a fence if it determines the field is volatile following resolution.
+                  TR::Instruction* fenceNOP = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
+
+                  uds->setFenceNOPInstruction(fenceNOP);
+
+                  return;
+                  }
+               }
+            }
+
+         cursor = cursor->getPrev();
+         }
+
+      TR_ASSERT_FATAL_WITH_NODE(node, false, "Could not find the BRCL instruction for volatile unresolved store");
+      }
+   else if (node->getSymbol()->isVolatile())
+      {
+      generateSerializationInstruction(cg, node);
+      }
+   }
+
 TR::Register *
 J9::Z::TreeEvaluator::fwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -6502,7 +6540,7 @@ J9::Z::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::MemoryReference *tempMR = TR::MemoryReference::create(cg, node);
    TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::ST : TR::InstOpCode::getStoreOpCode();
    TR::Instruction * instr = generateRXInstruction(cg, storeOp, node, opCodeIsIndirect ? compressedRegister : sourceRegister, tempMR);
-
+   xstoreVolatileHelper(node, cg);
    // When a new object is stored into an old object, we need to invoke jitWriteBarrierStore
    // helper to update the remembered sets for GC.  Helper call is needed only if the object
    // is in old space or is scanned (black). Since the checking involves control flow, we delay
@@ -6531,7 +6569,64 @@ J9::Z::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       }
    cg->stopUsingRegister(sourceRegister);
    tempMR->stopUsingMemRefRegister(cg);
+
    return NULL;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::bstoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::bstoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::sstoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::sstoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::istoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::istoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::lstoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::lstoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::astoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::astoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::fstoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::fstoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
+   }
+
+TR::Register*
+J9::Z::TreeEvaluator::dstoreEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto result = OMR::TreeEvaluatorConnector::dstoreEvaluator(node, cg);
+   xstoreVolatileHelper(node, cg);
+   return result;
    }
 
 TR::Register *

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -556,10 +556,16 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *dwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-
    static TR::Register *inlineIntegerStringSize(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineIntegerToCharsForLatin1Strings(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineIntegerToCharsForUTF16Strings(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 }
 

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -70,6 +70,7 @@ J9::Z::UnresolvedDataSnippet::UnresolvedDataSnippet(
    J9::UnresolvedDataSnippet(cg, node, symRef, isStore, canCauseGC),
       _branchInstruction(NULL),
       _dataReferenceInstruction(NULL),
+      _fenceNOPInst(NULL),
       _dataSymbolReference(symRef),
       _unresolvedData(NULL),
       _memoryReference(NULL),
@@ -180,6 +181,8 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
       if (resolveForStore())
          {
          glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedInstanceDataStoreGlue);
+
+         TR_ASSERT_FATAL_WITH_INSTRUCTION(getDataReferenceInstruction(), _fenceNOPInst != NULL, "Unresolved store must have a fence NOP instruction");
          }
       else
          {
@@ -226,6 +229,8 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
       if (resolveForStore())
          {
          glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStaticDataStoreGlue);
+
+         TR_ASSERT_FATAL_WITH_INSTRUCTION(getDataReferenceInstruction(), _fenceNOPInst != NULL, "Unresolved store must have a fence NOP instruction");
          }
       else
          {
@@ -314,6 +319,19 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
       }
    cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
                              __FILE__, __LINE__, getNode());
+   cursor += sizeof(uintptr_t);
+
+   // Fence NOP emitted for volatile field stores that may need patching for volatile fields
+   if (getFenceNOPInstruction() != NULL)
+      {
+      *(uintptr_t *) cursor = (uintptr_t) (getFenceNOPInstruction()->getBinaryEncoding());
+      cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
+                             __FILE__, __LINE__, getNode());
+      }
+   else
+      {
+      *(uintptr_t *) cursor = 0;
+      }
    cursor += sizeof(uintptr_t);
 
    // Literal Pool Address to patch.
@@ -423,7 +441,7 @@ uint32_t
 J9::Z::UnresolvedDataSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    TR::Compilation *comp = cg()->comp();
-   uint32_t length = (comp->target().is64Bit() ? (14 + 5 * sizeof(uintptr_t)) : (12 + 5 * sizeof(uintptr_t)));
+   uint32_t length = (comp->target().is64Bit() ? (14 + 6 * sizeof(uintptr_t)) : (12 + 6 * sizeof(uintptr_t)));
    // For instance snippets, we have the out-of-line sequence
    if (isInstanceData())
       length += (comp->target().is64Bit()) ? 36 : 28;
@@ -557,6 +575,19 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
       addr = (uintptr_t) (snippet->getBranchInstruction()->getNext())->getBinaryEncoding();
       }
    trfprintf(pOutFile, "DC    \t0x%p \t# Address Of Ref. Instruction", addr);
+
+   bufferPos += sizeof(intptr_t);
+
+   printPrefix(pOutFile, NULL, bufferPos, sizeof(intptr_t));
+   if (snippet->getFenceNOPInstruction() != NULL)
+      {
+      addr = (uintptr_t) (snippet->getFenceNOPInstruction()->getBinaryEncoding());
+      }
+   else
+      {
+      addr = 0;
+      }
+   trfprintf(pOutFile, "DC    \t0x%p \t# Address NOP fence", addr);
 
    bufferPos += sizeof(intptr_t);
 

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.hpp
@@ -56,9 +56,9 @@ namespace Z
 class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
    {
    /** _branchInstruction is actually the instruction which branch to the UDS. */
-   TR::Instruction     *_branchInstruction;
+   TR::Instruction         *_branchInstruction;
    TR::SymbolReference     *_dataSymbolReference;
-   TR::MemoryReference *_memoryReference;
+   TR::MemoryReference     *_memoryReference;
    bool                    _isStore;
 
    /**
@@ -66,10 +66,11 @@ class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
     * that references it. The address of this will be resolved
     * when emitting the snippet code.
     */
-   TR::Instruction         *_dataReferenceInstruction;
-   TR::S390WritableDataSnippet *_unresolvedData;
-   uint8_t                    *_literalPoolPatchAddress;
-   uint8_t                    *_literalPoolSlot;         ///< For trace file generation
+   TR::Instruction               *_dataReferenceInstruction;
+   TR::S390WritableDataSnippet   *_unresolvedData;
+   uint8_t                       *_literalPoolPatchAddress;
+   uint8_t                       *_literalPoolSlot;         ///< For trace file generation
+   TR::Instruction               *_fenceNOPInst;
 
    public:
 
@@ -112,6 +113,9 @@ class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
    TR::MemoryReference *getMemoryReference() {return _memoryReference;}
    TR::MemoryReference *setMemoryReference(TR::MemoryReference *mr)
       {return _memoryReference = mr;}
+
+   TR::Instruction *getFenceNOPInstruction() { return _fenceNOPInst; }
+   TR::Instruction *setFenceNOPInstruction(TR::Instruction *instr) { return _fenceNOPInst = instr; }
 
    bool isInstanceData();
 


### PR DESCRIPTION
This commits ports changes to add Fences after volatile field stores which was committed to snapshot repository with additional changes to fix the compilation failures reported by assembler on z/OS. 

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>