### PR TITLE
Deprecate unsigned IL

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -68,14 +68,6 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
       case TR::bloadi:
       case TR::sloadi:
       case TR::lloadi:
-      case TR::iuload:
-      case TR::luload:
-      case TR::buload:
-      case TR::iuloadi:
-      case TR::luloadi:
-      case TR::buloadi:
-      case TR::cload:
-      case TR::cloadi:
          return "load";
 
       case TR::istore:

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -101,10 +101,6 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
       case TR::ladd:
       case TR::badd:
       case TR::sadd:
-      case TR::iuadd:
-      case TR::luadd:
-      case TR::buadd:
-      case TR::cadd:
          return "add";
 
       case TR::fadd:
@@ -119,12 +115,6 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
       case TR::lneg:
       case TR::bneg:
       case TR::sneg:
-      case TR::iusub:
-      case TR::lusub:
-      case TR::busub:
-      case TR::iuneg:
-      case TR::luneg:
-      case TR::csub:
          return "sub";
 
       case TR::dsub:

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -84,14 +84,6 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
       case TR::bstorei:
       case TR::sstorei:
       case TR::istorei:
-      case TR::iustore:
-      case TR::lustore:
-      case TR::bustore:
-      case TR::iustorei:
-      case TR::lustorei:
-      case TR::bustorei:
-      case TR::cstore:
-      case TR::cstorei:
          return "store";
 
       case TR::Goto:

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3274,7 +3274,7 @@ TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTo
       // create
       // iand
       //    bu2i
-      //      buload &vmThread()->javaVM->hookInterface->flags[J9HOOK_VM_METHOD_ENTER/J9HOOK_VM_METHOD_RETURN];
+      //      bload &vmThread()->javaVM->hookInterface->flags[J9HOOK_VM_METHOD_ENTER/J9HOOK_VM_METHOD_RETURN];
       //    iconst J9HOOK_FLAG_HOOKED
       //
       int32_t event = root->getOpCodeValue() == TR::MethodEnterHook ? J9HOOK_VM_METHOD_ENTER : J9HOOK_VM_METHOD_RETURN;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4822,7 +4822,7 @@ TR_J9ByteCodeIlGenerator::runMacro(TR::SymbolReference * symRef)
                push(array);
                loadConstant(TR::iconst, i);
                push(arg);
-               storeArrayElement(arg->getDataType()); // TODO:JSR292: use icstore for char arguments
+               storeArrayElement(arg->getDataType()); // TODO:JSR292: use isstore for char arguments
                }
             argShepherd->removeAllChildren();
             push(array);


### PR DESCRIPTION
Simple cleanup operation. Related to, but not dependent on eclipse/omr#5983.