### PR TITLE
Mixedrefs build switches to nocompressedrefs automatically based on -Xmx

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -107,13 +107,6 @@
 #include "IdleGCManager.hpp"
 #endif
 
-#if defined(J9ZOS39064)
-#include "omriarv64.h"
-#pragma linkage (GETTTT,OS)
-#pragma map (getUserExtendedPrivateAreaMemoryType,"GETTTT")
-UDATA getUserExtendedPrivateAreaMemoryType();
-#endif /* defined(J9ZOS39064) */
-
 /**
  * If we fail to allocate heap structures with the default Xmx value,
  * we will try again with a smaller value. These parameters define
@@ -1088,20 +1081,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 			 * - 2_TO_64 to support heaps allocation below 64GB
 			 * - 2_TO_32 to support heaps allocation below 32GB
 			 */
-			UDATA maxHeapForCR = 0;
-			switch (getUserExtendedPrivateAreaMemoryType()) {
-			case ZOS64_VMEM_ABOVE_BAR_GENERAL:
-			default:
-				/* options are not supported, heap allocation will fail eventually */
-				break;
-			case ZOS64_VMEM_2_TO_32G:
-				maxHeapForCR = DEFAULT_LOW_MEMORY_HEAP_CEILING;
-				break;
-			case ZOS64_VMEM_2_TO_64G:
-				maxHeapForCR = LOW_MEMORY_HEAP_CEILING;
-				break;
-			}
-
+			U_64 maxHeapForCR = zosGetMaxHeapSizeForCR();
 			if (0 == maxHeapForCR) {
 				/* Redirector should not allow to run Compressed References JVM if options are not available */
 				Assert_MM_unreachable();

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -272,10 +272,6 @@ static const struct { \
 #define internalExitVMToJNI internalReleaseVMAccess
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI */
 
-/* Move macro MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_xxx from redirector.c in order to be referenced from IBM i series */
-#define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_COMPRESSEDREFS	((U_64)57 * 1024 * 1024 * 1024)
-#define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_3BIT_SHIFT_COMPRESSEDREFS	((U_64)25 * 1024 * 1024 * 1024)
-
 #define J9_IS_J9MODULE_UNNAMED(vm, module) ((NULL == module) || (module == vm->unamedModuleForSystemLoader))
 
 #define J9_IS_J9MODULE_OPEN(module) (TRUE == module->isOpen)

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -46,6 +46,7 @@
 #endif
 
 #if defined(J9ZOS39064)
+#include "omrutil.h"
 #include "omriarv64.h"
 #endif /* defined(J9ZOS39064) */
 
@@ -89,12 +90,6 @@ static void *j9vm_dllHandle = NULL;
 #endif
 /* define a size for the buffer which will hold the directory name containing the libjvm.so */
 #define J9_VM_DIR_LENGTH 32
-
-#if defined(J9ZOS39064)
-#pragma linkage (GETTTT,OS)
-#pragma map (getUserExtendedPrivateAreaMemoryType,"GETTTT")
-UDATA getUserExtendedPrivateAreaMemoryType();
-#endif /* defined(J9ZOS39064) */
 
 /*
  * Keep this structure synchronized with gc_policy_name table in parseGCPolicy()
@@ -640,17 +635,7 @@ chooseJVM(JavaVMInitArgs *args, char *retBuffer, size_t bufferLength)
 		if (isPackagedWithSubdir(OPENJ9_CR_JVM_DIR)) {
 			U_64 maxHeapForCR = 0;
 #if defined(J9ZOS39064)
-			switch (getUserExtendedPrivateAreaMemoryType()) {
-			case ZOS64_VMEM_ABOVE_BAR_GENERAL:
-			default:
-				break;
-			case ZOS64_VMEM_2_TO_32G:
-				maxHeapForCR = MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_3BIT_SHIFT_COMPRESSEDREFS;
-				break;
-			case ZOS64_VMEM_2_TO_64G:
-				maxHeapForCR = MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_COMPRESSEDREFS;
-				break;
-			}
+			maxHeapForCR = zosGetMaxHeapSizeForCR();
 #else /* defined(J9ZOS39064) */
 			maxHeapForCR = MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_COMPRESSEDREFS;
 #endif /* defined(J9ZOS39064) */


### PR DESCRIPTION
Mixedrefs build switches to `nocompressedrefs` if `-Xmx` value specified in command line is larger than the maximum heap size allowed for `compressedrefs` mode according to platform/spec.

Verified that this PR can start VM via `-Xmx300g -version` in MacOS & zOS 64bit.

closes https://github.com/eclipse-openj9/openj9/issues/12683

depending on https://github.com/eclipse/omr/pull/6036

Signed-off-by: Jason Feng <fengj@ca.ibm.com>