### PR TITLE
Enable warnings as errors in compiler component on OSX

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1235,13 +1235,17 @@ J9::CodeGenerator::printNVVMIR(
        return GPUSuccess;   // will handle in the parent
 
    if (opcode.isLoadConst())
-       if((node->getDataType() == TR::Address) && (node->getAddress() != 0))
-          {
-          traceMsg(self()->comp(), "Load Const with a non-zero address in node %p\n", node);
-          return GPUInvalidProgram;
-          }
-       else
-          return GPUSuccess;   // will handle in the parent
+      {
+      if((node->getDataType() == TR::Address) && (node->getAddress() != 0))
+         {
+         traceMsg(self()->comp(), "Load Const with a non-zero address in node %p\n", node);
+         return GPUInvalidProgram;
+         }
+      else
+         {
+         return GPUSuccess;   // will handle in the parent
+         }
+      }
 
    if (node->getOpCodeValue() == TR::asynccheck)
        return GPUSuccess;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2710,7 +2710,7 @@ static void processAOTGuardSites(TR::CodeGenerator *cg, uint32_t inlinedCallSize
 
          case TR_Breakpoint:
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
-                                                                             (uint8_t *)(*it)->getGuard()->getCurrentInlinedSiteIndex(),
+                                                                             (uint8_t *)(intptr_t)(*it)->getGuard()->getCurrentInlinedSiteIndex(),
                                                                              (uint8_t *)(*it)->getDestination(),
                                                                              type, cg),
                              __FILE__, __LINE__, NULL);

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -86,11 +86,16 @@ void *operator new(size_t size)
    return malloc(size);
    }
 
+// Avoid -Wimplicit-exception-spec-mismatch error on platforms that specify the global delete operator with throw()
+#ifndef _NOEXCEPT
+#define _NOEXCEPT 
+#endif
+
 /**
  * Since we are using arena allocation, heap deletions must be a no-op, and
  * can't be used by JIT code, so we inject an assertion here.
  */
-void operator delete(void *)
+void operator delete(void *) _NOEXCEPT
    {
    TR_ASSERT(0, "Invalid use of global operator delete");
    }

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1067,8 +1067,8 @@ J9::Compilation::verifyCompressedRefsAnchors(TR::Node *parent, TR::Node *node,
 
    // process loads/stores that are references
    //
-   if ((node->getOpCode().isLoadIndirect() || node->getOpCode().isStoreIndirect()) &&
-         node->getSymbolReference()->getSymbol()->getDataType() == TR::Address ||
+   if (((node->getOpCode().isLoadIndirect() || node->getOpCode().isStoreIndirect()) &&
+         node->getSymbolReference()->getSymbol()->getDataType() == TR::Address) ||
             (node->getOpCodeValue() == TR::arrayset && node->getSecondChild()->getDataType() == TR::Address))
       {
       TR_Pair<TR::Node, TR::TreeTop> *info = findCPtrsInfo(nodesList, node);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2035,8 +2035,8 @@ void TR::CompilationInfo::invalidateRequestsForUnloadedMethods(TR_OpaqueClassBlo
          TR_ASSERT(method, "_method can be NULL only at shutdown time");
          if ((!unloadedClass && hotCodeReplacement) || // replacement in FSD mode
              J9_CLASS_FROM_METHOD(method) == unloadedClass ||
-             details.isNewInstanceThunk() &&
-             static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass))
+             (details.isNewInstanceThunk() &&
+             static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass)))
             {
             if (!hotCodeReplacement)
                {
@@ -2078,8 +2078,8 @@ void TR::CompilationInfo::invalidateRequestsForUnloadedMethods(TR_OpaqueClassBlo
             TR_VerboseLog::writeLineLocked(TR_Vlog_HD,"Looking at compile request for method %p class %p", method, methodClass);
          if ((!unloadedClass && hotCodeReplacement) || // replacement in FSD mode
              methodClass == unloadedClass ||
-             details.isNewInstanceThunk() &&
-             static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass))
+             (details.isNewInstanceThunk() &&
+             static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass)))
             {
             if (verbose)
                TR_VerboseLog::writeLineLocked(TR_Vlog_HK,"Invalidating compile request for method %p class %p", method, methodClass);
@@ -9342,7 +9342,7 @@ TR::CompilationInfoPerThreadBase::compile(
       if ((_jitConfig->runtimeFlags & J9JIT_TOSS_CODE)
             || _methodBeingCompiled->isOutOfProcessCompReq()
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-            || vm.isAOT_DEPRECATED_DO_NOT_USE() && !_methodBeingCompiled->isRemoteCompReq()
+            || (vm.isAOT_DEPRECATED_DO_NOT_USE() && !_methodBeingCompiled->isRemoteCompReq())
 #endif //endif J9VM_INTERP_AOT_COMPILE_SUPPORT
         )
          {
@@ -9383,7 +9383,7 @@ TR::CompilationInfoPerThreadBase::compile(
             }
          }
 
-      if (vm.isAOT_DEPRECATED_DO_NOT_USE() && !_methodBeingCompiled->isRemoteCompReq() || _methodBeingCompiled->isOutOfProcessCompReq())
+      if ((vm.isAOT_DEPRECATED_DO_NOT_USE() && !_methodBeingCompiled->isRemoteCompReq()) || _methodBeingCompiled->isOutOfProcessCompReq())
          {
          TR_DataCache *dataCache = (TR_DataCache*)compiler->getReservedDataCache();
          TR_ASSERT(dataCache, "Must have a reserved dataCache for AOT compilations");
@@ -12014,8 +12014,8 @@ void TR_LowPriorityCompQueue::invalidateRequestsForUnloadedMethods(J9Class * unl
       if (method)
          {
          if (J9_CLASS_FROM_METHOD(method) == unloadedClass ||
-            details.isNewInstanceThunk() &&
-            static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass))
+            (details.isNewInstanceThunk() &&
+            static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass)))
             {
             TR_ASSERT(cur->_priority < CP_SYNC_MIN,
                "Unloading cannot happen for SYNC requests");
@@ -12590,8 +12590,8 @@ void TR_JProfilingQueue::invalidateRequestsForUnloadedMethods(J9Class * unloaded
       if (method)
          {
          if (J9_CLASS_FROM_METHOD(method) == unloadedClass ||
-            details.isNewInstanceThunk() &&
-            static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass))
+            (details.isNewInstanceThunk() &&
+            static_cast<J9::NewInstanceThunkDetails &>(details).isThunkFor(unloadedClass)))
             {
             TR_ASSERT(cur->_priority < CP_SYNC_MIN,
                "Unloading cannot happen for SYNC requests");

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8500,8 +8500,8 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP
                       && (disableNextGenHCRDuringStartup
                           || that->_methodBeingCompiled->isDLTCompile()
-                          || options->getOptLevel() <= warm
-                             && !enableStartupNextGenHCRAtAllOpts))
+                          || (options->getOptLevel() <= warm
+                             && !enableStartupNextGenHCRAtAllOpts)))
                      {
                      options->setOption(TR_DisableNextGenHCR);
                      }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8704,6 +8704,8 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                      options->setOption(TR_DebugInliner);
                      break;
                      }
+                  default:
+                     break;
                   }
                }
             }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -849,13 +849,17 @@ void DLTLogic(J9VMThread* vmThread, TR::CompilationInfo *compInfo)
       dltBlock->methods[idx] = 0;
       return;
       }
-   else if (extra = TR::CompilationInfo::getPCIfCompiled(walkState.method))
+   else
       {
-      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(extra);
-      if (bodyInfo && bodyInfo->getMethodInfo()->hasFailedDLTCompRetrials())
+      extra = TR::CompilationInfo::getPCIfCompiled(walkState.method);
+      if (extra)
          {
-         dltBlock->methods[idx] = 0;
-         return;
+         TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(extra);
+         if (bodyInfo && bodyInfo->getMethodInfo()->hasFailedDLTCompRetrials())
+            {
+            dltBlock->methods[idx] = 0;
+            return;
+            }
          }
       }
 

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -825,7 +825,7 @@ TR_PersistentCHTable::addClassToTable(J9VMThread *vmThread,
       return false;
 
    /* Trigger Pre-initialize Hook */
-   if (j9clazz->initializeStatus & J9ClassInitStatusMask != J9ClassInitNotInitialized)
+   if ((j9clazz->initializeStatus & J9ClassInitStatusMask) != J9ClassInitNotInitialized)
       {
       jitHookClassPreinitializeHelper(vmThread, jitConfig, j9clazz, &eventFailed);
       if (eventFailed)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3176,7 +3176,7 @@ TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTo
    else
       {
       TR::Node * child = root->getChild(0);
-      if (isAOT_DEPRECATED_DO_NOT_USE() || !isTrace && comp->cg()->getSupportsPartialInlineOfMethodHooks())
+      if (isAOT_DEPRECATED_DO_NOT_USE() || (!isTrace && comp->cg()->getSupportsPartialInlineOfMethodHooks()))
          child = child->duplicateTree();
 
       methodCall = TR::Node::createWithSymRef(TR::call, 2, 2, child, ramMethod, root->getSymbolReference());

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5370,7 +5370,7 @@ TR_J9VMBase::reportAnalysisPhase(uint8_t id)
    if (!_vmThread)
       return;
 
-   vmThread()->omrVMThread->vmState = vmThread()->omrVMThread->vmState & ~0xFF | id;
+   vmThread()->omrVMThread->vmState = (vmThread()->omrVMThread->vmState & ~0xFF) | id;
    }
 
 void

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -514,7 +514,7 @@ bool TR_AnnotationBase::extractValue(J9AnnotationInfoEntry * annotationInfoEntry
      ++dataPtr;// point at data
      *(int32_t* *)ptr = dataPtr;
      return true;
-   } while(namePtr = intFunc->annotationElementIteratorNext(&state,&data));
+   } while((namePtr = intFunc->annotationElementIteratorNext(&state,&data)));
     if(trace) printf("Search failed\n");
     return false;
   }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -896,6 +896,9 @@ TR_ResolvedJ9MethodBase::isCold(TR::Compilation * comp, bool isIndirectCall, TR:
       case TR::com_ibm_jit_DecimalFormatHelper_formatAsFloat:
       case TR::java_lang_invoke_MethodHandle_invokeExact:
       return false;
+
+      default:
+         break;
       }
 
    if (convertToMethod()->isArchetypeSpecimen())
@@ -5093,6 +5096,9 @@ TR_J9MethodBase::isUnsafeCAS(TR::Compilation * c)
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
          return true;
+
+      default:
+         break;
       }
 
    return false;

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -160,7 +160,7 @@ J9::Node::copyValidProperties(TR::Node *fromNode, TR::Node *toNode)
    UnionPropertyB_Type fromUnionPropertyB_Type = fromNode->getUnionPropertyB_Type();
    UnionPropertyB_Type toUnionPropertyB_Type = toNode->getUnionPropertyB_Type();
 
-   if ((fromUnionPropertyB_Type == toUnionPropertyB_Type))
+   if (fromUnionPropertyB_Type == toUnionPropertyB_Type)
       {
       switch (fromUnionPropertyB_Type)
          {

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -1368,18 +1368,17 @@ void TR_ClassLookahead::makeInfoPersistent()
             {
             if (_traceIt)
                printf("Creating persistent info for array field %s\n", persistentSig);
-            newFieldInfo = new (PERSISTENT_NEW) TR_PersistentArrayFieldInfo(persistentSig, length);
-            memcpy(newFieldInfo, fieldInfo, sizeof(TR_PersistentArrayFieldInfo));
+            newFieldInfo = new (PERSISTENT_NEW) TR_PersistentArrayFieldInfo(*arrayFieldInfo);
             }
          else
             {
             if (_traceIt)
                printf("Creating persistent info for field %s\n", persistentSig);
-            newFieldInfo = new (PERSISTENT_NEW) TR_PersistentFieldInfo(persistentSig, length);
-            memcpy(newFieldInfo, fieldInfo, sizeof(TR_PersistentFieldInfo));
+            newFieldInfo = new (PERSISTENT_NEW) TR_PersistentFieldInfo(*fieldInfo);
             }
 
          newFieldInfo->setFieldSignature(persistentSig);
+         newFieldInfo->setFieldSignatureLength(length);
 
          char *persistentType = 0;
          if (isTypeInfoValid)

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -356,8 +356,8 @@ TR_ClassLookahead::findInitializerMethods(List<TR_ResolvedMethod> *resolvedMetho
                 TR_ResolvedMethod *calleeMethod = calleeSymbol->getResolvedMethod();
                 if (calleeMethod->containingClass() == _classPointer &&
                     (!strncmp(calleeMethod->nameChars(), "<init>", 6) ||
-                    calleeMethod->isPrivate() &&
-                    !isCalledByNonConstructorMethodsInClass(calleeMethod, resolvedMethodSyms)))
+                    (calleeMethod->isPrivate() &&
+                    !isCalledByNonConstructorMethodsInClass(calleeMethod, resolvedMethodSyms))))
                     initializerMethodSymbol = calleeSymbol;
                 }
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2155,6 +2155,7 @@ bool TR_J9ByteCodeIlGenerator::replaceMethods(TR::TreeTop *tt, TR::Node *node)
    for (int i = 0; i < _numDecFormatRenames; i++)
       {
       if (!strcmp(nodeName, _decFormatRenames[i].srcMethodSignature))
+         {
          if (performTransformation(comp(), "%sreplaced %s by %s in [%p]\n",
                                      OPT_DETAILS, _decFormatRenames[i].srcMethodSignature, _decFormatRenames[i].dstMethodSignature, node))
             {
@@ -2164,7 +2165,10 @@ bool TR_J9ByteCodeIlGenerator::replaceMethods(TR::TreeTop *tt, TR::Node *node)
             return true;
             }
          else
+            {
             return false;
+            }
+         }
       }
    return true;
    }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4134,6 +4134,9 @@ break
       DAA_PRINT(TR::com_ibm_dataaccess_PackedDecimal_shiftLeftPackedDecimal);
       DAA_PRINT(TR::com_ibm_dataaccess_PackedDecimal_shiftRightPackedDecimal);
       DAA_PRINT(TR::com_ibm_dataaccess_PackedDecimal_movePackedDecimal);
+
+      default:
+         break;
       }
 
    if(symbol->getRecognizedMethod() == TR::com_ibm_dataaccess_DecimalData_JITIntrinsicsEnabled)
@@ -6732,6 +6735,9 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
         case TR::java_lang_StringCoding_encodeASCII:
         case TR::java_lang_StringCoding_encodeUTF8:
            node->setCanSkipZeroInitialization(true);
+           break;
+
+        default:
            break;
         }
      }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -991,7 +991,7 @@ TR_J9ByteCodeIlGenerator::expandPlaceholderSignature(TR::SymbolReference *symRef
    int32_t currentArgSignatureOffset = 1; // skip parenthesis
    for (int32_t childIndex = originalMethod->isStatic()? 0 : 1; childIndex < numArgs; childIndex++)
       {
-      int32_t explicitArgIndex = childIndex - originalMethod->isStatic()? 0 : 1;
+      int32_t explicitArgIndex = childIndex - (originalMethod->isStatic()? 0 : 1);
       TR_ResolvedMethod *symRefMethod = symRef->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod();
       char   *signatureChars  = symRefMethod->signatureChars();
       int nextArgSignatureOffset = nextSignatureArgument(signatureChars + currentArgSignatureOffset) - signatureChars;

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -3022,9 +3022,9 @@ bool TR_EscapeAnalysis::checkOverlappingLoopAllocation(TR::Node *node, TR::Node 
           && (_valueNumberInfo->getValueNumber(node) == _valueNumberInfo->getValueNumber(useNode)))
       {
       if (!_doLoopAllocationAliasChecking
-            || !(node->getOpCode().isLoadVarDirect()
+            || (!(node->getOpCode().isLoadVarDirect()
                     && _aliasesOfAllocNode->get(node->getSymbolReference()->getReferenceNumber()))
-                  && (numReferences > 0))
+                  && (numReferences > 0)))
          {
          return false;
          }
@@ -5921,7 +5921,7 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
      (loadOrStore->getOpCode().isLoadVarOrStore() || loadOrStore->getOpCode().isLoadConst()))
      treeAsExpected = true;
 
-      if (!treeAsExpected || loadOrStore->getOpCode().hasSymbolReference() && loadOrStore->getSymbolReference()->getSymbol()->isAuto())
+      if (!treeAsExpected || (loadOrStore->getOpCode().hasSymbolReference() && loadOrStore->getSymbolReference()->getSymbol()->isAuto()))
          {
          TR::Node::recreate(node, TR::treetop);
          node->getSecondChild()->decReferenceCount();

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -5627,7 +5627,7 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
                   // Uh, why are we re-calculating the fieldOffset?  Didn't we just do that above?
                   //
                   int32_t fieldOffset = node->getSymbolReference()->getOffset();
-                  if ((candidate->_origKind == TR::New))
+                  if (candidate->_origKind == TR::New)
                      {
                      TR::SymbolReference *symRef = node->getSymbolReference();
                      fieldOffset = symRef->getOffset();
@@ -6139,7 +6139,7 @@ bool TR_EscapeAnalysis::fixupFieldAccessForContiguousAllocation(TR::Node *node, 
        !candidate->escapesInColdBlocks() &&
        _valueNumberInfo->getValueNumber(node->getFirstChild()) == _valueNumberInfo->getValueNumber(candidate->_node))
       {
-        if ((candidate->_origKind == TR::New))
+        if (candidate->_origKind == TR::New)
          {
          TR::Node::recreate(node, TR::astorei);
          node->getChild(2)->recursivelyDecReferenceCount();
@@ -6159,7 +6159,7 @@ bool TR_EscapeAnalysis::fixupFieldAccessForContiguousAllocation(TR::Node *node, 
       }
 
    int32_t fieldOffset = node->getSymbolReference()->getOffset();
-   if ((candidate->_origKind == TR::New))
+   if (candidate->_origKind == TR::New)
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
       fieldOffset = symRef->getOffset();
@@ -6279,7 +6279,7 @@ bool TR_EscapeAnalysis::fixupFieldAccessForNonContiguousAllocation(TR::Node *nod
       return true;
       }
 
-   if ((candidate->_origKind == TR::New))
+   if (candidate->_origKind == TR::New)
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
       fieldOffset = symRef->getOffset();

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -4517,7 +4517,8 @@ TR_CISCTransformer::analyzeConnectionOnePair(TR_CISCNode *const p, TR_CISCNode *
                }
             else
                {
-               if (thisCount = analyzeConnectionOnePairChild(p, t, pn, t->getChild(i)))
+               thisCount = analyzeConnectionOnePairChild(p, t, pn, t->getChild(i));
+               if (thisCount)
                   {
                   successCount += thisCount;
                   break;
@@ -5503,7 +5504,8 @@ TR_CISCTransformer::getP2TInLoopAllowOptionalIfSingle(TR_CISCNode *p)
    TR_CISCNode *t;
    while(true)
       {
-      if (t = getP2TInLoopIfSingle(p)) return t;
+      t = getP2TInLoopIfSingle(p);
+      if (t) return t;
       if (!p->isOptionalNode()) return 0;
       p = p->getChild(0);
       if (!p) return 0;
@@ -7208,7 +7210,8 @@ TR_CISCTransformer::simpleOptimization()
                      switch(ch->getOpcode())
                         {
                         case TR::iload:
-                           if (def = ch->getNodeIfSingleChain())
+                           def = ch->getNodeIfSingleChain();
+                           if (def)
                               {
                               if ((def->getNumChildren() > 0) && def->getChild(0))  // There is a bug where def is a TR_entrynode, so getChild(0) is null.
                                  {

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -680,12 +680,12 @@ getThreeNodesForArray(TR_CISCNode *top, TR_CISCNode **ixloadORstore, TR_CISCNode
       case TR::ladd:
       case TR::iadd:
          // search iload
-         if (q = searchIload(p->getChild(1), allowArrayIndex))
+         if ((q = searchIload(p->getChild(1), allowArrayIndex)))
             {
             *iload = q;
             q = p->getChild(0);
             }
-         else if (q = searchIload(p->getChild(0), allowArrayIndex))
+         else if ((q = searchIload(p->getChild(0), allowArrayIndex)))
             {
             *iload = q;
             q = p->getChild(1);

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -515,8 +515,8 @@ reorderTargetNodesInBB(TR_CISCTransformer *trans)
 
                // Analyze whether we can move the node t to immediately before the nodes in nextPlist
                List<TR_CISCNode> *dagList = T->getDagId2Nodes()+t->getDagID();
-               TR_CISCNode *tgt;
-               if (tgt = analyzeMoveNodeForward(trans, dagList, t, nextPlist))
+               TR_CISCNode *tgt = analyzeMoveNodeForward(trans, dagList, t, nextPlist);
+               if (tgt)
                   {
                   T->duplicateListsDuplicator();
                   // OK, we can move the node t!

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2140,6 +2140,9 @@ TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode
          return false; // todo
       case TR::sun_misc_Unsafe_objectFieldOffset:
          return false; // todo
+
+      default:
+         break;
       }
 
    return false;
@@ -4722,6 +4725,7 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          case TR::java_lang_invoke_DirectHandle_nullCheckIfRequired:
          case TR::java_lang_invoke_PrimitiveHandle_initializeClassIfRequired:
          case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
+            {
             TR::IlGeneratorMethodDetails & details = comp->ilGenRequest().details();
             if (details.isMethodHandleThunk())
                {
@@ -4729,6 +4733,10 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
                   return thunkDetails.isCustom();
                }
             return true;
+            }
+
+         default:
+            break;
          }
       }
    return (callsite->_callNode && comp->fej9()->supressInliningRecognizedInitialCallee(callsite, comp));
@@ -5060,6 +5068,9 @@ bool TR_J9InlinerPolicy::isJSR292SmallHelperMethod(TR_ResolvedMethod *resolvedMe
       case TR::java_lang_invoke_MethodHandle_doCustomizationLogic:
       case TR::java_lang_invoke_MethodHandle_undoCustomizationLogic:
          return true;
+      
+      default:
+         break;
       }
    return false;
    }
@@ -5073,6 +5084,9 @@ bool TR_J9InlinerPolicy::isJSR292SmallGetterMethod(TR_ResolvedMethod *resolvedMe
       case TR::java_lang_invoke_MutableCallSite_getTarget:
       case TR::java_lang_invoke_MethodHandle_type:
          return true;
+
+      default:
+         break;
       }
    return false;
    }
@@ -6614,6 +6628,9 @@ bool TR_J9InlinerPolicy::dontPrivatizeArgumentsForRecognizedMethod(TR::Recognize
          {
          case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
             return true;
+
+         default:
+            break;
          }
       }
    return false;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -29,7 +29,7 @@
 #include "jilconsts.h"
 #include "il/ParameterSymbol.hpp"
 #include "optimizer/PreExistence.hpp"
-#include "il/OMRNode_inlines.hpp"
+#include "il/Node_inlines.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/CompilationRuntime.hpp"
 #include "env/j9methodServer.hpp"

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -257,6 +257,9 @@ InterpreterEmulator::maintainStackForIf(TR_J9ByteCode bc)
             canBranch = second->intValue != first->intValue;
             debugTrace(tracer(), "maintainStackForIf ifcmpne %d != %d\n", second->intValue, first->intValue);
             break;
+
+         default:
+            break;
          }
       canFallThru = !canBranch;
       }
@@ -756,6 +759,9 @@ InterpreterEmulator::maintainStackForCall()
          case J9BCinvokehandle:
             TR_ASSERT_FATAL(false, "Can't maintain stack for unresolved invokehandle");
             break;
+
+         default:
+            break;
          }
       TR::Method * calleeMethod = comp()->fej9()->createMethod(trMemory(), _calltarget->_calleeMethod->containingClass(), cpIndex);
       numOfArgs = calleeMethod->numberOfExplicitParameters() + (isStatic ? 0 : 1);
@@ -874,6 +880,9 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
             }
          break;
          }
+
+      default:
+         break;
       }
    return result;
    }
@@ -1005,6 +1014,9 @@ InterpreterEmulator::refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&cal
          return;
          }
 #endif //J9VM_OPT_OPENJDK_METHODHANDLE
+
+      default:
+         break;
       }
    }
 
@@ -1047,6 +1059,9 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
          case J9BCinvokestatic:
          case J9BCinvokestaticsplit: visitInvokestatic(); break;
          case J9BCinvokeinterface: visitInvokeinterface(); break;
+
+         default:
+            break;
          }
 
       if (_iteratorWithState)
@@ -1236,6 +1251,9 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
             case J9BCinvokestaticsplit:
                cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
                break;
+
+            default:
+               break;
             }
          TR::Method *meth = comp()->fej9()->createMethod(this->trMemory(), _calltarget->_calleeMethod->containingClass(), cpIndex);
          heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, meth->signature(comp()->trMemory()));
@@ -1306,6 +1324,9 @@ InterpreterEmulator::visitInvokevirtual()
          case TR::java_lang_invoke_MethodHandle_undoCustomizationLogic:
             if (_callerIsThunkArchetype)
                return;
+         
+         default:
+            break;
          }
 
       bool allconsts= false;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1160,8 +1160,8 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    // No need to peek LF methods, as we'll always interprete the method with state in order to propagate object info
    // through bytecodes to find call targets
    if (!inlineLambdaFormGeneratedMethod &&
-       (nph.doPeeking() && recurseDown ||
-       inlineArchetypeSpecimen && mhInlineWithPeeking))
+       ((nph.doPeeking() && recurseDown) ||
+       (inlineArchetypeSpecimen && mhInlineWithPeeking)))
       {
 
       heuristicTrace(tracer(), "*** Depth %d: ECS CSI -- needsPeeking is true for calltarget %p",

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1317,10 +1317,12 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          {
          int32_t i = bci.bcIndex();
          if (blocks[i])
+            {
             if (!blocks[i]->isCold() && blocks[i]->getFrequency() > coldBorderFrequency)
                isCold = false;
             else
                isCold = true;
+            }
 
          if (isCold)
             coldCode++;
@@ -1992,7 +1994,9 @@ TR_J9EstimateCodeSize::trimBlocksForPartialInlining(TR_CallTarget *calltarget, T
                calltarget->_cfg->getStart()->asBlock(), TR::Block::_endBlock,
                TR::Block::_partialInlineBlock);
          if (!gs)
+            {
             partialTrace(tracer(),"TrimBlocksForPartialInlining: No Complete Path from Start to End");
+            }
          }
 
       if (!gs)

--- a/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
+++ b/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
@@ -432,8 +432,8 @@ TR::Node *pd2udSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
       child = node->setChild(0, s->replaceNodeWithChild(child, child->getFirstChild(), s->_curTree, block, false)); // correctBCDPrecision=false because nodePrec==childPrec
       }
 
-   TR::Node * result = NULL;
-   if (result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, TR::ud2pd))
+   TR::Node * result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, TR::ud2pd);
+   if (result)
       return result;
 
    child = node->setChild(0,removeOperandWidening(child, node, block, s));
@@ -605,8 +605,8 @@ TR::Node *ud2pdSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   TR::Node * result = NULL;
-   if (result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, TR::pd2ud))
+   TR::Node * result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, TR::pd2ud);
+   if (result)
       return result;
    return node;
    }
@@ -624,8 +624,8 @@ TR::Node *udsx2pdSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
       {
       TR::ILOpCodes inverseOp = TR::ILOpCode::getProperConversion(targetDataType, sourceDataType, false /* !wantZeroExtension */); // inverse conversion to what we are given
 
-      TR::Node * result = NULL;
-      if (result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, inverseOp))
+      TR::Node * result = s->unaryCancelOutWithChild(node, node->getFirstChild(), s->_curTree, inverseOp);
+      if (result)
          return result;
       }
    return node;
@@ -833,8 +833,8 @@ TR::Node *zd2pdSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
 
    propagateSignStateUnaryConversion(node, block, s);
 
-   TR::Node * result = NULL;
-   if (result = s->unaryCancelOutWithChild(node, firstChild, s->_curTree, TR::pd2zd))
+   TR::Node * result = s->unaryCancelOutWithChild(node, firstChild, s->_curTree, TR::pd2zd);
+   if (result)
       return result;
 
    if (firstChild->getOpCodeValue() == TR::zdsle2zd &&
@@ -866,8 +866,8 @@ TR::Node *pd2zdSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
 
    propagateSignStateUnaryConversion(node, block, s);
 
-   TR::Node * result = NULL;
-   if (result = s->unaryCancelOutWithChild(node, firstChild, s->_curTree, TR::zd2pd))
+   TR::Node * result = s->unaryCancelOutWithChild(node, firstChild, s->_curTree, TR::zd2pd);
+   if (result)
       return result;
 
    TR::Node *child = node->setChild(0, flipCleanAndShift(node->getFirstChild(), block, s));

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2299,6 +2299,9 @@ void J9::TransformUtil::separateNullCheck(TR::Compilation* comp, TR::TreeTop* tr
             comp->getSymRefTab()->findOrCreateResolveCheckSymbolRef(comp->getMethodSymbol()));
          TR::Node::recreate(nullCheck, TR::ResolveCHK);
          break;
+
+      default:
+         break;
       }
    }
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -991,6 +991,9 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             return;
          break;
          }
+
+      default:
+         break;
       }
 
    // The following are opts that do not support AOT
@@ -1262,6 +1265,9 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                }
             break;
             }
+
+         default:
+            break;
          }
       }
    }

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -695,9 +695,9 @@ int32_t TR_JProfilingBlock::processCFGForCounting(BlockParents &parent, TR::Bloc
             }
          // if the source of the edge has a single source we can count the source
          else if (block != to && !block->isOSRCatchBlock() &&
-             (block->getSuccessors().size() == 1 && block->getExceptionSuccessors().size() == 0)
+             ((block->getSuccessors().size() == 1 && block->getExceptionSuccessors().size() == 0)
              || (block->getSuccessors().size() == 0 && block->getExceptionSuccessors().size() == 1)
-             || block->isOSRInduceBlock() || block->isOSRCodeBlock())
+             || block->isOSRInduceBlock() || block->isOSRCodeBlock()))
             {
             if (!countedBlocks.contains(block))
                {
@@ -710,9 +710,9 @@ int32_t TR_JProfilingBlock::processCFGForCounting(BlockParents &parent, TR::Bloc
          // if the destination of the edge has a single destination we can count the destination
          // if the destination is a catch block we also just count the destination
          else if (block != to &&
-             (to->getPredecessors().size() == 1 && to->getExceptionPredecessors().size() == 0)
+             ((to->getPredecessors().size() == 1 && to->getExceptionPredecessors().size() == 0)
              || (to->getPredecessors().size() == 0 && to->getExceptionPredecessors().size() == 1)
-             || to->isCatchBlock() || to->isOSRInduceBlock() || to->isOSRCodeBlock())
+             || to->isCatchBlock() || to->isOSRInduceBlock() || to->isOSRCodeBlock()))
             {
             if (!countedBlocks.contains(to))
                {

--- a/runtime/compiler/optimizer/JitProfiler.cpp
+++ b/runtime/compiler/optimizer/JitProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/JitProfiler.cpp
+++ b/runtime/compiler/optimizer/JitProfiler.cpp
@@ -136,22 +136,22 @@ int32_t TR_JitProfiler::performOnNode(TR::Node *node, TR::TreeTop *tt)
    // Profile address if node is an indirect call
    if (
         node->getOpCode().isCall() &&
-        ( comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeStatic) &&
-            node->getSymbol()->getMethodSymbol()->isStatic() ||
-          comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeVirtual) &&
-            node->getSymbol()->getMethodSymbol()->isVirtual() ||
-          comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeInterface) &&
-            node->getSymbol()->getMethodSymbol()->isInterface()
+        ( (comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeStatic) &&
+            node->getSymbol()->getMethodSymbol()->isStatic()) ||
+          (comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeVirtual) &&
+            node->getSymbol()->getMethodSymbol()->isVirtual()) ||
+          (comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInvokeInterface) &&
+            node->getSymbol()->getMethodSymbol()->isInterface())
         )
       )
       {
       addCallProfiling(node, tt, tt->getEnclosingBlock(), addProfilingBypass);
       changesPerformed++;
       }
-   else if ( comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInstanceOf) &&
-               node->getOpCodeValue() == TR::instanceof ||
-             comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingCheckCast) &&
-               node->getOpCodeValue() == TR::checkcast
+   else if ( (comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingInstanceOf) &&
+               node->getOpCodeValue() == TR::instanceof) ||
+             (comp()->getOptions()->getSamplingJProfilingOption(TR_SamplingJProfilingCheckCast) &&
+               node->getOpCodeValue() == TR::checkcast)
            )
       {
       addInstanceProfiling(node, tt, tt->getEnclosingBlock(), addProfilingBypass);

--- a/runtime/compiler/optimizer/LoopAliasRefiner.cpp
+++ b/runtime/compiler/optimizer/LoopAliasRefiner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/LoopAliasRefiner.cpp
+++ b/runtime/compiler/optimizer/LoopAliasRefiner.cpp
@@ -211,7 +211,7 @@ bool TR_LoopAliasRefiner::processArrayAliasCandidates()
    goodCandidateDetected = false;
    bool atLeastOneStore = false;
 
-   while (curTuple = _arrayMemberLoadCandidates->popHead())
+   while ((curTuple = _arrayMemberLoadCandidates->popHead()))
       { 
       memberCand.reset();
       int32_t refCount = 0;
@@ -268,8 +268,7 @@ bool TR_LoopAliasRefiner::processArrayAliasCandidates()
          if (curTupleBaseSymRef == currentBaseSymRef &&
              curTupleMemberSymRef == currentMemberSymRef)
             {
-            bool isStore;
-            if (isStore = curTuple->_parent->getOpCode().isStoreIndirect())
+            if (curTuple->_parent->getOpCode().isStoreIndirect())
                {
                numUses = 0;
                }

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -386,6 +386,9 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
               return mnIndex;
               }
            }
+
+         default:
+            break;
         }
       }
 
@@ -493,6 +496,9 @@ void TR_MethodHandleTransformer::visitCall(TR::TreeTop* tt, TR::Node* node)
          break;
       case TR::java_lang_invoke_Invokers_checkExactType:
          process_java_lang_invoke_Invokers_checkExactType(tt, node);
+         break;
+
+      default:
          break;
       }
    }

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -589,7 +589,7 @@ bool TR::MonitorElimination::findRedundantMonitors()
             if (trace())
                traceMsg(comp(),"Monitor node %p has a call at %p in its monitor region\n",monitor->getMonitorNode(),node);
 
-            if (!block->isCold() && block->getFrequency() >= minBlockCount ||
+            if ((!block->isCold() && block->getFrequency() >= minBlockCount) ||
                 (monitor->getMonitorTree() && (monitor->getMonitorTree()->getEnclosingBlock()->getNextBlock() == block)))
                {
                monitor->_containsCalls = true;
@@ -5220,7 +5220,7 @@ bool TR::MonitorElimination::symbolsAreNotWrittenInTrees(TR::TreeTop *startTree,
             }
          }
       else if (/* cursorNode->getOpCode().isCall() || */
-               (cursorNode->isGCSafePointWithSymRef()) && comp()->getOptions()->realTimeGC() ||
+               ((cursorNode->isGCSafePointWithSymRef()) && comp()->getOptions()->realTimeGC()) ||
                (cursorNode->getOpCode().hasSymbolReference() &&
                 cursorNode->getSymbolReference()->isUnresolved()))
          {

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -4144,6 +4144,9 @@ int TR_SPMDKernelParallelizer::symbolicEvaluateTree(TR::Node *node)
       case TR::isub:
       case TR::lsub:
          return (c1-c2);
+
+      default:
+         break;
       }
 
    return 0;

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -58,6 +58,9 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
             case TR::compressedRefs:
                if (node->getFirstChild()->getOpCode().isLoad())
                    continue;
+
+            default:
+               break;
             }
 
           // explicitly allowed families of opcodes

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -1886,14 +1886,14 @@ TR::TreeTop *TR_StringPeepholes::detectPattern(TR::Block *block, TR::TreeTop *tt
                                     initSymRef1);
          }
       }
-   else if ((stringCount == 3))
+   else if (stringCount == 3)
       {
       TR::SymbolReference *initSymRef2 = findSymRefForOptMethod(SPH_String_init_SSS) ? getSymRefTab()->findOrCreateMethodSymbol(stringNode->getSymbolReference()->getOwningMethodIndex(), -1, findSymRefForOptMethod(SPH_String_init_SSS)->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod(), TR::MethodSymbol::Special) : 0;
       initCall = TR::Node::createWithSymRef(TR::call, 4, 4,
                                  stringNode, appendedString[0], appendedString[1], appendedString[2],
                                  initSymRef2);
       }
-   else if ((stringCount == 5))
+   else if (stringCount == 5)
       {
       TR::SymbolReference *initSymRef7 = findSymRefForOptMethod(SPH_String_init_ISISS) ? getSymRefTab()->findOrCreateMethodSymbol(stringNode->getSymbolReference()->getOwningMethodIndex(), -1, findSymRefForOptMethod(SPH_String_init_ISISS)->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod(), TR::MethodSymbol::Special) : 0;
       initCall = TR::Node::createWithSymRef(TR::call, 6, 6,

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -313,6 +313,9 @@ static bool needUnsignedConversion(TR::RecognizedMethod methodToReduce)
       case TR::java_lang_StringUTF16_getChar:
       case TR::java_lang_StringUTF16_putChar:
          return true;
+
+      default:
+         break;
       }
 
    return false;
@@ -488,6 +491,9 @@ int32_t TR_UnsafeFastPath::perform()
             case TR::java_lang_StringUTF16_getChar:
                objectChild = 0;
                offsetChild = 1;
+               break;
+
+            default:
                break;
             }
 
@@ -735,6 +741,9 @@ int32_t TR_UnsafeFastPath::perform()
                {
                case TR::java_lang_StringUTF16_getChar:
                   unsafeSymRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::Int8);
+                  break;
+
+               default:
                   break;
                }
 

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -224,6 +224,9 @@ int32_t TR_VarHandleTransformer::perform()
                   case TR::ResolveCHK:
                        newOpCode = TR::treetop;
                        break;
+
+                  default:
+                     break;
                   }
                if (hasNULLCHK)
                   {

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2126,7 +2126,7 @@ TR_DebugExt::dxPrintPersistentJittedBodyInfo(TR_PersistentJittedBodyInfo *bodyIn
       _dbgPrintf("\tflags16_t                 _flags = 0x%04x\n", localBodyInfo->_flags.getValue());
       _dbgPrintf("\tint8_t                    _sampleIntervalCount = %d\n", localBodyInfo->_sampleIntervalCount);
       _dbgPrintf("\tuint8_t                   _aggressiveRecompilationChances = %d\n", localBodyInfo->_aggressiveRecompilationChances);
-      _dbgPrintf("\tTR_Hotness                _hotness = %d (%s)\n", localBodyInfo->_hotness, localBodyInfo->_hotness == -1 ? "unknown" : comp()->getHotnessName(localBodyInfo->_hotness));
+      _dbgPrintf("\tTR_Hotness                _hotness = %d (%s)\n", localBodyInfo->_hotness, comp()->getHotnessName(localBodyInfo->_hotness));
       _dbgPrintf("\tuint8_t                   _numScorchingIntervals = %d\n", localBodyInfo->_numScorchingIntervals);
       _dbgPrintf("\tbool                      _isInvalidated = %d\n", localBodyInfo->_isInvalidated);
       _dbgPrintf("\tDetails of flags:\n");

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -1147,7 +1147,7 @@ TR_DebugExt::dxTrPrint(const char* name1, void* addr2, uintptr_t argCount, const
    int32_t argc = 0;
    const char *argp1 = args;
    char *argp2 = myArgs;
-   while (*argp2++ = *argp1++);
+   while ((*argp2++ = *argp1++));
    for (argp2 = myArgs; *argp2; )
       {
       argv[argc++] = argp2;

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -849,6 +849,9 @@ TR_ValueProfiler::addListOrArrayProfilingTrees(
       case ValueInfo:
          helper = TR_jitProfileValue;
          break;
+
+      default:
+         break;
       }
    TR::SymbolReference *profiler = comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper, false, false, true);
 #if defined(TR_HOST_POWER) || defined(TR_HOST_ARM)

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1975,11 +1975,11 @@ TR_BlockFrequencyInfo::generateBlockRawCountCalculationSubTree(TR::Compilation *
    {
    TR::Node *root = NULL;
    if (blockNumber > -1 && (_counterDerivationInfo[blockNumber * 2]
-      && ((((uintptr_t)_counterDerivationInfo[blockNumber * 2]) & 0x1 == 1)
+      && (((((uintptr_t)_counterDerivationInfo[blockNumber * 2]) & 0x1) == 1)
       || !_counterDerivationInfo[blockNumber * 2]->isEmpty())))
       {
       TR::Node *addRoot = NULL;
-      if (((uintptr_t)_counterDerivationInfo[blockNumber * 2]) & 0x1 == 1)
+      if ((((uintptr_t)_counterDerivationInfo[blockNumber * 2]) & 0x1) == 1)
          {
          TR::SymbolReference *symRef = comp->getSymRefTab()->createKnownStaticDataSymbolRef(getFrequencyForBlock(((uintptr_t)_counterDerivationInfo[blockNumber * 2]) >> 1), TR::Int32);
          symRef->getSymbol()->setIsBlockFrequency();
@@ -2004,7 +2004,7 @@ TR_BlockFrequencyInfo::generateBlockRawCountCalculationSubTree(TR::Compilation *
       TR::Node *subRoot = NULL;
       if (_counterDerivationInfo[blockNumber * 2 +1] != NULL)
          {
-         if (((uintptr_t)_counterDerivationInfo[blockNumber *2 + 1]) & 0x1 == 1)
+         if ((((uintptr_t)_counterDerivationInfo[blockNumber *2 + 1]) & 0x1) == 1)
             {
             TR::SymbolReference *symRef = comp->getSymRefTab()->createKnownStaticDataSymbolRef(getFrequencyForBlock(((uintptr_t)_counterDerivationInfo[blockNumber * 2 + 1]) >> 1), TR::Int32);
             symRef->getSymbol()->setIsBlockFrequency();

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1949,7 +1949,7 @@ TR_BlockFrequencyInfo::getOriginalBlockNumberToGetRawCount(TR_ByteCodeInfo &bci,
    bool currentCallSiteInfo = TR_CallSiteInfo::getCurrent(comp) == _callSiteInfo;
    for (auto i=0; i < _numBlocks; ++i)
       {
-      if (currentCallSiteInfo && _callSiteInfo->hasSameBytecodeInfo(_blocks[i], searchBCI, comp) ||
+      if ((currentCallSiteInfo && _callSiteInfo->hasSameBytecodeInfo(_blocks[i], searchBCI, comp)) ||
             (!currentCallSiteInfo && _blocks[i].getCallerIndex() == searchBCI.getCallerIndex() && _blocks[i].getByteCodeIndex() == searchBCI.getByteCodeIndex()))
          {
          if (trace)

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -403,7 +403,7 @@ void TR_ValueProfiler::modifyTrees()
              !(arrayCopyLen->getOpCode().isCallIndirect() &&
                !arrayCopyLen->isTheVirtualCallNodeForAGuardedInlinedCall()))
              {
-             addProfilingTrees(arrayCopyLen, tt, 0, LastValueInfo, LastProfiler, true, &firstChild->getByteCodeInfo());
+             addProfilingTrees(arrayCopyLen, tt, firstChild->getByteCodeInfo(), 0, LastValueInfo, LastProfiler, true);
              }
          }
       else if (firstChild && firstChild->getOpCode().isCall() &&

--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -198,6 +198,7 @@ class TR_AbstractProfilerInfo : public TR_Link0<TR_AbstractProfilerInfo>
    public:
    TR_AbstractProfilerInfo(TR_ByteCodeInfo &bci) : _byteCodeInfo(bci) {}
 
+   virtual ~TR_AbstractProfilerInfo() {}
    /**
     * Common methods based on metadata and frequencies.
     */
@@ -1211,7 +1212,7 @@ TR_LinkedListProfilerInfo<T>::~TR_LinkedListProfilerInfo()
    while (cursor)
       {
       auto next = cursor->getNext();
-      ~Element(cursor);
+      cursor->~Element();
       jitPersistentFree(cursor);
       cursor = next;
       }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -285,10 +285,10 @@ static TR_OutlinedInstructions *generateArrayletReference(
    bool loadNeedsDecompression = false;
 
    if (loadOrStoreOrArrayElementNode->getOpCodeValue() == TR::l2a ||
-       ((loadOrStoreOrArrayElementNode->getOpCodeValue() == TR::aload ||
+       (((loadOrStoreOrArrayElementNode->getOpCodeValue() == TR::aload ||
          loadOrStoreOrArrayElementNode->getOpCodeValue() == TR::aRegLoad) &&
         node->isSpineCheckWithArrayElementChild()) &&
-       comp->target().is64Bit() && comp->useCompressedPointers())
+       comp->target().is64Bit() && comp->useCompressedPointers()))
       loadNeedsDecompression = true;
 
    TR::Node *actualLoadOrStoreOrArrayElementNode = loadOrStoreOrArrayElementNode;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1384,16 +1384,25 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    TR::Register *reg;
 
    if (callNode->getFirstChild() == node->getFirstChild())
-      if (reg = callNode->getFirstChild()->getRegister())
+      {
+      reg = callNode->getFirstChild()->getRegister();
+      if (reg)
          deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
 
    if (callNode->getSecondChild() == node->getSecondChild())
-      if (reg = callNode->getSecondChild()->getRegister())
+      {
+      reg = callNode->getSecondChild()->getRegister();
+      if (reg)
          deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
 
    if (callNode->getThirdChild() == node->getThirdChild())
-      if (reg = callNode->getThirdChild()->getRegister())
+      {
+      reg = callNode->getThirdChild()->getRegister();
+      if (reg)
          deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
 
    deps->stopAddingConditions();
 
@@ -3641,12 +3650,18 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node* node, TR::Code
    TR::Register *reg;
 
    if (callNode->getFirstChild() == node->getFirstChild())
-      if (reg = callNode->getFirstChild()->getRegister())
+      {
+      reg = callNode->getFirstChild()->getRegister();
+      if (reg)
          deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
 
    if (callNode->getSecondChild() == node->getSecondChild())
-      if (reg = callNode->getSecondChild()->getRegister())
+      {
+      reg = callNode->getSecondChild()->getRegister();
+      if (reg)
          deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
 
    deps->stopAddingConditions();
 
@@ -7991,13 +8006,19 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
       TR::Register *reg;
 
       if (callNode->getFirstChild() == node->getFirstChild())
-         if (reg = callNode->getFirstChild()->getRegister())
+         {
+         reg = callNode->getFirstChild()->getRegister();
+         if (reg)
             deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+         }
 
       if (node->getOpCodeValue() != TR::New)
          if (callNode->getSecondChild() == node->getSecondChild())
-            if (reg = callNode->getSecondChild()->getRegister())
+            {
+            reg = callNode->getSecondChild()->getRegister();
+            if (reg)
                deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+            }
       }
 
    deps->stopAddingConditions();


### PR DESCRIPTION
The commits have addressed all warnings on an OSX build, so to prevent
new warnings from being introduced we enable warnings as errors only on
this platform. Future platforms will follow. See each commit for an
explanation of what warning was triggered and fixed.