### PR TITLE
Do not lower decompressed NULL reference to iconst before storing compressed reference

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5210,20 +5210,20 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
    if (comp->useCompressedPointers() && firstChild->getOpCode().isIndirect())
       {
       usingCompressedPointers = true;
-
-      if (usingCompressedPointers)
+      while (sourceChild->getNumChildren() > 0 
+         && sourceChild->getOpCodeValue() != TR::a2l)
          {
-         while ((sourceChild->getNumChildren() > 0) &&
-                  (sourceChild->getOpCodeValue() != TR::a2l))
-            sourceChild = sourceChild->getFirstChild();
-         if (sourceChild->getOpCodeValue() == TR::a2l)
-            sourceChild = sourceChild->getFirstChild();
-         // artificially bump up the refCount on the value so
-         // that different registers are allocated for the actual
-         // and compressed values
-         //
-         sourceChild->incReferenceCount();
+         sourceChild = sourceChild->getFirstChild();
          }
+      if (sourceChild->getOpCodeValue() == TR::a2l)
+         {
+         sourceChild = sourceChild->getFirstChild();
+         }
+      // artificially bump up the refCount on the value so
+      // that different registers are allocated for the actual
+      // and compressed values
+      //
+      sourceChild->incReferenceCount();
       }
    TR::Node * memRefChild = firstChild->getFirstChild();
 


### PR DESCRIPTION
For 64-Bit platforms running with compressedrefs while lowering trees for compression sequence, we optimize compression of constant NULL object by recreating it as iconst 0. Codegenerators need actual decompressed reference for wrtbar and by lowering the aconst to iconst, we lose that information. Most of the codegen makes an assumption that the compression sequence for storing a reference would be lowered and when it needs actual decompressed object reference, it traverses the compressed child till it finds actual reference and rest of the code would be generated with the assumption that it has decompressed object reference which would take full 64 bit register. In case of constant NULL reference, it would end up iconst node which would be evaluated into the lower half of the register on Z. This was causing an issue particularly in ArrayStoreCHK where when performing NULLTEST on reference, it compares full 64-Bit reference which where it has only cleared out lower half of 0 and upper half might contain some garbage.

Fixes: #12557

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>