### PR TITLE
Update Dockerfile for AArch64 cross build

### DIFF
--- a/buildenv/docker/aarch64-linux_CC/Dockerfile
+++ b/buildenv/docker/aarch64-linux_CC/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,8 +87,8 @@ RUN cd /root \
 ADD \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5_arm64.deb            \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.3.1-11_arm64.deb                 \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.3.1-11_arm64.deb            \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.3.3op2-3_arm64.deb                 \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.3.3op2-3_arm64.deb            \
     http://ftp.us.debian.org/debian/pool/main/d/dwarfutils/libdwarf-dev_20180809-1_arm64.deb         \
     http://ftp.us.debian.org/debian/pool/main/e/elfutils/libelf-dev_0.176-1.1_arm64.deb              \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.6.3-3.2+deb9u1_arm64.deb     \
@@ -99,8 +99,8 @@ ADD \
     http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng16-16_1.6.28-1+deb9u1_arm64.deb   \
     http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng-dev_1.6.28-1+deb9u1_arm64.deb    \
     http://ftp.us.debian.org/debian/pool/main/libs/libsm/libsm-dev_1.2.2-1+b3_arm64.deb              \
-    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1f-1_arm64.deb                 \
-    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl-dev_1.1.1f-1_arm64.deb                \
+    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1k-1_arm64.deb                 \
+    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl-dev_1.1.1k-1_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/libx/libx11/libx11-6_1.6.4-3%2bdeb9u1_arm64.deb        \
     http://ftp.us.debian.org/debian/pool/main/libx/libx11/libx11-dev_1.6.4-3%2bdeb9u1_arm64.deb      \
     http://ftp.us.debian.org/debian/pool/main/libx/libxext/libxext6_1.3.3-1+b2_arm64.deb             \


### PR DESCRIPTION
This commit updates the Dockerfile for AArch64 cross build.
Some .deb files in it are missing.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>