### PR TITLE
Properly free ROMClass when caching at the JITServer fails

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -875,13 +875,7 @@ TR::CompilationInfoPerThread::getAndCacheRemoteROMClass(J9Class *clazz, TR_Memor
       JITServerHelpers::ClassInfoTuple classInfoTuple;
       TR_Memory *currentMemory = trMemory ? trMemory : TR::comp()->trMemory();
       romClass = JITServerHelpers::getRemoteROMClass(clazz, getStream(), currentMemory, &classInfoTuple);
-      bool cached = JITServerHelpers::cacheRemoteROMClass(getClientData(), clazz, romClass, &classInfoTuple);
-      if (!cached)
-         {
-         currentMemory->trPersistentMemory()->freePersistentMemory(romClass);
-         // return the ROM class from cache
-         romClass = getRemoteROMClassIfCached(clazz);
-         }
+      romClass = JITServerHelpers::cacheRemoteROMClassOrFreeIt(getClientData(), clazz, romClass, &classInfoTuple, currentMemory->trPersistentMemory());
       TR_ASSERT_FATAL(romClass, "ROM class of J9Class=%p must be cached at this point", clazz);
       }
    return romClass;

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -72,7 +72,8 @@ class JITServerHelpers
       >;
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory, bool serializeClass);
-   static bool cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
+   static void freeRemoteROMClass(J9ROMClass *romClass, TR_PersistentMemory *persistentMemory);
+   static J9ROMClass *cacheRemoteROMClassOrFreeIt(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, TR_PersistentMemory *persistentMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
    static J9ROMClass *getRemoteROMClass(J9Class *, JITServer::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -417,10 +417,7 @@ ClientSessionData::ClassInfo::ClassInfo() :
 void
 ClientSessionData::ClassInfo::freeClassInfo(TR_PersistentMemory *persistentMemory)
    {
-   if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
-      cache->release(_romClass);
-   else
-      persistentMemory->freePersistentMemory(_romClass);
+   JITServerHelpers::freeRemoteROMClass(_romClass, persistentMemory);
 
    // free cached _interfaces
    _interfaces->~PersistentVector<TR_OpaqueClassBlock *>();


### PR DESCRIPTION
JITServer caches class information sent by the JVM clients in order to
reduce client-server network communication. This is done in a two step
operation: (1) First we allocate space for the ROMClass data structure
using persistent memory; (2) Then we acquire a lock and cache the class
information.
Due to a race condition, it is possible that, by the time we allocated
and initialized the ROMClass copy, another thread already inserted a copy
into the cache. If that happens, we just have to deallocate the newly
created ROMClass copy.
The bug solved by this commit revolves around how to the perform the
deallocation: if the server uses a global cache of ROMClasses (shared
among all the clients) then we have to use routines specific to this
global cache, rather than just calling persistentFree.

Fixes: #12701

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>