### PR TITLE
Set system property native.encoding

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -582,6 +582,9 @@ private static void ensureProperties(boolean isInitialization) {
 	initializedProperties.put("ibm.system.encoding", platformEncoding); //$NON-NLS-1$
 	initializedProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
 	initializedProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
+	initializedProperties.put("native.encoding", (fileEncoding == null) ? platformEncoding : fileEncoding); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	initializedProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
 	/*[IF JAVA_SPEC_VERSION < 12]*/
 	/* System property java.specification.vendor is set via VersionProps.init(systemProperties) since JDK12 */


### PR DESCRIPTION
The logic is similar with `jdk.internal.util.SystemProps.initProperties()`.

With this PR, JDK17 (MacOS) builds and `-version` output is:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build nativecoding-6e9f600cfe, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210506_000000 (JIT enabled, AOT enabled)
OpenJ9   - 6e9f600cfe
OMR      - d96f2b34f
JCL      - c86a0903159 based on jdk-17+20)
```

closes https://github.com/eclipse-openj9/openj9/issues/12640

Note: Mac abuild failure was caused by https://github.com/eclipse-openj9/openj9/issues/12640.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>