### PR TITLE
Disable impdep1 handling for OpenJDK MHs

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5249,7 +5249,9 @@ typedef struct J9JavaVM {
 	UDATA  ( *unhookVMEvent)(struct J9JavaVM *javaVM, UDATA eventNumber, void * currentHandler, void * oldHandler) ;
 	UDATA classLoadingMaxStack;
 	U_8* callInReturnPC;
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	U_8* impdep1PC;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	UDATA  ( *jitExceptionHandlerSearch)(struct J9VMThread *currentThread, struct J9StackWalkState *walkState) ;
 	UDATA  ( *walkStackFrames)(struct J9VMThread *currentThread, struct J9StackWalkState *walkState) ;
 	UDATA  ( *walkFrame)(struct J9StackWalkState *walkState) ;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8674,6 +8674,7 @@ done:
 		return retFromNativeHelper(REGISTER_ARGS, 2, _vm->jitConfig->jitExitInterpreterJ);
 	}
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	VMINLINE VM_BytecodeAction
 	impdep1(REGISTER_ARGS_LIST)
 	{
@@ -8683,6 +8684,7 @@ done:
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		return next;
 	}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	VMINLINE VM_BytecodeAction
 	impdep2(REGISTER_ARGS_LIST)
@@ -9168,7 +9170,12 @@ public:
 		JUMP_TABLE_ENTRY(JBreturnFromJ2I), /* 0xFB(251) */
 		JUMP_TABLE_ENTRY(JBunimplemented), /* 0xFC(252) */
 		JUMP_TABLE_ENTRY(JBunimplemented), /* 0xFD(253) */
+#if defined(J9VM_OPT_METHOD_HANDLE)
 		JUMP_TABLE_ENTRY(JBimpdep1), /* 0xFE(254) */
+#else /* defined(J9VM_OPT_METHOD_HANDLE) */
+		/* impdep1 not used for OpenJDK method handles. */
+		JUMP_TABLE_ENTRY(JBunimplemented), /* 0xFE(254) */
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 		JUMP_TABLE_ENTRY(JBimpdep2),/* 0xFF(255) */
 	};
 	static JUMP_TABLE_TYPE sendTargetTable[] = {
@@ -10723,9 +10730,11 @@ executeBytecodeFromLocal:
 		JUMP_TARGET(JBreturnFromJ2I):
 			/* No single step for this bytecode */
 			PERFORM_ACTION(j2iReturn(REGISTER_ARGS));
+#if defined(J9VM_OPT_METHOD_HANDLE)
 		JUMP_TARGET(JBimpdep1):
 			/* No single step for this bytecode */
 			PERFORM_ACTION(impdep1(REGISTER_ARGS));
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 		JUMP_TARGET(JBimpdep2):
 			/* No single step for this bytecode */
 			PERFORM_ACTION(impdep2(REGISTER_ARGS));

--- a/runtime/vm/BytecodeInterpreter.inc
+++ b/runtime/vm/BytecodeInterpreter.inc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,8 +61,10 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 	if ((UDATA)pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) {
 		j9str_printf(PORTLIB, temp, sizeof(temp), "SPECIAL %d", pc);
 		strcat(buffer, temp);
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	} else if (((U_8*)-1 != pc) && (JBimpdep1 == *pc)) {
 		strcat(buffer, "MHMAGIC");
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	} else if (((U_8*)-1 != pc) && (JBimpdep2 == *pc)) {
 		strcat(buffer, "CALLIN");
 	} else if (((U_8*)-1 != pc) && (((*pc >= JBretFromNative0) && (*pc <= JBreturnFromJ2I)) || (JBreturnFromJ2I == *pc))) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -291,7 +291,9 @@ extern void populateRASNetData (J9JavaVM *javaVM, J9RAS *rasStruct);
 #endif /* J9VM_RAS_EYECATCHERS */
 
 const U_8 J9CallInReturnPC[] = { 0xFF, 0x00, 0x00, 0xFF }; /* impdep2, parm, parm, impdep2 */
+#if defined(J9VM_OPT_METHOD_HANDLE)
 const U_8 J9Impdep1PC[] = { 0xFE, 0x00, 0x00, 0xFE }; /* impdep1, parm, parm, impdep1 */
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 static jint (JNICALL * vprintfHookFunction)(FILE *fp, const char *format, va_list args) = NULL;
 static IDATA (* portLibrary_file_write_text) (struct OMRPortLibrary *portLibrary, IDATA fd, const char *buf, IDATA nbytes) = NULL;
@@ -2543,7 +2545,9 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			}
 #endif
 			vm->callInReturnPC = (U_8 *) J9CallInReturnPC;
+#if defined(J9VM_OPT_METHOD_HANDLE)
 			vm->impdep1PC = (U_8 *) J9Impdep1PC;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 			break;
 
 		case JIT_INITIALIZED :

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -926,12 +926,16 @@ walkBytecodeFrame(J9StackWalkState * walkState)
 
 		walkState->constantPool = UNTAGGED_METHOD_CP(walkState->method);
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 		/* If PC = impdep1, we haven't run the method (and never will) its just a placeholder */
 		if ((walkState->pc != vm->impdep1PC) && (walkState->pc != (vm->impdep1PC + 3))) {
 			walkState->bytecodePCOffset = walkState->pc - (U_8 *) J9_BYTECODE_START_FROM_RAM_METHOD(walkState->method);
 		} else {
 			walkState->bytecodePCOffset = 0;
 		}
+#else /* defined(J9VM_OPT_METHOD_HANDLE) */
+		walkState->bytecodePCOffset = walkState->pc - (U_8 *) J9_BYTECODE_START_FROM_RAM_METHOD(walkState->method);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 		walkState->argCount = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod);
 		argTempCount = J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod) + walkState->argCount;


### PR DESCRIPTION
Wrap the impdep1 handler in 'if defined J9VM_OPT_METHOD_HANDLE' as it
is OpenJ9 specific.

Fixes: #12251
Signed-off-by: Eric Yang <eric.yang@ibm.com>