### PR TITLE
LambdaForm methods inlining

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,6 +93,7 @@ class TR_EstimateCodeSize
 
    TR::Compilation *comp()              { return _inliner->comp(); }
    TR_InlinerTracer *tracer()          { return _tracer; }
+   TR_InlinerBase* getInliner()        { return _inliner; }
 
    protected:
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -27,10 +27,218 @@
 #include "optimizer/J9CallGraph.hpp"
 #include "ilgen/IlGenRequest.hpp"
 #include "jilconsts.h"
+#include "il/ParameterSymbol.hpp"
+#include "optimizer/PreExistence.hpp"
+#include "il/OMRNode_inlines.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/CompilationRuntime.hpp"
 #include "env/j9methodServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
+
+const char* Operand::KnowledgeStrings[] = {"NONE", "OBJECT", "MUTABLE_CALLSITE_TARGET", "PREEXISTENT", "FIXED_CLASS", "KNOWN_OBJECT", "ICONST" };
+
+char*
+ObjectOperand::getSignature(TR::Compilation *comp, TR_Memory *trMemory)
+   {
+   if (!_signature && _clazz)
+      _signature = TR::Compiler->cls.classSignature(comp, _clazz, trMemory);
+   return _signature;
+   }
+
+KnownObjOperand::KnownObjOperand(TR::KnownObjectTable::Index koi, TR_OpaqueClassBlock* clazz)
+   : knownObjIndex(koi), FixedClassOperand(clazz)
+   {
+   TR_ASSERT_FATAL(knownObjIndex != TR::KnownObjectTable::UNKNOWN, "Unexpected unknown object");
+   }
+
+TR_OpaqueClassBlock*
+KnownObjOperand::getClass()
+   {
+   if (_clazz)
+      return _clazz;
+
+   TR::Compilation* comp = TR::comp();
+   auto knot = comp->getOrCreateKnownObjectTable();
+   if (!knot || knot->isNull(knownObjIndex))
+      return NULL;
+
+#if defined(J9VM_OPT_JITSERVER)
+   // TODO: add JITServer support
+   if (comp->isOutOfProcessCompilation())
+      return NULL;
+   else
+#endif
+      {
+      TR::VMAccessCriticalSection KnownObjOperandCriticalSection(comp,
+                                                                 TR::VMAccessCriticalSection::tryToAcquireVMAccess);
+
+      if (KnownObjOperandCriticalSection.hasVMAccess())
+         {
+         _clazz = TR::Compiler->cls.objectClass(comp, knot->getPointer(knownObjIndex));
+         }
+      }
+
+   return _clazz;
+   }
+
+ObjectOperand*
+KnownObjOperand::asObjectOperand()
+   {
+   if (getClass())
+      return this;
+
+   return NULL;
+   }
+
+// FixedClassOperand need the class, if we can't get the class, return NULL
+FixedClassOperand*
+KnownObjOperand::asFixedClassOperand()
+   {
+   if (getClass())
+      return this;
+
+   return NULL;
+   }
+
+Operand*
+Operand::merge(Operand* other)
+   {
+   if (getKnowledgeLevel() > other->getKnowledgeLevel())
+      return other->merge1(this);
+   else
+      return merge1(other);
+   }
+
+Operand*
+Operand::merge1(Operand* other)
+   {
+   if (this == other)
+      return this;
+   else
+      return NULL;
+   }
+
+Operand*
+IconstOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   IconstOperand* otherIconst = other->asIconst();
+   if (otherIconst && this->intValue == otherIconst->intValue)
+      return this;
+   else
+      return NULL;
+   }
+
+// TODO: check instanceOf relationship and create new Operand if neccessary
+Operand*
+ObjectOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   ObjectOperand* otherObject = other->asObjectOperand();
+   if (otherObject && this->_clazz == otherObject->_clazz)
+      return this;
+   else
+      return NULL;
+   }
+
+// Both are preexistent objects
+Operand*
+PreexistentObjectOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   PreexistentObjectOperand* otherPreexistentObjectOperand = other->asPreexistentObjectOperand();
+   if (otherPreexistentObjectOperand && this->_clazz == otherPreexistentObjectOperand->_clazz)
+      return this;
+   else
+      return NULL;
+   }
+
+Operand*
+FixedClassOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   FixedClassOperand* otherFixedClass = other->asFixedClassOperand();
+   if (otherFixedClass && this->_clazz == otherFixedClass->_clazz)
+      return this;
+   else
+      return NULL;
+   }
+
+Operand*
+KnownObjOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   KnownObjOperand* otherKnownObj = other->asKnownObject();
+   if (otherKnownObj && this->knownObjIndex == otherKnownObj->knownObjIndex)
+      return this;
+   else
+      return NULL;
+   }
+
+Operand*
+MutableCallsiteTargetOperand::merge1(Operand* other)
+   {
+   TR_ASSERT(other->getKnowledgeLevel() >= this->getKnowledgeLevel(), "Should be calling other->merge1(this)");
+   MutableCallsiteTargetOperand* otherMutableCallsiteTarget = other->asMutableCallsiteTargetOperand();
+   if (otherMutableCallsiteTarget &&
+       this->mutableCallsiteIndex== otherMutableCallsiteTarget->mutableCallsiteIndex &&
+       this->methodHandleIndex && otherMutableCallsiteTarget->methodHandleIndex)
+      return this;
+   else
+      return NULL;
+   }
+
+void
+InterpreterEmulator::printOperandArray(OperandArray* operands)
+   {
+   int32_t size = operands->size();
+   for (int32_t i = 0; i < size; i++)
+      {
+      char buffer[20];
+      (*operands)[i]->printToString(buffer);
+      traceMsg(comp(), "[%d]=%s, ", i, buffer);
+      }
+   if (size > 0)
+      traceMsg(comp(), "\n");
+   }
+
+// Merge second OperandArray into the first one
+// The merge does an intersect
+//
+void InterpreterEmulator::mergeOperandArray(OperandArray *first, OperandArray *second)
+   {
+   bool enableTrace = tracer()->debugLevel();
+   if (enableTrace)
+      {
+      traceMsg(comp(), "Operands before merging:\n");
+      printOperandArray(first);
+      }
+
+   bool changed = false;
+   for (int i = 0; i < _numSlots; i++)
+      {
+      Operand* firstObj = (*first)[i];
+      Operand* secondObj = (*second)[i];
+
+      firstObj = firstObj->merge(secondObj);
+      if (firstObj == NULL)
+         firstObj = _unknownOperand;
+
+      if (firstObj != (*first)[i])
+         changed = true;
+      }
+
+   if (enableTrace)
+      {
+      if (changed)
+         {
+         traceMsg(comp(), "Operands after merging:\n");
+         printOperandArray(first);
+         }
+      else
+         traceMsg(comp(), "Operands is not changed after merging\n");
+      }
+   }
 
 void
 InterpreterEmulator::maintainStackForIf(TR_J9ByteCode bc)
@@ -43,7 +251,15 @@ InterpreterEmulator::maintainStackForIf(TR_J9ByteCode bc)
    IconstOperand * first = pop()->asIconst();
    bool canBranch = true;
    bool canFallThru = true;
-   if (second && first)
+   // Comment out the branch folding as all the paths have to be interpreted in order
+   // to propagate object info in operand stack or local slots. Since branch folding
+   // currently only affects thunk archetypes, with similar branch folding in ilgen,
+   // calls in dead path won't be inlined, disabling the following code doesn't affect
+   // performance
+   // TODO: add code to record dead path and ignore it in object info propagation, enable
+   // the following code if branch folding is possible in LambdaForm methods
+   //
+   if (false && second && first)
       {
       switch (bc)
          {
@@ -59,17 +275,25 @@ InterpreterEmulator::maintainStackForIf(TR_J9ByteCode bc)
       canFallThru = !canBranch;
       }
 
+   // The branch target can be successor of the fall through, so gen fall through block first such
+   // that the predecessor is interpreted before the successor in order to propagate the operand
+   // stack and local slots state.
+   // This doesn't work when the fall through contain control flow, but there is no functional issue
+   // as the object info won't be propagated if there exists unvisited predecessor. This will be
+   // fixed when we traverse the bytecodes in reverse post order at CFG level.
+   //
+   if (canFallThru)
+      {
+      debugTrace(tracer(), "maintainStackForIf canFallThrough to bcIndex=%d\n", fallThruBC);
+      genTarget(fallThruBC);
+      }
+
    if (canBranch)
       {
       debugTrace(tracer(), "maintainStackForIf canBranch to bcIndex=%d\n", branchBC);
       genTarget(branchBC);
       }
 
-   if (canFallThru)
-      {
-      debugTrace(tracer(), "maintainStackForIf canFallThrough to bcIndex=%d\n", fallThruBC);
-      genTarget(fallThruBC);
-      }
    }
 
 void
@@ -82,7 +306,12 @@ InterpreterEmulator::maintainStackForGetField()
    int32_t cpIndex = next2Bytes();
    Operand *newOperand = _unknownOperand;
    bool resolved = _calltarget->_calleeMethod->fieldAttributes(comp(), cpIndex, &fieldOffset, &type, &isVolatile, &isFinal, &isPrivate, false, &isUnresolvedInCP, false);
-   if (top()->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN && type == TR::Address)
+
+   TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
+   if (knot &&
+       top()->asKnownObject() &&
+       !knot->isNull(top()->getKnownObjectIndex())
+       && type == TR::Address)
       {
       TR::Symbol::RecognizedField recognizedField = TR::Symbol::searchRecognizedField(comp(), _calltarget->_calleeMethod, cpIndex, false);
       TR::Symbol *fieldSymbol = NULL;
@@ -95,54 +324,50 @@ InterpreterEmulator::maintainStackForGetField()
 
       if ((resolved || !isUnresolvedInCP) && comp()->fej9()->canDereferenceAtCompileTimeWithFieldSymbol(fieldSymbol, cpIndex, _calltarget->_calleeMethod))
          {
-         TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
-         if (knot)
-            {
 #if defined(J9VM_OPT_JITSERVER)
-            if (comp()->isOutOfProcessCompilation())
+         if (comp()->isOutOfProcessCompilation())
+            {
+            TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod*>(_calltarget->_calleeMethod);
+            TR_ResolvedMethod *clientMethod = serverMethod->getRemoteMirror();
+            TR::KnownObjectTable::Index baseObjectIndex = top()->getKnownObjectIndex();
+
+            auto stream = TR::CompilationInfo::getStream();
+            stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField,
+                  baseObjectIndex, clientMethod, cpIndex, fieldOffset);
+
+            auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*, uintptr_t, uintptr_t>();
+            TR::KnownObjectTable::Index resultIndex = std::get<0>(recv);
+            uintptr_t *objectPointerReference = std::get<1>(recv);
+            uintptr_t fieldAddress = std::get<2>(recv);
+            uintptr_t baseObjectAddress = std::get<3>(recv);
+
+            if (resultIndex != TR::KnownObjectTable::UNKNOWN)
                {
-               TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod*>(_calltarget->_calleeMethod);
-               TR_ResolvedMethod *clientMethod = serverMethod->getRemoteMirror();
-               TR::KnownObjectTable::Index baseObjectIndex = top()->getKnownObjectIndex();
+               knot->updateKnownObjectTableAtServer(resultIndex, objectPointerReference);
 
-               auto stream = TR::CompilationInfo::getStream();
-               stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField,
-                     baseObjectIndex, clientMethod, cpIndex, fieldOffset);
-
-               auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*, uintptr_t, uintptr_t>();
-               TR::KnownObjectTable::Index resultIndex = std::get<0>(recv);
-               uintptr_t *objectPointerReference = std::get<1>(recv);
-               uintptr_t fieldAddress = std::get<2>(recv);
-               uintptr_t baseObjectAddress = std::get<3>(recv);
-
-               if (resultIndex != TR::KnownObjectTable::UNKNOWN)
-                  {
-                  knot->updateKnownObjectTableAtServer(resultIndex, objectPointerReference);
-
-                  newOperand = new (trStackMemory()) KnownObjOperand(resultIndex);
-                  int32_t len = 0;
-                  debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
-                        newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
-                        fieldOffset, baseObjectIndex, baseObjectAddress);
-                  }
+               newOperand = new (trStackMemory()) KnownObjOperand(resultIndex);
+               int32_t len = 0;
+               debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
+                     newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
+                     fieldOffset, baseObjectIndex, baseObjectAddress);
                }
-            else
+            }
+         else
 #endif /* defined(J9VM_OPT_JITSERVER) */
+            {
+            TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
+            TR::KnownObjectTable::Index baseObjectIndex = top()->getKnownObjectIndex();
+            uintptr_t baseObjectAddress = knot->getPointer(baseObjectIndex);
+            TR_OpaqueClassBlock *baseObjectClass = comp()->fej9()->getObjectClass(baseObjectAddress);
+            TR_OpaqueClassBlock *fieldDeclaringClass = _calltarget->_calleeMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
+            if (fieldDeclaringClass && comp()->fej9()->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
                {
-               TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
-               TR::KnownObjectTable::Index baseObjectIndex = top()->getKnownObjectIndex();
-               uintptr_t baseObjectAddress = knot->getPointer(baseObjectIndex);
-               TR_OpaqueClassBlock *baseObjectClass = comp()->fej9()->getObjectClass(baseObjectAddress);
-               TR_OpaqueClassBlock *fieldDeclaringClass = _calltarget->_calleeMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
-               if (fieldDeclaringClass && comp()->fej9()->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
-                  {
-                  uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAtAddress(baseObjectAddress + fieldOffset);
-                  newOperand = new (trStackMemory()) KnownObjOperand(knot->getOrCreateIndex(fieldAddress));
-                  int32_t len = 0;
-                  debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
-                        newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
-                        fieldOffset, baseObjectIndex, baseObjectAddress);
-                  }
+               uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAtAddress(baseObjectAddress + fieldOffset);
+               newOperand = new (trStackMemory()) KnownObjOperand(knot->getOrCreateIndex(fieldAddress));
+               int32_t len = 0;
+               debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
+                     newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
+                     fieldOffset, baseObjectIndex, baseObjectAddress);
                }
             }
          }
@@ -156,11 +381,29 @@ InterpreterEmulator::maintainStackForGetField()
 void
 InterpreterEmulator::saveStack(int32_t targetIndex)
    {
-   if (_stack->isEmpty())
+   if (!_iteratorWithState)
       return;
-   bool createTargetStack = (targetIndex >= 0 && !_stacks[targetIndex]);
-   if (createTargetStack)
-      _stacks[targetIndex] = new (trStackMemory()) ByteCodeStack(this->trMemory(), std::max<uint32_t>(20, _stack->size()));
+
+   // Propagate stack state to successor
+   if (!_stack->isEmpty())
+      {
+      if (!_stacks[targetIndex])
+         _stacks[targetIndex] = new (trStackMemory()) ByteCodeStack(*_stack);
+      else
+         {
+         TR_ASSERT_FATAL(_stacks[targetIndex]->size() == _stack->size(), "operand stack from two paths must have the same size, predecessor bci %d target bci %d\n", _bcIndex, targetIndex);
+         mergeOperandArray(_stacks[targetIndex], _stack);
+         }
+      }
+
+   // Propagate local object info to successor
+   if (_numSlots)
+      {
+      if (!_localObjectInfos[targetIndex])
+         _localObjectInfos[targetIndex] = new (trStackMemory()) OperandArray(*_currentLocalObjectInfo);
+      else
+         mergeOperandArray(_localObjectInfos[targetIndex], _currentLocalObjectInfo);
+      }
    }
 
 void
@@ -174,10 +417,129 @@ InterpreterEmulator::initializeIteratorWithState()
    memset(_flags, 0, size * sizeof(flags8_t));
    memset(_stacks, 0, size * sizeof(ByteCodeStack *));
    _stack = new (trStackMemory()) TR_Stack<Operand *>(this->trMemory(), 20, false, stackAlloc);
+   _localObjectInfos = (OperandArray**) this->trMemory()->allocateStackMemory(size * sizeof(OperandArray *));
+   memset(_localObjectInfos, 0, size * sizeof(OperandArray *));
+
+   int32_t numParmSlots = method()->numberOfParameterSlots();
+   _numSlots = numParmSlots + method()->numberOfTemps();
 
    genBBStart(0);
    setupBBStartContext(0);
    this->setIndex(0);
+   }
+
+void
+InterpreterEmulator::setupMethodEntryLocalObjectState()
+   {
+   TR_PrexArgInfo *argInfo = _calltarget->_ecsPrexArgInfo;
+   if (argInfo)
+      {
+      TR_ASSERT_FATAL(argInfo->getNumArgs() == method()->numberOfParameters(), "Prex arg number should match parm number");
+
+      if(tracer()->heuristicLevel())
+         {
+         heuristicTrace(tracer(), "Save argInfo to slot state array");
+         argInfo->dumpTrace();
+         }
+
+      method()->makeParameterList(_methodSymbol);
+      ListIterator<TR::ParameterSymbol> parms(&_methodSymbol->getParameterList());
+
+      // save prex arg into local var arrays
+      for (TR::ParameterSymbol *p = parms.getFirst(); p != NULL; p = parms.getNext())
+          {
+          int32_t ordinal = p->getOrdinal();
+          int32_t slotIndex = p->getSlot();
+          TR_PrexArgument *prexArgument = argInfo->get(ordinal);
+          if (!prexArgument)
+             {
+             (*_currentLocalObjectInfo)[slotIndex] = _unknownOperand;
+             }
+          else
+             {
+             auto operand = createOperandFromPrexArg(prexArgument);
+             if (operand)
+                {
+                (*_currentLocalObjectInfo)[slotIndex] = operand;
+                }
+             else
+                (*_currentLocalObjectInfo)[slotIndex] = _unknownOperand;
+             }
+         char buffer[50];
+         (*_currentLocalObjectInfo)[slotIndex]->printToString(buffer);
+         heuristicTrace(tracer(), "Creating operand %s for parm %d slot %d from PrexArgument %p", buffer, ordinal, slotIndex, prexArgument);
+         }
+      }
+   }
+
+bool
+InterpreterEmulator::hasUnvisitedPred(TR::Block* block)
+   {
+   TR_PredecessorIterator pi(block);
+   for (TR::CFGEdge *edge = pi.getFirst(); edge != NULL; edge = pi.getNext())
+      {
+      TR::Block *fromBlock = toBlock(edge->getFrom());
+      auto fromBCIndex = fromBlock->getEntry()->getNode()->getByteCodeIndex();
+      if (!isGenerated(fromBCIndex))
+         {
+         return true;
+         }
+      }
+
+   return false;
+   }
+
+void
+InterpreterEmulator::setupBBStartStackState(int32_t index)
+   {
+   if (index == 0)
+      return;
+
+   auto block = blocks(index);
+   auto stack = _stacks[index];
+   if (stack && hasUnvisitedPred(block))
+      {
+      heuristicTrace(tracer(), "block_%d at bc index %d has unvisited predecessor, setting stack operand info to unknown", block->getNumber(), index);
+      for (int32_t i = 0; i < stack->size(); ++i)
+         (*stack)[i] = _unknownOperand;
+      }
+   }
+
+void
+InterpreterEmulator::setupBBStartLocalObjectState(int32_t index)
+   {
+   if (_numSlots == 0)
+      return;
+
+   if (!_localObjectInfos[index])
+      {
+      _localObjectInfos[index] = new (trStackMemory()) OperandArray(trMemory(), _numSlots, false, stackAlloc);
+      for (int32_t i = 0; i < _numSlots; i++)
+          (*_localObjectInfos[index])[i] = _unknownOperand;
+      }
+   else if (hasUnvisitedPred(blocks(index)))
+      {
+      heuristicTrace(tracer(), "block_%d at bc index %d has unvisited predecessor, setting local object info to unknown", blocks(index)->getNumber(), index);
+      for (int32_t i = 0; i < _numSlots; i++)
+          (*_localObjectInfos[index])[i] = _unknownOperand;
+      }
+
+   _currentLocalObjectInfo = _localObjectInfos[index];
+
+   if (index == 0)
+      setupMethodEntryLocalObjectState();
+   }
+
+int32_t
+InterpreterEmulator::setupBBStartContext(int32_t index)
+   {
+   if (_iteratorWithState)
+      {
+      setupBBStartStackState(index);
+      setupBBStartLocalObjectState(index);
+      }
+   Base::setupBBStartContext(index);
+   return index;
    }
 
 bool
@@ -197,7 +559,12 @@ InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
 
       case J9BCinvokespecial:
       case J9BCinvokespecialsplit:
-         maintainStackForDirectCall(_calltarget->_calleeMethod);
+      case J9BCinvokevirtual:
+      case J9BCinvokestatic:
+      case J9BCinvokestaticsplit:
+      case J9BCinvokedynamic:
+      case J9BCinvokehandle:
+         maintainStackForCall();
          break;
       case J9BCiconstm1: push (new (trStackMemory()) IconstOperand(-1)); break;
       case J9BCiconst0:  push (new (trStackMemory()) IconstOperand(0)); break;
@@ -225,18 +592,26 @@ InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
       case J9BCladd:
       case J9BCiadd:
       case J9BCisub:
+      case J9BCiand:
          popn(2);
          pushUnknownOperand();
          break;
-      case J9BCistore: case J9BClstore: case J9BCfstore: case J9BCdstore: case J9BCastore:
-      case J9BCistorew: case J9BClstorew: case J9BCfstorew: case J9BCdstorew: case J9BCastorew:
+      case J9BCistore: case J9BClstore: case J9BCfstore: case J9BCdstore:
+      case J9BCistorew: case J9BClstorew: case J9BCfstorew: case J9BCdstorew:
       case J9BCistore0: case J9BCistore1: case J9BCistore2: case J9BCistore3:
       case J9BClstore0: case J9BClstore1: case J9BClstore2: case J9BClstore3:
       case J9BCfstore0: case J9BCfstore1: case J9BCfstore2: case J9BCfstore3:
       case J9BCdstore0: case J9BCdstore1: case J9BCdstore2: case J9BCdstore3:
-      case J9BCastore0: case J9BCastore1: case J9BCastore2: case J9BCastore3:
          pop();
          break;
+      // Maintain stack for object store
+      case J9BCastorew: maintainStackForAstore(next2Bytes()); break;
+      case J9BCastore: maintainStackForAstore(nextByte()); break;
+      case J9BCastore0: maintainStackForAstore(0); break;
+      case J9BCastore1: maintainStackForAstore(1); break;
+      case J9BCastore2: maintainStackForAstore(2); break;
+      case J9BCastore3: maintainStackForAstore(3); break;
+
       case J9BCiload0: case J9BCiload1: case J9BCiload2: case J9BCiload3:
       case J9BCdload0: case J9BCdload1: case J9BCdload2: case J9BCdload3:
       case J9BClload0: case J9BClload1: case J9BClload2: case J9BClload3:
@@ -247,13 +622,21 @@ InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
          pushUnknownOperand();
          break;
       case J9BCgenericReturn:
+      case J9BCReturnC:
+      case J9BCReturnS:
+      case J9BCReturnB:
+      case J9BCReturnZ:
+         maintainStackForReturn();
+         break;
       case J9BCi2l:
          break;
-      //following bytecodes has been handled when creating callsites
-      case J9BCinvokevirtual:
-      case J9BCinvokestatic:
-      case J9BCinvokestaticsplit:
+      case J9BCcheckcast:
          break;
+      case J9BCdup:
+         push(top());
+         break;
+      case J9BCldc:
+         maintainStackForldc(nextByte()); break;
       default:
          static const bool assertfatal = feGetEnv("TR_AssertFatalForUnexpectedBytecodeInMethodHandleThunk") ? true: false;
          if (!assertfatal)
@@ -275,64 +658,150 @@ InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
    }
 
 void
+InterpreterEmulator::maintainStackForReturn()
+   {
+   if (method()->returnType() != TR::NoType)
+      pop();
+   }
+
+void
 InterpreterEmulator::maintainStackForAload(int slotIndex)
    {
    TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
-   TR_PrexArgInfo *argInfo = _calltarget->_ecsPrexArgInfo;
-   TR_ASSERT_FATAL(argInfo, "thunk archetype target doesn't have _ecsPrexArgInfo %p\n", _calltarget);
-   if (slotIndex < argInfo->getNumArgs())
+
+   push((*_currentLocalObjectInfo)[slotIndex]);
+   }
+
+void
+InterpreterEmulator::maintainStackForAstore(int slotIndex)
+   {
+   TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
+   (*_currentLocalObjectInfo)[slotIndex] = pop();
+   }
+
+void
+InterpreterEmulator::maintainStackForldc(int32_t cpIndex)
+   {
+   TR::DataType type = method()->getLDCType(cpIndex);
+   switch (type)
       {
-      TR_PrexArgument *prexArgument = argInfo->get(slotIndex);
-      if (prexArgument && TR_PrexArgument::knowledgeLevel(prexArgument) == KNOWN_OBJECT)
-         {
-         debugTrace(tracer(), "aload known obj%d from slot %d\n", prexArgument->getKnownObjectIndex(), slotIndex);
-         push(new (trStackMemory()) KnownObjOperand(prexArgument->getKnownObjectIndex()));
-         return;
-         }
+      case TR::Address:
+         // TODO: should add a function to check if cp entry is unresolved for all constant
+         // not just for string. Currently only do it for string because it may be patched
+         // to a different object in OpenJDK MethodHandle implementation
+         //
+         if (method()->isStringConstant(cpIndex) && !method()->isUnresolvedString(cpIndex))
+            {
+            uintptr_t * location = (uintptr_t *)method()->stringConstant(cpIndex);
+            TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
+            if (knot)
+               {
+               TR::KnownObjectTable::Index koi = knot->getOrCreateIndexAt(location);
+               push(new (trStackMemory()) KnownObjOperand(koi));
+               debugTrace(tracer(), "aload known obj%d from ldc %d", koi, cpIndex);
+               return;
+               }
+            }
+         break;
+      default:
+         break;
       }
+
    pushUnknownOperand();
    }
 
 void
-InterpreterEmulator::maintainStackForCall(TR_ResolvedMethod *callerMethod, Operand *result, bool isDirect)
+InterpreterEmulator::maintainStackForCall(Operand *result, int32_t numArgs, TR::DataType returnType)
    {
    TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
-   int32_t cpIndex = next2Bytes();
-   TR::Method * calleeMethod = comp()->fej9()->createMethod(trMemory(), callerMethod->containingClass(), cpIndex);
-   int32_t argNum = calleeMethod->numberOfExplicitParameters() + (isDirect ? 0: 1);
 
-   for (int i = 1; i <= argNum; i++)
+   for (int i = 1; i <= numArgs; i++)
       pop();
 
    if (result)
       push(result);
-   else if (calleeMethod->returnType() != TR::NoType)
+   else if (returnType != TR::NoType)
       pushUnknownOperand();
+   }
+
+void
+InterpreterEmulator::maintainStackForCall()
+   {
+   TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
+   int32_t numOfArgs = 0;
+   TR::DataType returnType = TR::NoType;
+   Operand* result = NULL;
+
+   if (_currentCallMethod)
+      result = getReturnValue(_currentCallMethod);
+
+   // If the caller is thunk archetype, the load of parm `argPlaceholder` can
+   // be expanded to loads of multiple arguments, so we can't pop the number
+   // of arguments of a refined call
+   //
+   if (_currentCallSite && !_callerIsThunkArchetype)
+      {
+      if (_currentCallSite->_isInterface)
+         {
+         numOfArgs = _currentCallSite->_interfaceMethod->numberOfExplicitParameters() + 1;
+         returnType = _currentCallSite->_interfaceMethod->returnType();
+         }
+      else if (_currentCallSite->_initialCalleeMethod)
+         {
+         numOfArgs = _currentCallSite->_initialCalleeMethod->numberOfParameters();
+         returnType = _currentCallSite->_initialCalleeMethod->returnType();
+         }
+      }
+   else
+      {
+      int32_t cpIndex = next2Bytes();
+      bool isStatic = false;
+      switch (current())
+         {
+         case J9BCinvokespecialsplit:
+            cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
+            break;
+         case J9BCinvokestaticsplit:
+            cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
+         case J9BCinvokestatic:
+            isStatic = true;
+            break;
+         case J9BCinvokedynamic:
+         case J9BCinvokehandle:
+            TR_ASSERT_FATAL(false, "Can't maintain stack for unresolved invokehandle");
+            break;
+         }
+      TR::Method * calleeMethod = comp()->fej9()->createMethod(trMemory(), _calltarget->_calleeMethod->containingClass(), cpIndex);
+      numOfArgs = calleeMethod->numberOfExplicitParameters() + (isStatic ? 0 : 1);
+      returnType = calleeMethod->returnType();
+      }
+   maintainStackForCall(result, numOfArgs, returnType);
    }
 
 void
 InterpreterEmulator::dumpStack()
    {
-   debugTrace(tracer(), "operandStack after %d : %s ", _bcIndex, comp()->fej9()->getByteCodeName(nextByte(0)));
+   debugTrace(tracer(), "operandStack after bytecode %d : %s ", _bcIndex, comp()->fej9()->getByteCodeName(nextByte(0)));
    for (int i = 0; i < _stack->size(); i++ )
       {
       Operand *x = (*_stack)[i];
-      char buffer[20];
+      char buffer[50];
       x->printToString(buffer);
-      debugTrace(tracer(), "[%d]=%s, ", i, buffer);
+      debugTrace(tracer(), "[%d]=%s", i, buffer);
       }
-   debugTrace(tracer(),"\n");
    }
 
 Operand *
-InterpreterEmulator::getReturnValueForInvokestatic(TR_ResolvedMethod *callee)
+InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
    {
    if (!callee)
       return NULL;
    Operand *result = NULL;
    TR::RecognizedMethod recognizedMethod = callee->getRecognizedMethod();
+   TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
+
    TR::IlGeneratorMethodDetails & details = comp()->ilGenRequest().details();
-   if (details.isMethodHandleThunk())
+   if (_callerIsThunkArchetype && details.isMethodHandleThunk())
       {
       J9::MethodHandleThunkDetails & thunkDetails = static_cast<J9::MethodHandleThunkDetails &>(details);
       if (!thunkDetails.isCustom())
@@ -347,56 +816,83 @@ InterpreterEmulator::getReturnValueForInvokestatic(TR_ResolvedMethod *callee)
       case TR::java_lang_invoke_ILGenMacros_isShareableThunk:
          result = new (trStackMemory()) IconstOperand(0);
          break;
-      }
-   return result;
-   }
-
-Operand *
-InterpreterEmulator::getReturnValueForInvokevirtual(TR_ResolvedMethod *callee)
-   {
-   if (!callee)
-      return NULL;
-   Operand *result = NULL;
-   int argNum = callee->numberOfExplicitParameters();
-   TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
-   TR::KnownObjectTable::Index receiverIndex = topn(argNum)->getKnownObjectIndex();
-   if (callee->getRecognizedMethod() == TR::java_lang_invoke_MutableCallSite_getTarget &&
-      receiverIndex != TR::KnownObjectTable::UNKNOWN &&
-      knot)
-      {
-      TR::KnownObjectTable::Index resultIndex = TR::KnownObjectTable::UNKNOWN;
-      TR_OpaqueClassBlock *mutableCallsiteClass = callee->classOfMethod();
-      debugTrace(tracer(), "java_lang_invoke_MutableCallSite_target receiver obj%d(*%p) mutableCallsiteClass %p\n", receiverIndex, knot->getPointerLocation(receiverIndex), mutableCallsiteClass);
-      if (mutableCallsiteClass)
+      case TR::java_lang_invoke_MutableCallSite_getTarget:
          {
-#if defined(J9VM_OPT_JITSERVER)
-         if (comp()->isOutOfProcessCompilation())
+         int argNum = callee->numberOfExplicitParameters();
+         TR::KnownObjectTable::Index receiverIndex = topn(argNum)->getKnownObjectIndex();
+         if (receiverIndex == TR::KnownObjectTable::UNKNOWN)
+            return NULL;
+
+         TR::KnownObjectTable::Index resultIndex = TR::KnownObjectTable::UNKNOWN;
+         TR_OpaqueClassBlock *mutableCallsiteClass = callee->classOfMethod();
+         debugTrace(tracer(), "java_lang_invoke_MutableCallSite_target receiver obj%d(*%p) mutableCallsiteClass %p\n", receiverIndex, knot->getPointerLocation(receiverIndex), mutableCallsiteClass);
+         if (mutableCallsiteClass)
             {
-            auto stream = TR::CompilationInfo::getStream();
-            stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField2, mutableCallsiteClass, receiverIndex);
-
-            auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*>();
-            resultIndex = std::get<0>(recv);
-            uintptr_t *objectPointerReference = std::get<1>(recv);
-
-            if (resultIndex != TR::KnownObjectTable::UNKNOWN)
+   #if defined(J9VM_OPT_JITSERVER)
+            if (comp()->isOutOfProcessCompilation())
                {
-               knot->updateKnownObjectTableAtServer(resultIndex, objectPointerReference);
+               auto stream = TR::CompilationInfo::getStream();
+               stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField2, mutableCallsiteClass, receiverIndex);
+
+               auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*>();
+               resultIndex = std::get<0>(recv);
+               uintptr_t *objectPointerReference = std::get<1>(recv);
+
+               if (resultIndex != TR::KnownObjectTable::UNKNOWN)
+                  {
+                  knot->updateKnownObjectTableAtServer(resultIndex, objectPointerReference);
+                  }
+               result = new (trStackMemory()) MutableCallsiteTargetOperand(resultIndex, receiverIndex);
                }
-            result = new (trStackMemory()) MutableCallsiteTargetOperand(resultIndex, receiverIndex);
+            else
+   #endif /* defined(J9VM_OPT_JITSERVER) */
+               {
+               TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
+               int32_t targetFieldOffset = comp()->fej9()->getInstanceFieldOffset(mutableCallsiteClass, "target", "Ljava/lang/invoke/MethodHandle;");
+               uintptr_t receiverAddress = knot->getPointer(receiverIndex);
+               TR_OpaqueClassBlock *receiverClass = comp()->fej9()->getObjectClass(receiverAddress);
+               TR_ASSERT_FATAL(comp()->fej9()->isInstanceOf(receiverClass, mutableCallsiteClass, true) == TR_yes, "receiver of mutableCallsite_getTarget must be instance of MutableCallSite (*%p)", knot->getPointerLocation(receiverIndex));
+               uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAt(receiverAddress, targetFieldOffset);
+               resultIndex = knot->getOrCreateIndex(fieldAddress);
+               result = new (trStackMemory()) MutableCallsiteTargetOperand(resultIndex, receiverIndex);
+               }
             }
-         else
-#endif /* defined(J9VM_OPT_JITSERVER) */
+         }
+         break;
+      case TR::java_lang_invoke_DirectMethodHandle_internalMemberName:
+      case TR::java_lang_invoke_DirectMethodHandle_internalMemberNameEnsureInit:
+         {
+         Operand* mh = top();
+         TR::KnownObjectTable::Index mhIndex = top()->getKnownObjectIndex();
+         debugTrace(tracer(), "Known DirectMethodHandle koi %d\n", mhIndex);
+         TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
+         if (knot && mhIndex != TR::KnownObjectTable::UNKNOWN && !knot->isNull(mhIndex))
             {
             TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
-            int32_t targetFieldOffset = comp()->fej9()->getInstanceFieldOffset(mutableCallsiteClass, "target", "Ljava/lang/invoke/MethodHandle;");
-            uintptr_t receiverAddress = knot->getPointer(receiverIndex);
-            TR_OpaqueClassBlock *receiverClass = comp()->fej9()->getObjectClass(receiverAddress);
-            TR_ASSERT_FATAL(comp()->fej9()->isInstanceOf(receiverClass, mutableCallsiteClass, true) == TR_yes, "receiver of mutableCallsite_getTarget must be instance of MutableCallSite (*%p)", knot->getPointerLocation(receiverIndex));
-            uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAt(receiverAddress, targetFieldOffset);
-            resultIndex = knot->getOrCreateIndex(fieldAddress);
-            result = new (trStackMemory()) MutableCallsiteTargetOperand(resultIndex, receiverIndex);
+            uintptr_t mhObjectAddress = knot->getPointer(mhIndex);
+            uintptr_t memberAddress = comp()->fej9()->getReferenceField(mhObjectAddress, "member", "Ljava/lang/invoke/MemberName;");
+            TR::KnownObjectTable::Index memberIndex = knot->getOrCreateIndex(memberAddress);
+            debugTrace(tracer(), "Known internal member name koi %d\n", memberIndex);
+            result = new (trStackMemory()) KnownObjOperand(memberIndex);
             }
+         break;
+         }
+      case TR::java_lang_invoke_DirectMethodHandle_constructorMethod:
+         {
+         Operand* mh = top();
+         TR::KnownObjectTable::Index mhIndex = top()->getKnownObjectIndex();
+         debugTrace(tracer(), "Known DirectMethodHandle koi %d\n", mhIndex);
+         TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
+         if (knot && mhIndex != TR::KnownObjectTable::UNKNOWN && !knot->isNull(mhIndex))
+            {
+            TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
+            uintptr_t mhObjectAddress = knot->getPointer(mhIndex);
+            uintptr_t memberNameObject = comp()->fej9()->getReferenceField(mhObjectAddress, "initMethod", "Ljava/lang/invoke/MemberName;");
+            TR::KnownObjectTable::Index memberIndex = knot->getOrCreateIndex(memberNameObject);
+            debugTrace(tracer(), "Known internal member name koi %d\n", memberIndex);
+            result = new (trStackMemory()) KnownObjOperand(memberIndex);
+            }
+         break;
          }
       }
    return result;
@@ -411,7 +907,8 @@ InterpreterEmulator::refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&cal
 
    bool isVirtual = false;
    bool isInterface = false;
-   switch (callee->getRecognizedMethod())
+   TR::RecognizedMethod rm = callee->getRecognizedMethod();
+   switch (rm)
       {
       // refine the ILGenMacros_invokeExact* callees
       case TR::java_lang_invoke_ILGenMacros_invokeExact:
@@ -505,12 +1002,37 @@ InterpreterEmulator::refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&cal
          callee = fej9->createResolvedMethod(this->trMemory(), j9method);
          return;
          }
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      case TR::java_lang_invoke_MethodHandle_linkToStatic:
+      case TR::java_lang_invoke_MethodHandle_linkToSpecial:
+      case TR::java_lang_invoke_MethodHandle_linkToVirtual:
+         {
+         TR::KnownObjectTable::Index memberNameIndex = top()->getKnownObjectIndex();
+         TR_J9VMBase* fej9 = comp()->fej9();
+         auto targetMethod = fej9->targetMethodFromMemberName(comp(), memberNameIndex);
+         if (!targetMethod)
+            return;
+
+         uint32_t vTableSlot = 0;
+         if (rm == TR::java_lang_invoke_MethodHandle_linkToVirtual)
+            vTableSlot = fej9->vTableOrITableIndexFromMemberName(comp(), memberNameIndex);
+
+         callee = fej9->createResolvedMethodWithVTableSlot(comp()->trMemory(), vTableSlot, targetMethod, _calltarget->_calleeMethod);
+         isIndirectCall = rm == TR::java_lang_invoke_MethodHandle_linkToVirtual || rm == TR::java_lang_invoke_MethodHandle_linkToInterface;
+         heuristicTrace(tracer(), "Refine linkTo to %s\n", callee->signature(trMemory(), stackAlloc));
+         // The refined method doesn't take MemberName as an argument, pop MemberName out of the operand stack
+         pop();
+         return;
+         }
+#endif //J9VM_OPT_OPENJDK_METHODHANDLE
       }
    }
 
 bool
 InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessfull, bool withState)
    {
+   heuristicTrace(tracer(),"Find and create callsite %s\n", withState ? "with state" : "without state");
+
    TR::Region findCallsitesRegion(comp()->region());
    if (withState)
       initializeIteratorWithState();
@@ -519,6 +1041,10 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
    TR_J9ByteCode bc = first();
    while (bc != J9BCunknown)
       {
+      heuristicTrace(tracer(), "%4d: %s\n", _bcIndex, comp()->fej9()->getByteCodeName(_code[_bcIndex]));
+
+      _currentCallSite = NULL;
+
       if (_InterpreterEmulatorFlags[_bcIndex].testAny(InterpreterEmulator::BytecodePropertyFlag::bbStart))
          {
          _currentInlinedBlock = TR_J9EstimateCodeSize::getBlock(comp(), _blocks, _calltarget->_calleeMethod, _bcIndex, *_cfg);
@@ -554,6 +1080,8 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
       _pca.updateArg(bc);
       bc = findNextByteCodeToVisit();
       }
+
+   heuristicTrace(tracer(), "Finish findAndCreateCallsitesFromBytecodes\n");
    return true;
    }
 
@@ -622,16 +1150,16 @@ InterpreterEmulator::visitInvokedynamic()
       uintptr_t *entryLocation = (uintptr_t*)owningMethod->callSiteTableEntryAddress(callSiteIndex);
       // Add callsite handle to known object table
       knot->getOrCreateIndexAt((uintptr_t*)entryLocation);
-      TR_ResolvedMethod * resolvedMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(this->trMemory(), entryLocation, owningMethod);
+      _currentCallMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(this->trMemory(), entryLocation, owningMethod);
       bool allconsts= false;
 
-      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n", resolvedMethod->numberOfExplicitParameters() , _pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-      if (resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n", _currentCallMethod->numberOfExplicitParameters() , _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()));
+      if (_currentCallMethod->numberOfExplicitParameters() > 0 && _currentCallMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()))
          allconsts = true;
 
       TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
-                                                                        callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        -1, -1, resolvedMethod,
+                                                                        callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+                                                                        -1, -1, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
 
@@ -692,10 +1220,22 @@ InterpreterEmulator::updateKnotAndCreateCallSiteUsingInvokeCacheArray(TR_Resolve
 bool
 InterpreterEmulator::isCurrentCallUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod, bool isUnresolvedInCP)
    {
+   if (!resolvedMethod)
+      return true;
+
    bool isIndirectCall = false;
    if (current() == J9BCinvokevirtual)
       isIndirectCall = true;
-   return (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), isIndirectCall));
+
+   // Since bytecodes in a thunk archetype are never interpreted,
+   // most of the cp entries may appear unresolved, and we always
+   // compile-time resolve the cp entries. Thus ignore resolution
+   // status of cp entries of thunk arthetype
+   //
+   if (_callerIsThunkArchetype)
+      return resolvedMethod->isCold(comp(), isIndirectCall);
+   else
+      return (isUnresolvedInCP || resolvedMethod->isCold(comp(), isIndirectCall));
    }
 
 void
@@ -724,27 +1264,76 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
    }
 
 void
+InterpreterEmulator::refineResolvedCalleeForInvokevirtual(TR_ResolvedMethod *&callee, bool &isIndirectCall)
+   {
+   TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
+   if (!comp()->getOrCreateKnownObjectTable())
+      return;
+
+   TR::RecognizedMethod rm = callee->getRecognizedMethod();
+   switch (rm)
+      {
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      case TR::java_lang_invoke_MethodHandle_invokeBasic:
+         {
+         int argNum = callee->numberOfExplicitParameters();
+         TR::KnownObjectTable::Index receiverIndex = topn(argNum)->getKnownObjectIndex();
+         TR_J9VMBase* fej9 = comp()->fej9();
+         auto targetMethod = fej9->targetMethodFromMethodHandle(comp(), receiverIndex);
+         if (!targetMethod) return;
+
+         isIndirectCall = false;
+         callee = fej9->createResolvedMethod(comp()->trMemory(), targetMethod, callee->owningMethod());
+         heuristicTrace(tracer(), "Refine invokeBasic to %s\n", callee->signature(trMemory(), stackAlloc));
+         return;
+         }
+#endif //J9VM_OPT_OPENJDK_METHODHANDLE
+      default:
+         return;
+      }
+   }
+
+void
 InterpreterEmulator::visitInvokevirtual()
    {
    int32_t cpIndex = next2Bytes();
    auto calleeMethod = (TR_ResolvedJ9Method*)_calltarget->_calleeMethod;
    bool isUnresolvedInCP;
-   TR_ResolvedMethod * resolvedMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
+   // Calls in thunk archetype won't be executed by interpreter, so they may appear as unresolved
+   bool ignoreRtResolve = _callerIsThunkArchetype;
+   _currentCallMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, ignoreRtResolve, &isUnresolvedInCP);
    Operand *result = NULL;
-   if (isCurrentCallUnresolvedOrCold(resolvedMethod, isUnresolvedInCP))
+   if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
-      debugUnresolvedOrCold(resolvedMethod);
+      debugUnresolvedOrCold(_currentCallMethod);
       }
-   else if (resolvedMethod)
+   else if (_currentCallMethod)
       {
+      bool isIndirectCall = !_currentCallMethod->isFinal() && !_currentCallMethod->isPrivate();
+      if (_iteratorWithState)
+         refineResolvedCalleeForInvokevirtual(_currentCallMethod, isIndirectCall);
+
+      // Customization logic is not needed in customized thunk or in inlining
+      // with known MethodHandle object
+      // Since branch folding is disabled and we're ignoring the coldness info
+      // in thunk archetype, calls to the following method will be added to the
+      // call site list and take up some inlining budget, causing less methods
+      // to be inlined. Don't create call site for them
+      //
+      switch (_currentCallMethod->getRecognizedMethod())
+         {
+         case TR::java_lang_invoke_MethodHandle_doCustomizationLogic:
+         case TR::java_lang_invoke_MethodHandle_undoCustomizationLogic:
+            if (_callerIsThunkArchetype)
+               return;
+         }
+
       bool allconsts= false;
-      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-      if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",_currentCallMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()));
+      if ( _currentCallMethod->numberOfExplicitParameters() > 0 && _currentCallMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()))
          allconsts = true;
 
       TR_CallSite *callsite;
-      bool isIndirectCall = resolvedMethod == NULL ||
-                           (!resolvedMethod->isFinal() && !resolvedMethod->isPrivate());
       bool isInterface = false;
       TR::Method *interfaceMethod = 0;
       TR::TreeTop *callNodeTreeTop = 0;
@@ -752,27 +1341,27 @@ InterpreterEmulator::visitInvokevirtual()
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
 
-      if (resolvedMethod->convertToMethod()->isArchetypeSpecimen() && resolvedMethod->getMethodHandleLocation())
+      if (_currentCallMethod->convertToMethod()->isArchetypeSpecimen() && _currentCallMethod->getMethodHandleLocation())
          {
          callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
-                                                                        callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        -1, cpIndex, resolvedMethod,
+                                                                        callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+                                                                        -1, cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
          }
-      else if (resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact)
+      else if (_currentCallMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact)
          {
          callsite = new (comp()->trHeapMemory()) TR_J9MutableCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
-                                                      callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                      (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                      callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+                                                      (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
                                                       resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                       _recursionDepth, allconsts);
          }
       else if (isIndirectCall)
          {
          callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent,
-                                                                        callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                        callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+                                                                        (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
 
@@ -780,8 +1369,8 @@ InterpreterEmulator::visitInvokevirtual()
       else
          {
          callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent,
-                                                                        callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                        callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+                                                                        -1, cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
 
@@ -792,8 +1381,6 @@ InterpreterEmulator::visitInvokevirtual()
       findTargetAndUpdateInfoForCallsite(callsite);
       }
 
-   if (_iteratorWithState)
-      maintainStackForIndirectCall(_calltarget->_calleeMethod, getReturnValueForInvokevirtual(resolvedMethod));
    }
 
 void
@@ -801,16 +1388,16 @@ InterpreterEmulator::visitInvokespecial()
    {
    int32_t cpIndex = next2Bytes();
    bool isUnresolvedInCP;
-   TR_ResolvedMethod *resolvedMethod = _calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (current() == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
-   if (isCurrentCallUnresolvedOrCold(resolvedMethod, isUnresolvedInCP))
+   _currentCallMethod = _calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (current() == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
+   if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
-      debugUnresolvedOrCold(resolvedMethod);
+      debugUnresolvedOrCold(_currentCallMethod);
       }
    else
       {
       bool allconsts= false;
-      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-      if (resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",_currentCallMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()));
+      if (_currentCallMethod->numberOfExplicitParameters() > 0 && _currentCallMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()))
          allconsts = true;
 
       bool isIndirectCall = false;
@@ -821,8 +1408,8 @@ InterpreterEmulator::visitInvokespecial()
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
       TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent,
-                                                                        callNode, interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
-                                                                        resolvedMethod, resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
+                                                                        callNode, interfaceMethod, _currentCallMethod->classOfMethod(), -1, cpIndex,
+                                                                        _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
       findTargetAndUpdateInfoForCallsite(callsite);
       }
@@ -833,25 +1420,24 @@ InterpreterEmulator::visitInvokestatic()
    {
    int32_t cpIndex = next2Bytes();
    bool isUnresolvedInCP;
-   TR_ResolvedMethod *resolvedMethod = _calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (current() == J9BCinvokestaticsplit) ? cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
-   TR_ResolvedMethod *origResolvedMethod = resolvedMethod;
-   if (isCurrentCallUnresolvedOrCold(resolvedMethod, isUnresolvedInCP))
+   _currentCallMethod = _calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (current() == J9BCinvokestaticsplit) ? cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
+   if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
-      debugUnresolvedOrCold(resolvedMethod);
+      debugUnresolvedOrCold(_currentCallMethod);
       }
    else
       {
       bool allconsts= false;
 
-      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-      if (resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+      heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n",_currentCallMethod->numberOfExplicitParameters() ,_pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()));
+      if (_currentCallMethod->numberOfExplicitParameters() > 0 && _currentCallMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()))
          allconsts = true;
 
       TR::KnownObjectTable::Index mhIndex = TR::KnownObjectTable::UNKNOWN;
       TR::KnownObjectTable::Index mcsIndex = TR::KnownObjectTable::UNKNOWN;
       bool isIndirectCall = false;
       if (_iteratorWithState)
-         refineResolvedCalleeForInvokestatic(resolvedMethod, mcsIndex, mhIndex, isIndirectCall);
+         refineResolvedCalleeForInvokestatic(_currentCallMethod, mcsIndex, mhIndex, isIndirectCall);
 
       bool isInterface = false;
       TR_CallSite *callsite = NULL;
@@ -861,23 +1447,23 @@ InterpreterEmulator::visitInvokestatic()
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
 
-      if (resolvedMethod->convertToMethod()->isArchetypeSpecimen() &&
-            resolvedMethod->getMethodHandleLocation() &&
+      if (_currentCallMethod->convertToMethod()->isArchetypeSpecimen() &&
+            _currentCallMethod->getMethodHandleLocation() &&
             mcsIndex == TR::KnownObjectTable::UNKNOWN)
          {
          callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( _calltarget->_calleeMethod, callNodeTreeTop,   parent,
-               callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-               -1, cpIndex, resolvedMethod,
+               callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+               -1, cpIndex, _currentCallMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                _recursionDepth, allconsts);
          }
-      else if (resolvedMethod->convertToMethod()->isArchetypeSpecimen() &&
-            resolvedMethod->getMethodHandleLocation() &&
+      else if (_currentCallMethod->convertToMethod()->isArchetypeSpecimen() &&
+            _currentCallMethod->getMethodHandleLocation() &&
             mcsIndex != TR::KnownObjectTable::UNKNOWN)
          {
          TR_J9MutableCallSite *mcs = new (comp()->trHeapMemory()) TR_J9MutableCallSite( _calltarget->_calleeMethod, callNodeTreeTop,   parent,
-               callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-               (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+               callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
+               (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                _recursionDepth, allconsts);
          if (mcsIndex != TR::KnownObjectTable::UNKNOWN)
@@ -891,22 +1477,20 @@ InterpreterEmulator::visitInvokestatic()
          {
          callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
                _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-               interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
-               resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
+               interfaceMethod, _currentCallMethod->classOfMethod(), (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex,
+               _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
                *_newBCInfo, comp(), _recursionDepth, allconsts);
          }
       else
          {
          callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent, callNode, interfaceMethod,
-               resolvedMethod->classOfMethod(), -1, cpIndex, resolvedMethod, resolvedSymbol,
+               _currentCallMethod->classOfMethod(), -1, cpIndex, _currentCallMethod, resolvedSymbol,
                isIndirectCall, isInterface, *_newBCInfo, comp(),
                _recursionDepth, allconsts);
          }
       findTargetAndUpdateInfoForCallsite(callsite);
       }
 
-   if (_iteratorWithState)
-      maintainStackForDirectCall(_calltarget->_calleeMethod, getReturnValueForInvokestatic(origResolvedMethod));
    }
 
 void
@@ -914,14 +1498,14 @@ InterpreterEmulator::visitInvokeinterface()
    {
    int32_t cpIndex = next2Bytes();
    auto calleeMethod = (TR_ResolvedJ9Method*)_calltarget->_calleeMethod;
-   TR_ResolvedMethod *resolvedMethod = calleeMethod->getResolvedImproperInterfaceMethod(comp(), cpIndex);
+   _currentCallMethod = calleeMethod->getResolvedImproperInterfaceMethod(comp(), cpIndex);
    bool isIndirectCall = true;
    bool isInterface = true;
-   if (resolvedMethod)
+   if (_currentCallMethod)
       {
       isInterface = false;
-      isIndirectCall = !resolvedMethod->isPrivate() &&
-                       !resolvedMethod->convertToMethod()->isFinalInObject();
+      isIndirectCall = !_currentCallMethod->isPrivate() &&
+                       !_currentCallMethod->convertToMethod()->isFinalInObject();
       }
 
    TR::Method * interfaceMethod = NULL;
@@ -937,7 +1521,7 @@ InterpreterEmulator::visitInvokeinterface()
    if (isInterface)
       explicitParams = interfaceMethod->numberOfExplicitParameters();
    else
-      explicitParams = resolvedMethod->numberOfExplicitParameters();
+      explicitParams = _currentCallMethod->numberOfExplicitParameters();
 
    bool allconsts= false;
    heuristicTrace(tracer(), "numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n", explicitParams, _pca.getNumPrevConstArgs(explicitParams));
@@ -950,7 +1534,7 @@ InterpreterEmulator::visitInvokeinterface()
       TR_OpaqueClassBlock * thisClass = NULL;
       callsite = new (comp()->trHeapMemory()) TR_J9InterfaceCallSite(
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-         interfaceMethod, thisClass, -1, cpIndex, resolvedMethod,
+         interfaceMethod, thisClass, -1, cpIndex, _currentCallMethod,
          resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo,
          comp(), _recursionDepth, allconsts);
       }
@@ -958,16 +1542,16 @@ InterpreterEmulator::visitInvokeinterface()
       {
       callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-         interfaceMethod, resolvedMethod->classOfMethod(), (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex,
-         resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
+         interfaceMethod, _currentCallMethod->classOfMethod(), (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex,
+         _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
          *_newBCInfo, comp(), _recursionDepth, allconsts);
       }
    else
       {
       callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-         interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
-         resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
+         interfaceMethod, _currentCallMethod->classOfMethod(), -1, cpIndex,
+         _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
          *_newBCInfo, comp(), _recursionDepth, allconsts);
       }
 
@@ -978,39 +1562,120 @@ InterpreterEmulator::visitInvokeinterface()
    findTargetAndUpdateInfoForCallsite(callsite);
    }
 
+Operand*
+InterpreterEmulator::createOperandFromPrexArg(TR_PrexArgument* prexArgument)
+   {
+   auto prexKnowledge = TR_PrexArgument::knowledgeLevel(prexArgument);
+   switch (prexKnowledge)
+      {
+      case KNOWN_OBJECT:
+         return new (trStackMemory()) KnownObjOperand(prexArgument->getKnownObjectIndex(), prexArgument->getClass());
+      case FIXED_CLASS:
+         return new (trStackMemory()) FixedClassOperand(prexArgument->getClass());
+      case PREEXISTENT:
+         return new (trStackMemory()) PreexistentObjectOperand(prexArgument->getClass());
+      case NONE:
+         return prexArgument->getClass() ? new (trStackMemory()) ObjectOperand(prexArgument->getClass()) : NULL;
+      }
+   return NULL;
+   }
+
+TR_PrexArgument*
+InterpreterEmulator::createPrexArgFromOperand(Operand* operand)
+   {
+   if (operand->asKnownObject())
+      {
+      auto koi = operand->getKnownObjectIndex();
+      auto knot = comp()->getOrCreateKnownObjectTable();
+      if (knot && !knot->isNull(koi))
+         return new (comp()->trHeapMemory()) TR_PrexArgument(operand->getKnownObjectIndex(), comp());
+      }
+   else if (operand->asObjectOperand() && operand->asObjectOperand()->getClass())
+      {
+      TR_OpaqueClassBlock* clazz = operand->asObjectOperand()->getClass();
+      TR_PrexArgument::ClassKind kind = TR_PrexArgument::ClassIsUnknown;
+      if (operand->asFixedClassOperand())
+         kind = TR_PrexArgument::ClassIsFixed;
+      else if (operand->asPreexistentObjectOperand())
+         kind = TR_PrexArgument::ClassIsPreexistent;
+
+      return new (comp()->trHeapMemory()) TR_PrexArgument(kind, clazz);
+      }
+
+   return NULL;
+   }
+
+TR_PrexArgInfo*
+InterpreterEmulator::computePrexInfo(TR_CallSite *callsite)
+   {
+   if (tracer()->heuristicLevel())
+      _ecs->getInliner()->tracer()->dumpCallSite(callsite, "Compute prex info for call site %p\n", callsite);
+
+   int32_t numOfArgs = 0;
+   if (callsite->_isInterface)
+      {
+      numOfArgs = callsite->_interfaceMethod->numberOfExplicitParameters() + 1;
+      }
+   else if (callsite->_initialCalleeMethod)
+      {
+      numOfArgs = callsite->_initialCalleeMethod->numberOfParameters();
+      }
+
+   if (numOfArgs == 0)
+      return NULL;
+
+   // Always favor prex arg from operand if we're iterating with state
+   // But not for thunk archetype as the method's bytecodes manipulate
+   // the operand stack differently, and one int `argPlacehowler`
+   // argument can represent more than one arguments
+   //
+   if (!_callerIsThunkArchetype && _iteratorWithState)
+      {
+      TR_PrexArgInfo* prexArgInfo = new (comp()->trHeapMemory()) TR_PrexArgInfo(numOfArgs, comp()->trMemory());
+      for (int32_t i = 0; i < numOfArgs; i++)
+         {
+         int32_t posInStack = numOfArgs - i - 1;
+         prexArgInfo->set(i, createPrexArgFromOperand(topn(posInStack)));
+         }
+
+      if (tracer()->heuristicLevel())
+         {
+         alwaysTrace(tracer(), "argInfo from operand stack:");
+         prexArgInfo->dumpTrace();
+         }
+      return prexArgInfo;
+      }
+   else if (_wasPeekingSuccessfull)
+      {
+      auto callNodeTT = TR_PrexArgInfo::getCallTree(_methodSymbol, callsite, tracer());
+      if (callNodeTT)
+         {
+         // Temporarily set call tree and call node of callsite such that computePrexInfo can use it
+         callsite->_callNodeTreeTop = callNodeTT;
+         callsite->_callNode = callNodeTT->getNode()->getChild(0);
+         auto prexArgInfo = TR_J9InlinerUtil::computePrexInfo(_ecs->getInliner(), callsite, _calltarget->_ecsPrexArgInfo);
+
+         // Reset call tree and call node
+         callsite->_callNodeTreeTop = NULL;
+         callsite->_callNode = NULL;
+         return prexArgInfo;
+         }
+      }
+
+   return NULL;
+   }
+
 void
 InterpreterEmulator::findTargetAndUpdateInfoForCallsite(TR_CallSite *callsite)
    {
+   _currentCallSite = callsite;
    callsite->_callerBlock = _currentInlinedBlock;
-   if (current() == J9BCinvokevirtual || current() == J9BCinvokeinterface)
-      {
-      if (_wasPeekingSuccessfull)
-         {
-         TR_PrexArgInfo::propagateReceiverInfoIfAvailable(_methodSymbol, callsite, _calltarget->_ecsPrexArgInfo, tracer());
-         if (tracer()->heuristicLevel())
-            {
-            alwaysTrace(tracer(), "propagateReceiverInfoIfAvailable :");
-            if (callsite->_ecsPrexArgInfo)
-               callsite->_ecsPrexArgInfo->dumpTrace();
-            }
-         }
-      }
+   callsite->_ecsPrexArgInfo = computePrexInfo(callsite);
 
    if (_ecs->isInlineable(_callStack, callsite))
       {
       _callSites[_bcIndex] = callsite;
       _inlineableCallExists = true;
-
-      if (_wasPeekingSuccessfull)
-         {
-         TR_PrexArgInfo::propagateArgsFromCaller(_methodSymbol, callsite, _calltarget->_ecsPrexArgInfo, tracer());
-         if (tracer()->heuristicLevel())
-            {
-            alwaysTrace(tracer(), "propagateArgs :");
-            if (callsite->numTargets() && callsite->getTarget(0)->_ecsPrexArgInfo)
-               callsite->getTarget(0)->_ecsPrexArgInfo->dumpTrace();
-            }
-         }
 
       if (!_currentInlinedBlock->isCold())
             _nonColdCallExists = true;


### PR DESCRIPTION
This commit adds support to inline LambdaForm methods used in OpenJDK
MethodHandle implementation. It includes changes to inlining heuristic
to treat LambdaForm methods in the same way as thunk archetype, also
changes to support emulating interpreter execution of LambdaForm methods
to find call sites to inline.

The InterpreterEmulator change includes:

1. Support iterating more bytecodes. InterpreterEmulator was originally
designed for thunk archetypes, which only uses a limited number of
bytecodes. However, LambdaForm can contain any bytecodes. This commit
adds support to bytecodes that are commonly used in LambdaForm methods.
The support for all bytecodes will be done separately.

2. Track object info in local slots. LambdaForm methods use local
variables to store intermediate results that are used as call arguments
later. Since the refining of MethodHandle INL (invokeBasic, linkTo*)
requires object info, we have to track the object info stored in local
variables.

3. Prex arg info propagation to callee in with state mode. Currently,
prex arg info propagation is done for non-static methods and when
peeking is done. However, LambdaForm methods are static. Since we track
the operand stack state, we can create prex arg info from operand stack
and propagate it down to callee.

4. Add new operand classes corresponding to PrexArgument.

5. Add merge functions on operand to support merging local slot states
and operand stack states. We have to merge information coming from
different blocks to continue tracking operand stack state and local
slots state.

This commit also fixes the following problem:

MutableCallSiteOperand extends KnownObjOperand, which is not right. As
knownObjOperand doesn't rely on any assumption, but
MutableCallSiteOperand represents a known object only when the call site
target remain unchanged. InterpeterEmulator does a few operations on
KnownObjOperand which shouldn't be applied to MutableCallSiteOperand
(for example creating known object for final fields of known objects).

Part of #10618

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>
