### PR TITLE
Fix warnings due to improper use of strncpy()

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -917,7 +917,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"numInterpCompReqToExitIdleMode=", "M<nnn>\tNumber of first time comp. req. that takes the JIT out of idle mode",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_numFirstTimeCompilationsToExitIdleMode, 0, "F%d", NOT_IN_SUBSET },
 #if defined(J9VM_OPT_JITSERVER)
-   {"oldAge=", " \tDefines what an old JITServer cache entry means", 
+   {"oldAge=", " \tDefines what an old JITServer cache entry means",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_oldAge,  0, " %d"},
    {"oldAgeUnderLowMemory=", " \tDefines what an old JITServer cache entry means when memory is low",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_oldAgeUnderLowMemory,  0, " %d" },
@@ -988,7 +988,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
 #endif /* defined(J9VM_OPT_JITSERVER) */
    {"testMode",           "D\tcompile but do not run the compiled code",  SET_JITCONFIG_RUNTIME_FLAG(J9JIT_TESTMODE) },
 #if defined(J9VM_OPT_JITSERVER)
-   {"timeBetweenPurges=", " \tDefines how often we are willing to scan for old entries to be purged", 
+   {"timeBetweenPurges=", " \tDefines how often we are willing to scan for old entries to be purged",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_timeBetweenPurges,  0, " %d"},
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_ARM64)
@@ -1052,7 +1052,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
 
 bool J9::Options::showOptionsInEffect()
    {
-   if (this == TR::Options::getAOTCmdLineOptions() && self()->getOption(TR_NoLoadAOT) &&	self()->getOption(TR_NoStoreAOT))
+   if (this == TR::Options::getAOTCmdLineOptions() && self()->getOption(TR_NoLoadAOT) && self()->getOption(TR_NoStoreAOT))
       return false;
    else
       return (TR::Options::isAnyVerboseOptionSet(TR_VerboseOptions, TR_VerboseExtended));
@@ -1720,7 +1720,7 @@ J9::Options::fePreProcess(void * base)
                return false;
             }
 
-          // Verify "pagesize=<size>" option. 
+          // Verify "pagesize=<size>" option.
           // This option must be specified for all platforms.
          if (0 == pageSizeHowMany)
             {
@@ -1732,7 +1732,7 @@ J9::Options::fePreProcess(void * base)
          //  [non]pageable option must be specified for Z platforms
          if ((0 == pageableHowMany) && (0 == nonPageableHowMany))
             {
-            // [non]pageable not found 
+            // [non]pageable not found
             char *xlpOptionErrorString = "-Xlp:codecache:";
             char *xlpMissingOptionString = "[non]pageable";
 
@@ -1759,7 +1759,7 @@ J9::Options::fePreProcess(void * base)
          char *lpOption = "-Xlp";
          GET_MEMORY_VALUE(xlpIndex, lpOption, requestedLargeCodePageSize);
          }
-      
+
       if (requestedLargeCodePageSize != 0)
          {
          // Check to see if requested size is valid
@@ -1767,7 +1767,7 @@ J9::Options::fePreProcess(void * base)
          largePageSize = requestedLargeCodePageSize;
          largePageFlags = requestedLargeCodePageFlags;
 
-         
+
          // j9vmem_find_valid_page_size happened to be changed to always return 0
          // However formally the function type still be IDATA so assert if it returns anything else
          j9vmem_find_valid_page_size(J9PORT_VMEM_MEMORY_MODE_EXECUTE, &largePageSize, &largePageFlags, &isRequestedSizeSupported);
@@ -2133,19 +2133,21 @@ static TR::FILE *fileOpen(TR::Options *options, J9JITConfig *jitConfig, char *na
    {
    PORT_ACCESS_FROM_ENV(jitConfig->javaVM);
    char tmp[1025];
-
+   char *formattedTmp = NULL;
    if (!options->getOption(TR_EnablePIDExtension))
       {
-      char *formattedTmp = TR_J9VMBase::getJ9FormattedName(jitConfig, PORTLIB, tmp, 1025, name, NULL, false);
-      return j9jit_fopen(formattedTmp, permission, b1, b2);
+      formattedTmp = TR_J9VMBase::getJ9FormattedName(jitConfig, PORTLIB, tmp, sizeof(tmp), name, NULL, false);
       }
    else
-     {
-     char *formattedTmp = TR_J9VMBase::getJ9FormattedName(jitConfig, PORTLIB, tmp, 1025, name, options->getSuffixLogsFormat(), true);
-     return j9jit_fopen(formattedTmp, permission, b1, b2);
-     }
-  }
-
+      {
+      formattedTmp = TR_J9VMBase::getJ9FormattedName(jitConfig, PORTLIB, tmp, sizeof(tmp), name, options->getSuffixLogsFormat(), true);
+      }
+   if (NULL != formattedTmp)
+      {
+      return j9jit_fopen(formattedTmp, permission, b1, b2);
+      }
+   return NULL;
+   }
 
 void
 J9::Options::openLogFiles(J9JITConfig *jitConfig)
@@ -2482,7 +2484,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    // input values to the options.
    if (_veryHighActiveThreadThreshold == -1)
       _veryHighActiveThreadThreshold = getNumUsableCompilationThreads() * 0.9;
-  
+
    if (_highActiveThreadThreshold == -1)
       _highActiveThreadThreshold = getNumUsableCompilationThreads() * 0.8;
 
@@ -2494,7 +2496,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       _highActiveThreadThreshold = getNumUsableCompilationThreads();
    if (_highActiveThreadThreshold  > _veryHighActiveThreadThreshold)
       _highActiveThreadThreshold  = _veryHighActiveThreadThreshold;
-      
+
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    // Determine whether or not to inline monitor enter/exit

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -939,20 +939,19 @@ compileClasses(J9VMThread * vmThread, const char * pattern)
 
    if (patternLength >= PATTERN_BUFFER_LENGTH)
       {
-      patternString = (char*)j9mem_allocate_memory((patternLength+1)*sizeof(char), J9MEM_CATEGORY_JIT);
+      patternString = (char*)j9mem_allocate_memory(patternLength + 1, J9MEM_CATEGORY_JIT);
       if (!patternString)
          return false;
       freePatternString = true;
       }
    #undef PATTERN_BUFFER_LENGTH
 
-   strncpy(patternString, (char*)pattern, patternLength);
+   memcpy(patternString, (char *)pattern, patternLength + 1);
 
    /* Slashify the className */
    for (int32_t i = 0; i < patternLength; ++i)
       if (patternString[i] == '.')
          patternString[i] = '/';
-   patternString[patternLength]='\0';
 
    bool threadHadNoVMAccess = (!(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS));
    if (threadHadNoVMAccess)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -286,7 +286,7 @@ public:
 
    static bool createGlobalFrontEnd(J9JITConfig * jitConfig, TR::CompilationInfo * compInfo);
    static TR_J9VMBase * get(J9JITConfig *, J9VMThread *, VM_TYPE vmType=DEFAULT_VM);
-   static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, int32_t, char *, char *, bool suffix=false);
+   static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, size_t, char *, char *, bool suffix=false);
 
    int32_t *getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, bool isVettedForAOT);
    virtual bool stringEquals(TR::Compilation * comp, uintptr_t* stringLocation1, uintptr_t* stringLocation2, int32_t& result);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1064,12 +1064,13 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
       intptr_t featureFlags = generateFeatureFlags(fe);
 
       TR_Version currentVersion;
-      memset(&currentVersion, 0, sizeof(TR_Version));
       currentVersion.structSize = sizeof(TR_Version);
       currentVersion.majorVersion = TR_AOTHeaderMajorVersion;
       currentVersion.minorVersion = TR_AOTHeaderMinorVersion;
-      strncpy(currentVersion.vmBuildVersion, EsBuildVersionString, std::min(strlen(EsBuildVersionString), sizeof(currentVersion.vmBuildVersion) - 1));
-      strncpy(currentVersion.jitBuildVersion, TR_BUILD_NAME, std::min(strlen(TR_BUILD_NAME), sizeof(currentVersion.jitBuildVersion) - 1));
+      strncpy(currentVersion.vmBuildVersion, EsBuildVersionString, sizeof(currentVersion.vmBuildVersion) - 1);
+      currentVersion.vmBuildVersion[sizeof(currentVersion.vmBuildVersion) - 1] = '\0';
+      strncpy(currentVersion.jitBuildVersion, TR_BUILD_NAME, sizeof(currentVersion.jitBuildVersion) - 1);
+      currentVersion.jitBuildVersion[sizeof(currentVersion.jitBuildVersion) - 1] = '\0';
 
       if (hdrInCache->eyeCatcher != TR_AOTHeaderEyeCatcher ||
           currentVersion.structSize != hdrInCache->version.structSize ||
@@ -1144,13 +1145,14 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       aotHeaderVersion->structSize = sizeof(TR_Version);
       aotHeaderVersion->majorVersion = TR_AOTHeaderMajorVersion;
       aotHeaderVersion->minorVersion = TR_AOTHeaderMinorVersion;
-      strncpy(aotHeaderVersion->vmBuildVersion, EsBuildVersionString, sizeof(EsBuildVersionString));
-      strncpy(aotHeaderVersion->jitBuildVersion, TR_BUILD_NAME, std::min(strlen(TR_BUILD_NAME), sizeof(aotHeaderVersion->jitBuildVersion)));
+      strncpy(aotHeaderVersion->vmBuildVersion, EsBuildVersionString, sizeof(aotHeaderVersion->vmBuildVersion) - 1);
+      aotHeaderVersion->vmBuildVersion[sizeof(aotHeaderVersion->vmBuildVersion) - 1] = '\0';
+      strncpy(aotHeaderVersion->jitBuildVersion, TR_BUILD_NAME, sizeof(aotHeaderVersion->jitBuildVersion) - 1);
+      aotHeaderVersion->jitBuildVersion[sizeof(aotHeaderVersion->jitBuildVersion) - 1] = '\0';
 
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
-      
 
       if (J9_ARE_ANY_BITS_SET(javaVM()->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))
          {
@@ -1428,7 +1430,7 @@ TR_JITServerRelocationRuntime::copyDataToCodeCache(const void *startAddress, siz
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 
-/** 
+/**
  * @brief Generate the processor feature string which is stored inside TR_AOTHeader of the SCC
  * @param[in] aotHeaderAddress : the start address of TR_AOTHeader
  * @param[out] buff : store the generated processor feautre string in this buff
@@ -1453,7 +1455,7 @@ printAOTHeaderProcessorFeatures(TR_AOTHeader * hdrInCache, char * buff, const si
    for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
       {
       size_t numberOfBits = CHAR_BIT * sizeof(processorDescription.features[i]);
-      for (int j = 0; j < numberOfBits; j++) 
+      for (int j = 0; j < numberOfBits; j++)
          {
          if (processorDescription.features[i] & (1<<j))
             {

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -62,7 +62,7 @@ extern "C" {
 #define MN_TRUSTED_MODE			-1
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
-/* Private MemberName object init helper 
+/* Private MemberName object init helper
  *
  * Set the MemberName fields based on the refObject given:
  * For j.l.reflect.Field:
@@ -282,12 +282,12 @@ getJ9UTF8SignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObjec
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	char** signatures = (char**)j9mem_allocate_memory((numArgs) * sizeof(char*), OMRMEM_CATEGORY_VM);
+	char** signatures = (char**)j9mem_allocate_memory(numArgs * sizeof(char*), OMRMEM_CATEGORY_VM);
 	if (NULL == signatures) {
 		goto done;
 	}
 
-	memset(signatures, 0, (numArgs) * sizeof(char*));
+	memset(signatures, 0, numArgs * sizeof(char*));
 
 	for (U_32 i = 0; i < numArgs; i++) {
 		j9object_t pObject = J9JAVAARRAYOFOBJECT_LOAD(currentThread, ptypes, i);
@@ -308,9 +308,9 @@ getJ9UTF8SignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObjec
 		if (NULL == rSignature) {
 			goto done;
 		}
-	}
 
-	signatureLength += strlen(rSignature);
+		signatureLength += strlen(rSignature);
+	}
 
 	methodDescriptor = (J9UTF8*)j9mem_allocate_memory(signatureLength + sizeof(J9UTF8), OMRMEM_CATEGORY_VM);
 	if (NULL == methodDescriptor) {
@@ -323,13 +323,13 @@ getJ9UTF8SignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObjec
 	/* Copy class signatures to descriptor string */
 	for (U_32 i = 0; i < numArgs; i++) {
 		UDATA len = strlen(signatures[i]);
-		strncpy(cursor, signatures[i], len);
+		memcpy(cursor, signatures[i], len);
 		cursor += len;
 	}
 
 	*cursor++ = ')';
 	/* Copy return type signature to descriptor string */
-	strncpy(cursor, rSignature, strlen(rSignature));
+	memcpy(cursor, rSignature, strlen(rSignature));
 
 done:
 	j9mem_free_memory(rSignature);
@@ -1257,7 +1257,7 @@ done:
 
 /**
  * static native long objectFieldOffset(MemberName self);  // e.g., returns vmindex
- * 
+ *
  * Returns the objectFieldOffset of the field represented by the MemberName
  * result should be same as if calling Unsafe.objectFieldOffset with the actual field object
  */
@@ -1298,7 +1298,7 @@ Java_java_lang_invoke_MethodHandleNatives_objectFieldOffset(JNIEnv *env, jclass 
 
 /**
  * static native long staticFieldOffset(MemberName self);  // e.g., returns vmindex
- * 
+ *
  * Returns the staticFieldOffset of the field represented by the MemberName
  * result should be same as if calling Unsafe.staticFieldOffset with the actual field object
  */
@@ -1337,7 +1337,7 @@ Java_java_lang_invoke_MethodHandleNatives_staticFieldOffset(JNIEnv *env, jclass 
 
 /**
  * static native Object staticFieldBase(MemberName self);  // e.g., returns clazz
- * 
+ *
  * Returns the staticFieldBase of the field represented by the MemberName
  * result should be same as if calling Unsafe.staticFieldBase with the actual field object
  */
@@ -1374,7 +1374,7 @@ Java_java_lang_invoke_MethodHandleNatives_staticFieldBase(JNIEnv *env, jclass cl
 
 /**
  * static native Object getMemberVMInfo(MemberName self);  // returns {vmindex,vmtarget}
- * 
+ *
  * Return a 2-element java array containing the vm offset/target data
  * For a field MemberName, array contains:
  * 		(field offset, declaring class)
@@ -1595,6 +1595,5 @@ Java_java_lang_invoke_MethodHandleNatives_registerNatives(JNIEnv *env, jclass cl
 {
 	return;
 }
-
 
 } /* extern "C" */


### PR DESCRIPTION
Use of `strncpy(dst, src, strlen(src))` yields a warning.