### PR TITLE
Update github URLs to refer to eclipse-openj9

### DIFF
--- a/.github/runlint.sh
+++ b/.github/runlint.sh
@@ -43,7 +43,7 @@ export CMAKE_BUILD_DIR=$PWD/build
 export LLVM_CONFIG=llvm-config-3.8 CLANG=clang++-3.8 CXX_PATH=clang++-3.8 CXX=clang++-3.8
 
 cd $J9SRC
-git clone --depth 1 --branch openj9 https://github.com/eclipse/openj9-omr.git omr
+git clone --depth 1 --branch openj9 https://github.com/eclipse-openj9/openj9-omr.git omr
 cd ..
 
 # We need some generated headers for the linter to run properly

--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2020 Red Hat and others
+# Copyright (c) 2020, 2021 Red Hat and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ jobs:
     - name: snapshot project assigner
       uses: srggrs/assign-one-project-github-action@1.2.0
       with:
-        project: 'https://github.com/eclipse/openj9/projects/17'
+        project: 'https://github.com/eclipse-openj9/openj9/projects/17'
 
   assign_mh_project:
     runs-on: ubuntu-latest
@@ -52,4 +52,4 @@ jobs:
     - name: MH project assigner
       uses: srggrs/assign-one-project-github-action@1.2.0
       with:
-        project: 'https://github.com/eclipse/openj9/projects/18'
+        project: 'https://github.com/eclipse-openj9/openj9/projects/18'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2020 IBM Corp. and others
+Copyright (c) 2017, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,9 @@ Thank you for your interest in Eclipse OpenJ9!
 We welcome and encourage all kinds of contributions to the project, not only
 code. This includes bug reports, user experience feedback, assistance in
 reproducing issues and more. Contributions to the website
-(https://github.com/eclipse/openj9-website), to the user documentation
-(https://github.com/eclipse/openj9-docs), to the system verification tests
-(https://github.com/eclipse/openj9-systemtest), or to Eclipse OMR
+(https://github.com/eclipse-openj9/openj9-website), to the user documentation
+(https://github.com/eclipse-openj9/openj9-docs), to the system verification tests
+(https://github.com/eclipse-openj9/openj9-systemtest), or to Eclipse OMR
 (https://github.com/eclipse/omr), which is an integral part of OpenJ9 are all
 also welcome.
 
@@ -53,7 +53,7 @@ Following these guidelines will help us merge your pull requests smoothly:
 
 4. If your contribution introduces an external change that requires an update
    to the [user documentation](https://www.eclipse.org/openj9/docs/), add the
-   label `doc:externals` and open an  [issue](https://github.com/eclipse/openj9-docs/issues/new?template=new-documentation-change.md)
+   label `doc:externals` and open an  [issue](https://github.com/eclipse-openj9/openj9-docs/issues/new?template=new-documentation-change.md)
    at the user documentation repository. Examples of an external change include
    a new command line option, a change in behavior, or a restriction.
 
@@ -63,7 +63,7 @@ Following these guidelines will help us merge your pull requests smoothly:
    
 ## Building and testing
 
-In order to build OpenJ9, see the [build instructions](https://github.com/eclipse/openj9/tree/master/doc/build-instructions).
+In order to build OpenJ9, see the [build instructions](https://github.com/eclipse-openj9/openj9/tree/master/doc/build-instructions).
 Once the build system is prepared, building consists of a few simple steps. If
 building the original source fails, check the [level of the compiler](https://eclipse.github.io/openj9-docs/openj9_support/)
 being used. 
@@ -75,7 +75,7 @@ committers from pull requests. You can see the latest results on the
 [Eclipse OpenJ9 Jenkins instance](https://ci.eclipse.org/openj9/).
 
 The tests can also be run manually on your own machine, refer to the
-[OpenJ9 test quick start guide](https://github.com/eclipse/openj9/blob/master/test/README.md).
+[OpenJ9 test quick start guide](https://github.com/eclipse-openj9/openj9/blob/master/test/README.md).
 
 
 ## Commit Guidelines

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 
 <p align="center">
-<img src="https://github.com/eclipse/openj9/blob/master/artwork/OpenJ9.svg" alt="OpenJ9 logo" align="middle" width="50%" height="50%" />
+<img src="https://github.com/eclipse-openj9/openj9/blob/master/artwork/OpenJ9.svg" alt="OpenJ9 logo" align="middle" width="50%" height="50%" />
 <p>
 
 Welcome to the Eclipse OpenJ9 repository
@@ -33,11 +33,11 @@ Welcome to the Eclipse OpenJ9 repository
 We're not sure which route you might have taken on your way here, but we're really pleased to see you! If you came directly from our website, you've probably already learned a lot about Eclipse OpenJ9 and how it fits in to the OpenJDK ecosystem. If you came via some other route, here are a few key links to get you started:
 
 - [Eclipse OpenJ9 website](http://www.eclipse.org/openj9) - Learn about this high performance, enterprise-grade Java Virtual Machine (JVM) and why we think you want to get involved in its development.
-- Build instructions for [JDK8](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md), [JDK11](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md), and [More](https://github.com/eclipse/openj9/blob/master/doc/build-instructions) - Here's how you can build an OpenJDK with OpenJ9 yourself.
+- Build instructions for [JDK8](https://github.com/eclipse-openj9/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md), [JDK11](https://github.com/eclipse-openj9/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md), and [More](https://github.com/eclipse-openj9/openj9/blob/master/doc/build-instructions) - Here's how you can build an OpenJDK with OpenJ9 yourself.
 
 If you're looking for ways to help out at the project (thanks!), we have:
-- [Beginner issues](https://github.com/eclipse/openj9/issues?q=is%3Aopen+is%3Aissue+label%3Abeginner)
-- [Help Wanted issues](https://github.com/eclipse/openj9/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+- [Beginner issues](https://github.com/eclipse-openj9/openj9/issues?q=is%3Aopen+is%3Aissue+label%3Abeginner)
+- [Help Wanted issues](https://github.com/eclipse-openj9/openj9/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 
 If you're here to learn more about the project, read on ...
 
@@ -57,10 +57,10 @@ the J9 JVM as "Eclipse OpenJ9" at the Eclipse Foundation. Significant parts of J
 at the [Eclipse OMR project](https://github.com/eclipse/omr). OpenJ9 has a permissive license (Apache
 License 2.0 or Eclipse Public License 2.0 with a secondary compatibility license for the OpenJDK project's
 GPLv2 license) that is designed to allow OpenJDK to be built with the OpenJ9 JVM.  Please see our
-[LICENSE file](https://github.com/eclipse/openj9/blob/master/LICENSE) for more details.
+[LICENSE file](https://github.com/eclipse-openj9/openj9/blob/master/LICENSE) for more details.
 
 Eclipse OpenJ9 is a source code project that can be built alongside Java class libraries. See the
-[build instructions](https://github.com/eclipse/openj9/blob/master/doc/build-instructions). Eclipse
+[build instructions](https://github.com/eclipse-openj9/openj9/blob/master/doc/build-instructions). Eclipse
 Foundation projects are not permitted to distribute, market or promote JDK binaries unless they have
 passed a Java SE Technology Compatibility Kit licensed from Oracle, to which the OpenJ9 project does
 not currently have access. See the [Eclipse Adoptium Project Charter](https://projects.eclipse.org/projects/adoptium/charter).
@@ -88,13 +88,13 @@ If you think you want to contribute but you're not ready to sign the Eclipse Con
 
 What repos are part of the project?
 ===================================
-- https://github.com/eclipse/openj9 : OpenJ9 main code base
-- https://github.com/eclipse/openj9-omr : Eclipse OMR clone to stage temporary OMR changes.  (None so far!)
-- https://github.com/eclipse/openj9-systemtest : OpenJ9-specific system tests
-- https://github.com/eclipse/openj9-website : OpenJ9 website repo
-- https://github.com/eclipse/openj9-docs : OpenJ9 documentation repo
-- https://github.com/eclipse/build-openj9 : OpenJ9 GitHub actions repo
-- https://github.com/eclipse/openj9-utils : OpenJ9 utility programs / tools repo, a place to develop community around the tools
+- https://github.com/eclipse-openj9/openj9 : OpenJ9 main code base
+- https://github.com/eclipse-openj9/openj9-omr : Eclipse OMR clone to stage temporary OMR changes.  (None so far!)
+- https://github.com/eclipse-openj9/openj9-systemtest : OpenJ9-specific system tests
+- https://github.com/eclipse-openj9/openj9-website : OpenJ9 website repo
+- https://github.com/eclipse-openj9/openj9-docs : OpenJ9 documentation repo
+- https://github.com/eclipse-openj9/build-openj9 : OpenJ9 GitHub actions repo
+- https://github.com/eclipse-openj9/openj9-utils : OpenJ9 utility programs / tools repo, a place to develop community around the tools
 
 
 Where can I learn more?

--- a/buildenv/ansible/roles/openj9-build-environment/tasks/main.yml
+++ b/buildenv/ansible/roles/openj9-build-environment/tasks/main.yml
@@ -19,7 +19,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
-# Copyright (c) 2020, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2021 IBM Corp. and others
 ###############################################################################
 ---
 - name: Create a build folder
@@ -32,7 +32,7 @@
 - name: Get script to build docker image
   get_url:
     dest: "{{ build_dir }}/mkdocker.sh"
-    url: "https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh"
+    url: "https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh"
     mode: 0644
     validate_certs: no
   tags:

--- a/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,8 @@
 
 FROM openj9:latest
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN apt-get update \
  && apt-get install -qq -y --no-install-recommends \

--- a/buildenv/docker/jdk8/x86_64/rhel7/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/rhel7/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,8 +27,8 @@ FROM registry.access.redhat.com/rhel7:7.6 AS jitserver_build
 #    -t=openj9-jitserver-build .`
 #
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN yum-config-manager --enable rhel-7-server-optional-rpms 
 RUN yum install -y autoconf \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,8 +31,8 @@
 #
 FROM openj9:latest AS jitserver_build
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,8 +32,8 @@
 
 FROM openj9:latest AS jitserver_build
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,8 +32,8 @@
 
 FROM openj9:latest AS jitserver_build
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,8 +31,8 @@
 #
 FROM openj9:latest AS jitserver_build
 
-ARG openj9_repo=https://github.com/eclipse/openj9.git
-ARG omr_repo=https://github.com/eclipse/openj9-omr.git
+ARG openj9_repo=https://github.com/eclipse-openj9/openj9.git
+ARG omr_repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \

--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -639,8 +639,8 @@ create_git_cache() {
   add_git_remote jdk11   https://github.com/ibmruntimes/openj9-openjdk-jdk11.git
   add_git_remote jdk16   https://github.com/ibmruntimes/openj9-openjdk-jdk16.git
   add_git_remote jdknext https://github.com/ibmruntimes/openj9-openjdk-jdk.git
-  add_git_remote omr     https://github.com/eclipse/openj9-omr.git
-  add_git_remote openj9  https://github.com/eclipse/openj9.git
+  add_git_remote omr     https://github.com/eclipse-openj9/openj9-omr.git
+  add_git_remote openj9  https://github.com/eclipse-openj9/openj9.git
   echo " && echo Fetching repository cache... \\"
   echo " && git fetch jdk16 \\"
   echo " && git fetch --all \\"

--- a/buildenv/docker/test/Dockerfile
+++ b/buildenv/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 #
 #   Follow both README in these two links
 #   https://www.eclipse.org/openj9/oj9_build.html
-#   https://github.com/eclipse/openj9/blob/master/test/README.md
+#   https://github.com/eclipse-openj9/openj9/blob/master/test/README.md
 #
 #   Highly recommend mounting folders to Docker container rather
 #   than cloning them within Docker container. e.g.

--- a/buildenv/docker/test/README.md
+++ b/buildenv/docker/test/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2020 IBM Corp. and others
+Copyright (c) 2017, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
    > https://www.eclipse.org/openj9/oj9_build.html
 
-   > https://github.com/eclipse/openj9/blob/master/test/README.md
+   > https://github.com/eclipse-openj9/openj9/blob/master/test/README.md
 
    Highly recommend mounting folders to Docker container rather
    than cloning them within Docker container. e.g.

--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -113,14 +113,14 @@ You can request a Pull Request build from the Eclipse OpenJ9 repository - [openj
 
 ##### Dependent Changes
 
-- If you have dependent change(s) in either eclipse/omr, eclipse/openj9-omr, or ibmruntimes/openj9-openjdk-jdk\*, you can build & test with all needed changes
+- If you have dependent change(s) in either eclipse/omr, eclipse-openj9/openj9-omr, or ibmruntimes/openj9-openjdk-jdk\*, you can build & test with all needed changes
 - Request a build by including the PR ref or branch name in your trigger comment
 - Ex. Dependent change in OMR Pull Request `#123`
     - `Jenkins test sanity xlinux jdk8 depends eclipse/omr#123`
 - Ex. Dependent change in eclipse/omr master branch (useful if a dependent OMR PR is already merged)
     - `Jenkins test sanity xlinux jdk8 depends eclipse/omr#master`
 - Ex. Dependent change in OpenJ9-OMR Pull Request `#456`
-    - `Jenkins test sanity xlinux jdk8 depends eclipse/openj9-omr#456`
+    - `Jenkins test sanity xlinux jdk8 depends eclipse-openj9/openj9-omr#456`
 - Ex. Dependent change in OpenJDK Pull Request `#789`
     - `Jenkins test sanity xlinux jdk8 depends ibmruntimes/openj9-openjdk-jdk8#789`
 - Ex. Dependent changes in OMR and OpenJDK
@@ -134,7 +134,7 @@ You can request a Pull Request build from the Eclipse OpenJ9 repository - [openj
 
 - If you have a PR against a release branch, it can be tested with a PR build that specifies the OMR and Extensions repos.
 - Ex. Release PR against the `v0.20.0-release` branch specifying both OMR and Extensions
-    - `Jenkins compile plinux jdk11 depends eclipse/openj9-omr#v0.20.0-release ibmruntimes/openj9-openjdk-jdk11#openj9-0.20.0`
+    - `Jenkins compile plinux jdk11 depends eclipse-openj9/openj9-omr#v0.20.0-release ibmruntimes/openj9-openjdk-jdk11#openj9-0.20.0`
 
 ##### Testing Changes to Pipeline code
 
@@ -250,7 +250,7 @@ Infrastructure pipelines are available [**here**](https://ci.eclipse.org/openj9/
 - Mirror-OMR-to-OpenJ9-OMR
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Mirror-OMR-to-OpenJ9-OMR)](https://ci.eclipse.org/openj9/job/Mirror-OMR-to-OpenJ9-OMR)
     - Description:
-        - Mirrors [eclipse/omr/master](https://github.com/eclipse/omr/tree/master) to [eclipse/openj9-omr/master](https://github.com/eclipse-openj9/openj9-omr/tree/master)
+        - Mirrors [eclipse/omr/master](https://github.com/eclipse/omr/tree/master) to [eclipse-openj9/openj9-omr/master](https://github.com/eclipse-openj9/openj9-omr/tree/master)
         - Triggers `Pipeline-OMR-Acceptance` when there is new content
     - Trigger:
         - Build periodically, 15 minutes
@@ -258,7 +258,7 @@ Infrastructure pipelines are available [**here**](https://ci.eclipse.org/openj9/
 - Promote_OMR
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Promote_OMR)](https://ci.eclipse.org/openj9/job/Promote_OMR)
     - Description:
-        - Promotes eclipse/openj9-omr branch master to branch openj9
+        - Promotes eclipse-openj9/openj9-omr branch master to branch openj9
     - Trigger:
         - Last step of `Pipeline-OMR-Acceptance`
 

--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2020 IBM Corp. and others
+Copyright (c) 2017, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
 - Request sanity.system test on all platforms and multiple versions
     - `Jenkins test sanity.system all jdk8,jdk11`
 
-You can request a Pull Request build from the Eclipse OpenJ9 repository - [openj9](https://github.com/eclipse/openj9) - or the Extensions OpenJDK\* for Eclipse OpenJ9 repositories:
+You can request a Pull Request build from the Eclipse OpenJ9 repository - [openj9](https://github.com/eclipse-openj9/openj9) - or the Extensions OpenJDK\* for Eclipse OpenJ9 repositories:
 
 - openj9-openjdk-jdk: https://github.com/ibmruntimes/openj9-openjdk-jdk
 - openj9-openjdk-jdk`<version>`: `https://github.com/ibmruntimes/openj9-openjdk-jdk<version>`
@@ -250,7 +250,7 @@ Infrastructure pipelines are available [**here**](https://ci.eclipse.org/openj9/
 - Mirror-OMR-to-OpenJ9-OMR
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Mirror-OMR-to-OpenJ9-OMR)](https://ci.eclipse.org/openj9/job/Mirror-OMR-to-OpenJ9-OMR)
     - Description:
-        - Mirrors [eclipse/omr/master](https://github.com/eclipse/omr/tree/master) to [eclipse/openj9-omr/master](https://github.com/eclipse/openj9-omr/tree/master)
+        - Mirrors [eclipse/omr/master](https://github.com/eclipse/omr/tree/master) to [eclipse/openj9-omr/master](https://github.com/eclipse-openj9/openj9-omr/tree/master)
         - Triggers `Pipeline-OMR-Acceptance` when there is new content
     - Trigger:
         - Build periodically, 15 minutes
@@ -265,7 +265,7 @@ Infrastructure pipelines are available [**here**](https://ci.eclipse.org/openj9/
 - Mirror-OpenJ9-Website-to-Eclipse
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Mirror-OpenJ9-Website-to-Eclipse)](https://ci.eclipse.org/openj9/job/Mirror-OpenJ9-Website-to-Eclipse)
     - Description:
-        - Mirrors [github.com/eclipse/openj9-website](https://github.com/eclipse/openj9-website/tree/master) to the Eclipse.org repo
+        - Mirrors [github.com/eclipse-openj9/openj9-website](https://github.com/eclipse-openj9/openj9-website/tree/master) to the Eclipse.org repo
     - Trigger:
         - Poll Github repo for changes
 

--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -213,7 +213,7 @@ def checkout_pullrequest() {
     // Checkout dependent PRs, if any were specified
     if (openj9_bool) {
         dir ('openj9') {
-            checkout_pullrequest(OPENJ9_PR, 'eclipse/openj9')
+            checkout_pullrequest(OPENJ9_PR, 'eclipse-openj9/openj9')
         }
     }
 

--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -409,7 +409,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
         echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}"
 
         // For PullRequest Builds, overwrite the OpenJ9 sha for test jobs so they checkout the PR (OpenJ9 PRs only)
-        if (params.ghprbPullId && params.ghprbGhRepository == 'eclipse/openj9') {
+        if (params.ghprbPullId && params.ghprbGhRepository == 'eclipse-openj9/openj9') {
             SHAS['OPENJ9'] = "origin/pr/${params.ghprbPullId}/merge"
         }
 

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -312,8 +312,8 @@ def set_repos_variables(BUILD_SPECS=null) {
         echo "Using OPENJDK_REPO = ${OPENJDK_REPO.toString()} OPENJDK_BRANCH = ${OPENJDK_BRANCH.toString()} OPENJDK_SHA = ${OPENJDK_SHA.toString()}"
 
         // default URL and branch for the OpenJ9 and OMR repositories (no entries in defaults.yml)
-        EXTENSIONS = ['OpenJ9': ['repo': 'https://github.com/eclipse/openj9.git',     'branch': 'master'],
-                      'OMR'   : ['repo': 'https://github.com/eclipse/openj9-omr.git', 'branch': 'openj9']]
+        EXTENSIONS = ['OpenJ9': ['repo': 'https://github.com/eclipse-openj9/openj9.git',     'branch': 'master'],
+                      'OMR'   : ['repo': 'https://github.com/eclipse-openj9/openj9-omr.git', 'branch': 'openj9']]
 
         // set OpenJ9 and OMR repos, branches and SHAs
         set_extensions_variables(EXTENSIONS)

--- a/buildenv/jenkins/docker-slaves/README.md
+++ b/buildenv/jenkins/docker-slaves/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2020 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,7 +67,7 @@ If the container is capable of building openj9 it will also have
 reference repos and bootJDKs. The reference repos can be used to
 improve clone times, and the bootJDKs can be used for compiling
 openj9. The locations of the reference repos and bootJDKs can be
-found [here](https://github.com/eclipse/openj9/blob/master/buildenv/jenkins/variables/defaults.yml).
+found [here](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/jenkins/variables/defaults.yml).
 A full list of docker commands for managing/using containers can
 be found [here](https://docs.docker.com/engine/reference/commandline/docker/).
 ## Docker and Jenkins

--- a/buildenv/jenkins/docker-slaves/README.md
+++ b/buildenv/jenkins/docker-slaves/README.md
@@ -50,16 +50,16 @@ build can be launched by making a comment in the PR with the following format
 Jenkins build docker <ARCH> <OS>
 ```
 Both jobs will push the Docker images to Docker Hub under the repo
-`eclipse/openj9-jenkins-agent-<ARCH>-<OS>:<TAG>`
+`eclipse-openj9/openj9-jenkins-agent-<ARCH>-<OS>:<TAG>`
 If a manual build is run the tag will be the build number of
 the job, as well as the `latest` tag. If a PR build is run the
 tag will contain `PR` followed by the ID of the pull request used to
 build the job.
 ## Using containers from a terminal
 If you have [docker installed](https://docs.docker.com/install/) then you can run
-`docker pull eclipse/openj9-jenkins-agent-<ARCH>-<OS>:<TAG>` to pull
+`docker pull eclipse-openj9/openj9-jenkins-agent-<ARCH>-<OS>:<TAG>` to pull
 a docker image of the specified architecture and os.
-You can use `docker run -it eclipse/openj9-jenkins-agent-<ARCH>-<OS>:<TAG> /bin/bash`
+You can use `docker run -it eclipse-openj9/openj9-jenkins-agent-<ARCH>-<OS>:<TAG> /bin/bash`
 to start up a new container and enter it. Once inside of a
 container, run `su - jenkins` to switch to the jenkins user.
 This way when you run your code you won't have root privileges.

--- a/buildenv/jenkins/docker-slaves/jenkinsfile-build-container.groovy
+++ b/buildenv/jenkins/docker-slaves/jenkinsfile-build-container.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ if ("${BUILD_OPTS}" == "") {
 }
 
 def NODE = (params.NODE) ? params.NODE : "sw.tool.docker && hw.arch.${ARCH}"
-def NAMESPACE = (params.NAMESPACE) ? params.NAMESPACE : "eclipse"
+def NAMESPACE = (params.NAMESPACE) ? params.NAMESPACE : "eclipse-openj9"
 def FOLDER = (params.FOLDER) ? "/" + params.FOLDER : ""
 def REPOSITORY = "${NAMESPACE}${FOLDER}/openj9-jenkins-agent-${ARCH}-${OS}"
 

--- a/buildenv/jenkins/jobs/infrastructure/branchSplit.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/branchSplit.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,8 @@
 // Assumes OPENJ9_SHA, OMR_SHA, and NEW_BRANCH_NAME are passed in Jenkins parameters
 
 HTTP = 'https://'
-OMR_REPO = 'github.com/eclipse/openj9-omr.git'
-OPENJ9_REPO = 'github.com/eclipse/openj9.git'
+OMR_REPO = 'github.com/eclipse-openj9/openj9-omr.git'
+OPENJ9_REPO = 'github.com/eclipse-openj9/openj9.git'
 
 DEFAULT_SPLIT_OPENJ9 = 'remotes/origin/master'
 DEFAULT_SPLIT_OMR = 'remotes/origin/openj9'

--- a/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ timestamps {
     timeout(time: 1, unit: 'HOURS') {
         def HTTP = 'https://'
         def SRC_REPO = 'github.com/eclipse/omr.git'
-        def TARGET_REPO = 'github.com/eclipse/openj9-omr.git'
+        def TARGET_REPO = 'github.com/eclipse-openj9/openj9-omr.git'
         def ARCHIVE_FILE = "OMR_COMMIT"
 
         stage("Mirror") {

--- a/buildenv/jenkins/jobs/infrastructure/tagRepos.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/tagRepos.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,8 @@
 // OPENJ9_SHA, OMR_SHA default to master/openj9 respectively if not set on Jenkins
 
 HTTP = 'https://'
-OMR_REPO = 'github.com/eclipse/openj9-omr.git'
-OPENJ9_REPO = 'github.com/eclipse/openj9.git'
+OMR_REPO = 'github.com/eclipse-openj9/openj9-omr.git'
+OPENJ9_REPO = 'github.com/eclipse-openj9/openj9.git'
 
 def clone_branch_push(REPO, TAG_NAME, TAG_ANNOTATION, TAG_POINT, POINT_TYPE) {
     timeout(time: 3, unit: 'HOURS') {

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
@@ -113,9 +113,9 @@ Release:
             OPENJDKNEXT_REPO:
                 - "https://github.com/ibmruntimes/openj9-openjdk-jdk.git"
             OPENJ9_REPO:
-                - "https://github.com/eclipse/openj9.git"
+                - "https://github.com/eclipse-openj9/openj9.git"
             OMR_REPO:
-                - "https://github.com/eclipse/openj9-omr.git"
+                - "https://github.com/eclipse-openj9/openj9-omr.git"
             BUILD_IDENTIFIER:
                 - "Release"
                 - "Custom"
@@ -129,7 +129,7 @@ PullRequest-OpenJ9:
     job_name: "PullRequest-OpenJ9"
     job_description: "<h3>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h3<p>This job defines the OpenJ9 Pull Requests Build<p>This job is defined in wrapper_template and wrapper_variables.yml in the openj9 repo, if you wish to change it modify that</p>"
     build_discarder_logs: 20
-    github_project: "https://github.com/eclipse/openj9/"
+    github_project: "https://github.com/eclipse-openj9/openj9/"
     triggers:
         pull_request_builder:
             trigger_phrase: .*\bjenkins\s+(compile|test)\b.*
@@ -163,6 +163,6 @@ general:
         PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
         RESTART_TIMEOUT: "Time allowed to restart a job"
         TIMEOUT_TIME: "Overall build timeout"
-    repository_url: "https://github.com/eclipse/openj9.git"
+    repository_url: "https://github.com/eclipse-openj9/openj9.git"
     repository_branch: "refs/heads/master"
     pipeline_script_path: "buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy"

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -29,10 +29,10 @@
  *
  * Parameters:
  *   PLATFORMS: String - Comma separated platforms to build, or `all`. For the list of platforms, see `id=` in the `.spec` files found in the buildspecs directory (the id should be the same as the spec file name without the `.spec`).
- *   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse/openj9.git (default)
+ *   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse-openj9/openj9.git (default)
  *   OPENJ9_BRANCH: String - the OpenJ9 branch to clone from: e.g. master (default)
  *   OPENJ9_SHA: String - the last commit SHA of the OpenJ9 repository
- *   OMR_REPO: String - the OMR git repository URL: e.g. https://github.com/eclipse/openj9-omr.git (default)
+ *   OMR_REPO: String - the OMR git repository URL: e.g. https://github.com/eclipse-openj9/openj9-omr.git (default)
  *   OMR_BRANCH: String - the OMR branch to clone from: e.g. openj9 (default)
  *   OMR_SHA: String - the last commit SHA of the OMR repository
  *   ADOPTOPENJDK_REPO: String - the AdoptOpenJDK testing repository URL: e.g. https://github.com/AdoptOpenJDK/openjdk-tests.git
@@ -310,7 +310,7 @@ echo "ghprbActualCommit:'${ghprbActualCommit}'"
 // If custom repo/branch/refspec is passed, use it,
 // elif build is OpenJ9 PR, use pr merge-ref/refspec,
 // else use eclipse/master/blank for defaults respectively.
-SCM_REPO = 'https://github.com/eclipse/openj9.git'
+SCM_REPO = 'https://github.com/eclipse-openj9/openj9.git'
 if (params.SCM_REPO) {
     SCM_REPO = params.SCM_REPO
 }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@ if (!binding.hasVariable('VENDOR_REPO_DEFAULT')) VENDOR_REPO_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_BRANCH_DEFAULT')) VENDOR_BRANCH_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID_DEFAULT = ''
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
-if (!binding.hasVariable('SCM_REPO')) SCM_REPO = 'https://github.com/eclipse/openj9.git'
+if (!binding.hasVariable('SCM_REPO')) SCM_REPO = 'https://github.com/eclipse-openj9/openj9.git'
 if (SCM_BRANCH ==~ /origin\/pr\/[0-9]+\/merge/) {
     SCM_BRANCH = 'master'
 }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -43,7 +43,7 @@ openjdk:
 # OpenJ9 & OMR Repos (used by ref repo updater)
 openj9:
   default:
-    repoUrl: 'https://github.com/eclipse/openj9.git'
+    repoUrl: 'https://github.com/eclipse-openj9/openj9.git'
 omr:
   default:
     repoUrl: 'https://github.com/eclipse/omr.git'

--- a/doc/GuideForCommitters.md
+++ b/doc/GuideForCommitters.md
@@ -138,7 +138,7 @@ possible between them.
     recently (generally within a day of a successful build).
     
     It is strongly recommended that you check that the tips of the
-    `eclipse/openj9-omr` [`master`](https://github.com/eclipse-openj9/openj9-omr/tree/master)
+    `eclipse-openj9/openj9-omr` [`master`](https://github.com/eclipse-openj9/openj9-omr/tree/master)
     and [`openj9`](https://github.com/eclipse-openj9/openj9-omr/tree/openj9)
     branches are the same before proceeding.  If they are different,
     be aware that you will be introducing other OMR changes that have
@@ -157,7 +157,7 @@ possible between them.
 5.  Launch a ["Mirror-OMR-To-OpenJ9-OMR Build"](https://ci.eclipse.org/openj9/job/Mirror-OMR-to-OpenJ9-OMR/)
     job in the Eclipse OpenJ9 project by clicking "Build Now".  This will
     pull the latest Eclipse OMR project `master` branch into the
-    [`eclipse/openj9-omr`](https://github.com/eclipse-openj9/openj9-omr) repo's
+    [`eclipse-openj9/openj9-omr`](https://github.com/eclipse-openj9/openj9-omr) repo's
     `master` branch and automatically launch an OMR Acceptance Build at
     OpenJ9 Jenkins.
     
@@ -166,7 +166,7 @@ possible between them.
     necessary to wait for this build to finish because an equivalent 
     of the OMR Acceptance Build was already tested in Step 1.
     
-7.  Verify that the `master` branch of the `eclipse/openj9-omr` repo
+7.  Verify that the `master` branch of the `eclipse-openj9/openj9-omr` repo
     contains the Eclipse OMR commit you merged in Step 3.  Make note
     of the commit SHA for Step 8.
 
@@ -181,15 +181,15 @@ possible between them.
     | TARGET_BRANCH  | `openj9`                                    |
 
     This will cause the OMR commit to be promoted from the
-    `master` branch into the `openj9` branch of the `eclipse/openj9-omr`
+    `master` branch into the `openj9` branch of the `eclipse-openj9/openj9-omr`
     repo.
     
 9.  When the Promotion Build in Step 8 completes, merge the OpenJ9
     commit.
     
     At this point, the OMR commit should now be in the `openj9` branch of
-    the `eclipse/openj9-omr` repo, and the OpenJ9 commit should now be
-    in the `master` branch of the `eclipse/openj9` repo.
+    the `eclipse-openj9/openj9-omr` repo, and the OpenJ9 commit should now be
+    in the `master` branch of the `eclipse-openj9/openj9` repo.
     
 10. Announce in the `#committers-public` Slack channel that the coordinated
     merge has completed.

--- a/doc/GuideForCommitters.md
+++ b/doc/GuideForCommitters.md
@@ -33,7 +33,7 @@ merging a pull request.
 
 * Committers should not merge their own pull requests.
 
-* If a pull request modifies the [Contribution Guidelines](https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md),
+* If a pull request modifies the [Contribution Guidelines](https://github.com/eclipse-openj9/openj9/blob/master/CONTRIBUTING.md),
 request the author to post a detailed summary of the changes on the
 `openj9-dev@eclipse.org` mailing list after the pull request is merged.
 
@@ -71,10 +71,10 @@ changes in the pull request.
 
 ## Pre-Merge Checklist
 
-* Ensure the pull request adheres to all the Eclipse OpenJ9 [Contribution Guidelines](https://github.com/eclipse/openj9/blob/master/CONTRIBUTING.md).
+* Ensure the pull request adheres to all the Eclipse OpenJ9 [Contribution Guidelines](https://github.com/eclipse-openj9/openj9/blob/master/CONTRIBUTING.md).
 
 * Ensure pull requests and issues are annotated with descriptive metadata by
-attaching GitHub labels. The current set of labels can be found [here](https://github.com/eclipse/openj9/labels).
+attaching GitHub labels. The current set of labels can be found [here](https://github.com/eclipse-openj9/openj9/labels).
 
 * Be sure to validate the commit title and message on **each** commit in the PR (not
 just the pull request message) and ensure they describe the contents of the commit.
@@ -88,7 +88,7 @@ same pull request.
 
 * You must initiate pull request builds sufficient to cover
 all affected architectures and language levels prior to merging. To launch a pull
-request build, see [Triggering PR Builds](https://github.com/eclipse/openj9/tree/master/buildenv/jenkins).
+request build, see [Triggering PR Builds](https://github.com/eclipse-openj9/openj9/tree/master/buildenv/jenkins).
 
    If testing is only warranted on a subset of platforms (for example, only files
 built on x86 are modified) then pull request testing can be limited to only those
@@ -107,7 +107,7 @@ from the `Checks` tab of the PR if necessary.
 
 * If the code change(s) necessitate change(s) to the [OpenJ9 Documentation](https://www.eclipse.org/openj9/docs/),
 first add the `depends:doc` label to the OpenJ9 PR, and then ensure the contributer 
-has opened an associated PR in the [openj9-docs](https://github.com/eclipse/openj9-docs) 
+has opened an associated PR in the [openj9-docs](https://github.com/eclipse-openj9/openj9-docs) 
 repository. An OpenJ9 PR that requires documentation changes should not be merged 
 until the associated `openj9-docs` PR is also approved and ready to be merged.
 
@@ -138,8 +138,8 @@ possible between them.
     recently (generally within a day of a successful build).
     
     It is strongly recommended that you check that the tips of the
-    `eclipse/openj9-omr` [`master`](https://github.com/eclipse/openj9-omr/tree/master)
-    and [`openj9`](https://github.com/eclipse/openj9-omr/tree/openj9)
+    `eclipse/openj9-omr` [`master`](https://github.com/eclipse-openj9/openj9-omr/tree/master)
+    and [`openj9`](https://github.com/eclipse-openj9/openj9-omr/tree/openj9)
     branches are the same before proceeding.  If they are different,
     be aware that you will be introducing other OMR changes that have
     not yet passed an OMR Acceptance build.  While not strictly
@@ -157,7 +157,7 @@ possible between them.
 5.  Launch a ["Mirror-OMR-To-OpenJ9-OMR Build"](https://ci.eclipse.org/openj9/job/Mirror-OMR-to-OpenJ9-OMR/)
     job in the Eclipse OpenJ9 project by clicking "Build Now".  This will
     pull the latest Eclipse OMR project `master` branch into the
-    [`eclipse/openj9-omr`](https://github.com/eclipse/openj9-omr) repo's
+    [`eclipse/openj9-omr`](https://github.com/eclipse-openj9/openj9-omr) repo's
     `master` branch and automatically launch an OMR Acceptance Build at
     OpenJ9 Jenkins.
     
@@ -176,7 +176,7 @@ possible between them.
    
     | Field          | Value                                       |
     | :------------- | :------------------------------------------ |
-    | REPO           | `https://github.com/eclipse/openj9-omr.git` |
+    | REPO           | `https://github.com/eclipse-openj9/openj9-omr.git` |
     | COMMIT         | *SHA of the OMR commit from Step 7*         |
     | TARGET_BRANCH  | `openj9`                                    |
 

--- a/doc/build-instructions/Build_Compiler_Only.md
+++ b/doc/build-instructions/Build_Compiler_Only.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ component; cross component work will require a full JVM rebuild.
 ## Steps
 
 First, build OpenJ9 as per the instructions 
-in https://github.com/eclipse/openj9/tree/master/doc/build-instructions.
+in https://github.com/eclipse-openj9/openj9/tree/master/doc/build-instructions.
 Then, to build only the Compiler component, set up your environment as 
 follows:
 

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -63,7 +63,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
 Download the docker build script to your local system or copy and paste the following command:```
 

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -68,7 +68,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 Download the docker build script to your local system or copy and paste the following command:```
 
 ```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
+wget https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh
 ```
 
 3. Next, run the following command to build a Docker image, called **openj9**:

--- a/doc/build-instructions/Build_Instructions_V16.md
+++ b/doc/build-instructions/Build_Instructions_V16.md
@@ -62,7 +62,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
 Download the docker build script to your local system or copy and paste the following command:
 

--- a/doc/build-instructions/Build_Instructions_V16.md
+++ b/doc/build-instructions/Build_Instructions_V16.md
@@ -67,7 +67,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 Download the docker build script to your local system or copy and paste the following command:
 
 ```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
+wget https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh
 ```
 
 3. Next, run the following command to build a Docker image, called **openj9**:

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -68,7 +68,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 Download the docker build script to your local system or copy and paste the following command:
 
 ```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
+wget https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh
 ```
 
 3. Next, run the following command to build a Docker image, called **openj9**:

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -63,7 +63,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
 Download the docker build script to your local system or copy and paste the following command:
 

--- a/doc/compiler/JitWriteBarriers.md
+++ b/doc/compiler/JitWriteBarriers.md
@@ -52,7 +52,7 @@ can be inlined at runtime to improve performance.
 The OpenJ9 VM supports a number of different write barriers depending on which
 GC policy has been selected. All possible write barriers required by the GC are
 defined in
-[gc_include/j9modron.h](https://github.com/eclipse/openj9/blob/f0a4235ef0e2e6e1a8d476c4cf8dbf1ea1bc1cdf/runtime/gc_include/j9modron.h#L42-L51).
+[gc_include/j9modron.h](https://github.com/eclipse-openj9/openj9/blob/f0a4235ef0e2e6e1a8d476c4cf8dbf1ea1bc1cdf/runtime/gc_include/j9modron.h#L42-L51).
 
 In summary:
 
@@ -213,7 +213,7 @@ object checks can be eliminated or if the write barrier can be skipped entirely.
 
 The ultimate reference for the operation of each write barrier kind is the
 garbage collector code itself. These implementations can be found in
-[gc_include/ObjectAccessBarrierAPI.hpp](https://github.com/eclipse/openj9/blob/master/runtime/gc_include/ObjectAccessBarrierAPI.hpp).
+[gc_include/ObjectAccessBarrierAPI.hpp](https://github.com/eclipse-openj9/openj9/blob/master/runtime/gc_include/ObjectAccessBarrierAPI.hpp).
 
 The following pseudocode is derived largely from those implementations.
 

--- a/doc/compiler/aot/InlinedMethods.md
+++ b/doc/compiler/aot/InlinedMethods.md
@@ -100,7 +100,7 @@ If the inlined method has a guard assocated with it, then the Inlined Method
 with NOP Guard / Profiled Inlined Method with Guard relocations are 
 generated. If not, then the Inlined Method / Profiled Inlined Method
 relocations are generated. Additionally, unless the 
-[SVM](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
+[SVM](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
 is enabled, the inlined method external relocations are the
 last entries added to the list; if the SVM is enabled, the SVM validation
 records are added next - part of the validation that would've been done by
@@ -134,8 +134,8 @@ which
 
 1. Materializes the class of the inlined method:
     * If the SVM is enabled, the class ID in the relocation record is used.
-    * If the SVM is disabled, the process described [here](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md#finding-a-candidate-j9class) is used, specifically the section about using the class chain of the first class loaded by the classloader that loaded the class of the inlined method.
-2. Validates the [Class Chain](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md)  of the class from 1.
+    * If the SVM is disabled, the process described [here](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/ClassChains.md#finding-a-candidate-j9class) is used, specifically the section about using the class chain of the first class loaded by the classloader that loaded the class of the inlined method.
+2. Validates the [Class Chain](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/ClassChains.md)  of the class from 1.
 3. Materializes the inlined method from the class from 1 using the method index stored in the relocation record.
 4. Checks if the inlined site can be activated because of debug or other JVM restrictions.
 

--- a/doc/compiler/aot/README.md
+++ b/doc/compiler/aot/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,9 +51,9 @@ method already exists in the SCC and loads that instead.
 2. [Introduction to AOT](https://blog.openj9.org/2018/10/10/intro-to-ahead-of-time-compilation/)
 3. [AOT: Relocation](https://blog.openj9.org/2018/10/26/ahead-of-time-compilation-relocation/)
 4. [AOT: Validation](https://blog.openj9.org/2018/11/08/ahead-of-time-compilation-validation/)
-5. [Class Chains](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md)
-6. [Symbol Validation Manager](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
-7. [Inlined Methods](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/InlinedMethods.md)
+5. [Class Chains](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/ClassChains.md)
+6. [Symbol Validation Manager](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
+7. [Inlined Methods](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/InlinedMethods.md)
 
 
 <hr/>

--- a/doc/compiler/aot/SymbolValidationManager.md
+++ b/doc/compiler/aot/SymbolValidationManager.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -119,7 +119,7 @@ validated; fail otherwise
 Class Chains are a core component of AOT validation; they ensure that
 the shape of a class is the same as that during the compile run. For
 technical details about Class Chains, see 
-[AOT Class Chains](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/AOTClassChains.md).
+[AOT Class Chains](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/AOTClassChains.md).
 Thus, for every validation record involving classes, a Class Chain
 Validation Record is also created (unless a record for that class
 already exists).

--- a/doc/compiler/il/IL_FAQ.md
+++ b/doc/compiler/il/IL_FAQ.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2000, 2018 IBM Corp. and others
+Copyright (c) 2000, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@ etc.  Over time this will become a comprehensive overview of TR IL.
 ## Do `monenter` & `monexit` trees have to be anchored to a 'treetop'?
 
 ### Detailed question:
-From [issue 475](https://github.com/eclipse/openj9/issues/475):
+From [issue 475](https://github.com/eclipse-openj9/openj9/issues/475):
 A log of `java/lang/StringBuffer.length()I` shows:
 ```
 n13n      monent  jitMethodMonitorEntry[#178  helper Method]

--- a/doc/compiler/jitserver/Build.md
+++ b/doc/compiler/jitserver/Build.md
@@ -106,7 +106,7 @@ git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8.git
 
 cd openj9-openjdk-jdk8
 
-bash get_source.sh -openj9-repo=https://github.com/eclipse/openj9.git -omr-repo=https://github.com/eclipse/openj9-omr.git
+bash get_source.sh -openj9-repo=https://github.com/eclipse-openj9/openj9.git -omr-repo=https://github.com/eclipse-openj9/openj9-omr.git
 
 bash configure --with-freemarker-jar=/root/freemarker.jar --with-boot-jdk=/root/bootjdk8 --enable-jitserver
 
@@ -114,7 +114,7 @@ make all
 ```
 Depending on where you want to fetch OpenJ9 sources from, you could use your own repository as shown below:
 ```
-bash get_source.sh -openj9-repo=https://github.com/<Your GitHub UserID>/openj9.git -omr-repo=https://github.com/eclipse/openj9-omr.git
+bash get_source.sh -openj9-repo=https://github.com/<Your GitHub UserID>/openj9.git -omr-repo=https://github.com/eclipse-openj9/openj9-omr.git
 ```
 See https://www.eclipse.org/openj9/oj9_build.html for more detail.
 

--- a/doc/compiler/jitserver/Docker.md
+++ b/doc/compiler/jitserver/Docker.md
@@ -25,7 +25,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 ## A Quick Start Demo on Building JITServer for JDK8 in Ubuntu 18.04 on x86_64
 1. Retrieve OpenJ9 Repo
    ```
-   git clone git@github.com:eclipse/openj9.git
+   git clone git@github.com:eclipse-openj9/openj9.git
    OR
    git clone https://github.com/eclipse-openj9/openj9.git
 

--- a/doc/compiler/jitserver/Docker.md
+++ b/doc/compiler/jitserver/Docker.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2020 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
    ```
    git clone git@github.com:eclipse/openj9.git
    OR
-   git clone https://github.com/eclipse/openj9.git
+   git clone https://github.com/eclipse-openj9/openj9.git
 
    # checkout master branch
    cd openj9
@@ -58,7 +58,7 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
    - Sets up the OpenJ9 test environment for JITServer
 
 ## How to use the JITServer Dockerfiles
-### [build/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile)
+### [build/Dockerfile](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile)
 - **Prerequisite**: obtain `openj9` image first
    ```
    docker build -f \
@@ -82,7 +82,7 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
   -t=openj9-jitserver-build .
   ```
 
-### [buildserver/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile)
+### [buildserver/Dockerfile](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile)
 - **Prerequisite**: [`openj9-jitserver-build`](#openj9-jitserver-build) image
 - Build `openj9-jitserver-run-server` using `buildserver/Dockerfile`
    ```
@@ -103,7 +103,7 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
    docker logs -f <openj9-jitserver-run-server-container-id>
    ```
 
-### [test/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/test/Dockerfile)
+### [test/Dockerfile](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/test/Dockerfile)
 - **Prerequisite**:
    - [`openj9-jitserver-build`](#openj9-jitserver-build) image
    - A running [`openj9-jitserver-run-server`](#openj9-jitserver-run-server) container and its IPAddress
@@ -127,7 +127,7 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
    make _<test_name> EXTRA_OPTIONS=" -XX:+UseJITServer:server=<IPAddress> "
    ```
 
-### [buildenv/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildenv/Dockerfile)
+### [buildenv/Dockerfile](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildenv/Dockerfile)
 - Build `openj9-jitserver-buildenv` using `buildenv/Dockerfile`:
    ```
    docker build -f \

--- a/doc/compiler/jitserver/Testing.md
+++ b/doc/compiler/jitserver/Testing.md
@@ -32,9 +32,9 @@ These are the steps to run the tests on your machine.
 1. Compile a build of openj9 from scratch. (Optional: compile a debug build if you need it. To do this pass the flag `--with-debug-level=slowdebug` to `configure`.
    Please note that debug build is much slower and the tests will take very long time to finish).
 
-2. Install [prerequisites](https://github.com/eclipse/openj9/blob/master/test/docs/Prerequisites.md)
+2. Install [prerequisites](https://github.com/eclipse-openj9/openj9/blob/master/test/docs/Prerequisites.md)
 
-   An example of how to install the prerequisites can be found [here](https://github.com/eclipse/openj9/blob/master/buildenv/docker/test/Dockerfile#L57-L68). Make sure that JAVA_HOME and JAVA_BIN are set (E.g. `export JAVA_HOME=/root/openj9-openjdk-jdk11/build/linux-x86_64-normal-server-release/images/jdk` and `export JAVA_BIN=/root/openj9-openjdk-jdk11/build/linux-x86_64-normal-server-release/images/jdk/bin`). Basically you want to test on the jdk you build, so point the environment variable to your personal build of jdk.
+   An example of how to install the prerequisites can be found [here](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/docker/test/Dockerfile#L57-L68). Make sure that JAVA_HOME and JAVA_BIN are set (E.g. `export JAVA_HOME=/root/openj9-openjdk-jdk11/build/linux-x86_64-normal-server-release/images/jdk` and `export JAVA_BIN=/root/openj9-openjdk-jdk11/build/linux-x86_64-normal-server-release/images/jdk/bin`). Basically you want to test on the jdk you build, so point the environment variable to your personal build of jdk.
 3. Compile  the tests (only need to compile once):
    ```
    cd $OPENJ9_DIR/openj9/test
@@ -92,7 +92,7 @@ These are the steps to run the tests on your machine.
    make <name_of_the_test>
    ```
 
-For more advanced testing features, refer to [this guide](https://github.com/eclipse/openj9/blob/master/test/docs/OpenJ9TestUserGuide.md).
+For more advanced testing features, refer to [this guide](https://github.com/eclipse-openj9/openj9/blob/master/test/docs/OpenJ9TestUserGuide.md).
 
 ## DOCKER
 

--- a/doc/compiler/runtime/CodeCacheReclamation.md
+++ b/doc/compiler/runtime/CodeCacheReclamation.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ Once it has been determined that the method body is stale, it is added to the Fa
 Cache Block list. However, not all of the stale body is slated to get reclaimed; the 
 pre-prologue and some number of instructions are kept intact. This is to ensure that
 other code that has a call to the stale body can continue execution - as described
-in the [Recompilation doc](https://github.com/eclipse/openj9/blob/master/doc/compiler/runtime/Recompilation.md), 
+in the [Recompilation doc](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/runtime/Recompilation.md), 
 the Start PC is patched to jump to a helper.
 
 At the end of a GC cycle, `jitReleaseCodeStackWalk` is invoked, which first walks

--- a/doc/diagnostics/VMState.md
+++ b/doc/diagnostics/VMState.md
@@ -32,7 +32,7 @@ javacore dump (in which it is referred to as "VM flags"), and serves
 as a first-order indicator of the failing component during problem
 determination. 
 
-[1]: https://github.com/eclipse/openj9/blob/master/runtime/oti/j9nonbuilder.h
+[1]: https://github.com/eclipse-openj9/openj9/blob/master/runtime/oti/j9nonbuilder.h
 
 ## Decoding
 
@@ -80,7 +80,7 @@ active component is likely to be in the compiler initialization or
 the IL generator.
 
 [2]: https://github.com/eclipse/omr/blob/master/compiler/optimizer/Optimizations.hpp
-[3]: https://github.com/eclipse/openj9/blob/master/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
+[3]: https://github.com/eclipse-openj9/openj9/blob/master/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
 
 ## Finding the VM state examples
 

--- a/doc/features/SharedClassesCache.md
+++ b/doc/features/SharedClassesCache.md
@@ -27,7 +27,7 @@ data between JVMs. For more information see [1].
 
 The JIT Compiler uses the SCC to store both AOT code as well as data either
 necessary for AOT 
-(e.g. [Class Chains](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md)),
+(e.g. [Class Chains](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/ClassChains.md)),
 or for performace (e.g. IProfiler data). The JIT interfaces with the SCC via
 the `TR_J9SharedCache` class.
 

--- a/doc/processes/labels.md
+++ b/doc/processes/labels.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ Label to indicate that a PR or issue requires external documentation (new featur
 
 * `doc:externals`
 
-**Note:** When you use this label, you must open an [issue](https://github.com/eclipse/openj9-docs/issues/new?template=new-documentation-change.md) in the OpenJ9 documentation repo.
+**Note:** When you use this label, you must open an [issue](https://github.com/eclipse-openj9/openj9-docs/issues/new?template=new-documentation-change.md) in the OpenJ9 documentation repo.
 
 End User issues
 ---

--- a/doc/processes/release_process.md
+++ b/doc/processes/release_process.md
@@ -24,12 +24,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 The OpenJ9 JVM is composed of two code repositories:
 
-* OpenJ9 https://github.com/eclipse/openj9
-* OMR https://github.com/eclipse/openj9-omr
+* OpenJ9 https://github.com/eclipse-openj9/openj9
+* OMR https://github.com/eclipse-openj9/openj9-omr
 
 and one has an external test repo:
 
-* https://github.com/eclipse/openj9-systemtest
+* https://github.com/eclipse-openj9/openj9-systemtest
 
 OpenJ9 needs to be combined with code from OpenJDK to create a Java SDK.
 The OpenJDK code is managed in separate github repos referred to as the 

--- a/doc/release-notes/0.10/0.10.md
+++ b/doc/release-notes/0.10/0.10.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -57,31 +57,31 @@ The following table covers notable changes in v0.10.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2108">#2108</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2108">#2108</a></td>
 <td valign="top">JEP 181 Nest-Based Access Control</td>
 <td valign="top">OpenJDK11</td>
 <td valign="top">Implementing OpenJDK 11 <a href="http://openjdk.java.net/jeps/181">JEP 181</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/954">#954</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/954">#954</a></td>
 <td valign="top">JEP 309 Dynamic Class-File Constants</td>
 <td valign="top">OpenJDK11</td>
 <td valign="top">Implementing OpenJDK 11 <a href="http://openjdk.java.net/jeps/309">JEP 309</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/992">#992</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/992">#992</a></td>
 <td valign="top">JEP 320 Remove the Java EE and CORBA Modules</td>
 <td valign="top">OpenJDK11</td>
 <td valign="top">Implementing OpenJDK 11 <a href="http://openjdk.java.net/jeps/320">JEP 320</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1875">#1875</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1875">#1875</a></td>
 <td valign="top">JEP 327 Unicode 10</td>
 <td valign="top">OpenJDK11</td>
 <td valign="top">Implementing OpenJDK 11 <a href="http://openjdk.java.net/jeps/327">JEP 327</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/2576">#2576</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/2576">#2576</a></td>
 <td valign="top">Performance improvements for VM entry/exit for JNI natives</td>
 <td valign="top">OpenJDK8 and later: All platforms</td>
 <td valign="top">Atomic compare-and-swap operations are replaced with
@@ -89,31 +89,31 @@ a modified Dekker algorithm, which provides a lightweight mechanism
 for synchronizing VM entry and exit for JNI native code.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1938">#1938</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1938">#1938</a></td>
 <td valign="top">The default shared classes cache size is increased.</td>
 <td valign="top">OpenJDK8: 64-bit platforms</td>
 <td valign="top">The default size is increased from 16 MB to 300 MB, with a "soft" maximum limit for the initial size of the cache (-Xscmx) set to 64 MB.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2746">#2746</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2746">#2746</a></td>
 <td valign="top">Java dump files now record the value for the soft maximum shared cache size (`-Xscmx`).</td>
 <td valign="top">OpenJDK8 and later: All platforms</td>
 <td valign="top">The value for `-Xscmx` is recorded in the `SHARED CLASSES` section of the Java dump file against the string `2SCLTEXTSMB`. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/2508">#2508</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/2508">#2508</a></td>
 <td valign="top">New OpenJ9 option, <code>-XX:HeapDumpPath</code>.</td>
 <td valign="top">OpenJDK8 and later: All platforms</td>
 <td valign="top">For compatibility with HotSpot, <code>-XX:HeapDumpPath</code> is accepted by OpenJ9, which has the same functionality as <code>-Xdump:directory</code>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/2533">#2533</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/2533">#2533</a></td>
 <td valign="top">New OpenJ9 option, <code>-XX:[+|-]HeapDumpOnOutOfMemoryError</code>.</td>
 <td valign="top">OpenJDK8 and later: All platforms</td>
 <td valign="top">For compatibility with HotSpot, <code>-XX:[+|-]HeapDumpOnOutOfMemoryError</code> is accepted by OpenJ9, which can enable or disable dumps when an OutOfMemory exception occurs.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/2196">#2196</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/2196">#2196</a></td>
 <td valign="top">New OpenJ9 option, <code>-XX:ActiveProcessorCount=<value></code>.</td>
 <td valign="top">OpenJDK8 and later: All platforms</td>
 <td valign="top">For compatibility with HotSpot, this option overrides the value for the number of CPUs that are automatically detected by the JVM. Additional Java dump information is recorded when the option is set.</td>
@@ -138,35 +138,35 @@ The v0.10.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/378">#378</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/378">#378</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">AIX</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -184,4 +184,4 @@ The v0.10.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.10.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.10.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.10.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.10.0).

--- a/doc/release-notes/0.11/0.11.md
+++ b/doc/release-notes/0.11/0.11.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -58,37 +58,37 @@ The following table covers notable changes in v0.11.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3118">#3118</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3118">#3118</a></td>
 <td valign="top">OpenSSL V1.1.1 support</td>
 <td valign="top">OpenJDK8 (All platforms)</td>
 <td valign="top">OpenSSL support is now available for improved cryptographic performance for the CBC, Digest, and GCM algorithms.  New command line options are available for disabling or enabling the algorithms.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2862">#2862</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2862">#2862</a></td>
 <td valign="top">The default shared cache and cache snapshot directory is changed to the user's home directory</td>
 <td valign="top">OpenJDK11 (AIX, Linux)</td>
 <td valign="top">This change is for non-Windows platforms and applies only if `-Xshareclasses:groupAccess` is not used. If `groupAccess` is used, the directory that gets set remains as `/tmp/javasharedresources/`.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2862">#2862</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2862">#2862</a></td>
 <td valign="top">Two new `-Xshareclasses` suboptions are introduced </td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">`-Xshareclasses:bootClassesOnly` prevents non-bootstrap class loaders caching classes in the shared classes cache. `-Xshareclasses:fatal` prevents the shared classes cache being started if an error occurs. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3184">#3184</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3184">#3184</a></td>
 <td valign="top">VM container-awareness is now enabled by default</td>
 <td valign="top">OpenJDK8 and later (Linux)</td>
 <td valign="top">In earlier releases, this behavior was enabled by setting the `-XX:+UseContainerSupport` option. This setting is now the default. When the VM is running in a container, and a memory limit is set, the VM allocates more memory to the Java heap. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3054">#3054</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3054">#3054</a></td>
 <td valign="top">Concurrent scavenge mode is now available on Linux x86</td>
 <td valign="top">OpenJDK8 and later (x86-64: Linux only)</td>
 <td valign="top">When this mode is enabled, (`-Xgc:concurrentScavenge`) the VM attempts to reduce GC pause-times for response-time sensitive, large heap applications. This mode is available only on compressed references builds. Attempting to use this option on a non-compressed references build results in an *unrecognized option* error message. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3062">#3062</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3062">#3062</a></td>
 <td valign="top">New command line option `-XX:[+|-]PositiveIdentityHash`</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">When enabled, identity hash codes (`System.identityHashCode` / `Object.hashCode`) always return non-negative values. Because the performance of identity hash-intensive operations might be impacted, this option is not enabled by default.</td>
@@ -113,7 +113,7 @@ The v0.11.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/378">#378</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/378">#378</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">AIX and macOS</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
@@ -127,35 +127,35 @@ The v0.11.0 release contains the following known issues and limitations:
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -173,4 +173,4 @@ The v0.11.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.11.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.11.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.11.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.11.0).

--- a/doc/release-notes/0.12/0.12.1.md
+++ b/doc/release-notes/0.12/0.12.1.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,7 @@ The following table covers notable changes in v0.12.1. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4530">#4530</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4530">#4530</a></td>
 <td valign="top">OpenSSL acceleration of the Digest algorithm is disabled by default.</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">Intermittent segmentation problems are observed when accelerating the Digest algorithm. This algorithm is now
@@ -80,14 +80,14 @@ The v0.12.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3483">#3483</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">macOS</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4222">#4222</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4222">#4222</a></td>
 <td valign="top">Shared classes no longer enabled by default</td>
 <td valign="top">All platforms</td>
 <td valign="top">In milestone 1, shared classes were enabled by default. This change has been reverted due to a performance regression.</td>
@@ -101,35 +101,35 @@ The v0.12.0 release contains the following known issues and limitations:
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -141,4 +141,4 @@ The v0.12.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.12.1](https://github.com/eclipse/openj9/releases/tag/openj9-0.12.1).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.12.1](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.12.1).

--- a/doc/release-notes/0.12/0.12.md
+++ b/doc/release-notes/0.12/0.12.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -55,51 +55,51 @@ The following table covers notable changes in v0.12.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/3446">#3446</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/3446">#3446</a></td>
 <td valign="top">Improved flexibility for managing the size of the JIT code cache</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">The size of the JIT code cache (-Xcodecachetotal) can now be decreased as well as increased, with a minimum size of 2 MB</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/3992">#3992</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/3992">#3992</a></td>
 <td valign="top">OpenSSL is now supported for OpenJDK 11 to improve native cryptographic performance </td>
 <td valign="top">OpenJDK11 (All platforms)</td>
 <td valign="top">The OpenSSL V1.1.x implementation is enabled by default and supported for the Digest, CBC, and GCM algorithms. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3478">#3478</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3478">#3478</a></td>
 <td valign="top">New environment variable OPENJ9_JAVA_OPTIONS</td>
 <td valign="top">OpenJDK8 and later (Linux)</td>
 <td valign="top">This environment variable replaces the IBM_JAVA_OPTIONS variable, whis is now deprecated and will be removed from a future release. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3338">#3338</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3338">#3338</a></td>
 <td valign="top">Concurrent scavenge mode is now available on Linux x86 for large heap applications</td>
 <td valign="top">OpenJDK8 and later (x86-64: Linux only)</td>
 <td valign="top">When this mode is enabled, (`-Xgc:concurrentScavenge`) the VM attempts to reduce GC pause-times for response-time sensitive, large heap applications. This mode is now available on large heap (non-compressed references) builds. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4108">#4108</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4108">#4108</a></td>
 <td valign="top">Concurrent scavenge mode is now available on Windows x86</td>
 <td valign="top">OpenJDK8 and later (x86-64: Windows only)</td>
 <td valign="top">When this mode is enabled, (`-Xgc:concurrentScavenge`) the VM attempts to reduce GC pause-times for response-time sensitive applications. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3226">#3226</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3226">#3226</a></td>
 <td valign="top">Idle-tuning is enabled by default</td>
 <td valign="top">OpenJDK8 and later (Linux only)</td>
 <td valign="top">When OpenJ9 is running in a container, a garbage collection cycle and compaction of the object heap is attempted when
 the state of the VM is set to idle. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/4025">#4025</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/4025">#4025</a></td>
 <td valign="top">Changes to the default permissions of shared classes cache directories</td>
 <td valign="top">OpenJDK8 and later (All platforms except Windows)</td>
 <td valign="top">Tighter restrictions are imposed on existing and new shared classes cache directories. For further
 information about this change, see the <a href="https://www.eclipse.org/openj9/docs/version0.12/">user documentation</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3636">#3636</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3636">#3636</a></td>
 <td valign="top">OpenSSL V1.1 support for the RSA algorithm</td>
 <td valign="top">OpenJDK8 and later (All platforms except AIX)</td>
 <td valign="top">OpenSSL 1.1.x support is now available for the RSA algorithm, in addition to Digest, CBC, and GCM.</a></td>
@@ -124,14 +124,14 @@ The v0.12.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3483">#3483</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">macOS</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4222">#4222</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4222">#4222</a></td>
 <td valign="top">Shared classes no longer enabled by default</td>
 <td valign="top">All platforms</td>
 <td valign="top">In milestone 1, shared classes were enabled by default. This change has been reverted due to a performance regression.</td>
@@ -145,35 +145,35 @@ The v0.12.0 release contains the following known issues and limitations:
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -185,4 +185,4 @@ The v0.12.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.12.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.12.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.12.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.12.0).

--- a/doc/release-notes/0.13/0.13.md
+++ b/doc/release-notes/0.13/0.13.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -54,7 +54,7 @@ The following table covers notable changes in v0.13. Further information about t
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4655">#4655</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4655">#4655</a></td>
 <td valign="top">Extended platform support for software-based pause-less garbage collection</td>
 <td valign="top">OpenJDK8 and later (Linux on POWER LE and AIX platforms)</td>
 <td valign="top">Reduced garbage collection pause times when using -Xgc:concurrentScavenge with the gencon GC policy for Linux on POWER LE and
@@ -67,19 +67,19 @@ AIX platforms. </td>
 <td valign="top">Improved cryptographic performance for the Digest, CBC, GCM, and RSA algorithms. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4655">#4655</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4655">#4655</a></td>
 <td valign="top">New Java process status tool (jps)</td>
 <td valign="top">OpenJDK12 (All platforms)</td>
 <td valign="top">The tool can be used to query running Java processes. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2837">#2837</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2837">#2837</a></td>
 <td valign="top">Ability to print a Java dump to STDOUT/STDERR</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">Although printing to a file is the best approach for recording a Java dump, the ability to print to STDOUT/STDERR can be useful in some scenarios.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1932">#1932</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1932">#1932</a></td>
 <td valign="top">Control group (cgroup) information is recorded in a Java dump file</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">Improved diagnostic capability where cgroups are used to control resources. For example, the Docker engine uses cgroups for Docker containers. </td>
@@ -104,42 +104,42 @@ The v0.13.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3483">#3483</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">macOS</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -151,4 +151,4 @@ The v0.13.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.13.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.13.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.13.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.13.0).

--- a/doc/release-notes/0.14/0.14.md
+++ b/doc/release-notes/0.14/0.14.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -56,7 +56,7 @@ The following table covers notable changes in v0.14. Further information about t
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5023">#5023</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5023">#5023</a></td>
 <td valign="top">Extended platform support for software-based pause-less garbage collection</td>
 <td valign="top">OpenJDK8 and later (Linux on POWER BE)</td>
 <td valign="top">Reduced garbage collection pause times when using -Xgc:concurrentScavenge with the gencon GC policy for Linux on POWER BE. </td>
@@ -68,51 +68,51 @@ The following table covers notable changes in v0.14. Further information about t
 <td valign="top">Improved cryptographic performance for the Digest, CBC, GCM, and RSA algorithms. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4435">#4435</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4435">#4435</a></td>
 <td valign="top">New -XX:[+|-]IgnoreUnrecognizedXXColonOptions command-line option</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">Ability to discover -XX: options that the VM does not recognize on the command line. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4988">#4988</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4988">#4988</a></td>
 <td valign="top">New -XX:[+|-]ReadIPInfoForRAS command-line option</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">Ability to skip a nameserver request to avoid the situation where hostname and IP address cannot be resolved and an application pauses for up to 60 seconds until the request times out.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3483">#3483</a></td>
 <td valign="top">DDR support enabled on macOS&reg; platforms</td>
 <td valign="top">OpenJDK8 and later (macOS platform)</td>
 <td valign="top">In earlier releases, DDR support was not available on the macOS platform, which affected problem diagnosis for the VM, garbage collector, and JIT compiler.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4858">#4858</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4858">#4858</a></td>
 <td valign="top">New Java stack tool (jstack)</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">This tool can be used to obtain Java stack traces and thread information for Java processes.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4655">#4655</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/4655">#4655</a></td>
 <td valign="top">New Java process status tool (jps)</td>
 <td valign="top">OpenJDK8 and 11 (All platforms)</td>
 <td valign="top">This tool can be used to query running Java processes. This tool is already available with OpenJDK 12. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1831">#1831</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1831">#1831</a></td>
 <td valign="top">Changes to the shared classes cache generation number</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
 <td valign="top">The shared cache generation number is changed, which causes the JVM to create a new shared classes cache, rather than re-creating or reusing an existing cache. To save space, all existing shared caches can be removed unless they are in use by an earlier release. For more
 information, see <a href="https://www.eclipse.org/openj9/docs/xshareclasses/">-Xshareclasses</a>. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3153">#3153</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3153">#3153</a></td>
 <td valign="top">Optimizations to support JVMTI field watches</td>
 <td valign="top">OpenJDK8 and later (Windows and Linux on x86  only)</td>
 <td valign="top">A new option is available to turn on experimental performance improvements for JVMTI watched fields. For more
 information, see <a href="https://www.eclipse.org/openj9/docs/xxjitinlinewatches/">-XX:[+|-]JITInlineWatches</a>. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5156">#5156</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5156">#5156</a></td>
 <td valign="top">Change to the default native stack size (set by -Xmso)</td>
 <td valign="top">OpenJDK8 and later (64-bit z/OS&reg; only)</td>
 <td valign="top">The default size is changed from 384 KB to 1 MB, see <a href="https://www.eclipse.org/openj9/docs/openj9_defaults/">Default settings for the OpenJ9 VM</a>. </td>
@@ -137,35 +137,35 @@ The v0.14.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Currently, shutdown signals (<code>SIGINT</code>, <code>SIGHUP</code> and <code>SIGTERM</code>) and <code>SIGCONT</code> are fully supported on Unix platforms (pLinux, zLinux, xLinux, AIX, and z/OS). Support for other POSIX signals is pending. See <code>SunMiscSignalTest.java</code> for the list of signals that need to be supported.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -177,4 +177,4 @@ The v0.14.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.14.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.14.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.14.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.14.0).

--- a/doc/release-notes/0.15/0.15.md
+++ b/doc/release-notes/0.15/0.15.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -53,14 +53,14 @@ The following table covers notable changes in v0.15. Further information about t
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5598">#5598</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5598">#5598</a></td>
 <td valign="top">Performance improvements for JVMTI watched fields by default</td>
 <td valign="top">OpenJDK8 and later (x86, Linux on Z, and z/OS only)</td>
 <td valign="top">Following successful results, the experimental <tt>-XX:[+|-]JITInlineWatches</tt> option is now enabled by default, providing
 performance improvements for JVMTI watched fields on x86 systems. Support is also extended from x86 to Linux on Z, and z/OS. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5183">#5183</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5183">#5183</a></td>
 <td valign="top">Extended platform support for software-based pause-less garbage collection</td>
 <td valign="top">OpenJDK8 and later (IBM Z systems)</td>
 <td valign="top">Reduced garbage collection pause times when using <tt>-Xgc:concurrentScavenge</tt> with the <tt>gencon</tt> GC policy for Linux on Z systems. </td>
@@ -75,48 +75,48 @@ performance improvements for JVMTI watched fields on x86 systems. Support is als
 <tr><td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/59">#59</a></td>
 <td valign="top">System property <tt>jdk.nativeDigest</tt> has no effect</td>
 <td valign="top">OpenJDK8 and later</td>
-<td valign="top">The Digest algorithm is now disabled for JDK 12 due to <a href="https://github.com/eclipse/openj9/issues/5611">#5611</a>. The algorithm was disabled in JDK 8 and 11 in Eclipse OpenJ9 release 0.14.2. The system property <tt>jdk.nativeDigest</tt> cannot be used to enable the use of the Digest algorithm with OpenSSL. </td>
+<td valign="top">The Digest algorithm is now disabled for JDK 12 due to <a href="https://github.com/eclipse-openj9/openj9/issues/5611">#5611</a>. The algorithm was disabled in JDK 8 and 11 in Eclipse OpenJ9 release 0.14.2. The system property <tt>jdk.nativeDigest</tt> cannot be used to enable the use of the Digest algorithm with OpenSSL. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">OpenJ9 now supports all POSIX signals listed in <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/openj9/test/jdk/sun/misc/SunMiscSignalTest.java"><tt>SunMiscSignalTest.java</tt></a>.</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Earlier release notes reported gaps in signal handling support, which are now resolved in this release. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5239">#5293</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5239">#5293</a></td>
 <td valign="top">Compatibility support for <tt>-XX:OnOutOfMemoryError</tt></td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For compatibility with HotSpot, this option can now be used to run a command or list of commands when a
 <tt>java.lang.OutOfMemoryError</tt> exception occurs. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6013">#6013</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6013">#6013</a></td>
 <td valign="top">Support for Transparent HugePage allocation</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The VM now supports Transparent HugePage on Linux when you use the <tt>madvise</tt> (<tt>/sys/kernel/mm/transparent_hugepage/enabled</tt>) setting. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5538">#5538</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5538">#5538</a></td>
 <td valign="top">New <tt>jmap</tt> tool</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For compatibility, OpenJ9 includes an independent implementation of the <tt>jmap</tt> tool, which
 prints statistics about classes on the heap, including number of objects and aggregate size.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/2679">#2679</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/2679">#2679</a></td>
 <td valign="top">JEP 331 is implemented</td>
 <td valign="top">OpenJDK11 and later</td>
 <td valign="top">An implementation of <a href="http://openjdk.java.net/jeps/331">JEP 331</a> (Low-Overhead Heap Profiling) is now available. Restrictions are detailed in the <a href="https://eclipse.github.io/openj9-docs/version0.15/">user documentation</a>. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5882">#5882</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5882">#5882</a></td>
 <td valign="top"><tt>-Xdiagnosticscollector</tt> option removed</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">No impact. Redundant option removed.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5374">#5374</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5374">#5374</a></td>
 <td valign="top">New heuristics to implement compaction during idle garbage collection</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Heuristics are added to automatically compact the heap during idle garbage collection (GC) processing. Therefore, if
@@ -124,14 +124,14 @@ prints statistics about classes on the heap, including number of objects and agg
 <tt>-XX:+IdleTuningCompactOnIdle</tt> must be enabled. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5374">#5374</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5374">#5374</a></td>
 <td valign="top">Change in shared classes behavior for checking timestamps of jar or zip files</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">In earlier releases, the shared classes cache checks timestamps of jar or zip files every time a class is loaded and reloads a class if the timestamp has changed. This behavior is now changed; timestamps are checked only when zip or jar files are added to class loaders and used for the first time to look for a class.
 To revert to the behavior of earlier releases, set the <tt>-Xshareclasses:checkURLTimestamps</tt> option on the command line when you start your application. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/6059">#6059</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/6059">#6059</a></td>
 <td valign="top">Automatically setting an initial heap size</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">OpenJ9 can now learn and set an appropriate initial heap size for an application as an alternative to a user manually sizing and setting an <tt>-Xms</tt> value. The VM records the size of the heap when startup processing ends, writing this data to the shared classes cache. An average value is set over a few restarts, helping to ensure that the value used for the initial heap size is as accurate as possible. See the <tt>-XX:[+|-]useGCStartupHints</tt> option (disabled by default). The hint
@@ -157,35 +157,35 @@ The v0.15.1 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5533">#5533</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5533">#5533</a></td>
 <td valign="top">Attach API internal interfaces have changed slightly, affecting both the JDK's internal class library and <tt>tools.jar</tt></td>
 <td valign="top">Java 8: all platforms</td>
 <td valign="top">If an application uses a private copy of <tt>tools.jar</tt>, the application might be unable to use the attach API if it is using a newer JDK, because the Java classes will not match.</td>
 <td valign="top">Use the <tt>tools.jar</tt> from the newer JDK.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -198,4 +198,4 @@ The v0.15.1 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.15.1](https://github.com/eclipse/openj9/releases/tag/openj9-0.15.1).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.15.1](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.15.1).

--- a/doc/release-notes/0.16/0.16.md
+++ b/doc/release-notes/0.16/0.16.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -54,52 +54,52 @@ The following table covers notable changes in v0.16. Further information about t
 <tbody>
 
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6271">#6271</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6271">#6271</a></td>
 <td valign="top">Class data sharing for bootstrap classes is enabled by default</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the <tt>-Xshareclasses</tt> option to change the default behavior.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6541">#6541</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6541">#6541</a></td>
 <td valign="top">New option to share VM anonymous classes in the shared classes cache</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Anonymous classes (defined by <tt>Unsafe.defineAnonymousClass</tt>) are now stored in the shared classes cache by default so that they are available for ahead-of-time (AOT) compilation. To
 prevent these classes being shared, use the <tt>-XX:-ShareAnonymousClasses</tt> option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6536">#6536</a>, <a href="https://github.com/eclipse/openj9/pull/5480">#5480</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6536">#6536</a>, <a href="https://github.com/eclipse-openj9/openj9/pull/5480">#5480</a></td>
 <td valign="top">Changes to the shared classes cache generation number</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The format of classes that are stored in the shared classes cache is changed. To save space, all existing shared caches can be removed unless they are in use by an earlier release. For more information about deleting a shared classes cache, see the <tt>-Xshareclasses</tt> option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6234">#6234</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6234">#6234</a></td>
 <td valign="top">Performance improvements for JVMTI watched fields on IBM Power&reg; systems</td>
 <td valign="top">OpenJDK8 and later (AIX&reg; and Linux on POWER)</td>
 <td valign="top">In earlier releases, performance improvements were introduced for JVMTI watched fields on x86, Linux on Z, and z/OS systems. These
 improvements are now available for AIX and Linux on POWER systems.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6713">#6713</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6713">#6713</a></td>
 <td valign="top">Support for Transparent HugePage allocation by default</td>
 <td valign="top">OpenJDK8 and later (Linux on x86)</td>
 <td valign="top">In release 0.15, support was introduced for Transparent HugePage on Linux when the <tt>madvise</tt> (<tt>/sys/kernel/mm/transparent_hugepage/enabled</tt>) setting is set by specifying the <tt>-XX:+TransparentHugePage</tt> option on the command line. This support is now enabled by default for Linux on x86 systems. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5164">#5164</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5164">#5164</a></td>
 <td valign="top">New <tt>jcmd</tt> tool</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For compatibility, OpenJ9 includes an independent implementation of the <tt>jcmd</tt> tool, which can run diagnostic commands on a specified VM or VMs.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3743">#3743</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/3743">#3743</a></td>
 <td valign="top">Automatically setting an initial heap size by default</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">In release 0.15, a new feature was introduced that allowed OpenJ9 to learn and set an appropriate initial heap size for an application as an alternative to a user manually sizing and setting an <tt>-Xms</tt> value. This feature could be enabled by setting the <tt>-XX:+UseGCStartupHints</tt> option on the command line. This
 option is now enabled by default.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5822">#5822</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5822">#5822</a></td>
 <td valign="top">Options <tt>-Xverify:none</tt> and <tt>-noverify</tt> are deprecated</td>
 <td valign="top">OpenJDK13 and later</td>
 <td valign="top">The <tt>-Xverify:none</tt> and <tt>-noverify</tt> options are deprecated in Java 13 and might be removed in a future release. A warning message is issued when these commands are used.</td>
@@ -124,28 +124,28 @@ The v0.16 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/2507">#2507</a></td>
 <td valign="top">Restriction analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -158,4 +158,4 @@ The v0.16 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.16.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.16.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.16.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.16.0).

--- a/doc/release-notes/0.17/0.17.md
+++ b/doc/release-notes/0.17/0.17.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2019 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -62,28 +62,28 @@ The following table covers notable changes in v0.17. Further information about t
 <tr><td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/324">#324</a> <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/191">#191</a></td>
 <td valign="top">OpenSSL Digest algorithm is reenabled</td>
 <td valign="top">OpenJDK8 and 11</td>
-<td valign="top">Following the resolution of issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is reenabled. This algorithm is already supported and enabled on OpenJDK 13.</td>
+<td valign="top">Following the resolution of issue [#5611](https://github.com/eclipse-openj9/openj9/issues/5611), the Digest algorithm is reenabled. This algorithm is already supported and enabled on OpenJDK 13.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7001">#7001</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7001">#7001</a></td>
 <td valign="top">New shared classes cache <tt>-Xshareclasses:noPersistentDiskSpaceCheck</tt> option </td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For file systems that do not support the checking of free space, this option causes the VM to skip the disk space check operation that is done before creating a persistent shared classes cache.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7149">#7149</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7149">#7149</a></td>
 <td valign="top">New option <tt>-XX:[+|-]ShareUnsafeClasses</tt> </td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Provides the ability to enable and disable the storing and finding of Unsafe classes in the shared classes cache, which are created with <tt>Unsafe.defineClass</tt>. This option is enabled by default.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7089">#7089</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7089">#7089</a></td>
 <td valign="top">New option <tt>-XX:[+|-]ClassRelationshipVerifier</tt> </td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Provides the ability to enable and disable the recording and lazy validating of class relationships in the verifier. When enabled, unnecessary class loading is avoided, which can reduce VM startup time. This option is disabled by default and cannot be used with <tt>-Xfuture</tt>, which is also enabled when the <tt>-Xverify:all</tt> option is set. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7213">#7213</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7213">#7213</a></td>
 <td valign="top">New experimental <tt>-Xshareclasses</tt> sub-options for creating layered caches</td>
 <td valign="top">OpenJDK8 and later (64-bit only)</td>
 <td valign="top">The <tt>-Xshareclasses:createLayer</tt> and <tt>-Xshareclasses:layer=<number></tt> options can be used to
@@ -91,28 +91,28 @@ create layered caches, where a cache builds on another cache with the same name.
 <tt>destroyAllLayers</tt>) are also available for managing layered caches. These options are experimental.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5884">#5884</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/5884">#5884</a></td>
 <td valign="top">Support for the IBM z15 processor</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">This release adds JIT compiler support for exploiting z15 instructions.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7332">#7332</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7332">#7332</a></td>
 <td valign="top">Change to default value of <tt>-Dcom.ibm.enableClassCaching=[true|false]</tt></td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">In earlier releases the default value for this option was <tt>true</tt>. The value for this option is now <tt>false</tt>, disabling LUDCL whilst
-[issue 7332](https://github.com/eclipse/openj9/issues/7332) is investigated.
+[issue 7332](https://github.com/eclipse-openj9/openj9/issues/7332) is investigated.
 </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6822">#6822</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/6822">#6822</a></td>
 <td valign="top">Change to Java dump output for HOOKS</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Output for internal VM event callbacks is changed from milliseconds to microseconds. A new field, <tt>3HKTOTALTIME</tt>, provides
 the total duration of previous events. Hook data is now reset after each Java dump. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7064">#7064</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7064">#7064</a></td>
 <td valign="top">Restriction removed for analyzing system (core) dumps</td>
 <td valign="top">Linux and Windows</td>
 <td valign="top">In earlier releases a restriction was in place whereby you had to use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction is now removed.</td>
@@ -137,28 +137,28 @@ The v0.17 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7459">#7549</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7459">#7549</a></td>
 <td valign="top">Startup regression on AIX</td>
 <td valign="top">AIX (64-bit POWER)</td>
 <td valign="top">A 40 - 80% startup regression is under investigation for OpenJDK 8 and 11.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Linux on Z, Linux on Power</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -171,4 +171,4 @@ The v0.17 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.17.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.17.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.17.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.17.0).

--- a/doc/release-notes/0.18/0.18.md
+++ b/doc/release-notes/0.18/0.18.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2019, 2020 IBM Corp. and others
+* Copyright (c) 2019, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -55,73 +55,73 @@ The following table covers notable changes in v0.18.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7841">#7841</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7841">#7841</a></td>
 <td valign="top">JITServer technology preview available</td>
 <td valign="top">OpenJDK8 and 11 (Linux x86-64 only)</td>
 <td valign="top">JITServer decouples the JIT compiler from the OpenJ9 VM, freeing up CPU and memory for an application. JITServer then runs in its own process, either locally or on a remote machine where resources can be separately managed.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7197">#7197</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7197">#7197</a></td>
 <td valign="top"><tt>jextract</tt> is now available on macOS systems</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">Support for the <tt>jextract tool</tt> is now available on macOS platforms in addition to AIX and Linux.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7575">#7575</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7575">#7575</a></td>
 <td valign="top">Timestamp checking of shared classes can be turned off</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The <tt>-Xshareclasses:noTimestampChecks</tt> suboption instructs the VM not to check the timestamps of shared classes, which can improve performance. This option is previously undocumented.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7304">#7304</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7304">#7304</a></td>
 <td valign="top">New minimum value for the <tt>-Xmso</tt> option</td>
 <td valign="top">OpenJDK8 and later (64-bit z/OS only)</td>
 <td valign="top">To match the minimum stack space provided by z/OS, the minimum value for the <tt>-Xmso</tt> option is now 1 MB. A value lower than 1 MB is ignored.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7240">#7240</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7240">#7240</a></td>
 <td valign="top">New <tt>jstat</tt> tool for monitoring Java statistics</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For compatibility with the HotSpot implementation, OpenJ9 now includes an independent implementation of the <tt>jstat</tt> tool for retrieving statistics on a VM.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7665">#7665</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7665">#7665</a></td>
 <td valign="top">Extended platform support for the <tt>-XX:+TransparentHugePage</tt> option</td>
 <td valign="top">OpenJDK8 and later (Linux on POWER and IBM Z)</td>
 <td valign="top">Platform support for the <tt>-XX:+TransparentHugePage</tt> option is now extended to Linux on POWER and Linux on IBM Z. This option takes affect only when Transparent Huge Pages (THP) is set to <tt>madvise</tt> on your system and might increase your application footprint.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7406">#7406</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7406">#7406</a></td>
 <td valign="top">New <tt>exit</tt> dump agent and <tt>-XX:[+|-]ExitOnOutOfMemoryError</tt> option</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The new <tt>exit</tt> dump agent saves information on the state of the VM when the VM shuts down, which can help you diagnose problems. For compatibility, OpenJ9 also supports the HotSpot option <tt>-XX:[+|-]ExitOnOutOfMemoryError</tt>. This option shuts down the VM when a <tt>java.lang.OutOfMemory</tt> error occurs by calling the <tt>exit</tt> dump agent.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7332">#7332</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7332">#7332</a></td>
 <td valign="top">LUDCL caching enabled by default</td>
 <td valign="top">OpenJDK8 and later</td>
-<td valign="top">This feature was disabled by default in Eclipse OpenJ9 0.17.0 due to issue <a href="https://github.com/eclipse/openj9/issues/7332">#7332</a>. This issue is resolved and the option is reenabled.</td>
+<td valign="top">This feature was disabled by default in Eclipse OpenJ9 0.17.0 due to issue <a href="https://github.com/eclipse-openj9/openj9/issues/7332">#7332</a>. This issue is resolved and the option is reenabled.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7427">#7427</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/7427">#7427</a></td>
 <td valign="top">Support for Terabyte suffixes for <tt>-X</tt> and <tt>-XX</tt> options</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">OpenJ9 now supports 't' and 'T' suffixes (indicating terabytes) for <tt>-X</tt> and <tt>-XX</tt> options that take a <tt>&lt;size&gt;</tt> parameter.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7728">#7728</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7728">#7728</a></td>
 <td valign="top">Extended platform support for pause-less garbage collection</td>
 <td valign="top">OpenJDK8 and later (macOS)</td>
 <td valign="top">Support for pause-less garbage collection (<tt>-Xgc:concurrentScavenge</tt>) is now extended to macOS systems.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7955">#7955</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7955">#7955</a></td>
 <td valign="top">Remove restriction on multi-layer shared cache</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">In the previous release, there is a restriction that the <tt>jvmtiSharedCacheInfo.isCorrupt</tt> field and the  <tt>SharedClassCacheInfo.isCacheCorrupt()</tt> method cannot detect a corrupted cache that has a layer number other than zero. This restriction is now removed.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7723">#7723</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/7723">#7723</a></td>
 <td valign="top">Support for OpenJDK HotSpot Garbage Collection options</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">For compatibility, the following HotSpot options are now supported by OpenJ9: <tt>-XX:ParallelGCThreads</tt>, <tt>-XX:ConcGCThreads</tt>, and <tt>-XX:ParallelCMSThreads</tt>.</td>
@@ -146,11 +146,11 @@ The v0.18.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -159,4 +159,4 @@ The v0.18.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.18.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.18.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.18.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.18.0).

--- a/doc/release-notes/0.19/0.19.md
+++ b/doc/release-notes/0.19/0.19.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -53,13 +53,13 @@ The following table covers notable changes in v0.19.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8467">#8467</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8467">#8467</a></td>
 <td valign="top">Change in behavior of <tt>StringBuffer</tt> and <tt>StringBuilder</tt></td>
 <td valign="top">OpenJDK8 only</td>
 <td valign="top"><tt>StringBuffer</tt> and <tt>StringBuilder</tt> grow differently when sized at 1 G char[] or larger. They immediately grow to the maximum possible size, which is the behavior in Java 11 and later releases. To revert to the older behavior of growing only as much as necessary, use the <tt>-Djava.lang.stringBuffer.growAggressively=false</tt> option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8328">#8328</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8328">#8328</a></td>
 <td valign="top">Option to print code cache usage to stderr at JVM shutdown</tt></td>
 <td valign="top">All versions</td>
 <td valign="top">A new command line option <tt>-XX:+PrintCodeCache</tt> allows you to print the code cache memory usage to stderr at JVM shutdown.</td>
@@ -84,11 +84,11 @@ The v0.19.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -97,4 +97,4 @@ The v0.19.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.19.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.19.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.19.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.19.0).

--- a/doc/release-notes/0.20/0.20.md
+++ b/doc/release-notes/0.20/0.20.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -55,25 +55,25 @@ The following table covers notable changes in v0.20.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8498">#8498</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8498">#8498</a></td>
 <td valign="top">Change to default maximum heap size for Java 8</td>
 <td valign="top">OpenJDK8 only</td>
 <td valign="top">For consistency with Java&trade; 11, the default maximum heap size (<tt>-Xmx</tt>) is changed to be 25% of the available memory with a maximum of 25 GB. Where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. If a JVM is not configured properly, this change might lead to increased footprint size, startup time, and longer garbage collection pause times. If you want to revert to the default setting in earlier releases of OpenJ9, use the <tt>-XX:+OriginalJDK8HeapSizeCompatibilityMode</tt> option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8886">#8886</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8886">#8886</a></td>
 <td valign="top">Change to the behavior of the <tt>-XX:[+|-]ExitOnOutOfMemoryError</tt> option</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The <tt>-XX:[+|-]ExitOnOutOfMemoryError</tt> option is updated to exit only on VM <tt>OutOfMemoryErrors</tt> instead of both VM and Java thrown errors to match the Hotspot option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8047">#8047</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8047">#8047</a></td>
 <td valign="top">New option, <tt>-XX:[+|-]GlobalLockReservation</tt></td>
 <td valign="top">OpenJDK8 and later (Power systems only)</td>
 <td valign="top">Option <tt>-XX:[+|-]GlobalLockReservation</tt> enables a new optimization targeted towards the more efficient handling of locking and unlocking Java objects.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/8744">#8744</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/8744">#8744</a></td>
 <td valign="top">Improvements to the <tt>jcmd</tt> tool</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The <tt>jcmd</tt> tool no longer requires a filename when used with the <tt>Dump.java</tt>, <tt>Dump.snap</tt>, or <tt>Dump.system</tt> options.</td>
@@ -98,14 +98,14 @@ The v0.20.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
 <td valign="top">Use an alternative GC policy, such as <tt>gencon</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8762">#8762</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8762">#8762</a></td>
 <td valign="top">Concurrent Scavenge mode not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The concurrent scavenge mode (<tt>-Xgc:concurrentScavenge</tt>) of the <tt>gencon</tt>
@@ -113,39 +113,39 @@ garbage collection policy cannot be used. </td>
 <td valign="top">The <tt>gencon</tt> policy can still be used without this mode operational.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5917">#5917</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/5917">#5917</a></td>
 <td valign="top">JIT dynamic loop transfer not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">Performance is not optimized in this release. </td>
 <td valign="top">None. Performance will improve in a future release.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/6607">#6607</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/6607">#6607</a></td>
 <td valign="top">JIT recompilation not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">Performance is not optimized in this release. </td>
 <td valign="top">None. Performance will improve in a future release.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8966">#8966</a>/<a href="https://github.com/eclipse/openj9/issues/9003">#9003</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8966">#8966</a>/<a href="https://github.com/eclipse-openj9/openj9/issues/9003">#9003</a></td>
 <td valign="top">AOT compilation is not working by default</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">When using shared classes, startup performance is not optimized in this release. </td>
 <td valign="top">To turn on AOT explicitly, specify the <tt>-Xquickstart</tt> or <tt>-Xaot</tt> option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/9251">#9251</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/9251">#9251</a></td>
 <td valign="top">Problems reading system dumps</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">Although core files are successfully generated on AArch64 systems, in some cases the dump viewer (<tt>jdmpview</tt>) in an Aarch64 JVM is unable to read them.</td>
 <td valign="top">Read Aarch64 core files from an alternative JVM, such as x86 Linux or macOS.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -154,4 +154,4 @@ garbage collection policy cannot be used. </td>
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.20.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.20.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.20.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.20.0).

--- a/doc/release-notes/0.21/0.21.md
+++ b/doc/release-notes/0.21/0.21.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -55,39 +55,39 @@ The following table covers notable changes in v0.21.0. Further information about
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/9610">#9610</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/9610">#9610</a></td>
 <td valign="top">New option that affects the handling of the SIGABRT signal</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">By default, the OpenJ9 VM handles SIGABRT signals and generates dump files. A new option is available to force OpenJ9 to match the
 reference implementation, where the signal is handled by the default operating system handler. To match the reference implementation, set <tt>-XX:-HandleSIGABRT</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/9567">#9567</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/9567">#9567</a></td>
 <td valign="top">New option <tt>-XX:[+|-]PrintFlagsFinal</tt> for compatibility with the reference implementation</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">This option provides output that lists configuration parameters for the OpenJ9 VM, such as the maximum heap size setting. The
 implementation is currently incomplete and provides output on only a subset of configuration parameters.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/9676">#9676</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/9676">#9676</a></td>
 <td valign="top">macOS shared libraries version updated</td>
 <td valign="top">OpenJDK8 and later (macOS&reg; only)</td>
 <td valign="top">The version information for shared libraries on macOS has been updated from 0.0.0 to 1.0.0. If an application has linked against a shared library from a previous OpenJ9 release, it needs to be re-linked against the new release.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/9588">#9588</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/9588">#9588</a></td>
 <td valign="top">Change to the output of the <tt>NoClassDefFoundError</tt> exception message to match the reference implementation</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">The order in which class names are printed now matches the reference implementation.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9-docs/pull/583">#583</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9-docs/pull/583">#583</a></td>
 <td valign="top">API reference documentation</td>
 <td valign="top">OpenJDK8 and OpenJDK 11</td>
 <td valign="top">API reference documentation for the OpenJ9 VM is now available in the <a href="https://www.eclipse.org/openj9/docs/api-overview/">user documentation</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8762">#8762</a> <a href="https://github.com/eclipse/openj9/issues/5917">#5917</a> <a href="https://github.com/eclipse/openj9/issues/6607">#6607</a> <a href="https://github.com/eclipse/openj9/issues/8966">#8966</a> <a href="https://github.com/eclipse/openj9/issues/9003">#9003</a> <a href="https://github.com/eclipse/openj9/issues/9251">#9251</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8762">#8762</a> <a href="https://github.com/eclipse-openj9/openj9/issues/5917">#5917</a> <a href="https://github.com/eclipse-openj9/openj9/issues/6607">#6607</a> <a href="https://github.com/eclipse-openj9/openj9/issues/8966">#8966</a> <a href="https://github.com/eclipse-openj9/openj9/issues/9003">#9003</a> <a href="https://github.com/eclipse-openj9/openj9/issues/9251">#9251</a></td>
 <td valign="top">Issue resolution</td>
 <td valign="top">OpenJDK 11 (Linux on 64-bit ARM (AArch64))</td>
 <td valign="top">The following issues that were recorded for this platform in earlier release notes are fixed: Concurrent Scavenge mode is supported,
@@ -113,18 +113,18 @@ The v0.21.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
 <td valign="top">Use an alternative GC policy, such as <tt>gencon</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -133,4 +133,4 @@ The v0.21.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.21.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.21.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.21.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.21.0).

--- a/doc/release-notes/0.22/0.22.md
+++ b/doc/release-notes/0.22/0.22.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -54,22 +54,22 @@ The following table covers notable changes in v0.22.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/pull/9731">#9731</a>, 
-<a href="https://github.com/eclipse/openj9/pull/9993">#9993</a>, 
+<a href="https://github.com/eclipse-openj9/openj9/pull/9731">#9731</a>, 
+<a href="https://github.com/eclipse-openj9/openj9/pull/9993">#9993</a>, 
 <a href="https://github.com/eclipse/omr/pull/5436">#5436</a>, 
-<a href="https://github.com/eclipse/openj9/pull/10305">#10305</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/pull/10305">#10305</a></td>
 <td valign="top">New <tt>-XX:[+|-]PortableSharedCache</tt> option added</td>
 <td valign="top">All versions</td>
 <td valign="top">This option enables AOT compiled code to be generated based on a chosen set of processor features that maximizes its portability across machines. It is currently supported only on x86. The feature is turned on by default in Docker containers and can be disabled with <tt>-XX:-PortableSharedCache</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/10217">#10217</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/10217">#10217</a></td>
 <td valign="top">Methods in <tt>com.ibm.lang.management.MemoryMXBean</tt> deprecated and replaced</td>
 <td valign="top">All versions</td>
 <td valign="top">The methods <tt>com.ibm.lang.management.MemoryMXBean.getGCMasterThreadCpuUsed()</tt> and <tt>com.ibm.lang.management.MemoryMXBean.getGCSlaveThreadsCpuUsed()</tt> are deprecated for removal in Java 16. The recommended methods to be used are <tt>com.ibm.lang.management.MemoryMXBean.getGCMainThreadCpuUsed()</tt> and <tt>com.ibm.lang.management.MemoryMXBean.getGCWorkerThreadsCpuUsed()</tt> respectively.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/9489">#9489</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/9489">#9489</a></td>
 <td valign="top"><tt>java.lang.System.mapLibraryName()</tt> string suffix</tt></td>
 <td valign="top">From OpenJDK15, on AIX&reg;</td>
 <td valign="top"><tt>java.lang.System.mapLibraryName(libname)</tt> returns a representation of a native library in a platform-specific string with a <tt>.so</tt> suffix. (Output from versions prior to OpenJDK15 has a <tt>.a</tt> suffix.)</td>
@@ -81,4 +81,4 @@ The following table covers notable changes in v0.22.0. Further information about
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.22.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.22.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.22.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.22.0).

--- a/doc/release-notes/0.23/0.23.md
+++ b/doc/release-notes/0.23/0.23.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -56,25 +56,25 @@ The following table covers notable changes in v0.23.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/pull/10305">#10305</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/pull/10305">#10305</a></td>
 <td valign="top"><tt>-XX:[+|-]PortableSharedCache</tt> option behavior changee</td>
 <td valign="top">All versions (x86 only)</td>
 <td valign="top">This option is improved in this release to increase the portability of AOT-compiled code.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/10507">#10507</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/10507">#10507</a></td>
 <td valign="top">-XX:[+|-]IdleTuningCompactOnIdle option now inactive</td>
 <td valign="top">All versions</td>
 <td valign="top">This deprecated option, which only applied to Linux systems, now has no effect. Instead, a compaction is triggered by internal heuristics that look into the number of fragmented pages.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/10386">#10386</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/10386">#10386</a></td>
 <td valign="top">Support added for <tt>-XX:[+|-]AlwaysPreTouch</td>
 <td valign="top">All versions</td>
 <td valign="top">For compatibility with the reference implementation, OpenJ9 now supports this option.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/6914">#6914</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/6914">#6914</a></td>
 <td valign="top">JITServer technology preview extended to Linux on Power and Linux on Z</td>
 <td valign="top">OpenJDK8 and 11 (Linux x86-64, Linux on Power and Linux on Z only)</td>
 <td valign="top">JITServer decouples the JIT compiler from the OpenJ9 VM, freeing up CPU and memory for an application. JITServer then runs in its own process, either locally or on a remote machine, where resources can be separately managed.</td>
@@ -98,18 +98,18 @@ The v0.23.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
 <td valign="top">Use an alternative GC policy, such as <tt>gencon</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -117,4 +117,4 @@ The v0.23.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.23.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.23.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.23.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.23.0).

--- a/doc/release-notes/0.24/0.24.md
+++ b/doc/release-notes/0.24/0.24.md
@@ -50,56 +50,56 @@ The following table covers notable changes in v0.24.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/pull/10873">#10873</a> and <a href="https://github.com/eclipse/openj9/pull/11082">#11082</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/pull/10873">#10873</a> and <a href="https://github.com/eclipse-openj9/openj9/pull/11082">#11082</a></td>
 <td valign="top">Changes to message logging</td>
 <td valign="top">All versions</td>
 <td valign="top">The <tt>-Xsyslog</tt> option replaces the <tt>-Xlog</tt> option for message logging. For compatibility with the reference implementation a limited set of <tt>-Xlog</tt> suboptions are supported.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/10175">#10175</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/10175">#10175</a></td>
 <td valign="top">Support for the <tt>JAVA_OPTIONS</tt> environment variable</td>
 <td valign="top">All versions</td>
 <td valign="top">For compatibility with the reference implementation, OpenJ9 now supports the <tt>JAVA_OPTIONS</tt> environment variable for setting command line options.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/10521">#10521</a> and <a href="https://github.com/eclipse/openj9/pull/10668">#10668</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/10521">#10521</a> and <a href="https://github.com/eclipse-openj9/openj9/pull/10668">#10668</a></td>
 <td valign="top"><tt>-XX:[+|-]PortableSharedCache</tt> option support update
 </td>
 <td valign="top">All versions</td>
 <td valign="top">This option is now supported on IBM Z systems&reg; and POWER&reg; systems.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/10819">#10819</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/10819">#10819</a></td>
 <td valign="top"><tt>-XX:[+|-]ShareAnonymousClasses</tt> option behavior update</td>
 <td valign="top">OpenJDK 15</td>
 <td valign="top">In earlier releases, this option controls the storage of VM anonymous classes in the shared classes cache for all OpenJDK versions. In this release, the option now enables and disables the storage of hidden classes in the shared classes cache on OpenJDK 15 and later versions.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/10774">#10774</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/10774">#10774</a></td>
 <td valign="top">Additional parameters for <tt>jcmd Dump.*</tt> commands</td>
 <td valign="top">All versions</td>
 <td valign="top">Additional parameters can now be included for the <tt>jcmd Dump.*</tt> commands. The default for both system and heap dumps is now <tt>request=exclusive+prepwalk</tt>. For more information, see the <a href="https://www.eclipse.org/openj9/docs/version0.24/"> user documentation</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/10761">#10761</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/10761">#10761</a></td>
 <td valign="top">Change in behavior for the <tt>jextract</tt> utility</td>
 <td valign="top">All versions</td>
 <td valign="top">If the build ID of the <tt>jextract</tt> utility does not match the build ID of the SDK that is recorded in the system dump, an exception message is generated. A new option, <tt>-r</tt>, is introduced to force the utility to continue. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/11000">#11000</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11000">#11000</a></td>
 <td valign="top">New suboption for <tt>-Xcheck:jni</tt> for fatal JNI errors</td>
 <td valign="top">All versions</td>
 <td valign="top">A new <tt>abortonerror</tt> suboption for <tt>-Xcheck:jni</tt> provides diagnostic data when fatal JNI errors occur. For more information, run <tt>-Xcheck:jni:help</tt>. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/11184">#11184</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11184">#11184</a></td>
 <td valign="top">New Java dump content on processor features</td>
 <td valign="top">All versions</td>
 <td valign="top">The ENVINFO section of a Java dump file now includes further information about processor features to help diagnose problems with JIT and AOT compilations that depend on underlying hardware. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/10129">#10129</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/10129">#10129</a></td>
 <td valign="top">Windows builds now compile with Microsoft Visual Studio 2013</td>
 <td valign="top">OpenJDK 8</td>
 <td valign="top">The Visual Studio redistributable files included with the build are updated to match. </td>
@@ -124,18 +124,18 @@ The v0.24.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
 <td valign="top">Use an alternative GC policy, such as <tt>gencon</tt>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX</td>
 <td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux, Windows, and macOS. </td>
-<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
 </tbody>
@@ -143,4 +143,4 @@ The v0.24.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.24.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.24.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.24.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.24.0).

--- a/doc/release-notes/0.25/0.25.md
+++ b/doc/release-notes/0.25/0.25.md
@@ -50,21 +50,21 @@ The following table covers notable changes in v0.25.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/issues/10620">#10620</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/issues/10620">#10620</a></td>
 <td valign="top">New option to support JEP 390: Warnings for value-based classes</td>
 <td valign="top">OpenJDK 16</td>
 <td valign="top">OpenJ9 adds option <strong>-XX:DiagnoseSyncOnValueBasedClasses=&lt;number&gt;</strong> for compatibility with the reference implementation. A value of <tt>1</tt> generates a <tt>VirtualMachineError</tt> error and a value of <tt>2</tt> prints a warning message.</td>
 </tr>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/pull/8847">#8847</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/pull/8847">#8847</a></td>
 <td valign="top">Single build for compressed references and non-compressed references</td>
 <td valign="top">All versions</td>
 <td valign="top">A single build now supports both compressed references and non-compressed references. The object reference mode is selected at run time based on the specified heap size (<strong>-Xmx</strong>) or by using command-line options that control the selection of compressed references. If compressed references mode is automatically selected and you don't want to use compressed references, turn it off using the command-line option <strong>-Xnocompressedrefs</strong>.</td>
 </tr>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/pull/11624">#11624</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/pull/11624">#11624</a></td>
 <td valign="top">Enabling zlibNX hardware-accelerated data compression and decompression on AIX&reg;</td>
 <td valign="top">All versions</td>
 <td valign="top">On AIX systems that contain the Nest accelerator (NX) co-processor, OpenJ9 now uses the <tt>zlibNX</tt> library instead, if it is installed. The NX co-processor is available on IBM POWER9&reg; systems.</td>
@@ -95,7 +95,7 @@ The v0.25.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
@@ -107,4 +107,4 @@ The v0.25.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.25.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.25.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.25.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.25.0).

--- a/doc/release-notes/0.26/0.26.md
+++ b/doc/release-notes/0.26/0.26.md
@@ -50,7 +50,7 @@ The following table covers notable changes in v0.26.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/issues/11278">#11278</a></td>
+<a href="https://github.com/eclipse-openj9/openj9/issues/11278">#11278</a></td>
 <td valign="top">The <strong>jextract</strong> tool is deprecated</td>
 <td valign="top">All versions</td>
 <td valign="top">The dump extractor tool, <strong>jextract</strong>, is deprecated in this release and is replaced by the <strong>jpackcore</strong> tool. The <strong>jpackcore</strong> tool uses the same syntax and takes the same parameters.</td>
@@ -58,7 +58,7 @@ The following table covers notable changes in v0.26.0. Further information about
 
 </table>
 
-**Note:** Eclipse OpenJ9 v0.25.0 supports OpenJDK 16. However, changes introduced in this release might also affect OpenJDK 8 and OpenJDK 11. To learn more about these changes see the [OpenJ9 V0.25.0 release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.25/0.25.md).
+**Note:** Eclipse OpenJ9 v0.25.0 supports OpenJDK 16. However, changes introduced in this release might also affect OpenJDK 8 and OpenJDK 11. To learn more about these changes see the [OpenJ9 V0.25.0 release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.25/0.25.md).
 
 ## Known Issues
 
@@ -76,7 +76,7 @@ The v0.26.0 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/8034">#8034</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/8034">#8034</a></td>
 <td valign="top">Balanced garbage collection policy not supported</td>
 <td valign="top">Linux on 64-bit ARM (AArch64)</td>
 <td valign="top">The Balanced GC policy cannot be used. </td>
@@ -88,4 +88,4 @@ The v0.26.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.26.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.26.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.26.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.26.0).

--- a/doc/release-notes/0.8/0.8.md
+++ b/doc/release-notes/0.8/0.8.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -48,16 +48,16 @@ The following platforms are available:
 The v0.8 release contains the following known issues and limitations:
 
 #### Direct dump reader
-[Issue #378](https://github.com/eclipse/openj9/issues/378):
-The direct dump reader is currently not working, which has an impact on diagnosing problems with the VM, Garbage Collector, and the JIT. For example, [issue #968](https://github.com/eclipse/openj9/issues/968).
+[Issue #378](https://github.com/eclipse-openj9/openj9/issues/378):
+The direct dump reader is currently not working, which has an impact on diagnosing problems with the VM, Garbage Collector, and the JIT. For example, [issue #968](https://github.com/eclipse-openj9/openj9/issues/968).
 
 #### Signal handling
-[Issue #54](https://github.com/eclipse/openj9/issues/54): Some signals are not being handled correctly by the VM. In particular, for CTRL-C or other signals that shutdown the VM, the shutdown hooks are not running. See [Issue #378](https://github.com/eclipse/openj9/issues/378)
+[Issue #54](https://github.com/eclipse-openj9/openj9/issues/54): Some signals are not being handled correctly by the VM. In particular, for CTRL-C or other signals that shutdown the VM, the shutdown hooks are not running. See [Issue #378](https://github.com/eclipse-openj9/openj9/issues/378)
 
 #### Large Java heaps
-[Issue #479](https://github.com/eclipse/openj9/issues/479): The binaries available at AdoptOpenJDK are built only with the compressed references VM, which does not support Java<sup>&trade;</sup> heaps larger
+[Issue #479](https://github.com/eclipse-openj9/openj9/issues/479): The binaries available at AdoptOpenJDK are built only with the compressed references VM, which does not support Java<sup>&trade;</sup> heaps larger
 than 57 GB (or ~62 GB with command line options). When builds that contain the non-compressed references VM are available, this limitation will be removed. If
-you want to build a non-compressed references VM yourself, you can do so now by following our [detailed build instructions](https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md).
+you want to build a non-compressed references VM yourself, you can do so now by following our [detailed build instructions](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md).
 
 #### Graphics Processor Unit (GPU) support
 GPU acceleration with `java.util.Arrays.sort()` is not supported, although `com.ibm.gpu.Maths` can be used directly.
@@ -65,15 +65,15 @@ GPU acceleration with `java.util.Arrays.sort()` is not supported, although `com.
 #### Functional verification tests
 The following issues relate to test failures:
 
-- [#238](https://github.com/eclipse/openj9/issues/238), [#244](https://github.com/eclipse/openj9/issues/244), [#362](https://github.com/eclipse/openj9/issues/362), [#366](https://github.com/eclipse/openj9/issues/366), [#480](https://github.com/eclipse/openj9/issues/480), [#858](https://github.com/eclipse/openj9/issues/858), [#968](https://github.com/eclipse/openj9/issues/968), [#1127](https://github.com/eclipse/openj9/issues/1127), [#1128](https://github.com/eclipse/openj9/issues/1128), [#1129](https://github.com/eclipse/openj9/issues/1129), [#1130](https://github.com/eclipse/openj9/issues/1130), [#1131](https://github.com/eclipse/openj9/issues/1131), [#1144](https://github.com/eclipse/openj9/issues/1144), [#1151](https://github.com/eclipse/openj9/issues/1151), [#1203](https://github.com/eclipse/openj9/issues/1203), [#1204](https://github.com/eclipse/openj9/issues/1204), [#1205](https://github.com/eclipse/openj9/issues/1205), [#1207](https://github.com/eclipse/openj9/issues/1207), [#1209](https://github.com/eclipse/openj9/issues/1209), [#1212](https://github.com/eclipse/openj9/issues/1212), and [#1244](https://github.com/eclipse/openj9/issues/1244).
+- [#238](https://github.com/eclipse-openj9/openj9/issues/238), [#244](https://github.com/eclipse-openj9/openj9/issues/244), [#362](https://github.com/eclipse-openj9/openj9/issues/362), [#366](https://github.com/eclipse-openj9/openj9/issues/366), [#480](https://github.com/eclipse-openj9/openj9/issues/480), [#858](https://github.com/eclipse-openj9/openj9/issues/858), [#968](https://github.com/eclipse-openj9/openj9/issues/968), [#1127](https://github.com/eclipse-openj9/openj9/issues/1127), [#1128](https://github.com/eclipse-openj9/openj9/issues/1128), [#1129](https://github.com/eclipse-openj9/openj9/issues/1129), [#1130](https://github.com/eclipse-openj9/openj9/issues/1130), [#1131](https://github.com/eclipse-openj9/openj9/issues/1131), [#1144](https://github.com/eclipse-openj9/openj9/issues/1144), [#1151](https://github.com/eclipse-openj9/openj9/issues/1151), [#1203](https://github.com/eclipse-openj9/openj9/issues/1203), [#1204](https://github.com/eclipse-openj9/openj9/issues/1204), [#1205](https://github.com/eclipse-openj9/openj9/issues/1205), [#1207](https://github.com/eclipse-openj9/openj9/issues/1207), [#1209](https://github.com/eclipse-openj9/openj9/issues/1209), [#1212](https://github.com/eclipse-openj9/openj9/issues/1212), and [#1244](https://github.com/eclipse-openj9/openj9/issues/1244).
 
-Because some tests are not yet enabled, functional problems might not be exposed. In addition, some IBM authored functional verification testing is not yet contributed to Eclipse, such as issue  [#724](https://github.com/eclipse/openj9/issues/724).
+Because some tests are not yet enabled, functional problems might not be exposed. In addition, some IBM authored functional verification testing is not yet contributed to Eclipse, such as issue  [#724](https://github.com/eclipse-openj9/openj9/issues/724).
 
 #### API documentation
 
-Some OpenJ9 extensions are missing, see [issue #897](https://github.com/eclipse/openj9/issues/897).
+Some OpenJ9 extensions are missing, see [issue #897](https://github.com/eclipse-openj9/openj9/issues/897).
 
-Some OpenJ9 extensions are unsupported, see [issue #898](https://github.com/eclipse/openj9/issues/898).
+Some OpenJ9 extensions are unsupported, see [issue #898](https://github.com/eclipse-openj9/openj9/issues/898).
 
 #### Shared libraries
 

--- a/doc/release-notes/0.9/0.9.md
+++ b/doc/release-notes/0.9/0.9.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -55,35 +55,35 @@ The following table covers notable changes in v0.9.0. Further information about 
 </tr>
 </thead>
 <tbody>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1288">#1288</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1288">#1288</a></td>
 <td valign="top"><code>SharedClassCacheInfo</code> no longer contains a <code>JVMLEVEL</code> constant</td>
 <td valign="top">OpenJDK10 and later: All platforms</td>
 <td valign="top"><code>SharedClassCacheInfo.getCacheJVMLevel()</code> used to return the <code>JVMLEVEL</code> constant that maps to a Java version number, for example <code>JVMLEVEL_JAVA8</code>. This call now returns only the Java version number, for example <code>10</code> for Java 10.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1370">#1370</a>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1370">#1370</a>
 <!-- (<a href="http://openjdk.java.net/jeps/318">JEP318</a>) --></td>
 <td valign="top">New <code>nogc</code> GC policy</td>
 <td valign="top">All platforms</td>
 <td valign="top">Under this policy, no memory is reclaimed through garbage collection. The Java object heap is expanded until an <code>OutOfMemory</code> error is generated and the VM shuts down.<br/>Enable this policy with the <b>-Xgcpolicy:nogc</b> or <b>-XX:+UseNoGC</b> options.<br/>You might use this mode for testing or for short-lived applications. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/378">#378</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/378">#378</a></td>
 <td valign="top">DDR support is now available</td>
 <td valign="top">Linux, Windows</td>
 <td valign="top">Ability to diagnose problems with the VM, garbage collector, or JIT.</td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1699">#1699</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1699">#1699</a></td>
 <td valign="top">Specify heap limits as a percentage of total memory</td>
 <td valign="top">All platforms</td>
 <td valign="top">Ability to easily set heap limits with the <b>-XX:MaxRAMPercentage</b> and <b>-XX:InitialRAMPercentage</b> options instead of statically setting them with the <b>-Xmx</b> and <b>-Xms</b> options.</td>
 </tr>
-<!-- Remove? Confirm.<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1776">#1776</a></td>
+<!-- Remove? Confirm.<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1776">#1776</a></td>
 <td valign="top">Extra page of memory no longer required when specifying an object heap size that is a multiple of the page size</td>
 <td valign="top">Linux on Z and z/OS</td>
 <td valign="top">This change avoids wasting memory or calculating a heap size that is 16 bytes less than the page size.</td>
 </tr>-->
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1668">#1668</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1668">#1668</a></td>
 <td valign="top">Idle tuning feature enabled</td>
 <td valign="top">Linux on Z, Linux on Power systems</td>
 <td valign="top">In addition to the support already available, there is the ability to maintain a minimal memory footprint during the life time of an application. See:<br/>
@@ -93,25 +93,25 @@ The following table covers notable changes in v0.9.0. Further information about 
 <b>-XX:IdleTuningMinFreeHeapOnIdle</b>
 </td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1517">#1517</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1517">#1517</a></td>
 <td valign="top">Changes to the default Java heap size for applications that run inside a container</td>
 <td valign="top">Linux</td>
 <td valign="top">By default, 75% of the physical memory is allocated for the maximum Java heap setting when the <b>-XX:+UseContainerSupport</b> option is set.</td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1500">#1500</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1500">#1500</a></td>
 <td valign="top">Support for nested jar files</td>
 <td valign="top">All platforms</td>
 <td valign="top">Improvements to the <code>com.ibm.oti.shared</code> API for manipulating nested jar files, such as used by Spring.</td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1786">#1786</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1786">#1786</a></td>
 <td valign="top">Changes to OpenJ9 <code>java.lang.String</code> class and use of OpenJDK <code>StringBuffer</code> and <code>StringBuilder</code></td>
 <td valign="top">OpenJDK 9+, all platforms</td>
 <td valign="top">To match the behavior of OpenJDK, <code>java.lang.String</code> no longer has a count field, which changes the way that <code>String.subString()</code> works compared to Java 8. Similarly <code>StringBuffer</code> and <code>StringBuilder</code> do not share the value array with any <code>String</code> created by <code>toString()</code>.</td>
 </tr>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/issues/1603">#1603</a>,
-<a href="https://github.com/eclipse/openj9/issues/1642">#1642</a>,
+<a href="https://github.com/eclipse-openj9/openj9/issues/1603">#1603</a>,
+<a href="https://github.com/eclipse-openj9/openj9/issues/1642">#1642</a>,
 <a href="https://github.com//eclipse/omr/issues/2494">eclipse/omr#2494</a>,
 <a href="https://github.com//eclipse/omr/issues/2524">eclipse/omr#2524</a>
 </td>
@@ -120,7 +120,7 @@ The following table covers notable changes in v0.9.0. Further information about 
 <td valign="top">For shutdown signals (<code>SIGINT</code>, <code>SIGTERM</code> and <code>SIGHUP</code>), a Java signal handler can be registered. The default Java shutdown handler is properly registered for shutdown signals. Similarly, a Java signal handler can be registered for <code>SIGCONT</code>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1816">#1816</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1816">#1816</a></td>
 <td valign="top">Temporary solution to support shutdown signal handlers on Windows</td>
 <td valign="top">Windows</td>
 <td valign="top">A native shutdown handler is registered for shutdown signals (<code>Ctrl+C</code>, <code>SIGINT</code> and <code>SIGTERM</code>). A shutdown handler is responsible for invoking <code>java.lang.Shutdown.exit</code>.</td>
@@ -143,7 +143,7 @@ The v0.9.0 release contains the following known issues and limitations:
 </tr>
 </thead>
 <tbody>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/378">#378</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/378">#378</a></td>
 <td valign="top">DDR support</td>
 <td valign="top">AIX</td>
 <td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
@@ -151,7 +151,7 @@ The v0.9.0 release contains the following known issues and limitations:
 </tr>
 
 <!--
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/54">#54</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some signals not being handled correctly by the VM.</td>
@@ -175,14 +175,14 @@ The v0.9.0 release contains the following known issues and limitations:
 </tr>
 -->
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
 <td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
 <td valign="top">Heaps larger than 57GB are not supported.</td>
-<td valign="top">Manual builds are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
+<td valign="top">Manual builds are possible by following our <a href="https://github.com/eclipse-openj9/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1938">#1938</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1938">#1938</a></td>
 <td valign="top">Default shared classes cache size (16MB) is too small on Java 8 64-bit binaries.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Poorer performance for applications that could benefit from a larger cache size.</td>
@@ -190,26 +190,26 @@ The v0.9.0 release contains the following known issues and limitations:
 </tr>
 
 <!--
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1252">#1252</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1252">#1252</a></td>
 <td valign="top">File <code>ibmjvmti.h</code> not found in OpenJ9 JDK</td>
 <td valign="top">All platforms</td>
 <td valign="top">JVMTI extensions cannot be compiled.</td>
 <td valign="top">None</td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1252">#1252</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/1252">#1252</a></td>
 <td valign="top">GPU acceleration with <code>java.util.Array.sort()</code> is not supported</td>
 <td valign="top">Linux and Windows platforms</td>
 <td valign="top">GPU acceleration on <code>sort()</code> operations is not available.</td>
 <td valign="top">None !-- , although <code>com.ibm.gpu.Maths</code> can be used directly. -- </td>
 </tr>
 -->
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/897">#897</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/897">#897</a></td>
 <td valign="top">Javadoc not building some OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation is missing in the <code>build/&lt;platform&gt;/docs</code> directory.</td>
 <td valign="top">None</td>
 </tr>
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/898">#898</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/898">#898</a></td>
 <td valign="top">Javadoc building some unsupported OpenJ9 extensions.</td>
 <td valign="top">All platforms</td>
 <td valign="top">Some API documentation in <code>build/&lt;platform&gt;/docs</code> is not supported with OpenJ9.</td>
@@ -228,46 +228,46 @@ The v0.9.0 release contains the following known issues and limitations:
 ## Functional verification tests
 The following issues (in numerical order) relate to test failures:
 
-[#244 ](https://github.com/eclipse/openj9/issues/244 )  testCrNocr in VmArgumentTests failed - java.lang.AssertionError: Target process failed
-<br/>[#366 ](https://github.com/eclipse/openj9/issues/366 )  cmdLineTest: cmdLineTester_jep178_staticLinking_SE90 failed due to  cannot find `/lib/amd64/compressedrefs/testjep178_static`
-<br/>[#480 ](https://github.com/eclipse/openj9/issues/480 )  j9vm.test.softmx.SoftmxRemoteTest.setUp server is not ready after 120 seconds
-<br/>[#1127](https://github.com/eclipse/openj9/issues/1127)  jdk_io test error
-<br/>[#1128](https://github.com/eclipse/openj9/issues/1128)  jdk_lang test failures
-<br/>[#1129](https://github.com/eclipse/openj9/issues/1129)  jdk_net test failure
-<br/>[#1130](https://github.com/eclipse/openj9/issues/1130)  jdk_nio test failures
-<br/>[#1131](https://github.com/eclipse/openj9/issues/1131)  jdk_util test failures
-<br/>[#1144](https://github.com/eclipse/openj9/issues/1144)  jdk_rmi test failures
-<br/>[#1151](https://github.com/eclipse/openj9/issues/1151)  ARM Hang while compiling test/Jsr292
-<br/>[#1203](https://github.com/eclipse/openj9/issues/1203)  TestUTF8 fails with assertion Unsafe_copySwapMemory0 is unimplemented
-<br/>[#1205](https://github.com/eclipse/openj9/issues/1205)  ARM sigbus from initialiseAOTRelocationHeader
-<br/>[#1209](https://github.com/eclipse/openj9/issues/1209)  ARM Assertion in J9TransformUtil.cpp
-<br/>[#1212](https://github.com/eclipse/openj9/issues/1212)  ARM JVM_GetVmArguments not implemented
-<br/>[#1430](https://github.com/eclipse/openj9/issues/1430)  openjdk9-openj9 jdk_lang test failures
-<br/>[#1431](https://github.com/eclipse/openj9/issues/1431)  openjdk9-openj9 jdk_io test failures
-<br/>[#1432](https://github.com/eclipse/openj9/issues/1432)  openjdk9-openj9 jdk_net  test failures
-<br/>[#1433](https://github.com/eclipse/openj9/issues/1433)  openjdk9-openj9 jdk_nio test failures
-<br/>[#1434](https://github.com/eclipse/openj9/issues/1434)  openjdk9-openj9 jdk_util test failures
-<br/>[#1435](https://github.com/eclipse/openj9/issues/1435)  openjdk9-openj9 jdk_rmi test failures
-<br/>[#1566](https://github.com/eclipse/openj9/issues/1566)  java.lang.IllegalArgumentException: argument type mismatch received in JMX Bean test in Hotspot, but none in OpenJ9
-<br/>[#1626](https://github.com/eclipse/openj9/issues/1626)  JDK10 JLM_Tests_interface FAILED
-<br/>[#1765](https://github.com/eclipse/openj9/issues/1765)  Annotation testing failures
-<br/>[#1796](https://github.com/eclipse/openj9/issues/1796)  ARM: Hang in SharedClassesSysVTesting_0
-<br/>[#1814](https://github.com/eclipse/openj9/issues/1814)  SCCommandLineOptionTests/SCURLClassLoaderNPTest failed on JDK10-win_x86-64_cmprssptrs
-<br/>[#2019](https://github.com/eclipse/openj9/issues/2019)  Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le TestAttachErrorHandling OOM in attach API
-<br/>[#2047](https://github.com/eclipse/openj9/issues/2047)  Intermittent NullPointerException in TestAttachErrorHandling.deleteIpcDirectories
-<br/>[#2114](https://github.com/eclipse/openj9/issues/2114)  cmdLineTester_jvmtitests_hcr_3 functional sanity rc010 gpf
-<br/>[#2129](https://github.com/eclipse/openj9/issues/2129)  Windows JDK8 jvmti tests failed with &quot;NPT ERROR: Cannot open library&quot;
-<br/>[#2141](https://github.com/eclipse/openj9/issues/2141)  Test-Extended-JDK8-aix_ppc-64_cmprssptrs startupShutdownRobustness IOException: Error deleting
-<br/>[#2213](https://github.com/eclipse/openj9/issues/2213)  Test-Extended-JDK8-win_x86 testOpenJ9DiagnosticsMXBean_0 hangs
-<br/>[#2227](https://github.com/eclipse/openj9/issues/2227)  Test-sanity.system-JDK10-linux_ppc-64_cmprssptrs_le Jlink directory count not be found
-<br/>[#2363](https://github.com/eclipse/openj9/issues/2363)  systemtest failed to build Test-sanity.system-JDK8-linux_390-64_cmprssptrs
-<br/>[#2385](https://github.com/eclipse/openj9/issues/2385)  DaaLoadTest_daa1_0 Test-sanity.system-JDK10-linux_x86-64 Segmentation error vmState=0x000507ff
-<br/>[#2472](https://github.com/eclipse/openj9/issues/2472)  cmdLineTester_jvmtitests_hcr_OSRG_nongold_1 Test-extended.functional-JDK10-linux_x86-64 rc004 gpf
+[#244 ](https://github.com/eclipse-openj9/openj9/issues/244 )  testCrNocr in VmArgumentTests failed - java.lang.AssertionError: Target process failed
+<br/>[#366 ](https://github.com/eclipse-openj9/openj9/issues/366 )  cmdLineTest: cmdLineTester_jep178_staticLinking_SE90 failed due to  cannot find `/lib/amd64/compressedrefs/testjep178_static`
+<br/>[#480 ](https://github.com/eclipse-openj9/openj9/issues/480 )  j9vm.test.softmx.SoftmxRemoteTest.setUp server is not ready after 120 seconds
+<br/>[#1127](https://github.com/eclipse-openj9/openj9/issues/1127)  jdk_io test error
+<br/>[#1128](https://github.com/eclipse-openj9/openj9/issues/1128)  jdk_lang test failures
+<br/>[#1129](https://github.com/eclipse-openj9/openj9/issues/1129)  jdk_net test failure
+<br/>[#1130](https://github.com/eclipse-openj9/openj9/issues/1130)  jdk_nio test failures
+<br/>[#1131](https://github.com/eclipse-openj9/openj9/issues/1131)  jdk_util test failures
+<br/>[#1144](https://github.com/eclipse-openj9/openj9/issues/1144)  jdk_rmi test failures
+<br/>[#1151](https://github.com/eclipse-openj9/openj9/issues/1151)  ARM Hang while compiling test/Jsr292
+<br/>[#1203](https://github.com/eclipse-openj9/openj9/issues/1203)  TestUTF8 fails with assertion Unsafe_copySwapMemory0 is unimplemented
+<br/>[#1205](https://github.com/eclipse-openj9/openj9/issues/1205)  ARM sigbus from initialiseAOTRelocationHeader
+<br/>[#1209](https://github.com/eclipse-openj9/openj9/issues/1209)  ARM Assertion in J9TransformUtil.cpp
+<br/>[#1212](https://github.com/eclipse-openj9/openj9/issues/1212)  ARM JVM_GetVmArguments not implemented
+<br/>[#1430](https://github.com/eclipse-openj9/openj9/issues/1430)  openjdk9-openj9 jdk_lang test failures
+<br/>[#1431](https://github.com/eclipse-openj9/openj9/issues/1431)  openjdk9-openj9 jdk_io test failures
+<br/>[#1432](https://github.com/eclipse-openj9/openj9/issues/1432)  openjdk9-openj9 jdk_net  test failures
+<br/>[#1433](https://github.com/eclipse-openj9/openj9/issues/1433)  openjdk9-openj9 jdk_nio test failures
+<br/>[#1434](https://github.com/eclipse-openj9/openj9/issues/1434)  openjdk9-openj9 jdk_util test failures
+<br/>[#1435](https://github.com/eclipse-openj9/openj9/issues/1435)  openjdk9-openj9 jdk_rmi test failures
+<br/>[#1566](https://github.com/eclipse-openj9/openj9/issues/1566)  java.lang.IllegalArgumentException: argument type mismatch received in JMX Bean test in Hotspot, but none in OpenJ9
+<br/>[#1626](https://github.com/eclipse-openj9/openj9/issues/1626)  JDK10 JLM_Tests_interface FAILED
+<br/>[#1765](https://github.com/eclipse-openj9/openj9/issues/1765)  Annotation testing failures
+<br/>[#1796](https://github.com/eclipse-openj9/openj9/issues/1796)  ARM: Hang in SharedClassesSysVTesting_0
+<br/>[#1814](https://github.com/eclipse-openj9/openj9/issues/1814)  SCCommandLineOptionTests/SCURLClassLoaderNPTest failed on JDK10-win_x86-64_cmprssptrs
+<br/>[#2019](https://github.com/eclipse-openj9/openj9/issues/2019)  Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le TestAttachErrorHandling OOM in attach API
+<br/>[#2047](https://github.com/eclipse-openj9/openj9/issues/2047)  Intermittent NullPointerException in TestAttachErrorHandling.deleteIpcDirectories
+<br/>[#2114](https://github.com/eclipse-openj9/openj9/issues/2114)  cmdLineTester_jvmtitests_hcr_3 functional sanity rc010 gpf
+<br/>[#2129](https://github.com/eclipse-openj9/openj9/issues/2129)  Windows JDK8 jvmti tests failed with &quot;NPT ERROR: Cannot open library&quot;
+<br/>[#2141](https://github.com/eclipse-openj9/openj9/issues/2141)  Test-Extended-JDK8-aix_ppc-64_cmprssptrs startupShutdownRobustness IOException: Error deleting
+<br/>[#2213](https://github.com/eclipse-openj9/openj9/issues/2213)  Test-Extended-JDK8-win_x86 testOpenJ9DiagnosticsMXBean_0 hangs
+<br/>[#2227](https://github.com/eclipse-openj9/openj9/issues/2227)  Test-sanity.system-JDK10-linux_ppc-64_cmprssptrs_le Jlink directory count not be found
+<br/>[#2363](https://github.com/eclipse-openj9/openj9/issues/2363)  systemtest failed to build Test-sanity.system-JDK8-linux_390-64_cmprssptrs
+<br/>[#2385](https://github.com/eclipse-openj9/openj9/issues/2385)  DaaLoadTest_daa1_0 Test-sanity.system-JDK10-linux_x86-64 Segmentation error vmState=0x000507ff
+<br/>[#2472](https://github.com/eclipse-openj9/openj9/issues/2472)  cmdLineTester_jvmtitests_hcr_OSRG_nongold_1 Test-extended.functional-JDK10-linux_x86-64 rc004 gpf
 
 
 
-Because some tests are not yet enabled, functional problems might not be exposed. In addition, some IBM authored functional verification testing is not yet contributed to Eclipse, such as issue  [#724](https://github.com/eclipse/openj9/issues/724).
+Because some tests are not yet enabled, functional problems might not be exposed. In addition, some IBM authored functional verification testing is not yet contributed to Eclipse, such as issue  [#724](https://github.com/eclipse-openj9/openj9/issues/724).
 
 ## Other changes
 
-The issues addressed in this release are listed at [Eclipse OpenJ9 v0.9.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.9.0).
+The issues addressed in this release are listed at [Eclipse OpenJ9 v0.9.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.9.0).

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2227,7 +2227,7 @@ private boolean useModularSearch(String absoluteResName, Module thisModule, Clas
 
 	if (thisModule.isNamed()) {
 		// When the caller class is null, assuming it is loaded by module java.base.
-		// See https://github.com/eclipse/openj9/issues/8993 for more info.
+		// See https://github.com/eclipse-openj9/openj9/issues/8993 for more info.
 		final Module callerModule = callerClass == null ? Class.class.getModule() : callerClass.getModule();
 		visible = (thisModule == callerModule);
 		if (!visible) {

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -260,7 +260,7 @@ public abstract class ClassLoader {
 		/* 
 		 * Following code ensures that the field jdk.internal.reflect.langReflectAccess 
 		 * is initialized before any usage references. This is a workaround.
-		 * More details are at https://github.com/eclipse/openj9/issues/3399#issuecomment-459004840.
+		 * More details are at https://github.com/eclipse-openj9/openj9/issues/3399#issuecomment-459004840.
 		 */
 		Modifier.isPublic(Modifier.PUBLIC);
 		/*[IF JAVA_SPEC_VERSION >= 10]*/

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -399,7 +399,7 @@ public final class StackWalker {
 			 * Disable including classloader name and module version in stack trace output
 			 * until StackWalker StackTraceElement include info flags can be set properly.
 			 *
-			 * See: https://github.com/eclipse/openj9/issues/11774
+			 * See: https://github.com/eclipse-openj9/openj9/issues/11774
 			 */
 			element.disableIncludeInfoFlags();
 

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -194,7 +194,7 @@ private Thread(String vmName, Object vmThreadGroup, int vmPriority, boolean vmIs
 		 * to lookup native address when not found within systemClassLoader native libraries.
 		 * This requires bootstrapClassLoader is initialized via initialize(booting, threadGroup, null, null, true) above before
 		 * invoking a native method not present within systemClassLoader native libraries such as following setNameImpl modified
-		 * via JVMTI agent SetNativeMethodPrefix (https://github.com/eclipse/openj9/issues/11181).
+		 * via JVMTI agent SetNativeMethodPrefix (https://github.com/eclipse-openj9/openj9/issues/11181).
 		 * After bootstrapClassLoader initialization, setNameImpl can be invoked before initialize() to set thread name earlier.
 		 */
 		setNameImpl(threadRef, threadName);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1153,7 +1153,7 @@ public abstract class MethodHandle
 /*[IF Sidecar18-SE-OpenJ9]*/
 	void customize() {
 		// this is an empty implementation to satisfy RI specific method calls
-		// https://github.com/eclipse/openj9/issues/7080
+		// https://github.com/eclipse-openj9/openj9/issues/7080
 	}
 /*[ENDIF]*/
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1738,7 +1738,7 @@ public class MethodHandles {
 			Class<?> declaringClass = field.getDeclaringClass();
 			Class<?> fieldType = field.getType();
 			String fieldName = field.getName();
-			/* https://github.com/eclipse/openj9/issues/3175
+			/* https://github.com/eclipse-openj9/openj9/issues/3175
 			 * Setters are allowed on instance final instance fields if they have been set accessible.
 			 */
 			if (Modifier.isFinal(modifiers) && 

--- a/runtime/compiler/codegen/PrivateLinkage.cpp
+++ b/runtime/compiler/codegen/PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ J9::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
       // This is a slightly convoluted way of enforcing the JVM specification which states that long and double 
       // variables take up two stack slots. A stack slot in OpenJ9 is a `uintptr_t`, so on 64-bit int variables
       // are still placed in 64-bit stack slots, hence the need to check for 64-bit in the query below. For more
-      // details please see eclipse/openj9#8360.
+      // details please see eclipse-openj9/openj9#8360.
       int32_t slotMultiplier = is64Bit && paramCursor->getDataType() != TR::Address ? 2 : 1;
 
       paramCursor->setParameterOffset(offsetToFirstArg -

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1483,7 +1483,7 @@ J9::SymbolReferenceTable::findOrCreateClassStaticsSymbol(TR::ResolvedMethodSymbo
    // care about cpIndex and also as Two or more (resolved) static field references belonging to same class will
    // share the same information (inlined call site index, cpIndex) , using a cpIndex for these cases will
    // need further changes to prevent any sharing hence it is set to -1 for static resolved fields.
-   // For more detailed information take a look at PR#4322 in eclipse/openj9 repo
+   // For more detailed information take a look at PR#4322 in eclipse-openj9/openj9 repo
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1);
 
    aliasBuilder.addressStaticSymRefs().set(symRef->getReferenceNumber()); // add the symRef to the statics list to get correct aliasing info

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5245,7 +5245,7 @@ TR::CompilationInfo::getNextMethodToBeCompiled(TR::CompilationInfoPerThread *com
    // entries while the JitDump process (in a crashed thread) is happening. This is because one compilation thread
    // must always be active, and there is a timing hole between purging of the queue in the JitDump process, and when
    // the diagnostic thread is resumed. This means a non-diagnostic thread could attempt to pick up a JitDump
-   // compilation request (see eclipse/openj9#11772 for details). We must ensure that this does not happen and simply
+   // compilation request (see eclipse-openj9/openj9#11772 for details). We must ensure that this does not happen and simply
    // skip the request if we are a non-diagnostic thread attempting to process a JitDump compilation.
    if (compInfoPT->isDiagnosticThread())
       {
@@ -7387,7 +7387,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             // for a method body that's already in the SCC
             && entry->_methodIsInSharedCache != TR_yes
 
-            // See eclipse/openj9#11879 for details
+            // See eclipse-openj9/openj9#11879 for details
             && (!TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug)
                 || !entry->_oldStartPC)
 

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -740,7 +740,7 @@ bool TR_SPMDKernelParallelizer::visitNodeToSIMDize(TR::Node *parent, int32_t chi
                   traceMsg(comp, "   Found use of induction variable at node [%p] - platform does not support this vectorization\n", node);
                if (trace && platformSupport)
                   traceMsg(comp, "   Found use of induction variable at node [%p] - vectorization disabled for now\n", node);
-               return false;  // see : eclipse/openj9/9446
+               return false;  // see : eclipse-openj9/openj9/9446
                }
             }
          }

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -6154,6 +6154,6 @@ checkZOSThrWeightEnvVar(void)
 void JNICALL
 JVM_BeforeHalt()
 {
-	/* To be implemented via https://github.com/eclipse/openj9/issues/1459 */
+	/* To be implemented via https://github.com/eclipse-openj9/openj9/issues/1459 */
 }
 

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclas
 			j9clazz = J9_CURRENT_CLASS(j9clazz);
 		}
 	} else {
-		/* Should link the class, see https://github.com/eclipse/openj9/issues/10297 */
+		/* Should link the class, see https://github.com/eclipse-openj9/openj9/issues/10297 */
 		vmFuncs->prepareClass(currentThread, j9clazz);
 	}
 

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -847,7 +847,7 @@ extern "C" {
 
 /*
  * These constants are declared only so that they are available in core files to retain
- * compatibility with old DTFJ plugins, see https://github.com/eclipse/openj9/issues/6316.
+ * compatibility with old DTFJ plugins, see https://github.com/eclipse-openj9/openj9/issues/6316.
  *
  * They should not be used for any other purpose.
  */

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4914,7 +4914,7 @@ j9shr_jvmPhaseChange(J9VMThread *currentThread, UDATA phase)
 	if (J9VM_PHASE_NOT_STARTUP == phase) {
 		J9JavaVM* vm = currentThread->javaVM;
 
-		/* OpenJ9 issue; https://github.com/eclipse/openj9/issues/3743
+		/* OpenJ9 issue; https://github.com/eclipse-openj9/openj9/issues/3743
 		 * GC decides whether to calls vm->sharedClassConfig->storeGCHints() to store the GC hints into the shared cache. */
 		storeStartupHintsToSharedCache(currentThread);
 		if (J9_ARE_NO_BITS_SET(vm->sharedClassConfig->runtimeFlags, J9SHR_RUNTIMEFLAG_MPROTECT_PARTIAL_PAGES_ON_STARTUP)) {

--- a/runtime/tests/jni/jnitest.c
+++ b/runtime/tests/jni/jnitest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@
 #include "vmi.h"
 /*
  * jvm.h is required by MemoryAllocator_allocateMemory:
- * https://github.com/eclipse/openj9/issues/1377
+ * https://github.com/eclipse-openj9/openj9/issues/1377
  */
 #include "../j9vm/jvm.h"
 #if defined(WIN32)

--- a/runtime/tests/port/j9processTest.c
+++ b/runtime/tests/port/j9processTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2234,7 +2234,7 @@ j9process_runTests(struct J9PortLibrary *portLibrary, char *argv0, char* j9proce
 		/* z/OS: writes extra characters to the console in the build environment when a process catches a SIGQUIT.
 		 * Linux: in certain Linux distros the /bin/sh command receives a SIGQUIT signal, see PR 56109.
 		 * OSX: make, tee and other test framework processes receive a SIGQUIT signal, which causes the test
-		 *      framework to crash. See https://github.com/eclipse/openj9/issues/4520.
+		 *      framework to crash. See https://github.com/eclipse-openj9/openj9/issues/4520.
 		 */
 		rc |= j9process_testNewProcessGroupByTriggeringSignal(portLibrary);
 #endif /* !(defined(J9ZOS390) || defined(LINUX) || defined(OSX)) */

--- a/runtime/tests/redirector/jep178/testjep178.c
+++ b/runtime/tests/redirector/jep178/testjep178.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@
 #ifdef LINUX
 /* kludge to work around known issue in glibc pre 2.25
  * https://sourceware.org/bugzilla/show_bug.cgi?id=16628
- * https://github.com/eclipse/openj9/issues/3672
+ * https://github.com/eclipse-openj9/openj9/issues/3672
  * Add a dummy pthread call to force libpthread to initialize.
  */
 #include <pthread.h>

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -210,7 +210,7 @@ endif()
 
 if(OMR_OS_WINDOWS AND (OMR_TOOLCONFIG STREQUAL "msvc"))
 	# JIT helper methods require us to disable buffer security checks on Windows
-	# See https://github.com/eclipse/openj9/pull/1494 for rationale
+	# See https://github.com/eclipse-openj9/openj9/pull/1494 for rationale
 	set_property(
 		SOURCE
 			cnathelp.cpp

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3077,7 +3077,7 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 			/*
 			* On Linux on Z libj9jit dynamically loads libj9zlib as it is used for AOT method data compression
 			* which is currently only enabled on Z platform. We want to ensure that when the JVM loads libj9jit,
-			* libj9zlib is already loaded. See eclipse/openj9#8561 for more details.
+			* libj9zlib is already loaded. See eclipse-openj9/openj9#8561 for more details.
 			*/
 #if (defined(S390) && defined(LINUX))
 			{

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2020 IBM Corp. and others
+dnl Copyright (c) 2017, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -175,9 +175,9 @@ dnl    code will be functionally incorrect we force a crash here so we fail fast
 dnl    and can manually debug.
 dnl
 dnl See the following PRs for more details:
-dnl eclipse/openj9#2545
-dnl eclipse/openj9#2790
-dnl eclipse/openj9#3763
+dnl eclipse-openj9/openj9#2545
+dnl eclipse-openj9/openj9#2790
+dnl eclipse-openj9/openj9#3763
     TM J9TR_VMThread_gsParameters_GSECI(J9VMTHREAD),128
     JZ LABEL_NAME(L_GS_CALL_HELPER)
     TM J9TR_VMThread_gsParameters_GSECI(J9VMTHREAD),64

--- a/test/docs/OpenJ9TestUserGuide.md
+++ b/test/docs/OpenJ9TestUserGuide.md
@@ -76,7 +76,7 @@ e.g.,
     export JDK_IMPL=openj9
 ```
 
-Please refer *.spec files in [buildspecs](https://github.com/eclipse/openj9/tree/master/buildspecs)
+Please refer *.spec files in [buildspecs](https://github.com/eclipse-openj9/openj9/tree/master/buildspecs)
 for possible SPEC values.
 
 #### Dependent libs for tests
@@ -99,10 +99,10 @@ Please read [DependentLibs.md](./DependentLibs.md) for details.
 
 #### For new functionality
 
-- If you have added new features to OpenJ9, you will likely need to add new tests. Check out [openj9/test/functional/TestExample/src/org/openj9/test/MyTest.java](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample/src/org/openj9/test/example/MyTest.java) for
+- If you have added new features to OpenJ9, you will likely need to add new tests. Check out [openj9/test/functional/TestExample/src/org/openj9/test/MyTest.java](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample/src/org/openj9/test/example/MyTest.java) for
 the format to use.
 
-- If you have many new test cases to add and special build requirements, then you may want to copy the [TestExample](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample) update the build.xml and playlist.xml files to match your new Test class names. The playlist.xml format is defined in TKG/playlist.xsd.
+- If you have many new test cases to add and special build requirements, then you may want to copy the [TestExample](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample) update the build.xml and playlist.xml files to match your new Test class names. The playlist.xml format is defined in TKG/playlist.xsd.
 
 - A test can be tagged with following elements:
       - level:   [sanity|extended|special] (extended default value)
@@ -183,9 +183,9 @@ e.g.,
     make _sanity.functional.native
 ```
 
-#### Run a specific individual test target (where test targets are defined in playlist files, see [testExample](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample/playlist.xml#L27)<br />
+#### Run a specific individual test target (where test targets are defined in playlist files, see [testExample](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample/playlist.xml#L27)<br />
 make _testTargetName_xxx <br />
-e.g., the [1st variation in playlist](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample/playlist.xml#L29) is suffixed by _0, 2nd variation by _1, and so forth
+e.g., the [1st variation in playlist](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample/playlist.xml#L29) is suffixed by _0, 2nd variation by _1, and so forth
 ```
     make _testExample_0
 ```
@@ -197,7 +197,7 @@ e.g.,
 ```
     make _testExample
 ```
-Above command will run [all possible variations in _testExample](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample/playlist.xml#L28-L30)
+Above command will run [all possible variations in _testExample](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample/playlist.xml#L28-L30)
 target
 
 #### Run a list of tests <br />
@@ -221,7 +221,7 @@ make _testList TESTLIST=jit_jitt,jit_recognizedMethod,testSCCMLTests2_1
 
 `<impl>` and `<version>` elements are used to annotate tests in playlist.xml, so that the tests will be run against the targeted JDK_IMPL and JDK_VERSION (and is determined by the SDK defined in TEST_JDK_HOME variable).  
 
-For example, adding a `<versions><version>8</version></versions>` block into the [target definition of TestExample](https://github.com/eclipse/openj9/blob/master/test/functional/TestExample/playlist.xml#L26-L49) would mean that test would only get run against jdk8 and would be skipped for other JDK versions.  If `<versions>` or `<impls>` are not included in the target definition, then it is assumed that ALL versions and implementations are valid for that test target.
+For example, adding a `<versions><version>8</version></versions>` block into the [target definition of TestExample](https://github.com/eclipse-openj9/openj9/blob/master/test/functional/TestExample/playlist.xml#L26-L49) would mean that test would only get run against jdk8 and would be skipped for other JDK versions.  If `<versions>` or `<impls>` are not included in the target definition, then it is assumed that ALL versions and implementations are valid for that test target.
 
 
 #### Rerun the failed tests from the last run
@@ -606,7 +606,7 @@ A common scenario is that automated testing finds a failure and a developer is a
 * implementation the test fails against (JDK_IMPL)
 * SDK build that was used by the test (in the console output of the Jenkins job, there is java -version info and a link to the SDK used)
 
-A specific example, [Issue 6555](https://github.com/eclipse/openj9/issues/6555) Test_openjdk13_j9_sanity.system_ppc64le_linux TestIBMJlmRemoteMemoryAuth_0 crash 
+A specific example, [Issue 6555](https://github.com/eclipse-openj9/openj9/issues/6555) Test_openjdk13_j9_sanity.system_ppc64le_linux TestIBMJlmRemoteMemoryAuth_0 crash 
 we get the following info (captured in the name of the issue):
 * TARGET = TestIBMJlmRemoteMemoryAuth_0
 * BUILD_LIST = system
@@ -618,4 +618,4 @@ Since only a link to the Jenkins job was provided in the example issue 6555, we 
 
 For more details on launching a Grinder job, you can see these instructions on [how to run a grinder job](https://github.com/AdoptOpenJDK/openjdk-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins).  
 
-To try and reproduce the failure locally, please check out this [wiki for guidance on reproducing failures locally](https://github.com/eclipse/openj9/wiki/Reproducing-Test-Failures-Locally) for details.
+To try and reproduce the failure locally, please check out this [wiki for guidance on reproducing failures locally](https://github.com/eclipse-openj9/openj9/wiki/Reproducing-Test-Failures-Locally) for details.

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/CoreGen.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/CoreGen.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ package j9vm.test.corehelper;
 		SimpleThread st = new SimpleThread();
 
 		/* Fork a thread for TestJITExt that is guaranteed to have a JIT frame
-		 * at the top of the stack. Fix until  https://github.com/eclipse/openj9/issues/5966 
+		 * at the top of the stack. Fix until  https://github.com/eclipse-openj9/openj9/issues/5966 
 		 * is resolved.
 		 */
 		Compiler.compileClass(j9vm.test.corehelper.TestJITExtHelperThread.class);

--- a/test/functional/JIT_Test/src/jit/test/tr/SIMDOpts/SIMDOptTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/SIMDOpts/SIMDOptTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ public class SIMDOptTest{
 	 * Apart from the ASSERT. This test aims to verify that specific transformation done by the
 	 * SIMD Optimization is functionally correct.
 	 *
-	 * For more details see eclipse/openj9#9446
+	 * For more details see eclipse-openj9/openj9#9446
 	 */
 	private void testSimpleLoopSIMD(){
 		final int token = returnCachedRandomNumber();

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -436,7 +436,7 @@
 	<test>
 		<testCaseName>testSoftMxRemote</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/480</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/480</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -469,7 +469,7 @@
 	<test>
 		<testCaseName>testSoftMxRemote_zlinux_64</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/480</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/480</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -502,7 +502,7 @@
 	<test>
 		<testCaseName>testSoftMxRemote_zlinux_31</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/480</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/480</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -535,7 +535,7 @@
 	<test>
 		<testCaseName>testSoftMxRemote_LP4k</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/480</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/480</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -568,7 +568,7 @@
 	<test>
 		<testCaseName>testSoftMxRemote_LP64k</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/480</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/480</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -1133,7 +1133,7 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	<!-- Exclude testOpenJ9DiagnosticsMXBean test on win32: https://github.com/eclipse/openj9/issues/2213-->
+	<!-- Exclude testOpenJ9DiagnosticsMXBean test on win32: https://github.com/eclipse-openj9/openj9/issues/2213-->
 	<test>
 		<testCaseName>testOpenJ9DiagnosticsMXBean</testCaseName>
 		<variations>
@@ -1266,7 +1266,7 @@
 	<test>
 		<testCaseName>testSoftMxUserScenario</testCaseName>
 		<disabled>
-			<comment>github.com/eclipse/openj9/issues/8967</comment>
+			<comment>github.com/eclipse-openj9/openj9/issues/8967</comment>
 			<plat>aarch64.*</plat>
 		</disabled>
 		<variations>

--- a/test/functional/JLM_Tests/src/org/openj9/test/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/management/TestOperatingSystemMXBean.java
@@ -75,7 +75,7 @@ public class TestOperatingSystemMXBean {
 
 	private static boolean isPhysicalMemoryTestExcluded() {
 		/* Exclude when running in a docker container
-		 * https://github.com/eclipse/openj9/issues/12038
+		 * https://github.com/eclipse-openj9/openj9/issues/12038
 		 */
 		if (inContainer == ContainerStatus.NOT_FOUND) {
 			return false;

--- a/test/functional/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
+++ b/test/functional/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -209,7 +209,7 @@ public class APITestJava10 extends ThreadMXBeanTestCase {
 
 	/* ThreadInfo objects contain MonitorInfo objects which carry stack depth info that can be higher than
 	 * max depth passed to dumpAllThreads. dumpAllThreads should still produce the ThreadInfo objects.
-	 * See https://github.com/eclipse/openj9/issues/10796
+	 * See https://github.com/eclipse-openj9/openj9/issues/10796
 	 */
 	@Test(groups = { "level.extended" })
 	public void testDumpWithMonitorDepthHigherThanLimit() {

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -74,7 +74,7 @@
 	<test>
 		<testCaseName>Nestmate_virtual_private</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/9167</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/9167</comment>
 			<plat>.*zos.*</plat>
 		</disabled>
 		<variations>

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -307,7 +307,7 @@
 	<test>
 		<testCaseName>TestAttachErrorHandling_SE80</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3081</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3081</comment>
 			<plat>.*aix.*</plat>
 		</disabled>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
@@ -335,7 +335,7 @@
 	<test>
 		<testCaseName>TestAttachErrorHandling</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3081</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3081</comment>
 			<plat>.*aix.*</plat>
 		</disabled>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \

--- a/test/functional/Java8andUp/scr_DupClassNameTest/version1/DupClassNameTest.java
+++ b/test/functional/Java8andUp/scr_DupClassNameTest/version1/DupClassNameTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 import org.testng.Assert;
 
 /*
- * Test for this change: https://github.com/eclipse/openj9/pull/10687
+ * Test for this change: https://github.com/eclipse-openj9/openj9/pull/10687
  * There are 2 classes with the same name (DupClassNameTest), which are loaded by 2 different class loaders.
  * This file is under directory version1, the other version of DupClassNameTest is under directory version2.
  */

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
@@ -37,7 +37,7 @@ import org.testng.log4testng.Logger;
  * verifies that IllegalStateException is now caught and the VM shuts
  * down properly.
  *
- * [1] https://github.com/eclipse/openj9/issues/932
+ * [1] https://github.com/eclipse-openj9/openj9/issues/932
  */
 @Test(groups = { "level.extended" })
 public final class MemoryMXBeanShutdownNotification {

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -379,7 +379,7 @@ public class Test_System {
 	 */
 	@Test
 	public void test_setSecurityManager3() {
-		/* https://github.com/eclipse/openj9/issues/6661 */
+		/* https://github.com/eclipse-openj9/openj9/issues/6661 */
 		try {
 			String helperName = "org.openj9.test.java.lang.Test_System$TestSecurityManagerNonPublicConstructor";
 			String output = Support_Exec.execJava(new String[] { "-Djava.security.manager=" + helperName, helperName },

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/Cmvc196982.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/Cmvc196982.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,7 +77,7 @@ public class Cmvc196982 {
 		logger.info("Cmvc196982 is setting up... ");
 
 		/* Java 12 disallows direct field reflection on java.lang.reflect.Method
-		 * (refer https://github.com/eclipse/openj9/issues/4658#issuecomment-461913909 for details), 
+		 * (refer https://github.com/eclipse-openj9/openj9/issues/4658#issuecomment-461913909 for details), 
 		 * this is a workaround via reflection of package access methods.
 		 */
 		getMethodAnnotationBytes = Method.class.getDeclaredMethod("getAnnotationBytes");

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -385,7 +385,7 @@
 	<!--
 		TODO: The following test cases specific to Lookup are temporarily excluded in Java 14
 		as there is no backward compatibility of these APIs since Java 14 due to the new changes
-		required at https://github.com/eclipse/openj9/issues/8571. These test cases here
+		required at https://github.com/eclipse-openj9/openj9/issues/8571. These test cases here
 		(mainly used prior to OpenJ9) will be re-evaluated against the Java 14 Spec and ideally copied
 		as a new version with modification to OpenJ9_Jsr_292_API to meet the new scenarios in Java 14.
 	-->

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -144,7 +144,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>jsigjnitest</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<variations>
@@ -516,7 +516,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>vmLifecyleTests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3561</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3561</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>
@@ -549,7 +549,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>vmLifecyleTests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3561</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3561</comment>
 		</disabled>
 		<variations>
 			<variation>Mode110</variation>

--- a/test/functional/OpenJ9_Jsr_292_API/playlist.xml
+++ b/test/functional/OpenJ9_Jsr_292_API/playlist.xml
@@ -24,7 +24,7 @@
 	<!--
 		TODO: The following test cases specific to Lookup are temporarily excluded in Java 14
 		as there is no backward compatibility of these APIs since Java 14 due to the new changes
-		required at https://github.com/eclipse/openj9/issues/8571. These test cases here
+		required at https://github.com/eclipse-openj9/openj9/issues/8571. These test cases here
 		(mainly used prior to OpenJ9) will be re-evaluated against the Java 14 Spec and copied
 		as a new version with modification to meet the new scenarios in Java 14.
 	-->

--- a/test/functional/RasapiTest/playlist.xml
+++ b/test/functional/RasapiTest/playlist.xml
@@ -28,7 +28,7 @@
 			<plat>.*mac.*</plat>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11800</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11800</comment>
 			<version>16+</version>
 		</disabled>
 		<command>

--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -201,7 +201,7 @@
 	<test>
 		<testCaseName>xlpTests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11374</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11374</comment>
 			<plat>.*mac.*</plat>
 		</disabled>
 		<variations>
@@ -227,7 +227,7 @@
 	<test>
 		<testCaseName>xlpCodeCacheTests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11104</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11104</comment>
 			<plat>.*aix.*</plat>
 		</disabled>
 		<variations>

--- a/test/functional/VM_Test/src/j9vm/test/clinit/GetStaticDuringClinit.java
+++ b/test/functional/VM_Test/src/j9vm/test/clinit/GetStaticDuringClinit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ public class GetStaticDuringClinit {
 	}
 
 	public static void jitWrite(String x) {
-		// https://github.com/eclipse/openj9/pull/2794
+		// https://github.com/eclipse-openj9/openj9/pull/2794
 		// The write to the static field causes jitResolveClassFromStaticField to be called on
 		// certain GC policies. On older VMs, this caused the CP entry to be resolved, meaning
 		// the call to jitResolveStaticField succeeds without the class init check.

--- a/test/functional/VM_Test/src/j9vm/test/clinit/PutStaticDuringClinit.java
+++ b/test/functional/VM_Test/src/j9vm/test/clinit/PutStaticDuringClinit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ public class PutStaticDuringClinit {
 	public static boolean passed = true;
 
 	public static void jitWrite(String x) {
-		// https://github.com/eclipse/openj9/pull/2794
+		// https://github.com/eclipse-openj9/openj9/pull/2794
 		// The write to the static field causes jitResolveClassFromStaticField to be called on
 		// certain GC policies. On older VMs, this caused the CP entry to be resolved, meaning
 		// the call to jitResolveStaticField succeeds without the class init check.

--- a/test/functional/VM_Test/src/j9vm/test/thread/FindDeadlockTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/thread/FindDeadlockTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -207,7 +207,7 @@ public class FindDeadlockTest {
 			e.printStackTrace();
 		} catch (Throwable t) {
 			/* Exceptions thrown while threads are deadlocked prevent VM shutdown.
-			 * https://github.com/eclipse/openj9/issues/3369
+			 * https://github.com/eclipse-openj9/openj9/issues/3369
 			 * Force VM exit in this case.
 			 */
 			System.out.println("Unexpected exception:");

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -58,7 +58,7 @@
 	<test>
 		<testCaseName>ValueTypeTestsJIT</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/pull/9392#issuecomment-661246648</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/pull/9392#issuecomment-661246648</comment>
 			<variation>-Xjit:count=0</variation>
 		</disabled>
 		<variations>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/playlist.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/playlist.xml
@@ -53,7 +53,7 @@
 	<test>
 		<testCaseName>SCURLClassLoaderTests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11965#issuecomment-778413238</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11965#issuecomment-778413238</comment>
 			<variation>Mode110</variation>
 			<plat>.*aarch.*</plat>
 		</disabled>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -79,7 +79,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_callsitedbgddrext_openj9</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 			<plat>.*zos.*</plat>
 		</disabled>
 		<variations>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -113,7 +113,7 @@
 	<test>
 		<testCaseName>cmdLineTest_J9test_native</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212;https://github.com/eclipse/openj9/issues/3560</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212;https://github.com/eclipse-openj9/openj9/issues/3560</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \

--- a/test/functional/cmdLineTests/dumpromtests/dumpromclasstests_excludes.xml
+++ b/test/functional/cmdLineTests/dumpromtests/dumpromclasstests_excludes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2011, 2018 IBM Corp. and others
+  Copyright (c) 2011, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
  
 <suite id="jdmpview tests" timeout="600">
-	<exclude id="Dump ROM method and check for type annotations" platform="all"><reason>https://github.com/eclipse/openj9/issues/3043</reason></exclude>
+	<exclude id="Dump ROM method and check for type annotations" platform="all"><reason>https://github.com/eclipse-openj9/openj9/issues/3043</reason></exclude>
 </suite>
 
 

--- a/test/functional/cmdLineTests/dumpromtests/playlist.xml
+++ b/test/functional/cmdLineTests/dumpromtests/playlist.xml
@@ -24,7 +24,7 @@
 	<test>
 		<testCaseName>cmdLineTester_dumpromclasstests</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3562</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3562</comment>
 			<plat>.*aix.*</plat>
 		</disabled>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
@@ -24,7 +24,7 @@
 	<test>
 		<testCaseName>cmdLineTester_forceLazySymbolResolution</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11076</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11076</comment>
 			<version>15+</version>
 		</disabled>
 		<variations>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -24,15 +24,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_jep178_staticLinking_SE80</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11854</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11854</comment>
 			<plat>ppc64le.*</plat>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/12050</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/12050</comment>
 			<plat>aarch64.*</plat>
 		</disabled>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
@@ -73,10 +73,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_jep178_staticLinking</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3560</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3560</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getSystemProperty/gsp001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getSystemProperty/gsp001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@ public class gsp001 {
 	 *   java.vm.info
 	 *   java.library.path
 	 *   java.class.path
-	 * Requested by https://github.com/eclipse/openj9/issues/5565, following system property is added as well:
+	 * Requested by https://github.com/eclipse-openj9/openj9/issues/5565, following system property is added as well:
 	 *   java.vm.specification.version
 	 */
 	private static String[] sysPropNames = {

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/retransformClasses/rtc001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/retransformClasses/rtc001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,7 @@ public class rtc001
 			}
 			
 			/* JDK12 disallows direct field reflection on java.lang.reflect.Method.methodAccessor 
-			 * (refer https://github.com/eclipse/openj9/issues/4658#issuecomment-461913909 for details), 
+			 * (refer https://github.com/eclipse-openj9/openj9/issues/4658#issuecomment-461913909 for details), 
 			 * this is a workaround via reflection of package access method java.lang.reflect.Method.getMethodAccessor().
 			 */
 			Method getMethodAccessor = method.getClass().getDeclaredMethod("getMethodAccessor");

--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -25,7 +25,7 @@
 	<test>
 		<testCaseName>cmdLineTester_libpathTestRtf</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3787</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3787</comment>
 			<plat>.*mac.*</plat>
 		</disabled>
 		<variations>
@@ -38,7 +38,7 @@
 	-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3787 -->
+		<!-- temporarily disable this test on osx; https://github.com/eclipse-openj9/openj9/issues/3787 -->
 		<platformRequirements>bits.64,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -54,7 +54,7 @@
 	<test>
 		<testCaseName>cmdLineTester_libpathTestRtfChild</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3787</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3787</comment>
 			<plat>.*mac.*</plat>
 		</disabled>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DEXTRA_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \

--- a/test/functional/cmdLineTests/pltest/playlist.xml
+++ b/test/functional/cmdLineTests/pltest/playlist.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_pltest</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<variations>
@@ -148,10 +148,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_pltest_tty_extended</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<variations>
@@ -185,10 +185,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_pltest_numcpus_notBound</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<variations>
@@ -254,10 +254,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_pltest_numcpus_bound_win</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
 		<variations>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
@@ -21,7 +21,7 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
-	<!-- Exclude it on windows for issue https://github.com/eclipse/openj9/issues/1814 -->
+	<!-- Exclude it on windows for issue https://github.com/eclipse-openj9/openj9/issues/1814 -->
 	<test>
 		<testCaseName>cmdLineTester_SCCommandLineOptionTests</testCaseName>
 		<variations>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_shrcdbgddrext</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 			<plat>.*zos.*</plat>
 		</disabled>
 		<variations>
@@ -57,7 +57,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>cmdLineTester_shrcdbgddrext_zos</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/1511</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2013, 2018 IBM Corp. and others
+  Copyright (c) 2013, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 <variable name="NOHANDLE" value="-XX:-HandleSIGXFSZ" />
 
 <!-- Add -Xshareclasses:none to the command lines of this test suite to ensure that signal SIGXFSZ is triggered on test.txt creation rather than 
-	on shared cache file creation (if shared classes is enabled by default). See issue: https://github.com/eclipse/openj9/issues/3333 -->
+	on shared cache file creation (if shared classes is enabled by default). See issue: https://github.com/eclipse-openj9/openj9/issues/3333 -->
  <test id="Default">
 	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 			${TEST_STATUS}
 		</command>
-		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->
 		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -79,7 +79,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 			${TEST_STATUS}
 		</command>
-		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->
 		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -117,7 +117,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 			${TEST_STATUS}
 		</command>
-		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->
 		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -155,7 +155,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 			${TEST_STATUS}
 		</command>
-		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->
 		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>

--- a/test/functional/cmdLineTests/verbosetest/playlist.xml
+++ b/test/functional/cmdLineTests/verbosetest/playlist.xml
@@ -34,7 +34,7 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJDK_VERSION=$(Q)$(JDK_VERSION)$(Q) -DREPORTDIR=$(REPORTDIR) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<!-- https://github.com/eclipse/openj9/issues/1608, exclude test on Win temporarily -->
+		<!-- https://github.com/eclipse-openj9/openj9/issues/1608, exclude test on Win temporarily -->
 		<platformRequirements>^arch.arm,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -54,7 +54,7 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJDK_VERSION=$(Q)$(JDK_VERSION)$(Q) -DREPORTDIR=$(REPORTDIR) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests_11.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<!-- https://github.com/eclipse/openj9/issues/1608, exclude test on Win temporarily -->
+		<!-- https://github.com/eclipse-openj9/openj9/issues/1608, exclude test on Win temporarily -->
 		<platformRequirements>^arch.arm,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
The openj9 repos have been moved from https://github.com/eclipse to
https://github.com/eclipse-openj9