### PR TITLE
Access.protectionDomain() invokes clazz.getProtectionDomainInternal()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -431,7 +431,7 @@ final class Access implements JavaLangAccess {
 	}
 
 	public ProtectionDomain protectionDomain(Class<?> clazz) {
-		return clazz.getProtectionDomain();
+		return clazz.getProtectionDomainInternal();
 	}
 
 	public MethodHandle stringConcatHelper(String arg0, MethodType type) {

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2051,10 +2051,14 @@ public ProtectionDomain getProtectionDomain() {
 	if (security != null) {
 		security.checkPermission(sun.security.util.SecurityConstants.GET_PD_PERMISSION);
 	}
+	return getProtectionDomainInternal();
+}
 
+ProtectionDomain getProtectionDomainInternal() {
 	ProtectionDomain result = getPDImpl();
-	if (result != null) return result;
-
+	if (result != null) {
+		return result;
+	}
 	if (AllPermissionsPD == null) {
 		allocateAllPermissionsPD();
 	}

--- a/test/functional/cmdLineTests/J9security/build.xml
+++ b/test/functional/cmdLineTests/J9security/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,8 +49,19 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 	
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
+			<then>
+				<property name="addExports" value="" />
+			</then>
+			<else>
+				<property name="addExports" value="--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
+			</else>
+		</if>
+
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
+			<compilerarg line="${addExports}" />
 			<classpath>
 				<pathelement location="${LIB_DIR}/asm-all.jar" />
 			</classpath>
@@ -65,7 +76,14 @@
 		<jar jarfile="${DEST}/CodeTrusted.jar" filesonly="true">
 			<fileset dir="${build}" includes="com/ibm/j9/security/bootpath/**"/>
 		</jar>
-		
+
+		<jar jarfile="${DEST}/TestJSR292Security.jar" filesonly="true">
+			<fileset dir="${build}" includes="com/ibm/j9/jsr292/indyn/TestJSR292*"/>
+		</jar>
+		<jar jarfile="${DEST}/CodeNotTrusted.jar" filesonly="true">
+			<fileset dir="${build}" includes="com/ibm/j9/jsr292/indyn/bootpath/CodeNotTrusted*"/>
+		</jar>
+
 		<jar jarfile="${DEST}/j9JEP140CodeTrusted.jar" filesonly="true">
 			<fileset dir="${build}" excludes="**/TestImplies*.class,**/JEP140Tests.class"/>
 			<fileset dir="${src}" excludes="**/TestImplies*.java,**/JEP140Tests.java"/>
@@ -78,6 +96,7 @@
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.xml" />
 			<fileset dir="${src}/../" includes="*.mk" />
+			<fileset dir="${src}/../" includes="*.policy" />
 		</copy>
 	</target>
 	

--- a/test/functional/cmdLineTests/J9security/j9SecurityTest.xml
+++ b/test/functional/cmdLineTests/J9security/j9SecurityTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2013, 2019 IBM Corp. and others
+  Copyright (c) 2013, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,9 +28,14 @@
 
 	<variable name="CLASSPATH" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$j9security.jar" />
 	<variable name="CLASSPATH_JEP140" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$j9JEP140Tests.jar" />
+	<variable name="CLASSPATH_JSR292" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$TestJSR292Security.jar" />
+	<variable name="BOOTCLASSPATH_CodeNotTrusted" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$CodeNotTrusted.jar" />
 	<variable name="BOOTCLASSPATH_CodeTrusted_JEP140" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$j9JEP140CodeTrusted.jar" />
 	<variable name="BOOTCLASSPATH_CodeTrusted_doPrivilegedWithCombiner" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$CodeTrusted.jar" />
 	<variable name="SECURITYMANAGER" value="-Djava.security.manager" />
+	<variable name="JSR292_PERMISSION_POLICY" value="-Djava.security.policy=$Q$$TESTJ9SECURITYJARPATH$$Q$jsr292.policy" />
+	<variable name="ADDEXPORTS_OPTION" value="$Q$$MODULE_ADDEXPORTS_OPTION$$Q$" />
+	<variable name="ADDEXPORTS_VALUE" value="$Q$$MODULE_ADDEXPORTS_VALUE$$Q$" />
 
 	<test id="testJ9Security">
 		<command>$EXE$ $CLASSPATH$ com.ibm.j9.security.TestImplies</command>
@@ -78,6 +83,15 @@
 		<output regex="no" type="success">ALL TESTS COMPLETED AND PASSED</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="no" regex="no">AccessControlException</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="testJSR292Permissions">
+		<command>$EXE$ $SECURITYMANAGER$ $JSR292_PERMISSION_POLICY$ $ADDEXPORTS_OPTION$ $ADDEXPORTS_VALUE$ $BOOTCLASSPATH_CodeNotTrusted$ $CLASSPATH_JSR292$ com.ibm.j9.jsr292.indyn.TestJSR292</command>
+		<output type="success" caseSensitive="no" regex="no">AccessControlException</output>
+		<output type="failure" caseSensitive="no" regex="no">Expected exception wasn't thrown, the test failed!</output>
+		<output type="failure" caseSensitive="no" regex="no">ClassNotFoundException</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/J9security/jsr292.policy
+++ b/test/functional/cmdLineTests/J9security/jsr292.policy
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+grant {
+    permission java.lang.RuntimePermission "createClassLoader";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.org.objectweb.asm";
+};

--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -22,11 +22,12 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_J9securityTests</testCaseName>
+		<testCaseName>cmdLineTester_J9securityTests_SE80</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+		-DMODULE_ADDEXPORTS_OPTION= -DMODULE_ADDEXPORTS_VALUE= \
 		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
 		-explainExcludes -nonZeroExitWhenError; \
@@ -37,6 +38,35 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<versions>
+			<version>8</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_J9securityTests</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+		-DMODULE_ADDEXPORTS_OPTION=$(Q)--add-exports$(Q) -DMODULE_ADDEXPORTS_VALUE=$(Q)java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) \
+		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/TestJSR292.java
+++ b/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/TestJSR292.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.j9.jsr292.indyn;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_STATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER;
+import static jdk.internal.org.objectweb.asm.Opcodes.H_INVOKESTATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.V1_7;
+
+import java.lang.reflect.Method;
+
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.Handle;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Type;
+
+public class TestJSR292 {
+
+	public static void main(String[] args) throws Throwable {
+		new TestJSR292().testJSR292Perm();
+	}
+
+	public void testJSR292Perm() throws Throwable {
+		CustomClassLoader cc = new CustomClassLoader();
+		Class<?> genindyn = cc.loadClass("com.ibm.j9.jsr292.indyn.GenIndyn");
+		Method method = genindyn.getMethod("testJSR292Perm");
+		method.invoke(null);
+		System.out.println("Expected exception wasn't thrown, the test failed!");
+	}
+
+	private static byte[] createIndyClass() throws Throwable {
+		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+		cw.visit(V1_7, ACC_PUBLIC | ACC_SUPER, "com/ibm/j9/jsr292/indyn/GenIndyn", null, "java/lang/Object", null);
+
+		MethodVisitor mv;
+		{
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testJSR292Perm", "()V", null, null);
+			mv.visitCode();
+			mv.visitInvokeDynamicInsn("testJSR292Perm", "()V", new Handle(H_INVOKESTATIC,
+					"com/ibm/j9/jsr292/indyn/bootpath/CodeNotTrusted", "bootstrap_test_privAction",
+					Type.getType(
+							"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;")
+							.getDescriptor()));
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	class CustomClassLoader extends ClassLoader {
+		protected Class<?> findClass(final String name) throws ClassNotFoundException {
+			if ("com.ibm.j9.jsr292.indyn.GenIndyn".equals(name)) {
+				try {
+					byte[] classBytes = createIndyClass();
+					return defineClass(name, classBytes, 0, classBytes.length);
+				} catch (Throwable e) {
+					e.printStackTrace();
+				}
+			}
+			return super.findClass(name);
+		}
+	}
+}

--- a/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/bootpath/CodeNotTrusted.java
+++ b/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/bootpath/CodeNotTrusted.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9.jsr292.indyn.bootpath;
+
+import static java.lang.invoke.MethodType.methodType;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MethodHandles.Lookup;
+
+public class CodeNotTrusted {
+	public static CallSite bootstrap_test_privAction(Lookup lookup, String name, MethodType type) throws Throwable {
+		System.out.println("user.home = " + System.getProperty("user.home"));
+
+		MethodHandle handle = MethodHandles.constant(Object.class, null).asType(MethodType.methodType(void.class));
+		return new ConstantCallSite(handle);
+	}
+
+	public static void voidMethod() {
+	}
+}


### PR DESCRIPTION
This avoids `AccessControlException` within `Lookup.lookupClassProtectionDomain` initiated by `MethodHandleResolver.resolveInvokeDynamic()`;
Added a test to ensure proper permission check when invoking BootstrapMethod.

closes https://github.com/eclipse-openj9/openj9/issues/12600

Signed-off-by: Jason Feng <fengj@ca.ibm.com>