### PR TITLE
Store number of arguments in vmThread.floatTemp1 for linkToStatic

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -785,18 +785,16 @@ J9::CodeGenerator::lowerTreeIfNeeded(
          // Furthermore, for unresolved invokedynamic and invokehandle bytecodes, we create a call to linkToStatic.
          // The appendix object in the invoke cache array entry could be NULL, which we cannot determine at compile
          // time when the callSite/invokeCache table entries are unresolved. The VM would have to remove the appendix
-         // object, which would require knowing the number of args of the method. To pass that information, we store to
+         // object, which would require knowing the number of args of the ROM method. To pass that information, we store to
          // vmThread.floatTemp1 field. The name of the field is misleading, as it is an lconst/iconst being stored. This
          // is also done for linkToSpecial, as it shares the same bytecode handler as linkToStatic.
-         int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
-         int32_t numArgs = node->getNumArguments();
          TR::Node * numArgsNode = NULL;
          TR::Node * numArgSlotsNode = NULL;
          TR::Node * tempSlotStoreNode = NULL;
          TR::Node * floatTemp1StoreNode = NULL;
          bool is64Bit = self()->comp()->target().is64Bit();
          TR::ILOpCodes storeOpCode;
-
+         int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
          if (is64Bit)
             {
             storeOpCode = TR::lstore;
@@ -815,6 +813,35 @@ J9::CodeGenerator::lowerTreeIfNeeded(
 
          if (rm == TR::java_lang_invoke_MethodHandle_linkToStatic || rm ==  TR::java_lang_invoke_MethodHandle_linkToSpecial)
             {
+            // The last child of the call node is the iload for the memberName object, from which we can obtain the callSite index or cpIndex.
+            TR::Node * invokeCacheArrayShadowNode = node->getLastChild();
+
+            // in compressed pointers mode, the compressed refs anchors are transformed right before codegen, for which we
+            // need to go a few levels down to reach the invoke cache array shadow node.
+            //
+            // n28n      compressedRefs
+            // n26n        l2a
+            // n49n          lshl (compressionSequence )
+            // n48n            iu2l
+            // n47n              iloadi  <array-shadow>[#229  Shadow] [flags 0x80000607 0x0 ]
+            // n25n                aladd (X>=0 internalPtr sharedMemory )
+            // n5n                   ==>aload
+            // n24n                  lconst 16 (highWordZero X!=0 X>=0 )
+            // n46n            iconst 3
+            // n15n        ==>lconst 0
+            //
+            if (self()->comp()->useCompressedPointers())
+               invokeCacheArrayShadowNode = invokeCacheArrayShadowNode->getFirstChild()->getFirstChild()->getFirstChild();
+
+            // finally, we can obtain the base address of the invoke cache array
+            TR::Node * sideTableEntryNode = invokeCacheArrayShadowNode->getFirstChild()->getFirstChild();
+            TR::StaticSymbol * sideTableEntrySymbol = sideTableEntryNode->getSymbolReference()->getSymbol()->castToStaticSymbol();
+            int32_t numArgs;
+            if(sideTableEntrySymbol->isCallSiteTableEntry())
+               numArgs = self()->comp()->getCurrentMethod()->romMethodArgCountAtCallSiteIndex(sideTableEntrySymbol->castToCallSiteTableEntrySymbol()->getCallSiteIndex());
+            else
+               numArgs = self()->comp()->getCurrentMethod()->romMethodArgCountAtCPIndex(sideTableEntrySymbol->castToMethodTypeTableEntrySymbol()->getMethodTypeIndex());
+
             numArgsNode = is64Bit ? TR::Node::lconst(node, numArgs) :
                                     TR::Node::iconst(node, numArgs);
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2395,6 +2395,21 @@ J9::SymbolReferenceTable::findOrCreateVMThreadTempSlotFieldSymbolRef()
    }
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateVMThreadFloatTemp1SymbolRef()
+   {
+   if (!element(j9VMThreadFloatTemp1Symbol))
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+      TR::Symbol * sym = TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(), "j9VMThreadFloatTemp1");
+      sym->setDataType(TR::Address);
+      element(j9VMThreadFloatTemp1Symbol) = new (trHeapMemory()) TR::SymbolReference(self(), j9VMThreadFloatTemp1Symbol, sym);
+      element(j9VMThreadFloatTemp1Symbol)->setOffset(fej9->thisThreadGetFloatTemp1Offset());
+      aliasBuilder.addressStaticSymRefs().set(getNonhelperIndex(j9VMThreadFloatTemp1Symbol));
+      }
+   return element(j9VMThreadFloatTemp1Symbol);
+   }
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateProfilingBufferSymbolRef(intptr_t offset)
    {
    if (!element(profilingBufferSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -85,6 +85,14 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     */
    TR::SymbolReference * findOrCreateVMThreadTempSlotFieldSymbolRef();
 
+   /** \brief
+    * Find or create VMThread.floatTemp1 symbol reference. J9VMThread.floatTemp1 provides an additional
+    * mechanism for the compiler to provide information that the VM can use for various reasons
+    *
+    * \return TR::SymbolReference* the VMThread.floatTemp1 symbol reference
+    */
+   TR::SymbolReference * findOrCreateVMThreadFloatTemp1SymbolRef();
+
    // CG linkage
    TR::SymbolReference * findOrCreateAcquireVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework
    TR::SymbolReference * findOrCreateReleaseVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5086,6 +5086,35 @@ TR_ResolvedJ9Method::isJITInternalNative()
    return isNative() && !isJNINative() && !isInterpreted();
    }
 
+uint32_t
+TR_ResolvedJ9Method::romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex)
+   {
+   J9ROMClass *romClass = romClassPtr();
+   J9SRP                 *namesAndSigs = (J9SRP*)J9ROMCLASS_CALLSITEDATA(romClass);
+   J9ROMNameAndSignature *nameAndSig   = NNSRP_GET(namesAndSigs[callSiteIndex], J9ROMNameAndSignature*);
+   J9UTF8                *signature    = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
+
+   U_8 paramBuffer[256];
+   uintptr_t    paramElements;
+   uintptr_t    paramSlots;
+   jitParseSignature(signature, paramBuffer, &paramElements, &paramSlots);
+   return paramElements;
+   }
+
+uint32_t
+TR_ResolvedJ9Method::romMethodArgCountAtCPIndex(int32_t cpIndex)
+   {
+   J9ROMMethodRef *romMethodRef = (J9ROMMethodRef *)(cp()->romConstantPool + cpIndex);
+   J9ROMNameAndSignature *nameAndSig = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
+   J9UTF8                *signature    = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
+
+   U_8 paramBuffer[256];
+   uintptr_t    paramElements;
+   uintptr_t    paramSlots;
+   jitParseSignature(signature, paramBuffer, &paramElements, &paramSlots);
+   return paramElements;
+   }
+
 bool
 TR_J9MethodBase::isUnsafeCAS(TR::Compilation * c)
    {

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -526,6 +526,21 @@ public:
     */
    virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
+   /**
+    * @brief Gets the number of arguments in the ROM method signature
+    *
+    * @param callSiteIndex the call site index of the ROM method
+    * @return uint32_t the number of arguments
+    */
+   virtual uint32_t romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex);
+   /**
+    * @brief Gets the number of arguments in the ROM method signature
+    *
+    * @param cpIndex the cpIndex to lookup the ROM method
+    * @return uint32_t the number of arguments
+    */
+   virtual uint32_t romMethodArgCountAtCPIndex(int32_t cpIndex);
+
 protected:
    virtual TR_J9MethodBase *       asJ9Method(){ return this; }
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4849,6 +4849,24 @@ typedef struct J9VMThread {
 #if 1 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 paddingToAlignFloatTemp;
 #endif
+	/**
+	 * floatTemp1 is an overloaded field used for multiple purposes.
+	 *
+	 * Note: Listed below is one such use, and the other uses of this field still need to be
+	 * documented.
+	 *
+	 * 1. OpenJDK MethodHandle implementation
+	 *		For signature-polymorphic INL calls from compiled code for the following methods:
+	 *		* java/lang/invoke/MethodHandle.linkToStatic
+	 *		* java/lang/invoke/MethodHandle.linkToSpecial
+	 *		the compiled code performs a store to this field right before the INL call. The
+	 *		stored value represents the number of args for the unresolved invokedynamic/invokehandle
+	 *		call. This is required because linkToStatic calls are generated for unresolved
+	 *		invokedynamic/invokehandle, where the JIT cannot determine whether the appendix object of
+	 *		the callSite/invokeCache table entry is valid. As a result, the JIT code may push NULL
+	 *		appendix objects on the stack which the interpreter must remove. To determine that, the
+	 *		interpreter would need to know the number of arguments of method.
+	 */
 	void* floatTemp1;
 	void* floatTemp2;
 	void* floatTemp3;


### PR DESCRIPTION
This changeset includes the following:
 * Add functionality to lookup/create j9VMThreadFloatTemp1Symbol
 * Insert trees to store num args to VMThread.floatTemp1 for
   linkToStatic/Special
 * Document this added use case of the floatTemp1 field

Depends: eclipse/omr#5961 (merged), eclipse/omr#5997 (merged)
Related: #12522

In draft state until OMR changes are merged.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>