### PR TITLE
Preserve entire contents of XMM registers across helper calls on X

### DIFF
--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -147,7 +147,6 @@ define({OLD_DUAL_MODE_HELPER},{
 	test _rax,_rax
 	je LABEL(L_done_$1)
 	SAVE_C_NONVOLATILE_REGS
-	SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
 	je SHORT_JMP LABEL(L_slow_$1)
@@ -172,7 +171,6 @@ define({OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE},{
 	test _rax,_rax
 	je LABEL(L_done_$1)
 	SAVE_C_NONVOLATILE_REGS
-	SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
 	je SHORT_JMP LABEL(L_slow_$1)
@@ -348,6 +346,35 @@ define({CINTERP},{
 	jmp uword ptr J9TR_JavaVM_cInterpreter[_rax]
 })
 
+dnl Helpers that are at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in xhelpers.m4
+dnl for details.
+
+define({METHOD_INVOCATION})
+
+PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
+SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
+
+dnl jitStackOverflow is special case in that the frame size argument
+dnl is implicit (in the register file) rather than being passed as
+dnl an argument in the usual way.
+
+SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitStackOverflow,0)
+
+dnl Helpers that are not at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in xhelpers.m4
+dnl for details.
+
+undefine({METHOD_INVOCATION})
+
 dnl Runtime helpers
 
 DUAL_MODE_ALLOCATION_HELPER(jitNewValue,1)
@@ -359,12 +386,6 @@ DUAL_MODE_HELPER(jitANewArrayNoZeroInit,2)
 DUAL_MODE_ALLOCATION_HELPER(jitNewArray,2)
 DUAL_MODE_ALLOCATION_HELPER(jitNewArrayNoZeroInit,2)
 SLOW_PATH_ONLY_HELPER(jitAMultiNewArray,3)
-
-dnl jitStackOverflow is special case in that the frame size argument
-dnl is implicit (in the register file) rather than being passed as
-dnl an argument in the usual way.
-
-SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitStackOverflow,0)
 
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitCheckAsyncMessages,0)
 DUAL_MODE_HELPER_NO_RETURN_VALUE(jitCheckCast,2)
@@ -410,7 +431,6 @@ dnl Only called from PicBuilder
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsNative,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsSync,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitResolvedFieldIsVolatile,3)
-PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveString,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClass,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClassFromStaticField,3)
@@ -418,10 +438,6 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveFieldSetter,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetter,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodType,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodHandle,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
@@ -439,7 +455,6 @@ dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)
 SLOW_PATH_ONLY_HELPER(jitRetranslateCallerWithPreparation,3)
-SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
 
 dnl Exception throw helpers
 
@@ -497,8 +512,6 @@ FAST_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitWriteBarrierStoreMetronome,3)
 
 dnl Misc
 
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
 SLOW_PATH_ONLY_HELPER(jitNewInstanceImplAccessCheck,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallCFunction,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallJitAddPicToPatchOnClassUnload,2)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5749,13 +5749,13 @@ typedef struct J9CInterpreterStackFrame {
 			UDATA r15;
 		} named;
 	} jitGPRs;
-	U_64 jitFPRs[16];
 #if defined(WIN32)
 	/* Windows x86-64
 	 *
 	 * Stack must be 16-byte aligned.
 	 */
-	U_8 preservedFPRs[10 * 16]; /* xmm6-15 */
+	U_8 jitFPRs[6 * 16]; /* xmm0-5 128-bit OR xmm0-7 64-bit */
+	U_8 preservedFPRs[10 * 16]; /* xmm6-15 128-bit */
 	UDATA align[1];
 	/* r15,r14,r13,r12,rdi,rsi,rbx,rbp,return address
 	 * RSP is 16-byte aligned at this point
@@ -5765,6 +5765,7 @@ typedef struct J9CInterpreterStackFrame {
 	 *
 	 * Stack must be 16-byte aligned.
 	 */
+	U_8 jitFPRs[16 * 16]; /* xmm0-15 128-bit OR xmm0-7 64-bit */
 	UDATA align[1];
 	/* r15,r14,r13,r12,rbx,rbp,return address
 	 * RSP is 16-byte aligned at this point
@@ -5788,8 +5789,9 @@ typedef struct J9CInterpreterStackFrame {
 			UDATA rsp;
 		} named;
 	} jitGPRs;
-	U_64 jitFPRs[8];
-	UDATA align[3];
+	UDATA align1[2];
+	U_8 jitFPRs[8 * 16]; /* xmm0-7 128-bit */
+	UDATA align2[1];
 	/* ebx,edi,esi
 	 * ESP is forcibly 16-byte aligned at this point
 	 * possible alignment

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2019 IBM Corp. and others
+dnl Copyright (c) 1991, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -308,12 +308,21 @@ define({SAVE_C_VOLATILE_REGS},{
 	mov qword ptr J9TR_cframe_r9[_rsp],r9
 	mov qword ptr J9TR_cframe_r10[_rsp],r10
 	mov qword ptr J9TR_cframe_r11[_rsp],r11
+ifdef({METHOD_INVOCATION},{
 	movq qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp],xmm0
 	movq qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp],xmm1
 	movq qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp],xmm2
 	movq qword ptr J9TR_cframe_jitFPRs+(3*8)[_rsp],xmm3
 	movq qword ptr J9TR_cframe_jitFPRs+(4*8)[_rsp],xmm4
 	movq qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp],xmm5
+},{ dnl METHOD_INVOCATION
+	movdqa J9TR_cframe_jitFPRs+(0*16)[_rsp],xmm0
+	movdqa J9TR_cframe_jitFPRs+(1*16)[_rsp],xmm1
+	movdqa J9TR_cframe_jitFPRs+(2*16)[_rsp],xmm2
+	movdqa J9TR_cframe_jitFPRs+(3*16)[_rsp],xmm3
+	movdqa J9TR_cframe_jitFPRs+(4*16)[_rsp],xmm4
+	movdqa J9TR_cframe_jitFPRs+(5*16)[_rsp],xmm5
+}) dnl METHOD_INVOCATION
 })
 
 define({RESTORE_C_VOLATILE_REGS},{
@@ -324,15 +333,24 @@ define({RESTORE_C_VOLATILE_REGS},{
 	mov r9,qword ptr J9TR_cframe_r9[_rsp]
 	mov r10,qword ptr J9TR_cframe_r10[_rsp]
 	mov r11,qword ptr J9TR_cframe_r11[_rsp]
+ifdef({METHOD_INVOCATION},{
 	movq xmm0,qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp]
 	movq xmm1,qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp]
 	movq xmm2,qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp]
 	movq xmm3,qword ptr J9TR_cframe_jitFPRs+(3*8)[_rsp]
 	movq xmm4,qword ptr J9TR_cframe_jitFPRs+(4*8)[_rsp]
 	movq xmm5,qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp]
+},{ dnl METHOD_INVOCATION
+	movdqa xmm0,J9TR_cframe_jitFPRs+(0*16)[_rsp]
+	movdqa xmm1,J9TR_cframe_jitFPRs+(1*16)[_rsp]
+	movdqa xmm2,J9TR_cframe_jitFPRs+(2*16)[_rsp]
+	movdqa xmm3,J9TR_cframe_jitFPRs+(3*16)[_rsp]
+	movdqa xmm4,J9TR_cframe_jitFPRs+(4*16)[_rsp]
+	movdqa xmm5,J9TR_cframe_jitFPRs+(5*16)[_rsp]
+}) dnl METHOD_INVOCATION
 })
 
-dnl No need to save/restore xmm9-15 - the stack walker will never need to read
+dnl No need to save/restore xmm8-15 - the stack walker will never need to read
 dnl or modify them (no preserved FPRs in the JIT private linkage).  xmm6-7
 dnl are preserved as they are JIT FP arguments which may need to be read
 dnl in order to decompile.  They do not need to be restored.
@@ -349,16 +367,12 @@ define({SAVE_C_NONVOLATILE_REGS},{
 	mov qword ptr J9TR_cframe_r13[_rsp],r13
 	mov qword ptr J9TR_cframe_r14[_rsp],r14
 	mov qword ptr J9TR_cframe_r15[_rsp],r15
-	movq qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp],xmm6
-	movq qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp],xmm7
-})
-
+ifdef({METHOD_INVOCATION},{
 dnl xmm6-7 are preserved as they are JIT FP arguments which may need
 dnl to be read in order to decompile.  They do not need to be restored.
-
-define({SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS},{
 	movq qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp],xmm6
 	movq qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp],xmm7
+}) dnl METHOD_INVOCATION
 })
 
 define({RESTORE_C_NONVOLATILE_REGS},{
@@ -383,6 +397,7 @@ define({SAVE_C_VOLATILE_REGS},{
 	mov qword ptr J9TR_cframe_r9[_rsp],r9
 	mov qword ptr J9TR_cframe_r10[_rsp],r10
 	mov qword ptr J9TR_cframe_r11[_rsp],r11
+ifdef({METHOD_INVOCATION},{
 	movq qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp],xmm0
 	movq qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp],xmm1
 	movq qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp],xmm2
@@ -391,14 +406,24 @@ define({SAVE_C_VOLATILE_REGS},{
 	movq qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp],xmm5
 	movq qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp],xmm6
 	movq qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp],xmm7
-	movq qword ptr J9TR_cframe_jitFPRs+(8*8)[_rsp],xmm8
-	movq qword ptr J9TR_cframe_jitFPRs+(9*8)[_rsp],xmm9
-	movq qword ptr J9TR_cframe_jitFPRs+(10*8)[_rsp],xmm10
-	movq qword ptr J9TR_cframe_jitFPRs+(11*8)[_rsp],xmm11
-	movq qword ptr J9TR_cframe_jitFPRs+(12*8)[_rsp],xmm12
-	movq qword ptr J9TR_cframe_jitFPRs+(13*8)[_rsp],xmm13
-	movq qword ptr J9TR_cframe_jitFPRs+(14*8)[_rsp],xmm14
-	movq qword ptr J9TR_cframe_jitFPRs+(15*8)[_rsp],xmm15
+},{ dnl METHOD_INVOCATION
+	movdqa J9TR_cframe_jitFPRs+(0*16)[_rsp],xmm0
+	movdqa J9TR_cframe_jitFPRs+(1*16)[_rsp],xmm1
+	movdqa J9TR_cframe_jitFPRs+(2*16)[_rsp],xmm2
+	movdqa J9TR_cframe_jitFPRs+(3*16)[_rsp],xmm3
+	movdqa J9TR_cframe_jitFPRs+(4*16)[_rsp],xmm4
+	movdqa J9TR_cframe_jitFPRs+(5*16)[_rsp],xmm5
+	movdqa J9TR_cframe_jitFPRs+(6*16)[_rsp],xmm6
+	movdqa J9TR_cframe_jitFPRs+(7*16)[_rsp],xmm7
+	movdqa J9TR_cframe_jitFPRs+(8*16)[_rsp],xmm8
+	movdqa J9TR_cframe_jitFPRs+(9*16)[_rsp],xmm9
+	movdqa J9TR_cframe_jitFPRs+(10*16)[_rsp],xmm10
+	movdqa J9TR_cframe_jitFPRs+(11*16)[_rsp],xmm11
+	movdqa J9TR_cframe_jitFPRs+(12*16)[_rsp],xmm12
+	movdqa J9TR_cframe_jitFPRs+(13*16)[_rsp],xmm13
+	movdqa J9TR_cframe_jitFPRs+(14*16)[_rsp],xmm14
+	movdqa J9TR_cframe_jitFPRs+(15*16)[_rsp],xmm15
+}) dnl METHOD_INVOCATION
 })
 
 define({RESTORE_C_VOLATILE_REGS},{
@@ -411,6 +436,7 @@ define({RESTORE_C_VOLATILE_REGS},{
 	mov r9,qword ptr J9TR_cframe_r9[_rsp]
 	mov r10,qword ptr J9TR_cframe_r10[_rsp]
 	mov r11,qword ptr J9TR_cframe_r11[_rsp]
+ifdef({METHOD_INVOCATION},{
 	movq xmm0,qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp]
 	movq xmm1,qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp]
 	movq xmm2,qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp]
@@ -419,14 +445,24 @@ define({RESTORE_C_VOLATILE_REGS},{
 	movq xmm5,qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp]
 	movq xmm6,qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp]
 	movq xmm7,qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp]
-	movq xmm8,qword ptr J9TR_cframe_jitFPRs+(8*8)[_rsp]
-	movq xmm9,qword ptr J9TR_cframe_jitFPRs+(9*8)[_rsp]
-	movq xmm10,qword ptr J9TR_cframe_jitFPRs+(10*8)[_rsp]
-	movq xmm11,qword ptr J9TR_cframe_jitFPRs+(11*8)[_rsp]
-	movq xmm12,qword ptr J9TR_cframe_jitFPRs+(12*8)[_rsp]
-	movq xmm13,qword ptr J9TR_cframe_jitFPRs+(13*8)[_rsp]
-	movq xmm14,qword ptr J9TR_cframe_jitFPRs+(14*8)[_rsp]
-	movq xmm15,qword ptr J9TR_cframe_jitFPRs+(15*8)[_rsp]
+},{ dnl METHOD_INVOCATION
+	movdqa xmm0,J9TR_cframe_jitFPRs+(0*16)[_rsp]
+	movdqa xmm1,J9TR_cframe_jitFPRs+(1*16)[_rsp]
+	movdqa xmm2,J9TR_cframe_jitFPRs+(2*16)[_rsp]
+	movdqa xmm3,J9TR_cframe_jitFPRs+(3*16)[_rsp]
+	movdqa xmm4,J9TR_cframe_jitFPRs+(4*16)[_rsp]
+	movdqa xmm5,J9TR_cframe_jitFPRs+(5*16)[_rsp]
+	movdqa xmm6,J9TR_cframe_jitFPRs+(6*16)[_rsp]
+	movdqa xmm7,J9TR_cframe_jitFPRs+(7*16)[_rsp]
+	movdqa xmm8,J9TR_cframe_jitFPRs+(8*16)[_rsp]
+	movdqa xmm9,J9TR_cframe_jitFPRs+(9*16)[_rsp]
+	movdqa xmm10,J9TR_cframe_jitFPRs+(10*16)[_rsp]
+	movdqa xmm11,J9TR_cframe_jitFPRs+(11*16)[_rsp]
+	movdqa xmm12,J9TR_cframe_jitFPRs+(12*16)[_rsp]
+	movdqa xmm13,J9TR_cframe_jitFPRs+(13*16)[_rsp]
+	movdqa xmm14,J9TR_cframe_jitFPRs+(14*16)[_rsp]
+	movdqa xmm15,J9TR_cframe_jitFPRs+(15*16)[_rsp]
+}) dnl METHOD_INVOCATION
 })
 
 define({SAVE_C_NONVOLATILE_REGS},{
@@ -487,28 +523,36 @@ define({SAVE_C_VOLATILE_REGS},{
 	mov dword ptr J9TR_cframe_rax[_rsp],eax
 	mov dword ptr J9TR_cframe_rcx[_rsp],ecx
 	mov dword ptr J9TR_cframe_rdx[_rsp],edx
-	movq qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp],xmm0
-	movq qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp],xmm1
-	movq qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp],xmm2
-	movq qword ptr J9TR_cframe_jitFPRs+(3*8)[_rsp],xmm3
-	movq qword ptr J9TR_cframe_jitFPRs+(4*8)[_rsp],xmm4
-	movq qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp],xmm5
-	movq qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp],xmm6
-	movq qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp],xmm7
+ifdef({METHOD_INVOCATION},{
+dnl No FP parameter registers
+},{ dnl METHOD_INVOCATION
+	movdqa J9TR_cframe_jitFPRs+(0*16)[_rsp],xmm0
+	movdqa J9TR_cframe_jitFPRs+(1*16)[_rsp],xmm1
+	movdqa J9TR_cframe_jitFPRs+(2*16)[_rsp],xmm2
+	movdqa J9TR_cframe_jitFPRs+(3*16)[_rsp],xmm3
+	movdqa J9TR_cframe_jitFPRs+(4*16)[_rsp],xmm4
+	movdqa J9TR_cframe_jitFPRs+(5*16)[_rsp],xmm5
+	movdqa J9TR_cframe_jitFPRs+(6*16)[_rsp],xmm6
+	movdqa J9TR_cframe_jitFPRs+(7*16)[_rsp],xmm7
+}) dnl METHOD_INVOCATION
 })
 
 define({RESTORE_C_VOLATILE_REGS},{
 	mov eax,dword ptr J9TR_cframe_rax[_rsp]
 	mov ecx,dword ptr J9TR_cframe_rcx[_rsp]
 	mov edx,dword ptr J9TR_cframe_rdx[_rsp]
-	movq xmm0,qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp]
-	movq xmm1,qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp]
-	movq xmm2,qword ptr J9TR_cframe_jitFPRs+(2*8)[_rsp]
-	movq xmm3,qword ptr J9TR_cframe_jitFPRs+(3*8)[_rsp]
-	movq xmm4,qword ptr J9TR_cframe_jitFPRs+(4*8)[_rsp]
-	movq xmm5,qword ptr J9TR_cframe_jitFPRs+(5*8)[_rsp]
-	movq xmm6,qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp]
-	movq xmm7,qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp]
+ifdef({METHOD_INVOCATION},{
+dnl No FP parameter registers
+},{ dnl METHOD_INVOCATION
+	movdqa xmm0,J9TR_cframe_jitFPRs+(0*16)[_rsp]
+	movdqa xmm1,J9TR_cframe_jitFPRs+(1*16)[_rsp]
+	movdqa xmm2,J9TR_cframe_jitFPRs+(2*16)[_rsp]
+	movdqa xmm3,J9TR_cframe_jitFPRs+(3*16)[_rsp]
+	movdqa xmm4,J9TR_cframe_jitFPRs+(4*16)[_rsp]
+	movdqa xmm5,J9TR_cframe_jitFPRs+(5*16)[_rsp]
+	movdqa xmm6,J9TR_cframe_jitFPRs+(6*16)[_rsp]
+	movdqa xmm7,J9TR_cframe_jitFPRs+(7*16)[_rsp]
+}) dnl METHOD_INVOCATION
 })
 
 define({SAVE_C_NONVOLATILE_REGS},{
@@ -568,12 +612,9 @@ ifdef({FASTCALL_INDIRECT_WITH_VMTHREAD},,{define({FASTCALL_INDIRECT_WITH_VMTHREA
 
 ifdef({FASTCALL_EXTERN},,{define({FASTCALL_EXTERN},{DECLARE_EXTERN(FASTCALL_SYMBOL($1,$2))})})
 
-ifdef({SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS},,{define({SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS},{})})
-
 define({SAVE_ALL_REGS},{
 	SAVE_C_VOLATILE_REGS($1)
 	SAVE_C_NONVOLATILE_REGS($1)
-	SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS
 })
 
 define({RESTORE_ALL_REGS},{


### PR DESCRIPTION
See issue for details.

Fixes: #12585

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>