### PR TITLE
AArch64: Support FastJNI

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1996,7 +1996,7 @@ TR_J9Method::TR_J9Method()
 
 static bool supportsFastJNI(TR_FrontEnd *fe)
    {
-#if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER)
+#if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER) || defined(TR_TARGET_ARM64)
    return true;
 #else
    return false;


### PR DESCRIPTION
Turn on a flag to enable FastJNI on aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>