### PR TITLE
Prevent expensive compilations from exhausting available memory at JITServer

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -173,8 +173,8 @@ outOfProcessCompilationEnd(
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       {
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d has successfully compiled %s",
-         compInfoPT->getCompThreadId(), compInfoPT->getCompilation()->signature());
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d has successfully compiled %s memoryState=%d",
+         compInfoPT->getCompThreadId(), compInfoPT->getCompilation()->signature(), memoryState);
       }
 
    Trc_JITServerCompileEnd(compInfoPT->getCompilationThread(), compInfoPT->getCompThreadId(),


### PR DESCRIPTION
Since the scratch space limit at JITServer is 512 MB, a few expensive
compilations that come more or less concurrently can easily exhaust
the entire available memory.
This commit adjusts the scratch space limit at JITServer dynamically
so that a compilation cannot use more than half the free physical memory,
leaving some memory for other compilations as well.

Closes #12619

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>