### PR TITLE
Adding `concurrent-start/end` for Concurrent Global/Marking

### DIFF
--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -156,7 +156,7 @@ public:
 	
 	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData);
 	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData);
-	virtual const char *getConcurrentTypeString() { return "GMP work packet processing"; }
+	virtual const char *getConcurrentTypeString(uintptr_t type) { return "GMP work packet processing"; }
 
 	/**
 	 * Write the verbose stanza for the GMP mark start event.

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -96,6 +96,7 @@ MM_IncrementalGenerationalGC::MM_IncrementalGenerationalGC(MM_EnvironmentVLHGC *
 	, _projectedSurvivalCollectionSetDelegate(env, manager)
 	, _globalCollectionStatistics()
 	, _partialCollectionStatistics()
+	, _concurrentPhaseStats(OMR_GC_CYCLE_TYPE_VLHGC_GLOBAL_MARK_PHASE)
 	, _workPacketsForPartialGC(NULL)
 	, _workPacketsForGlobalGC(NULL)
 	, _taxationThreshold(0)


### PR DESCRIPTION
This is follow up PR for https://github.com/eclipse/omr/pull/5781

Adapt `MM_VerboseHandlerOutputVLHGC::getConcurrentTypeString` to interface of parent class.

Signed-off-by: Enson Guo <enson.guo@ibm.com>