### PR TITLE
Improve JITServer::MessageBuffer capacity expansion mechanism

### DIFF
--- a/runtime/compiler/net/MessageBuffer.hpp
+++ b/runtime/compiler/net/MessageBuffer.hpp
@@ -183,29 +183,34 @@ public:
    /**
       @brief Expand the underlying buffer if more than allocated memory is needed.
 
-      If requiredSize is greater than _capacity, allocates a new buffer of size
-      requiredSize * 2 (to prevent frequent reallocations),
-      copies all existing data based on _curPtr location to the new buffer,
-      and frees the old buffer.
-
       @param requiredSize the number of bytes the buffer needs to fit.
    */
    void expandIfNeeded(uint32_t requiredSize);
 
    /**
-      @brief Expand the underlying buffer to requiredSize and copy numBytesToCopy
+      @brief Expand the underlying buffer to fit requiredSize and copy numBytesToCopy
       from the old buffer to the new buffer when requiredSize is greater than
       the capacity, and free the old buffer.
+
+      If requiredSize is greater than _capacity, allocates a new buffer that can fit requiredSize
+      bytes rounded up to the nearest power of 2,
+      copies all existing data based on _curPtr location to the new buffer,
+      and frees the old buffer.
+
+      @param requiredSize the number of bytes the buffer needs to fit.
+      @param numBytesToCopy the number of bytes that need to be copied over from the old buffer
    */
    void expand(uint32_t requiredSize, uint32_t numBytesToCopy);
 
    uint32_t getCapacity() const { return _capacity; }
 
+
 private:
-   static const size_t INITIAL_BUFFER_SIZE = 18000;
+   static const size_t INITIAL_BUFFER_SIZE = 32768; // Initial buffer size is 32K
    uint32_t offset(char *addr) const { return addr - _storage; }
    char *allocateMemory(uint32_t capacity) { return static_cast<char *>(_allocator.allocate(capacity)); }
    void freeMemory(char *storage) { _allocator.deallocate(storage); }
+   uint32_t computeRequiredCapacity(uint32_t requiredSize);
 
    uint32_t _capacity;
    char *_storage;


### PR DESCRIPTION
Message buffers store data that is exchanged between the server
and the client. When a message that is too big for the current buffer
is sent/received, `MessageBuffer::expandIfNeeded` or
`MessageBuffer::expand`
is called. These methods allocate a new, larger buffer and copy
any existing data over.

Previously, `MessageBuffer::expandIfNeeded` reallocated buffer to twice
the required size, and `MessageBuffer::expand` to exactly the required
size.
This leads to fragmentation of global persistent memory, as memory
blocks of arbitrary sizes cannot be easily reused for future allocations.

This commit sets the default buffer size to 32K, and all subsequent
expansions are done to the size of the nearest power of 2. This ensures
that memory allocations are standardized. Once a large buffer is freed,
subsequent large allocations will be able to reuse the
same memory block, while smaller allocations will split the block
into more reusable chunks, reducing fragmentation.