### PR TITLE
Fix object field copying issue on valueType

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -316,7 +316,11 @@ static const struct { \
 #define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) J9_VALUETYPE_FLATTENED_SIZE(clazz)
 #define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueType)
 #define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
-/* Disable flattening of volatile field that is > 8 bytes for now, as the current implementation of copyObjectFields() will tear this field. */  
+/**
+ * Disable flattening of volatile field that is > 8 bytes for now, as the current implementation of copyObjectFields() will tear this field.
+ * Check J9AccVolatile for now. A new way other that "volatile" will likely to be introduced to indicate a non-tearable VT class,
+ * probably a marker interface java.lang.NonTearable.
+ */
 #define J9_IS_FIELD_FLATTENED(fieldClazz, romFieldShape) \
 	(J9_IS_J9CLASS_FLATTENED(fieldClazz) && \
 	(J9_ARE_NO_BITS_SET((romFieldShape)->modifiers, J9AccVolatile) || (J9CLASS_UNPADDED_INSTANCE_SIZE(fieldClazz) <= sizeof(U_64))))

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3148,7 +3148,14 @@ fail:
 				ramArrayClass->module = leafComponentType->module;
 
 				if (J9_IS_J9CLASS_FLATTENED(ramArrayClass)) {
-					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
+					bool forceDoubleAlignment = false;
+					if (sizeof(U_64) == referenceSize) {
+						/* copyObjectFields() uses U_64 load/store. Put all nested fields at 8-byte aligned address. */
+						forceDoubleAlignment = true;
+					}
+					if (forceDoubleAlignment
+						|| J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)
+					) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
 					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), referenceSize));

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -1106,8 +1106,22 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 								}
 							} else {
 								U_32 size = fieldClass->totalInstanceSize;
+								bool forceDoubleAlignment = false;
+								if (sizeof(U_32) == referenceSize) {
+									/** 
+									 * Flattened volatile valueType that is 8 bytes should be put at 8-byte aligned address. Currently flattening is disabled for volatile valueType > 8 bytes. 
+									 * Check J9AccVolatile for now. A new way other that "volatile" will likely to be introduced to indicate a non-tearable VT class, 
+									 * probably a marker interface java.lang.NonTearable.
+									 */
+									forceDoubleAlignment = J9_ARE_ALL_BITS_SET(field->modifiers, J9AccVolatile) && (sizeof(U_64) == J9CLASS_UNPADDED_INSTANCE_SIZE(fieldClass));
+								} else {
+									/* copyObjectFields() uses U_64 load/store. Put all nested fields at 8-byte aligned address. */
+									forceDoubleAlignment = true;
+								}
 								state->result.flattenedClass = fieldClass;
-								if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
+								if (forceDoubleAlignment
+									|| J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintDouble)
+								) {
 									if (J9CLASS_HAS_4BYTE_PREPADDING(fieldClass)) {
 										size -= sizeof(U_32);
 									}

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -31,6 +31,9 @@
 			<!-- Use -XX:-EnableArrayFlattening. testDefaultValueInTriangleArray asserts the fields of each element are not NULL, 
 					which is not true as a FlatteningThreshold is set. -->
 			<variation>-Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=12 -XX:-EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:gencon</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1466,6 +1466,8 @@ public class ValueTypeTests {
 	 * Create a valueType with four valueType members including 2 volatile.  
 	 * 
 	 * value valueWithVolatile {
+	 *  flattened ValueInt i;
+	 *  flattened ValueInt i2;
 	 *  flattened Point2D point;   <--- 8 bytes, will be flattened.
 	 *  volatile Point2D vpoint;   <--- volatile 8 bytes, will be flattened.
 	 *  flattened Line2D 1ine;     <--- 16 bytes, will be flattened.
@@ -1474,9 +1476,10 @@ public class ValueTypeTests {
 	 */
 	@Test(priority=3)
 	static public Object createValueTypeWithVolatileFields() throws Throwable {
-		String fields[] = {"point:QPoint2D;:value", "vpoint:QPoint2D;:volatile", "line:QFlattenedLine2D;:value", "vline:QFlattenedLine2D;:volatile"};
+		String fields[] = {"i:QValueInt;:value", "i2:QValueInt;:value", "point:QPoint2D;:value", "vpoint:QPoint2D;:volatile", "line:QFlattenedLine2D;:value", "vline:QFlattenedLine2D;:volatile"};
 		Class ValueTypeWithVolatileFieldsClass = ValueTypeGenerator.generateValueClass("ValueTypeWithVolatileFields", fields);
-		MethodHandle valueWithVolatile = lookup.findStatic(ValueTypeWithVolatileFieldsClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		MethodHandle valueWithVolatile = lookup.findStatic(ValueTypeWithVolatileFieldsClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class, 
+				Object.class, Object.class, Object.class));
 		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(ValueTypeWithVolatileFieldsClass, fields);
 		Object valueWithVolatileObj = createAssorted(valueWithVolatile, fields);
 		checkFieldAccessMHOfAssortedType(getterAndWither, valueWithVolatileObj, fields, true);

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -26,6 +26,7 @@
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
 	<variable name="ARGS" value="-Xint -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="ARGS_NOCR" value="-Xint -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$:$JCOMMANDERJAR$:$TESTNGJAR$:$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />
@@ -157,9 +158,9 @@
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="no" type="required" showMatch="yes"> point (offset = 4) (Point2D)</output>
-		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 12) (Point2D)</output>
-		<output regex="no" type="required" showMatch="yes"> line (offset = 20) (FlattenedLine2D)</output>
+		<output regex="no" type="required" showMatch="yes"> point (offset = 20) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 4) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> line (offset = 28) (FlattenedLine2D)</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 0\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
@@ -171,8 +172,8 @@
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 12\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 20\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
 		<saveoutput regex="no" type="required" saveName="vlineAddr" splitIndex="1" splitBy="!fj9object " showMatch="yes">= !fj9object 0x</saveoutput>
@@ -190,4 +191,70 @@
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
+	
+	<test id="Create nocompressedrefs core file">
+		<command showMatch="yes">$EXE$ -Xmx24m $ARGS_NOCR$ $JARS$ $PROGRAM$</command>
+		<output regex="no" type="success" showMatch="yes">System dump written</output>
+		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
+		<output regex="no" type="failure">Exception caught!</output>
+	</test>
+	
+	<test id="Run !threads on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!threads</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!stack 0x</output>
+		<saveoutput regex="no" type="required" saveName="mainThreadId" splitIndex="1" splitBy="!stack ">!stack 0x</saveoutput>
+		<output regex="no" type="failure">DDR is not enabled for this core file</output>
+ 	</test>
+
+	<test id="Run !stackslots $mainThreadId$ on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!stackslots $mainThreadId$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+	
+	<test id="Run !j9object $objectAddr$ to display container array contents on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $objectAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+	
+	<test id="Run !j9object $valueAddr1$ to show the fields are all at 8 bytes aligned offsets on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 0)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 8)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 16)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 24)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 32)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 48)</output>
+
+		<output regex="no" type="failure">(offset = 4)</output>
+		<output regex="no" type="failure">(offset = 12)</output>
+		<output regex="no" type="failure">(offset = 20)</output>
+		<output regex="no" type="failure">(offset = 28)</output>
+		<output regex="no" type="failure">(offset = 36)</output>
+		<output regex="no" type="failure">(offset = 44)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
 </suite>


### PR DESCRIPTION
1. On 64-bit reference mode, ensure double alignment on all nested
fields.
2. On 32-bit reference mode, ensure double alignment on 8-byte volatile 
fields. copyObjectFields() will do 8-byte copy when possible.

closes #11178

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>