### PR TITLE
Initialize class fields in constructor

### DIFF
--- a/runtime/gc_structs/MixedObjectIterator.hpp
+++ b/runtime/gc_structs/MixedObjectIterator.hpp
@@ -234,7 +234,7 @@ public:
 	/**
 	 * @param vm[in] pointer to the JVM
 	 */
-	GC_MixedObjectIterator (OMR_VM *omrVM)
+	GC_MixedObjectIterator(OMR_VM *omrVM)
 		: _slotObject(GC_SlotObject(omrVM, NULL))
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
@@ -251,20 +251,11 @@ public:
 	 * @param vm[in] pointer to the JVM
 	 * @param objectPtr[in] the object to be processed
 	 */
-	GC_MixedObjectIterator (OMR_VM *omrVM, J9Object *objectPtr)
-		: _slotObject(GC_SlotObject(omrVM, NULL))
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
-		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
-		, _objectPtr(NULL)
-		, _scanPtr(NULL)
-		, _endPtr(NULL)
-		, _descriptionPtr(NULL)
-		, _description(0)
-		, _descriptionIndex(0)
-	  {
+	GC_MixedObjectIterator(OMR_VM *omrVM, J9Object *objectPtr)
+		: GC_MixedObjectIterator(omrVM)
+	{
 		initialize(omrVM, objectPtr);
-	  }
+	}
 };
 
 #endif /* MIXEDOBJECTITERATOR_HPP_ */

--- a/runtime/gc_structs/PointerArrayIterator.hpp
+++ b/runtime/gc_structs/PointerArrayIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,14 +58,12 @@ public:
 	 * @param objectPtr the array object to be processed
 	 */
 	GC_PointerArrayIterator(J9JavaVM *javaVM, J9Object *objectPtr)
-		: _contiguousArrayIterator(javaVM->omrVM)
-		, _pointerArrayletIterator(javaVM)
+		: GC_PointerArrayIterator(javaVM)
 	{
 		initialize(javaVM, objectPtr);
 	}
 
 	GC_PointerArrayIterator(J9JavaVM *javaVM)
-		/* It is unnecessary to initialize one of those iterators */
 		: _contiguousArrayIterator(javaVM->omrVM)
 		, _pointerArrayletIterator(javaVM)
 	{

--- a/runtime/gc_structs/PointerContiguousArrayIterator.hpp
+++ b/runtime/gc_structs/PointerContiguousArrayIterator.hpp
@@ -96,7 +96,10 @@ public:
 	}
 
 	GC_PointerContiguousArrayIterator(OMR_VM *omrVM)
-		: _slotObject(GC_SlotObject(omrVM, NULL))
+		:	_arrayPtr(NULL)
+		,	_slotObject(GC_SlotObject(omrVM, NULL))
+		,	_scanPtr(NULL)
+		,	_endPtr(NULL)
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
@@ -108,11 +111,7 @@ public:
 	 * @param objectPtr the array object to be processed
 	 */
 	GC_PointerContiguousArrayIterator(OMR_VM *omrVM, J9Object *objectPtr)
-		: _slotObject(GC_SlotObject(omrVM, NULL))
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
-		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
-		, _omrVM(omrVM)
+		: GC_PointerContiguousArrayIterator(omrVM)
 	{
 		initialize(objectPtr);
 	}


### PR DESCRIPTION
Fix warning treated as error by initialization of all
GC_PointerContiguousArrayIterator class fields in constructor

#fixes https://github.com/eclipse/openj9/issues/12568

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>