### PR TITLE
Avoid potential crash when converting pointers to SCC offsets

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -260,8 +260,8 @@ TR::SymbolValidationManager::populateWellKnownClasses()
 
       includedClasses |= 1 << i;
       _wellKnownClasses.push_back(wkClass);
-      *nextClassChainOffset++ =
-         (uintptr_t)_fej9->sharedCache()->offsetInSharedCacheFromPointer(chain);
+      if (!_fej9->sharedCache()->isPointerInSharedCache(chain, nextClassChainOffset++))
+         SVM_ASSERT_NONFATAL(false, "Failed to get SCC offset for well-known class %s chain %p", name, chain);
       }
 
    *classCount = _wellKnownClasses.size();


### PR DESCRIPTION
Using `TR_J9SharedCache::offsetInSharedCacheFromPointer()` in `TR::SymbolValidationManager::populateWellKnownClasses()` to convert class chain pointers returned by rememberClass() to SCC offsets can trigger a fatal assertion due to the following race condition. When Thread 1 stores a class chain, Thread 2 can look it up before Thread 1 updates the SCC area bounds in the SCC header, and converting the pointer to offset in Thread 2 fails with a fatal assertion. See discussion in #12405.

This PR is a workaround to avoid the fatal assertion by calling `TR_J9SharedCache::isPointerInSharedCache()` which checks if the pointer is in the SCC according to the current area bounds without a fatal assertion, and failing the compilation if this call does not succeed.