### PR TITLE
Fix race condition in JITServer cache initialization

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -587,37 +587,41 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          }
       else // Internal caches are empty
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will ask for address ranges of unloaded classes and CHTable for clientUID %llu",
-               getCompThreadId(), (unsigned long long)clientId);
-
-         stream->write(JITServer::MessageType::getUnloadedClassRangesAndCHTable, JITServer::Void());
-         auto response = stream->read<std::vector<TR_AddressRange>, int32_t, std::string>();
-         // TODO: we could send JVM info that is global and does not change together with CHTable
-         auto &unloadedClassRanges = std::get<0>(response);
-         auto maxRanges = std::get<1>(response);
-         std::string &serializedCHTable = std::get<2>(response);
-
-         clientSession->initializeUnloadedClassAddrRanges(unloadedClassRanges, maxRanges);
-         if (!unloadedClasses.empty())
+         OMR::CriticalSection cs(clientSession->getCacheInitMonitor());
+         if (clientSession->cachesAreCleared())
             {
-            // This function updates multiple caches based on the newly unloaded classes list.
-            // Pass `false` here to indicate that we want the unloaded class ranges table cache excluded,
-            // since we just retrieved the entire table and it should therefore already be up to date.
-            clientSession->processUnloadedClasses(unloadedClasses, false);
-            }
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will ask for address ranges of unloaded classes and CHTable for clientUID %llu",
+                  getCompThreadId(), (unsigned long long)clientId);
 
-         auto chTable = static_cast<JITServerPersistentCHTable *>(clientSession->getCHTable());
-         // Need CHTable mutex
-         TR_ASSERT_FATAL(!chTable->isInitialized(), "CHTable must be empty for clientUID=%llu", (unsigned long long)clientId);
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will initialize CHTable for clientUID %llu size=%zu",
-               getCompThreadId(), (unsigned long long)clientId, serializedCHTable.size());
-         chTable->initializeCHTable(_vm, serializedCHTable);
-         clientSession->setCachesAreCleared(false);
+            stream->write(JITServer::MessageType::getUnloadedClassRangesAndCHTable, JITServer::Void());
+            auto response = stream->read<std::vector<TR_AddressRange>, int32_t, std::string>();
+            // TODO: we could send JVM info that is global and does not change together with CHTable
+            auto &unloadedClassRanges = std::get<0>(response);
+            auto maxRanges = std::get<1>(response);
+            std::string &serializedCHTable = std::get<2>(response);
+
+            clientSession->initializeUnloadedClassAddrRanges(unloadedClassRanges, maxRanges);
+            if (!unloadedClasses.empty())
+               {
+               // This function updates multiple caches based on the newly unloaded classes list.
+               // Pass `false` here to indicate that we want the unloaded class ranges table cache excluded,
+               // since we just retrieved the entire table and it should therefore already be up to date.
+               clientSession->processUnloadedClasses(unloadedClasses, false);
+               }
+            auto chTable = static_cast<JITServerPersistentCHTable *>(clientSession->getCHTable());
+            // Need CHTable mutex
+            TR_ASSERT_FATAL(!chTable->isInitialized(), "CHTable must be empty for clientUID=%llu", (unsigned long long)clientId);
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will initialize CHTable for clientUID %llu size=%zu",
+                  getCompThreadId(), (unsigned long long)clientId, serializedCHTable.size());
+            chTable->initializeCHTable(_vm, serializedCHTable);
+            clientSession->setCachesAreCleared(false);
+            }
          }
 
-      // Critical requests must update lastProcessedCriticalSeqNo and notify any waiting threads. 
+
+      // Critical requests must update lastProcessedCriticalSeqNo and notify any waiting threads.
       // Dependent threads will pass through once we've released the sequencing monitor.
       if (isCriticalRequest)
          {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -62,6 +62,7 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo, TR_Pers
    _classMapMonitor = TR::Monitor::create("JIT-JITServerClassMapMonitor");
    _classChainDataMapMonitor = TR::Monitor::create("JIT-JITServerClassChainDataMapMonitor");
    _sequencingMonitor = TR::Monitor::create("JIT-JITServerSequencingMonitor");
+   _cacheInitMonitor = TR::Monitor::create("JIT-JITServerCacheInitMonitor");
    _constantPoolMapMonitor = TR::Monitor::create("JIT-JITServerConstantPoolMonitor");
    _vmInfo = NULL;
    _staticMapMonitor = TR::Monitor::create("JIT-JITServerStaticMapMonitor");
@@ -112,6 +113,7 @@ ClientSessionData::destroyMonitors()
    TR::Monitor::destroy(_classMapMonitor);
    TR::Monitor::destroy(_classChainDataMapMonitor);
    TR::Monitor::destroy(_sequencingMonitor);
+   TR::Monitor::destroy(_cacheInitMonitor);
    TR::Monitor::destroy(_constantPoolMapMonitor);
    TR::Monitor::destroy(_staticMapMonitor);
    TR::Monitor::destroy(_thunkSetMonitor);

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -348,6 +348,7 @@ public:
    int64_t getTimeOflastAccess() const { return _timeOfLastAccess; }
 
    TR::Monitor *getSequencingMonitor() { return _sequencingMonitor; }
+   TR::Monitor *getCacheInitMonitor() { return _cacheInitMonitor; }
    TR::Monitor *getConstantPoolMonitor() { return _constantPoolMapMonitor; }
    TR_MethodToBeCompiled *getOOSequenceEntryList() const { return _OOSequenceEntryList; }
    void setOOSequenceEntryList(TR_MethodToBeCompiled *m) { _OOSequenceEntryList = m; }
@@ -433,6 +434,7 @@ private:
    // The following monitor is used to protect access to _lastProcessedCriticalSeqNo and
    // the list of out-of-sequence compilation requests (_OOSequenceEntryList)
    TR::Monitor *_sequencingMonitor;
+   TR::Monitor *_cacheInitMonitor;
    TR::Monitor *_constantPoolMapMonitor;
    // Compilation requests that arrived out-of-sequence wait in
    // _OOSequenceEntryList for their turn to be processed


### PR DESCRIPTION
When server receives the first message from the client,
it needs to initialize caches, such as CH table and unloaded class ranges.
However, messages can arrive out order, resulting in double
initialization.
This commit creates a critical section around cache initialization,
to ensure that no double initialization can occur.

This code was written by @AlexeyKhrabrov, I'm committing it in his stead.