### PR TITLE
[WIP] Fix xlpCodeCacheTests on AIX

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -226,10 +226,6 @@
 	</test>
 	<test>
 		<testCaseName>xlpCodeCacheTests</testCaseName>
-		<disabled>
-			<comment>https://github.com/eclipse-openj9/openj9/issues/11104</comment>
-			<plat>.*aix.*</plat>
-		</disabled>
 		<variations>
 			<variation>Mode109</variation>
 			<variation>Mode110</variation>

--- a/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,7 +140,7 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 			xlpOptionsList.add(new XlpOption("-Xlp64K -Xlp:codecache:pagesize=16M", 16 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=16M -Xlp64K", 64 * ONE_KB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));
 			xlpOptionsList.add(new XlpOption("-Xlp16M -Xlp:codecache:pagesize=7M", 7 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));
-			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=7M -Xlp16M", 16 * ONE_KB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));
+			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=7M -Xlp16M", 16 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));
 
 			/* Test multiple '-Xlp<size>' options. In such cases rightmost option wins */
 			xlpOptionsList.add(new XlpOption("-Xlp64K -Xlp16M", 16 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, true));


### PR DESCRIPTION
Re-enable xlpCodeCacheTests on AIX and 
fix typo in XlpCodeCacheOptionsTestRunner.

Closes: #11104
Signed-off-by: Amarpreet Singh amarpreet1997@gmail.com