### PR TITLE
Move f2i, f2l, d2i, d2l evaluators from OMR to OpenJ9

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -573,12 +573,219 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    return instr;
    }
 
+// General float/double convert to long
+//
+TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::SymbolReference *helperSymRef, TR::CodeGenerator *cg)
+   {
+   TR::Compilation *comp = cg->comp();
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 doesn't use this logic");
+
+   TR::Node *child = node->getFirstChild();
+   TR::RegisterDependencyConditions  *deps;
+
+   TR::Register        *doubleReg = cg->evaluate(child);
+   TR::Register        *lowReg    = cg->allocateRegister(TR_GPR);
+   TR::Register        *highReg   = cg->allocateRegister(TR_GPR);
+   TR::RealRegister *espReal   = cg->machine()->getRealRegister(TR::RealRegister::esp);
+
+   deps = generateRegisterDependencyConditions((uint8_t) 0, 3, cg);
+   deps->addPostCondition(lowReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(highReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(doubleReg, TR::RealRegister::NoReg, cg);
+   deps->stopAddingConditions();
+
+   TR::LabelSymbol *reStartLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);   // exit routine label
+   TR::LabelSymbol *CallLabel    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);   // label where long (64-bit) conversion will start
+   TR::LabelSymbol *StartLabel   = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+
+   StartLabel->setStartInternalControlFlow();
+   reStartLabel->setEndInternalControlFlow();
+
+   // Attempt to convert a float/double in an XMM register to an integer using CVTTSS2SI for float
+   // and CVTTSD2SI for double. If the conversion succeeds, put the integer in lowReg and sign-extend
+   // it to highReg. If the conversion fails (the number is too large), call the helper.
+
+   TR_X86OpCodes opcode = child->getOpCode().isDouble() ? CVTTSD2SIReg4Reg : CVTTSS2SIReg4Reg;
+   generateRegRegInstruction(opcode, node, lowReg, doubleReg, cg);
+   generateRegImmInstruction(CMP4RegImm4, node, lowReg, 0x80000000, cg);
+
+   generateLabelInstruction(LABEL, node, StartLabel, cg);
+   generateLabelInstruction(JE4, node, CallLabel, cg);
+
+   generateRegRegInstruction(MOV4RegReg, node, highReg ,lowReg, cg);
+   generateRegImmInstruction(SAR4RegImm1, node, highReg , 31, cg);
+
+   generateLabelInstruction(LABEL, node, reStartLabel, deps, cg);
+
+   TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
+   TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE);
+   d2l->getSymbol()->getMethodSymbol()->setLinkage(TR_Helper);
+   TR::Node::recreate(node, TR::lcall);
+   node->setSymbolReference(d2l);
+   TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::lcall, targetRegister, CallLabel, reStartLabel, cg);
+   cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
+
+   cg->decReferenceCount(child);
+   node->setRegister(targetRegister);
+
+   return targetRegister;
+   }
+
+TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   bool doubleSource;
+   bool longTarget;
+   TR_X86OpCodes cvttOpCode;
+   // On AMD64, all four [fd]2[il] conversions are handled here
+   // On IA32, both [fd]2i conversions are handled here
+   switch (node->getOpCodeValue())
+      {
+      case TR::f2i:
+         cvttOpCode   = CVTTSS2SIReg4Reg;
+         doubleSource = false;
+         longTarget   = false;
+         break;
+      case TR::f2l:
+         cvttOpCode   = CVTTSS2SIReg8Reg;
+         doubleSource = false;
+         longTarget   = true;
+         break;
+      case TR::d2i:
+         cvttOpCode   = CVTTSD2SIReg4Reg;
+         doubleSource = true;
+         longTarget   = false;
+         break;
+      case TR::d2l:
+         cvttOpCode   = CVTTSD2SIReg8Reg;
+         doubleSource = true;
+         longTarget   = true;
+         break;
+      default:
+         TR_ASSERT(0, "Unknown opcode value in f2iEvaluator");
+         break;
+      }
+   TR_ASSERT(cg->comp()->target().is64Bit() || !longTarget, "Incorrect opcode value in f2iEvaluator");
+
+   TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
+
+   TR::Node        *child          = node->getFirstChild();
+   TR::Register    *sourceRegister = NULL;
+   TR::Register    *targetRegister = cg->allocateRegister(TR_GPR);
+   TR::LabelSymbol *startLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *endLabel       = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *exceptionLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+
+   sourceRegister = cg->evaluate(child);
+   if (sourceRegister->getKind() == TR_X87 && child->getReferenceCount() == 1)
+      {
+      TR_ASSERT(cg->comp()->target().is32Bit(), "assertion failure");
+      TR::MemoryReference *tempMR = cg->machine()->getDummyLocalMR(TR::Float);
+      generateFPMemRegInstruction(FSTMemReg, node, tempMR, sourceRegister, cg);
+      generateRegMemInstruction(CVTTSS2SIReg4Mem,
+                                node,
+                                targetRegister,
+                                generateX86MemoryReference(*tempMR, 0, cg), cg);
+      }
+   else
+      {
+      generateRegRegInstruction(cvttOpCode, node, targetRegister, sourceRegister, cg);
+      }
+
+   startLabel->setStartInternalControlFlow();
+   endLabel->setEndInternalControlFlow();
+
+   generateLabelInstruction(LABEL, node, startLabel, cg);
+
+   if (longTarget)
+      {
+      TR_ASSERT(cg->comp()->target().is64Bit(), "We should only get here on AMD64");
+      // We can't compare with 0x8000000000000000.
+      // Instead, rotate left 1 bit and compare with 0x0000000000000001.
+      generateRegInstruction(ROL8Reg1, node, targetRegister, cg);
+      generateRegImmInstruction(CMP8RegImms, node, targetRegister, 1, cg);
+      generateLabelInstruction(JE4, node, exceptionLabel, cg);
+      }
+   else
+      {
+      generateRegImmInstruction(CMP4RegImm4, node, targetRegister, INT_MIN, cg);
+      generateLabelInstruction(JE4, node, exceptionLabel, cg);
+      }
+
+   //TODO: (omr issue #4969): Remove once support for spills in OOL paths is added
+   TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)2, cg);
+   deps->addPostCondition(targetRegister, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
+      {
+      TR_OutlinedInstructionsGenerator og(exceptionLabel, node, cg);
+      // at this point, target is set to -INF and there can only be THREE possible results: -INF, +INF, NaN
+      // compare source with ZERO
+      generateRegMemInstruction(doubleSource ? UCOMISDRegMem : UCOMISSRegMem,
+                                node,
+                                sourceRegister,
+                                generateX86MemoryReference(doubleSource ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0), cg),
+                                cg);
+      // load max int if source is positive, note that for long case, LLONG_MAX << 1 is loaded as it will be shifted right
+      generateRegMemInstruction(CMOVARegMem(longTarget),
+                                node,
+                                targetRegister,
+                                generateX86MemoryReference(longTarget ? cg->findOrCreate8ByteConstant(node, LLONG_MAX << 1) : cg->findOrCreate4ByteConstant(node, INT_MAX), cg),
+                                cg);
+      // load zero if source is NaN
+      generateRegMemInstruction(CMOVPRegMem(longTarget),
+                                node,
+                                targetRegister,
+                                generateX86MemoryReference(longTarget ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0), cg),
+                                cg);
+
+      generateLabelInstruction(JMP4, node, endLabel, cg);
+      og.endOutlinedInstructionSequence();
+      }
+
+   generateLabelInstruction(LABEL, node, endLabel, deps, cg);
+   if (longTarget)
+      {
+      generateRegInstruction(ROR8Reg1, node, targetRegister, cg);
+      }
+
+   if (sourceRegister &&
+       sourceRegister->getKind() == TR_X87 &&
+       child->getReferenceCount() == 1)
+      {
+      generateFPSTiST0RegRegInstruction(FSTRegReg, node, sourceRegister, sourceRegister, cg);
+      }
+
+   node->setRegister(targetRegister);
+   cg->decReferenceCount(child);
+   return targetRegister;
+   }
+
+TR::Register *J9::X86::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong), cg);
+   }
+
+TR::Register *J9::X86::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
+
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong), cg);
+   }
+
 /*
  * J9 X86 specific tree evaluator table overrides
  */
 extern void TEMPORARY_initJ9X86TreeEvaluatorTable(TR::CodeGenerator *cg)
    {
    TR_TreeEvaluatorFunctionPointer *tet = cg->getTreeEvaluatorTable();
+   tet[TR::f2i] =                   TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::f2iu] =                  TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::f2l] =                   TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::f2lu] =                  TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::d2i] =                   TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::d2iu] =                  TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::d2l] =                   TR::TreeEvaluator::f2iEvaluator;
+   tet[TR::d2lu] =                  TR::TreeEvaluator::f2iEvaluator;
    tet[TR::monent] =                TR::TreeEvaluator::monentEvaluator;
    tet[TR::monexit] =               TR::TreeEvaluator::monexitEvaluator;
    tet[TR::monexitfence] =          TR::TreeEvaluator::monexitfenceEvaluator;
@@ -628,6 +835,10 @@ extern void TEMPORARY_initJ9X86TreeEvaluatorTable(TR::CodeGenerator *cg)
 
 #if defined(TR_TARGET_32BIT)
    // 32-bit overrides
+   tet[TR::f2l] =                   TR::TreeEvaluator::f2lEvaluator;
+   tet[TR::f2lu] =                  TR::TreeEvaluator::f2lEvaluator;
+   tet[TR::d2l] =                   TR::TreeEvaluator::d2lEvaluator;
+   tet[TR::d2lu =                   TR::TreeEvaluator::d2lEvaluator;
    tet[TR::ldiv] =                  TR::TreeEvaluator::integerPairDivEvaluator;
    tet[TR::lrem] =                  TR::TreeEvaluator::integerPairRemEvaluator;
 #endif

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,7 +154,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *generateConcurrentScavengeSequence(TR::Node *node, TR::CodeGenerator *cg);
-
+   static TR::Register *fpConvertToLong(TR::Node *node, TR::SymbolReference *helperSymRef, TR::CodeGenerator *cg);
+   static TR::Register *f2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    class CaseConversionManager;
    static TR::Register *stringCaseConversionHelper(TR::Node *node, TR::CodeGenerator *cg, CaseConversionManager& manager);
 


### PR DESCRIPTION
Signed-off-by: BradleyWood <bradley.wood@ibm.com>