### PR TITLE
Define system property 'native.encoding' for jdk17

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -583,6 +583,9 @@ private static void ensureProperties(boolean isInitialization) {
 	initializedProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
 	initializedProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
 	initializedProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
+	initializedProperties.put("native.encoding", (fileEncoding != null) ? fileEncoding : platformEncoding); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	/*[IF JAVA_SPEC_VERSION < 12]*/
 	/* System property java.specification.vendor is set via VersionProps.init(systemProperties) since JDK12 */
 	initializedProperties.put("java.specification.vendor", "Oracle Corporation"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
JDK17 (in the openj9-staging branch) requires it be set, even though it claims to otherwise ignore it.
Otherwise, a build fails:
```
Optimizing the exploded image
Exception in thread "(unnamed thread)" java/lang/InternalError: null property: native.encoding
	at jdk/internal/util/StaticProperty.getProperty (java.base@9/StaticProperty.java:71)
	at jdk/internal/util/StaticProperty.<clinit> (java.base@9/StaticProperty.java:65)
	at java/lang/System.ensureProperties (java.base@9/System.java:424)
	at java/lang/System.afterClinitInitialization (java.base@9/System.java:198)
	at java/lang/Thread.initialize (java.base@9/Thread.java:419)
	at java/lang/Thread.<init> (java.base@9/Thread.java:164)
```
See this [comment](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/openj9-staging/src/java.base/share/classes/java/lang/System.java#L702-L704) in System.java.
