### PR TITLE
Enabled Global Lock Reservation by default on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -4980,7 +4980,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
       baseReg = objectClassReg;
       }
 
-   /* If the -XX:+GlobalLockReservation option is NOT set, try to use the original aggressive reserved locking code path. */
+   /* If the -XX:-GlobalLockReservation option is set, try to use the original aggressive reserved locking code path. */
    if (!fej9->isEnableGlobalLockReservationSet())
       {
       bool reserveLocking = false, normalLockWithReservationPreserving = false;
@@ -7405,7 +7405,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Co
       baseReg = objectClassReg;
       }
 
-   /* If the -XX:+GlobalLockReservation option is NOT set, try to use the original aggressive reserved locking code path. */
+   /* If the -XX:-GlobalLockReservation option is set, try to use the original aggressive reserved locking code path. */
    if (!fej9->isEnableGlobalLockReservationSet())
       {
       bool reserveLocking = false, normalLockWithReservationPreserving = false;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2424,8 +2424,14 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				printLockwordWhat(vm);
 			}
 
-			/* Global Lock Reservation is off by default. */
+			/* Global Lock Reservation is currently only supported on Power. */
+#if defined(AIXPPC) || defined(LINUXPPC)
+			/* Global Lock Reservation is ON by default on Power. */
+			vm->enableGlobalLockReservation = 1;
+#else
+			/* Global Lock Reservation is OFF by default on other platforms. */
 			vm->enableGlobalLockReservation = 0;
+#endif /* defined(AIXPPC) || defined(LINUXPPC) */
 
 			/* Set default parameters for Global Lock Reservation. */
 			vm->reservedTransitionThreshold = 1;
@@ -2437,22 +2443,19 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			argIndex = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOGLOBALLOCKRESERVATION, NULL);
 			argIndex2 = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXGLOBALLOCKRESERVATION, NULL);
 
-			if ((argIndex2 >= 0) && (argIndex2 > argIndex)) {
-				/* Global Lock Reservation is currently only supported on Power. */
-#if defined(AIXPPC) || defined(LINUXPPC)
-				vm->enableGlobalLockReservation = 1;
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+			if ((argIndex >= 0) && (argIndex > argIndex2)) {
+				vm->enableGlobalLockReservation = 0;
 			}
 
 			argIndex2 = FIND_AND_CONSUME_ARG_FORWARD(STARTSWITH_MATCH, VMOPT_XXGLOBALLOCKRESERVATIONCOLON, NULL);
 
 			while (argIndex2 >= 0) {
-				if (argIndex2 > argIndex) {
-					/* Global Lock Reservation is currently only supported on Power. */
+				/* Global Lock Reservation is currently only supported on Power. */
 #if defined(AIXPPC) || defined(LINUXPPC)
+				if (argIndex2 > argIndex) {
 					vm->enableGlobalLockReservation = 1;
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
 				}
+#endif /* defined(AIXPPC) || defined(LINUXPPC) */
 
 				optionValue = NULL;
 				GET_OPTION_OPTION(argIndex2, ':', ':', &optionValue);


### PR DESCRIPTION
Global Lock Reservation is now enabled by default on Power. This is the same
behavior as if the -XX:+GlobalLockReservation option was used. To use the
previous form of lock reservation, Global Lock Reservation can be disabled
with the option -XX:-GlobalLockReservation.

Global Lock Reservation is not supported on other platforms so this change
only affects Power.

Updated documentation and comments to reflect Global Lock Reservation now
being on by default on Power.

Closes: #11424
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>