### PR TITLE
Look for opportunities in Value Propagation to replace nonhelper and helper calls for value type support with inline IL

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,6 +123,30 @@ class ValuePropagation : public OMR::ValuePropagation
 
    TR::VP_BCDSign **_bcdSignConstraints;
    List<TreeNodeResultPair> _callsToBeFoldedToNode;
+
+   struct ValueTypesHelperCallTransform {
+      TR_ALLOC(TR_Memory::ValuePropagation)
+      TR::TreeTop *_tree;
+      TR::Node *_callNode;
+      flags8_t _flags;
+      bool _isLoad;
+      bool _requiresStoreCheck;
+      ValueTypesHelperCallTransform(TR::TreeTop *tree, TR::Node *callNode, flags8_t flags)
+         : _tree(tree), _callNode(callNode), _flags(flags) {} // _isLoad(isLoad), _requiresStoreCheck(requiresStoreCheck) {}
+      enum // flag bits
+         {
+         IsArrayLoad        = 0x01,
+         IsArrayStore       = 0x02,
+         RequiresStoreCheck = 0x04,
+         IsRefCompare       = 0x08,
+         InsertDebugCounter = 0x10,
+         Unused3            = 0x20,
+         Unused2            = 0x40,
+         Unused1            = 0x80,
+         };
+   };
+
+   List<ValueTypesHelperCallTransform> _valueTypesHelperCallsToBeFolded;
    };
 
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -59,6 +59,16 @@ class ValuePropagation : public OMR::ValuePropagation
    bool isKnownStringObject(TR::VPConstraint *constraint);
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
 
+   /**
+    * Determine whether the component type of an array is, or might be, a value
+    * type.
+    * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
+    * \returns \c TR_yes if the array's component type is definitely a value type;\n
+    *          \c TR_no if it is definitely not a value type; or\n
+    *          \c TR_maybe otherwise.
+    */
+   virtual TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
+
    virtual void getParmValues();
 
    /**


### PR DESCRIPTION
During IL generation with value type support enabled, the JIT compiler generates calls to an equality comparison non-helper to compare objects, as simple address comparisons are not sufficient for comparison of value type instances in general.  It also generates calls to helpers to perform array element load and store operations.

This pull request makes changes to the Value Propagation optimization to have it detect calls to the equality comparison non-helper for which at least one operand is not a value type, and calls to the array load/store helpers for which the component type of the array is known not to be a value type.  For each case detected, the call is replaced with inline IL similar to that which would ordinarily be generated by IL generation.

Resolves:  #12175