### PR TITLE
Fix ddrblob compilation for object iterators

### DIFF
--- a/runtime/gc_structs/MixedObjectIterator.hpp
+++ b/runtime/gc_structs/MixedObjectIterator.hpp
@@ -245,14 +245,24 @@ public:
 		, _descriptionPtr(NULL)
 		, _description(0)
 		, _descriptionIndex(0)
-	{}
+	{
+	}
 
 	/**
 	 * @param vm[in] pointer to the JVM
 	 * @param objectPtr[in] the object to be processed
 	 */
 	GC_MixedObjectIterator(OMR_VM *omrVM, J9Object *objectPtr)
-		: GC_MixedObjectIterator(omrVM)
+		: _slotObject(GC_SlotObject(omrVM, NULL))
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+		, _objectPtr(NULL)
+		, _scanPtr(NULL)
+		, _endPtr(NULL)
+		, _descriptionPtr(NULL)
+		, _description(0)
+		, _descriptionIndex(0)
 	{
 		initialize(omrVM, objectPtr);
 	}

--- a/runtime/gc_structs/PointerArrayIterator.hpp
+++ b/runtime/gc_structs/PointerArrayIterator.hpp
@@ -58,7 +58,8 @@ public:
 	 * @param objectPtr the array object to be processed
 	 */
 	GC_PointerArrayIterator(J9JavaVM *javaVM, J9Object *objectPtr)
-		: GC_PointerArrayIterator(javaVM)
+		: _contiguousArrayIterator(javaVM->omrVM)
+		, _pointerArrayletIterator(javaVM)
 	{
 		initialize(javaVM, objectPtr);
 	}

--- a/runtime/gc_structs/PointerContiguousArrayIterator.hpp
+++ b/runtime/gc_structs/PointerContiguousArrayIterator.hpp
@@ -96,10 +96,10 @@ public:
 	}
 
 	GC_PointerContiguousArrayIterator(OMR_VM *omrVM)
-		:	_arrayPtr(NULL)
-		,	_slotObject(GC_SlotObject(omrVM, NULL))
-		,	_scanPtr(NULL)
-		,	_endPtr(NULL)
+		: _arrayPtr(NULL)
+		, _slotObject(GC_SlotObject(omrVM, NULL))
+		, _scanPtr(NULL)
+		, _endPtr(NULL)
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
@@ -111,7 +111,14 @@ public:
 	 * @param objectPtr the array object to be processed
 	 */
 	GC_PointerContiguousArrayIterator(OMR_VM *omrVM, J9Object *objectPtr)
-		: GC_PointerContiguousArrayIterator(omrVM)
+		: _arrayPtr(NULL)
+		, _slotObject(GC_SlotObject(omrVM, NULL))
+		, _scanPtr(NULL)
+		, _endPtr(NULL)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+		, _omrVM(omrVM)
 	{
 		initialize(objectPtr);
 	}


### PR DESCRIPTION
There was an attempt to minimize code by calling another constructor.
While there is no problem for C++ compiler itself ddrblob compilation
failed

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>