### PR TITLE
CMake: modify debug flags on z/OS

### DIFF
--- a/runtime/cmake/platform/toolcfg/xlc.cmake
+++ b/runtime/cmake/platform/toolcfg/xlc.cmake
@@ -43,5 +43,11 @@ if(CMAKE_C_COMPILER_IS_XLCLANG)
 	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -fno-rtti)
 else()
 	# xlc/xlc++ options
-	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -g)
+	if(OMR_OS_ZOS)
+		# Specifying -g on z/OS inhibits compiler optimizations.
+		# Instead we use these flags to info required for DDR without hindering the optimizer.
+		list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -qdebug=nohook -qxplink=noback)
+	else()
+		list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -g)
+	endif()
 endif()


### PR DESCRIPTION
Allow generating debug info for DDR, without hindering the optimizer.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>