### PR TITLE
Initial AOT support for new MH implementation

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1260,7 +1260,9 @@ void J9::ARM64::PrivateLinkage::buildDirectCall(TR::Node *callNode,
       TR::LabelSymbol *label = generateLabelSymbol(cg());
       TR::Snippet *snippet;
 
-      if (callSymRef->isUnresolved() || comp()->compileRelocatableCode())
+      bool forceUnresolvedDispatch = comp()->fej9()->forceUnresolvedDispatch() && !comp()->genRelocatableResolvedDispatchSnippet(callSymbol);
+
+      if (callSymRef->isUnresolved() || forceUnresolvedDispatch)
          {
          snippet = new (trHeapMemory()) TR::ARM64UnresolvedCallSnippet(cg(), callNode, label, argSize);
          }

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -233,6 +233,21 @@ J9::Compilation::~Compilation()
    _profileInfo->~TR_AccessedProfileInfo();
    }
 
+bool
+J9::Compilation::genRelocatableResolvedDispatchSnippet(TR::MethodSymbol *sym)
+   {
+   TR_ASSERT_FATAL(self()->compileRelocatableCode(),
+                   "Should only call this API for a relocatable compilation!\n");
+
+   bool genResolved = false;
+   if (self()->getOption(TR_UseSymbolValidationManager)
+       || (sym && sym->isVMInternalNative()))
+      {
+      genResolved = true;
+      }
+   return genResolved;
+   }
+
 TR_J9VMBase *
 J9::Compilation::fej9()
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -351,6 +351,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
+   bool genRelocatableResolvedDispatchSnippet(TR::MethodSymbol *sym);
+
 private:
    enum CachedClassPointerId
       {

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -474,7 +474,7 @@ J9::SymbolReferenceTable::findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMetho
    void *entryLocation = owningMethod->callSiteTableEntryAddress(callSiteIndex);
    for (symRef = i.getNext(); symRef; symRef = i.getNext())
       if (  owningMethodSymbol->getResolvedMethodIndex() == symRef->getOwningMethodIndex()
-         && symRef->getSymbol()->castToStaticSymbol()->getStaticAddress() == entryLocation)
+         && symRef->getSymbol()->castToStaticSymbol()->getCallSiteIndex() == callSiteIndex)
          {
          return symRef;
          }
@@ -520,7 +520,7 @@ J9::SymbolReferenceTable::findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMet
    void *entryLocation = owningMethod->methodTypeTableEntryAddress(cpIndex);
    for (symRef = i.getNext(); symRef; symRef = i.getNext())
       if (  owningMethodSymbol->getResolvedMethodIndex() == symRef->getOwningMethodIndex()
-         && symRef->getSymbol()->castToStaticSymbol()->getStaticAddress() == entryLocation)
+         && symRef->getCPIndex() == cpIndex)
          {
          return symRef;
          }
@@ -541,7 +541,7 @@ J9::SymbolReferenceTable::findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMet
 #endif
       }
 
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1,
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex,
                                                     (isUnresolved ? _numUnresolvedSymbols++ : 0), knownObjectIndex);
 
    if (isUnresolved)
@@ -566,7 +566,7 @@ J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::Re
    void *entryLocation = owningMethod->varHandleMethodTypeTableEntryAddress(cpIndex);
    for (symRef = i.getNext(); symRef; symRef = i.getNext())
       if (  owningMethodSymbol->getResolvedMethodIndex() == symRef->getOwningMethodIndex()
-         && symRef->getSymbol()->castToStaticSymbol()->getStaticAddress() == entryLocation)
+         && symRef->getCPIndex() == cpIndex)
          {
          return symRef;
          }
@@ -574,7 +574,7 @@ J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::Re
    TR::StaticSymbol *sym = TR::StaticSymbol::createMethodTypeTableEntry(trHeapMemory(),cpIndex);
    sym->setStaticAddress(entryLocation);
    bool isUnresolved = owningMethod->isUnresolvedVarHandleMethodTypeTableEntry(cpIndex);
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1,
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex,
                                                        isUnresolved ? _numUnresolvedSymbols++ : 0);
    if (isUnresolved)
       {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7002,9 +7002,11 @@ TR::CompilationInfoPerThreadBase::isMethodIneligibleForAot(J9Method *method)
    const J9ROMClass *romClass = J9_CLASS_FROM_METHOD(method)->romClass;
    J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
+#if !defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    // Don't AOT-compile anything in j/l/i for now
    if (strncmp(utf8Data(className), "java/lang/invoke/", sizeof("java/lang/invoke/") - 1) == 0)
       return true;
+#endif
 
    if (J9UTF8_LENGTH(className) == 36 &&
       0 == memcmp(utf8Data(className), "com/ibm/rmi/io/FastPathForCollocated", 36))

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2196,6 +2196,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotBlockFrequencyReloFailure:
             case compilationAotRecompQueuedFlagReloFailure:
             case compilationAOTValidateOSRFailure:
+            case compilationFailedToAcquireVMINLMethod:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
@@ -11283,6 +11284,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTRelocationRecordGenerationFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationAOTRelocationRecordGenerationFailure;
+      }
+   catch (const J9::VMINLMethodFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationFailedToAcquireVMINLMethod;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -212,8 +212,9 @@ char *compilationErrorNames[]={
    "compilationAotBlockFrequencyReloFailure", //58
    "compilationAotRecompQueuedFlagReloFailure", //59
    "compilationAOTValidateOSRFailure", //60
+   "compilationFailedToAcquireVMINLMethod", //61
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //compilationFirstJITServerFailure=61
+   "compilationStreamFailure", //compilationFirstJITServerFailure=62
    "compilationStreamLostMessage", // compilationFirstJITServerFailure+1
    "compilationStreamMessageTypeMismatch", //compilationFirstJITServerFailure+2
    "compilationStreamVersionIncompatible", //compilationFirstJITServerFailure+3

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -84,6 +84,7 @@ typedef enum {
    compilationAotBlockFrequencyReloFailure         = 58,
    compilationAotRecompQueuedFlagReloFailure       = 59,
    compilationAOTValidateOSRFailure                = 60,
+   compilationFailedToAcquireVMINLMethod           = 61,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1634,6 +1634,30 @@ TR_ResolvedRelocatableJ9Method::isUnresolvedString(I_32 cpIndex, bool optimizeFo
    }
 
 void *
+TR_ResolvedRelocatableJ9Method::getConstantDynamicTypeFromCP(int32_t cpIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isConstantDynamic(int32_t cpIndex)
+   {
+   return TR_ResolvedJ9Method::isConstantDynamic(cpIndex);
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isUnresolvedConstantDynamic(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9Method::dynamicConstant(int32_t cpIndex, uintptr_t *obj)
+   {
+   return NULL;
+   }
+
+void *
 TR_ResolvedRelocatableJ9Method::methodTypeConstant(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
@@ -1659,6 +1683,42 @@ TR_ResolvedRelocatableJ9Method::isUnresolvedMethodHandle(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return true;
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9Method::callSiteTableEntryAddress(int32_t callSiteIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9Method::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
+   {
+   return NULL;
    }
 
 TR_ResolvedMethod *

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1467,13 +1467,8 @@ bool
 TR_ResolvedRelocatableJ9Method::isInterpreted()
    {
    bool alwaysTreatAsInterpreted = true;
-#if defined(TR_TARGET_S390)
-   TR::Compilation *comp = TR::comp();
-   if (comp && comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager))
-      alwaysTreatAsInterpreted = true;
-   else
-      alwaysTreatAsInterpreted = false;
-#elif defined(TR_TARGET_X86)
+
+#if defined(TR_TARGET_X86)
 
    /*if isInterpreted should be only overridden for JNI methods.
    Otherwise buildDirectCall in X86PrivateLinkage.cpp will generate CALL 0

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -588,10 +588,23 @@ public:
 
    virtual void *                  stringConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false);
+
+   virtual void *                  getConstantDynamicTypeFromCP(int32_t cpIndex);
+   virtual bool                    isConstantDynamic(int32_t cpIndex);
+   virtual bool                    isUnresolvedConstantDynamic(int32_t cpIndex);
+   virtual void *                  dynamicConstant(int32_t cpIndex, uintptr_t *obj);
+
    virtual void *                  methodTypeConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedMethodType(int32_t cpIndex);
    virtual void *                  methodHandleConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedMethodHandle(int32_t cpIndex);
+
+   virtual bool                    isUnresolvedCallSiteTableEntry(int32_t callSiteIndex);
+   virtual void *                  callSiteTableEntryAddress(int32_t callSiteIndex);
+   virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
+   virtual void *                  methodTypeTableEntryAddress(int32_t cpIndex);
+   virtual bool                    isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
+   virtual void *                  varHandleMethodTypeTableEntryAddress(int32_t cpIndex);
 
    virtual bool                    fieldAttributes ( TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2454,6 +2454,30 @@ TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool o
    }
 
 void *
+TR_ResolvedRelocatableJ9JITServerMethod::getConstantDynamicTypeFromCP(int32_t cpIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9JITServerMethod::isConstantDynamic(int32_t cpIndex)
+   {
+   return TR_ResolvedJ9JITServerMethod::isConstantDynamic(cpIndex);
+   }
+
+bool
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedConstantDynamic(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9JITServerMethod::dynamicConstant(int32_t cpIndex, uintptr_t *obj)
+   {
+   return NULL;
+   }
+
+void *
 TR_ResolvedRelocatableJ9JITServerMethod::methodTypeConstant(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
@@ -2479,6 +2503,42 @@ TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedMethodHandle(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return true;
+   }
+
+bool
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9JITServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9JITServerMethod::methodTypeTableEntryAddress(int32_t cpIndex)
+   {
+   return NULL;
+   }
+
+bool
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
+   {
+   return true;
+   }
+
+void *
+TR_ResolvedRelocatableJ9JITServerMethod::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
+   {
+   return NULL;
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -296,10 +296,24 @@ class TR_ResolvedRelocatableJ9JITServerMethod : public TR_ResolvedJ9JITServerMet
    virtual bool                  validateClassFromConstantPool(TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateClass) override;
    virtual bool                  validateArbitraryClass(TR::Compilation *comp, J9Class *clazz) override;
    virtual bool                  isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false) override;
+
+   virtual void *                getConstantDynamicTypeFromCP(int32_t cpIndex) override;
+   virtual bool                  isConstantDynamic(int32_t cpIndex) override;
+   virtual bool                  isUnresolvedConstantDynamic(int32_t cpIndex) override;
+   virtual void *                dynamicConstant(int32_t cpIndex, uintptr_t *obj) override;
+
    virtual void *                methodTypeConstant(int32_t cpIndex) override;
    virtual bool                  isUnresolvedMethodType(int32_t cpIndex) override;
    virtual void *                methodHandleConstant(int32_t cpIndex) override;
    virtual bool                  isUnresolvedMethodHandle(int32_t cpIndex) override;
+
+   virtual bool                  isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) override;
+   virtual void *                callSiteTableEntryAddress(int32_t callSiteIndex) override;
+   virtual bool                  isUnresolvedMethodTypeTableEntry(int32_t cpIndex) override;
+   virtual void *                methodTypeTableEntryAddress(int32_t cpIndex) override;
+   virtual bool                  isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex) override;
+   virtual void *                varHandleMethodTypeTableEntryAddress(int32_t cpIndex) override;
+
    virtual TR_OpaqueClassBlock * classOfStatic(int32_t cpIndex, bool returnClassForAOT = false) override;
    virtual TR_ResolvedMethod *   getResolvedPossiblyPrivateVirtualMethod(TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP) override;
    virtual bool                  getUnresolvedFieldInCP(I_32 cpIndex) override;

--- a/runtime/compiler/exceptions/RuntimeFailure.hpp
+++ b/runtime/compiler/exceptions/RuntimeFailure.hpp
@@ -79,6 +79,11 @@ class EnforceProfiling : public virtual TR::InsufficientlyAggressiveCompilation
    {
    virtual const char* what() const throw() { return "Enforce Profiling"; }
    };
+
+class VMINLMethodFailure : public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "LinkTo Method Failure"; }
+   };
 }
 
 #endif // RUNTIME_FAILURE

--- a/runtime/compiler/exceptions/RuntimeFailure.hpp
+++ b/runtime/compiler/exceptions/RuntimeFailure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3310,11 +3310,6 @@ static char *suffixedName(char *baseName, char typeSuffix, char *buf, int32_t bu
 void
 TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    {
-   if (comp()->compileRelocatableCode())
-      {
-      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
-      }
-
    if (comp()->getOption(TR_FullSpeedDebug) && !isPeekingMethod())
       comp()->failCompilation<J9::FSDHasInvokeHandle>("FSD_HAS_INVOKEHANDLE 0");
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
@@ -3359,6 +3354,11 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
 
 #else
 
+   if (comp()->compileRelocatableCode())
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
+      }
+
    TR::SymbolReference *symRef = symRefTab()->findOrCreateDynamicMethodSymbol(_methodSymbol, callSiteIndex);
 
    // Compute the receiver handle
@@ -3391,11 +3391,6 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
 TR::Node *
 TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    {
-   if (comp()->compileRelocatableCode())
-      {
-      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 1");
-      }
-
    if (comp()->getOption(TR_FullSpeedDebug) && !isPeekingMethod())
       comp()->failCompilation<J9::FSDHasInvokeHandle>("FSD_HAS_INVOKEHANDLE 1");
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
@@ -3440,6 +3435,11 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    TR::Node* callNode = genInvokeDirect(targetMethodSymRef);
 
 #else
+
+   if (comp()->compileRelocatableCode())
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 1");
+      }
 
    TR::SymbolReference * invokeExactSymRef = symRefTab()->findOrCreateHandleMethodSymbol(_methodSymbol, cpIndex);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 24;
+   static const uint16_t MINOR_NUMBER = 25;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -170,6 +170,11 @@ struct TR_RelocationRecordBreakpointGuardPrivateData
    uint8_t *_destinationAddress;
    };
 
+struct TR_RelocationRecordVMINLMethodPrivateData
+   {
+   TR_OpaqueMethodBlock *_vminlMethod;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -188,6 +193,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordBlockFrequencyPrivateData blockFrequency;
    TR_RelocationRecordRecompQueuedFlagPrivateData recompQueuedFlag;
    TR_RelocationRecordBreakpointGuardPrivateData breakpointGuard;
+   TR_RelocationRecordVMINLMethodPrivateData vminlMethod;
    };
 
 enum TR_RelocationRecordAction
@@ -1865,6 +1871,26 @@ class TR_RelocationRecordBreakpointGuard : public TR_RelocationRecordWithInlined
 
       void setDestinationAddress(TR_RelocationTarget *reloTarget, uintptr_t destinationAddress);
       uintptr_t destinationAddress(TR_RelocationTarget *reloTarget);
+   };
+
+class TR_RelocationRecordVMINLMethod : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordVMINLMethod() {}
+      TR_RelocationRecordVMINLMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
+         : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name() { return "TR_RelocationRecordVMINLMethod"; }
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      void setRomClassOffsetInSCC(TR_RelocationTarget *reloTarget, uintptr_t romClassOffsetInSCC);
+      uintptr_t romClassOffsetInSCC(TR_RelocationTarget *reloTarget);
+
+      void setRomMethodOffsetInSCC(TR_RelocationTarget *reloTarget, uintptr_t romMethodOffsetInSCC);
+      uintptr_t romMethodOffsetInSCC(TR_RelocationTarget *reloTarget);
    };
 
 #endif   // RELOCATION_RECORD_INCL

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -813,9 +813,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
          }
       }
 
-   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      forceUnresolvedDispatch = false;
+   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch() && !comp->genRelocatableResolvedDispatchSnippet(methodSymbol);
 
    if (methodSymRef->isUnresolved() || forceUnresolvedDispatch)
       {
@@ -981,6 +979,14 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
                                                                                           (uint8_t *)ramMethod,
                                                                                           (uint8_t *)TR::SymbolType::typeMethod,
                                                                                           TR_SymbolFromManager,
+                                                                                          cg()),
+                                        __FILE__, __LINE__, getNode());
+            }
+         else if (comp->compileRelocatableCode() && methodSymbol->isVMInternalNative())
+            {
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                          (uint8_t *)ramMethod,
+                                                                                          TR_VMINLMethod,
                                                                                           cg()),
                                         __FILE__, __LINE__, getNode());
             }

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -2399,7 +2399,7 @@ J9::Z::PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference 
       TR::LabelSymbol * label = generateLabelSymbol(cg());
       TR::Snippet * snippet;
 
-      if (callSymRef->isUnresolved() || (comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager)))
+      if (callSymRef->isUnresolved() || (comp()->compileRelocatableCode() && !comp()->genRelocatableResolvedDispatchSnippet(callSymbol)))
          {
          snippet = new (trHeapMemory()) TR::S390UnresolvedCallSnippet(cg(), callNode, label, argSize);
          }


### PR DESCRIPTION
This commit adds initial AOT support for the OpenJDK Method Handles implementation. The overview is:

- Pretend other methods are interpreted (to ensure we gen an interpreter dispatch snippet)
- Add ability to relocate VMINL Methods
- Generate resolved interpreter dispatch snippet for VMINL Methods
- Update symref sharing of MH related symrefs to use the cpIndex/callSiteIndex rather than the static address of the symbol (https://github.com/eclipse/openj9/issues/12427)
- Enable compilation of `java/lang/invoke` methods

We pretend invokeDynamic and invokeHandle dispatches are unresolved; this results in the compiler generating a resolved dispatch to `java/lang/invoke/MethodHandle.linkToStatic` which is a VMINL method.

It is worth noting that this only adds support for JDK16. There needs to be an additional change to support JDK11.