### PR TITLE
Update ClassLoader_defineClassImpl1 + Redo InjectedInvoker Support

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -170,8 +170,12 @@ public class MethodHandles {
 		private static final String INVOKE = "invoke"; //$NON-NLS-1$
 		
 		/*[IF JAVA_SPEC_VERSION >= 15]*/
-		private static final int CLASSOPTION_FLAG_NESTMATE = 1;
-		private static final int CLASSOPTION_FLAG_STRONG = 2;
+		/* Should match OJDK's j.l.i.MethodHandleNatives.Constants.NESTMATE_CLASS (0x1). */
+		private static final int CLASSOPTION_FLAG_NESTMATE = 0x1;
+		/* Should match OJDK's j.l.i.MethodHandleNatives.Constants.HIDDEN_CLASS (0x2). */
+		private static final int CLASSOPTION_FLAG_HIDDEN = 0x2;
+		/* Should match OJDK's j.l.i.MethodHandleNatives.Constants.STRONG_LOADER_LINK (0x4). */
+		private static final int CLASSOPTION_FLAG_STRONG = 0x4;
 		/*[ENDIF] JAVA_SPEC_VERSION >= 15*/
 
 		static final int VARARGS = 0x80;
@@ -2438,12 +2442,12 @@ public class MethodHandles {
 		}
 
 		ClassDefiner makeHiddenClassDefiner(String name, byte[] template) {
-			ClassDefiner definer = new ClassDefiner(name, template, this);
+			ClassDefiner definer = new ClassDefiner(name, template, this, CLASSOPTION_FLAG_HIDDEN);
 			return definer;
 		}
 		
 		ClassDefiner makeHiddenClassDefiner(String name, byte[] template, int flag) {
-			ClassDefiner definer = new ClassDefiner(name, template, this, flag);
+			ClassDefiner definer = new ClassDefiner(name, template, this, flag | CLASSOPTION_FLAG_HIDDEN);
 			return definer;
 		}
 		

--- a/runtime/bcutil/ROMClassBuilder.hpp
+++ b/runtime/bcutil/ROMClassBuilder.hpp
@@ -130,7 +130,7 @@ private:
 	InterfaceInjectionInfo _interfaceInjectionInfo;
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
-	BuildResult handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda, U_8* hostPackageName, UDATA hostPackageLength);
+	BuildResult handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda, ROMClassCreationContext *context);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	BuildResult injectInterfaces(ClassFileOracle *classFileOracle);
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -402,7 +402,6 @@ public:
 				U_16 classNameLenToCompare0 = (U_16)_classNameLength;
 				U_16 classNameLenToCompare1 = classNameLength;
 				BOOLEAN misMatch = FALSE;
-				BOOLEAN isInjectedInvoker = FALSE;
 				if (isClassHidden()) {
 					if (isROMClassShareable()) {
 						U_8* lambdaClass0 = (U_8*)getLastDollarSignOfLambdaClassName((const char*)_className, _classNameLength);
@@ -426,33 +425,9 @@ public:
 						/* for hidden class className has ROM address appended at the end, _className does not have that */
 						classNameLenToCompare1 = (U_16)_classNameLength;
 					}
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-#define J9_INJECTED_INVOKER_CLASSNAME_BYTECODE "InjectedInvoker/0x0"
-#define J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS "$$InjectedInvoker"
-					if (0 == memcmp(
-							className, J9_INJECTED_INVOKER_CLASSNAME_BYTECODE,
-							LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_BYTECODE))
-					) {
-						/* className has InjectedInvoker/0x0000000000000000. */
-						U_8 *start = _className + _classNameLength
-								- LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS);
-						if (0 == memcmp(
-								start, J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS,
-								LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS))
-						) {
-#undef J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS
-#undef J9_INJECTED_INVOKER_CLASSNAME_BYTECODE
-							/* _className has $$InjectedInvoker at the end. */
-							isInjectedInvoker = TRUE;
-						} else {
-							misMatch = TRUE;
-						}
-					}
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 				}
-				if (!isInjectedInvoker
-					&& (misMatch
-						|| (!J9UTF8_DATA_EQUALS(_className, classNameLenToCompare0, className, classNameLenToCompare1)))
+				if (misMatch
+				|| !J9UTF8_DATA_EQUALS(_className, classNameLenToCompare0, className, classNameLenToCompare1)
 				) {
 #define J9WRONGNAME " (wrong name: "
 					PORT_ACCESS_FROM_PORT(_portLibrary);


### PR DESCRIPTION
### Commit 1: Update `ClassLoader_defineClassImpl1` to work with OJDK `ClassDefiner`

In OJDK, `MethodHandles.Lookup.ClassDefiner` is used by
- `Lookup.defineClass` (normal/non-hidden classes)
- `Lookup.defineHiddenClass`
- `Lookup.defineHiddenClassWithClassData`

In OJDK, `ClassDefiner` can define both normal and hidden classes.

In OJ9, `ClassDefiner` is only used by
- `Lookup.defineHiddenClass`
- `Lookup.defineHiddenClassWithClassData`

In OJ9, ClassDefiner is only used to define hidden classes.

`ClassDefiner` invokes `ClassLoader_defineClassImpl1` (native function).

Currently, `ClassLoader_defineClassImpl1` only defines hidden classes. It is
updated to define both hidden and normal classes. This will allow us to
support both OJ9 and OJDK verions of `Lookup`.

Without this fix, all classes created by OJDK's `Lookup.defineClass` will be
hidden classes.

### Commit 2: Redo `InjectedInvoker` Support

This commit reverts the changes in eclipse-openj9#12303.

`InjectedInvoker` is a hidden and inner class.

`InjectedInvoker` bytecodes have class name set to `"InjectedInvoker"`. The
`HOST_CLASS` name is missing in the `InjectedInvoker` bytecodes.

The hidden class name for `InjectedInvoker` includes the `HOST_CLASS` name.

`InjectedInvoker` bytecodes are created by OpenJDK code in
`MethodHandleImpl.generateInvokerTemplate`. OpenJ9 does not have control on
`InjectedInvoker` bytecodes.

`ROMClassBuilder::handleAnonClassName` malfunctions because the class name in
`InjectedInvoker` bytecodes does not include the `HOST_CLASS` name.

In `handleAnonClassName`, `InjectedInvoker` ROM class name is set using the hidden
class name, which includes the `HOST_CLASS` name, instead of only using the class
name from the bytecodes.

Correcting the `InjectedInvoker` ROM class name fixes the class name mismatch in
`ROMClassCreationContext::checkClassName` (eclipse-openj9#11926).

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>