### PR TITLE
Update to use new omr base implementation of adjustExpansionWithinSoftMax()

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,6 @@ public:
 private:
 	bool initialize(MM_EnvironmentBase *env);
 	UDATA adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, UDATA expandSize);
-	UDATA adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired);
 	UDATA checkForRatioExpand(MM_EnvironmentBase *env, UDATA bytesRequired);	
 	bool checkForRatioContract(MM_EnvironmentBase *env);
 	UDATA calculateExpandSize(MM_EnvironmentBase *env, UDATA bytesRequired, bool expandToSatisfy);


### PR DESCRIPTION
Offsetting the softmx by the nursery size is not necessary. The base
MM_MemorySubSpace in omr now implements a cleaned up version of
adjustExpansionWithinSoftMax.

Signed-off-by: Jason <jasonhal@ca.ibm.com>