### PR TITLE
Delayed transformation tree lowering

### DIFF
--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -51,7 +51,7 @@ TR::TreeLowering::perform()
       TR::Node* node = nodeIter.currentNode();
       TR::TreeTop* tt = nodeIter.currentTree();
 
-      lowerValueTypeOperations(nodeIter, node, tt);
+      lowerValueTypeOperations(transformations, node, tt);
       }
 
    transformations.doTransformations();
@@ -184,68 +184,6 @@ TR::TreeLowering::Transformer::splitForFastpath(TR::Block* const block, TR::Tree
    }
 
 /**
- * @brief Perform lowering related to Valhalla value types
- *
- */
-void
-TR::TreeLowering::lowerValueTypeOperations(TR::PreorderNodeIterator& nodeIter, TR::Node* node, TR::TreeTop* tt)
-   {
-   TR::SymbolReferenceTable * symRefTab = comp()->getSymRefTab();
-   static char *disableInliningCheckAastore = feGetEnv("TR_DisableVT_AASTORE_Inlining");
-
-   if (node->getOpCode().isCall())
-      {
-      if (symRefTab->isNonHelper(node->getSymbolReference(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
-         {
-         // turn the non-helper call into a VM helper call
-         node->setSymbolReference(symRefTab->findOrCreateAcmpHelperSymbolRef());
-         static const bool disableAcmpFastPath =  NULL != feGetEnv("TR_DisableVT_AcmpFastpath");
-         if (!disableAcmpFastPath)
-            {
-            fastpathAcmpHelper(nodeIter, node, tt);
-            }
-         }
-      else if (node->getSymbolReference()->getReferenceNumber() == TR_ldFlattenableArrayElement)
-         {
-         static char *disableInliningCheckAaload = feGetEnv("TR_DisableVT_AALOAD_Inlining");
-
-         if (!disableInliningCheckAaload)
-            {
-            const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/inlinecheck/aaload/(%s)/bc=%d",
-                                                            comp()->signature(), node->getByteCodeIndex());
-            TR::DebugCounter::incStaticDebugCounter(comp(), counterName);
-
-            TR_ASSERT_FATAL_WITH_NODE(tt->getNode(),
-                                      (tt->getNode()->getOpCodeValue() == TR::treetop) || (tt->getNode()->getOpCodeValue() == TR::NULLCHK),
-                                      "lowerLoadArrayElement cannot process the treetop node that is neither a treetop nor a NULLCHK\n");
-
-            lowerLoadArrayElement(nodeIter, node, tt);
-            }
-         }
-      else if (node->getSymbolReference()->getReferenceNumber() == TR_strFlattenableArrayElement)
-         {
-         if (!disableInliningCheckAastore)
-            {
-            const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/inlinecheck/aastore/(%s)/bc=%d",
-                                                            comp()->signature(), node->getByteCodeIndex());
-            TR::DebugCounter::incStaticDebugCounter(comp(), counterName);
-
-            TR_ASSERT_FATAL_WITH_NODE(tt->getNode(),
-                                      (tt->getNode()->getOpCodeValue() == TR::treetop) || (tt->getNode()->getOpCodeValue() == TR::NULLCHK),
-                                      "lowerStoreArrayElement cannot process the treetop node that is neither a treetop nor a NULLCHK\n");
-            lowerStoreArrayElement(nodeIter, node, tt);
-            }
-         }
-      }
-   // If inlining check for aastore is enabled, the NULLCHK on the value reference is
-   // taken care of by lowerStoreArrayElement.
-   else if (node->getOpCodeValue() == TR::ArrayStoreCHK && disableInliningCheckAastore)
-      {
-      lowerArrayStoreCHK(node, tt);
-      }
-   }
-
-/**
  * @brief Copy register dependencies between GlRegDeps node at exit points.
  *
  * This function is only intended to work with GlRegDeps nodes for exit points,
@@ -342,6 +280,16 @@ TR::TreeLowering::splitForFastpath(TR::Block* const block, TR::TreeTop* const sp
    cfg->addEdge(block, targetBlock);
    return newBlock;
    }
+
+class AcmpTransformer: public TR::TreeLowering::Transformer
+   {
+   public:
+   explicit AcmpTransformer(TR::TreeLowering* opt)
+      : TR::TreeLowering::Transformer(opt)
+      {}
+
+   void lower(TR::Node* const node, TR::TreeTop* const tt) override;
+   };
 
 /**
  * @brief Add checks to skip (fast-path) acmpHelper call
@@ -471,9 +419,9 @@ TR::TreeLowering::splitForFastpath(TR::Block* const block, TR::TreeTop* const sp
  *
  */
 void
-TR::TreeLowering::fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Node * const node, TR::TreeTop * const tt)
+AcmpTransformer::lower(TR::Node * const node, TR::TreeTop * const tt)
    {
-   TR::Compilation* comp = self()->comp();
+   TR::Compilation* comp = this->comp();
    TR::CFG* cfg = comp->getFlowGraph();
    cfg->invalidateStructure();
 
@@ -630,14 +578,6 @@ TR::TreeLowering::fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Nod
    if (trace())
       traceMsg(comp, "Call node isolated in block_%d by splitPostGRA\n", callBlock->getNumber());
 
-   // Force nodeIter to first TreeTop of next block so that
-   // moving callBlock won't cause problems while iterating
-   while (nodeIter.currentTree() != targetBlock->getEntry())
-      ++nodeIter;
-
-   if (trace())
-      traceMsg(comp, "FORCED treeLowering ITERATOR TO POINT TO NODE n%unn\n", nodeIter.currentNode()->getGlobalIndex());
-
    // Move call block out of line.
    // The CFG edge that exists from prevBlock to callBlock is kept because
    // it will be needed once the branch for the fastpath gets added.
@@ -692,6 +632,17 @@ TR::TreeLowering::fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Nod
       }
    }
 
+
+class ArrayStoreCHKTransformer: public TR::TreeLowering::Transformer
+   {
+   public:
+   explicit ArrayStoreCHKTransformer(TR::TreeLowering* opt)
+      : TR::TreeLowering::Transformer(opt)
+      {}
+
+   void lower(TR::Node* const node, TR::TreeTop* const tt) override;
+   };
+
 /**
  * If value types are enabled, and the value that is being assigned to the array
  * element might be a null reference, lower the ArrayStoreCHK by splitting the
@@ -702,7 +653,7 @@ TR::TreeLowering::fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Nod
  * @param tt is the treetop at the root of the tree ancoring the current node
  */
 void
-TR::TreeLowering::lowerArrayStoreCHK(TR::Node *node, TR::TreeTop *tt)
+ArrayStoreCHKTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
    {
    // Pattern match the ArrayStoreCHK operands to get the source of the assignment
    // (sourceChild) and the array to which an element will have a value assigned (destChild)
@@ -930,8 +881,18 @@ copyRegisterDependency(TR::Node *fromNode, TR::Node *toNode)
       }
    }
 
+class LoadArrayElementTransformer: public TR::TreeLowering::Transformer
+   {
+   public:
+   explicit LoadArrayElementTransformer(TR::TreeLowering* opt)
+      : TR::TreeLowering::Transformer(opt)
+      {}
+
+   void lower(TR::Node* const node, TR::TreeTop* const tt) override;
+   };
+
 /*
- * lowerLoadArrayElement transforms the block that contains the jitLoadFlattenableArrayElement helper call into three blocks:
+ * LoadArrayElementTransformer transforms the block that contains the jitLoadFlattenableArrayElement helper call into three blocks:
  *   1. The merge block (blockAfterHelperCall) that contains the tree tops after the helper call
  *   2. The helper call block (helperCallBlock) that contains the helper call and is moved to the end of the tree top list
  *   3. The new non-VT array load block (arrayElementLoadBlock) which is an extended block of the original block
@@ -1031,10 +992,10 @@ copyRegisterDependency(TR::Node *fromNode, TR::Node *toNode)
  *
  */
 void
-TR::TreeLowering::lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::Node *node, TR::TreeTop *tt)
+LoadArrayElementTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
    {
    bool enableTrace = trace();
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = this->comp();
    TR::Block *originalBlock = tt->getEnclosingBlock();
 
    TR::Node *elementIndexNode = node->getFirstChild();
@@ -1044,6 +1005,9 @@ TR::TreeLowering::lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::
           tt->getNode()->getGlobalIndex(), node->getGlobalIndex(), node, originalBlock->getNumber(),
           elementIndexNode->getGlobalIndex(), arrayBaseAddressNode->getGlobalIndex(), tt->getNextTreeTop()->getNode()->getGlobalIndex()))
       return;
+
+   const char *counterName = TR::DebugCounter::debugCounterName(comp, "vt-helper/inlinecheck/aaload/(%s)/bc=%d", comp->signature(), node->getByteCodeIndex());
+   TR::DebugCounter::incStaticDebugCounter(comp, counterName);
 
    TR::CFG *cfg = comp->getFlowGraph();
    cfg->invalidateStructure();
@@ -1206,11 +1170,6 @@ TR::TreeLowering::lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::
    cfg->removeEdge(arrayElementLoadBlock, helperCallBlock);
    cfg->addEdge(arrayElementLoadBlock, blockAfterHelperCall);
 
-   // Force nodeIter to first TreeTop of next block so that
-   // moving callBlock won't cause problems while iterating
-   while (nodeIter.currentTree() != blockAfterHelperCall->getEntry())
-       ++nodeIter;
-
    // Move helper call to the end of the tree list
    arrayElementLoadBlock->getExit()->join(blockAfterHelperCall->getEntry());
 
@@ -1230,8 +1189,18 @@ TR::TreeLowering::lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::
       }
    }
 
+class StoreArrayElementTransformer: public TR::TreeLowering::Transformer
+   {
+   public:
+   explicit StoreArrayElementTransformer(TR::TreeLowering* opt)
+      : TR::TreeLowering::Transformer(opt)
+      {}
+
+   void lower(TR::Node* const node, TR::TreeTop* const tt) override;
+   };
+
 /*
- * lowerStoreArrayElement transforms the block that contains the jitStoreFlattenableArrayElement helper call into three blocks:
+ * StoreArrayElementTransformer transforms the block that contains the jitStoreFlattenableArrayElement helper call into three blocks:
  *   1. The merge block that contains the tree tops after the helper call
  *   2. The helper call block that contains the helper call and is moved to the end of the tree top list
  *   3. The new non-VT array store block which is an extended block of the original block
@@ -1340,10 +1309,10 @@ TR::TreeLowering::lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::
  *
  */
 void
-TR::TreeLowering::lowerStoreArrayElement(TR::PreorderNodeIterator& nodeIter, TR::Node *node, TR::TreeTop *tt)
+StoreArrayElementTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
    {
    bool enableTrace = trace();
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = this->comp();
    TR::Block *originalBlock = tt->getEnclosingBlock();
 
    TR::Node *valueNode = node->getFirstChild();
@@ -1353,6 +1322,9 @@ TR::TreeLowering::lowerStoreArrayElement(TR::PreorderNodeIterator& nodeIter, TR:
    if (!performTransformation(comp, "%sTransforming storeArrayElement treetop n%dn node n%dn [%p] in block_%d: children (n%dn, n%dn, n%dn) ttAfterHelperCall n%dn\n", optDetailString(), tt->getNode()->getGlobalIndex(), node->getGlobalIndex(), node, originalBlock->getNumber(),
           valueNode->getGlobalIndex(), elementIndexNode->getGlobalIndex(), arrayBaseAddressNode->getGlobalIndex(), tt->getNextTreeTop()->getNode()->getGlobalIndex()))
       return;
+
+   const char *counterName = TR::DebugCounter::debugCounterName(comp, "vt-helper/inlinecheck/aastore/(%s)/bc=%d", comp->signature(), node->getByteCodeIndex());
+   TR::DebugCounter::incStaticDebugCounter(comp, counterName);
 
    TR::CFG *cfg = comp->getFlowGraph();
    cfg->invalidateStructure();
@@ -1510,11 +1482,6 @@ TR::TreeLowering::lowerStoreArrayElement(TR::PreorderNodeIterator& nodeIter, TR:
    cfg->removeEdge(arrayElementStoreBlock, helperCallBlock);
    cfg->addEdge(arrayElementStoreBlock, blockAfterHelperCall);
 
-   // Force nodeIter to first TreeTop of next block so that
-   // moving callBlock won't cause problems while iterating
-   while (nodeIter.currentTree() != blockAfterHelperCall->getEntry())
-       ++nodeIter;
-
    arrayElementStoreBlock->getExit()->join(blockAfterHelperCall->getEntry());
 
    TR::TreeTop *lastTreeTop = comp->getMethodSymbol()->getLastTreeTop();
@@ -1530,5 +1497,59 @@ TR::TreeLowering::lowerStoreArrayElement(TR::PreorderNodeIterator& nodeIter, TR:
       helperCallBlock->getExit()->getNode()->setNumChildren(0);
       deps->decReferenceCount();
       gotoAfterHelperCallNode->addChildren(&deps, 1);
+      }
+   }
+
+/**
+ * @brief Perform lowering related to Valhalla value types
+ *
+ */
+void
+TR::TreeLowering::lowerValueTypeOperations(TransformationManager& transformations, TR::Node* node, TR::TreeTop* tt)
+   {
+   TR::SymbolReferenceTable * symRefTab = comp()->getSymRefTab();
+   static char *disableInliningCheckAastore = feGetEnv("TR_DisableVT_AASTORE_Inlining");
+
+   if (node->getOpCode().isCall())
+      {
+      if (symRefTab->isNonHelper(node->getSymbolReference(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
+         {
+         // turn the non-helper call into a VM helper call
+         node->setSymbolReference(symRefTab->findOrCreateAcmpHelperSymbolRef());
+         static const bool disableAcmpFastPath =  NULL != feGetEnv("TR_DisableVT_AcmpFastpath");
+         if (!disableAcmpFastPath)
+            {
+            transformations.addTransformation(getTransformer<AcmpTransformer>(), node, tt);
+            }
+         }
+      else if (node->getSymbolReference()->getReferenceNumber() == TR_ldFlattenableArrayElement)
+         {
+         static char *disableInliningCheckAaload = feGetEnv("TR_DisableVT_AALOAD_Inlining");
+
+         if (!disableInliningCheckAaload)
+            {
+            TR_ASSERT_FATAL_WITH_NODE(tt->getNode(),
+                                      (tt->getNode()->getOpCodeValue() == TR::treetop) || (tt->getNode()->getOpCodeValue() == TR::NULLCHK),
+                                      "LoadArrayElementTransformer cannot process the treetop node that is neither a treetop nor a NULLCHK\n");
+
+            transformations.addTransformation(getTransformer<LoadArrayElementTransformer>(), node, tt);
+            }
+         }
+      else if (node->getSymbolReference()->getReferenceNumber() == TR_strFlattenableArrayElement)
+         {
+         if (!disableInliningCheckAastore)
+            {
+            TR_ASSERT_FATAL_WITH_NODE(tt->getNode(),
+                                      (tt->getNode()->getOpCodeValue() == TR::treetop) || (tt->getNode()->getOpCodeValue() == TR::NULLCHK),
+                                      "StoreArrayElementTransformer cannot process the treetop node that is neither a treetop nor a NULLCHK\n");
+            transformations.addTransformation(getTransformer<StoreArrayElementTransformer>(), node, tt);
+            }
+         }
+      }
+   // If inlining check for aastore is enabled, the NULLCHK on the value reference is
+   // taken care of by StoreArrayElementTransformer.
+   else if (node->getOpCodeValue() == TR::ArrayStoreCHK && disableInliningCheckAastore)
+      {
+      transformations.addTransformation(getTransformer<ArrayStoreCHKTransformer>(), node, tt);
       }
    }

--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -60,63 +60,6 @@ TR::TreeLowering::perform()
    }
 
 void
-TR::TreeLowering::moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node, bool isAddress)
-   {
-   TR::Compilation* comp = self()->comp();
-   TR::TreeTop* blockExit = block->getExit();
-   TR::TreeTop* iterTT = tt->getNextTreeTop();
-
-   if (iterTT != blockExit)
-      {
-      if (trace())
-         {
-         traceMsg(comp, "Moving treetop containing node n%dn [%p] for helper call to end of prevBlock in preparation of final block split\n", tt->getNode()->getGlobalIndex(), tt->getNode());
-         }
-
-      // Remove TreeTop for call node, and gather it and the treetops for stores that
-      // resulted from un-commoning in a TreeTop chain from tt to lastTTForCallBlock
-      tt->unlink(false);
-      TR::TreeTop* lastTTForCallBlock = tt;
-
-      while (iterTT != blockExit)
-         {
-         TR::TreeTop* nextTT = iterTT->getNextTreeTop();
-         TR::ILOpCodes op = iterTT->getNode()->getOpCodeValue();
-         bool isStoreOp = false;
-
-         if (isAddress)
-            {
-            isStoreOp = (op == TR::aRegStore || op == TR::astore);
-            }
-         else
-            {
-            isStoreOp = (op == TR::iRegStore || op == TR::istore);
-            }
-
-         if (isStoreOp && iterTT->getNode()->getFirstChild() == node)
-            {
-            if (trace())
-               {
-               traceMsg(comp, "Moving treetop containing node n%dn [%p] for store of helper result to end of prevBlock in preparation of final block split\n", iterTT->getNode()->getGlobalIndex(), iterTT->getNode());
-               }
-
-            // Remove store node from prevBlock temporarily
-            iterTT->unlink(false);
-            lastTTForCallBlock->join(iterTT);
-            lastTTForCallBlock = iterTT;
-            }
-
-         iterTT = nextTT;
-         }
-
-      // Move the treetops that were gathered for the call and any stores of the
-      // result to the end of the block in preparation for the split of the call block
-      blockExit->getPrevTreeTop()->join(tt);
-      lastTTForCallBlock->join(blockExit);
-      }
-   }
-
-void
 TR::TreeLowering::Transformer::moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node, bool isAddress)
    {
    TR::Compilation* comp = this->comp();
@@ -269,16 +212,6 @@ copyBranchGlRegDepsAndSubstitute(TR::Node* const branchNode, TR::Node* const sou
       branchNode->addChildren(&glRegDepsCopy, 1);
       }
    return glRegDepsCopy;
-   }
-
-TR::Block*
-TR::TreeLowering::splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock)
-   {
-   TR::CFG* const cfg = self()->comp()->getFlowGraph();
-   TR::Block* const newBlock = block->split(splitPoint, cfg);
-   newBlock->setIsExtensionOfPreviousBlock(true);
-   cfg->addEdge(block, targetBlock);
-   return newBlock;
    }
 
 class AcmpTransformer: public TR::TreeLowering::Transformer

--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -43,6 +43,8 @@ TR::TreeLowering::perform()
       return 0;
       }
 
+   TransformationManager transformations(comp()->region());
+
    TR::ResolvedMethodSymbol* methodSymbol = comp()->getMethodSymbol();
    for (TR::PreorderNodeIterator nodeIter(methodSymbol->getFirstTreeTop(), comp()); nodeIter != NULL; ++nodeIter)
       {
@@ -51,6 +53,8 @@ TR::TreeLowering::perform()
 
       lowerValueTypeOperations(nodeIter, node, tt);
       }
+
+   transformations.doTransformations();
 
    return 0;
    }

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -223,43 +223,6 @@ class TreeLowering : public TR::Optimization
    virtual const char * optDetailString() const throw();
 
    private:
-
-   /**
-    * @brief Moves a node down to the end of a block
-    *
-    * Any stores of the value of the node are also moved down.
-    *
-    * This can be useful to do after a call to splitPostGRA where, as part of un-commoning,
-    * it is possible that code to store the anchored node into a register or temp-slot is
-    * appended to the original block.
-    *
-    * @param block is the block containing the TreeTop to be moved
-    * @param tt is a pointer to the TreeTop to be moved
-    * @param isAddress shows if the node is address, otherwise it is assumed to be an integer
-    */
-   void moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node, bool isAddress);
-
-   /**
-    * @brief Split a block after having inserted a fastpath branch
-    *
-    * The function should be used to split a block after a branch has been inserted.
-    * After the split, the resulting fall-through block is marked as an extension of
-    * the previous block (the original block that was split), which implies that 
-    * uncommoning is not required. The cfg is also updated with an edge going from
-    * the original block to some target block, which should be the same as the
-    * target of the branch inserted before the split.
-    *
-    * Note that this function does not call TR::CFG::invalidateStructure() as it assumes
-    * the caller is using this function in a context where TR::CFG::invalidateStructure()
-    * is likely to have already been called.
-    *
-    * @param block is the block that will be split
-    * @param splitPoint is the TreeTop within block at which the split must happen
-    * @param targetBlock is the target block of the branch inserted before the split point
-    * @return TR::Block* the (fallthrough) block created from the split
-    */
-   TR::Block* splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock);
-
    // helpers related to Valhalla value type lowering
    void lowerValueTypeOperations(TransformationManager& transformation, TR::Node* node, TR::TreeTop* tt);
 

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -82,6 +82,44 @@ class TreeLowering : public TR::Optimization
        */
       virtual void lower(TR::Node* const node, TR::TreeTop* const tt) = 0;
 
+      protected:
+       /**
+       * @brief Moves a TreeTop down to the end of a block
+       *
+       * Any stores of the value of the node are also moved down.
+       *
+       * This can be useful to do after a call to splitPostGRA where, as part of un-commoning,
+       * it is possible that code to store the anchored node into a register or temp-slot is
+       * appended to the original block.
+       *
+       * @param block is the block containing the TreeTop to be moved
+       * @param tt is a pointer to the TreeTop to be moved
+       * @param node is a pointer to the node that stores a value 
+       * @param isAddress shows if the node is address, otherwise it is assumed to be an integer
+       */
+      void moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node, bool isAddress);
+
+      /**
+       * @brief Split a block after having inserted a fastpath branch
+       *
+       * The function should be used to split a block after a branch has been inserted.
+       * After the split, the resulting fall-through block is marked as an extension of
+       * the previous block (the original block that was split), which implies that 
+       * uncommoning is not required. The cfg is also updated with an edge going from
+       * the original block to some target block, which should be the same as the
+       * target of the branch inserted before the split.
+       *
+       * Note that this function does not call TR::CFG::invalidateStructure() as it assumes
+       * the caller is using this function in a context where TR::CFG::invalidateStructure()
+       * is likely to have already been called.
+       *
+       * @param block is the block that will be split
+       * @param splitPoint is the TreeTop within block at which the split must happen
+       * @param targetBlock is the target block of the branch inserted before the split point
+       * @return TR::Block* the (fallthrough) block created from the split
+       */
+      TR::Block* splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock);
+
       private:
       TR::Compilation* _comp;
       TR::TreeLowering* _treeLoweringOpt;

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -71,6 +71,8 @@ class TreeLowering : public TR::Optimization
 
       const char* optDetailString() { return _treeLoweringOpt->optDetailString(); }
 
+      void prepareToReplaceNode(TR::Node * node) { _treeLoweringOpt->prepareToReplaceNode(node); }
+      
       /**
        * @brief Main callback method to apply a transformation.
        *
@@ -259,12 +261,7 @@ class TreeLowering : public TR::Optimization
    TR::Block* splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock);
 
    // helpers related to Valhalla value type lowering
-   void lowerValueTypeOperations(TR::PreorderNodeIterator& nodeIter, TR::Node* node, TR::TreeTop* tt);
-   void fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Node* const node, TR::TreeTop* const tt);
-   void lowerArrayStoreCHK(TR::Node* node, TR::TreeTop* tt);
-
-   void lowerLoadArrayElement(TR::PreorderNodeIterator& nodeIter, TR::Node* node, TR::TreeTop* tt);
-   void lowerStoreArrayElement(TR::PreorderNodeIterator& nodeIter, TR::Node* node, TR::TreeTop* tt);
+   void lowerValueTypeOperations(TransformationManager& transformation, TR::Node* node, TR::TreeTop* tt);
 
    template <typename T>
    Transformer* getTransformer() { return new (comp()->region()) T(this); }


### PR DESCRIPTION
This PR contains Leo's implementation of delayed transformation in tree lowering. It is based on building a queue of callbacks and arguments (technically closures) that define what transformations to perform. The treeLowering optimization will then consist of a pass that  finds the trees to be lowered and records them in the queue followed by a pass (of the queue) that actually does the lowering transformations.

The original transformation methods from `TreeLowering` become a class that subclasses from `Transformer` and overrides `Transformer::lower()`. 
```
TreeLowering::fastpathAcmpHelper => class AcmpTransformer: public TR::TreeLowering::Transformer
TreeLowering::lowerArrayStoreCHK => class ArrayStoreCHKTransformer: public TR::TreeLowering::Transformer
TreeLowering::lowerLoadArrayElement => class LoadArrayElementTransformer: public TR::TreeLowering::Transformer
TreeLowering::lowerStoreArrayElemen => class StoreArrayElementTransformer: public TR::TreeLowering::Transformer
```

Co-Authored-By: Leonardo Banderali <leonardo2718@protonmail.com>
