### PR TITLE
Adopt TR::InstOpCode on x86

### DIFF
--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/OMRSnippet.cpp \
     omr/compiler/x/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/x/codegen/OMRX86Instruction.cpp \
-    omr/compiler/x/codegen/OpNames.cpp \
     omr/compiler/x/codegen/OutlinedInstructions.cpp \
     omr/compiler/x/codegen/RegisterRematerialization.cpp \
     omr/compiler/x/codegen/SIMDTreeEvaluator.cpp \

--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -36,13 +36,13 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/OMRLinkage.cpp \
     omr/compiler/x/codegen/OMRMachine.cpp \
     omr/compiler/x/codegen/OMRMemoryReference.cpp \
+    omr/compiler/x/codegen/OMRInstOpCode.cpp \
     omr/compiler/x/codegen/OMRRealRegister.cpp \
     omr/compiler/x/codegen/OMRRegister.cpp \
     omr/compiler/x/codegen/OMRRegisterDependency.cpp \
     omr/compiler/x/codegen/OMRSnippet.cpp \
     omr/compiler/x/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/x/codegen/OMRX86Instruction.cpp \
-    omr/compiler/x/codegen/OpBinary.cpp \
     omr/compiler/x/codegen/OpNames.cpp \
     omr/compiler/x/codegen/OutlinedInstructions.cpp \
     omr/compiler/x/codegen/RegisterRematerialization.cpp \

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -163,7 +163,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
       // adjust sp is necessary, because for java, the stack is native stack, not java stack.
       // we need to restore native stack sp properly to the correct place.
       TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
-      TR_X86OpCodes op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? ADDRegImms() : ADDRegImm4();
+      TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? ADDRegImms() : ADDRegImm4();
       generateRegImmInstruction(op, callNode, espReal, memoryArgSize, cg());
       }
 

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -236,7 +236,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(
       if ((adjustedMemoryArgSize % 16) != 0)
          memoryArgSize += 8;
 
-      TR_X86OpCodes op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? SUBRegImms() : SUBRegImm4();
+      TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? SUBRegImms() : SUBRegImm4();
       generateRegImmInstruction(op, callNode, espReal, memoryArgSize, cg());
       }
 
@@ -799,7 +799,7 @@ J9::X86::AMD64::JNILinkage::generateMethodDispatch(
 
       if (cleanUpSize != 0)
          {
-         TR_X86OpCodes op = (cleanUpSize >= -128 && cleanUpSize <= 127) ? ADDRegImms() : ADDRegImm4();
+         TR::InstOpCode::Mnemonic op = (cleanUpSize >= -128 && cleanUpSize <= 127) ? ADDRegImms() : ADDRegImm4();
          generateRegImmInstruction(op, callNode, espReal, cleanUpSize, cg());
          }
       }
@@ -825,7 +825,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
    //    scratch2 <-> NoReg
    //    scratch3 <-> NoReg
    //
-   TR_X86OpCodes op;
+   TR::InstOpCode::Mnemonic op;
 
    TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
    TR::Register *scratchReg1 = cg()->allocateRegister();
@@ -951,7 +951,7 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
    TR::LabelSymbol *longReacquireSnippetLabel = generateLabelSymbol(cg());
    TR::LabelSymbol *longReacquireRestartLabel = generateLabelSymbol(cg());
 
-   TR_X86OpCodes op = comp()->target().isSMP() ? LCMPXCHGMemReg() : CMPXCHGMemReg(cg());
+   TR::InstOpCode::Mnemonic op = comp()->target().isSMP() ? LCMPXCHGMemReg() : CMPXCHGMemReg(cg());
    generateMemRegInstruction(
       op,
       callNode,
@@ -1075,7 +1075,7 @@ void J9::X86::AMD64::JNILinkage::cleanupReturnValue(
       // Native and JNI methods may not return a full register in some cases so we need to get the declared
       // type so that we sign and zero extend the narrower integer return types properly.
       //
-      TR_X86OpCodes op;
+      TR::InstOpCode::Mnemonic op;
       TR::SymbolReference      *callSymRef = callNode->getSymbolReference();
       TR::ResolvedMethodSymbol *callSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
       TR_ResolvedMethod *resolvedMethod = callSymbol->getResolvedMethod();

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -267,7 +267,7 @@ J9::X86::AMD64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
 static uint8_t *flushArgument(
       uint8_t*cursor,
-      TR_X86OpCodes op,
+      TR::InstOpCode::Mnemonic op,
       TR::RealRegister::RegNum regIndex,
       int32_t offset,
       TR::CodeGenerator *cg)
@@ -304,7 +304,7 @@ static uint8_t *flushArgument(
    }
 
 static int32_t flushArgumentSize(
-      TR_X86OpCodes op,
+      TR::InstOpCode::Mnemonic op,
       int32_t offset)
    {
    int32_t size = TR::InstOpCode(op).length() + 1;   // length including ModRM + 1 SIB
@@ -333,7 +333,7 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::flushArguments(
       offset += sizeof(intptr_t);
 
    TR::RealRegister::RegNum reg = TR::RealRegister::NoReg;
-   TR_X86OpCodes            op  = BADIA32Op;
+   TR::InstOpCode::Mnemonic            op  = BADIA32Op;
    TR::DataType            dt  = TR::NoType;
 
    if (calculateSizeOnly)
@@ -414,7 +414,7 @@ J9::X86::AMD64::PrivateLinkage::generateFlushInstruction(
 
    // Opcode
    //
-   TR_X86OpCodes opCode = TR::Linkage::movOpcodes(operandType, movType(dataType));
+   TR::InstOpCode::Mnemonic opCode = TR::Linkage::movOpcodes(operandType, movType(dataType));
 
    // Registers
    //
@@ -1143,7 +1143,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
          }
       else
          {
-         TR_X86OpCodes op = picSlot.needsShortConditionalBranch() ? JNE1 : JNE4;
+         TR::InstOpCode::Mnemonic op = picSlot.needsShortConditionalBranch() ? JNE1 : JNE4;
          generateLabelInstruction(op, node, mismatchLabel, cg());
          }
       }
@@ -1155,7 +1155,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
          }
       else
          {
-         TR_X86OpCodes op = picSlot.needsShortConditionalBranch() ? JE1 : JE4;
+         TR::InstOpCode::Mnemonic op = picSlot.needsShortConditionalBranch() ? JE1 : JE4;
          generateLabelInstruction(op, node, mismatchLabel, cg());
          }
       }

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -46,7 +46,7 @@
 #include "x/codegen/CheckFailureSnippet.hpp"
 #include "x/codegen/HelperCallSnippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
-#include "x/codegen/X86Ops.hpp"
+#include "codegen/InstOpCode.hpp"
 #include "x/codegen/X86Ops_inlines.hpp"
 
 ////////////////////////////////////////////////

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -274,7 +274,7 @@ static uint8_t *flushArgument(
       TR::CodeGenerator *cg)
    {
    /* TODO:AMD64: Share code with the other flushArgument */
-   cursor = TR_X86OpCode(op).binary(cursor);
+   cursor = TR::InstOpCode(op).binary(cursor);
 
    // Mod | Reg | R/M
    //
@@ -308,7 +308,7 @@ static int32_t flushArgumentSize(
       TR_X86OpCodes op,
       int32_t offset)
    {
-   int32_t size = TR_X86OpCode(op).length() + 1;   // length including ModRM + 1 SIB
+   int32_t size = TR::InstOpCode(op).length() + 1;   // length including ModRM + 1 SIB
    return size + (((offset >= -128 && offset <= 127)) ? 1 : 4);
    }
 

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -47,7 +47,6 @@
 #include "x/codegen/HelperCallSnippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
 #include "codegen/InstOpCode.hpp"
-#include "x/codegen/X86Ops_inlines.hpp"
 
 ////////////////////////////////////////////////
 //

--- a/runtime/compiler/x/codegen/Instruction.hpp
+++ b/runtime/compiler/x/codegen/Instruction.hpp
@@ -38,17 +38,17 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
    /*
     * Generic constructors
     */
-   inline Instruction(TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg);
+   inline Instruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
-   inline Instruction(TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
+   inline Instruction(TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
 
    /*
     * X86 specific constructors, need to call initializer to perform proper construction
     */
-   inline Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg);
+   inline Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
-   inline Instruction(TR::RegisterDependencyConditions *cond, TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
+   inline Instruction(TR::RegisterDependencyConditions *cond, TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    };
 
@@ -56,21 +56,21 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
 
 #include "codegen/J9Instruction_inlines.hpp"
 
-TR::Instruction::Instruction(TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg) :
+TR::Instruction::Instruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg) :
    J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->initialize();
    }
 
-TR::Instruction::Instruction(TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
+TR::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
    J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
    {
    self()->setOpCodeValue(op);
    self()->initialize();
    }
 
-TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg) :
+TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg) :
    J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
@@ -78,7 +78,7 @@ TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *n
    self()->initialize(cg, cond, op, true);
    }
 
-TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
+TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
    J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
    {
    self()->setOpCodeValue(op);

--- a/runtime/compiler/x/codegen/Instruction.hpp
+++ b/runtime/compiler/x/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/Instruction.hpp
+++ b/runtime/compiler/x/codegen/Instruction.hpp
@@ -57,21 +57,21 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
 #include "codegen/J9Instruction_inlines.hpp"
 
 TR::Instruction::Instruction(TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg) :
-   J9::InstructionConnector(cg, TR::InstOpCode::BAD, node)
+   J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->initialize();
    }
 
 TR::Instruction::Instruction(TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
-   J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::BAD)
+   J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
    {
    self()->setOpCodeValue(op);
    self()->initialize();
    }
 
 TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR_X86OpCodes op, TR::CodeGenerator *cg) :
-   J9::InstructionConnector(cg, TR::InstOpCode::BAD, node)
+   J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->setDependencyConditions(cond);
@@ -79,7 +79,7 @@ TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *n
    }
 
 TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR_X86OpCodes op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
-   J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::BAD)
+   J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
    {
    self()->setOpCodeValue(op);
    self()->setDependencyConditions(cond);

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -56,7 +56,7 @@ void J9LinkageUtils::cleanupReturnValue(
       // Native and JNI methods may not return a full register in some cases so we need to get the declared
       // type so that we sign and zero extend the narrower integer return types properly.
       //
-      TR_X86OpCodes op;
+      TR::InstOpCode::Mnemonic op;
       TR::ResolvedMethodSymbol *callSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
       TR_ResolvedMethod *resolvedMethod = callSymbol->getResolvedMethod();
       TR::Compilation *comp = cg->comp();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -257,7 +257,7 @@ static TR_OutlinedInstructions *generateArrayletReference(
 
       if (!indexReg)
          {
-         TR_X86OpCodes op = (indexValue >= -128 && indexValue <= 127) ? CMP4MemImms : CMP4MemImm4;
+         TR::InstOpCode::Mnemonic op = (indexValue >= -128 && indexValue <= 127) ? CMP4MemImms : CMP4MemImm4;
          generateMemImmInstruction(op, node, arraySizeMR, indexValue, cg);
          }
       else
@@ -327,7 +327,7 @@ static TR_OutlinedInstructions *generateArrayletReference(
    //
    if (indexReg)
       {
-      TR_X86OpCodes op = comp->target().is64Bit() ? MOVSXReg8Reg4 : MOVRegReg();
+      TR::InstOpCode::Mnemonic op = comp->target().is64Bit() ? MOVSXReg8Reg4 : MOVRegReg();
       generateRegRegInstruction(op, node, scratchReg, indexReg, cg);
 
       int32_t spineShift = fej9->getArraySpineShift(elementSize);
@@ -349,7 +349,7 @@ static TR_OutlinedInstructions *generateArrayletReference(
       spineMR = generateX86MemoryReference(baseArrayReg, spineDisp32, cg);
       }
 
-   TR_X86OpCodes op = (spinePointerSize == 8) ? L8RegMem : L4RegMem;
+   TR::InstOpCode::Mnemonic op = (spinePointerSize == 8) ? L8RegMem : L4RegMem;
    generateRegMemInstruction(op, node, scratchReg, spineMR, cg);
 
    // Decompress the arraylet pointer from the spine.
@@ -392,7 +392,7 @@ static TR_OutlinedInstructions *generateArrayletReference(
 
    if (!actualLoadOrStoreOrArrayElementNode->getOpCode().isStore())
       {
-      TR_X86OpCodes op;
+      TR::InstOpCode::Mnemonic op;
 
       TR::MemoryReference *highArrayletMR = NULL;
       TR::Register *highRegister = NULL;
@@ -469,7 +469,7 @@ static TR_OutlinedInstructions *generateArrayletReference(
          {
          // movE [S + S2], value
          //
-         TR_X86OpCodes op;
+         TR::InstOpCode::Mnemonic op;
          bool needStore = true;
 
          switch (dt)
@@ -724,7 +724,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
       {
       int32_t      value            = secondChild->getInt();
       TR::Node     *firstChild       = testNode->getFirstChild();
-      TR_X86OpCodes opCode;
+      TR::InstOpCode::Mnemonic opCode;
       if (value >= -128 && value <= 127)
          opCode = CMP4MemImms;
       else
@@ -842,7 +842,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
       // Try to compare memory directly with immediate
       //
       TR::MemoryReference * memRef = generateX86MemoryReference(testNode->getFirstChild(), cg);
-      TR_X86OpCodes op;
+      TR::InstOpCode::Mnemonic op;
 
       if (testIs64Bit)
          {
@@ -1117,7 +1117,7 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
       else
          {
          int32_t value = secondChild->getInt();
-         TR_X86OpCodes op = (value < 127 && value >= -128) ? CMPMemImms() : CMPMemImm4();
+         TR::InstOpCode::Mnemonic op = (value < 127 && value >= -128) ? CMPMemImms() : CMPMemImm4();
          TR::X86CheckAsyncMessagesMemImmInstruction *ins =
             generateCheckAsyncMessagesInstruction(node, op, mr, value, cg);
          }
@@ -1841,7 +1841,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(
          if (!appendTo)
              appendTo = cg->getAppendInstruction();
 
-         TR_X86OpCodes op = CMPMemImms();
+         TR::InstOpCode::Mnemonic op = CMPMemImms();
          appendTo = generateMemImmInstruction(appendTo, op, tempMR, NULLVALUE, cg);
          tempMR->decNodeReferenceCounts(cg);
          needLateEvaluation = false;
@@ -2160,7 +2160,7 @@ static bool isInteger(TR::ILOpCode &op, TR::CodeGenerator *cg)
    }
 
 
-static TR_X86OpCodes branchOpCodeForCompare(TR::ILOpCode &op, bool opposite=false)
+static TR::InstOpCode::Mnemonic branchOpCodeForCompare(TR::ILOpCode &op, bool opposite=false)
    {
    int32_t index = 0;
    if (op.isCompareTrueIfLess())
@@ -2175,7 +2175,7 @@ static TR_X86OpCodes branchOpCodeForCompare(TR::ILOpCode &op, bool opposite=fals
    if (opposite)
       index ^= 7;
 
-   static const TR_X86OpCodes opTable[] =
+   static const TR::InstOpCode::Mnemonic opTable[] =
       {
       BADIA32Op,  JL4,  JG4,  JNE4,
       JE4,        JLE4, JGE4, BADIA32Op,
@@ -2862,7 +2862,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
    // that the array bound is a constant, and lowered TR::arraylength into an
    // iconst.  In this case, make sure that the constant is the second child.
    //
-   TR_X86OpCodes branchOpCode;
+   TR::InstOpCode::Mnemonic branchOpCode;
 
    // For primitive stores anchored under the check node, we must evaluate the source node
    // before the bound check branch so that its available to the snippet.  We can make
@@ -4378,7 +4378,7 @@ J9::X86::TreeEvaluator::generateCheckForValueMonitorEnterOrExit(
    auto fej9 = (TR_J9VMBase *)(cg->fe());
    TR::MemoryReference *classFlagsMR = generateX86MemoryReference(j9classReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
 
-   TR_X86OpCodes testOpCode;
+   TR::InstOpCode::Mnemonic testOpCode;
    if ((uint32_t)classFlag <= USHRT_MAX)
       testOpCode = TEST2MemImm2;
    else
@@ -4583,7 +4583,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    //    label   restartLabel
    //
    TR::Register *lockedReg = NULL;
-   TR_X86OpCodes op = BADIA32Op;
+   TR::InstOpCode::Mnemonic op = BADIA32Op;
 
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
@@ -4719,7 +4719,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          // Otherwise we'll necessarily call the helper.
          generateLabelInstruction(LABEL, node, mismatchLabel, cg);
 
-         TR_X86OpCodes cmpOp = CMPMemImms();
+         TR::InstOpCode::Mnemonic cmpOp = CMPMemImms();
          if (cg->comp()->target().is64Bit() && fej9->generateCompressedLockWord())
             cmpOp = CMP4MemImms;
 
@@ -4757,8 +4757,8 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          }
       else
          {
-         TR_X86OpCodes loadOp = LRegMem();
-         TR_X86OpCodes testOp = TESTRegImm4();
+         TR::InstOpCode::Mnemonic loadOp = LRegMem();
+         TR::InstOpCode::Mnemonic testOp = TESTRegImm4();
          if (cg->comp()->target().is64Bit() && fej9->generateCompressedLockWord())
             {
             loadOp = L4RegMem;
@@ -5212,7 +5212,7 @@ TR::Register
    generateLabelInstruction(JNE4, node, snippetLabel, cg);
 
 
-   TR_X86OpCodes op = cg->comp()->target().isSMP() ? LCMPXCHGMemReg(gen64BitInstr) : CMPXCHGMemReg(gen64BitInstr);
+   TR::InstOpCode::Mnemonic op = cg->comp()->target().isSMP() ? LCMPXCHGMemReg(gen64BitInstr) : CMPXCHGMemReg(gen64BitInstr);
 
    // compare-and-swap to unlock:
    generateRegRegInstruction(XORRegReg(), node, eaxReal, eaxReal, cg);
@@ -5322,7 +5322,7 @@ TR::Register
       generateRegRegInstruction(XORRegReg(), node, unlockedReg, unlockedReg, cg);
       generateRegImmInstruction(MOVRegImm4(), node, eaxReal, INC_DEC_VALUE, cg);
 
-      TR_X86OpCodes op = cg->comp()->target().isSMP() ? LCMPXCHGMemReg(gen64BitInstr) : CMPXCHGMemReg(gen64BitInstr);
+      TR::InstOpCode::Mnemonic op = cg->comp()->target().isSMP() ? LCMPXCHGMemReg(gen64BitInstr) : CMPXCHGMemReg(gen64BitInstr);
       cg->setImplicitExceptionPoint(generateMemRegInstruction(op, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), unlockedReg, cg));
       numDeps += 2;
       }
@@ -5805,7 +5805,7 @@ static void genHeapAlloc(
          generateLabelInstruction(JAE4, node, failLabel, cg);
 
          // we have an object in eaxReal, now bump the current updatepointer
-         TR_X86OpCodes opcode;
+         TR::InstOpCode::Mnemonic opcode;
          uint32_t cellSize = fej9->getCellSizeForSizeClass(sizeClass);
          if (cellSize <= 127)
             opcode = ADDMemImms();
@@ -6652,7 +6652,7 @@ static void genInitObjectHeader(TR::Node             *node,
    //
    // --------------------------------------------------------------------------------
    //
-   TR_X86OpCodes opSMemReg = SMemReg(use64BitClasses);
+   TR::InstOpCode::Mnemonic opSMemReg = SMemReg(use64BitClasses);
 
    TR::Register * clzReg = classReg;
 
@@ -6849,7 +6849,7 @@ static void genInitArrayHeader(
          {
          // Native 64-bit needs to cover the discontiguous size field
          //
-         TR_X86OpCodes storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? S8MemReg : S4MemReg;
+         TR::InstOpCode::Mnemonic storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? S8MemReg : S4MemReg;
          generateMemRegInstruction(storeOp, node, arraySizeMR, sizeReg, cg);
          }
       else
@@ -6871,7 +6871,7 @@ static void genInitArrayHeader(
          {
          // Native 64-bit needs to cover the discontiguous size field
          //
-         TR_X86OpCodes storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? S8MemImm4 : S4MemImm4;
+         TR::InstOpCode::Mnemonic storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? S8MemImm4 : S4MemImm4;
          instanceSize = node->getFirstChild()->getInt();
          generateMemImmInstruction(storeOp, node, arraySizeMR, instanceSize, cg);
          }
@@ -6892,7 +6892,7 @@ static void genInitArrayHeader(
    if (generateArraylets)
       {
       // write arraylet pointer
-      TR_X86OpCodes storeOp;
+      TR::InstOpCode::Mnemonic storeOp;
 
       generateRegMemInstruction(
          LEARegMem(), node,
@@ -7281,11 +7281,11 @@ static bool genZeroInitObject(
 
       if (initLw)
          {
-         TR_X86OpCodes op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemReg : SMemReg();
+         TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemReg : SMemReg();
          generateMemRegInstruction(op, node, generateX86MemoryReference(segmentReg, lwOffset-startOfZeroInits, cg), targetReg, cg);
          }
 
-      TR_X86OpCodes op = comp->target().is64Bit() ? REPSTOSQ : REPSTOSD;
+      TR::InstOpCode::Mnemonic op = comp->target().is64Bit() ? REPSTOSQ : REPSTOSD;
       generateInstruction(op, node, cg);
 
       if (comp->target().is64Bit())
@@ -7310,7 +7310,7 @@ static bool genZeroInitObject(
 
       if (initLw)
          {
-         TR_X86OpCodes op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemReg : SMemReg();
+         TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemReg : SMemReg();
          generateMemRegInstruction(op, node, generateX86MemoryReference(targetReg, lwOffset, cg), tempReg, cg);
          }
       }
@@ -7322,7 +7322,7 @@ static bool genZeroInitObject(
 
       if (initLw)
          {
-         TR_X86OpCodes op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemImm4 : SMemImm4();
+         TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? S4MemImm4 : SMemImm4();
          generateMemImmInstruction(op, node, generateX86MemoryReference(targetReg, lwOffset, cg), 0, cg);
          }
       return false;
@@ -8523,7 +8523,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
       // Neither object is known to be an array
       // Check that object 1 is an array. If not, throw exception.
       //
-      TR_X86OpCodes testOpCode;
+      TR::InstOpCode::Mnemonic testOpCode;
       if ((J9AccClassRAMArray >= CHAR_MIN) && (J9AccClassRAMArray <= CHAR_MAX))
          testOpCode = TEST1MemImm1;
       else
@@ -8611,7 +8611,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
          {
          // Check that object 2 is an array. If not, throw exception.
          //
-         TR_X86OpCodes testOpCode;
+         TR::InstOpCode::Mnemonic testOpCode;
          if ((J9AccClassRAMArray >= CHAR_MIN) && (J9AccClassRAMArray <= CHAR_MAX))
             testOpCode = TEST1MemImm1;
          else
@@ -9472,7 +9472,7 @@ inlineCompareAndSwapNative(
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-   TR_X86OpCodes op;
+   TR::InstOpCode::Mnemonic op;
 
    if (TR::Compiler->om.canGenerateArraylets() && !node->isUnsafeGetPutCASCallOnNonArray())
       return false;
@@ -9999,7 +9999,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
  * Note that RealTimeGC is handled separately in a different method.
  */
 static void generateWriteBarrierCall(
-   TR_X86OpCodes          branchOp,
+   TR::InstOpCode::Mnemonic          branchOp,
    TR::Node*              node,
     MM_GCWriteBarrierType gcMode,
    TR::Register*          owningObjectReg,
@@ -10741,7 +10741,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
       {
       static char *disableWrtbarOpt = feGetEnv("TR_DisableWrtbarOpt");
 
-      TR_X86OpCodes branchOp;
+      TR::InstOpCode::Mnemonic branchOp;
       auto gcModeForSnippet = gcMode;
 
       bool skipSnippetIfSrcNotOld = false;
@@ -10898,7 +10898,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
             }
 
          branchOp = skipSnippetIfOld ? JB4 : JAE4;  // For branch to snippet
-         TR_X86OpCodes reverseBranchOp = skipSnippetIfOld ? JAE4 : JB4;  // For branch past snippet
+         TR::InstOpCode::Mnemonic reverseBranchOp = skipSnippetIfOld ? JAE4 : JB4;  // For branch past snippet
 
          // Now performing check for remembered
          if (skipSnippetIfDestRemembered)
@@ -10963,7 +10963,7 @@ doReferenceStore(
    TR::CodeGenerator      *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR_X86OpCodes storeOp = usingCompressedPointers ? S4MemReg : SMemReg();
+   TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? S4MemReg : SMemReg();
    TR::Instruction *instr = generateMemRegInstruction(storeOp, node, storeMR, sourceReg, cg);
 
    // for real-time GC, the data reference has already been resolved into an earlier LEA instruction so this padding isn't needed

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9901,7 +9901,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             {
             if (comp->target().cpu.supportsMFence())
                {
-               TR_X86OpCode fenceOp;
+               TR::InstOpCode fenceOp;
                fenceOp.setOpCodeValue(MFENCE);
                generateInstruction(fenceOp.getOpCodeValue(), node, cg);
                }
@@ -9915,7 +9915,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             if (comp->target().cpu.requiresLFence() &&
                 comp->target().cpu.supportsLFence())
                {
-               TR_X86OpCode fenceOp;
+               TR::InstOpCode fenceOp;
                fenceOp.setOpCodeValue(LFENCE);
                generateInstruction(fenceOp.getOpCodeValue(), node, cg);
                }
@@ -9928,7 +9928,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             {
             if (comp->target().cpu.supportsSFence())
                {
-               TR_X86OpCode fenceOp;
+               TR::InstOpCode fenceOp;
                fenceOp.setOpCodeValue(SFENCE);
                generateInstruction(fenceOp.getOpCodeValue(), node, cg);
                }

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -382,7 +382,7 @@ J9::X86::UnresolvedDataSnippet::emitConstantPoolIndex(uint8_t *cursor)
    if (!comp->getOption(TR_DisableNewX86VolatileSupport) && getDataReferenceInstruction() != NULL)
       {
       TR::Instruction *dataRefInst = getDataReferenceInstruction();
-      TR_X86OpCodes opCode = dataRefInst->getOpCode().getOpCodeValue();
+      TR::InstOpCode::Mnemonic opCode = dataRefInst->getOpCode().getOpCodeValue();
 
       // If this is a store operation on an unresolved field, set the volatility check flag.
       //

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -40,7 +40,7 @@
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "x/codegen/X86Instruction.hpp"
-#include "x/codegen/X86Ops.hpp"
+#include "codegen/InstOpCode.hpp"
 #include "x/codegen/X86Ops_inlines.hpp"
 
 J9::X86::UnresolvedDataSnippet::UnresolvedDataSnippet(

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -41,7 +41,6 @@
 #include "runtime/J9Runtime.hpp"
 #include "x/codegen/X86Instruction.hpp"
 #include "codegen/InstOpCode.hpp"
-#include "x/codegen/X86Ops_inlines.hpp"
 
 J9::X86::UnresolvedDataSnippet::UnresolvedDataSnippet(
       TR::CodeGenerator *cg,

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -110,7 +110,7 @@ J9::X86::UnresolvedDataSnippet::emitSnippetBody()
 
    if (!stackMapInstr)
       {
-      return TR_X86OpCode(BADIA32Op).binary(cursor);
+      return TR::InstOpCode(BADIA32Op).binary(cursor);
       }
 
    _glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -32,7 +32,7 @@
 #include "codegen/X86Instruction.hpp"
 #include "codegen/Snippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
-#include "x/codegen/X86Ops.hpp"
+#include "codegen/InstOpCode.hpp"
 #include "x/codegen/X86Ops_inlines.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -38,7 +38,7 @@
 // TR::X86MemImmSnippetInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR_X86OpCodes                op,
+TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR::InstOpCode::Mnemonic                op,
                                                              TR::Node                     *node,
                                                              TR::MemoryReference       *mr,
                                                              int32_t                      imm,
@@ -49,7 +49,7 @@ TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR_X86OpCodes      
    }
 
 TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR::Instruction              *precedingInstruction,
-                                                             TR_X86OpCodes                op,
+                                                             TR::InstOpCode::Mnemonic                op,
                                                              TR::MemoryReference       *mr,
                                                              int32_t                      imm,
                                                              TR::UnresolvedDataSnippet *us,
@@ -134,7 +134,7 @@ uint8_t *TR::X86MemImmSnippetInstruction::generateBinaryEncoding()
 
 TR::X86CheckAsyncMessagesMemImmInstruction::X86CheckAsyncMessagesMemImmInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    int32_t                value,
    TR::CodeGenerator      *cg) :
@@ -144,7 +144,7 @@ TR::X86CheckAsyncMessagesMemImmInstruction::X86CheckAsyncMessagesMemImmInstructi
 
 TR::X86CheckAsyncMessagesMemRegInstruction::X86CheckAsyncMessagesMemRegInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    TR::Register           *valueReg,
    TR::CodeGenerator      *cg) :
@@ -155,7 +155,7 @@ TR::X86CheckAsyncMessagesMemRegInstruction::X86CheckAsyncMessagesMemRegInstructi
 
 TR::X86StackOverflowCheckInstruction::X86StackOverflowCheckInstruction(
    TR::Instruction        *precedingInstruction,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::Register           *cmpRegister,
    TR::MemoryReference *mr,
    TR::CodeGenerator      *cg) :
@@ -174,7 +174,7 @@ uint8_t *TR::X86StackOverflowCheckInstruction::generateBinaryEncoding()
 
 TR::X86StackOverflowCheckInstruction *generateStackOverflowCheckInstruction(
    TR::Instruction        *precedingInstruction,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::Register           *cmpRegister,
    TR::MemoryReference *mr,
    TR::CodeGenerator      *cg)
@@ -184,7 +184,7 @@ TR::X86StackOverflowCheckInstruction *generateStackOverflowCheckInstruction(
 
 TR::X86CheckAsyncMessagesMemImmInstruction *generateCheckAsyncMessagesInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    int32_t                value,
    TR::CodeGenerator      *cg)
@@ -194,7 +194,7 @@ TR::X86CheckAsyncMessagesMemImmInstruction *generateCheckAsyncMessagesInstructio
 
 TR::X86CheckAsyncMessagesMemRegInstruction *generateCheckAsyncMessagesInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    TR::Register           *reg,
    TR::CodeGenerator      *cg)
@@ -215,7 +215,7 @@ uint8_t *TR::X86CheckAsyncMessagesMemRegInstruction::generateBinaryEncoding()
    };
 
 TR::X86MemImmSnippetInstruction  *
-generateMemImmSnippetInstruction(TR_X86OpCodes op, TR::Node * node, TR::MemoryReference  * mr, int32_t imm, TR::UnresolvedDataSnippet * snippet, TR::CodeGenerator *cg)
+generateMemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::MemoryReference  * mr, int32_t imm, TR::UnresolvedDataSnippet * snippet, TR::CodeGenerator *cg)
    {
    return new (cg->trHeapMemory()) TR::X86MemImmSnippetInstruction(op, node, mr, imm, snippet, cg);
    }

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -33,7 +33,6 @@
 #include "codegen/Snippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
 #include "codegen/InstOpCode.hpp"
-#include "x/codegen/X86Ops_inlines.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemImmSnippetInstruction:: member functions

--- a/runtime/compiler/x/codegen/J9X86Instruction.hpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.hpp
@@ -40,7 +40,7 @@ class X86MemImmSnippetInstruction : public TR::X86MemImmInstruction
 
    public:
 
-   X86MemImmSnippetInstruction(TR_X86OpCodes op,
+   X86MemImmSnippetInstruction(TR::InstOpCode::Mnemonic op,
                                TR::Node *node,
                                TR::MemoryReference *mr,
                                int32_t imm,
@@ -48,7 +48,7 @@ class X86MemImmSnippetInstruction : public TR::X86MemImmInstruction
                                TR::CodeGenerator *cg);
 
    X86MemImmSnippetInstruction(TR::Instruction *precedingInstruction,
-                               TR_X86OpCodes op,
+                               TR::InstOpCode::Mnemonic op,
                                TR::MemoryReference *mr,
                                int32_t imm,
                                TR::UnresolvedDataSnippet *us,
@@ -75,7 +75,7 @@ class X86CheckAsyncMessagesMemRegInstruction : public TR::X86MemRegInstruction
    {
    public:
 
-   X86CheckAsyncMessagesMemRegInstruction(TR::Node *node, TR_X86OpCodes op, TR::MemoryReference *mr, TR::Register *valueReg, TR::CodeGenerator *cg);
+   X86CheckAsyncMessagesMemRegInstruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, TR::Register *valueReg, TR::CodeGenerator *cg);
 
    virtual char *description() { return "X86CheckAsyncMessagesMemReg"; }
 
@@ -88,7 +88,7 @@ class X86CheckAsyncMessagesMemImmInstruction : public TR::X86MemImmInstruction
    {
    public:
 
-   X86CheckAsyncMessagesMemImmInstruction(TR::Node *node, TR_X86OpCodes op, TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg);
+   X86CheckAsyncMessagesMemImmInstruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg);
 
    virtual char *description() { return "X86CheckAsyncMessagesMemImm"; }
 
@@ -103,7 +103,7 @@ class X86StackOverflowCheckInstruction : public TR::X86RegMemInstruction
 
    X86StackOverflowCheckInstruction(
       TR::Instruction        *precedingInstruction,
-      TR_X86OpCodes          op,
+      TR::InstOpCode::Mnemonic          op,
       TR::Register           *cmpRegister,
       TR::MemoryReference *mr,
       TR::CodeGenerator      *cg);
@@ -117,25 +117,25 @@ class X86StackOverflowCheckInstruction : public TR::X86RegMemInstruction
 }
 
 
-TR::X86MemImmSnippetInstruction * generateMemImmSnippetInstruction(TR_X86OpCodes op, TR::Node *, TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
+TR::X86MemImmSnippetInstruction * generateMemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
 
 TR::X86CheckAsyncMessagesMemImmInstruction *generateCheckAsyncMessagesInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    int32_t                value,
    TR::CodeGenerator      *cg);
 
 TR::X86CheckAsyncMessagesMemRegInstruction *generateCheckAsyncMessagesInstruction(
    TR::Node               *node,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::MemoryReference *mr,
    TR::Register           *reg,
    TR::CodeGenerator      *cg);
 
 TR::X86StackOverflowCheckInstruction *generateStackOverflowCheckInstruction(
    TR::Instruction        *precedingInstruction,
-   TR_X86OpCodes          op,
+   TR::InstOpCode::Mnemonic          op,
    TR::Register           *cmpRegister,
    TR::MemoryReference *mr,
    TR::CodeGenerator      *cg);

--- a/runtime/compiler/x/codegen/J9X86Instruction.hpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2114,7 +2114,7 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
       }
    }
 
-TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref)
+TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR::InstOpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref)
    {
    TR::Node *callNode = site.getCallNode();
    if (cg()->enableSinglePrecisionMethods() &&

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -740,7 +740,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          TR_ASSERT(minInstructionSize <= 5, "Can't guarantee SUB instruction will be at least %d bytes", minInstructionSize);
          TR_ASSERT(allocSize >= 1, "When allocSize >= 1, the frame should be small or large, but never medium");
 
-         const TR_X86OpCodes subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)? SUBRegImms() : SUBRegImm4();
+         const TR::InstOpCode::Mnemonic subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)? SUBRegImms() : SUBRegImm4();
          cursor = new (trHeapMemory()) TR::X86RegImmInstruction(cursor, subOp, espReal, allocSize, cg());
 
          minInstructionSize = 0; // The SUB satisfies the constraint
@@ -841,7 +841,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
    else if (!doAllocateFrameSpeculatively)
       {
       TR_ASSERT(minInstructionSize <= 5, "Can't guarantee SUB instruction will be at least %d bytes", minInstructionSize);
-      const TR_X86OpCodes subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)? SUBRegImms() : SUBRegImm4();
+      const TR::InstOpCode::Mnemonic subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)? SUBRegImms() : SUBRegImm4();
       cursor = new (trHeapMemory()) TR::X86RegImmInstruction(cursor, subOp, espReal, allocSize, cg());
       }
 
@@ -2087,7 +2087,7 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
       // We can do an explicit guard
       //
       uint32_t overRiddenBit = fej9->offsetOfIsOverriddenBit();
-      TR_X86OpCodes opCode;
+      TR::InstOpCode::Mnemonic opCode;
 
       if (overRiddenBit <= 0xff)
          opCode = TEST1MemImm1;

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -269,7 +269,7 @@ class PrivateLinkage : public J9::PrivateLinkage
    virtual TR::Instruction *buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site)=0;
    virtual void buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel);
    virtual void buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)=0;
-   virtual TR::Instruction *buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref);
+   virtual TR::Instruction *buildVFTCall(TR::X86CallSite &site, TR::InstOpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref);
    virtual void buildInterfaceDispatchUsingLastITable (TR::X86CallSite &site, int32_t numIPicSlots, TR::X86PICSlot &lastPicSlot, TR::Instruction *&slotPatchInstruction, TR::LabelSymbol *doneLabel, TR::LabelSymbol *lookupDispatchSnippetLabel, TR_OpaqueClassBlock *declaringClass, uintptr_t itableIndex);
 
    // Creates a thunk for interpreted virtual calls, used to initialize

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -448,7 +448,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
          // leave a bunch of pinned garbage behind that screws up the gc quality forever.
          //
          uint32_t flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
-         TR_X86OpCodes op = flagValue <= 255 ? TEST1MemImm1 : TEST4MemImm4;
+         TR::InstOpCode::Mnemonic op = flagValue <= 255 ? TEST1MemImm1 : TEST4MemImm4;
          TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
          TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
          generateMemImmInstruction(op, callNode, generateX86MemoryReference(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue, cg());

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -343,7 +343,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
       if (child->getOpCode().isLoadConst())
          {
          int32_t value = child->getInt();
-         TR_X86OpCodes pushOp;
+         TR::InstOpCode::Mnemonic pushOp;
          if (value >= -128 && value <= 127)
             {
             pushOp = PUSHImms;
@@ -468,7 +468,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(
          }
       else
          {
-         TR_X86OpCodes op = picSlot.needsShortConditionalBranch() ? JNE1 : JNE4;
+         TR::InstOpCode::Mnemonic op = picSlot.needsShortConditionalBranch() ? JNE1 : JNE4;
          generateLabelInstruction(op, node, mismatchLabel, cg());
          }
       }
@@ -480,7 +480,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(
          }
       else
          {
-         TR_X86OpCodes op = picSlot.needsShortConditionalBranch() ? JE1 : JE4;
+         TR::InstOpCode::Mnemonic op = picSlot.needsShortConditionalBranch() ? JE1 : JE4;
          generateLabelInstruction(op, node, mismatchLabel, cg());
          }
       }


### PR DESCRIPTION
This PR is a sequence of commits each of which is able to compile on its own and which systematically eliminate `TR_X86OpCodes` and `TR_X86OpCode` in favour of `TR::InstOpCode::Mnemonic` and `TR::InstOpCode` respectively. Please see each commit message for what was done and why. Semantically there should be no change in behaviour following these changes.

There is still two large pieces of work do be done which will be handled in separate PRs so as to avoid introducing hundreds (thousands?) more changes here:

1. Currently we have a temporary “defines” file which for every opcode does for example #define   ADC1AccImm1 OMR::InstOpCode::ADC1AccImm1. Ideally we would like to get rid of this defines file and qualify all x86 instruction mnemonics with TR::InstOpCode:: as we do on all other platforms. This unfortunately introduces many many lines changed as you can imagine. It is largely mechanical work though.
2. Introduce OMRInstOpCodeProperties.hpp as we do on other platforms instead of using X86Ops.inc. This is also a mechanical change. After reading more of the x86 codegen I believe we should standardize a way to do this cross-platform similarly to how we centralized the IL opcodes. Looks like x86 more or less does this but in its own custom way. It would be really nice to do this cross-platform. This change will get us consistent with other platforms, making such future work of centralizing instruction properties, names, descriptions, encodings, etc. much easier if we start from a common “look and feel”. This will introduce many more lines changed but is all mechanical.

Depends on eclipse/omr#6020