### PR TITLE
Update the error action for ACC_MODULE

### DIFF
--- a/runtime/bcutil/j9bcu.tdf
+++ b/runtime/bcutil/j9bcu.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2020 IBM Corp. and others
+// Copyright (c) 2006, 2021 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -379,3 +379,5 @@ TraceAssert=Trc_BCU_Assert_True_Level1 NoEnv Overhead=1 Level=1 Assert="(P1)"
 
 TraceEvent=Trc_BCU_ClassFileOracle_walkRecordComponents_UnknownAttribute Noenv Overhead=1 Level=3 Template="BCU ClassFileOracle::walkRecordComponents: Unknown attribute tag=%d name=%.*s length=%d"
 TraceExit=Trc_BCU_j9bcutil_readClassFileBytes_Basic_Check_Exit NoEnv Overhead=1 Level=3 Template="BCU j9bcutil_readClassFileBytes: exiting with result=%d" 
+
+TraceException=Trc_BCU_j9bcutil_readClassFileBytes_NoClassDefFoundError_Exception NoEnv Overhead=1 Level=3 Template="BCU j9bcutil_readClassFileBytes: NoClassDefFoundError %d - %s"

--- a/test/functional/Java9andUp/src/org/openj9/test/defineModuleAsClass/DefineModuleAsClassTest.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/defineModuleAsClass/DefineModuleAsClassTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,7 @@ class MyClassLoader extends ClassLoader {
 
 		try {
 			Class<?> testClass = defineClass(name, classBytes, 0, classBytes.length);
-		} catch (ClassFormatError e) {
+		} catch (NoClassDefFoundError e) {
 			String message = e.getMessage();
 			if (message.contains("is not a class because access_flag ACC_MODULE is set")) {
 				result = true;


### PR DESCRIPTION
The change is to change the error action for ACC_MODULE (0x8000)
from ClassFormatError to NoClassDefFoundError so as to match
the RI's behaviour when loading a class with ACC_MODULE set
in the class file.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>