### PR TITLE
Replace decompress calls with StringLatin1.inflate and improve StringLatin1.inflate API tests

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -126,7 +126,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (String.LATIN1 == coder) {
 				compressedArrayCopy(value, srcIndex, bytes, destIndex, length);
 			} else {
-				decompress(value, srcIndex, bytes, destIndex, length);
+				StringLatin1.inflate(value, srcIndex, bytes, destIndex, length);
 			}
 		} else {
 			decompressedArrayCopy(value, srcIndex, bytes, destIndex, length);
@@ -144,7 +144,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (String.LATIN1 == coder) {
 				compressedArrayCopy(value, 0, bytes, offset, currentLength);
 			} else {
-				decompress(value, 0, bytes, offset, currentLength);
+				StringLatin1.inflate(value, 0, bytes, offset, currentLength);
 			}
 		} else {
 			decompressedArrayCopy(value, 0, bytes, offset, currentLength);
@@ -716,7 +716,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s.coder == LATIN1) {
-				decompress(s.value, 0, value, 0, slen);
+				StringLatin1.inflate(s.value, 0, value, 0, slen);
 			} else {
 				decompressedArrayCopy(s.value, 0, value, 0, slen);
 			}		
@@ -986,14 +986,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s1.coder == LATIN1) {
-				decompress(s1.value, 0, value, 0, s1len);
+				StringLatin1.inflate(s1.value, 0, value, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, 0, s1len);
 			}
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s2.coder == LATIN1) {
-				decompress(s2.value, 0, value, s1len, s2len);
+				StringLatin1.inflate(s2.value, 0, value, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, s1len, s2len);
 			}
@@ -1044,21 +1044,21 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s1.coder == LATIN1) {
-				decompress(s1.value, 0, value, 0, s1len);
+				StringLatin1.inflate(s1.value, 0, value, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, 0, s1len);
 			}
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s2.coder == LATIN1) {
-				decompress(s2.value, 0, value, s1len, s2len);
+				StringLatin1.inflate(s2.value, 0, value, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, s1len, s2len);
 			}
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s3.coder == LATIN1) {
-				decompress(s3.value, 0, value, s1len + s2len, s3len);
+				StringLatin1.inflate(s3.value, 0, value, s1len + s2len, s3len);
 			} else {
 				decompressedArrayCopy(s3.value, 0, value, (s1len + s2len), s3len);
 			}
@@ -1271,7 +1271,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s3.coder == LATIN1) {
-				decompress(s3.value, 0, value, start, s3len);
+				StringLatin1.inflate(s3.value, 0, value, start, s3len);
 			} else {
 				decompressedArrayCopy(s3.value, 0, value, start, s3len);
 			}
@@ -1281,7 +1281,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s2.coder == LATIN1) {
-				decompress(s2.value, 0, value, start, s2len);
+				StringLatin1.inflate(s2.value, 0, value, start, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, start, s2len);
 			}
@@ -1308,7 +1308,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s1.coder == LATIN1) {
-				decompress(s1.value, 0, value, start, s1len);
+				StringLatin1.inflate(s1.value, 0, value, start, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, start, s1len);
 			}
@@ -1605,14 +1605,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s1.coder == LATIN1) {
-				decompress(s1.value, 0, buffer, 0, s1len);
+				StringLatin1.inflate(s1.value, 0, buffer, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, buffer, 0, s1len);
 			}
 
 			// Check if the String is compressed
 			if (COMPACT_STRINGS && s2.coder == LATIN1) {
-				decompress(s2.value, 0, buffer, s1len, s2len);
+				StringLatin1.inflate(s2.value, 0, buffer, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, buffer, s1len, s2len);
 			}
@@ -1972,7 +1972,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	void getCharsNoBoundChecks(int start, int end, char[] data, int index) {
 		// Check if the String is compressed
 		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
-			decompress(value, start, data, index, end - start);
+			StringLatin1.inflate(value, start, data, index, end - start);
 		} else {
 			decompressedArrayCopy(value, start, data, index, end - start);
 		}
@@ -1983,7 +1983,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	void getCharsNoBoundChecks(int start, int end, byte[] data, int index) {
 		// Check if the String is compressed
 		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
-			decompress(value, start, data, index, end - start);
+			StringLatin1.inflate(value, start, data, index, end - start);
 		} else {
 			decompressedArrayCopy(value, start, data, index, end - start);
 		}
@@ -2561,7 +2561,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			} else {
 				byte[] buffer = StringUTF16.newBytesFor(len);
 
-				decompress(value, 0, buffer, 0, len);
+				StringLatin1.inflate(value, 0, buffer, 0, len);
 
 				do {
 					helpers.putCharInArrayByIndex(buffer, index++, (char) newChar);
@@ -2793,7 +2793,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		// Check if the String is compressed
 		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
-			decompress(value, 0, buffer, 0, len);
+			StringLatin1.inflate(value, 0, buffer, 0, len);
 		} else {
 			decompressedArrayCopy(value, 0, buffer, 0, len);
 		}

--- a/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangStringLatin1.java
+++ b/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangStringLatin1.java
@@ -159,5 +159,45 @@ public class TestJavaLangStringLatin1 {
         expected = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
         actual = new String(expected).toCharArray();
         AssertJUnit.assertArrayEquals("Incorrect result for length 50 array", expected, actual);
+
+        // For tests where the expected and actual arrays are different from the initial input array.
+        char[] input = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
+        String inputString = new String(input);
+
+        // Test if copying last 49 elements works correctly from input[]
+        expected = new char[] { '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
+        actual = new char[49];
+        inputString.getChars(1, 50, actual, 0);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy last 49 elements from 50 element array", expected, actual);
+
+        // Test if copying first 49 works as expected from input[]
+        expected = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE' };
+        actual = new char[49];
+        inputString.getChars(0, 49, actual, 0);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy first 49 elements from 50 length array", expected, actual);
+
+        // Test if copying elements 1-48 works as expected from input[]
+        expected = new char[] { '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE' };
+        actual = new char[48];
+        inputString.getChars(1, 49, actual, 0);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy elements 1-48 from 50 element array", expected, actual);
+
+        // Test if elements 10-49 can be copied correctly from input[]
+        expected = new char[] { '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
+        actual = new char[40];
+        inputString.getChars(10, 50, actual, 0);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy elements 10-49 from 50 element array", expected, actual);
+
+        // Test if elements 0-39 can be copied correctly from input[]
+        expected = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5' };
+        actual = new char[40];
+        inputString.getChars(0, 40, actual, 0);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy elements 0-39 from 50 element array", expected, actual);
+
+        // Copy elements 29-38 (inclusive) from input and place them at index 10-19 in resulting arrays.
+        expected = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', /* start*/'\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4' /*end*/, '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
+        actual = new char[] { '\u008E', '\u008F', '\u0090', '\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098', '\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u00A0', '\u00A1', '\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00A6', '\u00A7', '\u00A8', '\u00A9', '\u00AA', '\u00AB', '\u00AC', '\u00AD', '\u00AE', '\u00AF', '\u00B0', '\u00B1', '\u00B2', '\u00B3', '\u00B4', '\u00B5', '\u00B6', '\u00B7', '\u00B8', '\u00B9', '\u00BA', '\u00BB', '\u00BC', '\u00BD', '\u00BE', '\u00BF' };
+        inputString.getChars(29, 39, actual, 10);
+        AssertJUnit.assertArrayEquals("Incorrect result when trying to copy elements 29-38 from 50 element array and overwrite elements 10-19 in resulting arrays", expected, actual);
     }
 }


### PR DESCRIPTION
For Java 11, `StringLatin1.inflate` is the preferred API over `String.decompress`. This commit replaces those calls.
Additionally, `StringLatin1.inflate` tests are improved to account for more corner cases.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>