### PR TITLE
JITServer AOT cache deserializer

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -405,6 +405,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/CompileService.cpp \
     compiler/runtime/JITClientSession.cpp \
     compiler/runtime/JITServerAOTCache.cpp \
+    compiler/runtime/JITServerAOTDeserializer.cpp \
     compiler/runtime/JITServerIProfiler.cpp \
     compiler/runtime/JITServerROMClassHash.cpp \
     compiler/runtime/JITServerSharedROMClassCache.cpp \

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -76,6 +76,7 @@ typedef J9JITExceptionTable TR_MethodMetaData;
 #if defined(J9VM_OPT_JITSERVER)
 class ClientSessionHT;
 class JITServerAOTCacheMap;
+class JITServerAOTDeserializer;
 class JITServerSharedROMClassCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
@@ -1064,6 +1065,9 @@ public:
 
    JITServerAOTCacheMap *getJITServerAOTCacheMap() const { return _JITServerAOTCacheMap; }
    void setJITServerAOTCacheMap(JITServerAOTCacheMap *map) { _JITServerAOTCacheMap = map; }
+
+   JITServerAOTDeserializer *getJITServerAOTDeserializer() const { return _JITServerAOTDeserializer; }
+   void setJITServerAOTDeserializer(JITServerAOTDeserializer *deserializer) { _JITServerAOTDeserializer = deserializer; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static void replenishInvocationCount(J9Method* method, TR::Compilation* comp);
@@ -1275,6 +1279,7 @@ private:
    JITServer::CompThreadActivationPolicy _activationPolicy;
    JITServerSharedROMClassCache *_sharedROMClassCache;
    JITServerAOTCacheMap *_JITServerAOTCacheMap;
+   JITServerAOTDeserializer *_JITServerAOTDeserializer;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }; // CompilationInfo
 }

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@
 #include "runtime/IProfiler.hpp"
 #include "runtime/J9Profiler.hpp"
 #if defined(J9VM_OPT_JITSERVER)
+#include "runtime/JITServerAOTDeserializer.hpp"
 #include "runtime/Listener.hpp"
 #endif /* J9VM_OPT_JITSERVER */
 #include "runtime/codertinit.hpp"
@@ -374,6 +375,10 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                TR_PersistentClassLoaderTable *loaderTable = persistentMemory->getPersistentInfo()->getPersistentClassLoaderTable();
                sharedCache->setPersistentClassLoaderTable(loaderTable);
                loaderTable->setSharedCache(sharedCache);
+#if defined(J9VM_OPT_JITSERVER)
+               if (auto deserializer = getCompilationInfo(vm->jitConfig)->getJITServerAOTDeserializer())
+                  deserializer->setSharedCache(sharedCache);
+#endif /* defined(J9VM_OPT_JITSERVER) */
                }
             }
          else

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -71,6 +71,13 @@ class JITServerHelpers
       uintptr_t, std::vector<J9ROMMethod *>                          // 20: _classChainOffsetOfIdentifyingLoaderForClazz 21. _origROMMethods
       >;
 
+   // Packs a ROMClass to be transferred to the server.
+   // The result is allocated from the stack region of trMemory (as well as temporary data
+   // structures used for packing). This function should be used with TR::StackMemoryRegion.
+   // If passed non-zero expectedSize, and it doesn't match the resulting packedSize
+   // (which is returned to the caller by reference), this function returns NULL.
+   static J9ROMClass *packROMClass(J9ROMClass *romClass, TR_Memory *trMemory, size_t &packedSize, size_t expectedSize = 0);
+
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory, bool serializeClass);
    static void freeRemoteROMClass(J9ROMClass *romClass, TR_PersistentMemory *persistentMemory);
    static J9ROMClass *cacheRemoteROMClassOrFreeIt(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, TR_PersistentMemory *persistentMemory);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -117,6 +117,7 @@
 #include "net/LoadSSLLibs.hpp"
 #include "runtime/JITClientSession.hpp"
 #include "runtime/JITServerAOTCache.hpp"
+#include "runtime/JITServerAOTDeserializer.hpp"
 #include "runtime/JITServerIProfiler.hpp"
 #include "runtime/JITServerSharedROMClassCache.hpp"
 #include "runtime/JITServerStatisticsThread.hpp"
@@ -1786,6 +1787,14 @@ onLoadInternal(
          return -1;
 
       JITServer::CommunicationStream::initConfigurationFlags();
+
+      if (compInfo->getPersistentInfo()->getJITServerUseAOTCache())
+         {
+         auto deserializer = new (PERSISTENT_NEW) JITServerAOTDeserializer(loaderTable);
+         if (!deserializer)
+            return -1;
+         compInfo->setJITServerAOTDeserializer(deserializer);
+         }
       }
 #endif // J9VM_OPT_JITSERVER
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -900,12 +900,11 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
 
    LOG(3, "\tcreating chain now: 1 + 1 + %d superclasses + %d interfaces\n", numSuperclasses, numInterfaces);
    UDATA chainLength = (2 + numSuperclasses + numInterfaces) * sizeof(UDATA);
-   const uint32_t maxChainLength = 32;
-   UDATA typicalChainData[maxChainLength];
-   chainData = typicalChainData;
-   if (chainLength > maxChainLength*sizeof(UDATA))
+   UDATA chainDataBuffer[maxClassChainLength];
+   chainData = chainDataBuffer;
+   if (chainLength > maxClassChainLength * sizeof(UDATA))
       {
-      LOG(1, "\t\t > %d so bailing\n", maxChainLength);
+      LOG(1, "\t\t > %u so bailing\n", maxClassChainLength);
       return NULL;
       }
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -171,6 +171,8 @@ public:
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp);
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp);
 
+   static const uint32_t maxClassChainLength = 32;
+
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
       {
       return (rememberClass((J9Class *) classPtr, false) != NULL);

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -64,6 +64,7 @@ if(J9VM_OPT_JITSERVER)
 		runtime/CompileService.cpp
 		runtime/JITClientSession.cpp
 		runtime/JITServerAOTCache.cpp
+		runtime/JITServerAOTDeserializer.cpp
 		runtime/JITServerIProfiler.cpp
 		runtime/JITServerROMClassHash.cpp
 		runtime/JITServerSharedROMClassCache.cpp

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -277,7 +277,9 @@ public:
    using KnownIdSet = PersistentUnorderedSet<uintptr_t/*recordIdAndType*/>;
 
    // Get serialization records the method refers to, excluding the ones already
-   // present in the knownIds set (i.e. already deseralized at the client)
+   // present in the knownIds set (i.e. already deseralized and cached at the client).
+   // The result is sorted in "dependency order": for each record in the resulting list,
+   // all the records that it depends on are stored in the list at lower indices.
    Vector<const AOTSerializationRecord *>
    getSerializationRecords(const CachedAOTMethod *method, const KnownIdSet &knownIds, TR_Memory &trMemory) const;
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -1,0 +1,814 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "control/JITServerHelpers.hpp"
+#include "compile/Compilation.hpp"
+#include "env/ClassLoaderTable.hpp"
+#include "env/StackMemoryRegion.hpp"
+#include "env/VerboseLog.hpp"
+#include "infra/CriticalSection.hpp"
+#include "runtime/JITServerAOTDeserializer.hpp"
+
+
+JITServerAOTDeserializer::JITServerAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable) :
+   _loaderTable(loaderTable), _sharedCache(NULL),
+   _classLoaderIdMap(decltype(_classLoaderIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classLoaderPtrMap(decltype(_classLoaderPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classLoaderMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassLoaderMonitor")),
+   _classIdMap(decltype(_classIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classPtrMap(decltype(_classPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassMonitor")),
+   _methodMap(decltype(_methodMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _methodMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerMethodMonitor")),
+   _classChainMap(decltype(_classChainMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classChainMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassChainMonitor")),
+   _wellKnownClassesMap(decltype(_wellKnownClassesMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _wellKnownClassesMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerWellKnownClassesMonitor")),
+   _newKnownIds(decltype(_newKnownIds)::allocator_type(TR::Compiler->persistentAllocator())),
+   _newKnownIdsMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerNewKnownIdsMonitor")),
+   _resetInProgress(false),
+   _resetMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerResetMonitor"))
+   {
+   bool allMonitors = _classLoaderMonitor && _classMonitor && _methodMonitor &&
+                      _classChainMonitor && _wellKnownClassesMonitor && _resetMonitor;
+   if (!allMonitors)
+       throw std::bad_alloc();
+   }
+
+JITServerAOTDeserializer::~JITServerAOTDeserializer()
+   {
+   TR::Monitor::destroy(_classLoaderMonitor);
+   TR::Monitor::destroy(_classMonitor);
+   TR::Monitor::destroy(_methodMonitor);
+   TR::Monitor::destroy(_classChainMonitor);
+   TR::Monitor::destroy(_wellKnownClassesMonitor);
+   TR::Monitor::destroy(_newKnownIdsMonitor);
+   TR::Monitor::destroy(_resetMonitor);
+   }
+
+
+bool
+JITServerAOTDeserializer::deserialize(SerializedAOTMethod *method, const std::vector<std::string> &records,
+                                      TR::Compilation *comp)
+   {
+   TR_ASSERT((comp->j9VMThread()->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) &&
+             !comp->j9VMThread()->omrVMThread->exclusiveCount, "Must have shared VM access");
+
+   TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
+   Vector<uintptr_t> newIds(Vector<uintptr_t>::allocator_type(comp->trMemory()->currentStackRegion()));
+   newIds.reserve(records.size());
+   bool wasReset = false;
+   bool failed = false;
+
+   // Deserialize/validate and cache serialization records, keeping track of IDs of the new ones.
+   // Since the records are sorted in "dependency order", by the time a given record is about
+   // to be cached, all the records that it depends on are already successfully cached.
+   for (size_t i = 0; i < records.size(); ++i)
+      {
+      auto record = AOTSerializationRecord::get(records[i]);
+      bool isNew = false;
+
+      if (!cacheRecord(record, comp, isNew, wasReset))
+         {
+         failed = true;
+         break;
+         }
+      if (isNew)
+         newIds.push_back(AOTSerializationRecord::idAndType(record->id(), record->type()));
+      }
+
+   // Remember IDs of newly cached records to be sent to the server with the next
+   // compilation request, unless caching a record failed because of a concurrent reset.
+   // If we encountered an invalid record (i.e. adding it failed, but not because of a
+   // concurrent reset), remember IDs of new records that were successfully cached so far.
+   if (!wasReset)
+      {
+      OMR::CriticalSection cs(_newKnownIdsMonitor);
+      // Check again that a reset operation has not started. Note that we need to read
+      // _resetInProgress after acquiring the monitor (it implies the required memory barrier).
+      if (!_resetInProgress)
+         _newKnownIds.insert(newIds.begin(), newIds.end());
+      }
+
+   if (failed)
+      return deserializationFailure(method, comp, wasReset);
+
+   // Update SCC offsets in relocation data so that the method can be stored in the local SCC and AOT-loaded
+   if (!updateSCCOffsets(method, comp, wasReset))
+      return deserializationFailure(method, comp, wasReset);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Deserialized AOT method %s", comp->signature());
+   return true;
+   }
+
+
+// Invalidating classes and class loaders during GC can be done without locking since current thread
+// has exclusive VM access, and compilation threads have shared VM access during deserialization.
+static void
+assertExclusiveVmAccess(J9VMThread *vmThread)
+   {
+   TR_ASSERT((vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) && vmThread->omrVMThread->exclusiveCount,
+             "Must have exclusive VM access");
+   }
+
+void
+JITServerAOTDeserializer::invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader)
+   {
+   assertExclusiveVmAccess(vmThread);
+
+   auto p_it = _classLoaderPtrMap.find(loader);
+   if (p_it == _classLoaderPtrMap.end())// Not cached
+      return;
+
+   uintptr_t id = p_it->second;
+   auto i_it = _classLoaderIdMap.find(id);
+   TR_ASSERT(i_it != _classLoaderIdMap.end(), "Broken two-way map");
+
+   // Mark entry as unloaded, but keep the (still valid) SCC offset
+   i_it->second._loader = NULL;
+   _classLoaderPtrMap.erase(p_it);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated class loader %p ID %zu", loader, id);
+   }
+
+void
+JITServerAOTDeserializer::invalidateClass(J9VMThread *vmThread, J9Class *ramClass)
+   {
+   assertExclusiveVmAccess(vmThread);
+
+   auto p_it = _classPtrMap.find(ramClass);
+   if (p_it == _classPtrMap.end())// Not cached
+      return;
+
+   uintptr_t id = p_it->second;
+   auto i_it = _classIdMap.find(id);
+   TR_ASSERT(i_it != _classIdMap.end(), "Broken two-way map");
+
+   if (i_it->second._ramClass)
+      {
+      // Class ID is valid. Keep the entry. Mark it as unloaded, but keep the (still valid) SCC offsets.
+      i_it->second._ramClass = NULL;
+      }
+   else
+      {
+      // Class ID is invalid. Remove the entry so that it can be replaced
+      // if a matching version of the class is ever loaded in the future.
+      _classIdMap.erase(i_it);
+      }
+
+   _classPtrMap.erase(p_it);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated RAMClass %p ID %zu", ramClass, id);
+   }
+
+
+void
+JITServerAOTDeserializer::reset()
+   {
+   // Only allow one thread at a time, so that other threads currently deserializing
+   // methods can use a simple boolean flag to reliably detect a concurrent reset
+   // (a second thread running reset() would possibly clear the flag too early).
+   OMR::CriticalSection cs(_resetMonitor);
+   _resetInProgress = true;
+
+      {
+      OMR::CriticalSection cs(_classLoaderMonitor);
+      _classLoaderIdMap.clear();
+      _classLoaderPtrMap.clear();
+      }
+
+      {
+      OMR::CriticalSection cs(_classMonitor);
+      _classIdMap.clear();
+      _classPtrMap.clear();
+      }
+
+      {
+      OMR::CriticalSection cs(_methodMonitor);
+      _methodMap.clear();
+      }
+
+      {
+      OMR::CriticalSection cs(_classChainMonitor);
+      _classChainMap.clear();
+      }
+
+      {
+      OMR::CriticalSection cs(_wellKnownClassesMonitor);
+      _wellKnownClassesMap.clear();
+      }
+
+      {
+      OMR::CriticalSection cs(_newKnownIdsMonitor);
+      _newKnownIds.clear();
+      }
+
+   _resetInProgress = false;
+   }
+
+
+std::vector<uintptr_t>
+JITServerAOTDeserializer::getNewKnownIds()
+   {
+   OMR::CriticalSection cs(_newKnownIdsMonitor);
+   if (_resetInProgress)
+      return std::vector<uintptr_t>();
+
+   std::vector<uintptr_t> result(_newKnownIds.begin(), _newKnownIds.end());
+   _newKnownIds.clear();
+   return result;
+   }
+
+
+bool
+JITServerAOTDeserializer::cacheRecord(const AOTSerializationRecord *record, TR::Compilation *comp,
+                                      bool &isNew, bool &wasReset)
+   {
+   switch (record->type())
+      {
+      case ClassLoader:
+         return cacheRecord((const ClassLoaderSerializationRecord *)record, isNew, wasReset);
+      case Class:
+         return cacheRecord((const ClassSerializationRecord *)record, comp, isNew, wasReset);
+      case Method:
+         return cacheRecord((const MethodSerializationRecord *)record, comp, isNew, wasReset);
+      case ClassChain:
+         return cacheRecord((const ClassChainSerializationRecord *)record, comp, isNew, wasReset);
+      case WellKnownClasses:
+         return cacheRecord((const WellKnownClassesSerializationRecord *)record, comp, isNew, wasReset);
+      default:
+         TR_ASSERT_FATAL(false, "Invalid record type: %u", record->type());
+         return false;
+      }
+   }
+
+
+#define RECORD_NAME(record) (int)(record)->nameLength(), (const char *)(record)->name()
+#define LENGTH_AND_DATA(str) J9UTF8_LENGTH(str), (const char *)J9UTF8_DATA(str)
+#define ROMCLASS_NAME(romClass) LENGTH_AND_DATA(J9ROMCLASS_CLASSNAME(romClass))
+#define ROMMETHOD_NAS(romMethod) \
+   LENGTH_AND_DATA(J9ROMMETHOD_NAME(romMethod)), LENGTH_AND_DATA(J9ROMMETHOD_SIGNATURE(romMethod))
+
+
+bool
+JITServerAOTDeserializer::isClassMatching(const ClassSerializationRecord *record,
+                                          J9Class *ramClass, TR::Compilation *comp)
+   {
+   TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
+
+   size_t packedSize;
+   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass(ramClass->romClass, comp->trMemory(),
+                                                               packedSize, record->romClassSize());
+   if (!packedROMClass)
+      {
+      // Packed ROMClass size mismatch. Fail early (no need to compute the hash).
+      TR_ASSERT(packedSize != record->romClassSize(), "packROMClass() returned NULL but expected size matches");
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: ROMClass size mismatch for class %.*s ID %zu: %zu != %u",
+            RECORD_NAME(record), record->id(), packedSize, record->romClassSize()
+         );
+      return false;
+      }
+
+   JITServerROMClassHash hash(packedROMClass);
+   if (hash != record->hash())
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         {
+         char actual[ROMCLASS_HASH_BYTES * 2 + 1];
+         char expected[ROMCLASS_HASH_BYTES * 2 + 1];
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: ROMClass hash mismatch for class %.*s ID %zu: %s != %s",
+            RECORD_NAME(record), record->id(), hash.toString(actual, sizeof(actual)),
+            record->hash().toString(expected, sizeof(expected))
+         );
+         }
+      return false;
+      }
+
+   return true;
+}
+
+
+// Atomically (w.r.t. exceptions) insert into two maps. id is the key in map0 and the value in map1.
+template<typename V0, typename K1> static void
+addToMaps(PersistentUnorderedMap<uintptr_t, V0> &map0,
+          PersistentUnorderedMap<K1, uintptr_t> &map1,
+          typename PersistentUnorderedMap<uintptr_t, V0>::const_iterator it,
+          uintptr_t id, const V0 &value0, const K1 &key1)
+   {
+   it = map0.insert(it, { id, value0 });
+   try
+      {
+      map1.insert({ key1, id });
+      }
+   catch (...)
+      {
+      map0.erase(it);
+      throw;
+      }
+   }
+
+
+bool
+JITServerAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *record, bool &isNew, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_classLoaderMonitor);
+   if (isResetInProgress(wasReset))
+      return false;
+
+   auto it = _classLoaderIdMap.find(record->id());
+   if (it != _classLoaderIdMap.end())
+      return true;
+   isNew = true;
+
+   // Lookup the class loader using the name of the first class that it loaded
+   auto result = _loaderTable->lookupClassLoaderAndChainAssociatedWithClassName(record->name(), record->nameLength());
+   auto loader = (J9ClassLoader *)result.first;
+   void *chain = result.second;
+   if (!loader)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to find class loader for first loaded class %.*s", RECORD_NAME(record)
+         );
+      return false;
+      }
+
+   uintptr_t offset = _sharedCache->offsetInSharedCacheFromPointer(chain);
+   addToMaps(_classLoaderIdMap, _classLoaderPtrMap, it, record->id(), { loader, offset }, loader);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "Cached class loader record ID %zu -> { %p, %zu } for first loaded class %.*s",
+         record->id(), loader, offset, RECORD_NAME(record)
+      );
+   return true;
+   }
+
+bool
+JITServerAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp,
+                                      bool &isNew, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_classMonitor);
+   if (isResetInProgress(wasReset))
+      return false;
+
+   auto it = _classIdMap.find(record->id());
+   if (it != _classIdMap.end())
+      {
+      if (it->second._romClassSCCOffset != (uintptr_t)-1)
+         return true;
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Mismatching class ID %zu", record->id());
+      return false;
+      }
+   isNew = true;
+
+   // Get the class loader for this class loader ID (which should already be cached)
+   uintptr_t loaderOffset = (uintptr_t)-1;
+   J9ClassLoader *loader = getClassLoader(record->classLoaderId(), loaderOffset, wasReset);
+   if (!loader)
+      return false;
+
+   // Lookup the RAMClass by name in the class loader
+   J9Class *ramClass = jitGetClassInClassloaderFromUTF8(comp->j9VMThread(), loader, (char *)record->name(),
+                                                        record->nameLength());
+   if (!ramClass)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to find class %.*s ID %zu in class loader %p",
+            RECORD_NAME(record), record->id(), loader
+         );
+      return false;
+      }
+
+   // Check that the ROMClass is in the SCC and get its SCC offset
+   uintptr_t offset = (uintptr_t)-1;
+   if (!_sharedCache->isROMClassInSharedCache(ramClass->romClass, &offset))
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: ROMClass %p %.*s ID %zu is not in SCC",
+                                        ramClass->romClass, RECORD_NAME(record), record->id());
+      return false;
+      }
+
+   // Check that the ROMClass hash matches, otherwise remember that it doesn't
+   if (!isClassMatching(record, ramClass, comp))
+      {
+      addToMaps(_classIdMap, _classPtrMap, it, record->id(), { ramClass, (uintptr_t)-1, (uintptr_t)-1 }, ramClass);
+      return false;
+      }
+
+   addToMaps(_classIdMap, _classPtrMap, it, record->id(), { ramClass, offset, loaderOffset }, ramClass);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "Cached class record ID %zu -> { %p, %zu, %zu } for class %.*s",
+         record->id(), ramClass, offset, loaderOffset, RECORD_NAME(record)
+      );
+   return true;
+   }
+
+bool
+JITServerAOTDeserializer::cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp,
+                                      bool &isNew, bool &wasReset)
+{
+   OMR::CriticalSection cs(_methodMonitor);
+   if (isResetInProgress(wasReset))
+      return false;
+
+   auto it = _methodMap.find(record->id());
+   if (it != _methodMap.end())
+      return true;
+   isNew = true;
+
+   // Get defining RAMClass using its ID (which should already be cached)
+   J9Class *ramClass = getRAMClass(record->definingClassId(), comp, wasReset);
+   if (!ramClass)
+      return false;
+
+   // Get RAMMethod (and its ROMMethod) in defining RAMClass by index
+   TR_ASSERT(record->index() < ramClass->romClass->romMethodCount, "Invalid method index");
+   J9Method *ramMethod = &ramClass->ramMethods[record->index()];
+   J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
+
+   uintptr_t offset = _sharedCache->offsetInSharedCacheFromROMMethod(romMethod);
+   _methodMap.insert(it, { record->id(), offset });
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "Cached method record ID %zu -> { %p, %zu } for method %.*s.%.*s%.*s",
+         record->id(), ramMethod, offset, ROMCLASS_NAME(ramClass->romClass), ROMMETHOD_NAS(romMethod)
+      );
+   return true;
+   }
+
+bool
+JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp,
+                                      bool &isNew, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_classChainMonitor);
+   if (isResetInProgress(wasReset))
+      return false;
+
+   auto it = _classChainMap.find(record->id());
+   if (it != _classChainMap.end())
+      return true;
+   isNew = true;
+
+   // Get the RAMClasses for each class ID in the chain (which should already be cached)
+   TR_ASSERT(record->list().length() <= TR_J9SharedCache::maxClassChainLength, "Class chain is too long");
+   J9Class *ramClasses[TR_J9SharedCache::maxClassChainLength];
+   for (size_t i = 0; i < record->list().length(); ++i)
+      {
+      ramClasses[i] = getRAMClass(record->list().ids()[i], comp, wasReset);
+      if (!ramClasses[i])
+         return false;
+      }
+
+   // Create the class chain in the local SCC or find the existing one
+   uintptr_t *chain = _sharedCache->rememberClass((TR_OpaqueClassBlock *)ramClasses[0]);
+   if (!chain)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to get class chain ID %zu for class %.*s ID %zu",
+            record->id(), ROMCLASS_NAME(ramClasses[0]->romClass), record->list().ids()[0]
+         );
+      return false;
+      }
+
+   uintptr_t offset = _sharedCache->offsetInSharedCacheFromPointer(chain);
+   uintptr_t chainLength = chain[0] / sizeof(chain[0]) - 1;
+   uintptr_t *chainItems = chain + 1;
+
+   // Check that the local version of the class chain has the expected length
+   if (record->list().length() != chainLength)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Class chain length mismatch for class %.*s ID %zu: %zu != %zu",
+            ROMCLASS_NAME(ramClasses[0]->romClass), record->list().ids()[0], record->list().length(), chainLength
+         );
+      return false;
+      }
+
+   // Validate each ROMClass in the chain
+   for (size_t i = 0; i < chainLength; ++i)
+      {
+      J9ROMClass *romClass = _sharedCache->romClassFromOffsetInSharedCache(chainItems[i]);
+      if (romClass != ramClasses[i]->romClass)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+               "ERROR: Class %.*s mismatch in class chain ID %zu for class %.*s ID %zu",
+               ROMCLASS_NAME(ramClasses[i]->romClass), record->id(),
+               ROMCLASS_NAME(ramClasses[0]->romClass), record->list().ids()[0]
+            );
+         return false;
+         }
+      }
+
+   _classChainMap.insert(it, { record->id(), offset });
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "Cached class chain record ID %zu -> { %p, %zu } for class %.*s ID %zu",
+         record->id(), ramClasses[0], offset, ROMCLASS_NAME(ramClasses[0]->romClass), record->list().ids()[0]
+      );
+   return true;
+   }
+
+bool
+JITServerAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord *record,
+                                      TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_wellKnownClassesMonitor);
+   if (isResetInProgress(wasReset))
+      return false;
+
+   auto it = _wellKnownClassesMap.find(record->id());
+   if (it != _wellKnownClassesMap.end())
+      return true;
+   isNew = true;
+
+   // Initialize the "well-known classes" object (see SymbolValidationManager::populateWellKnownClasses()).
+   TR_ASSERT(record->list().length() <= WELL_KNOWN_CLASS_COUNT, "Too many well-known classes");
+   uintptr_t chainOffsets[1 + WELL_KNOWN_CLASS_COUNT] = { record->list().length() };
+   // Get the class chain SCC offsets for each class chain ID (which should already be cached).
+   for (size_t i = 0; i < record->list().length(); ++i)
+      {
+      chainOffsets[1 + i] = getSCCOffset(AOTSerializationRecordType::ClassChain, record->list().ids()[i], wasReset);
+      if (chainOffsets[1 + i] == (uintptr_t)-1)
+         return false;
+      }
+
+   // Get the key that it will be stored under in the local SCC
+   char key[128];
+   TR::SymbolValidationManager::getWellKnownClassesSCCKey(key, sizeof(key), record->includedClasses());
+   J9SharedDataDescriptor desc = { .address = (uint8_t *)chainOffsets,
+                                   .length = (1 + record->list().length()) * sizeof(chainOffsets[0]),
+                                   .type = J9SHR_DATA_TYPE_JITHINT };
+
+   // Store the "well-known classes" object in the local SCC or find the existing one
+   auto offsets = _sharedCache->storeSharedData(comp->j9VMThread(), key, &desc);
+   if (!offsets)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Failed to get well-known class chain offsets");
+      return false;
+      }
+
+   uintptr_t offset = _sharedCache->offsetInSharedCacheFromPointer((void *)offsets);
+   _wellKnownClassesMap.insert(it, { record->id(), offset });
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Cached well-known classes record ID %zu -> %zu",
+                                     record->id(), offset);
+   return true;
+   }
+
+
+J9ClassLoader *
+JITServerAOTDeserializer::getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffset, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_classLoaderMonitor);
+   if (isResetInProgress(wasReset))
+      return NULL;
+
+   auto it = _classLoaderIdMap.find(id);
+   if (it == _classLoaderIdMap.end())
+      {
+      // Class loader ID should be cached by now, unless it was removed by a concurrent reset
+      wasReset = true;
+      return NULL;
+      }
+
+   // Check if the cached entry has a valid class loader pointer
+   if (it->second._loader)
+      {
+      loaderSCCOffset = it->second._loaderChainSCCOffset;
+      return it->second._loader;
+      }
+
+   // Class loader was unloaded. Try to lookup a new version using the identifying class chain SCC offset.
+   void *chain = _sharedCache->pointerFromOffsetInSharedCache(it->second._loaderChainSCCOffset);
+   auto loader = (J9ClassLoader *)_loaderTable->lookupClassLoaderAssociatedWithClassChain(chain);
+   if (!loader)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to get class loader ID %zu for identifying class chain %p", id, chain
+         );
+      return NULL;
+      }
+
+   // Put the new class loader pointer back into the maps
+   _classLoaderPtrMap.insert({ loader, id });
+   it->second._loader = loader;
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Re-cached class loader ID %zu -> { %p, %zu }",
+                                     id, loader, it->second._loaderChainSCCOffset);
+   loaderSCCOffset = it->second._loaderChainSCCOffset;
+   return loader;
+   }
+
+J9Class *
+JITServerAOTDeserializer::getRAMClass(uintptr_t id, TR::Compilation *comp, bool &wasReset)
+   {
+   OMR::CriticalSection cs(_classMonitor);
+   if (isResetInProgress(wasReset))
+      return NULL;
+
+   auto it = _classIdMap.find(id);
+   if (it == _classIdMap.end())
+      {
+      // Class ID should be cached by now, unless it was removed by a concurrent reset
+      wasReset = true;
+      return NULL;
+      }
+
+   // Check if the cached entry has a valid RAMClass pointer
+   if (it->second._ramClass)
+      {
+      if (it->second._romClassSCCOffset == (uintptr_t)-1)
+         {
+         // This entry is for a previously cached mismatching class ID
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Mismatching class ID %zu", id);
+         return NULL;
+         }
+      return it->second._ramClass;
+      }
+
+   // Class was unloaded. Try to lookup a new version of its class loader using the identifying class chain SCC offset.
+   void *chain = _sharedCache->pointerFromOffsetInSharedCache(it->second._loaderChainSCCOffset);
+   auto loader = (J9ClassLoader *)_loaderTable->lookupClassLoaderAssociatedWithClassChain(chain);
+   if (!loader)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to get class loader for identifying class chain %p", chain
+         );
+      return NULL;
+      }
+
+   // Get the class name using the cached ROMClass SCC offset, which is guaranteed to be valid at this point.
+   // Note that romClassFromOffsetInSharedCache() already has a fatal assertion that the offset is valid.
+   J9ROMClass *romClass = _sharedCache->romClassFromOffsetInSharedCache(it->second._romClassSCCOffset);
+   const J9UTF8 *name = J9ROMCLASS_CLASSNAME(romClass);
+
+   // Try to lookup a new version of the class in its class loader by name
+   J9Class *ramClass = jitGetClassInClassloaderFromUTF8(comp->j9VMThread(), loader, (char *)J9UTF8_DATA(name),
+                                                        J9UTF8_LENGTH(name));
+   if (!ramClass)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Failed to find class %.*s ID %zu in class loader %p", ROMCLASS_NAME(romClass), id, loader
+         );
+      return NULL;
+      }
+
+   // Check that the ROMClass is still the same
+   if (ramClass->romClass != romClass)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: ROMClass mismatch for %.*s ID %zu",
+                                        ROMCLASS_NAME(romClass), id);
+      return NULL;
+      }
+
+   // Put the new RAMClass pointer back into the maps
+   _classPtrMap.insert({ ramClass, id });
+   it->second._ramClass = ramClass;
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Re-cached class ID %zu -> { %p, %zu, %zu }",
+                                     id, ramClass, it->second._romClassSCCOffset, it->second._loaderChainSCCOffset);
+   return ramClass;
+   }
+
+
+// Find a cached entry for the given ID in the map
+template<typename V>
+V findInMap(const PersistentUnorderedMap<uintptr_t, V> &map, uintptr_t id, TR::Monitor *monitor, bool &wasReset)
+   {
+   OMR::CriticalSection cs(monitor);
+
+   auto it = map.find(id);
+   if (it != map.end())
+      return it->second;
+
+   // This record ID can only be missing from the cache if it was removed by a concurrent reset
+   wasReset = true;
+   return V();
+   }
+
+uintptr_t
+JITServerAOTDeserializer::getSCCOffset(AOTSerializationRecordType type, uintptr_t id, bool &wasReset)
+   {
+   switch (type)
+      {
+      case ClassLoader:
+         {
+         uintptr_t offset = findInMap(_classLoaderIdMap, id, _classLoaderMonitor, wasReset)._loaderChainSCCOffset;
+         return wasReset ? (uintptr_t)-1 : offset;
+         }
+      case Class:
+         {
+         uintptr_t offset = findInMap(_classIdMap, id, _classMonitor, wasReset)._romClassSCCOffset;
+         // Check if this cached ID is for a valid class
+         if ((offset == (uintptr_t)-1) && TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Mismatching class ID %zu", id);
+         return wasReset ? (uintptr_t)-1 : offset;
+         }
+      case Method:
+         {
+         uintptr_t offset = findInMap(_methodMap, id, _methodMonitor, wasReset);
+         return wasReset ? (uintptr_t)-1 : offset;
+         }
+      case ClassChain:
+         {
+         uintptr_t offset = findInMap(_classChainMap, id, _classChainMonitor, wasReset);
+         return wasReset ? (uintptr_t)-1 : offset;
+         }
+      case WellKnownClasses:
+         {
+         uintptr_t offset = findInMap(_wellKnownClassesMap, id, _wellKnownClassesMonitor, wasReset);
+         return wasReset ? (uintptr_t)-1 : offset;
+         }
+      default:
+         TR_ASSERT_FATAL(false, "Invalid record type: %u", type);
+         return (uintptr_t)-1;
+      }
+   }
+
+
+bool
+JITServerAOTDeserializer::deserializationFailure(const SerializedAOTMethod *method,
+                                                 TR::Compilation *comp, bool wasReset)
+   {
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "ERROR: Failed to deserialize AOT method %s%s",
+         comp->signature(), wasReset ? " due to concurrent deserializer reset" : ""
+      );
+   return false;
+   }
+
+bool
+JITServerAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset)
+   {
+   //NOTE: Defining class chain record is validated by now
+
+   auto header = (TR_AOTMethodHeader *)(method->data() + sizeof(J9JITDataCacheHeader));
+   if (header->offsetToRelocationDataItems == 0)
+      {
+      TR_ASSERT_FATAL(method->numRecords() == 0, "Unexpected serialization records in serialized method %s",
+                      comp->signature());
+      return true;
+      }
+
+   for (size_t i = 0; i < method->numRecords(); ++i)
+      {
+      // Get the SCC offset of the corresponding entity in the local SCC
+      const SerializedSCCOffset &serializedOffset = method->offsets()[i];
+      uintptr_t sccOffset = getSCCOffset(serializedOffset.recordType(), serializedOffset.recordId(), wasReset);
+      if (sccOffset == (uintptr_t)-1)
+         return false;
+
+      // Update the SCC offset stored in AOT method relocation data
+      uint8_t *ptr = method->data() + header->offsetToRelocationDataItems + serializedOffset.reloDataOffset();
+      TR_ASSERT_FATAL(ptr < method->data() + method->dataSize(),
+                      "Out-of-bounds relocation data offset in serialized method %s", comp->signature());
+      *(uintptr_t *)ptr = sccOffset;
+      }
+
+   return true;
+   }

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITSERVER_AOT_DESERIALIZER_H
+#define JITSERVER_AOT_DESERIALIZER_H
+
+#include "env/TRMemory.hpp"
+#include "env/PersistentCollections.hpp"
+#include "runtime/JITServerAOTSerializationRecords.hpp"
+
+class TR_PersistentClassLoaderTable;
+namespace TR { class Compilation; }
+namespace TR { class Monitor; }
+
+
+// This class implements deserialization of cached AOT methods received from JITServer.
+//
+// Deserialization involves looking up classes, methods etc. by name, and computing hashes of packed ROMClasses
+// (which can be a relatively heavy operation). To improve performance, the deserializer caches results of
+// lookups and ROMClass hash validations (including mismatches) for each AOT serialization record.
+//
+// The IDs of newly cached records are communicated back to the server (with subsequent compilation requests)
+// so that it doesn't keep sending records used by multiple methods (e.g. class and class chain records for
+// all well-known classes are referred to by any AOT method compiled with SVM).
+//
+// The deserializer cache stores pointers to "RAM" entities, which have to be invalidated when classes and
+// class loaders are unloaded, and SCC offsets to "ROM" entities, which always remain valid once cached.
+//
+// JIT client can reconnect do a different JITServer instance after the previous instance fails or shuts down.
+// Since AOT cache record IDs are specific to a JITServer instance, the deserializer cache must be purged
+// upon connecting to a new instance. This is done in the reset() function. Any concurrent deserialization
+// (of a method received just before the server failure) detects that a reset is in progress and fails.
+class JITServerAOTDeserializer
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
+
+   JITServerAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable);
+   ~JITServerAOTDeserializer();
+
+   void setSharedCache(TR_J9SharedCache *sharedCache) { _sharedCache = sharedCache; }
+
+   // Deserializes in place a serialized AOT method received from JITServer. Returns true on success.
+   // Caches new serialization records and adds their IDs to the set of new known IDs.
+   bool deserialize(SerializedAOTMethod *method, const std::vector<std::string> &records,
+                    TR::Compilation *comp);
+
+   // Invalidation functions called from class and class loader unload JIT hooks to invalidate RAMClass
+   // and class loader pointers cached by the deserializer. Note that cached SCC offsets stay valid.
+   void invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader);
+   void invalidateClass(J9VMThread *vmThread, J9Class *ramClass);
+
+   // Invalidates all cached serialization records. Must be called when the client
+   // connects to a new server instance (e.g. upon receving a VM_getVMInfo message),
+   // before attempting to deserialize any method received from the new server instance.
+   void reset();
+
+   // IDs of records newly cached during deserialization of an AOT method are sent to the JITServer with
+   // the next compilation request, so that the server can update its set of known IDs for this client.
+   // This function returns the list of IDs cached since the last call, and clears the set of new known IDs.
+   std::vector<uintptr_t/*idAndType*/> getNewKnownIds();
+
+private:
+   struct ClassLoaderEntry
+      {
+      J9ClassLoader *_loader;// NULL if class loader was unloaded
+      uintptr_t _loaderChainSCCOffset;
+      };
+
+   struct ClassEntry
+      {
+      J9Class *_ramClass;// NULL if class ID is invalid (was not found or its hash didn't match), or class was unloaded
+      uintptr_t _romClassSCCOffset;// -1 if class ID is invalid
+      uintptr_t _loaderChainSCCOffset;
+      };
+
+   bool isResetInProgress(bool &wasReset) { return _resetInProgress ? (wasReset = true) : false; }
+
+   //NOTE: All the functions below that take a 'bool &wasReset' argument set it to true
+   //      if the operation failed due to a concurrent reset of the deserializer.
+
+   // Deserializes/validates and caches an AOT serialization record.
+   // Returns true if the record is valid (e.g. class was found and its hash matches),
+   // and sets isNew to true if the record was newly cached (not already known).
+   // Returns false if the record is invalid (e.g. ROMClass hash doesn't match)
+   // or not yet valid (e.g. class has not been loaded yet).
+   bool cacheRecord(const AOTSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+
+   // Returns true if ROMClass hash matches the one in the serialization record
+   bool isClassMatching(const ClassSerializationRecord *record, J9Class *ramClass, TR::Compilation *comp);
+
+   bool cacheRecord(const ClassLoaderSerializationRecord *record, bool &isNew, bool &wasReset);
+   bool cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+   bool cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+   bool cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+   bool cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+
+   // Returns the class loader for given class loader ID, either cached or
+   // looked up using the cached SCC offset if the class loader was unloaded.
+   // The SCC offset of the identifying class chain is returned in loaderSCCOffset.
+   J9ClassLoader *getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffset, bool &wasReset);
+   // Returns the RAMClass for given class ID, either cached or
+   // looked up using the cached SCC offsets if the class was unloaded.
+   J9Class *getRAMClass(uintptr_t id, TR::Compilation *comp, bool &wasReset);
+
+   // Returns -1 on failure
+   uintptr_t getSCCOffset(AOTSerializationRecordType type, uintptr_t id, bool &wasReset);
+
+   bool deserializationFailure(const SerializedAOTMethod *method, TR::Compilation *comp, bool wasReset);
+   // Returns false on failure
+   bool updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset);
+
+   TR_PersistentClassLoaderTable *const _loaderTable;
+   TR_J9SharedCache *_sharedCache;
+
+   //NOTE: Locking hierarchy used in this class follows cycle-free dependency order
+   // between serialization record types and guarantees that there are no deadlocks:
+   // - _resetMonitor < _wellKnownClassesMonitor < _classChainMonitor < _classMonitor;
+   // - _methodMonitor < _classMonitor;
+   // - remaining monitors are "leafs".
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, ClassLoaderEntry> _classLoaderIdMap;
+   // This map is needed for invalidating unloaded class loaders
+   PersistentUnorderedMap<J9ClassLoader *, uintptr_t/*ID*/> _classLoaderPtrMap;
+   TR::Monitor *const _classLoaderMonitor;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, ClassEntry> _classIdMap;
+   // This map is needed for invalidating unloaded classes
+   PersistentUnorderedMap<J9Class *, uintptr_t/*ID*/> _classPtrMap;
+   TR::Monitor *const _classMonitor;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _methodMap;
+   TR::Monitor *const _methodMonitor;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _classChainMap;
+   TR::Monitor *const _classChainMonitor;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _wellKnownClassesMap;
+   TR::Monitor *const _wellKnownClassesMonitor;
+
+   PersistentUnorderedSet<uintptr_t/*idAndType*/> _newKnownIds;
+   TR::Monitor *const _newKnownIdsMonitor;
+
+   volatile bool _resetInProgress;
+   TR::Monitor *const _resetMonitor;
+   };
+
+
+#endif /* JITSERVER_AOT_DESERIALIZER_H */

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -30,7 +30,8 @@
 
 enum AOTSerializationRecordType
    {
-   // Not associated with an SCC entity; used for class loader identification (by name of the 1st loaded class)
+   // Used for class loader identification (by name of the first loaded class).
+   // Associated with an SCC class chain identifying a class loader (class chain of its first loaded class).
    ClassLoader,
    // Associated with a ROMClass
    Class,
@@ -258,8 +259,7 @@ public:
    SerializedSCCOffset(uintptr_t recordId, AOTSerializationRecordType recordType, uintptr_t reloDataOffset) :
       _recordIdAndType(AOTSerializationRecord::idAndType(recordId, recordType)), _reloDataOffset(reloDataOffset)
       {
-      TR_ASSERT((recordType > AOTSerializationRecordType::ClassLoader) &&
-                (recordType < AOTSerializationRecordType::AOTHeader), "Invalid record type: %u", recordType);
+      TR_ASSERT(recordType < AOTSerializationRecordType::AOTHeader, "Invalid record type: %u", recordType);
       }
 
    uintptr_t recordId() const { return AOTSerializationRecord::getId(_recordIdAndType); }

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -195,6 +195,13 @@ TR::SymbolValidationManager::getSystemClassNotWorthRemembering(int idx)
    }
 
 void
+TR::SymbolValidationManager::getWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses)
+   {
+   int len = snprintf(buffer, size, "AOTWellKnownClasses:%x", includedClasses);
+   TR_ASSERT(len <= size, "Buffer too small");
+   }
+
+void
 TR::SymbolValidationManager::populateWellKnownClasses()
    {
 #define REQUIRED_WELL_KNOWN_CLASS_COUNT 0
@@ -279,7 +286,7 @@ TR::SymbolValidationManager::populateWellKnownClasses()
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    char key[128];
-   snprintf(key, sizeof (key), "AOTWellKnownClasses:%x", includedClasses);
+   getWellKnownClassesSCCKey(key, sizeof(key), includedClasses);
 
    J9SharedDataDescriptor dataDescriptor;
    dataDescriptor.address = (U_8*)classChainOffsets;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -648,6 +648,7 @@ public:
 
    #define WELL_KNOWN_CLASS_COUNT 9
 
+   static void getWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses);
    void populateWellKnownClasses();
    bool validateWellKnownClasses(const uintptr_t *wellKnownClassChainOffsets);
    bool isWellKnownClass(TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
This PR adds the `JITServerAOTDeserializer` class that will be used at the JIT client to deserialize cached AOT methods received from the JITServer. The deserializer updates each SCC offset in relocation and validation records stored in method relocation data such that it points to the correct entity in the local SCC, which is looked up and validated using the information in AOT serialization records attached to the serialized AOT method.