### PR TITLE
Convert RegisterDependencyGroup to an extensible class

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1528,9 +1528,7 @@ J9::ARM64::TreeEvaluator::VMinstanceofEvaluator(TR::Node *node, TR::CodeGenerato
    cg->decReferenceCount(castClassNode);
    // Stop using every reg in the deps except these ones.
    //
-   TR::Register *nodeRegs[2] = {objectReg, resultReg};
-   auto nodeRegsBegin = std::begin(nodeRegs);
-   deps->stopUsingDepRegs(cg, nodeRegsBegin, std::next(nodeRegsBegin, 2));
+   deps->stopUsingDepRegs(cg, objectReg, resultReg);
 
    node->setRegister(resultReg);
 

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -91,6 +91,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/OMRPeephole.cpp \
     omr/compiler/codegen/OMRRealRegister.cpp \
     omr/compiler/codegen/OMRRegister.cpp \
+    omr/compiler/codegen/OMRRegisterDependency.cpp \
     omr/compiler/codegen/OMRRegisterPair.cpp \
     omr/compiler/codegen/OMRSnippet.cpp \
     omr/compiler/codegen/OMRSnippetGCMap.cpp \

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1553,8 +1553,8 @@ void TR::X86CallSite::stopAddingConditions()
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    if (COPY_PRECONDITIONS_TO_POSTCONDITIONS)
       {
-      TR_X86RegisterDependencyGroup *preconditions  = getPreConditionsUnderConstruction()->getPreConditions();
-      TR_X86RegisterDependencyGroup *postconditions = getPostConditionsUnderConstruction()->getPostConditions();
+      TR::RegisterDependencyGroup *preconditions  = getPreConditionsUnderConstruction()->getPreConditions();
+      TR::RegisterDependencyGroup *postconditions = getPostConditionsUnderConstruction()->getPostConditions();
       for (uint8_t i = 0; i < getPreConditionsUnderConstruction()->getAddCursorForPre(); i++)
          {
          TR::RegisterDependency *pre  = preconditions->getRegisterDependency(i);
@@ -2279,7 +2279,7 @@ TR::Register *J9::X86::PrivateLinkage::buildCallPostconditions(TR::X86CallSite &
    // (The typical example is the ramMethod.)
    //
    int32_t gprsAlreadyPresent = TR::RealRegister::noRegMask;
-   TR_X86RegisterDependencyGroup *group = dependencies->getPostConditions();
+   TR::RegisterDependencyGroup *group = dependencies->getPostConditions();
    for (int i = 0; i < dependencies->getAddCursorForPost(); i++)
       {
       TR::RegisterDependency *dep = group->getRegisterDependency(i);
@@ -2295,7 +2295,7 @@ TR::Register *J9::X86::PrivateLinkage::buildCallPostconditions(TR::X86CallSite &
       // postcondition, thus indicating that the arguments are preserved.
       // Note: this assumes the postcondition regdeps have preconditions too; see COPY_PRECONDITIONS_TO_POSTCONDITIONS.
       //
-      TR_X86RegisterDependencyGroup *preConditions = dependencies->getPreConditions();
+      TR::RegisterDependencyGroup *preConditions = dependencies->getPreConditions();
       for (int i = 0; i < dependencies->getAddCursorForPre(); i++)
          {
          TR::RegisterDependency *preCondition = preConditions->getRegisterDependency(i);

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1559,7 +1559,7 @@ void
 J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
    TR::Register * vftReg, uint32_t sizeOfArguments)
    {
-   TR_S390RegisterDependencyGroup * Dgroup = dependencies->getPreConditions();
+   TR::RegisterDependencyGroup * Dgroup = dependencies->getPreConditions();
    TR::SymbolReference * methodSymRef = callNode->getSymbolReference();
    TR::MethodSymbol * methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
    TR::LabelSymbol * vcallLabel = generateLabelSymbol(cg());


### PR DESCRIPTION
A series of commits which converts the various `RegisterDependencyGroup` classes on each platform to a cross platform extensible class. This prepares the register dependencies to be further unified and commoned up.