### PR TITLE
Fix mismatch in filename case causing macOS builds to fail

### DIFF
--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -101,7 +101,7 @@ if(OMR_ARCH_X86)
 	elseif(OMR_OS_OSX)
 		target_sources(ffi
 			PRIVATE
-			x86/darwin64.s
+			x86/darwin64.S
 		)
 	endif()
 elseif(OMR_ARCH_POWER)


### PR DESCRIPTION
Builds in macOS with case-sensitive filesystem fail because they expect
to find runtime/libffi/x86/darwin64.s, but it doesn't exist. Instead,
there is runtime/libffi/x86/darwin64.S (note the upper case 'S' at the
end). Since all other assembly files are using '.S', CMakeLists.txt has
been updated accordingly.

Signed-off-by: Sergio Aguayo <sergioag@qmailhosting.net>