### PR TITLE
Fixup OS stack free with more accurate stack size ver2

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -946,17 +946,11 @@ wrappedAgentThreadStart(J9PortLibrary* portLib, void * entryArg)
 	jvmtiEnv * jvmti_env = args->jvmti_env;
 	jvmtiStartFunction proc = args->proc;
 	const void * arg = args->arg;
-	UDATA osStackFree;
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	j9mem_free_memory(args);
 
-	/* Determine the thread's free OS stack size (the default value has already been set if the query fails) */
-
-	osStackFree = omrthread_current_stack_free();
-	if (osStackFree != 0) {
-		vmThread->currentOSStackFree = osStackFree - (osStackFree / J9VMTHREAD_RESERVED_C_STACK_FRACTION);
-	}
+	initializeCurrentOSStackFree(vmThread, vmThread->osThread, vm->defaultOSStackSize);
 
 	vm->internalVMFunctions->threadAboutToStart(vmThread);
 

--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -92,8 +92,12 @@
 #define J9_JIT_DATA_CACHE_SIZE (8 * 1024 * 1024)
 #endif /* J9VM_ARCH_X86 && !J9VM_ENV_DATA64 */
 
-
-#define J9_OS_STACK_GUARD (16 * 1024)
+/*
+ * J9_OS_STACK_GUARD needs to be large enough such that we can run
+ * the initializer for StackOverflow and construct a new instance. On
+ * some platforms this can use up more than 16kb from an overflow check.
+ */
+#define J9_OS_STACK_GUARD (32 * 1024)
 
 #if defined(J9VM_ENV_DATA64) && defined(J9ZOS390)
 /* Use a 1MB OS stack on z/OS 64-bit as this is what the OS

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1753,6 +1753,16 @@ isSameOrSuperInterfaceOf(J9Class *superInterface, J9Class *baseInterface);
 J9VMThread *
 getVMThreadFromOMRThread(J9JavaVM *vm, omrthread_t omrthread);
 
+/**
+ * @brief Initialize the currentOSStackFree field in the J9VMThread. Must be called by
+ *	running thread, not thread creating the new vmThread.
+ * @param currentThread vmThread token
+ * @param osThread omrThread token
+ * @param osStackSize requested stack size, determined by -Xmso or J9_OS_STACK_SIZE
+ */
+void
+initializeCurrentOSStackFree(J9VMThread *currentThread, omrthread_t osThread, UDATA osStackSize);
+
 /* ---------------- thrinfo.c ---------------- */
 
 /**

--- a/runtime/util/thrhelp.c
+++ b/runtime/util/thrhelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #include "j9.h"
 #include "omrthread.h"
 #include "util_api.h"
+#include "ut_j9util.h"
 
 J9VMThread *
 getVMThreadFromOMRThread(J9JavaVM *vm, omrthread_t omrthread)
@@ -36,4 +37,25 @@ getVMThreadFromOMRThread(J9JavaVM *vm, omrthread_t omrthread)
 		}
 	}
 	return vmThread;
+}
+
+void
+initializeCurrentOSStackFree(J9VMThread *currentThread, omrthread_t osThread, UDATA osStackSize)
+{
+	UDATA actualStackSize = 0;
+	UDATA stackStart = 0;
+	UDATA stackEnd = 0;
+
+	if (J9THREAD_SUCCESS == omrthread_get_stack_range(osThread, (void**)&stackStart, (void **)&stackEnd)) {
+		actualStackSize = stackEnd - stackStart;
+		currentThread->currentOSStackFree = ((UDATA)&stackStart - stackStart);
+	} else {
+		UDATA osStackFree = omrthread_current_stack_free();
+		if (0 != osStackFree) {
+			currentThread->currentOSStackFree = osStackFree - (osStackFree / J9VMTHREAD_RESERVED_C_STACK_FRACTION);
+		} else {
+			currentThread->currentOSStackFree = osStackSize - (osStackSize / J9VMTHREAD_RESERVED_C_STACK_FRACTION);
+		}
+	}
+	Trc_Util_thrhelp_initializeCurrentOSStackFree(currentThread, osThread, osStackSize, actualStackSize, currentThread->currentOSStackFree, &actualStackSize);
 }

--- a/runtime/util/util.tdf
+++ b/runtime/util/util.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2021 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,3 +79,6 @@ TraceException=Trc_Util_validateLibrary_memAllocFailed Noenv Overhead=1 Level=1 
 TraceEvent=Trc_Util_validateLibrary_onLoadSignature NoEnv Overhead=1 Level=5 Template="validateLibrary signature (switch-string: %s, clear-string: %s)"
 TraceEvent=Trc_Util_validateLibrary_libraryStatus NoEnv Overhead=1 Level=3 Template="validateLibrary shared library %s flagged as %s"
 TraceExit=Trc_Util_validateLibrary_Exit Noenv Overhead=1 Level=5 Template="validateLibrary returns"
+
+TraceEvent=Trc_Util_thrhelp_initializeCurrentOSStackFree Overhead=1 Level=1 Template="Setup osStack free for osthread=%p requested stacksize=%zu realStacksize=%zu (zero is not found) stackfree=%zu starting sp=%p"
+

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -299,6 +299,9 @@ buildCallInStackFrame(J9VMThread *currentThread, J9VMEntryLocalStorage *newELS, 
 		UDATA usedBytes = ((UDATA)oldELS - (UDATA)newELS);
 		freeBytes -= usedBytes;
 		currentThread->currentOSStackFree = freeBytes;
+
+		Trc_VM_callin_stackFree(currentThread, freeBytes, newELS);
+
 		if ((IDATA)freeBytes < J9_OS_STACK_GUARD) {
 			if (J9_ARE_NO_BITS_SET(currentThread->privateFlags, J9_PRIVATE_FLAGS_CONSTRUCTING_EXCEPTION)) {
 				setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGSTACKOVERFLOWERROR, J9NLS_VM_OS_STACK_OVERFLOW);

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -877,3 +877,6 @@ TraceEntry=Trc_VM_romClassLoadFromCookie_Entry2 Overhead=1 Level=3 Template="rom
 
 TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentModule Overhead=1 Level=1 Template="The sealed super class/interface (RAM class=%p) is not in the same module as %.*s"
 TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentPackage Overhead=1 Level=1 Template="The sealed super class/interface (RAM class=%p) is not in the same package as %.*s (non-public)"
+
+TraceEvent=Trc_VM_callin_stackFree Overhead=1 Level=5 Template="OS Stack free=%zi, current native sp=%p"
+

--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -627,7 +627,6 @@ protectedInternalAttachCurrentThread(J9PortLibrary* portLibrary, void * userData
 	char *modifiedThreadName = NULL; /* needed if the original thread name is bad UTF8 */
 	j9object_t *threadGroup = NULL;
 	J9VMThread *env;
-	UDATA osStackFree;
 	void *memorySpace = vm->defaultMemorySpace;
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 	BOOLEAN ifaEnabled = FALSE;
@@ -694,11 +693,7 @@ protectedInternalAttachCurrentThread(J9PortLibrary* portLibrary, void * userData
 
 	/* Determine the thread's remaining OS stack */
 
-	osStackFree = omrthread_current_stack_free();
-	if (osStackFree == 0) {
-		osStackFree = vm->defaultOSStackSize;
-	}
-	env->currentOSStackFree = osStackFree - (osStackFree / J9VMTHREAD_RESERVED_C_STACK_FRACTION);
+	initializeCurrentOSStackFree(env, args->osThread, vm->defaultOSStackSize);
 
 	threadAboutToStart(env);
 


### PR DESCRIPTION
Fixup OS stack free with more accurate stack size

Currently on non-windows platforms we estimate the size of the native
stack and use that for stackoverflow calculations on callin frames. The
estimation has shown to be incredibly inaccurate specifically on AIX.
The issue comes form the fact that the requested stack size and the
actual stack space allocated by the OS can differ.

This PR attempts to get a more accurate stack size so that the
stackoverflow can detect cases where we would run out of stack space.

This is the first set of changes, additional changes will be required to
address the issue where the java launcher passes the -Xss value as the
native stack size for the main thread.

Also more changes will be needed to address cases where we have a stack
overflow, but we've run out of stack space to throw the exception.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>