### PR TITLE
Enable JitDump support on JITServer

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -343,6 +343,9 @@ class CompilationInfoPerThreadBase
     */
    bool isCPUCheapCompilation(uint32_t bcsz, TR_Hotness optLevel);
    bool shouldPerformLocalComp(const TR_MethodToBeCompiled *entry);
+
+   bool compilationCanBeInterrupted() const { return _compilationCanBeInterrupted; }
+
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    protected:
@@ -456,7 +459,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    int32_t                getCompThreadPriority() const { return _compThreadPriority; }
    void                   setCompThreadPriority(int32_t priority) { _compThreadPriority = priority; }
    int32_t                changeCompThreadPriority(int32_t priority, int32_t locationCode);
-   TR::Monitor *getCompThreadMonitor() { return _compThreadMonitor; }
+   TR::Monitor           *getCompThreadMonitor() { return _compThreadMonitor; }
    void                   run();
    void                   processEntries();
    virtual void           processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider);

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -103,6 +103,10 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    void deleteClientSessionData(uint64_t clientId, TR::CompilationInfo* compInfo, J9VMThread* compThread);
    virtual void freeAllResources() override;
 
+   void incrementClassUnloadReadMutexDepth() { _classUnloadReadMutexDepth++; }
+   void decrementClassUnloadReadMutexDepth() { _classUnloadReadMutexDepth--; }
+   int32_t getClassUnloadReadMutexDepth() { return _classUnloadReadMutexDepth; }
+
    private:
    /* Template method for allocating a cache of type T on the heap.
     * Cache pointer must be NULL.
@@ -172,6 +176,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    FieldOrStaticAttrTable_t *_fieldAttributesCache;
    FieldOrStaticAttrTable_t *_staticAttributesCache;
    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
+   int32_t _classUnloadReadMutexDepth;
    }; // class CompilationInfoPerThreadRemote
 } // namespace TR
 

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -374,7 +374,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 
    bool _externalStartupEndedSignal; // the app will tell us when startup ends
 
-   bool _disableFurtherCompilation;
+   volatile bool _disableFurtherCompilation;
 
    uint32_t _loadFactor; // set in samplerThread; increases with active threads, decreases with CPUs
 

--- a/runtime/compiler/env/j9jit.tdf
+++ b/runtime/compiler/env/j9jit.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2000, 2020 IBM Corp. and others
+// Copyright (c) 2000, 2021 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,4 +132,4 @@ TraceEvent=Trc_JIT_portableSharedCache_enabled_or_disabled Overhead=1 Level=3 Te
 
 TraceEvent=Trc_JITServerClientSessionData1   Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u (isCritical=%d) (expectedSeqNo=%u lastProcessedCriticalSeqNo=%u)"
 TraceEvent=Trc_JITServerOutOfSequenceMsg1    Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d clientSessionData=%p clientUID=%llu (entry=%p) (seqNo=%u, expectedSeqNo=%u, numActiveThreads=%d) out-of-sequence msg detected (lastProcessedCriticalSeqNo=%u). Parking this thread"
-
+TraceEvent=Trc_JITServerCompThreadCrashed    Overhead=1 Level=1 Test Template="JITClient: compThreadID=%d server compilation thread crashed while compiling %s @ %s. Requesting JitDump recompilation and switching to local compilations."

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -38,6 +38,8 @@ enum MessageType : uint16_t
    compilationInterrupted, // type used when client informs the server to abort the remote compilation
    clientSessionTerminate, // type used when client process is about to terminate
    connectionTerminate, // type used when client informs the server to close the connection
+   compilationThreadCrashed, 
+   jitDumpPrintIL,
 
    // For TR_ResolvedJ9JITServerMethod methods
    ResolvedMethod_setRecognizedMethodInfo,
@@ -285,6 +287,8 @@ static const char *messageNames[] =
    "compilationInterrupted",
    "clientSessionTerminate",
    "connectionTerminate",
+   "compilationThreadCrashed", 
+   "jitDumpPrintIL",
    "ResolvedMethod_setRecognizedMethodInfo",
    "ResolvedMethod_startAddressForInterpreterOfJittedMethod",
    "ResolvedMethod_staticAttributes",

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -88,6 +88,7 @@ public:
       {
       if (isReadingClassUnload() &&
           isClassUnloadingAttempted() &&
+          TR::compInfoPT->compilationCanBeInterrupted() &&
           (MessageType::compilationFailure != type) &&
           (MessageType::compilationCode != type))
          {
@@ -123,7 +124,11 @@ public:
          {
          case MessageType::compilationInterrupted:
             {
-            throw StreamInterrupted();
+            // If we are inside an uninterruptible operation on the server,
+            // but the corresponding operation hasn't yet started on the client,
+            // ignore the request to interrupt a compilation
+            if (TR::compInfoPT->compilationCanBeInterrupted())
+               throw StreamInterrupted();
             }
          case MessageType::connectionTerminate:
             {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -25,6 +25,7 @@
 #include "control/CompilationRuntime.hpp" // for CompilationInfo
 #include "control/MethodToBeCompiled.hpp" // for TR_MethodToBeCompiled
 #include "control/JITServerHelpers.hpp"
+#include "control/JITServerCompilationThread.hpp"
 #include "env/ut_j9jit.h"
 #include "net/ServerStream.hpp" // for JITServer::ServerStream
 #include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
@@ -666,14 +667,18 @@ void ClientSessionData::purgeCache(std::vector<ClassUnloadedData> *unloadedClass
    }
 
 void
-ClientSessionData::readAcquireClassUnloadRWMutex()
+ClientSessionData::readAcquireClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT)
    {
+   // compInfoPT must be associated with the compilation thread that calls this
    omrthread_rwmutex_enter_read(_classUnloadRWMutex);
+   static_cast<TR::CompilationInfoPerThreadRemote *>(compInfoPT)->incrementClassUnloadReadMutexDepth();
    }
 
 void
-ClientSessionData::readReleaseClassUnloadRWMutex()
+ClientSessionData::readReleaseClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT)
    {
+   // compInfoPT must be associated with the compilation thread that calls this
+   static_cast<TR::CompilationInfoPerThreadRemote *>(compInfoPT)->decrementClassUnloadReadMutexDepth();
    omrthread_rwmutex_exit_read(_classUnloadRWMutex);
    }
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -41,8 +41,8 @@ class TR_MethodToBeCompiled;
 class TR_AddressRange;
 class TR_PersistentCHTable;
 class JITServerPersistentCHTable;
+namespace TR { class CompilationInfoPerThreadBase; }
 namespace JITServer { class ServerStream; }
-
 
 using IPTable_t = PersistentUnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
 using TR_JitFieldsCacheEntry = std::pair<J9Class*, UDATA>;
@@ -388,8 +388,8 @@ public:
    volatile bool isClassUnloadingAttempted() const { return _bClassUnloadingAttempt; }
    volatile bool isReadingClassUnload() { return !omrthread_rwmutex_is_writelocked(_classUnloadRWMutex); }
 
-   void readAcquireClassUnloadRWMutex();
-   void readReleaseClassUnloadRWMutex();
+   void readAcquireClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT);
+   void readReleaseClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT);
    void writeAcquireClassUnloadRWMutex();
    void writeReleaseClassUnloadRWMutex();
 


### PR DESCRIPTION
This commit allows server to produce a JitDump log when a crash occurs
during a compilation.

Once the crash happens, the JitDump handler runs normally, producing
an IL log of the crashed thread until it reaches the point when
the problematic method needs to be recompiled. There, it sends
the client a `compilationThreadCrashed` message, asking it to schedule
a JitDump recompilation and blocks until the recompilation is done.

When the client receives the error message, it temporarily stops all
further compilations, purges the compilation queue and sends a request
to the server to recompile the method as a JitDump compilation.
The server will compile the method on the diagnostic thread, notify
the waiting crashed thread, allowing the JitDump handler to finish and
terminate the server.

Once the diagnostic compilation is complete, the client will resume
compilations locally until another server comes up.

Closes: #12394