### PR TITLE
Sending Client feedback about number of active compilations threads

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4490,7 +4490,7 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
             compInfo->getRampDownMCT() ? "RampDownMCT" : "",
             compInfo->getSuspendThreadDueToLowPhysicalMemory() ? "LowPhysicalMem" : "",
 #if defined(J9VM_OPT_JITSERVER)
-            compInfo->getCompThreadActivationPolicy() == JITServer::CompThreadActivationPolicy::SUSPEND ? "ServerLowPhysicalMem" :
+            compInfo->getCompThreadActivationPolicy() == JITServer::CompThreadActivationPolicy::SUSPEND ? "ServerLowPhysicalMemOrHighThreadCount" :
 #endif
             ""
             );

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -94,6 +94,12 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static int32_t _samplingFrequencyInDeepIdleMode;
    static int32_t getSamplingFrequencyInDeepIdleMode() {return _samplingFrequencyInDeepIdleMode;}
+
+   static int32_t _highActiveThreadThreshold;
+   static int32_t getHighActiveThreadThreshold() {return _highActiveThreadThreshold;}
+
+   static int32_t _veryHighActiveThreadThreshold;
+   static int32_t getVeryHighActiveThreadThreshold() {return _veryHighActiveThreadThreshold;}
    
    static int32_t _maxCheckcastProfiledClassTests;
    static int32_t getCheckcastMaxProfiledClassTests() {return _maxCheckcastProfiledClassTests;}

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -78,6 +78,13 @@ enum ServerMemoryState
    NORMAL,
    };
 
+enum ServerActiveThreadsState
+   {
+   VERY_HIGH_THREAD = 0,
+   HIGH_THREAD,
+   NORMAL_THREAD,
+   };
+
 enum CompThreadActivationPolicy
    {
    // Order is important, we use comparison operators

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 25;
+   static const uint16_t MINOR_NUMBER = 26;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
When JITServer reaches 63 compilation threads any compilation request after that will be added
to the queue and requests waiting in the queue will experience delays and therefore the client can timeout.

In this commit, I send feedback to the client about the number of active compilation threads. I added a new
enum that represents the state of the active compilation threads "ServerActiveThreadState", which has 3 states: HIGH,
VERY_HIGH and NORMAL_THREAD.

JITServer sends the client feedback about the state of Active threads at the end of every compilation. The client then
receives it and in the "JITServer::CompThreadActivationPolicy" decides based on the number of Active Threads when
to suspend/maintain the compilation threads.

If the number of Active threads >= to VERY_HIGH, then we suspend active threads.
If the number of Active threads >= to HIGH, then we maintain the number of active threads.
If the number of Active threads < HIGH, then we subdue.

issue: #12459

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>