### PR TITLE
Refactor CopyForward to reuse fixupForwardedObject

### DIFF
--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -568,6 +568,19 @@ public:
 			_indexableObjectModel->fixupDataAddr(forwardedHeader, destinationObjectPtr);
 		}
 
+		fixupHashFlagsAndSlot(forwardedHeader, destinationObjectPtr);
+	}
+
+	/**
+	 * This will install the correct (i.e. unforwarded) class pointer, update the hashed/moved
+	 * flags and install the hash code if the object has been hashed but not previously moved.
+	 *
+	 * @param[in] forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @param[in] destinationObjectPtr pointer to the copied object to be fixed up
+	 */
+	MMINLINE void
+	fixupHashFlagsAndSlot(MM_ForwardedHeader *forwardedHeader, omrobjectptr_t destinationObjectPtr)
+	{
 		/*	To have ability to backout last scavenge we need to recognize objects just moved (moved first time) in current scavenge
 		 *
 		 *	Bits	State

--- a/runtime/gc_glue_java/ObjectModelDelegate.cpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.cpp
@@ -54,36 +54,6 @@ GC_ObjectModelDelegate::initializeAllocation(MM_EnvironmentBase *env, void *allo
 void
 GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *reservedObjectSizeInBytes, uintptr_t *hotFieldAlignmentDescriptor)
 {
-	GC_ObjectModel *objectModel = &(env->getExtensions()->objectModel);
-	J9Class* clazz = objectModel->getPreservedClass(forwardedHeader);
-	uintptr_t actualObjectCopySizeInBytes = 0;
-	uintptr_t hashcodeOffset = 0;
-
-	if (objectModel->isIndexable(clazz)) {
-		uint32_t size = getArrayObjectModel()->getPreservedIndexableSize(forwardedHeader);
-		*objectCopySizeInBytes = getArrayObjectModel()->getSizeInBytesWithHeader(clazz, size);
-		hashcodeOffset = getArrayObjectModel()->getHashcodeOffset(clazz, size);
-	} else {
-		*objectCopySizeInBytes = clazz->totalInstanceSize + J9GC_OBJECT_HEADER_SIZE(this);
-		hashcodeOffset = getMixedObjectModel()->getHashcodeOffset(clazz);
-	}
-
-	if (hashcodeOffset == *objectCopySizeInBytes) {
-		if (objectModel->hasBeenMoved(objectModel->getPreservedFlags(forwardedHeader))) {
-			*objectCopySizeInBytes += sizeof(uintptr_t);
-		} else if (objectModel->hasBeenHashed(objectModel->getPreservedFlags(forwardedHeader))) {
-			actualObjectCopySizeInBytes += sizeof(uintptr_t);
-		}
-	}
-	actualObjectCopySizeInBytes += *objectCopySizeInBytes;
-	*reservedObjectSizeInBytes = objectModel->adjustSizeInBytes(actualObjectCopySizeInBytes);
-	*hotFieldAlignmentDescriptor = clazz->instanceHotFieldDescription;
-}
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
-
-void
-GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader* forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash)
-{
 	/* NOTE: the size is fetched by hand from the class in the mixed case because a forwarding pointer could have been substituted into the clazz slot.
 	 * the class pointer passed into this routine is guaranteed to have been checked
 	 */
@@ -101,7 +71,6 @@ GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, M
 
 	/* IF the object has been hashed and has not been moved, then we need generate hash from the old address */
 	uintptr_t forwardedHeaderPreservedFlags = objectModel->getPreservedFlags(forwardedHeader);
-	*doesObjectNeedHash = (objectModel->hasBeenHashed(forwardedHeaderPreservedFlags) && !objectModel->hasBeenMoved(forwardedHeaderPreservedFlags));
 
 	if (hashcodeOffset == *objectCopySizeInBytes) {
 		if (objectModel->hasBeenMoved(forwardedHeaderPreservedFlags)) {
@@ -111,5 +80,7 @@ GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, M
 		}
 	}
 	actualObjectCopySizeInBytes += *objectCopySizeInBytes;
-	*objectReserveSizeInBytes = objectModel->adjustSizeInBytes(actualObjectCopySizeInBytes);
+	*reservedObjectSizeInBytes = objectModel->adjustSizeInBytes(actualObjectCopySizeInBytes);
+	*hotFieldAlignmentDescriptor = clazz->instanceHotFieldDescription;
 }
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */

--- a/runtime/gc_glue_java/ObjectModelDelegate.hpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.hpp
@@ -461,18 +461,10 @@ public:
 	void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, uintptr_t *hotFieldAlignmentDescriptor);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
-	/**
-	 * Calculate the actual object size and the size adjusted to object alignment. The calculated object size
-	 * includes any expansion bytes allocated if the object will grow when moved. TODO: Merge this with the
-	 * above calculateObjectDetailsForCopy()
-	 *
-	 * @param[in] env points to the environment for the calling thread
-	 * @param[in] forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @param[out] objectCopySizeInBytes actual object size
-	 * @param[out] objectReserveSizeInBytes size adjusted to object alignment
-	 * @param[out] doesObjectNeedHash flag that indicates if object needs hashing
-	 */
-	void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader* forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash);
+	MMINLINE void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash)
+	{
+		/* TO BE REMOVED */
+	}
 
 	/**
 	 * Constructor receives a copy of OMR's object flags mask, normalized to low order byte. Delegate


### PR DESCRIPTION
Refactor CopyForward to be more consistent with Scavenger by reusing the existing fixupForwardedObject method from ObjectModel. Additionally, simplify calculateObjectDetailsForCopy for balanced as doesObjectNeedHash argument is no longer needed.

Related to: https://github.com/eclipse/omr/pull/5990

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>