### PR TITLE
Replace TR_RequireJITServer with a command line option

### DIFF
--- a/doc/compiler/jitserver/Problem.md
+++ b/doc/compiler/jitserver/Problem.md
@@ -34,6 +34,11 @@ If you suddenly discover a crash on the server that you haven't seen before, it'
 for JITServer. If that's the case, the crash should be in the newly added code. You should find the commit that introduced it, and rewrite it in such a way
 that accounts for JITServer, i.e. do not dereference client pointers directly but fetch the result from the client first.
 
+If you want the client to terminate immediately once the server crashes, pass it `-XX:+JITServerRequireServer` option. This will cause the client
+to exit if a remote compilation fails with `compilationStreamFailure` error code, which indicates that the server is missing/crashed or a network error has occured.
+This option can be useful when you are running a suite of tests, e.g. `_sanity.functional` and want to detect any server crashes. Once the crash happens,
+the current and all subsequent tests will fail, and you will be able to determine which test caused the server to crash.
+
 ## Client-side crashes
 If the client crashes in `handleServerMessage` after receiving some bad data from the server, you will need to find out what the server was doing when it sent the message. The easiest way to do this is by running both the server and client in gdb, then sending the server a Ctrl-C after the client crashes. From the gdb prompt on the server you can type `thread apply all backtrace` and find the appropriate compilation thread to determine where the server was.
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2219,12 +2219,10 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
                break;
 #if defined(J9VM_OPT_JITSERVER)
             case compilationStreamFailure:
-               // This feature TR_RequireJITServer is used when we would like the client to fail when server crashes
-               static char *requireJITServer = feGetEnv("TR_RequireJITServer");
-               if (requireJITServer)
+               // if -XX:+JITServerRequireServer is used, we would like the client to fail when server crashes
+               if (entry->_compInfoPT->getCompilationInfo()->getPersistentInfo()->getRequireJITServer())
                   {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "In mode TR_RequireJITServer, exit JITClient due to unavailable JITServer.");
-                  exit(25);
+                  TR_ASSERT_FATAL(false, "Option -XX:+JITServerRequireServer is used, terminate the JITClient due to unavailable JITServer.");
                   }
             case compilationStreamMessageTypeMismatch:
             case compilationStreamVersionIncompatible:

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1113,6 +1113,8 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    const char *xxJITServerSSLRootCertsOption = "-XX:JITServerSSLRootCerts=";
    const char *xxJITServerUseAOTCacheOption = "-XX:+JITServerUseAOTCache";
    const char *xxDisableJITServerUseAOTCacheOption = "-XX:-JITServerUseAOTCache";
+   const char *xxRequireJITServerOption = "-XX:+RequireJITServer";
+   const char *xxDisableRequireJITServerOption = "-XX:-RequireJITServer";
 
    int32_t xxJITServerPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerPortOption, 0);
    int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
@@ -1121,6 +1123,8 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    int32_t xxJITServerSSLRootCertsArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLRootCertsOption, 0);
    int32_t xxJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerUseAOTCacheOption, 0);
    int32_t xxDisableJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerUseAOTCacheOption, 0);
+   int32_t xxRequireJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxRequireJITServerOption, 0);
+   int32_t xxDisableRequireJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableRequireJITServerOption, 0);
 
    if (xxJITServerPortArgIndex >= 0)
       {
@@ -1128,6 +1132,15 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
       IDATA ret = GET_INTEGER_VALUE(xxJITServerPortArgIndex, xxJITServerPortOption, port);
       if (ret == OPTION_OK)
          compInfo->getPersistentInfo()->setJITServerPort(port);
+      }
+
+   if (xxRequireJITServerArgIndex > xxDisableRequireJITServerArgIndex)
+      {
+      // If a debugging option to require JITServer connection is enabled, increase socket timeout,
+      // to prevent false positives from streams failing due to timeout.
+      // User-provided values still take priority.
+      compInfo->getPersistentInfo()->setRequireJITServer(true);
+      compInfo->getPersistentInfo()->setSocketTimeout(60000);
       }
 
    if (xxJITServerTimeoutArgIndex >= 0)

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -159,6 +159,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _socketTimeoutMs(2000),
          _clientUID(0),
          _JITServerUseAOTCache(false),
+         _requireJITServer(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -334,6 +335,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setClientUID(uint64_t val) { _clientUID = val; }
    bool getJITServerUseAOTCache() const { return _JITServerUseAOTCache; }
    void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
+   bool getRequireJITServer() const { return _requireJITServer; }
+   void setRequireJITServer(bool requireJITServer) { _requireJITServer = requireJITServer; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -424,6 +427,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    uint64_t    _clientUID;
    bool        _JITServerUseAOTCache;
+   bool        _requireJITServer;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 


### PR DESCRIPTION
Passing `TR_RequireJITServer` environment variable on the client
will cause the JVM to exit with error, if it ever detects a
stream failure. This can be used for debugging purposes,
to ensure that a test fails if the server crashes, instead
of continuing compiling locally.
However, in real-life scenarios there are many false positives,
because if a client stream stops sending compilations for a time
and the stream times out (default timeout is 2 seconds),
we will detect a stream failure and terminate the JVM
even though the server is still running.
This commit replaces `TR_RequireJITServer` with a command line
option `-XX:+RequireJITServer` so that it can be more
easily passed to testing infrastructure and increases the default
timeout to 1 minute if the option is provided, while still respecting
user-specified timeouts.