### PR TITLE
New eden and heap sizing logic in Balanced GC

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -156,8 +156,6 @@ public:
 	UDATA deadClassLoaderCacheSize;
 #endif /*defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
 
-
-
 	MM_UnfinalizedObjectList* unfinalizedObjectLists; /**< The global linked list of unfinalized object lists. */
 	
 	UDATA objectListFragmentCount; /**< the size of Local Object Buffer(per gc thread), used by referenceObjectBuffer, UnfinalizedObjectBuffer and OwnableSynchronizerObjectBuffer */

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -919,24 +919,32 @@ gcParseSovereignArguments(J9JavaVM *vm)
 		goto _error;
 	}
 
-	result =  option_set_to_opt_percent(vm, "-Xmaxt", &index, EXACT_MEMORY_MATCH, &extensions->heapExpansionGCTimeThreshold);
-	if (OPTION_OK != result) {
-		if (OPTION_MALFORMED == result) {
-			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-Xmaxt");
-		} else {
-			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_PERCENT_OUT_OF_RANGE, "-Xmaxt", 0.0, 1.0);
+
+	if (-1 != FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, "-Xmaxt", NULL)) {
+		extensions->heapExpansionGCRatioThreshold._wasSpecified = true;
+		result =  option_set_to_opt_percent(vm, "-Xmaxt", &index, EXACT_MEMORY_MATCH, &extensions->heapExpansionGCRatioThreshold._valueSpecified);
+		if (OPTION_OK != result) {
+			if (OPTION_MALFORMED == result) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-Xmaxt");
+			} else {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_PERCENT_OUT_OF_RANGE, "-Xmaxt", 0.0, 1.0);
+			}
+			goto _error;
 		}
-		goto _error;
 	}
 
-	result =  option_set_to_opt_percent(vm, "-Xmint", &index, EXACT_MEMORY_MATCH, &extensions->heapContractionGCTimeThreshold);
-	if (OPTION_OK != result) {
-		if (OPTION_MALFORMED == result) {
-			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-Xmint");
-		} else {
-			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_PERCENT_OUT_OF_RANGE, "-Xmint", 0.0, 1.0);
+
+	if (-1 != FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, "-Xmint", NULL)) {
+		extensions->heapContractionGCRatioThreshold._wasSpecified = true;
+		result =  option_set_to_opt_percent(vm, "-Xmint", &index, EXACT_MEMORY_MATCH, &extensions->heapContractionGCRatioThreshold._valueSpecified);
+		if (OPTION_OK != result) {
+			if (OPTION_MALFORMED == result) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-Xmint");
+			} else {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_PERCENT_OUT_OF_RANGE, "-Xmint", 0.0, 1.0);
+			}
+			goto _error;
 		}
-		goto _error;
 	}
 
 	if(-1 != FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, VMOPT_XGCTHREADS, NULL)) {

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -162,6 +162,14 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 		goto _exit;
 	}
 
+	if (try_scan(scan_start, "overrideHiresTimerCheck")) {
+		extensions->overrideHiresTimerCheck = true;
+		goto _exit;
+	}
+
+#endif /* J9VM_GC_REALTIME */
+
+#if defined(J9VM_GC_REALTIME)|| defined(J9VM_GC_VLHGC)
 	if (try_scan(scan_start, "targetPausetime=")) {
 		/* the unit of target pause time option is in milliseconds */
 		UDATA beatMilli = 0;
@@ -172,18 +180,20 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_MUST_BE_ABOVE, "targetPausetime=", (UDATA)0);
 			goto _error;
 		}
-		/* convert the unit to microseconds and store in extensions */
-		extensions->beatMicro = beatMilli * 1000;
 
-		goto _exit;
-	}
-
-	if (try_scan(scan_start, "overrideHiresTimerCheck")) {
-		extensions->overrideHiresTimerCheck = true;
-		goto _exit;
-	}
-
+#if defined(J9VM_GC_REALTIME)
+			/* convert the unit to microseconds and store in extensions */
+			extensions->beatMicro = beatMilli * 1000;
 #endif /* J9VM_GC_REALTIME */
+
+#if defined(J9VM_GC_VLHGC)
+		    /* Save soft pause target for balanced */
+			extensions->tarokTargetMaxPauseTime = beatMilli;
+#endif /* J9VM_GC_VLHGC */
+
+		goto _exit;
+	}
+#endif /* J9VM_GC_REALTIME || J9VM_GC_VLHGC */
 
 //todo temporary option to allow LOA to be enabled for testing with non-default gc policies
 //Remove once LOA code stable 
@@ -666,7 +676,8 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_INTEGER_OUT_OF_RANGE, "dnssExpectedTimeRatioMinimum=", (UDATA)0, (UDATA)100);
 			goto _error;
 		}
-		extensions->dnssExpectedTimeRatioMinimum = ((double)value) / ((double)100);
+		extensions->dnssExpectedRatioMinimum._wasSpecified = true;
+		extensions->dnssExpectedRatioMinimum._valueSpecified = ((double)value) / ((double)100);
 		goto _exit;
 	}
 
@@ -679,7 +690,8 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_INTEGER_OUT_OF_RANGE, "dnssExpectedTimeRatioMaximum=", (UDATA)0, (UDATA)100);
 			goto _error;
 		}
-		extensions->dnssExpectedTimeRatioMaximum = ((double)value) / ((double)100);
+		extensions->dnssExpectedRatioMaximum._wasSpecified = true;
+		extensions->dnssExpectedRatioMaximum._valueSpecified = ((double)value) / ((double)100);
 		goto _exit;
 	}
 

--- a/runtime/gc_stats/MarkVLHGCStats.hpp
+++ b/runtime/gc_stats/MarkVLHGCStats.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,6 +80,9 @@ public:
 	UDATA _splitArraysProcessed; /**< The number of array chunks (not counting parts smaller than the split size) processed by this thread */
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
+	U_64 _concurrentGCThreadsCPUStartTimeSum; /**< The sum of all gc cpu thread times when concurrent gc work began */
+	U_64 _concurrentGCThreadsCPUEndTimeSum; /**< The sum of all gc cpu thread times when concurrent gc work ended */
+	U_64 _concurrentMarkGCThreadsTotalWorkTime; /**< The slowdown attributed to concurrent GC work */
 /* function members */
 private:
 protected:
@@ -113,6 +116,11 @@ public:
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		_splitArraysProcessed = 0;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+
+		_concurrentGCThreadsCPUStartTimeSum = 0;
+		_concurrentGCThreadsCPUEndTimeSum = 0;
+		_concurrentMarkGCThreadsTotalWorkTime = 0;
+
 	}
 
 	void merge(MM_MarkVLHGCStats *statsToMerge)
@@ -140,6 +148,9 @@ public:
 		_doubleMappedArrayletsCandidates += statsToMerge->_doubleMappedArrayletsCandidates;
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */	
 
+		_concurrentGCThreadsCPUStartTimeSum += statsToMerge->_concurrentGCThreadsCPUStartTimeSum;
+		_concurrentGCThreadsCPUEndTimeSum += statsToMerge->_concurrentGCThreadsCPUEndTimeSum;
+		_concurrentMarkGCThreadsTotalWorkTime += statsToMerge->_concurrentMarkGCThreadsTotalWorkTime;
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		/* It may not ever be useful to merge these stats, but do it anyways */
@@ -168,6 +179,9 @@ public:
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		,_splitArraysProcessed(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+		,_concurrentGCThreadsCPUStartTimeSum(0)
+		,_concurrentGCThreadsCPUEndTimeSum(0)
+		,_concurrentMarkGCThreadsTotalWorkTime(0)
 	{
 	}
 	

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -306,6 +306,18 @@ MM_VerboseHandlerOutputVLHGC::hasOutputMemoryInfoInnerStanza()
 	return true;
 }
 
+const char *
+MM_VerboseHandlerOutputVLHGC::getSubSpaceType(uintptr_t typeFlags)
+{
+	const char *subSpaceType = NULL;
+	if (MEMORY_TYPE_NEW == typeFlags) {
+		subSpaceType = "eden";
+	} else {
+		subSpaceType = "total heap";
+	}
+	return subSpaceType;
+}
+
 void
 MM_VerboseHandlerOutputVLHGC::outputMemoryInfoInnerStanza(MM_EnvironmentBase *env, UDATA indent, MM_CollectionStatistics *statsBase)
 {

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -103,6 +103,8 @@ protected:
 	 * The actual body (excluding first and last line) of memory-info stanza.
 	 */
 	virtual void outputMemoryInfoInnerStanza(MM_EnvironmentBase *env, UDATA indent, MM_CollectionStatistics *stats);
+
+	virtual const char *getSubSpaceType(uintptr_t typeFlags);
 	
 	/* Print out allocations statistics
 	 * @param current Env

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -310,6 +310,22 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 		extensions->tarokMinimumGMPWorkTargetBytes._valueSpecified = extensions->regionSize;
 	}
 
+	if (!extensions->dnssExpectedRatioMaximum._wasSpecified) {
+		extensions->dnssExpectedRatioMaximum._valueSpecified = 0.05;
+	}
+
+	if (!extensions->dnssExpectedRatioMinimum._wasSpecified) {
+		extensions->dnssExpectedRatioMinimum._valueSpecified = 0.02;
+	}
+
+	if (!extensions->heapExpansionGCRatioThreshold._wasSpecified) {
+		extensions->heapExpansionGCRatioThreshold._valueSpecified = 5;
+	}
+
+	if (!extensions->heapContractionGCRatioThreshold._wasSpecified) {
+		extensions->heapContractionGCRatioThreshold._valueSpecified = 2;
+	}
+
 	return result;
 }
 

--- a/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
+++ b/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,7 @@ MM_EnvironmentVLHGC::initializeGCThread()
 {
 	Assert_MM_true(NULL == _rememberedSetCardBucketPool);
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(this);
-	UDATA threadPoolSize = extensions->getHeap()->getHeapRegionManager()->getTableRegionCount();
+	uintptr_t threadPoolSize = extensions->getHeap()->getHeapRegionManager()->getTableRegionCount();
 	/* Make this thread aware of its RSCL buckets for all regions */
 	_rememberedSetCardBucketPool = &extensions->rememberedSetCardBucketPool[getWorkerID() * threadPoolSize];
     /* Associate buckets with appropriate RSCL (each RSCL maintains a list of its own buckets) */

--- a/runtime/gc_vlhgc/EnvironmentVLHGC.hpp
+++ b/runtime/gc_vlhgc/EnvironmentVLHGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,11 +67,11 @@ public:
 
 	MM_CopyForwardCompactGroup *_copyForwardCompactGroups;  /**< List of copy-forward data for each compact group for the given GC thread (only for GC threads during copy forward operations) */
 	
-	UDATA _previousConcurrentYieldCheckBytesScanned;	/**< The number of bytes scanned in the mark stats at the end of the previous shouldYieldFromTask check in concurrent mark */
+	uintptr_t _previousConcurrentYieldCheckBytesScanned;	/**< The number of bytes scanned in the mark stats at the end of the previous shouldYieldFromTask check in concurrent mark */
 
 	MM_CardBufferControlBlock *_rsclBufferControlBlockHead; /**< head of BufferControlBlock thread local pool list */
 	MM_CardBufferControlBlock *_rsclBufferControlBlockTail; /**< tail of BufferControlBlock thread local pool list */
-	IDATA _rsclBufferControlBlockCount;	/**< count of buffers in BufferControlBlock thread local pool list */
+	intptr_t _rsclBufferControlBlockCount;	/**< count of buffers in BufferControlBlock thread local pool list */
 	MM_RememberedSetCardBucket *_rememberedSetCardBucketPool; /**< GC thread local pool of RS Card Buckets for each Region (its Card List) */
 	MM_RememberedSetCardList *_lastOverflowedRsclWithReleasedBuffers; /**< in global list of overflowed RSCL, this is the last RSCL this thread visited */
 
@@ -79,6 +79,7 @@ public:
 
 	MM_MarkVLHGCStats _markVLHGCStats;
 	MM_SweepVLHGCStats _sweepVLHGCStats;
+
 #if defined(J9VM_GC_MODRON_COMPACTION)
 	MM_CompactVLHGCStats _compactVLHGCStats;
 #endif /* J9VM_GC_MODRON_COMPACTION */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -157,6 +157,15 @@ MM_ParallelGlobalMarkTask::setup(MM_EnvironmentBase *envBase)
 	}
 	env->_markVLHGCStats.clear();
 	env->_workPacketStats.clear();
+
+	/*
+	 * Get gc threads cpu time for when mark started, and add it to the stats structure.
+	 * If the current platform does not support this operation, there are failsafes in place - no need for an else condition here
+	 */
+	int64_t gcThreadCpuTime = omrthread_get_cpu_time(env->getOmrVMThread()->_os_thread);
+	if (-1 != gcThreadCpuTime) {
+		env->_markVLHGCStats._concurrentGCThreadsCPUStartTimeSum += gcThreadCpuTime;
+	}
 	
 	/* record that this thread is participating in this cycle */
 	env->_markVLHGCStats._gcCount = MM_GCExtensions::getExtensions(env)->globalVLHGCStats.gcCount;
@@ -168,9 +177,19 @@ MM_ParallelGlobalMarkTask::cleanup(MM_EnvironmentBase *envBase)
 {
 	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
-	
+
+	/*
+	 * Get gc threads cpu time for when mark finished, and add it to the stats structure
+	 * If the current platform does not support this operation, there are failsafes in place - no need for an else condition here
+	 */
+	int64_t gcThreadCpuTime = omrthread_get_cpu_time(env->getOmrVMThread()->_os_thread);
+	if (-1 != gcThreadCpuTime) {
+		env->_markVLHGCStats._concurrentGCThreadsCPUEndTimeSum += gcThreadCpuTime;
+	}
+
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats.merge(&env->_markVLHGCStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.merge(&env->_workPacketStats);
+
 	if(!env->isMainThread()) {
 		env->_cycleState = NULL;
 	}

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -176,6 +176,10 @@ MM_IncrementalGenerationalGC::initialize(MM_EnvironmentVLHGC *env)
  		goto error_no_memory;
  	}
 
+	if (!_schedulingDelegate.initialize(env)) {
+		goto error_no_memory;
+	}
+
  	if(!_collectionSetDelegate.initialize(env)) {
  		goto error_no_memory;
  	}
@@ -359,7 +363,7 @@ MM_IncrementalGenerationalGC::mainThreadGarbageCollect(MM_EnvironmentBase *envBa
 		/* This thread is doing GC work, account for the time spent into the GC bucket */
 		omrthread_set_category(vmThread->osThread, J9THREAD_CATEGORY_SYSTEM_GC_THREAD, J9THREAD_TYPE_SET_GC);
 	}
-	
+
 	switch(env->_cycleState->_collectionType) {
 	case MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION:
 		runPartialGarbageCollect(env, allocDescription);
@@ -416,6 +420,7 @@ MM_IncrementalGenerationalGC::globalMarkPhase(MM_EnvironmentVLHGC *env, bool inc
 	
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats.clear();
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._startTime = j9time_hires_clock();
 
 	if (incrementalMark) {
@@ -944,7 +949,13 @@ MM_IncrementalGenerationalGC::partialGarbageCollectPreWork(MM_EnvironmentVLHGC *
 	if (_schedulingDelegate.isGlobalSweepRequired()) {
 		Assert_MM_true(NULL == env->_cycleState->_externalCycleState);
 
+		PORT_ACCESS_FROM_ENVIRONMENT(env);
+
 		_reclaimDelegate.runGlobalSweepBeforePGC(env, allocDescription, env->_cycleState->_activeSubSpace, env->_cycleState->_gcCode);
+
+		U_64 sweepTimeStart = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._sweepStats._startTime;
+		U_64 sweepTimeEnd = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._sweepStats._endTime;
+		U_64 globalSweepTimeUs = j9time_hires_delta(sweepTimeStart, sweepTimeEnd, J9PORT_TIME_DELTA_IN_MICROSECONDS);
 
 		/* TODO: lpnguyen make another statisticsDelegate or something that both schedulingDelegate and reclaimDelegate can see
 		 * so that we can avoid this kind of stats-passing mess.
@@ -956,6 +967,7 @@ MM_IncrementalGenerationalGC::partialGarbageCollectPreWork(MM_EnvironmentVLHGC *
 
 		double optimalEmptinessRegionThreshold = _reclaimDelegate.calculateOptimalEmptinessRegionThreshold(env, regionConsumptionRate, avgSurvivorRegions, avgCopyForwardRate, scanTimeCostPerGMP);
 		_schedulingDelegate.setAutomaticDefragmentEmptinessThreshold(optimalEmptinessRegionThreshold);
+		_schedulingDelegate.setGlobalSweepTime(globalSweepTimeUs);
 	}
 
 	/* Determine if there are enough regions available to attempt a copy-forward collection.
@@ -1061,6 +1073,8 @@ MM_IncrementalGenerationalGC::runGlobalMarkPhaseIncrement(MM_EnvironmentVLHGC *e
 	/* If a GMP hasn't already begun, this will be the first increment of a new cycle */
 	if(!isGlobalMarkPhaseRunning()) {
 		reportGMPCycleStart(env);
+		/* Inform scheduling delegate that it's internal metrics need to update/reset */
+		_schedulingDelegate.globalMarkCycleStart(env);
 		_persistentGlobalMarkPhaseState._vlhgcCycleStats.clear();
 	}
 
@@ -1111,6 +1125,10 @@ MM_IncrementalGenerationalGC::runGlobalMarkPhaseIncrement(MM_EnvironmentVLHGC *e
 		reportGCIncrementEnd(env);
 		reportGMPIncrementEnd(env);
 		reportGMPCycleEnd(env);
+		/* Remember how many PGC's occured per GMP cycle, so that we can weight GMP cost properly */
+		_extensions->globalVLHGCStats._previousPgcPerGmpCount = _schedulingDelegate.getPgcCountSinceGMPEnd(env);
+		_schedulingDelegate.globalMarkCycleEnd(env);
+		_extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd = true;
 		/* clear new OwnableSynchronizerObject count after scanOwnableSynchronizerObject in clearable phase */
 		_extensions->allocationStats.clearOwnableSynchronizer();
 	} else {
@@ -1202,6 +1220,7 @@ MM_IncrementalGenerationalGC::runGlobalGarbageCollection(MM_EnvironmentVLHGC *en
 	env->_cycleState->_markMap = NULL;
 	env->_cycleState->_currentIncrement = 0;
 
+	_extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd = true;
 	if (attemptHeapResize(env, allocDescription)) {
 		/* Check was it successful contraction */
 		if (env->_cycleState->_activeSubSpace->wasContractedThisGC(_extensions->globalVLHGCStats.gcCount)) {
@@ -1273,6 +1292,10 @@ bool
 MM_IncrementalGenerationalGC::attemptHeapResize(MM_EnvironmentVLHGC *env, MM_AllocateDescription *allocDescription)
 {
 	bool isSystemGC = env->_cycleState->_gcCode.isExplicitGC();
+
+	/* Take a snapshot of the current information relevant to heap sizing (PGC/GMP time, eden + survivor space, etc.) */
+	_schedulingDelegate.updateHeapSizingData(env);
+
 	env->_cycleState->_activeSubSpace->checkResize(env, allocDescription, isSystemGC);
 	env->_cycleState->_activeSubSpace->performResize(env, allocDescription);
 
@@ -1290,6 +1313,16 @@ MM_IncrementalGenerationalGC::preProcessPGCUsingCopyForward(MM_EnvironmentVLHGC 
 
 	/* Record stats before a copy forward */
 	UDATA freeMemoryForSurvivor = _extensions->getHeap()->getActualFreeMemorySize();
+	/*
+	 * In certain situations (eg, startup, change in allocation pattern, etc), the amount of free tenure might be overestimated.
+	 * This overestimate, can cause "tenure" to be too small, resulting in excessive GMP's or GCC's.
+	 *
+	 * At this moment in time (right before copy forward), eden is 100% full, so all free memory is part of "tenure"
+	 *
+	 * NOTE: A second estimate for free tenure is later made - The lowest estimate for free tenure is used in heap sizing calculations
+	 */
+	_extensions->globalVLHGCStats._heapSizingData.freeTenure = freeMemoryForSurvivor;
+
 	cycleState->_vlhgcIncrementStats._copyForwardStats._freeMemoryBefore = freeMemoryForSurvivor;
 	cycleState->_vlhgcIncrementStats._copyForwardStats._totalMemoryBefore = _extensions->getHeap()->getMemorySize();
 
@@ -1910,7 +1943,6 @@ void
 MM_IncrementalGenerationalGC::reportCopyForwardStart(MM_EnvironmentVLHGC *env)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
-
 	Trc_MM_CopyForwardStart(env->getLanguageVMThread());
 	TRIGGER_J9HOOK_MM_PRIVATE_COPY_FORWARD_START(
 		_extensions->privateHookInterface,
@@ -1958,11 +1990,19 @@ MM_IncrementalGenerationalGC::preConcurrentInitializeStatsAndReport(MM_Environme
 	stats->_cycleID = _persistentGlobalMarkPhaseState._verboseContextID;
 	stats->_scanTargetInBytes = _globalMarkPhaseIncrementBytesStillToScan;
 	env->_cycleState = &_persistentGlobalMarkPhaseState;
-	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._startTime = j9time_hires_clock();
+	U_64 markStartTime = j9time_hires_clock();
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._startTime = markStartTime;
+
+	/* Get an estimate of total process time when concurrent mark started. This is used to determine how much GMP costs*/
+	omrthread_process_time_t processStart;
+	omrthread_get_process_times(&processStart);
+	U_64 concurrentMarkStartTime = processStart._systemTime + processStart._userTime;
+	stats->_concurrentMarkProcessStartTime = (uintptr_t)concurrentMarkStartTime;
+
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START(
 			_extensions->privateHookInterface,
 			env->getOmrVMThread(),
-			j9time_hires_clock(),
+			markStartTime,
 			J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START,
 			stats);
 }
@@ -2009,6 +2049,9 @@ MM_IncrementalGenerationalGC::postConcurrentUpdateStatsAndReport(MM_EnvironmentB
 	stats->_bytesScanned = bytesConcurrentlyScanned;
 	stats->_terminationWasRequested = _forceConcurrentTermination;
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._endTime = j9time_hires_clock();
+
+	calculateConcurrentMarkWorkTime(env, stats);
+
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END(
 			_extensions->privateHookInterface,
 			env->getOmrVMThread(),
@@ -2016,6 +2059,48 @@ MM_IncrementalGenerationalGC::postConcurrentUpdateStatsAndReport(MM_EnvironmentB
 			J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END,
 			stats);
 	env->_cycleState = NULL;
+}
+
+void
+MM_IncrementalGenerationalGC::calculateConcurrentMarkWorkTime(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats)
+{
+	/* Get an estimate of total process time now that concurrent mark increment has finished*/
+	omrthread_process_time_t processEnd;
+	omrthread_get_process_times(&processEnd);
+	U_64 processEndTime = processEnd._systemTime + processEnd._userTime;
+
+	/* Calculate how much process time has elapsed since the start of the concurrent mark increment */
+	U_64 concurrentCpuElapsedTime = processEndTime - stats->_concurrentMarkProcessStartTime;
+
+	/* Work time we attribute to concurrent work is difference of process time of gc threads now vs when concurrent phase started */
+	MM_MarkVLHGCStats markStats = _persistentGlobalMarkPhaseState._vlhgcIncrementStats._markStats;
+	double concurrentGCRatio = 0.5;
+
+	if (markStats._concurrentGCThreadsCPUEndTimeSum != markStats._concurrentGCThreadsCPUStartTimeSum) {
+		/* If the platform supports getting time for each thread, calculate what % of time gc threads were active relative to application threads. */
+		/* Determine the ratio of time spent doing GC work vs non-gc related work during the concurrent phase */
+		U_64 concurrentGcCpuWorkTime = markStats._concurrentGCThreadsCPUEndTimeSum - markStats._concurrentGCThreadsCPUStartTimeSum;
+		concurrentGCRatio = (double)concurrentGcCpuWorkTime/concurrentCpuElapsedTime;
+
+		/* If there was a clock error, concurrentGcCpuWorkTime might be too high or negative. Make sure ratio is between 0.1 and 0.9 */
+		concurrentGCRatio = OMR_MIN(concurrentGCRatio, 0.9);
+		concurrentGCRatio = OMR_MAX(concurrentGCRatio, 0.1);
+	}
+
+	/*
+	 * The slowdown to the application due concurrent GMP work, is closely related to concurrentGCRatio, but requires some extra analysis
+	 *
+	 * If GC ratio is high because CPU is underutilized by application threads, then the slowdown is 1 - concurrentGCRatio.
+	 * If CPU ratio is low because application threads are overloading CPU, then slowdown is concurrentGCRatio.
+	 */
+	concurrentGCRatio = OMR_MIN(1.0 - concurrentGCRatio, concurrentGCRatio);
+
+	/* The GC time we attribute to concurrent phase is (ratio of time doing GC work instead of mutator work) * time interval of concurrent mark increment */
+	U_64 concurrentMarkGCThreadsWorkTime = (U_64)(concurrentCpuElapsedTime * concurrentGCRatio);
+	_persistentGlobalMarkPhaseState._vlhgcCycleStats._concurrentMarkStats._concurrentMarkGCThreadsTotalWorkTime += concurrentMarkGCThreadsWorkTime;
+	Trc_MM_IncrementalGenerationalGC_calculateConcurrentMarkWorkTime(env->getLanguageVMThread(), concurrentGCRatio, concurrentMarkGCThreadsWorkTime / 1000, _persistentGlobalMarkPhaseState._vlhgcCycleStats._concurrentMarkStats._concurrentMarkGCThreadsTotalWorkTime / 1000);
+
+	_schedulingDelegate.setConcurrentGlobalMarkTime(_persistentGlobalMarkPhaseState._vlhgcCycleStats._concurrentMarkStats._concurrentMarkGCThreadsTotalWorkTime);
 }
 
 void

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -388,6 +388,14 @@ public:
 	virtual void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned);
 
 	/**
+	 * Called by the MainGCThread after it re-acquires the GC control monitor in order to calculate statistics
+	 * regarding how long GC threads spent doing concurrent mark work relative to threads outside the GC.
+	 * @param env[in] The main GC thread
+	 * @param stats[in/out] The stats data structure meant to be populated with the state of the collector after the concurrent operation ends (data populated before the collect is still in the structure)
+	 */
+	virtual void calculateConcurrentMarkWorkTime(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats);
+
+	/**
 	 * Triggers a termination flag used to interrupt the concurrent task so that it will return.  This is called in the
 	 * cases where an external thread requires that the main GC thread return to its control mutex to receive a new
 	 * GC request.

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -21,6 +21,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <math.h>
+
 #include "j9.h"
 #include "j9cfg.h"
 #include "modronopt.h"
@@ -54,6 +56,7 @@
 
 #define HEAP_FREE_RATIO_EXPAND_DIVISOR		100
 #define HEAP_FREE_RATIO_EXPAND_MULTIPLIER	17
+#define GMP_OVERHEAD_WEIGHT					0.4
 
 /**
  * Return the memory pool associated to the receiver.
@@ -70,7 +73,7 @@ MM_MemorySubSpaceTarok::getMemoryPool()
  * Return the number of memory pools associated to the receiver.
  * @return count of number of memory pools 
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getMemoryPoolCount()
 {
 	Assert_MM_unreachable();
@@ -81,7 +84,7 @@ MM_MemorySubSpaceTarok::getMemoryPoolCount()
  * Return the number of active memory pools associated to the receiver.
  * @return count of number of memory pools 
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getActiveMemoryPoolCount()
 {
 	Assert_MM_unreachable();
@@ -113,7 +116,7 @@ MM_MemorySubSpaceTarok::getMemoryPool(void * addr)
  * @return MM_MemoryPool
  */
 MM_MemoryPool *
-MM_MemorySubSpaceTarok::getMemoryPool(UDATA size)
+MM_MemorySubSpaceTarok::getMemoryPool(uintptr_t size)
 {
 	/* this function is only used by ConcurrentSweepScheme, which is disabled in Tarok */
 	Assert_MM_unreachable();
@@ -138,7 +141,7 @@ MM_MemorySubSpaceTarok::getMemoryPool(MM_EnvironmentBase *env,
 
 	if ((NULL != addrBase) && (NULL != addrTop)) {
 		MM_HeapRegionDescriptorVLHGC *descriptor = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress(addrBase);
-		MM_HeapRegionDescriptorVLHGC *highDescriptor = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress((void *)((UDATA)addrTop-1));
+		MM_HeapRegionDescriptorVLHGC *highDescriptor = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress((void *)((uintptr_t)addrTop-1));
 		/* we can only work on committed regions with in-use memory pools */
 		if (descriptor->containsObjects()) {
 			pool = descriptor->getMemoryPool();
@@ -163,7 +166,7 @@ MM_MemorySubSpaceTarok::getMemoryPool(MM_EnvironmentBase *env,
 /**
  * @copydoc MM_MemorySubSpace::getActualFreeMemorySize()
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getActualFreeMemorySize()
 {
 	if (isActive()) {
@@ -176,7 +179,7 @@ MM_MemorySubSpaceTarok::getActualFreeMemorySize()
 /**
  * @copydoc MM_MemorySubSpace::getApproximateFreeMemorySize()
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getApproximateFreeMemorySize()
 {
 	if (isActive()) {
@@ -186,14 +189,14 @@ MM_MemorySubSpaceTarok::getApproximateFreeMemorySize()
 	}
 }
 
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getActiveMemorySize()
 {
 	return getCurrentSize();
 }
 
-UDATA
-MM_MemorySubSpaceTarok::getActiveMemorySize(UDATA includeMemoryType)
+uintptr_t
+MM_MemorySubSpaceTarok::getActiveMemorySize(uintptr_t includeMemoryType)
 {
 	if (getTypeFlags() & includeMemoryType) {
 		return getCurrentSize();
@@ -202,8 +205,8 @@ MM_MemorySubSpaceTarok::getActiveMemorySize(UDATA includeMemoryType)
 	}	
 }
 
-UDATA
-MM_MemorySubSpaceTarok::getActiveLOAMemorySize(UDATA includeMemoryType)
+uintptr_t
+MM_MemorySubSpaceTarok::getActiveLOAMemorySize(uintptr_t includeMemoryType)
 {
 	/* LOA is not supported in Tarok */
 	return 0;
@@ -212,17 +215,17 @@ MM_MemorySubSpaceTarok::getActiveLOAMemorySize(UDATA includeMemoryType)
 /**
  * @copydoc MM_MemorySubSpace::getActualActiveFreeMemorySize()
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getActualActiveFreeMemorySize()
 {
 	return _globalAllocationManagerTarok->getActualFreeMemorySize();
 }
 
 /**
- * @copydoc MM_MemorySubSpace::getActualActiveFreeMemorySize(UDATA)
+ * @copydoc MM_MemorySubSpace::getActualActiveFreeMemorySize(uintptr_t)
  */
-UDATA
-MM_MemorySubSpaceTarok::getActualActiveFreeMemorySize(UDATA includeMemoryType)
+uintptr_t
+MM_MemorySubSpaceTarok::getActualActiveFreeMemorySize(uintptr_t includeMemoryType)
 {
 	if (getTypeFlags() & includeMemoryType ) {
 		return _globalAllocationManagerTarok->getActualFreeMemorySize();
@@ -234,17 +237,17 @@ MM_MemorySubSpaceTarok::getActualActiveFreeMemorySize(UDATA includeMemoryType)
 /**
  * @copydoc MM_MemorySubSpace::getApproximateActiveFreeMemorySize()
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getApproximateActiveFreeMemorySize()
 {
 	return _globalAllocationManagerTarok->getApproximateFreeMemorySize();
 }
 
 /**
- * @copydoc MM_MemorySubSpace::getApproximateActiveFreeMemorySize(UDATA)
+ * @copydoc MM_MemorySubSpace::getApproximateActiveFreeMemorySize(uintptr_t)
  */
-UDATA
-MM_MemorySubSpaceTarok::getApproximateActiveFreeMemorySize(UDATA includeMemoryType)
+uintptr_t
+MM_MemorySubSpaceTarok::getApproximateActiveFreeMemorySize(uintptr_t includeMemoryType)
 {
 	if (getTypeFlags() & includeMemoryType ) {
 		return _globalAllocationManagerTarok->getApproximateFreeMemorySize();
@@ -257,7 +260,7 @@ MM_MemorySubSpaceTarok::getApproximateActiveFreeMemorySize(UDATA includeMemoryTy
 /**
  * @copydoc MM_MemorySubSpace::getApproximateActiveFreeLOAMemorySize()
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::getApproximateActiveFreeLOAMemorySize()
 {
 	/* LOA is not supported in Tarok */
@@ -265,10 +268,10 @@ MM_MemorySubSpaceTarok::getApproximateActiveFreeLOAMemorySize()
 }
 
 /**
- * @copydoc MM_MemorySubSpace::getApproximateActiveFreeLOAMemorySize(UDATA)
+ * @copydoc MM_MemorySubSpace::getApproximateActiveFreeLOAMemorySize(uintptr_t)
  */
-UDATA
-MM_MemorySubSpaceTarok::getApproximateActiveFreeLOAMemorySize(UDATA includeMemoryType)
+uintptr_t
+MM_MemorySubSpaceTarok::getApproximateActiveFreeLOAMemorySize(uintptr_t includeMemoryType)
 {
 	/* LOA is not supported in Tarok */
 	return 0;
@@ -281,7 +284,7 @@ MM_MemorySubSpaceTarok::mergeHeapStats(MM_HeapStats *heapStats)
 }
 
 void
-MM_MemorySubSpaceTarok::mergeHeapStats(MM_HeapStats *heapStats, UDATA includeMemoryType)
+MM_MemorySubSpaceTarok::mergeHeapStats(MM_HeapStats *heapStats, uintptr_t includeMemoryType)
 {
 	_globalAllocationManagerTarok->mergeHeapStats(heapStats, includeMemoryType);
 }
@@ -356,7 +359,7 @@ MM_MemorySubSpaceTarok::collectorAllocate(MM_EnvironmentBase *env, MM_Collector 
 
 void *
 MM_MemorySubSpaceTarok::collectorAllocateTLH(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription, 
-												UDATA maximumBytesRequired, void * &addrBase, void * &addrTop)
+												uintptr_t maximumBytesRequired, void * &addrBase, void * &addrTop)
 {
 	Assert_MM_unreachable();
 	return NULL;
@@ -369,7 +372,7 @@ MM_MemorySubSpaceTarok::abandonHeapChunk(void *addrBase, void *addrTop)
 {
 	if (addrBase != addrTop) {
 		MM_HeapRegionDescriptorVLHGC *base = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress(addrBase);
-		MM_HeapRegionDescriptorVLHGC *verify = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress((void *)((UDATA)addrTop - 1));
+		MM_HeapRegionDescriptorVLHGC *verify = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress((void *)((uintptr_t)addrTop - 1));
 		Assert_MM_true(base == verify);
 		/* we can only work on committed regions with in-use memory pools */
 		Assert_MM_true(base->containsObjects());
@@ -470,7 +473,7 @@ MM_MemorySubSpaceTarok::recycleRegion(MM_EnvironmentBase *env, MM_HeapRegionDesc
 	}
 }
 
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::findLargestFreeEntry(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription)
 {
 	return _globalAllocationManagerTarok->getLargestFreeEntry();
@@ -480,7 +483,7 @@ MM_MemorySubSpaceTarok::findLargestFreeEntry(MM_EnvironmentBase *env, MM_Allocat
  * Initialization
  */
 MM_MemorySubSpaceTarok *
-MM_MemorySubSpaceTarok::newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize, UDATA memoryType, U_32 objectFlags)
+MM_MemorySubSpaceTarok::newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, uintptr_t minimumSize, uintptr_t initialSize, uintptr_t maximumSize, uintptr_t memoryType, U_32 objectFlags)
 {
 	MM_MemorySubSpaceTarok *memorySubSpace;
 	
@@ -592,7 +595,7 @@ void
 MM_MemorySubSpaceTarok::addExistingMemory(
 	MM_EnvironmentBase *env,
 	MM_PhysicalSubArena *subArena,
-	UDATA size,
+	uintptr_t size,
 	void *lowAddress,
 	void *highAddress,
 	bool canCoalesce)
@@ -609,7 +612,7 @@ void *
 MM_MemorySubSpaceTarok::removeExistingMemory(
 	MM_EnvironmentBase *env,
 	MM_PhysicalSubArena *subArena,
-	UDATA contractSize,
+	uintptr_t contractSize,
 	void *lowAddress,
 	void *highAddress)
 {
@@ -622,7 +625,7 @@ MM_MemorySubSpaceTarok::removeExistingMemory(
 }
 
 MM_HeapRegionDescriptor * 
-MM_MemorySubSpaceTarok::selectRegionForContraction(MM_EnvironmentBase *env, UDATA numaNode)
+MM_MemorySubSpaceTarok::selectRegionForContraction(MM_EnvironmentBase *env, uintptr_t numaNode)
 {
 	MM_AllocationContextTarok * allocationContext = _globalAllocationManagerTarok->getAllocationContextForNumaNode(numaNode);
 	Assert_MM_true(NULL != allocationContext);
@@ -653,14 +656,14 @@ MM_MemorySubSpaceTarok::lockedReplenishAndAllocate(MM_EnvironmentBase *env, MM_A
 }
 
 void
-MM_MemorySubSpaceTarok::setBytesRemainingBeforeTaxation(UDATA remaining)
+MM_MemorySubSpaceTarok::setBytesRemainingBeforeTaxation(uintptr_t remaining)
 {
 	Trc_MM_setBytesRemainingBeforeTaxation(remaining);
 	_bytesRemainingBeforeTaxation = remaining;
 }
 
 bool 
-MM_MemorySubSpaceTarok::consumeFromTaxationThreshold(MM_EnvironmentBase *env, UDATA bytesToConsume)
+MM_MemorySubSpaceTarok::consumeFromTaxationThreshold(MM_EnvironmentBase *env, uintptr_t bytesToConsume)
 {
 	bool success = false;
 	
@@ -669,13 +672,13 @@ MM_MemorySubSpaceTarok::consumeFromTaxationThreshold(MM_EnvironmentBase *env, UD
 	 */
 	bool thresholdUpdated = false;
 	do {
-		UDATA oldBytesRemaining = _bytesRemainingBeforeTaxation;
+		uintptr_t oldBytesRemaining = _bytesRemainingBeforeTaxation;
 		if (oldBytesRemaining < bytesToConsume) {
 			_bytesRemainingBeforeTaxation = 0;
 			success = false;
 			thresholdUpdated = true;
 		} else {
-			UDATA newBytesRemaining = oldBytesRemaining - bytesToConsume;
+			uintptr_t newBytesRemaining = oldBytesRemaining - bytesToConsume;
 			success = true;
 			thresholdUpdated = (MM_AtomicOperations::lockCompareExchange(&_bytesRemainingBeforeTaxation, oldBytesRemaining, newBytesRemaining) == oldBytesRemaining);
 		}
@@ -688,7 +691,7 @@ void *
 MM_MemorySubSpaceTarok::replenishAllocationContextFailed(MM_EnvironmentBase *env, MM_MemorySubSpace *replenishingSpace, MM_AllocationContext *context, MM_ObjectAllocationInterface *objectAllocationInterface, MM_AllocateDescription *allocateDescription, AllocationType allocationType)
 {
 	void *result = NULL;
-	Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_Entry(env->getLanguageVMThread(), context, (UDATA)allocationType, allocateDescription->getContiguousBytes());
+	Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_Entry(env->getLanguageVMThread(), context, (uintptr_t)allocationType, allocateDescription->getContiguousBytes());
 	Assert_MM_true(this == replenishingSpace);
 
 	/* we currently have no design for handling AC replenishment in a multi-subspace world, so reach for the collector */
@@ -732,7 +735,7 @@ MM_MemorySubSpaceTarok::replenishAllocationContextFailed(MM_EnvironmentBase *env
 			collector->taxationEntryPoint(env, this, allocateDescription);
 			allocateDescription->restoreObjects(env);
 			result = lockedAllocate(env, context, objectAllocationInterface, allocateDescription, allocationType);
-			Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformTaxationAndReplenish(env->getLanguageVMThread(), context, (UDATA)allocationType, allocateDescription->getContiguousBytes(), result);
+			Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformTaxationAndReplenish(env->getLanguageVMThread(), context, (uintptr_t)allocationType, allocateDescription->getContiguousBytes(), result);
 		}
 	}
 	if (NULL == result) {
@@ -743,19 +746,19 @@ MM_MemorySubSpaceTarok::replenishAllocationContextFailed(MM_EnvironmentBase *env
 		/* first, try a resize to satisfy without invoking the collector */
 		performResize(env, allocateDescription);
 		result = lockedAllocate(env, context, objectAllocationInterface, allocateDescription, allocationType);
-		Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformResizeAndReplenish(env->getLanguageVMThread(), context, (UDATA)allocationType, allocateDescription->getContiguousBytes(), result);
+		Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformResizeAndReplenish(env->getLanguageVMThread(), context, (uintptr_t)allocationType, allocateDescription->getContiguousBytes(), result);
 		if (NULL == result) {
 			/* the resize wasn't enough so invoke the collector */
 			allocateDescription->saveObjects(env);
 			allocateDescription->setAllocationType(allocationType);
 			result = collector->garbageCollect(env, this, allocateDescription, J9MMCONSTANT_IMPLICIT_GC_DEFAULT, objectAllocationInterface, replenishingSpace, context);
-			Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformCollect(env->getLanguageVMThread(), context, (UDATA)allocationType, allocateDescription->getContiguousBytes(), result);
+			Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformCollect(env->getLanguageVMThread(), context, (uintptr_t)allocationType, allocateDescription->getContiguousBytes(), result);
 			allocateDescription->restoreObjects(env);
 			if (NULL == result) {
 				/* we _still_ failed so invoke an aggressive collect */
 				allocateDescription->saveObjects(env);
 				result = collector->garbageCollect(env, this, allocateDescription, J9MMCONSTANT_IMPLICIT_GC_AGGRESSIVE, objectAllocationInterface, replenishingSpace, context);
-				Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformAggressiveCollect(env->getLanguageVMThread(), context, (UDATA)allocationType, allocateDescription->getContiguousBytes(), result);
+				Trc_MM_MemorySubSpaceTarok_replenishAllocationContextFailed_didPerformAggressiveCollect(env->getLanguageVMThread(), context, (uintptr_t)allocationType, allocateDescription->getContiguousBytes(), result);
 				allocateDescription->restoreObjects(env);
 			}
 		}
@@ -795,13 +798,13 @@ MM_MemorySubSpaceTarok::lockedAllocate(MM_EnvironmentBase *env, MM_AllocationCon
  * Adjust the specified expansion amount by the specified user increment amount (i.e. -Xmoi)
  * @return the updated expand size
  */
-UDATA
-MM_MemorySubSpaceTarok::adjustExpansionWithinUserIncrement(MM_EnvironmentBase *env, UDATA expandSize)
+uintptr_t
+MM_MemorySubSpaceTarok::adjustExpansionWithinUserIncrement(MM_EnvironmentBase *env, uintptr_t expandSize)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env->getOmrVM());
 
 	if (extensions->allocationIncrementSetByUser) {
-		UDATA expandIncrement = extensions->allocationIncrement;
+		uintptr_t expandIncrement = extensions->allocationIncrement;
 
 		/* increment of 0 means no expansion is to occur. Don't round  to a size of 0 */
 		if (0 == expandIncrement) {
@@ -822,12 +825,12 @@ MM_MemorySubSpaceTarok::adjustExpansionWithinUserIncrement(MM_EnvironmentBase *e
  * 
  * @return the amount by which the receiver can expand
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::maxExpansionInSpace(MM_EnvironmentBase *env)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env->getOmrVM());
-	UDATA expandIncrement = extensions->allocationIncrement;
-	UDATA maxExpandAmount;
+	uintptr_t expandIncrement = extensions->allocationIncrement;
+	uintptr_t maxExpandAmount;
 	
 	if (extensions->allocationIncrementSetByUser) {
 		/* increment of 0 means no expansion */
@@ -847,13 +850,13 @@ MM_MemorySubSpaceTarok::maxExpansionInSpace(MM_EnvironmentBase *env)
  * available space.
  * @return The amount of heap available for contraction factoring in the size of the allocate (if applicable)
  */
-UDATA 
+uintptr_t
 MM_MemorySubSpaceTarok::getAvailableContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
 	return _physicalSubArena->getAvailableContractionSize(env, this, allocDescription);
 }
 
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription)
 {
 	/* we inherit this collectorExpand method, but don't implement it with this signature. */
@@ -861,7 +864,7 @@ MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env, MM_Collector *r
 	return 0;
 }
 
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env)
 {
 	Trc_MM_MemorySubSpaceTarok_collectorExpand_Entry(env->getLanguageVMThread());
@@ -869,14 +872,14 @@ MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env)
 	_expandLock.acquire();
 
 	/* Determine the amount to expand the heap */
-	UDATA expandSize = calculateCollectorExpandSize(env);
+	uintptr_t expandSize = calculateCollectorExpandSize(env);
 	Assert_MM_true((0 == expandSize) || (_heapRegionManager->getRegionSize() == expandSize));
 
 	_extensions->heap->getResizeStats()->setLastExpandReason(SATISFY_COLLECTOR);
 	
 	/* expand by a single region */
 	/* for the most part the code path is not multi-threaded safe, so we do this under expandLock */
-	UDATA expansionAmount= expand(env, expandSize);
+	uintptr_t expansionAmount= expand(env, expandSize);
 	Assert_MM_true((0 == expansionAmount) || (expandSize == expansionAmount));
 
 	/* Inform the requesting collector that an expand attempt took place (even if the expansion failed) */
@@ -895,20 +898,20 @@ MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env)
  * Perform the contraction/expansion based on decisions made by checkResize.
  * Adjustments in contraction size is possible (because compaction might have yielded less then optimal results),
  * therefore allocDescriptor is still passed.
- * @return the actual amount of resize (having IDATA return result will contain valid value only if contract/expand size is half of maxOfUDATA)
+ * @return the actual amount of resize (having intptr_t return result will contain valid value only if contract/expand size is half of maxOfuintptr_t)
  */
-IDATA
+intptr_t
 MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
-	UDATA oldVMState = env->pushVMstate(OMRVMSTATE_GC_PERFORM_RESIZE);
+	uintptr_t oldVMState = env->pushVMstate(OMRVMSTATE_GC_PERFORM_RESIZE);
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
 	/* If -Xgc:fvtest=forceTenureResize is specified, then repeat a sequence of 5 expands followed by 5 contracts */	
 	if (extensions->fvtest_forceOldResize) {
-		UDATA resizeAmount = 0;
-		UDATA regionSize = _extensions->regionSize;
+		uintptr_t resizeAmount = 0;
+		uintptr_t regionSize = _extensions->regionSize;
 		resizeAmount = 2*regionSize;
 		if (5 > extensions->fvtest_oldResizeCounter) {
-			UDATA expansionSize = MM_Math::roundToCeiling(extensions->heapAlignment, resizeAmount);
+			uintptr_t expansionSize = MM_Math::roundToCeiling(extensions->heapAlignment, resizeAmount);
 			expansionSize = MM_Math::roundToCeiling(regionSize, expansionSize);
 			if (canExpand(env, expansionSize)) {
 				extensions->heap->getResizeStats()->setLastExpandReason(FORCED_NURSERY_EXPAND);
@@ -917,7 +920,7 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 				extensions->fvtest_oldResizeCounter += 1;
 			}
 		} else if (10 > extensions->fvtest_oldResizeCounter) {
-			UDATA contractionSize = MM_Math::roundToCeiling(extensions->heapAlignment, resizeAmount);
+			uintptr_t contractionSize = MM_Math::roundToCeiling(extensions->heapAlignment, resizeAmount);
 			contractionSize = MM_Math::roundToCeiling(regionSize, contractionSize);
 			if (canContract(env, contractionSize)) {
 				_contractionSize = contractionSize;
@@ -932,10 +935,10 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 		}
 	}	
 	
-	IDATA resizeAmount = 0;
+	intptr_t resizeAmount = 0;
 
 	if (_contractionSize != 0) {
-		resizeAmount = -(IDATA)performContract(env, allocDescription);
+		resizeAmount = -(intptr_t)performContract(env, allocDescription);
 	} else if (_expansionSize != 0) {
 		resizeAmount = performExpand(env);
 	}
@@ -951,21 +954,292 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 void
 MM_MemorySubSpaceTarok::checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool _systemGC)
 {
-	UDATA oldVMState = env->pushVMstate(OMRVMSTATE_GC_CHECK_RESIZE);
-	if (!timeForHeapContract(env, allocDescription, _systemGC)) {
-		timeForHeapExpand(env, allocDescription);
+	uintptr_t oldVMState = env->pushVMstate(OMRVMSTATE_GC_CHECK_RESIZE);
+
+	Trc_MM_MemorySubSpaceTarok_checkResize_1(env->getLanguageVMThread(), _extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd ? "true" : "false");
+
+	intptr_t heapSizeChange = calculateHeapSizeChange(env, allocDescription, _systemGC);
+
+	intptr_t edenChangeRegions = _extensions->globalVLHGCStats._heapSizingData.edenRegionChange;
+	intptr_t edenChangeRegionsBytes = edenChangeRegions * (intptr_t)_heapRegionManager->getRegionSize();
+
+	Trc_MM_MemorySubSpaceTarok_checkResize_2(env->getLanguageVMThread(), heapSizeChange, edenChangeRegionsBytes);
+
+	ExpandReason nonEdenHeapLastExpandReason = _extensions->heap->getResizeStats()->getLastExpandReason();
+	ContractReason nonEdenHeapLastContractReason = _extensions->heap->getResizeStats()->getLastContractReason();
+
+	if (edenChangeRegionsBytes != 0) {
+		/*
+		 * Report eden sizing by itself, as well as why eden is being resized.
+		 * When contract/expand is actually performed, VGC will report the -overall- change in heap size, and report it accordingly.
+		 * This -overall- change in heap size, is change in eden size + change in non-eden size
+		 */
+		if (edenChangeRegionsBytes > 0) {
+			_extensions->heap->getResizeStats()->setLastExpandReason(EDEN_EXPANDING);
+			reportHeapResizeAttempt(env, edenChangeRegionsBytes, HEAP_EXPAND, MEMORY_TYPE_NEW);
+		} else if (edenChangeRegionsBytes < 0) {
+			_extensions->heap->getResizeStats()->setLastContractReason(EDEN_CONTRACTING);
+			reportHeapResizeAttempt(env, (edenChangeRegionsBytes * -1), HEAP_CONTRACT, MEMORY_TYPE_NEW);
+		}
+
+		/*
+		 * Now that eden resizing has been reported, revert back to previous expand/contract reasons if non-eden sizing logic set any.
+		 * This makes sure that when VGC reports total heap size change, the reason that is used is non-eden resizing reason, instead of repeating eden sizing resize reason
+		 */
+		if (heapSizeChange > 0) {
+			_extensions->heap->getResizeStats()->setLastExpandReason(nonEdenHeapLastExpandReason);
+		} else if (heapSizeChange < 0) {
+			_extensions->heap->getResizeStats()->setLastContractReason(nonEdenHeapLastContractReason);
+		}
 	}
+
+	/* Adjust the heap size by both the required amount for eden AND non-eden. Non-eden size should generally be kept the same size, so that GMP kickoff, and incremental defragmentation timing stays accurate */
+	heapSizeChange += edenChangeRegionsBytes;
+
+	if (0 > heapSizeChange) {
+		_contractionSize = (uintptr_t)(heapSizeChange * -1);
+		_expansionSize = 0;
+	} else if (0 < heapSizeChange) {
+		_contractionSize = 0;
+		_expansionSize = (uintptr_t)heapSizeChange;
+	} else {
+		_contractionSize = 0;
+		_expansionSize = 0;
+	}
+
+	_extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd = false;
+
 	env->popVMstate(oldVMState);
+}
+
+/**
+ * Calculate by how many bytes we should change the current heap size.
+ * @return positive number of bytes represents how many bytes the heap should expand.
+ * 		   If heap should contract, a negative number representing how many bytes the heap should contract is returned.
+ */
+intptr_t
+MM_MemorySubSpaceTarok::calculateHeapSizeChange(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool _systemGC)
+{
+	intptr_t sizeChange = 0;
+
+	bool expandToSatisfy = false;
+	uintptr_t sizeInRegionsRequired = 0;
+
+	if (NULL != allocDescription) {
+		sizeInRegionsRequired = 1;
+		if (allocDescription->isArrayletSpine()) {
+			sizeInRegionsRequired += allocDescription->getNumArraylets();
+		}
+
+		if (sizeInRegionsRequired > _globalAllocationManagerTarok->getFreeRegionCount()) {
+			expandToSatisfy = true;
+		}
+	}
+
+	/*
+	 * Heap sizing is driven by "hybrid Heap overhead". This is a blended value, which combines free memory in "tenure" along with observed GC overhead.
+	 * If the hybrid score is too high (can be acheived by low free memory %, high gc %, or a hybrid of the 2), then the heap calculates an expansion value.
+	 * If the hybrid score is too low (can be acheived with high free memory %, low gc %, or hybrid of the 2), then the heap calculates a contraction value.
+	 *
+	 * Notes: - If gc % is very low (suggesting contraction), and memory % is also very low (suggesting expansion), the hybrid heap score will likely suggest expansion to avoid OOM error
+	 *        - If the hybrid value falls within the acceptable thresholds, the heap will not resize
+	 */
+	double hybridHeapScore = calculateCurrentHybridHeapOverhead(env);
+
+	/* Based on the hybrid overhead of gc cpu, and free memory, decide if heap should expand or contract */
+	if ((hybridHeapScore > (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified) || expandToSatisfy) {
+		/* Try to expand the heap. Note: We enter this block even if readyToResizeAtGlobalEnd might be false, since expansion might be necessary if free space is very small and allocation failure will occur */
+		sizeChange = (intptr_t)calculateExpansionSize(env, allocDescription, _systemGC, expandToSatisfy, sizeInRegionsRequired);
+	} else if ((hybridHeapScore < (double)_extensions->heapContractionGCRatioThreshold._valueSpecified) && _extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd) {
+		/* Try to contract the heap */
+		sizeChange = calculateContractionSize(env, allocDescription, _systemGC, true);
+	}
+
+	if ((0 == sizeChange) && ((double)_extensions->heapContractionGCRatioThreshold._valueSpecified <= hybridHeapScore)) {
+		/*
+		 * There are certain edge cases where the heap should shrink in order to respect Xsoftmx, that will not be picked up if hybrid heap score is ABOVE heapContractionGCRatioThreshold
+		 * We need to inform the calculateContractionSize() that it should not try to get the hybrid heap score within acceptable bounds, but rather, should
+		 * just make sure -Xsoftmx is being respected
+		 */
+		sizeChange = calculateContractionSize(env, allocDescription, _systemGC, false);
+	}
+
+	return sizeChange;
+}
+
+double
+MM_MemorySubSpaceTarok::calculateHybridHeapOverhead(MM_EnvironmentBase *env, intptr_t heapChange)
+{
+	double gcPercentage = calculateGcPctForHeapChange(env, heapChange);
+	double freeMemComponant = mapMemoryPercentageToGcOverhead(env, heapChange);
+
+	if (0 == heapChange) {
+		/* Do not trigger this tracepoint for heapChange != 0, since this function is run dozens of time when changing heap size */
+		Trc_MM_MemorySubSpaceTarok_calculateHybridHeapOverhead(env->getLanguageVMThread(), gcPercentage, freeMemComponant);
+	}
+	return MM_Math::weightedAverage(gcPercentage, freeMemComponant, GMP_OVERHEAD_WEIGHT);
+}
+
+double MM_MemorySubSpaceTarok::mapMemoryPercentageToGcOverhead(MM_EnvironmentBase *env, intptr_t heapSizeChange)
+{
+	double memoryScore = 0.0;
+
+	/* At this point, eden is full, so all the free space is all part of tenure */
+	uintptr_t tenureSize = getActiveMemorySize() - (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.reservedSize;
+	uintptr_t freeTenure = (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.freeTenure;
+
+	if (0 == heapSizeChange) {
+		Trc_MM_MemorySubSpaceTarok_mapMemoryPercentageToGcOverhead_1(env->getLanguageVMThread(), tenureSize, freeTenure);
+	}
+
+	if (tenureSize < freeTenure) {
+		/*
+		 * In certain edge cases (usually in startup), "tenure" is measured slightly innacuratly (due to dynamics of survivor space), resulting in free tenure memory being innacurate.
+		 * Counter-intuitively, free tenure memory here is very small, so suggest expansion
+		 */
+		memoryScore = (double)(2.0 * _extensions->heapExpansionGCRatioThreshold._valueSpecified);
+
+	} else {
+
+		intptr_t newFreeTenureSize = (intptr_t)freeTenure + heapSizeChange;
+		intptr_t newTotalMemorySize = (intptr_t)tenureSize + heapSizeChange;
+		double freeMemoryRatio = ((double)newFreeTenureSize/ (double)newTotalMemorySize) * 100;
+		if (0 != heapSizeChange) {
+			Trc_MM_MemorySubSpaceTarok_mapMemoryPercentageToGcOverhead_2(env->getLanguageVMThread(), heapSizeChange, freeMemoryRatio);
+		}
+
+		if ((0 == freeMemoryRatio) || (0 >= newTotalMemorySize) || (0 >= newFreeTenureSize)) {
+			/* The heap size change will result in no free memory left - return a very high score, suggesting expansion */
+			memoryScore = 100.0;
+		} else {
+			uintptr_t xminf = _extensions->heapFreeMinimumRatioMultiplier;
+			uintptr_t xmaxf = _extensions->heapFreeMaximumRatioMultiplier;
+			uintptr_t xmint = _extensions->heapContractionGCRatioThreshold._valueSpecified;
+			uintptr_t xmaxt = _extensions->heapExpansionGCRatioThreshold._valueSpecified;
+
+			double freeSpaceToGcPctRatio = (double)(xmaxt - xmint) / (xmaxf - xminf);
+
+			double linearMemoryScore = xmaxt - ((freeMemoryRatio - xminf) *  freeSpaceToGcPctRatio);
+
+			/* Adjust the weight for when free memory is low - the function maps to a higher gc cpu overhead (suggesting expansion) */
+			double adjustedMemoryScore = linearMemoryScore * ( (freeMemoryRatio + 10) / freeMemoryRatio);
+
+			memoryScore = OMR_MAX(adjustedMemoryScore, 0);
+		}
+	}
+
+	Trc_MM_MemorySubSpaceTarok_mapMemoryPercentageToGcOverhead_3(env->getLanguageVMThread(), memoryScore);
+
+	return memoryScore;
+}
+
+
+uintptr_t
+MM_MemorySubSpaceTarok::calculateExpansionSize(MM_EnvironmentBase * env, MM_AllocateDescription *allocDescription, bool systemGc, bool expandToSatisfy, uintptr_t sizeInRegionsRequired)
+{
+
+	if((NULL == _physicalSubArena) || !_physicalSubArena->canExpand(env) || (maxExpansionInSpace(env) == 0 )) {
+		/* The PSA or memory sub space cannot be expanded ... we are done */
+		return 0;
+	}
+
+	uintptr_t sizeInBytesRequired = sizeInRegionsRequired * _heapRegionManager->getRegionSize();
+	uintptr_t expansionSize = calculateExpansionSizeInternal(env, sizeInBytesRequired, expandToSatisfy);
+
+	return expansionSize;
+}
+
+intptr_t
+MM_MemorySubSpaceTarok::calculateContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool systemGC, bool shouldIncreaseHybridHeapScore)
+{
+	Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Entry(env->getLanguageVMThread(), systemGC ? "true" : "false");
+
+	/* If PSA or memory sub space can't be shrunk don't bother trying */
+	if ( (NULL == _physicalSubArena) || !_physicalSubArena->canContract(env) || (maxContraction(env) == 0)) {
+		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit1(env->getLanguageVMThread());
+		return 0;
+	}
+
+	/* Don't shrink if we have not met the allocation request... we will be expanding soon if possible anyway */
+	if (NULL != allocDescription) {
+		uintptr_t sizeInRegionsRequired = 1;
+		if (allocDescription->isArrayletSpine()) {
+			sizeInRegionsRequired += allocDescription->getNumArraylets();
+		}
+		uintptr_t freeRegionCount = _globalAllocationManagerTarok->getFreeRegionCount();
+		if (sizeInRegionsRequired >= freeRegionCount) {
+			Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit4(env->getLanguageVMThread(), sizeInRegionsRequired, freeRegionCount);
+			return 0;
+		}
+	}
+
+	/* Don't shrink if we expanded in last extensions->heapContractionStabilizationCount global collections */
+	/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
+	uintptr_t gcCount = _extensions->globalVLHGCStats.gcCount;
+	if (_extensions->heap->getResizeStats()->getLastHeapExpansionGCCount() + _extensions->heapContractionStabilizationCount > gcCount) {
+		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit5(env->getLanguageVMThread());
+		return 0;
+	}
+
+	/* Don't shrink if its a system GC and we had less than -Xminf free at
+	 * the start of the garbage collection
+	 */
+	 if (systemGC) {
+		uintptr_t minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor)
+								* _extensions->heapFreeMinimumRatioMultiplier;
+		uintptr_t freeBytesAtSystemGCStart = _extensions->heap->getResizeStats()->getFreeBytesAtSystemGCStart();
+
+		if (freeBytesAtSystemGCStart < minimumFree) {
+			Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit6(env->getLanguageVMThread(), freeBytesAtSystemGCStart, minimumFree);
+			return 0;
+		}
+	 }
+
+	MM_Heap * heap = MM_GCExtensions::getExtensions(_extensions)->getHeap();
+	uintptr_t actualSoftMx = heap->getActualSoftMxSize(env);
+
+	if(0 != actualSoftMx) {
+		if(actualSoftMx < getActiveMemorySize()) {
+			/* the softmx is less than the currentsize so we're going to attempt an aggressive contract */
+			intptr_t contractionSize = (intptr_t)(getActiveMemorySize() - actualSoftMx) * -1;
+			_extensions->heap->getResizeStats()->setLastContractReason(SOFT_MX_CONTRACT);
+			return contractionSize;
+		}
+	}
+
+	/* No need to shrink if we will not be above -Xmaxf after satisfying the allocate */
+	uintptr_t allocSize = allocDescription ? allocDescription->getBytesRequested() : 0;
+
+	/*
+	 * How much, if any, do we need to contract by? If we entered this function in attempts to increase hybrid heap score, we need to determine
+	 * by how much the heap should shrink to meet the desired hybrid heap score.
+	 * If not, we only entered this function in attempts to respect -Xsoftmx, and should skip this block entirely
+	 */
+	uintptr_t contractSize = 0;
+	if (shouldIncreaseHybridHeapScore || _extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd) {
+		contractSize = calculateTargetContractSize(env, allocSize);
+	}
+
+	if (0 == contractSize) {
+		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit3(env->getLanguageVMThread());
+		return 0;
+	}
+
+	/* Remember reason for contraction for later */
+	_extensions->heap->getResizeStats()->setLastContractReason(FREE_SPACE_HIGH_OR_GC_LOW);
+
+	Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit7(env->getLanguageVMThread(), contractSize);
+	return (intptr_t)contractSize * -1;
 }
 
 /**
  * Expand the heap by required amount
  * @return
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::performExpand(MM_EnvironmentBase *env)
 {
-	UDATA actualExpandAmount;
+	uintptr_t actualExpandAmount;
 	
 	Trc_MM_MemorySubSpaceTarok_performExpand_Entry(env->getLanguageVMThread(), _expansionSize);
 
@@ -979,7 +1253,7 @@ MM_MemorySubSpaceTarok::performExpand(MM_EnvironmentBase *env)
 		 * number of last gc.
 	 	 */ 
 		/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
-		UDATA gcCount = _extensions->globalVLHGCStats.gcCount;
+		uintptr_t gcCount = _extensions->globalVLHGCStats.gcCount;
 
 		_extensions->heap->getResizeStats()->setLastHeapExpansionGCCount(gcCount);
 	}	
@@ -992,11 +1266,11 @@ MM_MemorySubSpaceTarok::performExpand(MM_EnvironmentBase *env)
  * Determine how much we should attempt to contract heap by and call contract()
  * @return The amount we actually managed to contract the heap
  */
-UDATA
+uintptr_t
 MM_MemorySubSpaceTarok::performContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
-	UDATA contractSize, targetContractSize, maximumContractSize;
-	UDATA allocationSize = 0;
+	uintptr_t contractSize, targetContractSize, maximumContractSize;
+	uintptr_t allocationSize = 0;
 	if (NULL != allocDescription) {
 		allocationSize = allocDescription->getBytesRequested();
 	}
@@ -1041,13 +1315,13 @@ MM_MemorySubSpaceTarok::performContract(MM_EnvironmentBase *env, MM_AllocateDesc
 		Trc_MM_MemorySubSpaceTarok_performContract_Exit2(env->getLanguageVMThread());
 		return 0;	
 	} else {
-		UDATA actualContractSize= contract(env, contractSize);
+		uintptr_t actualContractSize= contract(env, contractSize);
 		if (actualContractSize > 0 ) {
 			/* Remember the gc count at the time of last contraction. If contract is outside a gc 
 	 		 * this will be number of last gc.
 	 		 */
 			/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
-			UDATA gcCount = _extensions->globalVLHGCStats.gcCount;
+			uintptr_t gcCount = _extensions->globalVLHGCStats.gcCount;
 
 			_extensions->heap->getResizeStats()->setLastHeapContractionGCCount(gcCount);
 		}	
@@ -1058,140 +1332,6 @@ MM_MemorySubSpaceTarok::performContract(MM_EnvironmentBase *env, MM_AllocateDesc
 }
 
 /**
- * Determine how much we should attempt to expand subspace by and store the result in _expansionSize
- * @return true if expansion size is non zero
- */
-bool
-MM_MemorySubSpaceTarok::timeForHeapExpand(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
-{
-	bool doExpand = false;
-	
-	if((NULL == _physicalSubArena) || !_physicalSubArena->canExpand(env) || (maxExpansionInSpace(env) == 0 )) {
-		/* The PSA or memory sub space cannot be expanded ... we are done */
-	} else {
-		bool expandToSatisfy = false;
-		UDATA sizeInRegionsRequired = 0;
-
-		if (NULL != allocDescription) {
-			sizeInRegionsRequired = 1;
-			if (allocDescription->isArrayletSpine()) {
-				sizeInRegionsRequired += allocDescription->getNumArraylets();
-			}
-			if (sizeInRegionsRequired > _globalAllocationManagerTarok->getFreeRegionCount()) {
-				expandToSatisfy = true;
-			}
-		}
-	
-		UDATA sizeInBytesRequired = sizeInRegionsRequired * _heapRegionManager->getRegionSize();
-		_expansionSize = calculateExpandSize(env, sizeInBytesRequired, expandToSatisfy);
-		doExpand = (0 != _expansionSize);
-	}
-	return doExpand;
-}
-
-/**
- * Determine how much we should attempt to contract subspace by and store the result in _contractionSize
- * 
- * @return true if contraction size is non zero
- */
-bool
-MM_MemorySubSpaceTarok::timeForHeapContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool systemGC)
-{
-	Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Entry(env->getLanguageVMThread(), systemGC ? "true" : "false");
-
-	/* If PSA or memory sub space can't be shrunk don't bother trying */
-	if ( (NULL == _physicalSubArena) || !_physicalSubArena->canContract(env) || (maxContraction(env) == 0)) {
-		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit1(env->getLanguageVMThread());
-		return false;
-	}
-
-	/* Don't shrink if we have not met the allocation request
-	 * ..we will be expanding soon if possible anyway
-	 */
-	if (NULL != allocDescription) {
-		UDATA sizeInRegionsRequired = 1;
-		if (allocDescription->isArrayletSpine()) {
-			sizeInRegionsRequired += allocDescription->getNumArraylets();
-		}
-		UDATA freeRegionCount = _globalAllocationManagerTarok->getFreeRegionCount();
-		if (sizeInRegionsRequired >= freeRegionCount) {
-			Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit4(env->getLanguageVMThread(), sizeInRegionsRequired, freeRegionCount);
-			_contractionSize = 0;
-			return false;
-		}
-	}
-
-	MM_Heap * heap = MM_GCExtensions::getExtensions(_extensions)->getHeap();
-	UDATA actualSoftMx = heap->getActualSoftMxSize(env);
-
-	if(0 != actualSoftMx) {
-		if(actualSoftMx < getActiveMemorySize()) {
-			/* the softmx is less than the currentsize so we're going to attempt an aggressive contract */
-			_contractionSize = getActiveMemorySize() - actualSoftMx;
-			_extensions->heap->getResizeStats()->setLastContractReason(SOFT_MX_CONTRACT);
-			return true;
-		}
-	}
-	
-	/* Don't shrink if -Xmaxf1.0 specified , i.e max free is 100% */
-	if ( _extensions->heapFreeMaximumRatioMultiplier == 100 ) {
-		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit2(env->getLanguageVMThread());
-		return false;
-	}
-	
-	/* No need to shrink if we will not be above -Xmaxf after satisfying the allocate */
-	UDATA allocSize = allocDescription ? allocDescription->getBytesRequested() : 0;
-	
-	/* Are we spending too little time in GC ? */
-	bool ratioContract = checkForRatioContract(env);
-	
-	/* How much, if any, do we need to contract by ? */
-	_contractionSize = calculateTargetContractSize(env, allocSize, ratioContract);
-	
-	if (_contractionSize == 0 ) {
-		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit3(env->getLanguageVMThread());
-		return false;
-	}	
-	
-
-	
-	/* Don't shrink if we expanded in last extensions->heapContractionStabilizationCount global collections */
-	/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
-	UDATA gcCount = _extensions->globalVLHGCStats.gcCount;
-	if (_extensions->heap->getResizeStats()->getLastHeapExpansionGCCount() + _extensions->heapContractionStabilizationCount > gcCount) {
-		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit5(env->getLanguageVMThread());
-		_contractionSize = 0;
-		return false;	
-	}	
-	
-	/* Don't shrink if its a system GC and we had less than -Xminf free at 
-	 * the start of the garbage collection 
-	 */ 
-	 if (systemGC) {
-	 	UDATA minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor) 
-								* _extensions->heapFreeMinimumRatioMultiplier;
-		UDATA freeBytesAtSystemGCStart = _extensions->heap->getResizeStats()->getFreeBytesAtSystemGCStart();
-		
-		if (freeBytesAtSystemGCStart < minimumFree) {
-	 		Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit6(env->getLanguageVMThread(), freeBytesAtSystemGCStart, minimumFree);
-			_contractionSize = 0;
-	 		return false;	
-		}	
-	 }	
-	
-	/* Remember reason for contraction for later */
-	if (ratioContract) {
-		_extensions->heap->getResizeStats()->setLastContractReason(GC_RATIO_TOO_LOW);
-	} else {
-		_extensions->heap->getResizeStats()->setLastContractReason(FREE_SPACE_GREATER_MAXF);
-	}	
-		
-	Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit7(env->getLanguageVMThread(), _contractionSize);
-	return true;
-}
-
-
-/**
  * Determine the amount of heap to contract.
  * Calculate the contraction size while factoring in the pending allocate and whether a contract based on
  * percentage of GC time to total time is required.  If there is room to contract, the value is derived from,
@@ -1199,14 +1339,13 @@ MM_MemorySubSpaceTarok::timeForHeapContract(MM_EnvironmentBase *env, MM_Allocate
  * 2) The heap maximum/minimum contraction sizes
  * 3) The heap alignment
  * @note We use the approximate heap size to account for defered work that may during execution free up more memory.
- * @todo Explain what the fudge factors of +5 and +1 mean
  * @return the recommended amount of heap in bytes to contract.
  */
-UDATA
-MM_MemorySubSpaceTarok::calculateTargetContractSize(MM_EnvironmentBase *env, UDATA allocSize, bool ratioContract)
+uintptr_t
+MM_MemorySubSpaceTarok::calculateTargetContractSize(MM_EnvironmentBase *env, uintptr_t allocSize)
 {
-	Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Entry(env->getLanguageVMThread(), allocSize, ratioContract ? "true":"false");
-	UDATA contractionSize = 0;
+	Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Entry2(env->getLanguageVMThread(), allocSize);
+	uintptr_t contractionSize = 0;
 
 	/* If there is not enough memory to satisfy the alloc, don't contract.  If allocSize is greater than the total free memory,
 	 * the currentFree value is a large positive number (negative unsigned number calculated above).
@@ -1214,114 +1353,54 @@ MM_MemorySubSpaceTarok::calculateTargetContractSize(MM_EnvironmentBase *env, UDA
 	if (allocSize > getApproximateActiveFreeMemorySize()) {
 		contractionSize = 0;
 	} else {
-		UDATA currentFree = getApproximateActiveFreeMemorySize() - allocSize;
-		UDATA currentHeapSize = getActiveMemorySize();
-		UDATA maximumFreePercent =  ratioContract ? OMR_MIN(_extensions->heapFreeMinimumRatioMultiplier + 5, _extensions->heapFreeMaximumRatioMultiplier + 1) :
-													_extensions->heapFreeMaximumRatioMultiplier + 1;
-		UDATA maximumFree = (currentHeapSize / _extensions->heapFreeMaximumRatioDivisor) * maximumFreePercent;
+		/* At this point, we know that our hybrid heap score is too high, so we aim to simply get within acceptable bounds */
+		uintptr_t heapSizeWithinGoodHybridRange = getHeapSizeWithinBounds(env);
 
-		/* Do we have more free than is desirable ? */
-		if (currentFree > maximumFree ) {
-			/* How big a heap do we need to leave maximumFreePercent free given current live data */
-			UDATA targetHeapSize = ((currentHeapSize - currentFree) / (_extensions->heapFreeMaximumRatioDivisor - maximumFreePercent))
-										 * _extensions->heapFreeMaximumRatioDivisor;
-			
-			if (currentHeapSize < targetHeapSize) {
-				/* due to rounding errors, targetHeapSize may actually be larger than currentHeapSize */
+		if (0 != heapSizeWithinGoodHybridRange) {
+			/* This means the heap size we are aiming for is actually possible. This is likely always true for contraction of the heap - but may not always be true for expansion */
+
+			contractionSize = getActiveMemorySize() - heapSizeWithinGoodHybridRange;
+
+			if (contractionSize > heapSizeWithinGoodHybridRange) {
+				/* A calculation went wrong due to overflow - do not contract */
 				contractionSize = 0;
-			} else {
-				/* Calculate how much we need to contract by to get to target size.
-				 * Note: PSA code will ensure we do not drop below initial heap size
-				 */
-				contractionSize= currentHeapSize - targetHeapSize;
-							
-				Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Event1(env->getLanguageVMThread(), contractionSize);
-				
-				/* But we don't contract too quickly or by a trivial amount */	
-				UDATA maxContract = (UDATA)(currentHeapSize * _extensions->globalMaximumContraction);
-				UDATA minContract = (UDATA)(currentHeapSize * _extensions->globalMinimumContraction);
-				UDATA contractionGranule = _extensions->regionSize;
-				
-				/* If max contraction is less than a single region (minimum contraction granularity) round it up */
-				if (maxContract < contractionGranule) {
-					maxContract = contractionGranule;
-				} else {
-					maxContract = MM_Math::roundToCeiling(contractionGranule, maxContract);
-				}
-				
-				contractionSize = OMR_MIN(contractionSize, maxContract);
-				
-				/* We will contract in multiples of region size. Result may become zero */
-				contractionSize = MM_Math::roundToFloor(contractionGranule, contractionSize);
-				
-				/* Make sure contract is worthwhile, don't want to go to possible expense of a 
-				 * compact for a small contraction
-				 */
-				if (contractionSize < minContract) { 
-					contractionSize = 0;
-				}	
-				
-				Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Event2(env->getLanguageVMThread(), contractionSize, maxContract);
+			} else if (getApproximateActiveFreeMemorySize() < (allocSize + contractionSize)) {
+				/* After we contract, we will not have enough space to satisfy allocation, so don't suggest contraction at all */
+				contractionSize = 0;
 			}
-		} else {
-			/* No need to contract as current free less than max */
-			contractionSize = 0;
-		}	
+		}
 	}
-		
+
 	Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Exit1(env->getLanguageVMThread(), contractionSize);
+
 	return contractionSize;
-}	
+}
 
 
 /**
- * Determine how much space we need to expand the heap by on this GC cycle to meet the users specified -Xminf amount
+ * Determine how much space we need to expand the heap by on this GC cycle to get to a better hybrid heap score
  * @note We use the approximate heap size to account for defered work that may during execution free up more memory.
  * @param expandToSatisfy - if TRUE ensure we epxand heap by at least "byteRequired" bytes
- * @return Number of bytes required or 0 if current free already meets the desired bytes free
+ * @return Number of bytes to expand. 0 if no expansion is required
  */
-UDATA
-MM_MemorySubSpaceTarok::calculateExpandSize(MM_EnvironmentBase *env, UDATA bytesRequired, bool expandToSatisfy)
+uintptr_t
+MM_MemorySubSpaceTarok::calculateExpansionSizeInternal(MM_EnvironmentBase *env, uintptr_t bytesRequired, bool expandToSatisfy)
 {
-	UDATA currentFree, minimumFree, desiredFree;
-	UDATA expandSize = 0;
+	uintptr_t expandSize = 0;
 	
 	Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Entry(env->getLanguageVMThread(), bytesRequired);
-	
-	/* How much heap space currently free ? */
-	currentFree = getApproximateActiveFreeMemorySize();
-	
-	/* and how much do we need free after this GC to meet -Xminf ? */
-	minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor) * _extensions->heapFreeMinimumRatioMultiplier;
-	
-	/* The desired free is the sum of these 2 rounded to heapAlignment */
-	desiredFree= MM_Math::roundToCeiling(_extensions->heapAlignment, minimumFree + bytesRequired);
 
-	if(desiredFree <= currentFree) {
+	uintptr_t gcCount = _extensions->globalVLHGCStats.gcCount;
+
+	if ((_extensions->heap->getResizeStats()->getLastHeapExpansionGCCount() + _extensions->heapExpansionStabilizationCount <= gcCount) && (_extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd || (0 == _extensions->globalVLHGCStats._heapSizingData.freeTenure))) {
 		/* Only expand if we didn't expand in last _extensions->heapExpansionStabilizationCount global collections */
 		/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
-		UDATA gcCount = _extensions->globalVLHGCStats.gcCount;
+		uintptr_t heapSizeWithinGoodHybridRange = getHeapSizeWithinBounds(env);
 
-		if (_extensions->heap->getResizeStats()->getLastHeapExpansionGCCount() + _extensions->heapExpansionStabilizationCount <= gcCount )
-		{
-			/* Determine if its time for a ratio expand ? */
-			expandSize = checkForRatioExpand(env,bytesRequired);
+		expandSize = heapSizeWithinGoodHybridRange - getActiveMemorySize();
+		if (0 != expandSize) {
+			_extensions->heap->getResizeStats()->setLastExpandReason(FREE_SPACE_LOW_OR_GC_HIGH);
 		}
-
-		if (expandSize > 0 ) {
-			/* Remember reason for expansion for later */
-			_extensions->heap->getResizeStats()->setLastExpandReason(GC_RATIO_TOO_HIGH);
-		} 
-	} else {
-		/* Calculate how much we need to expand the heap by in order to meet the 
-		 * allocation request and the desired -Xminf amount AFTER expansion 
-		 */
-		expandSize= ((desiredFree - currentFree) / (100 - _extensions->heapFreeMinimumRatioMultiplier)) * _extensions->heapFreeMinimumRatioDivisor;
-
-		if (expandSize > 0 ) {
-			/* Remember reason for contraction for later */
-			_extensions->heap->getResizeStats()->setLastExpandReason(FREE_SPACE_LESS_MINF);
-		}	
 	}
 
 	if (expandToSatisfy){
@@ -1341,9 +1420,7 @@ MM_MemorySubSpaceTarok::calculateExpandSize(MM_EnvironmentBase *env, UDATA bytes
 		/* and adjust to user increment values (Xmoi) */
 		expandSize = adjustExpansionWithinUserIncrement(env, expandSize);
 	}
-	
-	/* Expand size now in range -Xmine =< expandSize <= -Xmaxe */
-	
+
 	/* Adjust within -XsoftMx limit */
 	if (expandToSatisfy){
 		/* we need at least bytesRequired or we will get an OOM */
@@ -1355,18 +1432,179 @@ MM_MemorySubSpaceTarok::calculateExpandSize(MM_EnvironmentBase *env, UDATA bytes
 		expandSize = adjustExpansionWithinSoftMax(env, expandSize, 0);
 	}
 	
-	Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit1(env->getLanguageVMThread(), desiredFree, currentFree, expandSize);
+	Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit2(env->getLanguageVMThread(), expandSize);
 	return expandSize;
 }
 
+uintptr_t
+MM_MemorySubSpaceTarok::getHeapSizeWithinBounds(MM_EnvironmentBase *env)
+{
+	double currentHybridHeapScore = calculateCurrentHybridHeapOverhead(env);
+	uintptr_t recommendedHeapSize = getActiveMemorySize();
+	double maxHeapDeviation = 0.25;
 
-UDATA
+	/*
+	 * If the hybrid overhead is too high, we attempt to bring it back down to an acceptable level.
+	 * Conversely, if hybrid overhead is too low, we aim to increase the hybrid overhead to an acceptable level.
+	 *
+	 * In order to decrease hybrid overhead, heap must expand. When the heap expands, gc cpu % will decrease, and free memory % will increase, resulting in a lower overhead.
+	 * In order to increase hybrid overhead, heap must contract. When heap contracts, gc cpu % will increase, and free memory % will decrease, resulting in a higher hybrid overhead.
+	 */
+	bool hybridOverheadTooHigh = currentHybridHeapScore > (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified;
+	bool foundAcceptableHeapSizeChange = false;
+	/* in order to decrease the hybrid overhead, we need to expand the heap. Conversely, to increase hybrid overhead, we contract the heap  */
+	intptr_t heapSizeChangeGranularity = hybridOverheadTooHigh ? (intptr_t)_heapRegionManager->getRegionSize() : (-1 * (intptr_t)_heapRegionManager->getRegionSize());
+	uintptr_t maxHeapExpansion = (uintptr_t)((1 + maxHeapDeviation) * (double)recommendedHeapSize);
+	uintptr_t maxHeapContraction = (uintptr_t)(_extensions->globalVLHGCStats._heapSizingData.freeTenure * maxHeapDeviation);
+
+	intptr_t suggestedChange = heapSizeChangeGranularity;
+
+	/* Aiming to expand the heap so that hybrid heap score is 0.1 below heapExpansionGCRatioThreshold, prevents head from expanding again due to noise */
+	double maxHybridOverheadScore = (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified - 0.1;
+	double minHybridOverheadScore = (double)_extensions->heapContractionGCRatioThreshold._valueSpecified;
+
+	/* Move the heap size in the right direction (expand/contract) to see what the memory overhead, and gc cpu overhead will be, until we find an acceptable change in heap size */
+	while (!foundAcceptableHeapSizeChange) {
+
+		if (hybridOverheadTooHigh) {
+			/* We are trying to expand - but the potential expansion amount is too high*/
+			if ((recommendedHeapSize + suggestedChange) > maxHeapExpansion) {
+				break;
+			}
+		} else {
+			/*
+			 * Leave headroom for free tenure (ie. do not contract by more than 25% of current free tenure space)
+			 * This is both to remain symetric with max expansion of 25%, and to prevent overly aggressive contraction
+			 */
+			if ((suggestedChange * -1) >= (intptr_t)maxHeapContraction) {
+				break;
+			}
+		}
+
+		/* Test what will happen to gc cpu % and free memory % if we expand/contract by heapSizeChange bytes */
+		double potentialHybridOverhead = calculateHybridHeapOverhead(env, suggestedChange);
+
+		if ((potentialHybridOverhead <= maxHybridOverheadScore) && (potentialHybridOverhead >= minHybridOverheadScore)) {
+			/* The heap size we tested will give us an acceptable amount of free space, and better gc cpu % */
+			recommendedHeapSize += suggestedChange;
+			foundAcceptableHeapSizeChange = true;
+			Trc_MM_MemorySubSpaceTarok_getHeapSizeWithinBounds_1(env->getLanguageVMThread(), recommendedHeapSize, potentialHybridOverhead);
+		} else {
+			/* The heap size we tried was not satisfactory. Keep searching */
+			suggestedChange += heapSizeChangeGranularity;
+		}
+	}
+
+	/*
+	 * If looking at the overhead curve did not work, base the expansion/contraction off of how high/low the hybrid overhead is.
+	 * For each % above heapExpansionGCRatioThreshold, expand more aggresively.
+	 * Ie, if heapExpansionGCRatioThreshold = 13, and measured hybrid overhead is 20, we want to expand by a larger amount than if measured hybrid overhead is 14.
+	 */
+	if (!foundAcceptableHeapSizeChange) {
+		/* Expansion and contraction may increase/decrease by larger/smaller amounts */
+		uintptr_t sizeChangeFactor = 0;
+
+		/* percentDiff is represented as percent between 0 - 100 */
+		double percentDiff = 0.0;
+
+		if (currentHybridHeapScore >= (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified) {
+			/* Try to bring hybridHeapScore a little bit below _extensions->heapExpansionGCRatioThreshold */
+			percentDiff = currentHybridHeapScore - (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified;
+
+			/* Limit the percent difference to prevent any accidental big changes.
+			 * This helps deal with cases with one GC that is too long for whatever reason, causing a massive, undesired increase in heap size
+			 */
+			percentDiff = OMR_MAX(percentDiff, 5.0);
+
+			/* Be a bit more aggressive with expansion than contraction.  */
+			sizeChangeFactor = 2;
+
+		} else if (currentHybridHeapScore <= (double)_extensions->heapContractionGCRatioThreshold._valueSpecified) {
+			/* Try to bring hybridHeapScore a little bit above _extensions->heapContractionGCRatioThreshold.
+			 * If this doesn't cause the hybrid heap score to increase enough so that it is within acceptable bounds, this path will be taken
+			 * again later, and another small contraction will occur.
+			 */
+			percentDiff = currentHybridHeapScore - (double)_extensions->heapContractionGCRatioThreshold._valueSpecified;
+			sizeChangeFactor = 1;
+		}
+
+		/* Since percentDiff is 0 - 100, make sure to convert it to 0-1 percentage */
+		double heapSizePercentChange = (1.0 + ((double)sizeChangeFactor * (percentDiff / 100 )));
+		Trc_MM_MemorySubSpaceTarok_getHeapSizeWithinBounds_2(env->getLanguageVMThread(), heapSizePercentChange);
+		recommendedHeapSize = (uintptr_t)(heapSizePercentChange * recommendedHeapSize);
+	}
+
+	return recommendedHeapSize;
+}
+
+
+double
+MM_MemorySubSpaceTarok::calculateGcPctForHeapChange(MM_EnvironmentBase *env, intptr_t heapSizeChange)
+{
+	/*
+	 * If we are resizing after PGC, calculate by how much gc % will change for given change in heap size.
+	 * Otherwise, we are resizing after a Global GC, and some statistics might be unusable
+	 */
+
+	if (MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType) {
+		/* Resizing after a PGC */
+
+		uintptr_t pgcCount = _extensions->globalVLHGCStats.getRepresentativePgcPerGmpCount();
+
+		if ((0 == pgcCount) && (0 == _lastObservedGcPercentage)) {
+			/* Very first time we are resizing, assume GC % is heapExpansionGCRatioThreshold. This makes it slightly easier to expand the heap */
+			_lastObservedGcPercentage = (double)_extensions->heapExpansionGCRatioThreshold._valueSpecified;
+
+		} else {
+
+			if (0 != heapSizeChange) {
+				/*
+				 * Determine what the gc cpu % would be if we changed the heap by heapSizeChange bytes
+				 * Main idea is that the change in number of pgc's (per gmp) will be proportional to how much free tenure changes;
+				 */
+				uintptr_t currentFreeTenure = (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.freeTenure;
+				uintptr_t potentialFreeTenure = 0;
+				if (heapSizeChange <= (-1 * (intptr_t)currentFreeTenure) ) {
+					/* If we try to shrink too much, too fast, tenure will be way too small, causing lots of GC work */
+					potentialFreeTenure = 1;
+				} else {
+					potentialFreeTenure = currentFreeTenure + heapSizeChange;
+				}
+				pgcCount = (uintptr_t)(((double)potentialFreeTenure / currentFreeTenure) * pgcCount);
+			}
+
+			/* For total heap resizing, only consider GMP cpu overhead. PGC overhead is being controlled by eden sizing logic, so no need to include it here */
+			double gcActiveTime = (double)_extensions->globalVLHGCStats._heapSizingData.gmpTime;
+			double gcInterval = (double)(pgcCount  * (_extensions->globalVLHGCStats._heapSizingData.avgPgcTimeUs + _extensions->globalVLHGCStats._heapSizingData.avgPgcIntervalUs));
+			double gcActiveRatio = gcActiveTime / gcInterval;
+
+			_lastObservedGcPercentage = gcActiveRatio * 100;
+		}
+
+	} else {
+		Assert_MM_true(MM_CycleState::CT_GLOBAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
+		/*
+		 * Resizing the heap after global GC. The PGC and GMP timing data MAY no longer be accurate - look at backup methods.
+		 * The values below do not change if heapSizeChange != 0, since global GC is proportional to live data in heap, rather than heap size.
+		 * This means changing the heap size will not change the gc% by much
+		 */
+		if (NULL != _collector) {
+			_lastObservedGcPercentage = (double)_collector->getGCTimePercentage(env);
+		} else {
+			_lastObservedGcPercentage = (double)_extensions->getGlobalCollector()->getGCTimePercentage(env);
+		}
+	}
+
+	return _lastObservedGcPercentage;
+}
+
+uintptr_t
 MM_MemorySubSpaceTarok::calculateCollectorExpandSize(MM_EnvironmentBase *env)
 {
 	Trc_MM_MemorySubSpaceTarok_calculateCollectorExpandSize_Entry(env->getLanguageVMThread());
 	
 	/* expand by a single region */
-	UDATA expandSize = _heapRegionManager->getRegionSize(); 
+	uintptr_t expandSize = _heapRegionManager->getRegionSize();
 	
 	/* Adjust within -XsoftMx limit */
 	expandSize = adjustExpansionWithinSoftMax(env, expandSize,0);
@@ -1377,122 +1615,14 @@ MM_MemorySubSpaceTarok::calculateCollectorExpandSize(MM_EnvironmentBase *env)
 }
 
 /**
- * Determine if a  expand is required 
- * @note We use the approximate heap size to account for defered work that may during execution free up more memory.
- * @return expand size if ratio expand required or 0 otherwise
- */
-UDATA
-MM_MemorySubSpaceTarok::checkForRatioExpand(MM_EnvironmentBase *env, UDATA bytesRequired)
-{
-	Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Entry(env->getLanguageVMThread(), bytesRequired);
-	
-	U_32 gcPercentage;
-	UDATA currentFree, maxFree;
-
-	/* How many bytes currently free ? */	 
-	currentFree = getApproximateActiveFreeMemorySize();
-						 
-	/* How many bytes free would constitute -Xmaxf at current heap size ? */				 
-	maxFree = (UDATA)(((U_64)getActiveMemorySize()  * _extensions->heapFreeMaximumRatioMultiplier)
-														 / ((U_64)_extensions->heapFreeMaximumRatioDivisor));
-														 
-	/* If we have hit -Xmaxf limit already ...return immediately */													 
-	if (currentFree >= maxFree) { 
-		Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Exit1(env->getLanguageVMThread());
-		return 0;
-	}														 
-						 
-	/* Ask the collector for percentage of time being spent in GC */
-	if(NULL != _collector) {
-		gcPercentage = _collector->getGCTimePercentage(env);
-	} else {
-		gcPercentage= _extensions->getGlobalCollector()->getGCTimePercentage(env);
-	}
-	
-	/* Is too much time is being spent in GC? */
-	if (gcPercentage < _extensions->heapExpansionGCTimeThreshold) {
-		Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Exit2(env->getLanguageVMThread(), gcPercentage);
-		return 0;
-	} else { 
-		/* 
-		 * We are spending too much time in gc and are below -Xmaxf free space so expand to 
-		 * attempt to reduce gc time.
-		 * 
-		 * At this point we already know we have -Xminf storage free. 
-		 * 
-		 * We expand by HEAP_FREE_RATIO_EXPAND_MULTIPLIER percentage provided this does not take us above
-		 * -Xmaxf. If it does we expand up to the -Xmaxf limit.
-		 */ 
-		UDATA ratioExpandAmount, maxExpandSize;
-			
-		/* How many bytes (maximum) do we want to expand by ?*/
-		ratioExpandAmount =(UDATA)(((U_64)getActiveMemorySize()  * HEAP_FREE_RATIO_EXPAND_MULTIPLIER)
-						 / ((U_64)HEAP_FREE_RATIO_EXPAND_DIVISOR));		
-						 
-		/* If user has set -Xmaxf1.0 then they do not care how much free space we have
-		 * so no need to limit expand size here. Expand size will later be checked  
-		 * against -Xmaxe value.
-		 */
-		if (_extensions->heapFreeMaximumRatioMultiplier < 100 ) {					 
-			
-			/* By how much could we expand current heap without taking us above -Xmaxf bytes in 
-			 * resulting new (larger) heap
-			 */ 
-			maxExpandSize = ((maxFree - currentFree) / (100 - _extensions->heapFreeMaximumRatioMultiplier)) *
-								_extensions->heapFreeMaximumRatioDivisor;
-				
-			ratioExpandAmount = OMR_MIN(maxExpandSize,ratioExpandAmount);
-		}	
-
-		/* Round expansion amount UP to heap alignment */
-		ratioExpandAmount = MM_Math::roundToCeiling(_extensions->heapAlignment, ratioExpandAmount);	
-				
-		Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Exit3(env->getLanguageVMThread(), gcPercentage, ratioExpandAmount);
-		return ratioExpandAmount;
-	}
-}	
-	
-/**
- * Determine if a ratio contract is required.
- * Calculate the percentage of GC time relative to total execution time, and if this percentage
- * is less than a particular threshold, it is time to contract.
- * @return true if a contraction is desirable, false otherwise.
- */
-bool
-MM_MemorySubSpaceTarok::checkForRatioContract(MM_EnvironmentBase *env) 
-{
-	Trc_MM_MemorySubSpaceTarok_checkForRatioContract_Entry(env->getLanguageVMThread());
-	
-	/* Ask the collector for percentage of time spent in GC */
-	U_32 gcPercentage;
-	if(NULL != _collector) {
-		gcPercentage = _collector->getGCTimePercentage(env);
-	} else {
-		gcPercentage = _extensions->getGlobalCollector()->getGCTimePercentage(env);
-	}
-	
-	/* If we are spending less than extensions->heapContractionGCTimeThreshold of
-	 * our time in gc then we should attempt to shrink the heap
-	 */ 	
-	if (gcPercentage > 0 && gcPercentage < _extensions->heapContractionGCTimeThreshold) {
-		Trc_MM_MemorySubSpaceTarok_checkForRatioContract_Exit1(env->getLanguageVMThread(), gcPercentage);
-		return true;
-	} else {
-		Trc_MM_MemorySubSpaceTarok_checkForRatioContract_Exit2(env->getLanguageVMThread(), gcPercentage);
-		return false;
-	}			
-}
-
-
-/**
  * Compare the specified expand amount with the specified minimum and maximum expansion amounts
  * (-Xmine and -Xmaxe command line options) and round the amount to within these limits
  * @return Updated expand size
  */		
-MMINLINE UDATA		
-MM_MemorySubSpaceTarok::adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, UDATA expandSize)
+MMINLINE uintptr_t
+MM_MemorySubSpaceTarok::adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, uintptr_t expandSize)
 {		
-	UDATA result = expandSize;
+	uintptr_t result = expandSize;
 	
 	if (expandSize > 0 ) { 
 		if(_extensions->heapExpansionMinimumSize > 0 ) {

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -56,10 +56,11 @@ class MM_MemorySubSpaceTarok : public MM_MemorySubSpace
 private:
 	MM_GlobalAllocationManagerTarok *_globalAllocationManagerTarok;	/**< Provides the API for accessing information about the underlying regions (owned by the AllocationContextTarok instances) */
 	bool _allocateAtSafePointOnly;
-	volatile UDATA _bytesRemainingBeforeTaxation;	/**< The number of bytes which this subspace can use for allocation before triggering an early allocation failure */
+	volatile uintptr_t _bytesRemainingBeforeTaxation;	/**< The number of bytes which this subspace can use for allocation before triggering an early allocation failure */
 
 	MM_HeapRegionManager *_heapRegionManager;	/**< Stored so that we can resolve the table descriptor for given addresses when asked for a pool corresponding to a specific address */
 	MM_LightweightNonReentrantLock _expandLock; /**< Most of the common expand code is not multi-threaded safe (since it used in standard collectors on alloc path fail path which is single threaded)  */
+	double _lastObservedGcPercentage; /**< The most recently observed GC percentage (time gc is active / time gc is not active) */
 
 protected:
 public:
@@ -67,28 +68,90 @@ public:
 /* function members */
 private:
 	bool initialize(MM_EnvironmentBase *env);
-	UDATA adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, UDATA expandSize);
-	UDATA checkForRatioExpand(MM_EnvironmentBase *env, UDATA bytesRequired);	
-	bool checkForRatioContract(MM_EnvironmentBase *env);
-	UDATA calculateExpandSize(MM_EnvironmentBase *env, UDATA bytesRequired, bool expandToSatisfy);
-	
+	uintptr_t adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, uintptr_t expandSize);
+	uintptr_t calculateExpansionSizeInternal(MM_EnvironmentBase *env, uintptr_t bytesRequired, bool expandToSatisfy);
+
+	/**
+	 * @return Current GC percentage expressed as value between 0-100
+	 */
+	double calculateCurrentGcPct(MM_EnvironmentBase *env) { return calculateGcPctForHeapChange(env, 0); }
+
+	/**
+	 *	Calculates the GC percentage if the heap were to change "heapSizeChange" bytes.
+	 *  Uses values in VLHGCEnvironment to get most accurate GC percentage available, and resorts to alternative methods if these stats are unavailable
+	 *  @param heapSizeChange represents how many bytes we increase/decrease the heap by
+	 *  @return GC percentage expressed as a value between 0 and 100, that will occur if we change heap by heapSizeChange bytes.
+	 */
+	double calculateGcPctForHeapChange(MM_EnvironmentBase *env, intptr_t heapSizeChange);
+
+	/**
+	 * Calculate by how many bytes we should change the current heap size.
+	 * @return positive number of bytes representing how many bytes the heap should expand.
+	 * 		   If heap should contract, a negative representing how many bytes the heap should contract is returned.
+	 */
+	intptr_t calculateHeapSizeChange(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool _systemGC);
+
+	/**
+	 * Calculate the 'hybrid overhead' for the current heap size. It is a hybrid value combining gc ratio, and free tenure heap space
+	 * @return the current hybrid heap overhead
+	 */
+	double calculateCurrentHybridHeapOverhead(MM_EnvironmentBase *env) { return calculateHybridHeapOverhead(env, 0); }
+
+	/**
+	 * Calculates the hybrid heap if the heap were to change by heapSizeChange bytes.
+	 * The hybrid heap score is a value which blends free memory % and gc %, giving each appropriate weight depending on user specified thresholds
+	 * @param heapSizeChange by how many bytes the heap will change
+	 * @return the hybrid heap overhead if the heap were to change by heapSizeChange bytes
+	 */
+	double calculateHybridHeapOverhead(MM_EnvironmentBase *env, intptr_t heapSizeChange);
+
+	/**
+	 * Maps free memory percentage into a "equivalent" gc percentage.
+	 * Memory is measured as thought it would change by heapSizeChange bytes. If "tenure" currently is 2G, and 1G is free, while heapSizeChange is +1G
+	 * Memory will be mapped as though "tenure" changed by 1G (ie, Tenure is 3G, and 2G is free)
+	 * @param heapSizeChange how much the heapSize will change. If passing in 0, this function will return the current memory overhead
+	 * @return the mapped value of free memory to gc%
+	 */
+	double mapMemoryPercentageToGcOverhead(MM_EnvironmentBase *env, intptr_t heapSizeChange);
+
+	/**
+	 * Calculates by how many bytes the heap should expand.
+	 * @param env[in] the current thread
+	 * @param allocDescription[in] information about the allocation
+	 * @param systemGc[in] if system gc just occured
+	 * @param expandToSatisfy GC needs to expand by at least `sizeInRegionsRequired` to avoid Global GC/OOM error
+	 * @param sizeInRegionsRequired by how many regions heap needs to expand to avoid OOM
+	 * @return the number of bytes by which the heap should expand. Return 0 if expansion is not desired, or not possible.
+	 */
+	uintptr_t calculateExpansionSize(MM_EnvironmentBase * env, MM_AllocateDescription *allocDescription, bool systemGc, bool expandToSatisfy, uintptr_t sizeInRegionsRequired);
+
+	/**
+	 * @param shouldIncreaseHybridHeapScore informs the function that it should try to contract in order to meet the hybrid heap score requirements. If this is set to false, then we enter this function only to meet -Xsoftmx
+	 * @return the number of bytes by which the heap should contract. Return 0 if contraction is not desired, or not possible
+	 */
+	intptr_t calculateContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool systemGC, bool shouldIncreaseHybridHeapScore);
+
+	/**
+	 * Attempts to calculate what size of heap will give a hybrid heap score within the acceptable bounds (between heapExpansionGCTimeThreshold and heapContractionGCTimeThreshold).
+	 * @return size of heap that acheives a hybrid heap score within acceptable range. 0 is returned if it is not possible to get heap to a range with an acceptable heap score
+	 */
+	uintptr_t getHeapSizeWithinBounds(MM_EnvironmentBase *env);
+
 	/**
 	 * Determine how much space we need to expand the heap by on this GC cycle to meet the collector's requirement.
 	 * @param env[in] the current thread  
 	 * @return Number of bytes required
 	 */
-	UDATA calculateCollectorExpandSize(MM_EnvironmentBase *env);
-	UDATA calculateTargetContractSize(MM_EnvironmentBase *env, UDATA allocSize, bool ratioContract);
-	bool timeForHeapContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool systemGC);
-	bool timeForHeapExpand(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);	
-	UDATA performExpand(MM_EnvironmentBase *env);
-	UDATA performContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
+	uintptr_t calculateCollectorExpandSize(MM_EnvironmentBase *env);
+	uintptr_t calculateTargetContractSize(MM_EnvironmentBase *env, uintptr_t allocSize);
+	uintptr_t performExpand(MM_EnvironmentBase *env);
+	uintptr_t performContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
 	/**
 	 * This function is inherited but we can't implement it with this signature.
 	 * Overridden as private to prevent invocation, and implemented as Assert_MM_unreachable()
 	 */
-	virtual UDATA collectorExpand(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription);
+	virtual uintptr_t collectorExpand(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription);
 
 	/**
 	 * Attempt to allocate the described entity (object, TLH or leaf), replenishing the allocate region if necessary.
@@ -107,44 +170,44 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 	
 public:
-	static MM_MemorySubSpaceTarok *newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize, UDATA memoryType, U_32 objectFlags);
+	static MM_MemorySubSpaceTarok *newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, uintptr_t minimumSize, uintptr_t initialSize, uintptr_t maximumSize, uintptr_t memoryType, U_32 objectFlags);
 	
 	virtual const char *getName() { return MEMORY_SUBSPACE_NAME_TAROK; }
 	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_TAROK; }
 
 	virtual MM_MemoryPool *getMemoryPool();
 	virtual MM_MemoryPool *getMemoryPool(void *addr);
-	virtual MM_MemoryPool *getMemoryPool(UDATA size);
+	virtual MM_MemoryPool *getMemoryPool(uintptr_t size);
 	virtual MM_MemoryPool *getMemoryPool(MM_EnvironmentBase *env, 
 										void *addrBase, void *addrTop, 
 										void * &highAddr);
-	virtual UDATA getMemoryPoolCount();
-	virtual UDATA getActiveMemoryPoolCount();
+	virtual uintptr_t getMemoryPoolCount();
+	virtual uintptr_t getActiveMemoryPoolCount();
 	
-	virtual UDATA getActiveMemorySize();
-	virtual UDATA getActiveMemorySize(UDATA includeMemoryType);
+	virtual uintptr_t getActiveMemorySize();
+	virtual uintptr_t getActiveMemorySize(uintptr_t includeMemoryType);
 	
-	virtual UDATA getActualFreeMemorySize();
-	virtual UDATA getApproximateFreeMemorySize();
+	virtual uintptr_t getActualFreeMemorySize();
+	virtual uintptr_t getApproximateFreeMemorySize();
 	
-	virtual UDATA getActualActiveFreeMemorySize();
-	virtual UDATA getActualActiveFreeMemorySize(UDATA includememoryType);
-	virtual UDATA getApproximateActiveFreeMemorySize();
-	virtual UDATA getApproximateActiveFreeMemorySize(UDATA includememoryType);
+	virtual uintptr_t getActualActiveFreeMemorySize();
+	virtual uintptr_t getActualActiveFreeMemorySize(uintptr_t includememoryType);
+	virtual uintptr_t getApproximateActiveFreeMemorySize();
+	virtual uintptr_t getApproximateActiveFreeMemorySize(uintptr_t includememoryType);
 	
-	virtual UDATA getActiveLOAMemorySize(UDATA includememoryType);
-	virtual UDATA getApproximateActiveFreeLOAMemorySize();
-	virtual UDATA getApproximateActiveFreeLOAMemorySize(UDATA includememoryType);
+	virtual uintptr_t getActiveLOAMemorySize(uintptr_t includememoryType);
+	virtual uintptr_t getApproximateActiveFreeLOAMemorySize();
+	virtual uintptr_t getApproximateActiveFreeLOAMemorySize(uintptr_t includememoryType);
 		
 	virtual	void mergeHeapStats(MM_HeapStats *heapStats);
-	virtual	void mergeHeapStats(MM_HeapStats *heapStats, UDATA includeMemoryType);
+	virtual	void mergeHeapStats(MM_HeapStats *heapStats, uintptr_t includeMemoryType);
 	virtual void resetHeapStatistics(bool globalCollect);	
 	virtual MM_AllocationFailureStats *getAllocationFailureStats();
 
 	virtual void *allocationRequestFailed(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, AllocationType allocationType, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace);
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 
-	virtual UDATA largestDesirableArraySpine()
+	virtual uintptr_t largestDesirableArraySpine()
 	{
 		return _extensions->getOmrVM()->_arrayletLeafSize;
 	}
@@ -160,7 +223,7 @@ public:
 	/* Calls for internal collection routines */
 	virtual void *collectorAllocate(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription);
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-	virtual void *collectorAllocateTLH(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription, UDATA maximumBytesRequired, void * &addrBase, void * &addrTop);
+	virtual void *collectorAllocateTLH(MM_EnvironmentBase *env, MM_Collector *requestCollector, MM_AllocateDescription *allocDescription, uintptr_t maximumBytesRequired, void * &addrBase, void * &addrTop);
 #endif /* J9VM_GC_THREAD_LOCAL_HEAP */
 
 	/**
@@ -169,15 +232,15 @@ public:
 	 * @param env[in] the current thread
 	 * @return the number of bytes expanded
 	 */
-	UDATA collectorExpand(MM_EnvironmentBase *env);
+	uintptr_t collectorExpand(MM_EnvironmentBase *env);
 
-	virtual UDATA adjustExpansionWithinUserIncrement(MM_EnvironmentBase *env, UDATA expandSize);
-	virtual UDATA maxExpansionInSpace(MM_EnvironmentBase *env);
+	virtual uintptr_t adjustExpansionWithinUserIncrement(MM_EnvironmentBase *env, uintptr_t expandSize);
+	virtual uintptr_t maxExpansionInSpace(MM_EnvironmentBase *env);
 	virtual bool expanded(MM_EnvironmentBase *env, MM_PhysicalSubArena *subArena, MM_HeapRegionDescriptor *region, bool canCoalesce);
-	virtual UDATA getAvailableContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);	
+	virtual uintptr_t getAvailableContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
 	virtual void checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription = NULL, bool _systemGC = false);
-	virtual IDATA performResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription = NULL);
+	virtual intptr_t performResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription = NULL);
 
 	virtual void abandonHeapChunk(void *addrBase, void *addrTop);
 
@@ -189,12 +252,12 @@ public:
 	
 	virtual void resetLargestFreeEntry();
 	virtual void recycleRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptor *region);
-	virtual UDATA findLargestFreeEntry(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription);
+	virtual uintptr_t findLargestFreeEntry(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription);
 
 	virtual bool completeFreelistRebuildRequired(MM_EnvironmentBase *env);
 	
-	virtual void addExistingMemory(MM_EnvironmentBase *env, MM_PhysicalSubArena *subArena, UDATA size, void *lowAddress, void *highAddress, bool canCoalesce);
-	virtual void *removeExistingMemory(MM_EnvironmentBase *env, MM_PhysicalSubArena *subArena, UDATA size, void *lowAddress, void *highAddress);
+	virtual void addExistingMemory(MM_EnvironmentBase *env, MM_PhysicalSubArena *subArena, uintptr_t size, void *lowAddress, void *highAddress, bool canCoalesce);
+	virtual void *removeExistingMemory(MM_EnvironmentBase *env, MM_PhysicalSubArena *subArena, uintptr_t size, void *lowAddress, void *highAddress);
 
 	virtual bool isActive();
 
@@ -203,17 +266,17 @@ public:
 	/**
 	 * Called by IncrementalGenerationalGC to permit the subspace to do more work before the next taxation.
 	 */
-	void setBytesRemainingBeforeTaxation(UDATA remaining);
+	void setBytesRemainingBeforeTaxation(uintptr_t remaining);
 
 	/**
 	 * @return the number of bytes which can still be allocated by this subspace before triggering taxation 
 	 */
-	MMINLINE UDATA getBytesRemainingBeforeTaxation() { return _bytesRemainingBeforeTaxation; }
+	MMINLINE uintptr_t getBytesRemainingBeforeTaxation() { return _bytesRemainingBeforeTaxation; }
 	
 	/**
 	 * @see MM_MemorySubSpace::selectRegionForContraction()
 	 */
-	virtual MM_HeapRegionDescriptor * selectRegionForContraction(MM_EnvironmentBase *env, UDATA numaNode);
+	virtual MM_HeapRegionDescriptor * selectRegionForContraction(MM_EnvironmentBase *env, uintptr_t numaNode);
 
 	/**
 	 * Called when an allocation context replenishment request fails in order to invoke a GC.
@@ -234,17 +297,18 @@ public:
 	 * @param bytesToConsume the number of bytes about to be allocated
 	 * @return true if the bytes were available, false if the threshold has been reached
 	 */
-	bool consumeFromTaxationThreshold(MM_EnvironmentBase *env, UDATA bytesToConsume);
+	bool consumeFromTaxationThreshold(MM_EnvironmentBase *env, uintptr_t bytesToConsume);
 
 	/**
 	 * Create a MemorySubSpaceGeneric object
 	 */
-	MM_MemorySubSpaceTarok(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, MM_HeapRegionManager *heapRegionManager, bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize, UDATA memoryType, U_32 objectFlags)
+	MM_MemorySubSpaceTarok(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, MM_HeapRegionManager *heapRegionManager, bool usesGlobalCollector, uintptr_t minimumSize, uintptr_t initialSize, uintptr_t maximumSize, uintptr_t memoryType, U_32 objectFlags)
 		: MM_MemorySubSpace(env, NULL, physicalSubArena, usesGlobalCollector, minimumSize, initialSize, maximumSize, memoryType, objectFlags)
 		, _globalAllocationManagerTarok(gamt)
 		, _allocateAtSafePointOnly(false)
 		, _bytesRemainingBeforeTaxation(0)
 		, _heapRegionManager(heapRegionManager)
+		, _lastObservedGcPercentage(0)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_vlhgc/ReclaimDelegate.cpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.cpp
@@ -885,7 +885,9 @@ MM_ReclaimDelegate::reportSweepEnd(MM_EnvironmentBase *env)
 {
 	J9VMThread *vmThread = (J9VMThread *)env->getLanguageVMThread();
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
-	Trc_MM_SweepEnd(vmThread);
+	MM_SweepVLHGCStats sweepStats = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._sweepStats;
+
+	Trc_MM_SweepEndBalancedGC(vmThread, j9time_hires_delta(sweepStats._startTime, sweepStats._endTime, J9PORT_TIME_DELTA_IN_MICROSECONDS));
 
 	TRIGGER_J9HOOK_MM_PRIVATE_SWEEP_END(
 		MM_GCExtensions::getExtensions(env)->privateHookInterface,

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -57,9 +57,18 @@
  */
 const double measureScanRateHistoricWeightForGMP = 0.50;
 const double measureScanRateHistoricWeightForPGC = 0.95;
-const double partialGCTimeHistoricWeight = 0.80;
+const double partialGCTimeHistoricWeight = 0.50;
 const double incrementalScanTimePerGMPHistoricWeight = 0.50;
 const double bytesScannedConcurrentlyPerGMPHistoricWeight = 0.50;
+const double pgcCpuOverheadWeight = 0.5;
+const double pgcIntervalHistoricWeight = 0.5;
+const double pgcOverheadHistoricWeight = 0.5;
+const double gcOverheadImprovementHighPassFilter = 0.975;
+const double edenChangePctHeapNotFullyExpanded = 0.05;
+const uintptr_t minimumEdenRegionChangeHeapNotFullyExpanded = 2;
+const uintptr_t maximumEdenRegionChangeHeapNotFullyExpanded = 10;
+const uintptr_t minimumPgcTime = 5;
+const uintptr_t consecutivePGCToChangeEden = 16;
 
 MM_SchedulingDelegate::MM_SchedulingDelegate (MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager)
 	: MM_BaseNonVirtual()
@@ -70,6 +79,7 @@ MM_SchedulingDelegate::MM_SchedulingDelegate (MM_EnvironmentVLHGC *env, MM_HeapR
 	, _nextIncrementWillDoPartialGarbageCollection(false)
 	, _nextIncrementWillDoGlobalMarkPhase(false)
 	, _nextPGCShouldCopyForward(_extensions->tarokPGCShouldCopyForward)
+	, _currentlyPerformingGMP(false)
 	, _globalSweepRequired(false)
 	, _disableCopyForwardDuringCurrentGlobalMarkPhase(false)
 	, _idealEdenRegionCount(0)
@@ -77,6 +87,7 @@ MM_SchedulingDelegate::MM_SchedulingDelegate (MM_EnvironmentVLHGC *env, MM_HeapR
 	, _edenRegionCount(0)
 	, _edenSurvivalRateCopyForward(1.0)
 	, _nonEdenSurvivalCountCopyForward(0)
+	, _numberOfHeapRegions(0)
 	, _previousReclaimableRegions(0)
 	, _previousDefragmentReclaimableRegions(0)
 	, _regionConsumptionRate(0.0)
@@ -97,17 +108,56 @@ MM_SchedulingDelegate::MM_SchedulingDelegate (MM_EnvironmentVLHGC *env, MM_HeapR
 	, _scannableBytesRatio(1.0)
 	, _historicTotalIncrementalScanTimePerGMP(0)
 	, _historicBytesScannedConcurrentlyPerGMP(0)
+	, _estimatedFreeTenure(0)
+	, _maxEdenRegionCount(1)
+	, _minEdenRegionCount(1)
 	, _partialGcStartTime(0)
+	, _partialGcOverhead(0.00)
 	, _historicalPartialGCTime(0)
+	, _recentPartialGCTime(0)
+	, _globalMarkIncrementsTotalTime(0)
+	, _globalMarkIntervalStartTime(0)
+	, _globalMarkOverhead(0.0)
+	, _globalSweepTimeUs(0)
+	, _concurrentMarkGCThreadsTotalWorkTime(0)
 	, _dynamicGlobalMarkIncrementTimeMillis(50)
+	, _pgcTimeIncreasePerEdenFactor(1.0001)
+	, _edenSizeFactor(0)
+	, _pgcCountSinceGMPEnd(0)
+	, _averagePgcInterval(0)
+	, _totalGMPWorkTimeUs(0)
 	, _scanRateStats()
 {
 	_typeId = __FUNCTION__;
 }
 
+bool
+MM_SchedulingDelegate::initialize(MM_EnvironmentVLHGC *env)
+{
+	uintptr_t maxHeapSize = _extensions->memoryMax;
 
+	double minEdenPercent = 0.00;
+	double maxEdenPercent = 0.75;
 
-UDATA
+	if (_extensions->userSpecifiedParameters._Xmn._wasSpecified || _extensions->userSpecifiedParameters._Xmns._wasSpecified) {
+		minEdenPercent = (double)_extensions->tarokIdealEdenMinimumBytes / maxHeapSize;
+	}
+
+	if (_extensions->userSpecifiedParameters._Xmn._wasSpecified || _extensions->userSpecifiedParameters._Xmnx._wasSpecified) {
+		maxEdenPercent = (double)_extensions->tarokIdealEdenMaximumBytes / maxHeapSize;
+	}
+
+	_minEdenRegionCount = (uintptr_t)(maxHeapSize * minEdenPercent) / _regionManager->getRegionSize();
+	_minEdenRegionCount = OMR_MAX(1, (uintptr_t)_minEdenRegionCount);
+
+	_maxEdenRegionCount = (uintptr_t)(maxHeapSize * maxEdenPercent) / _regionManager->getRegionSize();
+
+	_partialGcOverhead = _extensions->dnssExpectedRatioMaximum._valueSpecified;
+
+	return true;
+}
+
+uintptr_t
 MM_SchedulingDelegate::getInitialTaxationThreshold(MM_EnvironmentVLHGC *env)
 {
 	/* reset all stored state and call getNextTaxationThreshold() */
@@ -124,6 +174,57 @@ MM_SchedulingDelegate::getInitialTaxationThreshold(MM_EnvironmentVLHGC *env)
 }
 
 void 
+MM_SchedulingDelegate::globalMarkCycleStart(MM_EnvironmentVLHGC *env)
+{
+	calculateGlobalMarkOverhead(env);
+
+	_currentlyPerformingGMP = true;
+	/* Reset the total time taken for each increment of global mark phase, along with the time for concurrent mark GC work*/
+	_globalMarkIncrementsTotalTime = 0;
+	_concurrentMarkGCThreadsTotalWorkTime = 0;
+}
+
+void
+MM_SchedulingDelegate::calculateGlobalMarkOverhead(MM_EnvironmentVLHGC *env)
+{
+	/* Calculate statistics regarding GMP overhead */
+	PORT_ACCESS_FROM_ENVIRONMENT(env);
+
+	/* Determine how long it has been since previous global mark cycle started */
+	uint64_t globalMarkIntervalEndTime = j9time_hires_clock();
+	uint64_t globalMarkIntervalTime = j9time_hires_delta(_globalMarkIntervalStartTime, globalMarkIntervalEndTime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+
+	uint64_t concurrentCostUs = _concurrentMarkGCThreadsTotalWorkTime / 1000;
+
+	/* Total GMP work time, is time taken for all increments + the time we attribute for concurrent GC parts of GMP, and global sweep time. */
+	uint64_t potentialGMPWorkTime =  _globalMarkIncrementsTotalTime + _globalSweepTimeUs + concurrentCostUs;
+	double potentialOverhead = (double)potentialGMPWorkTime / globalMarkIntervalTime;
+
+	if ((0.0 < potentialOverhead) && (1.0 > potentialOverhead) && (0 != _globalMarkIntervalStartTime)) {
+		/* Make sure no clock error occured */
+		_totalGMPWorkTimeUs = potentialGMPWorkTime;
+	} else if (0 == _totalGMPWorkTimeUs) {
+		/* At the very beggining of a run, assume GMP time is 5x larger than avg pgc time.
+		 * This is a very rough approximation, but it gives us enough data to make decision about eden size
+		 */
+		_totalGMPWorkTimeUs = (_historicalPartialGCTime * 1000) * 5;
+	}
+
+	_globalMarkOverhead = (double)_totalGMPWorkTimeUs / globalMarkIntervalTime;
+
+	Trc_MM_SchedulingDelegate_calculateGlobalMarkOverhead(env->getLanguageVMThread(), _globalMarkOverhead, _globalMarkIncrementsTotalTime, concurrentCostUs, globalMarkIntervalTime / 1000);
+
+	/* Set start time of next GMP phase, as end of current one */
+	_globalMarkIntervalStartTime = globalMarkIntervalEndTime;
+
+}
+
+void MM_SchedulingDelegate::globalMarkCycleEnd(MM_EnvironmentVLHGC *env)
+{
+	_currentlyPerformingGMP = false;
+}
+
+void
 MM_SchedulingDelegate::globalMarkPhaseCompleted(MM_EnvironmentVLHGC *env)
 {
 	/* Taking a snapshot of _liveSetBytesAfterPartialCollect from the last PGC.
@@ -144,17 +245,24 @@ MM_SchedulingDelegate::globalMarkPhaseCompleted(MM_EnvironmentVLHGC *env)
 	_disableCopyForwardDuringCurrentGlobalMarkPhase = false;
 
 	updateGMPStats(env);
-
 }
 
 void 
 MM_SchedulingDelegate::globalMarkIncrementCompleted(MM_EnvironmentVLHGC *env)
 {
 	measureScanRate(env, measureScanRateHistoricWeightForGMP);
+	/* Time how long the last global mark increment took */
+	PORT_ACCESS_FROM_ENVIRONMENT(env);
+	uint64_t globalMarkIncrementStartTime = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._startTime;
+	uint64_t globalMarkIncrementEndTime = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats._endTime;
+
+	uint64_t globalMarkIncrementElapsedTime = j9time_hires_delta(globalMarkIncrementStartTime, globalMarkIncrementEndTime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+
+	_globalMarkIncrementsTotalTime += globalMarkIncrementElapsedTime;
 }
 
 void 
-MM_SchedulingDelegate::globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, UDATA reclaimableRegions, UDATA defragmentReclaimableRegions)
+MM_SchedulingDelegate::globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, uintptr_t reclaimableRegions, uintptr_t defragmentReclaimableRegions)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 
@@ -183,12 +291,28 @@ MM_SchedulingDelegate::globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, U
 void
 MM_SchedulingDelegate::partialGarbageCollectStarted(MM_EnvironmentVLHGC *env)
 {
-	Assert_MM_true(0 == _partialGcStartTime);
-
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
+
+	/* Don't count the very first PGC */
+	if (0 != _partialGcStartTime) {
+		uint64_t recentPgcInterval = j9time_hires_delta(_partialGcStartTime, j9time_hires_clock(), J9PORT_TIME_DELTA_IN_MICROSECONDS);
+		_averagePgcInterval = (uintptr_t)(pgcIntervalHistoricWeight * _averagePgcInterval) + (uintptr_t)((1- pgcIntervalHistoricWeight) * recentPgcInterval);
+	}
 
 	/* Record the GC start time in order to track Partial GC times (and averages) over the course of the application lifetime */
 	_partialGcStartTime = j9time_hires_clock();
+	calculatePartialGarbageCollectOverhead(env);
+}
+
+void
+MM_SchedulingDelegate::calculatePartialGarbageCollectOverhead(MM_EnvironmentVLHGC *env)
+{
+	if ((0 != _averagePgcInterval) && (0 != _historicalPartialGCTime)) {
+		double recentOverhead = (double)(_historicalPartialGCTime * 1000.0) / _averagePgcInterval;
+		_partialGcOverhead = MM_Math::weightedAverage(_partialGcOverhead, recentOverhead, pgcOverheadHistoricWeight);
+
+		Trc_MM_SchedulingDelegate_calculatePartialGarbageCollectOverhead(env->getLanguageVMThread(), _partialGcOverhead, _averagePgcInterval / 1000, _historicalPartialGCTime);
+	}
 }
 
 void
@@ -216,36 +340,45 @@ MM_SchedulingDelegate::determineNextPGCType(MM_EnvironmentVLHGC *env)
 }
 
 void
-MM_SchedulingDelegate::calculateGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env, U_64 pgcTime)
+MM_SchedulingDelegate::calculateGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env, uint64_t pgcTime)
 {
 	if(U_32_MAX < pgcTime) {
 		/* Time likely traveled backwards due to a clock adjustment - just ignore this round */
 	} else {
+
+		_recentPartialGCTime = pgcTime;
+
 		/* Prime or calculate the running weighted average for PGC times */
 		if (0 == _historicalPartialGCTime) {
 			_historicalPartialGCTime = pgcTime;
 		} else {
-			_historicalPartialGCTime = (U_64) ((_historicalPartialGCTime * partialGCTimeHistoricWeight) + (pgcTime * (1-partialGCTimeHistoricWeight)));
+			_historicalPartialGCTime = (uint64_t) ((_historicalPartialGCTime * partialGCTimeHistoricWeight) + (pgcTime * (1-partialGCTimeHistoricWeight)));
 		}
 
 		Assert_MM_true(U_32_MAX >= _historicalPartialGCTime);
 		/* we just take a fraction (1/3) of the recent average, so that we do not impede mutator utilization significantly */
 		/* (note that we need to assume a mark increment took at least 1 millisecond or else we will divide by zero in later calculations) */
-		_dynamicGlobalMarkIncrementTimeMillis = OMR_MAX((UDATA)(_historicalPartialGCTime / 3), 1);
+		_dynamicGlobalMarkIncrementTimeMillis = OMR_MAX((uintptr_t)(_historicalPartialGCTime / 3), 1);
 	}
 
 }
 
 void
-MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, UDATA reclaimableRegions, UDATA defragmentReclaimableRegions)
+MM_SchedulingDelegate::resetPgcTimeStatistics(MM_EnvironmentVLHGC *env)
+{
+	_pgcCountSinceGMPEnd = 0;
+}
+
+void
+MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, uintptr_t reclaimableRegions, uintptr_t defragmentReclaimableRegions)
 {
 	Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_Entry(env->getLanguageVMThread(), reclaimableRegions, defragmentReclaimableRegions);
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 	MM_CopyForwardStats *copyForwardStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats;
-	
+	bool globalSweepHappened = _globalSweepRequired;
 	_globalSweepRequired = false;
 	/* copy out the Eden size of the previous interval (between the last PGC and this one) before we recalculate the next one */
-	UDATA edenCountBeforeCollect = getCurrentEdenSizeInRegions(env);
+	uintptr_t edenCountBeforeCollect = getCurrentEdenSizeInRegions(env);
 	
 	Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_stats(env->getLanguageVMThread(),
 			copyForwardStats->_edenEvacuateRegionCount,
@@ -255,11 +388,11 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 			edenCountBeforeCollect);
 
 	if (env->_cycleState->_shouldRunCopyForward) {
-		UDATA regionSize = _regionManager->getRegionSize();
+		uintptr_t regionSize = _regionManager->getRegionSize();
 		
 		/* count the number of survivor regions allocated specifically to support Eden survivors */
-		UDATA edenSurvivorCount = copyForwardStats->_edenSurvivorRegionCount;
-		UDATA nonEdenSurvivorCount = copyForwardStats->_nonEdenSurvivorRegionCount;
+		uintptr_t edenSurvivorCount = copyForwardStats->_edenSurvivorRegionCount;
+		uintptr_t nonEdenSurvivorCount = copyForwardStats->_nonEdenSurvivorRegionCount;
 		
 		/* estimate how many more regions we would have needed to avoid abort */
 		Assert_MM_true( (0 == copyForwardStats->_scanBytesEden) || copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount));
@@ -281,18 +414,23 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 		/* measure scan rate in PGC, only if we did M/S/C collect */
 		measureScanRate(env, measureScanRateHistoricWeightForPGC);
 	}
-
 	measureConsumptionForPartialGC(env, reclaimableRegions, defragmentReclaimableRegions);
-	calculateAutomaticGMPIntermission(env);
-	calculateEdenSize(env);
-	estimateMacroDefragmentationWork(env);
-	
+
 	/* Calculate the time spent in the current Partial GC */
-	U_64 partialGcEndTime = j9time_hires_clock();
-	U_64 pgcTime = j9time_hires_delta(_partialGcStartTime, partialGcEndTime, J9PORT_TIME_DELTA_IN_MILLISECONDS);
-	/* Clear the start time to be clear that we've used it */
-	_partialGcStartTime = 0;
+	uint64_t partialGcEndTime = j9time_hires_clock();
+	uint64_t pgcTime = j9time_hires_delta(_partialGcStartTime, partialGcEndTime, J9PORT_TIME_DELTA_IN_MILLISECONDS);
+
+	_pgcCountSinceGMPEnd += 1;
+
+	/* Check eden size based off of new PGC stats */
+	checkEdenSizeAfterPgc(env, globalSweepHappened);
+	calculateEdenSize(env);
+	/* Recalculate GMP intermission after (possibly) resizing eden */
+	calculateAutomaticGMPIntermission(env);
+	estimateMacroDefragmentationWork(env);
+
 	calculateGlobalMarkIncrementTimeMillis(env, pgcTime);
+	updatePgcTimePrediction(env);
 
 	TRIGGER_J9HOOK_MM_PRIVATE_VLHGC_GARBAGE_COLLECT_COMPLETED(
 		_extensions->privateHookInterface,
@@ -303,19 +441,19 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 	Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_Exit(env->getLanguageVMThread());
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::getNextTaxationThresholdInternal(MM_EnvironmentVLHGC *env)
 {
 	/* these must be in their initial invalid state (both false) when this is called */
 	Assert_MM_false(_nextIncrementWillDoPartialGarbageCollection);
 	Assert_MM_false(_nextIncrementWillDoGlobalMarkPhase);
 	 
-	UDATA threshold = (_edenRegionCount * _regionManager->getRegionSize());
-	UDATA nextTaxationIndex = _taxationIndex;
+	uintptr_t threshold = (_edenRegionCount * _regionManager->getRegionSize());
+	uintptr_t nextTaxationIndex = _taxationIndex;
 	
 	if(_extensions->tarokEnableIncrementalGMP) {
-		UDATA numerator = _extensions->tarokPGCtoGMPNumerator;
-		UDATA denominator = _extensions->tarokPGCtoGMPDenominator;
+		uintptr_t numerator = _extensions->tarokPGCtoGMPNumerator;
+		uintptr_t denominator = _extensions->tarokPGCtoGMPDenominator;
 		if (1 == numerator) {
 			/* the PGC:GMP ratio is 1:n. Therefore every (n+1)th taxation point is a PGC, and the remainder are GMPs.
 			 * e.g. --GMP--PGC--GMP--GMP--GMP--PGC--GMP--GMP--GMP--PGC--
@@ -360,7 +498,7 @@ MM_SchedulingDelegate::getNextTaxationThresholdInternal(MM_EnvironmentVLHGC *env
 	return threshold;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::getNextTaxationThreshold(MM_EnvironmentVLHGC *env)
 {
 	/* TODO: eventually this should be some adaptive number which the 
@@ -369,8 +507,8 @@ MM_SchedulingDelegate::getNextTaxationThreshold(MM_EnvironmentVLHGC *env)
 	
 	Trc_MM_SchedulingDelegate_getNextTaxationThreshold_Entry(env->getLanguageVMThread());
 	
-	UDATA nextTaxationIndex = _taxationIndex;
-	UDATA threshold = 0;
+	uintptr_t nextTaxationIndex = _taxationIndex;
+	uintptr_t threshold = 0;
 	
 	/* consume thresholds until we complete the GMP intermission or we encounter a PGC. */
 	/* TODO: this could be time consuming if the intermission were very large */
@@ -384,7 +522,7 @@ MM_SchedulingDelegate::getNextTaxationThreshold(MM_EnvironmentVLHGC *env)
 		}
 	} while (!_nextIncrementWillDoGlobalMarkPhase && !_nextIncrementWillDoPartialGarbageCollection);
 
-	UDATA regionSize = _regionManager->getRegionSize();
+	uintptr_t regionSize = _regionManager->getRegionSize();
 	threshold = OMR_MAX(regionSize, MM_Math::roundToFloor(regionSize, threshold));
 	
 	Trc_MM_SchedulingDelegate_getNextTaxationThreshold_Exit(env->getLanguageVMThread(),
@@ -412,8 +550,8 @@ void
 MM_SchedulingDelegate::measureScanRate(MM_EnvironmentVLHGC *env, double historicWeight)
 {
 	Trc_MM_SchedulingDelegate_measureScanRate_Entry(env->getLanguageVMThread(), env->_cycleState->_collectionType);
-	UDATA currentBytesScanned = 0;
-	U_64 scantime = 0;
+	uintptr_t currentBytesScanned = 0;
+	uint64_t scantime = 0;
 	if (env->_cycleState->_collectionType == MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION) {
 		/* mark/compact PGC has been replaced with CopyForwardHybrid collector, so retrieve scan stats from  */
 		MM_CopyForwardStats *copyforwardStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats;
@@ -428,15 +566,15 @@ MM_SchedulingDelegate::measureScanRate(MM_EnvironmentVLHGC *env, double historic
 
 	if (0 != currentBytesScanned) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
-		UDATA historicalBytesScanned = _scanRateStats.historicalBytesScanned;
-		U_64 historicalScanMicroseconds = _scanRateStats.historicalScanMicroseconds;
+		uintptr_t historicalBytesScanned = _scanRateStats.historicalBytesScanned;
+		uint64_t historicalScanMicroseconds = _scanRateStats.historicalScanMicroseconds;
 		/* NOTE: scan time is the total time all threads spent scanning */
-		U_64 currentScanMicroseconds = j9time_hires_delta(0, scantime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+		uint64_t currentScanMicroseconds = j9time_hires_delta(0, scantime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
 
 		if (0 != historicalBytesScanned) {
 			/* Keep a historical count of bytes scanned and scan times and re-derive microsecondsperBytes every time we receive new data */
-			_scanRateStats.historicalBytesScanned = (UDATA) ((historicalBytesScanned * historicWeight) + (currentBytesScanned * (1.0 - historicWeight)));
-			_scanRateStats.historicalScanMicroseconds = (U_64) ((historicalScanMicroseconds * historicWeight) + (currentScanMicroseconds * (1.0 - historicWeight)));
+			_scanRateStats.historicalBytesScanned = (uintptr_t) ((historicalBytesScanned * historicWeight) + (currentBytesScanned * (1.0 - historicWeight)));
+			_scanRateStats.historicalScanMicroseconds = (uint64_t) ((historicalScanMicroseconds * historicWeight) + (currentScanMicroseconds * (1.0 - historicWeight)));
 		} else {
 			/* if we have no historic data, do not use averaging */
 			_scanRateStats.historicalBytesScanned = currentBytesScanned;
@@ -468,12 +606,12 @@ void
 MM_SchedulingDelegate::updateCurrentMacroDefragmentationWork(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region)
 {
 	MM_MemoryPool *memoryPool = region->getMemoryPool();
-	UDATA freeMemory = memoryPool->getFreeMemoryAndDarkMatterBytes();
-	UDATA liveData = _regionManager->getRegionSize() - freeMemory;
+	uintptr_t freeMemory = memoryPool->getFreeMemoryAndDarkMatterBytes();
+	uintptr_t liveData = _regionManager->getRegionSize() - freeMemory;
 
 	double bytesDiscardedPerByteCopied = (_averageCopyForwardBytesCopied > 0.0) ? (_averageCopyForwardBytesDiscarded / _averageCopyForwardBytesCopied) : 0.0;
-	UDATA estimatedFreeMemoryDiscarded = (UDATA)(liveData * bytesDiscardedPerByteCopied);
-	UDATA recoverableFreeMemory = MM_Math::saturatingSubtract(freeMemory, estimatedFreeMemoryDiscarded);
+	uintptr_t estimatedFreeMemoryDiscarded = (uintptr_t)(liveData * bytesDiscardedPerByteCopied);
+	uintptr_t recoverableFreeMemory = MM_Math::saturatingSubtract(freeMemory, estimatedFreeMemoryDiscarded);
 
 	/* take a min out of free memory and live data.
 	 * However, this is an overestimate, since the work will often be calculated twice (both as source and as destination).
@@ -524,7 +662,158 @@ MM_SchedulingDelegate::calculateEstimatedGlobalBytesToScan() const
 	return liveSetAdjustedForScannableBytesRatio;
 }
 
-UDATA
+intptr_t
+MM_SchedulingDelegate::calculateRecommendedEdenChangeForExpandedHeap(MM_EnvironmentVLHGC *env)
+{
+
+	if (0 == _pgcCountSinceGMPEnd) {
+		/* No statistics have been collected - just return the current eden size */
+		return getCurrentEdenSizeInBytes(env);
+	}
+
+	/*
+	 * Several statistics have observed which are needed to predict best eden size.
+	 * These statistics are used to predict what eden size will lead to the lowest overhead, where overhead, is a hybrid
+	 * between % of time spent in gc, and pgc pause times. The goal is to minimize % of time spent in gc,
+	 * while staying below the specific gc pause time threshold
+	 */
+
+	uint64_t avgPgcTimeUs = _historicalPartialGCTime * 1000;
+	/*
+	 * Since _averagePgcInterval measures from start of one PGC to the next, we subtract the avg PGC duration
+	 * to get the avg time between end and start of consecutive PGC's
+	 */
+	uint64_t avgPgcIntervalUs = _averagePgcInterval - avgPgcTimeUs;
+	uintptr_t currentIdealEdenSize = getIdealEdenSizeInBytes(env);
+	uintptr_t currentHeapSize = _regionManager->getRegionSize() * _numberOfHeapRegions;
+
+	double freeTenureHeadroom = 0.75;
+
+	/*
+	 * _estimatedFreeTenure is free space outside of eden and survivor space, plus some additional headroom.
+	 *  We add additional headroom so that we don't ever exhaust that free space
+	 */
+	uintptr_t freeTenure = OMR_MAX((uintptr_t)(_estimatedFreeTenure * freeTenureHeadroom), 1);
+
+	if (0 == _totalGMPWorkTimeUs) {
+		/* We haven't seen a GMP yet, so _estimatedFreeTenure will still be 0, which is not accurate. Use another estimate for free tenure until a GMP happens*/
+		intptr_t freeTenureFromPGCInfo = (intptr_t)currentHeapSize - currentIdealEdenSize - _liveSetBytesAfterPartialCollect - (intptr_t)_averageSurvivorSetRegionCount;
+		freeTenure = freeTenureFromPGCInfo > 0 ? freeTenureFromPGCInfo : 1;
+	}
+
+	Assert_MM_true(freeTenure != 0);
+
+	/* Determine how far we can increase or decrease eden from where eden currently stands. */
+	intptr_t minEdenChange = (intptr_t)currentIdealEdenSize * -1;
+	intptr_t maxEdenChange = (intptr_t)freeTenure;
+
+	/* How many samples we want to test between minEdenChange and maxEdenChange? */
+	uintptr_t numberOfSamples = 100;
+
+	/*
+	 * Initially, we suggest the current eden size as the best size - until proven there is a better size.
+	 * The "better" size, will have a better blend of gc overhead (% of time gc is active relative to mutator),
+	 * and more satisfactory pgc pause time (below target pgc pause is the goal).
+	 */
+	intptr_t recommendedEdenChange = 0;
+	double currentCpuEdenOverhead = predictCpuOverheadForEdenSize(env, currentIdealEdenSize, recommendedEdenChange, freeTenure, avgPgcIntervalUs);
+	double currentEdenHybridOverhead = calculateHybridEdenOverhead(env, (uintptr_t)_historicalPartialGCTime, currentCpuEdenOverhead, true);
+	double bestOverheadPrediction = currentEdenHybridOverhead;
+
+	Trc_MM_SchedulingDelegate_calculateRecommendedEdenChangeForExpandedHeap(env->getLanguageVMThread(), currentEdenHybridOverhead, (uintptr_t)_historicalPartialGCTime, mapPgcPauseOverheadToPgcCPUOverhead(env, (uintptr_t)_historicalPartialGCTime, true));
+
+	/*
+	 * In order to prevent very minor fluctuations in eden size, which don't result in significant performance improvements,
+	 * apply a high pass filter - so that only large enough improvements result in eden changing size
+	 */
+	double hybridOverheadRequiredToChangeEden = currentEdenHybridOverhead * gcOverheadImprovementHighPassFilter;
+
+	/* How large the hops (in bytes) between samples should be */
+	uintptr_t samplingGranularity = (uintptr_t)(maxEdenChange - minEdenChange) / numberOfSamples;
+
+	/* Try "numberOfSamples" tests on the hybrid overhead curve, to determine which eden change will have best hybrid overhead */
+	for (uintptr_t i = 0; i < numberOfSamples; i++) {
+		/* Start from the right side of the curve */
+		intptr_t edenChange = (intptr_t)maxEdenChange - (samplingGranularity * i);
+
+		/* Predict what the pgc pause time, and gc overhead will be, if eden changes by 'edenChange' bytes*/
+		double estimatedCpuOverhead = predictCpuOverheadForEdenSize(env, currentIdealEdenSize, edenChange, freeTenure, avgPgcIntervalUs);
+		double estimatedPGCAvgTime = predictPgcTime(env, currentIdealEdenSize, edenChange);
+		double estimatedHybridOverhead = calculateHybridEdenOverhead(env, (uintptr_t)estimatedPGCAvgTime / 1000, estimatedCpuOverhead, true);
+
+		if ((estimatedHybridOverhead < bestOverheadPrediction) && (estimatedHybridOverhead < hybridOverheadRequiredToChangeEden)) {
+			/* The hybrid between pgc pause time, and gc overhead (% time gc is active), is better than what was previously thought to be the best, save the eden size */
+			recommendedEdenChange = edenChange;
+			bestOverheadPrediction = estimatedHybridOverhead;
+		}
+	}
+
+	Trc_MM_SchedulingDelegate_calculateRecommendedEdenChangeForExpandedHeap_Exit(env->getLanguageVMThread(), freeTenure, _totalGMPWorkTimeUs / 1000, avgPgcTimeUs, avgPgcIntervalUs, _edenSurvivalRateCopyForward, currentIdealEdenSize + recommendedEdenChange, bestOverheadPrediction);
+
+	return recommendedEdenChange;
+}
+
+double
+MM_SchedulingDelegate::predictCpuOverheadForEdenSize(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uintptr_t freeTenure, uint64_t pgcAvgIntervalTime)
+{
+	double predictedNumberOfCollections = predictNumberOfCollections(env, currentEdenSize, edenSizeChange, freeTenure);
+	double predictedIntervalTime = predictIntervalBetweenCollections(env, currentEdenSize, edenSizeChange, pgcAvgIntervalTime);
+	double predictedAvgPgcTime = predictPgcTime(env, currentEdenSize, edenSizeChange);
+
+	uint64_t gmpTime = _totalGMPWorkTimeUs;
+	if (0 == gmpTime) {
+		/* GMP has not yet happened, so make a rough guess - but a relatively high guess, so that eden thinks GMP is very expensive relative to PGC */
+		gmpTime = 20 * (_historicalPartialGCTime * 1000);
+	}
+
+	double gcActiveTime = (double)gmpTime + (predictedAvgPgcTime * predictedNumberOfCollections);
+	double totalIntervalTime = (double)gmpTime + ((predictedAvgPgcTime + predictedIntervalTime) * predictedNumberOfCollections);
+
+	double estimatedOverhead = gcActiveTime / totalIntervalTime;
+	return estimatedOverhead;
+}
+
+double
+MM_SchedulingDelegate::predictIntervalBetweenCollections(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uint64_t pgcAvgIntervalTime)
+{
+	/* The interval between PGC collections is proportional to eden size. Ex. If eden size doubles, we expect the interval between PGC collections to double as well */
+	double intervalChange = (double)(currentEdenSize + edenSizeChange) / currentEdenSize;
+	return (double)pgcAvgIntervalTime * intervalChange;
+}
+
+double
+MM_SchedulingDelegate::predictNumberOfCollections(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uintptr_t freeTenure)
+{
+	/* The number of PGC collections is proportional to how much free tenure will be left after we expand/contract eden */
+	double collectionCountChange = (double)(freeTenure - edenSizeChange) / freeTenure;
+	return (double)_extensions->globalVLHGCStats.getRepresentativePgcPerGmpCount() * collectionCountChange;
+}
+
+double
+MM_SchedulingDelegate::predictPgcTime(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange)
+{
+	/*
+	 * PGC avg time MAY be related to eden size. Certain applications/allocation patterns, will cause pgc time to increase as eden increases,
+	 * while certain different workloads may keep pgc time relatively constant even as eden size increases.
+	 * Create a model to determine how pgc time will be afffected by eden size - keeping in mind that _pgcTimeIncreasePerEdenFactor can vary depending on the application
+	 */
+	double edenSizeGb = (double)currentEdenSize / 1000000000.0;
+	double edenChangeGb = (double)edenSizeChange / 1000000000.0;
+	double edenChangeRatio = (edenChangeGb + edenSizeGb + 1.0) / (edenSizeGb + 1.0);
+
+	/* Use a math workaround for "log base _pgcTimeIncreasePerEdenFactor (edenChangeRatio) "*/
+	double pgcTimeDeltaForEdenChange = log(edenChangeRatio) / log(_pgcTimeIncreasePerEdenFactor);
+	double predictedPgcTime = (double)_historicalPartialGCTime + pgcTimeDeltaForEdenChange;
+
+	/* If the prediction returned a value less than minimumPgcTime, then there may have been a small rounding mistake */
+	predictedPgcTime = OMR_MAX(predictedPgcTime, (double)minimumPgcTime);
+
+	/* Convert from ms to us */
+	return predictedPgcTime * 1000.0;
+}
+
+
+uintptr_t
 MM_SchedulingDelegate::estimateGlobalMarkIncrements(MM_EnvironmentVLHGC *env, double liveSetAdjustedForScannableBytesRatio) const
 {
 	Trc_MM_SchedulingDelegate_estimateGlobalMarkIncrements_Entry(env->getLanguageVMThread());
@@ -532,28 +821,28 @@ MM_SchedulingDelegate::estimateGlobalMarkIncrements(MM_EnvironmentVLHGC *env, do
 	/* we can consider liveSetAdjustedForScannableBytesRatio to be the total bytes the GMP needs to scan */
 	Assert_MM_true(0 != _extensions->gcThreadCount);
 	double estimatedScanMillis = liveSetAdjustedForScannableBytesRatio * _scanRateStats.microSecondsPerByteScanned / _extensions->gcThreadCount / 1000.0;
-	UDATA currentMarkIncrementMillis = currentGlobalMarkIncrementTimeMillis(env);
+	uintptr_t currentMarkIncrementMillis = currentGlobalMarkIncrementTimeMillis(env);
 	Assert_MM_true(0 != currentMarkIncrementMillis);
 	double estimatedGMPIncrements = estimatedScanMillis / currentMarkIncrementMillis;
-	Trc_MM_SchedulingDelegate_estimateGlobalMarkIncrements_liveSetBytes(env->getLanguageVMThread(), _liveSetBytesAfterPartialCollect, (UDATA)0, (UDATA)liveSetAdjustedForScannableBytesRatio);
+	Trc_MM_SchedulingDelegate_estimateGlobalMarkIncrements_liveSetBytes(env->getLanguageVMThread(), _liveSetBytesAfterPartialCollect, (uintptr_t)0, (uintptr_t)liveSetAdjustedForScannableBytesRatio);
 	Trc_MM_SchedulingDelegate_estimateGlobalMarkIncrements_summary(env->getLanguageVMThread(), estimatedScanMillis, estimatedGMPIncrements);
 	
 	/* adding 1 increment for final GMP phase (most importantly clearable processing) */
-	UDATA result = (UDATA)ceil(estimatedGMPIncrements) + 1;
+	uintptr_t result = (uintptr_t)ceil(estimatedGMPIncrements) + 1;
 	Trc_MM_SchedulingDelegate_estimateGlobalMarkIncrements_Exit(env->getLanguageVMThread(), result);
 	return result;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::getBytesToScanInNextGMPIncrement(MM_EnvironmentVLHGC *env) const
 {
-	UDATA targetPauseTimeMillis = currentGlobalMarkIncrementTimeMillis(env);
+	uintptr_t targetPauseTimeMillis = currentGlobalMarkIncrementTimeMillis(env);
 	double calculatedWorkTargetDouble = (((double)targetPauseTimeMillis * 1000.0) / _scanRateStats.microSecondsPerByteScanned) * (double)_extensions->gcThreadCount;
 
 	/* minimum to UDATA_MAX in case we overflowed */
-	UDATA calculatedWorkTarget = (UDATA) OMR_MIN(calculatedWorkTargetDouble, (double)UDATA_MAX);
+	uintptr_t calculatedWorkTarget = (uintptr_t) OMR_MIN(calculatedWorkTargetDouble, (double)UDATA_MAX);
 
-	UDATA workTarget = OMR_MAX(calculatedWorkTarget, _extensions->tarokMinimumGMPWorkTargetBytes._valueSpecified);
+	uintptr_t workTarget = OMR_MAX(calculatedWorkTarget, _extensions->tarokMinimumGMPWorkTargetBytes._valueSpecified);
 
 	Trc_MM_SchedulingDelegate_getBytesToScanInNextGMPIncrement(env->getLanguageVMThread(), targetPauseTimeMillis, _scanRateStats.microSecondsPerByteScanned, _extensions->gcThreadCount, workTarget);
 
@@ -561,7 +850,7 @@ MM_SchedulingDelegate::getBytesToScanInNextGMPIncrement(MM_EnvironmentVLHGC *env
 }
 
 void 
-MM_SchedulingDelegate::measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, UDATA currentReclaimableRegions, UDATA currentDefragmentReclaimableRegions)
+MM_SchedulingDelegate::measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, uintptr_t currentReclaimableRegions, uintptr_t currentDefragmentReclaimableRegions)
 {
 	/* check to see if we have a valid previous data point */
 	if (0 == _previousReclaimableRegions) {
@@ -590,15 +879,15 @@ MM_SchedulingDelegate::measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, 
 	_previousDefragmentReclaimableRegions = currentDefragmentReclaimableRegions;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) const
 {
 	Trc_MM_SchedulingDelegate_estimatePartialGCsRemaining_Entry(env->getLanguageVMThread(), _regionConsumptionRate, _previousDefragmentReclaimableRegions);
 
-	UDATA partialCollectsRemaining = UDATA_MAX;
+	uintptr_t partialCollectsRemaining = UDATA_MAX;
 	if (_regionConsumptionRate > 0.0) {
 		/* TODO: decide how to reconcile kick-off with dynamic Eden size */
-		UDATA edenRegions = _idealEdenRegionCount;
+		uintptr_t edenRegions = _idealEdenRegionCount;
 
 		/* TODO:  This kick-off logic needs to be adapted to work with a dynamic mix of copy-forward and compact PGC increments.  For now, use the cycle state flags since they at least will let us test both code paths here. */
 		if (env->_cycleState->_shouldRunCopyForward) {
@@ -609,7 +898,7 @@ MM_SchedulingDelegate::estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) con
 			if ((0 != _extensions->fvtest_forceCopyForwardHybridRatio) && (100 >= _extensions->fvtest_forceCopyForwardHybridRatio)) {
 				survivorRegions = survivorRegions * (100 - _extensions->fvtest_forceCopyForwardHybridRatio) / 100;
 			}
-			Trc_MM_SchedulingDelegate_estimatePartialGCsRemaining_survivorNeeds(env->getLanguageVMThread(), (UDATA)_averageSurvivorSetRegionCount, MM_GCExtensions::getExtensions(env)->tarokKickoffHeadroomInBytes, (UDATA)survivorRegions);
+			Trc_MM_SchedulingDelegate_estimatePartialGCsRemaining_survivorNeeds(env->getLanguageVMThread(), (uintptr_t)_averageSurvivorSetRegionCount, MM_GCExtensions::getExtensions(env)->tarokKickoffHeadroomInBytes, (uintptr_t)survivorRegions);
 
 			double freeRegions = (double)((MM_GlobalAllocationManagerTarok *)_extensions->globalAllocationManager)->getFreeRegionCount();
 
@@ -619,14 +908,14 @@ MM_SchedulingDelegate::estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) con
 
 			/* Copy PGC has compact selection goal work drive, so it optimistically relies on our projected compact work to indeed recover all reclaimable regions */
 			if ((freeRegions + recoverableRegions) > (edenRegions + survivorRegions)) {
-				partialCollectsRemaining = (UDATA)((freeRegions + recoverableRegions - edenRegions - survivorRegions) / _regionConsumptionRate);
+				partialCollectsRemaining = (uintptr_t)((freeRegions + recoverableRegions - edenRegions - survivorRegions) / _regionConsumptionRate);
 			} else {
 				partialCollectsRemaining = 0;
 			}
 		} else {
 			/* MarkSweepCompact PGC has compact selection driven by free region goal, so it counts on reclaimable regions */
 			if (_previousDefragmentReclaimableRegions > edenRegions) {
-				partialCollectsRemaining = (UDATA)((double)(_previousDefragmentReclaimableRegions - edenRegions) / _regionConsumptionRate);
+				partialCollectsRemaining = (uintptr_t)((double)(_previousDefragmentReclaimableRegions - edenRegions) / _regionConsumptionRate);
 			} else {
 				partialCollectsRemaining = 0;
 			}
@@ -659,8 +948,8 @@ MM_SchedulingDelegate::calculateHeapOccupancyTrend(MM_EnvironmentVLHGC *env)
 void
 MM_SchedulingDelegate::calculateScannableBytesRatio(MM_EnvironmentVLHGC *env)
 {
-	UDATA scannableBytes = 0;
-	UDATA nonScannableBytes = 0;
+	uintptr_t scannableBytes = 0;
+	uintptr_t nonScannableBytes = 0;
 
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
@@ -722,10 +1011,47 @@ MM_SchedulingDelegate::getDefragmentEmptinessThreshold(MM_EnvironmentVLHGC *env)
 
 }
 
-UDATA
-MM_SchedulingDelegate::estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, UDATA freeRegionMemory, UDATA defragmentedMemory, UDATA reservedFreeMemory)
+void
+MM_SchedulingDelegate::updateHeapSizingData(MM_EnvironmentVLHGC *env)
 {
-	UDATA estimatedFreeMemory = 0;
+	uintptr_t regionSize = _regionManager->getRegionSize();
+	uintptr_t totalHeapSize = regionSize * _numberOfHeapRegions;
+	/* Determine how much space needs to be reserved for eden + survivor space */
+	uintptr_t survivorSize = (uintptr_t)(regionSize * _averageSurvivorSetRegionCount);
+	/* In certain edge cases, eden + survivor might be calculated as larger than the heap size (which is not possible), and that causes innacuracies down the line */
+	uintptr_t reservedFreeMemory =  OMR_MIN((getCurrentEdenSizeInBytes(env) + survivorSize), totalHeapSize);
+
+	/* If a GMP has not yet occured, make a rough guess as to how expensive GMP will be */
+	_extensions->globalVLHGCStats._heapSizingData.gmpTime = _totalGMPWorkTimeUs == 0 ? _historicalPartialGCTime * 1000 : _totalGMPWorkTimeUs;
+	_extensions->globalVLHGCStats._heapSizingData.pgcCountSinceGMPEnd = _pgcCountSinceGMPEnd;
+	_extensions->globalVLHGCStats._heapSizingData.avgPgcTimeUs = _historicalPartialGCTime * 1000;
+
+	/* After the first PGC, _averagePgcInterval will still be 0, so make a very rough estimate as to how big the interval between PGC's will be */
+	_extensions->globalVLHGCStats._heapSizingData.avgPgcIntervalUs = _averagePgcInterval != 0 ? (_averagePgcInterval - (_historicalPartialGCTime * 1000)) : (_historicalPartialGCTime * 5);
+	_extensions->globalVLHGCStats._heapSizingData.reservedSize = reservedFreeMemory;
+
+	if (_extensions->globalVLHGCStats._heapSizingData.reservedSize + _liveSetBytesAfterPartialCollect < totalHeapSize) {
+		uintptr_t freeTenureEstimate = totalHeapSize - _extensions->globalVLHGCStats._heapSizingData.reservedSize - _liveSetBytesAfterPartialCollect;
+		uintptr_t freeTenureEstimateFromBeforePgc = _extensions->globalVLHGCStats._heapSizingData.freeTenure;
+
+		/*
+		 * Until a GMP occurs, and _estimatedFreeTenure is set, use the most conservative estimate between the free tenure estimate recorded before a PGC,
+		 * and a free tenure estimate made by looking at live data after PGC. Neither of these two methods is as precise _estimatedFreeTenure,
+		 * but until GMP occurs, one of those two estimates must be used for purposes of heap resizing (Note: the minimum of the two values is used, so that heap more likely to expand)
+		 */
+		_extensions->globalVLHGCStats._heapSizingData.freeTenure = _estimatedFreeTenure != 0 ? _estimatedFreeTenure : OMR_MIN(freeTenureEstimateFromBeforePgc, freeTenureEstimate);
+	} else {
+		/* Certain edge cases (usually in startup) the total heap might be too small for eden + survivor, and the live set, so free tenure is effectively 0 */
+		_extensions->globalVLHGCStats._heapSizingData.freeTenure = 0;
+	}
+
+	/* NOTE: _extensions->globalVLHGCStats._heapSizingData.edenRegionChange is updated elsewhere, and should not be included here */
+}
+
+uintptr_t
+MM_SchedulingDelegate::estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, uintptr_t freeRegionMemory, uintptr_t defragmentedMemory, uintptr_t reservedFreeMemory)
+{
+	uintptr_t estimatedFreeMemory = 0;
 
 	/* Adjust estimatedFreeMemory - we are only interested in area that shortfall can be fed from.
 	 * Thus exclude reservedFreeMemory(Eden and Survivor size).
@@ -736,52 +1062,52 @@ MM_SchedulingDelegate::estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, UDATA f
 	return estimatedFreeMemory;
 }
 
-UDATA
-MM_SchedulingDelegate::calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, UDATA totalFreeMemory)
+uintptr_t
+MM_SchedulingDelegate::calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, uintptr_t totalFreeMemory)
 {
 	if (_extensions->tarokForceKickoffHeadroomInBytes) {
 		return _extensions->tarokKickoffHeadroomInBytes;
 	}
-	UDATA newHeadroom = totalFreeMemory * _extensions->tarokKickoffHeadroomRegionRate / 100;
+	uintptr_t newHeadroom = totalFreeMemory * _extensions->tarokKickoffHeadroomRegionRate / 100;
 	Trc_MM_SchedulingDelegate_calculateKickoffHeadroom(env->getLanguageVMThread(), _extensions->tarokKickoffHeadroomInBytes, newHeadroom);
 	_extensions->tarokKickoffHeadroomInBytes = newHeadroom;
 	return newHeadroom;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::initializeKickoffHeadroom(MM_EnvironmentVLHGC *env)
 {
 	/* total free memory = total heap size - eden size */
-	UDATA totalFreeMemory = _regionManager->getTotalHeapSize() - getCurrentEdenSizeInBytes(env);
+	uintptr_t totalFreeMemory = _regionManager->getTotalHeapSize() - getCurrentEdenSizeInBytes(env);
 	return calculateKickoffHeadroom(env, totalFreeMemory);
 }
 
 void
-MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDATA edenSizeInBytes)
+MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, uintptr_t edenSizeInBytes)
 {
 	/* Ideally, copy-forwarded regions should be 100% full (i.e. 0% empty), but there are inefficiencies due to parallelism and compact groups.
 	 * We measure this so that we can detect regions which are unlikely to become less empty if we copy-and-forward them.
 	 */
 	const double defragmentEmptinessThreshold = getDefragmentEmptinessThreshold(env);
 	Assert_MM_true( (defragmentEmptinessThreshold >= 0.0) && (defragmentEmptinessThreshold <= 1.0) );
-	const UDATA regionSize = _regionManager->getRegionSize();
+	const uintptr_t regionSize = _regionManager->getRegionSize();
 
-	UDATA totalLiveDataInCollectableRegions = 0;
-	UDATA totalLiveDataInNonCollectibleRegions = 0;
-	UDATA fullyCompactedData = 0;
+	uintptr_t totalLiveDataInCollectableRegions = 0;
+	uintptr_t totalLiveDataInNonCollectibleRegions = 0;
+	uintptr_t fullyCompactedData = 0;
 
-	UDATA freeMemoryInCollectibleRegions = 0;
-	UDATA freeMemoryInNonCollectibleRegions = 0;
-	UDATA freeMemoryInFullyCompactedRegions = 0;
-	UDATA freeRegionMemory = 0;
+	uintptr_t freeMemoryInCollectibleRegions = 0;
+	uintptr_t freeMemoryInNonCollectibleRegions = 0;
+	uintptr_t freeMemoryInFullyCompactedRegions = 0;
+	uintptr_t freeRegionMemory = 0;
 
-	UDATA collectibleRegions = 0;
-	UDATA nonCollectibleRegions = 0;
-	UDATA freeRegions = 0;
-	UDATA fullyCompactedRegions = 0;
+	uintptr_t collectibleRegions = 0;
+	uintptr_t nonCollectibleRegions = 0;
+	uintptr_t freeRegions = 0;
+	uintptr_t fullyCompactedRegions = 0;
 
-	UDATA estimatedFreeMemory = 0;
-	UDATA defragmentedMemory = 0;
+	uintptr_t estimatedFreeMemory = 0;
+	uintptr_t defragmentedMemory = 0;
 
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager, MM_HeapRegionDescriptor::MANAGED);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
@@ -790,7 +1116,7 @@ MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDAT
 		region->_defragmentationTarget = false;
 		if (region->containsObjects()) {
 			Assert_MM_true(region->_sweepData._alreadySwept);
-			UDATA freeMemory = region->getMemoryPool()->getFreeMemoryAndDarkMatterBytes();
+			uintptr_t freeMemory = region->getMemoryPool()->getFreeMemoryAndDarkMatterBytes();
 			if (!region->getRememberedSetCardList()->isAccurate()) {
 				/* Overflowed regions or those that RSCL is being rebuilt will not be compacted */
 				nonCollectibleRegions += 1;
@@ -805,13 +1131,13 @@ MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDAT
 					collectibleRegions += 1;
 					freeMemoryInCollectibleRegions += freeMemory;
 					/* see ReclaimDelegate::deriveCompactScore() for an explanation of potentialWastedWork */
-					UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
+					uintptr_t compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
 					double weightedSurvivalRate = MM_GCExtensions::getExtensions(env)->compactGroupPersistentStats[compactGroup]._weightedSurvivalRate;
 					double potentialWastedWork = (1.0 - weightedSurvivalRate) * (1.0 - emptiness);
 
 					/* the probability that we'll recover the free memory is determined by the potential gainful work, so use that determine how much memory we're likely to actually compact */
-					defragmentedMemory += (UDATA)((double)freeMemory * (1.0 - potentialWastedWork));
-					totalLiveDataInCollectableRegions += (UDATA)((double)(regionSize - freeMemory) * (1.0 - potentialWastedWork));
+					defragmentedMemory += (uintptr_t)((double)freeMemory * (1.0 - potentialWastedWork));
+					totalLiveDataInCollectableRegions += (uintptr_t)((double)(regionSize - freeMemory) * (1.0 - potentialWastedWork));
 					region->_defragmentationTarget = true;
 
 				} else {
@@ -830,21 +1156,23 @@ MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDAT
 	/* Survivor space needs to accommodate for Nursery set, Dynamic collection set and Compaction set
 	 */
 	/* estimate totalFreeMemory for recalculating kickoffHeadroomRegionCount */	 
-	UDATA surivivorSize = (UDATA)(regionSize * _averageSurvivorSetRegionCount);
-	UDATA reservedFreeMemory = edenSizeInBytes + surivivorSize;
+	uintptr_t surivivorSize = (uintptr_t)(regionSize * _averageSurvivorSetRegionCount);
+	uintptr_t reservedFreeMemory = edenSizeInBytes + surivivorSize;
 	estimatedFreeMemory = estimateTotalFreeMemory(env, freeRegionMemory, defragmentedMemory, reservedFreeMemory);
 	calculateKickoffHeadroom(env, estimatedFreeMemory);
 
 	/* estimate totalFreeMemory for recalculating PGCCompactionRate with tarokKickoffHeadroomInBytes */
 	reservedFreeMemory += _extensions->tarokKickoffHeadroomInBytes;
 	estimatedFreeMemory = estimateTotalFreeMemory(env, freeRegionMemory, defragmentedMemory, reservedFreeMemory);
+	/* Remeber the total free memory estimate, so it can be used to calculate how big eden should be */
+	_estimatedFreeTenure = estimatedFreeMemory;
 
 	double bytesDiscardedPerByteCopied = (_averageCopyForwardBytesCopied > 0.0) ? (_averageCopyForwardBytesDiscarded / _averageCopyForwardBytesCopied) : 0.0;
 	double estimatedFreeMemoryDiscarded = (double)totalLiveDataInCollectableRegions * bytesDiscardedPerByteCopied;
 	double recoverableFreeMemory = (double)estimatedFreeMemory - estimatedFreeMemoryDiscarded;
 
 	if (0.0 < recoverableFreeMemory) {
-		_bytesCompactedToFreeBytesRatio = ((double)totalLiveDataInCollectableRegions)/recoverableFreeMemory;
+		_bytesCompactedToFreeBytesRatio = ((double)totalLiveDataInCollectableRegions) / recoverableFreeMemory;
 	} else {
 		_bytesCompactedToFreeBytesRatio = (double)(_regionManager->getTableRegionCount() + 1);
 	}
@@ -855,14 +1183,14 @@ MM_SchedulingDelegate::calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDAT
 	Trc_MM_SchedulingDelegate_calculatePGCCompactionRate_liveToFreeRatio4(env->getLanguageVMThread(), _bytesCompactedToFreeBytesRatio, edenSizeInBytes, surivivorSize, reservedFreeMemory, defragmentEmptinessThreshold, defragmentedMemory, estimatedFreeMemory);
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::getDesiredCompactWork()
 {
 	/* compact work (mostly) driven by M/S from GMP */
-	UDATA desiredCompactWork = (UDATA)(_bytesCompactedToFreeBytesRatio * OMR_MAX(0.0, _regionConsumptionRate) * _regionManager->getRegionSize());
+	uintptr_t desiredCompactWork = (uintptr_t)(_bytesCompactedToFreeBytesRatio * OMR_MAX(0.0, _regionConsumptionRate) * _regionManager->getRegionSize());
 	
 	/* defragmentation work (mostly) driven by compact group merging (maxAge - 1 into maxAge) */
-	desiredCompactWork += (UDATA)_averageMacroDefragmentationWork;
+	desiredCompactWork += (uintptr_t)_averageMacroDefragmentationWork;
 
 	return desiredCompactWork;
 }
@@ -883,21 +1211,21 @@ void
 MM_SchedulingDelegate::copyForwardCompleted(MM_EnvironmentVLHGC *env)
 {
 	MM_CopyForwardStats * copyForwardStats = &(static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats);
-	UDATA bytesCopied = copyForwardStats->_copyBytesTotal;
-	UDATA bytesDiscarded = copyForwardStats->_copyDiscardBytesTotal;
-	UDATA bytesScanned = copyForwardStats->_scanBytesTotal;
-	UDATA bytesCompacted = copyForwardStats->_externalCompactBytes;
-	UDATA regionSize = _regionManager->getRegionSize();
+	uintptr_t bytesCopied = copyForwardStats->_copyBytesTotal;
+	uintptr_t bytesDiscarded = copyForwardStats->_copyDiscardBytesTotal;
+	uintptr_t bytesScanned = copyForwardStats->_scanBytesTotal;
+	uintptr_t bytesCompacted = copyForwardStats->_externalCompactBytes;
+	uintptr_t regionSize = _regionManager->getRegionSize();
 	double copyForwardRate = calculateAverageCopyForwardRate(env);
 	
-	const double historicWeight = 0.70; /* arbitrarily give 70% weight to historical result, 30% to newest result */
+	const double historicWeight = 0.50; /* arbitrarily give 50% weight to historical result, 50% to newest result */
 	_averageCopyForwardBytesCopied = (_averageCopyForwardBytesCopied * historicWeight) + ((double)bytesCopied * (1.0 - historicWeight));
 	_averageCopyForwardBytesDiscarded = (_averageCopyForwardBytesDiscarded * historicWeight) + ((double)bytesDiscarded * (1.0 - historicWeight));
 
 	/* calculate the number of additional regions which would have been required to complete the copy-forward without aborting */
-	UDATA failedEvacuateRegionCount = (bytesScanned + regionSize - 1) / regionSize;
-	UDATA compactSetSurvivorRegionCount = (bytesCompacted + regionSize - 1) / regionSize;
-	UDATA survivorSetRegionCount = env->_cycleState->_pgcData._survivorSetRegionCount + failedEvacuateRegionCount + compactSetSurvivorRegionCount;
+	uintptr_t failedEvacuateRegionCount = (bytesScanned + regionSize - 1) / regionSize;
+	uintptr_t compactSetSurvivorRegionCount = (bytesCompacted + regionSize - 1) / regionSize;
+	uintptr_t survivorSetRegionCount = env->_cycleState->_pgcData._survivorSetRegionCount + failedEvacuateRegionCount + compactSetSurvivorRegionCount;
 	
 	_averageSurvivorSetRegionCount = (_averageSurvivorSetRegionCount * historicWeight) + ((double)survivorSetRegionCount * (1.0 - historicWeight));
 	_averageCopyForwardRate = (_averageCopyForwardRate * historicWeight) + (copyForwardRate * (1.0 - historicWeight));
@@ -924,9 +1252,9 @@ MM_SchedulingDelegate::calculateAverageCopyForwardRate(MM_EnvironmentVLHGC *env)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 	MM_CopyForwardStats * copyForwardStats = &(static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats);
-	UDATA bytesCopied = copyForwardStats->_copyBytesTotal;
-	U_64 timeSpentReferenceClearing = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._irrsStats._clearFromRegionReferencesTimesus;
-	U_64 timeSpentInCopyForward = j9time_hires_delta(copyForwardStats->_startTime, copyForwardStats->_endTime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+	uintptr_t bytesCopied = copyForwardStats->_copyBytesTotal;
+	uint64_t timeSpentReferenceClearing = static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._irrsStats._clearFromRegionReferencesTimesus;
+	uint64_t timeSpentInCopyForward = j9time_hires_delta(copyForwardStats->_startTime, copyForwardStats->_endTime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
 
 	double copyForwardRate = 0.0;
 	if (timeSpentInCopyForward > timeSpentReferenceClearing) {
@@ -951,7 +1279,7 @@ MM_SchedulingDelegate::calculateAutomaticGMPIntermission(MM_EnvironmentVLHGC *en
 	Trc_MM_SchedulingDelegate_calculateAutomaticGMPIntermission_Entry(env->getLanguageVMThread(), _extensions->tarokAutomaticGMPIntermission ? "true" : "false", _remainingGMPIntermissionIntervals);
 	
 	/* call these even if automatic intermissions aren't enabled, so that we get the trace data. This is useful for debugging */
-	UDATA partialCollectsRemaining = estimatePartialGCsRemaining(env);
+	uintptr_t partialCollectsRemaining = estimatePartialGCsRemaining(env);
 	updateLiveBytesAfterPartialCollect();
 	
 	if (_extensions->tarokAutomaticGMPIntermission) {
@@ -961,10 +1289,10 @@ MM_SchedulingDelegate::calculateAutomaticGMPIntermission(MM_EnvironmentVLHGC *en
 		/* if we haven't kicked off yet, recalculate the intermission until kick-off based on current estimates */
 		if (_remainingGMPIntermissionIntervals > 0) {
 			double liveSetAdjustedForScannableBytesRatio = calculateEstimatedGlobalBytesToScan();
-			UDATA incrementHeadroom = calculateGlobalMarkIncrementHeadroom(env);
-			UDATA globalMarkIncrementsRequired = estimateGlobalMarkIncrements(env, liveSetAdjustedForScannableBytesRatio);
-			UDATA globalMarkIncrementsRequiredWithHeadroom = globalMarkIncrementsRequired + incrementHeadroom;
-			UDATA globalMarkIncrementsRemaining = partialCollectsRemaining * _extensions->tarokPGCtoGMPDenominator / _extensions->tarokPGCtoGMPNumerator;
+			uintptr_t incrementHeadroom = calculateGlobalMarkIncrementHeadroom(env);
+			uintptr_t globalMarkIncrementsRequired = estimateGlobalMarkIncrements(env, liveSetAdjustedForScannableBytesRatio);
+			uintptr_t globalMarkIncrementsRequiredWithHeadroom = globalMarkIncrementsRequired + incrementHeadroom;
+			uintptr_t globalMarkIncrementsRemaining = partialCollectsRemaining * _extensions->tarokPGCtoGMPDenominator / _extensions->tarokPGCtoGMPNumerator;
 			_remainingGMPIntermissionIntervals = MM_Math::saturatingSubtract(globalMarkIncrementsRemaining, globalMarkIncrementsRequiredWithHeadroom);
 		}
 	}
@@ -973,65 +1301,328 @@ MM_SchedulingDelegate::calculateAutomaticGMPIntermission(MM_EnvironmentVLHGC *en
 }
 
 void
-MM_SchedulingDelegate::updateSurvivalRatesAfterCopyForward(double thisEdenSurvivalRate, UDATA thisNonEdenSurvivorCount)
+MM_SchedulingDelegate::updateSurvivalRatesAfterCopyForward(double thisEdenSurvivalRate, uintptr_t thisNonEdenSurvivorCount)
 {
 	/* Note that this weight value is currently arbitrary */
 	double historicalWeight = 0.5;
 	double newWeight = 1.0 - historicalWeight;
 	_edenSurvivalRateCopyForward =  (historicalWeight * _edenSurvivalRateCopyForward) + (newWeight * thisEdenSurvivalRate);
-	_nonEdenSurvivalCountCopyForward = (UDATA)((historicalWeight * _nonEdenSurvivalCountCopyForward) + (newWeight * thisNonEdenSurvivorCount));
+	_nonEdenSurvivalCountCopyForward = (uintptr_t)((historicalWeight * _nonEdenSurvivalCountCopyForward) + (newWeight * thisNonEdenSurvivorCount));
 }
 
 void 
 MM_SchedulingDelegate::calculateEdenSize(MM_EnvironmentVLHGC *env)
 {
-	UDATA regionSize = _regionManager->getRegionSize();
-	UDATA previousEdenSize = _edenRegionCount * regionSize;
+	uintptr_t regionSize = _regionManager->getRegionSize();
+	uintptr_t previousEdenSize = _edenRegionCount * regionSize;
 	Trc_MM_SchedulingDelegate_calculateEdenSize_Entry(env->getLanguageVMThread(), previousEdenSize);
 	
 	MM_GlobalAllocationManagerTarok *globalAllocationManager = (MM_GlobalAllocationManagerTarok *)_extensions->globalAllocationManager;
-	UDATA freeRegions = globalAllocationManager->getFreeRegionCount();
+	uintptr_t freeRegions = globalAllocationManager->getFreeRegionCount();
 
-	UDATA edenMinimumCount = _minimumEdenRegionCount;
-	UDATA edenMaximumCount = _idealEdenRegionCount;
+	/* Eden sizing logic may have suggested a change to eden size. Apply those changes, while still respecting -Xmns/-Xmnx */
+	adjustIdealEdenRegionCount(env);
+
+	uintptr_t edenMinimumCount = _minimumEdenRegionCount;
+	uintptr_t edenMaximumCount = _idealEdenRegionCount;
+
 	Assert_MM_true(edenMinimumCount >= 1);
 	Assert_MM_true(edenMaximumCount >= 1);
 	Assert_MM_true(edenMaximumCount >= edenMinimumCount);
-	
-	UDATA desiredEdenCount = freeRegions;
-	if (desiredEdenCount > edenMaximumCount) {
-		desiredEdenCount = edenMaximumCount;
-	} else if (desiredEdenCount < edenMinimumCount) {
-		desiredEdenCount = edenMinimumCount;
-	}
+
+	/* Allow eden to expand as much as it wants, as long as the total heap can expand to accomodate it */
+	uintptr_t desiredEdenCount = OMR_MAX(edenMaximumCount, edenMinimumCount);
+	intptr_t desiredEdenChangeSize = (intptr_t)desiredEdenCount - (intptr_t)_edenRegionCount;
+	/* Determine if eden should try to grow anyways, or if the heap is tight on memory */
+	uintptr_t maximumHeap = _extensions->softMx == 0 ? _extensions->memoryMax : _extensions->softMx;
+	uintptr_t maximumHeapRegions = maximumHeap / _regionManager->getRegionSize();
+	intptr_t maxHeapExpansionRegions = OMR_MAX(0, ((intptr_t)maximumHeapRegions - (intptr_t)_numberOfHeapRegions - 1));
+
 	Trc_MM_SchedulingDelegate_calculateEdenSize_dynamic(env->getLanguageVMThread(), desiredEdenCount, _edenSurvivalRateCopyForward, _nonEdenSurvivalCountCopyForward, freeRegions, edenMinimumCount, edenMaximumCount);
-	if (desiredEdenCount <= freeRegions) {
-		_edenRegionCount = desiredEdenCount;
+
+	/* Make sure that the total heap can expand enough to satisfy the desired change in eden size
+	 * If heap is fully expanded (or close to) make sure that there are enough free regions to satisfy given eden size change
+	 */
+	intptr_t maxEdenChange = 0;
+	uintptr_t maxEdenRegionCount = _extensions->getHeap()->getHeapRegionManager()->getTableRegionCount();
+	bool edenIsVerySmall = (_edenRegionCount * 64) < maxEdenRegionCount;
+
+	if (0 == maxHeapExpansionRegions) {
+		/*
+		 * The heap is fully expanded. Eden will be stealing free regions from the entire heap, without telling the heap to grow.
+		 * Note: When heap is fully expanded, the eden sizing logic knows how much free memory is available in the heap, and knows to not grow too much
+		 */
+		maxEdenChange = freeRegions;
+		_extensions->globalVLHGCStats._heapSizingData.edenRegionChange = 0;
 	} else {
-		/* there isn't enough memory left for a desired Eden. Allow Eden to shrink to free size(could be less than minimum size or 0) before
-		 * triggering an allocation failure collection (i.e. a global STW collect)
-		 */ 
-		_edenRegionCount = freeRegions;
-		Trc_MM_SchedulingDelegate_calculateEdenSize_reduceToFreeBytes(env->getLanguageVMThread(), desiredEdenCount, _edenRegionCount);
+		/* Eden will inform the total heap resizing logic, that it needs to change total heap size in order to maintain same "tenure" size */
+		maxEdenChange = maxHeapExpansionRegions;
+		intptr_t edenChangeWithSurvivorHeadroom = desiredEdenChangeSize;
+
+		/* Total heap needs to be aware that by changing eden size, the amount of survivor space might also need to change */
+		if (0 < desiredEdenChangeSize) {
+			edenChangeWithSurvivorHeadroom = desiredEdenChangeSize + (intptr_t)ceil(((double)desiredEdenChangeSize * _edenSurvivalRateCopyForward));
+		} else if ((0 > desiredEdenChangeSize) && !edenIsVerySmall) {
+			/* If eden is shrinking, only factor adjusting in survivor regions for total heap resizing when eden is not very small.
+			 * Factoring in survivor regions when eden is tiny can lead to some innacuracies, and reduce free non-eden regions, which may impact performance
+			 */
+			edenChangeWithSurvivorHeadroom = desiredEdenChangeSize + (intptr_t)floor(((double)desiredEdenChangeSize * _edenSurvivalRateCopyForward));
+		}
+		_extensions->globalVLHGCStats._heapSizingData.edenRegionChange = OMR_MIN(maxEdenChange, edenChangeWithSurvivorHeadroom);
 	}
+
+	desiredEdenChangeSize = OMR_MIN(maxEdenChange, desiredEdenChangeSize);
+
+	_edenRegionCount = (uintptr_t)OMR_MAX(1, ((intptr_t)_edenRegionCount + desiredEdenChangeSize));
+
 	Trc_MM_SchedulingDelegate_calculateEdenSize_Exit(env->getLanguageVMThread(), (_edenRegionCount * regionSize));
 }
 
-UDATA
+intptr_t
+MM_SchedulingDelegate::moveTowardRecommendedEdenForExpandedHeap(MM_EnvironmentVLHGC *env, double edenChangeSpeed)
+{
+	Assert_MM_true((edenChangeSpeed <= 1.0) && (edenChangeSpeed >= 0.0));
+
+	intptr_t edenRegionChange = 0;
+
+	if ((0 != _historicalPartialGCTime) && (0 != _averagePgcInterval)) {
+		/* Make sure at least one PGC has occured */
+		uintptr_t currentIdealEdenBytes = getIdealEdenSizeInBytes(env);
+		uintptr_t currentIdealEdenRegions = _idealEdenRegionCount;
+
+		/*
+		* The closer edenChangeSpeed is to 1, the larger the move towards edenChange will be.
+		* 1 implies that eden should move all the way towards edenChange.
+		*/
+		intptr_t edenChange = calculateRecommendedEdenChangeForExpandedHeap(env);
+		intptr_t targetEdenChange = (intptr_t)(edenChange * edenChangeSpeed);
+		uintptr_t targetEdenBytes = currentIdealEdenBytes + targetEdenChange;
+		uintptr_t targetEdenRegions = targetEdenBytes / _regionManager->getRegionSize();
+
+		edenRegionChange = (intptr_t)targetEdenRegions - (intptr_t)currentIdealEdenRegions;
+	}
+
+	return edenRegionChange;
+}
+
+double
+MM_SchedulingDelegate::calculatePercentOfHeapExpanded(MM_EnvironmentVLHGC *env)
+{
+	double ratioOfHeapExpanded = 0.0;
+	uintptr_t currentHeapSize = _regionManager->getRegionSize() * _numberOfHeapRegions;
+	uintptr_t minimumHeap = OMR_MIN(_extensions->initialMemorySize, currentHeapSize);
+	uintptr_t maximumHeap = _extensions->softMx == 0 ? _extensions->memoryMax : _extensions->softMx;
+
+	if ((maximumHeap == currentHeapSize) || (maximumHeap == minimumHeap)) {
+		ratioOfHeapExpanded = 1.0;
+	} else {
+		uintptr_t heapBytesOverMinimum = currentHeapSize - minimumHeap;
+		uintptr_t maximumHeapVariation = maximumHeap - minimumHeap;
+		ratioOfHeapExpanded = ((double)heapBytesOverMinimum) / ((double)maximumHeapVariation);
+	}
+	return ratioOfHeapExpanded;
+}
+
+void
+MM_SchedulingDelegate::checkEdenSizeAfterPgc(MM_EnvironmentVLHGC *env, bool globalSweepHappened)
+{
+	double ratioOfHeapExpanded = calculatePercentOfHeapExpanded(env);
+
+	double heapFullyExpandedThreshold = 0.9;
+	double heapPercentExpandedAboveThreshold = 0.0;
+	if (heapFullyExpandedThreshold < ratioOfHeapExpanded) {
+		heapPercentExpandedAboveThreshold = ratioOfHeapExpanded - heapFullyExpandedThreshold;
+	}
+
+	intptr_t heapNotFullyExpandedRecommendation = 0;
+	intptr_t heapFullyExpandedRecommendation = 0;
+
+	if (0.0 == heapPercentExpandedAboveThreshold) {
+		heapNotFullyExpandedRecommendation = calculateEdenChangeHeapNotFullyExpanded(env);
+	} else if (0.0 < heapPercentExpandedAboveThreshold) {
+		/**
+		 * If heap is almost fully expanded, start to consider the recommendation given from moveTowardRecommendedEdenForExpandedHeap().
+		 */
+		if (globalSweepHappened) {
+			heapFullyExpandedRecommendation = moveTowardRecommendedEdenForExpandedHeap(env, 0.5);
+			heapNotFullyExpandedRecommendation = calculateEdenChangeHeapNotFullyExpanded(env);
+		} else if (0 == (_pgcCountSinceGMPEnd % consecutivePGCToChangeEden)){
+			/**
+			 * Every consecutivePGCToChangeEden number of PGC's, check to see if eden size should change.
+			 * This allows PGC to do some defragmentation work to finish, and for some statistics to stabilize
+			 */
+			heapFullyExpandedRecommendation = moveTowardRecommendedEdenForExpandedHeap(env, 0.25);
+			heapNotFullyExpandedRecommendation = calculateEdenChangeHeapNotFullyExpanded(env);
+		}
+	}
+
+	if (globalSweepHappened) {
+		resetPgcTimeStatistics(env);
+	}
+
+	Trc_MM_SchedulingDelegate_checkEdenSizeAfterPgc(env->getLanguageVMThread(), heapNotFullyExpandedRecommendation, heapFullyExpandedRecommendation, ratioOfHeapExpanded);
+
+	/**
+	 * Once ratioOfHeapExpanded is over heapFullyExpandedThreshold, start to blend the recommendations provided by
+	 * heapFullyExpandedRecommendation and heapNotFullyExpandedRecommendation, based off of how closely heap is to being fully expanded.
+	 * We do this to ensure a smoother transition between the 2 recommendations, which could potentially be pulling in opposite directions.
+	 * If the heap is 100% expanded for example, only care about heapFullyExpandedRecommendation, whereas if heap is not close to being fully expanded,
+	 * only consider heapNotFullyExpandedRecommendation for purpose of eden resizing.
+	 */
+	double heapFullyExpandedSuggestionWeight = heapPercentExpandedAboveThreshold / (1.0 - heapFullyExpandedThreshold);
+	_edenSizeFactor += (intptr_t)MM_Math::weightedAverage((double)heapFullyExpandedRecommendation, (double)heapNotFullyExpandedRecommendation, heapFullyExpandedSuggestionWeight);
+}
+
+intptr_t
+MM_SchedulingDelegate::calculateEdenChangeHeapNotFullyExpanded(MM_EnvironmentVLHGC *env)
+{
+	intptr_t edenRegionChange = 0;
+	intptr_t edenChangeMagnitude = (intptr_t)ceil((edenChangePctHeapNotFullyExpanded * getIdealEdenSizeInBytes(env)) / _regionManager->getRegionSize());
+	edenChangeMagnitude = OMR_MIN(edenChangeMagnitude, (intptr_t)maximumEdenRegionChangeHeapNotFullyExpanded);
+	/* By changing by at least 2 regions, it allows eden size to grow a bit faster (usually in startup phase when no Xmx was set, and there is only 1 eden region) */
+	edenChangeMagnitude = OMR_MAX(edenChangeMagnitude, (intptr_t)minimumEdenRegionChangeHeapNotFullyExpanded);
+
+	/* Use _recentPartialGCTime instead of _historicalPartialGCTime here, since target pause time needs the immediate feedback which happens when eden (possibly) changes size */
+	double hybridEdenOverhead = calculateHybridEdenOverhead(env, (uintptr_t)_recentPartialGCTime, _partialGcOverhead, false);
+
+	Trc_MM_SchedulingDelegate_calculateEdenChangeHeapNotFullyExpanded(env->getLanguageVMThread(), hybridEdenOverhead, (uintptr_t)_recentPartialGCTime, mapPgcPauseOverheadToPgcCPUOverhead(env, (uintptr_t)_recentPartialGCTime, false));
+
+	/*
+	 * Aim to get hybrid PGC overhead between extensions->dnssExpectedRatioMinimum and extensions->dnssExpectedRatioMaximum
+	 * by increasing or decreasing eden by edenChangePctHeapNotFullyExpanded
+	 */
+	if (_extensions->dnssExpectedRatioMinimum._valueSpecified > hybridEdenOverhead ) {
+		/* Shrink eden a bit */
+		edenRegionChange = edenChangeMagnitude * -1;
+	} else if (_extensions->dnssExpectedRatioMaximum._valueSpecified < hybridEdenOverhead) {
+		/* Expand eden a bit */
+		edenRegionChange = edenChangeMagnitude;
+	}
+	return edenRegionChange;
+}
+
+double
+MM_SchedulingDelegate::mapPgcPauseOverheadToPgcCPUOverhead(MM_EnvironmentVLHGC *env, uintptr_t pgcPauseTimeMs, bool heapFullyExpanded)
+{
+	/* Convert expectedTimeRatioMinimum/Maximum to 0-100 based for this formula */
+	const double xminpct = _extensions->dnssExpectedRatioMinimum._valueSpecified * 100.0;
+	const double xmaxpct = _extensions->dnssExpectedRatioMaximum._valueSpecified * 100.0;
+	const double targetPauseTimeMs = (double)_extensions->tarokTargetMaxPauseTime;
+	const double pauseTimeTooHighOverheadLogBase = 1.0156;
+
+	/*
+	 * This value determines how much contraction will be suggested, for each ms over target pause time.
+	 * Closer to 0 means target pause time will be closely respected,
+	 * while large values (>20) will not attribute enough weight to target pause time
+	 *
+	 * Empirically, 20 is a good value, since it gives enough weight to target pause time to make it very useful,
+	 * but not too much that it can sacrifice PGC overhead (in certain applications)
+	 */
+	const double targetPauseTimeWeightFactor = 20.0;
+
+	double overhead = 0.0;
+
+	if (heapFullyExpanded) {
+		/*
+		 * Eden size is being driven by heuristic which is trying to MINIMIZE hybrid overead, while trying to stay within tarokTargetMaxPauseTime,
+		 * The overhead logic here will map a low avg pgc time (ie, under targetPauseTimeMs), to a low overhead value (aka, a "better"/more desirable value)
+		 * Ex. Suppose tarokTargetMaxPauseTime == 100ms. 20ms -> 5% (good/desirable), 100ms -> 5% (still good), 110ms -> 6% (should possibly shrink) 500ms -> 80% (bad/undesirable/eden should probably shrink)
+		 */
+		double midpointPct = (xmaxpct + xminpct) / 2.0;
+		if (pgcPauseTimeMs <= targetPauseTimeMs) {
+			/* Once the pgc time is at, or below the max pgc time, there is no "benefit" from shrinking it further, since we are already satisfying tarokTargetMaxPauseTime */
+			overhead = midpointPct;
+		} else {
+			/*
+			 * If pgc time is above the max pgc time, map high PGC time values as very very high overhead, in efforts to bring the PGC time down to tarokTargetMaxPauseTime
+			 * If pgc time is only slightly above tarokTargetMaxPauseTime, then there is only a very small overhead penalty,
+			 * wheras being 2x higher than the target pause time leads to a significantly bigger penalty.
+			 */
+			double overheadCurve = pow(pauseTimeTooHighOverheadLogBase, ((double)pgcPauseTimeMs - targetPauseTimeMs)) + midpointPct - 1.0;
+			overhead = OMR_MIN(100.0, overheadCurve);
+		}
+
+	} else {
+		/*
+		 * Eden sizing logic is trying to keep hybrid overhead between xminpct and xmaxpct, while trying to respect targetPauseTimeMs.
+		 * The function/model used below adheres to the following high level concepts:
+		 * - if pgcPauseTimeMs is greater than targetPauseTimeMs, explicitly suggest contraction. ie, return a value < xminpct. Note: it is possible for this overhead to be negative if pgcPauseTimeMs is far beyond pause target - this is okay.
+		 * - if pgcPauseTimeMs < targetPauseTimeMs - targetPauseTimeWeightFactor, suggest neither explicit contraction nor explicit expansion, but rather, whatever the current cpu overhead currently is (which may be either expansion or contraction). In this case, we are far from targetPauseTimeMs, so cpu overhead can drive eden size
+		 * - if (targetPauseTimeMs - targetPauseTimeWeightFactor) < pgcPauseTimeMs < targetPauseTimeMs, the mapped overhead is somewhere between xmaxpct and xminpct. The closer pgcPauseTimeMs is to targetPauseTimeMs, the closer the overhead will be to xminpct (which suggests contraction)
+		 *
+		 *  NOTE: This mapped overhead value is later blended with pgc cpu overhead. This means that if the pgc pause time mapping suggested eden contraction, contraction is not guaranteed.
+		 */
+		double slope = (xminpct - xmaxpct) / targetPauseTimeWeightFactor;
+		overhead = (slope * (double)pgcPauseTimeMs) + (xminpct - (slope * targetPauseTimeMs));
+		/*
+		 * Suggesting expansion simply because pgc time is small, isn't necessarily a good idea.
+		 * Instead, if the pgc pause time is still relatively far from target pause time, simply return _partialGcOverhead so that pgc cpu overhead, so that pgc cpu overhead is effectively dictating eden size
+		 */
+		overhead = OMR_MIN(overhead, _partialGcOverhead * 100.0);
+	}
+
+	return overhead;
+}
+
+double
+MM_SchedulingDelegate::calculateHybridEdenOverhead(MM_EnvironmentVLHGC *env, uintptr_t pgcPauseTimeMs, double overhead, bool heapFullyExpanded)
+{
+	/*
+	 * When trying to size eden, there is a delicate balance between pgc overhead (here, overhead is cpu %, or % of time that pgc is active
+	 * versus inactive -> ex: pgc = 100ms, over 1000ms, overhead = 10%). In certain applications, with certain allocation patterns/liveness,
+	 * pgc average time may be negatively impacted by growing eden unbounded.
+	 * This function blends the pgc average time (whether it be the actual pgc historic time, or a "predicted" pgc pause time, is left up to the caller) with overhead (% of time gc is active relative to mutator).
+	 * This strikes a much better balance between pgc pause times, and gc cpu overhead, than if just cpu overhead was used.
+	 *
+	 * By mapping a pgc time to a corresponding overhead (% of time gc is active relative to mutator), eden sizing logic can make a decision as to whether
+	 * it wants to contract/expand, based on how much it will change the overhead and pgc times.
+	 */
+	double pgcTimeOverhead = mapPgcPauseOverheadToPgcCPUOverhead(env, pgcPauseTimeMs, heapFullyExpanded);
+	double hybridEdenOverheadHundredBased = MM_Math::weightedAverage(overhead * 100.0, pgcTimeOverhead, pgcCpuOverheadWeight);
+	return hybridEdenOverheadHundredBased / 100.0;
+}
+
+void
+MM_SchedulingDelegate::adjustIdealEdenRegionCount(MM_EnvironmentVLHGC *env)
+{
+	intptr_t edenChange = _edenSizeFactor;
+	/* Be clear that we have already consumed _edenSizeFactor */
+	_edenSizeFactor = 0;
+
+	/* Do not allow eden to grow/shrink past the min/max eden count */
+	intptr_t possibleEdenRegionCount = (intptr_t)_idealEdenRegionCount + edenChange;
+
+	if ((intptr_t)_minEdenRegionCount > possibleEdenRegionCount) {
+		edenChange = (intptr_t)_minEdenRegionCount - (intptr_t)_idealEdenRegionCount;
+	} else if ((intptr_t)_maxEdenRegionCount < possibleEdenRegionCount){
+		edenChange = (intptr_t)_maxEdenRegionCount - (intptr_t)_idealEdenRegionCount;
+	}
+
+	Trc_MM_SchedulingDelegate_adjustIdealEdenRegionCount(env->getLanguageVMThread(), _minEdenRegionCount, _maxEdenRegionCount, _idealEdenRegionCount, edenChange);
+
+	/* Inform the _idealEdenRegionCount that we need to change from current value. If there are not enough free regions, then eden will only as big as the amount of free regions */
+	_idealEdenRegionCount += edenChange;
+	/* Make sure we request at least 1 eden region as max */
+	_idealEdenRegionCount = OMR_MAX(1, _idealEdenRegionCount);
+	/* Make sure Min <= Max */
+	_minimumEdenRegionCount = OMR_MIN(_minimumEdenRegionCount, _idealEdenRegionCount);
+}
+
+uintptr_t
 MM_SchedulingDelegate::currentGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env) const
 {
-	UDATA markIncrementMillis = 0;
+	uintptr_t markIncrementMillis = 0;
 	
 	if (0 == _extensions->tarokGlobalMarkIncrementTimeMillis) {
-		UDATA partialCollectsRemaining = estimatePartialGCsRemaining(env);
+		uintptr_t partialCollectsRemaining = estimatePartialGCsRemaining(env);
 
 		if (0 == partialCollectsRemaining) {
 			/* We're going to AF very soon so we need to finish the GMP this increment.  Set current global mark increment time to max */
 			markIncrementMillis = UDATA_MAX;
 		} else {
-			UDATA desiredGlobalMarkIncrementMillis = _dynamicGlobalMarkIncrementTimeMillis;
+			uintptr_t desiredGlobalMarkIncrementMillis = _dynamicGlobalMarkIncrementTimeMillis;
 			double remainingMillisToScan = estimateRemainingTimeMillisToScan();
-			UDATA minimumGlobalMarkIncrementMillis = (UDATA) (remainingMillisToScan / (double)partialCollectsRemaining);
+			uintptr_t minimumGlobalMarkIncrementMillis = (uintptr_t) (remainingMillisToScan / (double)partialCollectsRemaining);
 
 			markIncrementMillis = OMR_MAX(desiredGlobalMarkIncrementMillis, minimumGlobalMarkIncrementMillis);
 		}
@@ -1043,13 +1634,19 @@ MM_SchedulingDelegate::currentGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC 
 	return markIncrementMillis;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::getCurrentEdenSizeInBytes(MM_EnvironmentVLHGC *env)
 {
 	return (_edenRegionCount * _regionManager->getRegionSize());
 }
 
-UDATA
+uintptr_t
+MM_SchedulingDelegate::getIdealEdenSizeInBytes(MM_EnvironmentVLHGC *env)
+{
+	return (_idealEdenRegionCount * _regionManager->getRegionSize());
+}
+
+uintptr_t
 MM_SchedulingDelegate::getCurrentEdenSizeInRegions(MM_EnvironmentVLHGC *env)
 {
 	return _edenRegionCount;
@@ -1058,74 +1655,54 @@ MM_SchedulingDelegate::getCurrentEdenSizeInRegions(MM_EnvironmentVLHGC *env)
 void
 MM_SchedulingDelegate::heapReconfigured(MM_EnvironmentVLHGC *env)
 {
-	UDATA edenMaximumBytes = _extensions->tarokIdealEdenMaximumBytes;
-	UDATA edenMinimumBytes = _extensions->tarokIdealEdenMinimumBytes;
+	uintptr_t edenMaximumBytes = _extensions->tarokIdealEdenMaximumBytes;
+	uintptr_t edenMinimumBytes = _extensions->tarokIdealEdenMinimumBytes;
 	Trc_MM_SchedulingDelegate_heapReconfigured_Entry(env->getLanguageVMThread(), edenMaximumBytes, edenMinimumBytes);
 	
-	UDATA regionSize = _regionManager->getRegionSize();
-	UDATA heapRegions = 0;
+	uintptr_t regionSize = _regionManager->getRegionSize();
+	_numberOfHeapRegions = 0;
 	
 	/* walk the managed regions (skipping cold area) to determine how large the managed heap is */
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager, MM_HeapRegionDescriptor::MANAGED);
 	while (NULL != regionIterator.nextRegion()) {
-		heapRegions += 1;
-	}
-	UDATA currentHeapSize = heapRegions * regionSize;
-	/* since the heap is allowed to be one region less than the size requested (due to "acceptLess" in Virtual Memory), make sure that we consider the "reachable minimum" to be the real minimum heap size */
-	UDATA minimumHeap = OMR_MIN(_extensions->initialMemorySize, currentHeapSize);
-	UDATA edenIdealBytes = 0;
-	UDATA maximumHeap = _extensions->memoryMax;
-	if (currentHeapSize == maximumHeap) {
-		/* we are fully expanded or mx == ms so just return the maximum ideal eden */
-		edenIdealBytes = edenMaximumBytes;
-	} else {
-		/* interpolate between the maximum and minimum */
-		/* This logic follows the formula given in JAZZ 39694
-		 * for:  -XmsA -XmxB -XmnsC -XmnxD, "current heap size" W, "current Eden size" Z:
-		 * Z := C + ((W-A)/(B-A))(D-C)
-		 */
-		UDATA heapBytesOverMinimum = currentHeapSize - minimumHeap;
-		UDATA maximumHeapVariation = maximumHeap - minimumHeap;
-		/* if this is 0, we should have taken the first half of this if */
-		Assert_MM_true(0 != maximumHeapVariation);
-		double ratioOfHeapExpanded = ((double)heapBytesOverMinimum) / ((double)maximumHeapVariation);
-		UDATA maximumEdenVariation = edenMaximumBytes - edenMinimumBytes;
-		UDATA edenLinearScale = (UDATA)(ratioOfHeapExpanded * (double)maximumEdenVariation);
-		edenIdealBytes = edenMinimumBytes + edenLinearScale;
+		_numberOfHeapRegions += 1;
 	}
 
-	_idealEdenRegionCount = (edenIdealBytes + regionSize - 1) / regionSize;
+	/* The eden size is  being driven by GC overhead and time - Keep eden size the same. If eden needs to change, it will change elsewhere */
+	uintptr_t edenIdealBytes = getIdealEdenSizeInBytes(env);
+	_idealEdenRegionCount = OMR_MAX((edenIdealBytes + regionSize - 1) / regionSize, (edenMinimumBytes + regionSize - 1) / regionSize);
+
 	Assert_MM_true(_idealEdenRegionCount > 0);
 	_minimumEdenRegionCount = OMR_MIN(_idealEdenRegionCount, ((MM_GlobalAllocationManagerTarok *)_extensions->globalAllocationManager)->getManagedAllocationContextCount());
 	Assert_MM_true(_minimumEdenRegionCount > 0);
 
-	Trc_MM_SchedulingDelegate_heapReconfigured_Exit(env->getLanguageVMThread(), heapRegions, _idealEdenRegionCount, _minimumEdenRegionCount);
+	Trc_MM_SchedulingDelegate_heapReconfigured_Exit(env->getLanguageVMThread(), _numberOfHeapRegions, _idealEdenRegionCount, _minimumEdenRegionCount);
 	Assert_MM_true(_idealEdenRegionCount >= _minimumEdenRegionCount);
 	
 	/* recalculate Eden Size after resize heap */
 	calculateEdenSize(env);
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::calculateGlobalMarkIncrementHeadroom(MM_EnvironmentVLHGC *env) const
 {
-	UDATA headroomIncrements = 0;
+	uintptr_t headroomIncrements = 0;
 
 	if (_regionConsumptionRate > 0.0) {
 		double headroomRegions = (double) _extensions->tarokKickoffHeadroomInBytes / _regionManager->getRegionSize();
 		double headroomPartialGCs = headroomRegions / _regionConsumptionRate;
 		double headroomGlobalMarkIncrements = headroomPartialGCs * (double)_extensions->tarokPGCtoGMPDenominator / (double)_extensions->tarokPGCtoGMPNumerator;
-		headroomIncrements = (UDATA) ceil(headroomGlobalMarkIncrements);
+		headroomIncrements = (uintptr_t) ceil(headroomGlobalMarkIncrements);
 	}
 	return headroomIncrements;
 }
 
-UDATA
+uintptr_t
 MM_SchedulingDelegate::estimateRemainingGlobalBytesToScan() const
 {
-	UDATA expectedGlobalBytesToScan = (UDATA) calculateEstimatedGlobalBytesToScan();
-	UDATA globalBytesScanned = ((MM_IncrementalGenerationalGC *)_extensions->getGlobalCollector())->getBytesScannedInGlobalMarkPhase();
-	UDATA remainingGlobalBytesToScan = MM_Math::saturatingSubtract(expectedGlobalBytesToScan, globalBytesScanned);
+	uintptr_t expectedGlobalBytesToScan = (uintptr_t) calculateEstimatedGlobalBytesToScan();
+	uintptr_t globalBytesScanned = ((MM_IncrementalGenerationalGC *)_extensions->getGlobalCollector())->getBytesScannedInGlobalMarkPhase();
+	uintptr_t remainingGlobalBytesToScan = MM_Math::saturatingSubtract(expectedGlobalBytesToScan, globalBytesScanned);
 
 	return remainingGlobalBytesToScan;
 }
@@ -1157,27 +1734,54 @@ MM_SchedulingDelegate::updateGMPStats(MM_EnvironmentVLHGC *env)
 	MM_MarkVLHGCStats * incrementalMarkStats = &(persistentGMPState->_vlhgcCycleStats._incrementalMarkStats);
 	MM_MarkVLHGCStats * concurrentMarkStats = &(persistentGMPState->_vlhgcCycleStats._concurrentMarkStats);
 
-	U_64 incrementalScanTime = (U_64) (((double) j9time_hires_delta(0, incrementalMarkStats->getScanTime(), J9PORT_TIME_DELTA_IN_MICROSECONDS)) / ((double) _extensions->gcThreadCount));
-	UDATA concurrentBytesScanned = concurrentMarkStats->_bytesScanned;
+	uint64_t incrementalScanTime = (uint64_t) (((double) j9time_hires_delta(0, incrementalMarkStats->getScanTime(), J9PORT_TIME_DELTA_IN_MICROSECONDS)) / ((double) _extensions->gcThreadCount));
+	uintptr_t concurrentBytesScanned = concurrentMarkStats->_bytesScanned;
 
-	_historicTotalIncrementalScanTimePerGMP = (U_64) ((_historicTotalIncrementalScanTimePerGMP * incrementalScanTimePerGMPHistoricWeight) + (incrementalScanTime * (1 - incrementalScanTimePerGMPHistoricWeight)));
-	_historicBytesScannedConcurrentlyPerGMP = (UDATA) ((_historicBytesScannedConcurrentlyPerGMP * bytesScannedConcurrentlyPerGMPHistoricWeight) + (concurrentBytesScanned * (1 - bytesScannedConcurrentlyPerGMPHistoricWeight)));
+	_historicTotalIncrementalScanTimePerGMP = (uint64_t) ((_historicTotalIncrementalScanTimePerGMP * incrementalScanTimePerGMPHistoricWeight) + (incrementalScanTime * (1 - incrementalScanTimePerGMPHistoricWeight)));
+	_historicBytesScannedConcurrentlyPerGMP = (uintptr_t) ((_historicBytesScannedConcurrentlyPerGMP * bytesScannedConcurrentlyPerGMPHistoricWeight) + (concurrentBytesScanned * (1 - bytesScannedConcurrentlyPerGMPHistoricWeight)));
 
 	Trc_MM_SchedulingDelegate_updateGMPStats(env->getLanguageVMThread(), _historicTotalIncrementalScanTimePerGMP, incrementalScanTime, _historicBytesScannedConcurrentlyPerGMP, concurrentBytesScanned);
 }
 
-U_64
+void
+MM_SchedulingDelegate::updatePgcTimePrediction(MM_EnvironmentVLHGC *env)
+{
+	/*
+	 * Create a model that passes through (minimumEdenRegions,minimumPgcTime) and (current eden size in regions, pgcTime)
+	 * By remembering historic values of _pgcTimeIncreasePerEdenFactor, it is possible to reasonably accuratly predict how long PGC will take, if eden were to change size.
+	 *
+	 * Note: The formula derived for predicting pgc times, require that x1 and x2 are in GB.
+	 */
+	double x1 = (double)_regionManager->getRegionSize() / 1000000000.0;
+	double y1 = (double)minimumPgcTime;
+
+	double x2 = (double)getCurrentEdenSizeInBytes(env) / 1000000000.0;
+	double y2 = (double)_historicalPartialGCTime;
+
+	/*
+	 * Calculate how closely related PGC is to eden time. The closer _pgcTimeIncreasePerEdenFactor is to 1.0, the more directly changing eden size will impact pgc time.
+	 * The higher _pgcTimeIncreasePerEdenFactor is from 1, the less changing eden size will affect pgc time.
+	 * In certain edge cases where eden is very small (minimumEdenRegions in size), or pgc time is very small, skip this set of calculation, since the results will not be correct
+	 */
+	if ((x1 < x2) && (y1 < y2)) {
+		double timeDiff = y1 - y2;
+		double edenSizeRatio = ((x1 + 1.0) / (x2 + 1.0));
+		_pgcTimeIncreasePerEdenFactor = pow(edenSizeRatio, (1.0 / timeDiff));
+		Trc_MM_SchedulingDelegate_updatePgcTimePrediction(env->getLanguageVMThread(), x1, y1, x2, y2, edenSizeRatio, _pgcTimeIncreasePerEdenFactor);
+	}
+}
+
+uint64_t
 MM_SchedulingDelegate::getScanTimeCostPerGMP(MM_EnvironmentVLHGC *env)
 {
 	MM_GCExtensions * extensions = MM_GCExtensions::getExtensions(env);
 	double incrementalCost = (double)_historicTotalIncrementalScanTimePerGMP;
 	double concurrentCost = 0.0;
 	double scanRate = _scanRateStats.microSecondsPerByteScanned / (double)extensions->gcThreadCount;
-	
+
 	if (scanRate > 0.0) {
 		concurrentCost = extensions->tarokConcurrentMarkingCostWeight * ((double)_historicBytesScannedConcurrentlyPerGMP * scanRate );
 	}
 
-	return (U_64) (incrementalCost + concurrentCost);
+	return (uint64_t) (incrementalCost + concurrentCost);
 }
-

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,21 +42,23 @@ class MM_SchedulingDelegate : public MM_BaseNonVirtual
 private:
 	MM_GCExtensions *_extensions; /**< The GC extensions structure */
 	MM_HeapRegionManager *_regionManager; /** A cached pointer to the region manager */
-	UDATA _taxationIndex;  /**< Counter of the number of times that taxation has occurred. This is used to determine if the current taxation point should perform a GMP and/or PGC */
-	UDATA _remainingGMPIntermissionIntervals; /**< Counter of the remaining intervals to skip before starting another GMP cycle */ 
+	uintptr_t _taxationIndex;  /**< Counter of the number of times that taxation has occurred. This is used to determine if the current taxation point should perform a GMP and/or PGC */
+	uintptr_t _remainingGMPIntermissionIntervals; /**< Counter of the remaining intervals to skip before starting another GMP cycle */
 	bool _nextIncrementWillDoPartialGarbageCollection; /**< Record whether a PGC is planned for the next taxation point */
 	bool _nextIncrementWillDoGlobalMarkPhase; /**< Record whether a GMP increment is planned for the next taxation point */
 	bool _nextPGCShouldCopyForward;	/**< True if the next PGC increment will be attempted using copy-forward (read and set when PGC starts).  False implies compaction will be used, instead */
+	bool _currentlyPerformingGMP; /**< Set to true when a GMP cycle is active */
 	bool _globalSweepRequired;	/**< Set when a GMP finishes so that the next PGC to run knows that it is responsible for the first global sweep on the new mark map */
 	bool _disableCopyForwardDuringCurrentGlobalMarkPhase; /**< Set to true when a PGC Abort happens during GMP. Reset only when GMP is complete. */
-	UDATA _idealEdenRegionCount;	/**< The ideal number of regions for eden space at the current heap size */
-	UDATA _minimumEdenRegionCount;	/**< The minimum number of regions for eden space at the current heap size */
-	UDATA _edenRegionCount; /**< The current size of Eden, in regions */
+	uintptr_t _idealEdenRegionCount;	/**< The ideal number of regions for eden space at the current heap size */
+	uintptr_t _minimumEdenRegionCount;	/**< The minimum number of regions for eden space at the current heap size */
+	uintptr_t _edenRegionCount; /**< The current size of Eden, in regions */
 	double _edenSurvivalRateCopyForward;	/**< The running average ratio of the number of regions consumed to copy-forward Eden to the number of regions allocated as Eden */
-	UDATA _nonEdenSurvivalCountCopyForward;	/**< The running average count of the number of non-Eden regions allocated by copy-forward for its survival set (Eden regions are excluded since they are tracked with _edenSurvivalRateCopyForward) */
+	uintptr_t _nonEdenSurvivalCountCopyForward;	/**< The running average count of the number of non-Eden regions allocated by copy-forward for its survival set (Eden regions are excluded since they are tracked with _edenSurvivalRateCopyForward) */
+	uintptr_t _numberOfHeapRegions; /**< The number of heap regions according to the region manager */
 
-	UDATA _previousReclaimableRegions; /**< The number of reclaimable regions at the end of the last reclaim. Used to estimate consumption rate. */
-	UDATA _previousDefragmentReclaimableRegions; /**< The number of reclaimable regions in the defragment set at the end of the last reclaim. Used to estimate GMP kickoff and compact rate. */
+	uintptr_t _previousReclaimableRegions; /**< The number of reclaimable regions at the end of the last reclaim. Used to estimate consumption rate. */
+	uintptr_t _previousDefragmentReclaimableRegions; /**< The number of reclaimable regions in the defragment set at the end of the last reclaim. Used to estimate GMP kickoff and compact rate. */
 	double _regionConsumptionRate; /**< The average number of regions consumed per PGC */
 	double _defragmentRegionConsumptionRate; /**< The average number of defragment regions consumed per PGC */
 	double _bytesCompactedToFreeBytesRatio; /**< Ratio of bytes to be compacted / bytes to be freed, for regions created after GMP, and used to spread the work until next GMP */
@@ -65,25 +67,45 @@ private:
 	double _averageSurvivorSetRegionCount; /**< Weighted average of survivor regions */
 	double _averageCopyForwardRate; /**< Weighted average of (bytesCopied / timeSpentInCopyForward).  Disregards time spent related RSCL clearing. Measured in bytes/microseconds */
 	double _averageMacroDefragmentationWork; /**< Average work to be done to mitigate influx of fragmented regions into the oldest age */
-	UDATA _currentMacroDefragmentationWork;	 /**< As we age out regions and find macro defrag work, we sum it up */
+	uintptr_t _currentMacroDefragmentationWork;	 /**< As we age out regions and find macro defrag work, we sum it up */
 	bool _didGMPCompleteSinceLastReclaim; /**< true if a GMP completed since the last reclaim cycle */
-	UDATA _liveSetBytesAfterPartialCollect;		/**< Live set estimate for the current (at the end of) PGC */
+	uintptr_t _liveSetBytesAfterPartialCollect;		/**< Live set estimate for the current (at the end of) PGC */
 	double _heapOccupancyTrend;			/**< Expected ratio of survival of newly created (since last GMP) live set */
-	UDATA _liveSetBytesBeforeGlobalSweep;		/**< Live set estimate recorded value for PGC before last/current GMP sweep */
-	UDATA _liveSetBytesAfterGlobalSweep;		/**< Live set estimate recorded value for PGC after last/current GMP sweep */
-	UDATA _previousLiveSetBytesAfterGlobalSweep; /**< Live set estimate recorded value for PGC after previous GMP sweep */
+	uintptr_t _liveSetBytesBeforeGlobalSweep;		/**< Live set estimate recorded value for PGC before last/current GMP sweep */
+	uintptr_t _liveSetBytesAfterGlobalSweep;		/**< Live set estimate recorded value for PGC after last/current GMP sweep */
+	uintptr_t _previousLiveSetBytesAfterGlobalSweep; /**< Live set estimate recorded value for PGC after previous GMP sweep */
 	double _scannableBytesRatio;			/**< Ratio of scannable byte vs total bytes (scannable + non-scannable) as measured from past */
-	U_64 _historicTotalIncrementalScanTimePerGMP;  /**< Historic average of the total wall-clock time we spend scanning in all stop-the-world global mark increments over a GMP cycle in microseconds */
-	UDATA _historicBytesScannedConcurrentlyPerGMP; /**< Historic average amount of bytes we scan concurrently per GMP cycle */
+	uint64_t _historicTotalIncrementalScanTimePerGMP;  /**< Historic average of the total wall-clock time we spend scanning in all stop-the-world global mark increments over a GMP cycle in microseconds */
+	uintptr_t _historicBytesScannedConcurrentlyPerGMP; /**< Historic average amount of bytes we scan concurrently per GMP cycle */
+	uintptr_t _estimatedFreeTenure; /**< The amount of free memory we estimate in the total heap - includes some headroom for GMP kickoff */
 
-	U_64 _partialGcStartTime;  /**< Start time of the in progress Partial GC in hi-resolution format (recorded to track total time spent in Partial GC) */
-	U_64 _historicalPartialGCTime;  /**< Weighted historical average of Partial GC times */
+	uintptr_t _maxEdenRegionCount; /**< The maximum size of eden, in regions */
+	uintptr_t _minEdenRegionCount; /**< The minimum size of eden, in regions */
 
-	UDATA _dynamicGlobalMarkIncrementTimeMillis;  /**< The dynamically calculated current time to be spent per GMP increment (subject to change over the course of the run) */
+	uint64_t _partialGcStartTime;  /**< Start time of the in progress Partial GC in hi-resolution format (recorded to track total time spent in Partial GC) */
+	double _partialGcOverhead; /**< Used to keep track of relative Partial GC overhead. Is calculated by dividing total time spent in a single PGC phase, by the time interval since the end of the previous PGC */
+	uint64_t _historicalPartialGCTime;  /**< Weighted historical average of Partial GC times, measured in ms */
+	uint64_t _recentPartialGCTime; /**< Most recent PGC time, measured in ms */
+
+	uint64_t _globalMarkIncrementsTotalTime; /**< Agregate of time spent doing GMP increments for current phase */
+	uint64_t _globalMarkIntervalStartTime; /**< Time interval between start of sucessive GMP increments */
+	double _globalMarkOverhead; /**< Used to keep track of relative Global Mark overhead. Is calculated by dividing total time spent in Global Mark increments, Concurrent GMP work, and global sweep, by the time interval since the completion of the last global mark  */
+	uint64_t _globalSweepTimeUs; /**< Used to keep track of time spent doing global sweep, corresponding to previous GMP cycle */
+	uint64_t _concurrentMarkGCThreadsTotalWorkTime; /**< Sum of all time intervals (cpu) for GC threads doing concurrent work */
+
+	uintptr_t _dynamicGlobalMarkIncrementTimeMillis;  /**< The dynamically calculated current time to be spent per GMP increment (subject to change over the course of the run) */
+
+	double _pgcTimeIncreasePerEdenFactor; /**< Used to keep track of how much pgc time will increase as eden size increases */
+
+	intptr_t _edenSizeFactor; /**< Used to indicate how far eden should increase or decrease from current value. Positive values indicate max eden should be larger, while - values indicate max eden should shrink. Value corresponds to number of regions */
+	uintptr_t _pgcCountSinceGMPEnd; /**< Counts the number of PGC's from end of last GMP cycle, to the end of current(next) GMP cycle */
+	uint64_t _averagePgcInterval; /**< The average interval time between start of 2 consecutive PGC's, measured in Us */
+
+	uint64_t _totalGMPWorkTimeUs; /**< Represents the total time that the previous GMP cycle took. Includes concurrent work, increments of work, and global sweep time  */
 
 	struct MM_SchedulingDelegate_ScanRateStats {
-		UDATA historicalBytesScanned;		/**< Historical number of bytes scanned for mark operations */
-		U_64 historicalScanMicroseconds;	/**< Historical scan times for mark operations */
+		uintptr_t historicalBytesScanned;		/**< Historical number of bytes scanned for mark operations */
+		uint64_t historicalScanMicroseconds;	/**< Historical scan times for mark operations */
 		double microSecondsPerByteScanned; /**< The average scan rate, measured in microseconds per byte */
 		
 		MM_SchedulingDelegate_ScanRateStats() :
@@ -110,6 +132,13 @@ public:
 	 */
 	void updateCurrentMacroDefragmentationWork(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region);
 
+	/**
+	 * Updates statistics required for total heap sizing
+	 */
+	void updateHeapSizingData(MM_EnvironmentVLHGC *env);
+
+	uintptr_t getPgcCountSinceGMPEnd(MM_EnvironmentVLHGC *env) { return _pgcCountSinceGMPEnd; }
+
 private:
 	/**
 	 * Internal helper for determining the next taxation threshold. This does all
@@ -117,7 +146,7 @@ private:
 	 * getNextTaxationThreshold calls this in a loop until the intermission has 
 	 * been consumed.
 	 */
-	UDATA getNextTaxationThresholdInternal(MM_EnvironmentVLHGC *env);
+	uintptr_t getNextTaxationThresholdInternal(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Called to update the _liveSetBytesAfterPartialCollect instance variable based
@@ -131,10 +160,56 @@ private:
 	double calculateEstimatedGlobalBytesToScan() const;
 
 	/**
+	 * Aim to find the change in eden size with the best blend of gc overhead (% of time gc is active relative to mutators), and pgc average time
+	 * @return The recommended change in eden size (in bytes) given the current heap sizing (eden, tenure, etc), and PGC and GMP data.
+	 */
+	intptr_t calculateRecommendedEdenChangeForExpandedHeap(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * @return The predicted overhead (% of time gc is active relative to mutators) if eden changes by 'edenChange' bytes
+	 * @param env[in] The main GC thread
+	 * @param currentEdenSize The current size of eden, in bytes
+	 * @param edenSizeChange How far away from currentEdenSize we want to observe overhead
+	 * @param freeTenure The amount of free space in tenure, in bytes
+	 * @param pgcAvgIntervalTime The observed avg time between PGC's (in us) since the last GMP ended
+	 */
+	double predictCpuOverheadForEdenSize(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uintptr_t freeTenure, uint64_t pgcAvgIntervalTime);
+
+	/**
+	 * @return The predicted interval between PGC collections. We expect the interval between collections to be linearly related to how much eden grows
+	 * 	ie, if we double eden size, we expect the interval between collections to double as well
+	 * @param env[in] The main GC thread
+	 * @param currentEdenSize The current eden size, in bytes
+	 * @param edenSizeChange How much we want to increase/decrease eden by, in bytes
+	 * @param pgcAvgIntervalTime The observed pgc avg interval time
+	 */
+	double predictIntervalBetweenCollections(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uint64_t pgcAvgIntervalTime);
+
+	/**
+	 * @return The predicted number of PGC collections per GMP cycle. We expect the number of PGC collections to be proportional to free tenure.
+	 * ie, if we have twice as much free tenure given the new eden size, we would expect twice as many PGC collections
+	 * @param env[in] The main GC thread
+	 * @param currentEdenSize The current eden size, in bytes
+	 * @param edenSizeChange How much we want to increase/decrease eden by, in bytes
+	 * @param freeTenure How much free tenure we have
+	 */
+	double predictNumberOfCollections(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange, uintptr_t freeTenure);
+
+	/**
+	 * @return The predicted avg time that PGC will take, if eden becomes currentEdenSize +/- edenSizeChange
+	 * PGC time is somewhat dependent on eden size. Larger eden will typically take more time to collect than smaller eden.
+	 * We can use this general observation to get a rough estimate of how long PGC will take
+	 * @param env[in] The main GC thread
+	 * @param currentEdenSize The current size of eden
+	 * @param edenSizeChange How much we want to increase/decrease eden by, in bytes
+	 */
+	double predictPgcTime(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange);
+
+	/**
 	 * @return The estimated number of bytes which we have remaining to scan for the current GMP cycle.  
 	 * If there is not currently a GMP running, returns calculateEstimatedGlobalBytesToScan()
 	 */
-	UDATA estimateRemainingGlobalBytesToScan() const;
+	uintptr_t estimateRemainingGlobalBytesToScan() const;
 
 	/**
 	 * @return The estimated amount of time (wall-clock time in millis) we need to spend scanning to finish the current GMP.  
@@ -151,7 +226,7 @@ private:
 	 * @param liveSetAdjustedForScannableBytesRatio[in] The estimated number of scannable bytes on the heap
 	 * @return the estimated number of increments required
 	 */
-	UDATA estimateGlobalMarkIncrements(MM_EnvironmentVLHGC *env, double liveSetAdjustedForScannableBytesRatio) const;
+	uintptr_t estimateGlobalMarkIncrements(MM_EnvironmentVLHGC *env, double liveSetAdjustedForScannableBytesRatio) const;
 	
 	/**
 	 * Monitor influx of regions into the oldest age group,
@@ -167,7 +242,7 @@ private:
 	 * @param env[in] The main GC thread
 	 * @return the estimated number of PGCs remaining before AF (anything from 0 to UDATA_MAX)
 	 */
-	UDATA estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) const;
+	uintptr_t estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) const;
 	
 	/**
 	 * Called after a PGC has been completed in order to measure the region consumption and update
@@ -176,7 +251,7 @@ private:
 	 * @param currentReclaimableRegions the estimated number of reclaimable regions
 	 * @param defragmentReclaimableRegions he estimated number of reclaimable defragment regions
 	 */
-	void measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, UDATA currentReclaimableRegions, UDATA defragmentReclaimableRegions);
+	void measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, uintptr_t currentReclaimableRegions, uintptr_t defragmentReclaimableRegions);
 	
 	/**
 	 * Called after marking to update statistics related to the scan rate. This data is used
@@ -202,6 +277,67 @@ private:
 	void calculateEdenSize(MM_EnvironmentVLHGC *env);
 
 	/**
+	 * Compute what the ideal eden size should be, and return by how many regions eden should change
+	 * @param env[in] the main GC thread
+	 * @param edenChangeSpeed How quickly eden should jump from current eden size to the ideal eden size. edenChangeSpeed must be between 0 and 1.
+	 * @return by how many regions eden should change. Positive values mean eden should expand, while negative values means eden should shrink
+	 * 0.1 indicates that current eden size should move a little bit towards ideal eden size
+	 * 0.9 indicates that current eden size should move very aggresively towards ideal eden size
+	 * 0.5 indicates that current eden size should move halfway towards ideal eden size
+	 */
+	intptr_t moveTowardRecommendedEdenForExpandedHeap(MM_EnvironmentVLHGC *env, double edenChangeSpeed);
+
+	/**
+	 * Calculate how much the heap has expanded, relative to -Xms and -Xmx/-Xsoftmx.
+	 * Ex: If -Xmx1G and -Xmx5G, and current heap is 3G, then we return 0.5
+	 * @param env[in] the main GC thread
+	 * @return Percent of heap expanded, as ratio between 0-1
+	 */
+	double calculatePercentOfHeapExpanded(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Following a PGC, check how PGC overhead and PGC times are behaving, and modyfing _edenSizeFactor to increase/decrease eden size if needed
+	 * @param env[in] the main GC thread
+	 * @param globalSweepHappened true if a global sweep was performed during the PGC that just completed
+	 */
+	void checkEdenSizeAfterPgc(MM_EnvironmentVLHGC *env, bool globalSweepHappened);
+
+	/**
+	 * Calculates how much eden size should change when heap is not fully expanded, based off of pgc time, and pgc cpu overhead
+	 * @return by how many regions eden should change
+	 */
+	intptr_t calculateEdenChangeHeapNotFullyExpanded(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Maps a pgc time, to a corresponding GC overhead (as a % of time being active). This is used for calculating hybrid eden overhead.
+	 * Depending on if the heap is fully expanded (ie, heap size >= Xsoftmx), the returned overhead will take a slightly different meaning
+	 * @param env[in] the main GC thread
+	 * @param pgcPauseTimeMs the pgc pause time in Ms that needs to be mapped to a cpu overhead
+	 * @param heapIsFullyExpanded set to true will use the mapping for when heap is fully expanded, which differs from the false case.
+	 * @return PGC overhead corresponding to pgc time, as a % between 0 and 100
+	 */
+	double mapPgcPauseOverheadToPgcCPUOverhead(MM_EnvironmentVLHGC *env, uintptr_t pgcPauseTimeMs, bool heapIsFullyExpanded);
+
+	/**
+	 * Blends a pgc average time, and a GC overhead, and returns the hybrid overhead of the 2 values.
+	 * Note that if heap is fully expanded (current heap size > softmx/mx), the returned values mean slightly different things
+	 * @param env[in] the main GC thread
+	 * @param pgcPauseTimeMs the pgc time in Ms that needs to be mapped to a cpu overhead
+	 * @param overhead The overhead we need to blend. Must be value between 0 and 1
+	 * @param heapIsFullyExpanded set to true will use the pgc time mapping for when heap is fully expanded, which differs from the false case.
+	 * @return Hybrid overhead for pgc avg time and pgc overhead, as a % between 0 and 1
+	 */
+	double calculateHybridEdenOverhead(MM_EnvironmentVLHGC *env, uintptr_t pgcPauseTimeMs, double overhead, bool heapIsFullyExpanded);
+
+	/**
+	 * Modify the _idealEdenRegionCount count based on _edenSizeFactor. If _edenSizeFactor is postive, we increase eden.
+	 * If _edenSizeFactor is negative, we shrink eden.
+	 * Eden will be bounded by _maxEdenPercent and _minEdenPercent, or by any -Xmn/s/x options if provided
+	 * @param env[in] the main GC thread
+	 */
+	void adjustIdealEdenRegionCount(MM_EnvironmentVLHGC *env);
+
+	/**
 	 * Calculate the new Global Mark increment time given the most recent Partial GC time.
 	 * Attempt to keep the GMP times in line with the times in PGC.  Keep track of a weighted
 	 * historic average and set the new GMP increment time to be a result of the adjusted
@@ -209,7 +345,7 @@ private:
 	 * @param env[in] the main GC thread
 	 * @param pgcTime[in] New PGC-time to update weighted average with
 	 */
-	void calculateGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env, U_64 pgcTime);
+	void calculateGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env, uint64_t pgcTime);
 
 	/**
 	 * Updates the _edenSurvivalRateCopyForward and _nonEdenSurvivalCountCopyForward running averages by including thisEdenSurvivalRate and
@@ -217,19 +353,25 @@ private:
 	 * @param thisEdenSurvivalRate[in] A value >= 0.0 (and typically <= 1.0) representing the number of regions out of those allocated for this Eden which survived
 	 * @param thisNonEdenSurvivorCount[in] The number of non-Eden regions consumed by this a Copy-Forward
 	 */
-	void updateSurvivalRatesAfterCopyForward(double thisEdenSurvivalRate, UDATA thisNonEdenSurvivorCount);
+	void updateSurvivalRatesAfterCopyForward(double thisEdenSurvivalRate, uintptr_t thisNonEdenSurvivorCount);
 
 	/**
 	 * Get number of GMP increments we wish to have as headroom to ensure that the GMP cycle finishes before AF with the desired pause time.
 	 * @param env[in] the main GC thread
 	 */
-	UDATA calculateGlobalMarkIncrementHeadroom(MM_EnvironmentVLHGC *env) const;
+	uintptr_t calculateGlobalMarkIncrementHeadroom(MM_EnvironmentVLHGC *env) const;
 
 	/**
 	 * Called after a GMP completes to update GMP-related statistics necessary for scheduling.  This is done by examining env->cycleState.
 	 * @param env[in] the main GC thread
 	 */
 	void updateGMPStats(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Updates statistics used to predict PGC time, with the PGC historic time.
+	 * @param env[in] the main GC thread
+	 */
+	void updatePgcTimePrediction(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Called after a copy forward rate to update the averageCopyForwardRate
@@ -245,31 +387,38 @@ private:
 	 * @oaram reservedFreeMemory[in]
 	 * @return total free memory(bytes)
 	 */
-	UDATA estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, UDATA freeRegionMemory, UDATA defragmentedMemory, UDATA reservedFreeMemory);
+	uintptr_t estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, uintptr_t freeRegionMemory, uintptr_t defragmentedMemory, uintptr_t reservedFreeMemory);
 
 	/**
 	 * Calculate GMP Kickoff Headroom In Bytes
 	 * the
 	 */
-	UDATA calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, UDATA totalFreeMemory);
+	uintptr_t calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, uintptr_t totalFreeMemory);
 
 protected:
 	
 public:
-	UDATA initializeKickoffHeadroom(MM_EnvironmentVLHGC *env);
+	/**
+	 * Initialize the receiver.
+	 * @param env[in] The thread initializing the collector
+	 * @return Whether or not the initialization succeeded
+	 */
+	bool initialize(MM_EnvironmentVLHGC *env);
+
+	uintptr_t initializeKickoffHeadroom(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Calculate the allocation threshold for the first taxation period. This should be called
 	 * to initialize the threshold any time that the heap is reset (e.g. initialized or a global
 	 * collect is performed).
 	 */
-	UDATA getInitialTaxationThreshold(MM_EnvironmentVLHGC *env);
+	uintptr_t getInitialTaxationThreshold(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Calculate the allocation threshold for the next taxation.  Note that this must only
 	 * be called once per increment, as it also advances the receiver to the next increment.
 	 */
-	UDATA getNextTaxationThreshold(MM_EnvironmentVLHGC *env);
+	uintptr_t getNextTaxationThreshold(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Determine what work should be performed during the current increment.
@@ -307,7 +456,7 @@ public:
 	 * @return the scan time cost (in microseconds) we attribute to performing a GMP.  
 	 * 
 	 */
-	U_64 getScanTimeCostPerGMP(MM_EnvironmentVLHGC *env);
+	uint64_t getScanTimeCostPerGMP(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Return measured average scan rate.
@@ -334,7 +483,7 @@ public:
 	 * @param env[in] The main GC thread
 	 * @param edenSizeInBytes[in] The size of the Eden space which preceded this PGC, in bytes
 	 */
-	void calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, UDATA edenSizeInBytes);
+	void calculatePGCCompactionRate(MM_EnvironmentVLHGC *env, uintptr_t edenSizeInBytes);
 
 	/**
 	 * Calculate ratio of scannable bytes vs total live set (scannable + non-scannable)
@@ -361,7 +510,7 @@ public:
 	 * @param env[in] the main GC thread
 	 * @return desired bytes to be compacted
 	 */
-	UDATA getDesiredCompactWork();
+	uintptr_t getDesiredCompactWork();
 
 	/**
 	 * @return true if it is first PGC after GMP completed (so we can calculate compact-bytes/free-bytes ratio, etc.)
@@ -382,11 +531,39 @@ public:
 	 */
 	bool isGlobalSweepRequired() { return _globalSweepRequired; }
 
+	/*
+	 * Sets the time taken for global sweep in microseconds
+	 */
+	void setGlobalSweepTime(uint64_t globalSweepTime) { _globalSweepTimeUs = globalSweepTime; }
+
+	/*
+	 * Adds the time taken for concurrent mark
+	 */
+	void setConcurrentGlobalMarkTime(uint64_t concurrentMarkTotalTime) { _concurrentMarkGCThreadsTotalWorkTime = concurrentMarkTotalTime; }
+
 	/**
 	 * Inform the receiver that a copy-forward cycle has completed
 	 * @param env[in] the main GC thread
 	 */
 	void copyForwardCompleted(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Inform the receiver that a Global Mark phase is starting
+	 * @param env[in] the main GC thread
+	 */
+	void globalMarkCycleStart(MM_EnvironmentVLHGC *env);
+
+	/**
+	 *  Calculate GMP overhead
+	 *  @param env[in] the main GC thread
+	 */
+	void calculateGlobalMarkOverhead(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Inform the receiver that a Global Mark phase is ending
+	 * @param env[in] the main GC thread
+	 */
+	void globalMarkCycleEnd(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Inform the receiver that a Global Mark Phase has completed and that a GMP intermission should begin
@@ -399,14 +576,14 @@ public:
 	 * @param env[in] the main GC thread
 	 */
 	void globalMarkIncrementCompleted(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Inform the receiver that a Global GC has completed.
 	 * @param env[in] the main GC thread
 	 * @param reclaimableRegions[in] an estimate of the reclaimable memory
 	 * @param defragmentReclaimableRegions[in] an estimate of the reclaimable defragment memory
 	 */
-	void globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, UDATA reclaimableRegions, UDATA defragmentReclaimableRegions);
+	void globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, uintptr_t reclaimableRegions, uintptr_t defragmentReclaimableRegions);
 	
 	/**
 	 * Inform the receiver that a Partial GC has started.
@@ -414,13 +591,26 @@ public:
 	 */
 	void partialGarbageCollectStarted(MM_EnvironmentVLHGC *env);
 
+
+	/**
+	 *  Calculate interval between consecutive start PGC increment starts, and calculate PGC overhead
+	 *  @param env[in] the main GC thread
+	 */
+	void calculatePartialGarbageCollectOverhead(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Resets statistics which keep track of PGC count
+	 * @param env[in] the main GC thread
+	 */
+	void resetPgcTimeStatistics(MM_EnvironmentVLHGC *env);
+
 	/**
 	 * Inform the receiver that a Partial GC has completed.
 	 * @param env[in] the main GC thread
 	 * @param reclaimableRegions[in] an estimate of the reclaimable memory
 	 * @param defragmentReclaimableRegions[in] an estimate of the reclaimable defragment memory
 	 */
-	void partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, UDATA reclaimableRegions, UDATA defragmentReclaimableRegions);
+	void partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, uintptr_t reclaimableRegions, uintptr_t defragmentReclaimableRegions);
 
 	/**
 	 * Determine what type of PGC should be run next PGC cycle (Copy-Forward, Mark-Sweep-Compact etc)
@@ -434,26 +624,33 @@ public:
 	 * @param env[in] the main GC thread
 	 * @return Time in milliseconds for Global Mark increment
 	 */
-	UDATA currentGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env) const;
+	uintptr_t currentGlobalMarkIncrementTimeMillis(MM_EnvironmentVLHGC *env) const;
 
 	/**
 	 * Used to request the size, in bytes, of the active calculated Eden space.
 	 * @param env[in] The main GC thread
 	 * @return The current size of Eden, in bytes
 	 */
-	UDATA getCurrentEdenSizeInBytes(MM_EnvironmentVLHGC *env);
+	uintptr_t getCurrentEdenSizeInBytes(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Used to request the size, in bytes, of the ideal calculated Eden space.
+	 * @param env[in] The main GC thread
+	 * @return The ideal size of Eden, in bytes
+	 */
+	uintptr_t getIdealEdenSizeInBytes(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Used to request the size, in regions, of the active calculated Eden space.
 	 * @param env[in] The main GC thread
 	 * @return The current size of Eden, in regions
 	 */
-	UDATA getCurrentEdenSizeInRegions(MM_EnvironmentVLHGC *env);
+	uintptr_t getCurrentEdenSizeInRegions(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * @return The number of bytes which we expect to scan during the next GMP increment
 	 */
-	UDATA getBytesToScanInNextGMPIncrement(MM_EnvironmentVLHGC *env) const;
+	uintptr_t getBytesToScanInNextGMPIncrement(MM_EnvironmentVLHGC *env) const;
 
 	/**
 	 * Adjust internal structures to reflect the change in heap size.


### PR DESCRIPTION
This change introduces 2 different major components to balanced gc, which are working together.

---------Change 1: New heap sizing logic in balanced gc
The old heap sizing logic, relied primarily on free memory %, in relation to -Xminf and -Xmaxf to decide whether or not the heap should shrink/expand.
If free memory was within the acceptable boundary, the heap sizing logic would then look at gc cpu% to decide whether to expand/contract.

The new logic (which is included in this commit), aims to take a more hybrid approach, where TENURE free memory % and GMP cpu % are working together, to determine whether or not the heap needs to change.
The function ```calculateCurrentHybridHeapOverhead``` determines what the current "hybrid overhead" of the heap/gc is (blend of gc cpu % and free memory %).
If this "hybrid overhead" is above -Xmaxt (default to 5%), the heap will expand. Conversely, if the "hybrid overhead" is below -Xmint (2% default), the heap will shrink. 

--------Change 2: New eden sizing logic in balanced

The current logic for eden sizing is fairly simple - By default, eden is taken to be 25% of the heap - unless specified otherwise by -Xmn/-Xmns/-Xmnx

The new logic, aims to make use of a few heuristics to improve overall PGC overheaad (% of time being active relative to total time), while trying to respect the newly introduced, `tarokTargetMaxPauseTime`.
Eden sizing logic now adheres to the following high level concepts:

 1. If the heap is not fully expanded ( that is current heap size <= -Xsoftmx/-Xmx), then eden will increase by 5% if PGC overhead and pgc avg time blend, is above
   dnssExpectedTimeRatioMinimum (5% default). Conversely, eden will shrink by 5% if the hybrid blend of pgc overhead and pgc time, falls below dnssExpectedTimeRatioMaximum (2% default). When the heap is not fully expanded, any changes in eden size, will result in the total heap to be resized by the same amount, in order to keep non-eden size the same.

 2. If the heap is fully expanded, a prediction will be made as to which eden size will produce the lowest total GC cpu overhead, while attempting to respect tarokTargetMaxPauseTime, given the constraints imposed by the heap (free memory, GMP cost, etc.
    This prediction accounts for PGC average time/intervals, GMP time/intervals, free Tenure space, and survival ratio of objects being copied out of eden, in order to determine the "best" eden size.
When the heap is fully expanded, and eden grows, it will "steal" free regions from "tenure"/non-eden.

Note: The following command line options are now supported by balanced gc policy as part of this change.
	- `-Xgc:dnssExpectedTimeRatioMinimum` -> sets min expected % of time spent in pgc pauses (default 2% for balanced)
	- `-Xgc:dnssExpectedTimeRatioMaximum` -> sets max expected % of time spent in pgc pauses (default 5% for balanced)
	- `-Xgc:targetPausetime` -> sets target (tarokTargetMaxPauseTime defaults to 200ms in balanced)

Depends on: eclipse/omr#5825

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>