### PR TITLE
Preparations to support extensible non helper SymbolReferenceTable enum

### DIFF
--- a/runtime/compiler/compile/J9NonHelperSymbols.enum
+++ b/runtime/compiler/compile/J9NonHelperSymbols.enum
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments, preprocessor macros,
+ * and enumerator definitions are permitted.
+ */
+
+   #include "compile/OMRNonHelperSymbols.enum"
+
+   J9firstNonhelperSymbol,
+
+   classRomPtrSymbol = J9firstNonhelperSymbol,
+   ramStaticsFromClassSymbol,
+   componentClassAsPrimitiveSymbol,
+   initializeStatusFromClassSymbol,
+   threadPrivateFlagsSymbol,  // private flags slot on j9vmthread
+   arrayletSpineFirstElementSymbol,// address of contiguous arraylet spine first element
+   dltBlockSymbol,            // DLT Block field in j9vmthread
+   classFromJavaLangClassAsPrimitiveSymbol,
+   javaVMSymbol,
+   j9methodExtraFieldSymbol,
+   j9methodConstantPoolSymbol,
+   startPCLinkageInfoSymbol,
+   instanceShapeFromROMClassSymbol,
+
+   /** \brief
+    * This symbol represents the tempSlot field in j9vmthread. It will provide a mechanism for the compiler
+    * to insert temporary information that the VM can use - such as the number of args when calling
+    * signature-polymorphic methods that are implemented in the VM as internal natives. The VM can use that
+    * information in a number of ways, such as locating items on the stack.
+    *
+    * \code
+    *    istore  <j9VMThreadTempSlotField>
+    *       iconst <number of args for the call to the signature-polymorphic VM internal native method>
+    *    icall <VM internal native method>
+    *       <object the VM needs to locate>
+    *       <parm1>
+    *       <parm2>
+    *       .
+    *       .
+    * \endcode
+    */
+   j9VMThreadTempSlotFieldSymbol,
+
+   J9lastNonhelperSymbol = j9VMThreadTempSlotFieldSymbol,

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "omrformatconsts.h"
 #include "codegen/CodeGenerator.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/AliasBuilder.hpp"
@@ -2523,4 +2524,45 @@ J9::SymbolReferenceTable::findClassRomPtrSymbolRef()
    return element(classRomPtrSymbol);
    }
 
+const char *J9::SymbolReferenceTable::_commonNonHelperSymbolNames[] =
+   {
+   "<classRomPtr>",
+   "<ramStaticsFromClass>",
+   "<componentClassAsPrimitive>",
+   "<initializeStatusFromClass>",
+   "<threadPrivateFlags>",
+   "<arrayletSpineFirstElement>",
+   "<dltBlock>",
+   "<classFromJavaLangClassAsPrimitive>",
+   "<javaVM>",
+   "<j9methodExtraField>",
+   "<j9methodConstantPoolField>",
+   "<startPCLinkageInfo>",
+   "<instanceShapeFromROMClass>",
+   "<j9VMThreadTempSlotField>"
+   };
+
+
+const char *
+J9::SymbolReferenceTable::getNonHelperSymbolName(CommonNonhelperSymbol nonHelper)
+   {
+#ifdef OMR_ENABLE_NONHELPER_EXTENSIBLE_ENUM
+   TR_ASSERT_FATAL(nonHelper <= J9lastNonhelperSymbol, "unknown nonhelper %" OMR_PRId32, static_cast<int32_t>(nonHelper));
+
+   static_assert(sizeof(_commonNonHelperSymbolNames)/sizeof(_commonNonHelperSymbolNames[0]) ==
+                 static_cast<int32_t>(J9lastNonhelperSymbol - J9firstNonhelperSymbol + 1),
+              "_commonNonHelperSymbolNames array must match CommonNonHelperSymbol enumeration");
+
+   if (nonHelper >= J9firstNonhelperSymbol)
+      {
+      return _commonNonHelperSymbolNames[static_cast<int32_t>(nonHelper - J9firstNonhelperSymbol)];
+      }
+   else
+      {
+      return OMR::SymbolReferenceTableConnector::getNonHelperSymbolName(nonHelper);
+      }
+#else
+   return NULL;
+#endif
+   }
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2510,3 +2510,17 @@ J9::SymbolReferenceTable::createParameterSymbol(
 
    return sym;
    }
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findArrayClassRomPtrSymbolRef()
+   {
+   return element(arrayClassRomPtrSymbol);
+   }
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findClassRomPtrSymbolRef()
+   {
+   return element(classRomPtrSymbol);
+   }
+
+

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -363,6 +363,15 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    TR::SymbolReference * findShadowSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataType, TR::Symbol::RecognizedField *recognizedField = NULL);
 
+   /**
+    * @brief Retrieve the textual name of the given NonHelperSymbol
+    *
+    * @param[in] nonHelper : the nonHelper symbol
+    *
+    * @return Textual name of the NonHelperSymbol
+    */
+   static const char *getNonHelperSymbolName(CommonNonhelperSymbol nonHelper);
+
    protected:
 
    TR::Symbol                           *_currentThreadDebugEventDataSymbol;
@@ -463,6 +472,9 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR_Array<TR::SymbolReference *> * _unsafeJavaStaticVolatileSymRefs;
 
    ResolvedFieldShadows _resolvedFieldShadows;
+
+   static const char *_commonNonHelperSymbolNames[];
+
    };
 
 }

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -221,6 +221,9 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    TR::SymbolReference * findOrCreateClassIsArraySymbolRef();
 
+   TR::SymbolReference * findArrayClassRomPtrSymbolRef();
+   TR::SymbolReference * findClassRomPtrSymbolRef();
+
    TR::SymbolReference * findClassFromJavaLangClassAsPrimitiveSymbolRef();
    TR::SymbolReference * findOrCreateClassFromJavaLangClassAsPrimitiveSymbolRef();
 

--- a/runtime/compiler/compile/NonHelperSymbols.enum
+++ b/runtime/compiler/compile/NonHelperSymbols.enum
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "compile/J9NonHelperSymbols.enum"
+


### PR DESCRIPTION
* Relocate OpenJ9-specific SymbolReference functions to OpenJ9
* Make NonHelperSymbols enum extensible