### PR TITLE
Introduce New Default Scan Ordering 'None'

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -276,10 +276,8 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 	env->disableHotFieldDepthCopy();
 
 	if (result) {
-		if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST != extensions->scavengerScanOrdering) {
-			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
-		} else {
-			extensions->adaptiveGcCountBetweenHotFieldSort = false;
+		if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_NONE == extensions->scavengerScanOrdering) {
+			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
 		}
 		extensions->setVLHGC(true);
 	}


### PR DESCRIPTION
Introduce a new default scan ordering type 'none'. In gencon configuration, scan ordering will be set to hierarchical if it has not already been overridden by an option. In balanced, scan ordering will be set to dynamic BF if it has not already been overridden by an option.

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>