### PR TITLE
Avoid folding MutableCallSite.target

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -828,26 +828,14 @@ J9::SymbolReferenceTable::createShadowSymbol(
    const char *name,
    TR::Symbol::RecognizedField recognizedField)
    {
-   TR::Symbol *sym = NULL;
-   if (recognizedField != TR::Symbol::UnknownField)
-      sym = TR::Symbol::createRecognizedShadow(trHeapMemory(), type, recognizedField);
-   else
-      sym = TR::Symbol::createShadow(trHeapMemory(), type);
+   TR::Symbol *sym = TR::Symbol::createPossiblyRecognizedShadowWithFlags(
+      trHeapMemory(), type, isVolatile, isFinal, isPrivate, recognizedField);
 
    if (name != NULL)
       {
       sym->setNamedShadowSymbol();
       sym->setName(name);
       }
-
-   if (isVolatile)
-      sym->setVolatile();
-
-   if (isPrivate)
-      sym->setPrivate();
-
-   if (isFinal)
-      sym->setFinal();
 
    static char *dontAliasShadowsToEarlierGISEnv = feGetEnv("TR_dontAliasShadowsToEarlierGIS");
    bool dontAliasShadowsToEarlierGIS = dontAliasShadowsToEarlierGISEnv != NULL;

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -370,6 +370,74 @@ J9::Symbol::createRecognizedShadow(AllocatorType m, TR::DataType d, uint32_t s, 
    return sym;
    }
 
+template <typename AllocatorType>
+TR::Symbol *
+J9::Symbol::createPossiblyRecognizedShadowWithFlags(
+   AllocatorType m,
+   TR::DataType type,
+   bool isVolatile,
+   bool isFinal,
+   bool isPrivate,
+   RecognizedField recognizedField)
+   {
+   TR::Symbol *fieldSymbol = NULL;
+   if (recognizedField != TR::Symbol::UnknownField)
+      fieldSymbol = TR::Symbol::createRecognizedShadow(m, type, recognizedField);
+   else
+      fieldSymbol = TR::Symbol::createShadow(m, type);
+
+   if (isVolatile)
+      fieldSymbol->setVolatile();
+
+   if (isFinal)
+      fieldSymbol->setFinal();
+
+   if (isPrivate)
+      fieldSymbol->setPrivate();
+
+   return fieldSymbol;
+   }
+
+template <typename AllocatorType>
+TR::Symbol *
+J9::Symbol::createPossiblyRecognizedShadowFromCP(
+   TR::Compilation *comp,
+   AllocatorType m,
+   TR_ResolvedMethod *owningMethod,
+   int32_t cpIndex,
+   TR::DataType *type, // can be determined accurately even for unresolved field refs
+   uint32_t *offset, // typically stored for some reason on symref (not Symbol)
+   bool needsAOTValidation)
+   {
+   *type = TR::NoType;
+   *offset = 0;
+
+   const bool isStatic = false;
+   RecognizedField recognizedField =
+      TR::Symbol::searchRecognizedField(comp, owningMethod, cpIndex, isStatic);
+
+   bool isVolatile, isFinal, isPrivate, isUnresolvedInCP;
+
+   const bool isStore = false;
+   bool resolved = owningMethod->fieldAttributes(
+      comp,
+      cpIndex,
+      offset,
+      type,
+      &isVolatile,
+      &isFinal,
+      &isPrivate,
+      isStore,
+      &isUnresolvedInCP,
+      needsAOTValidation);
+
+   if (!resolved)
+      return NULL;
+
+   return createPossiblyRecognizedShadowWithFlags(
+      m, *type, isVolatile, isFinal, isPrivate, recognizedField);
+   }
+
 /*
  * Explicit instantiation of factories for each TR_Memory type.
  */
@@ -380,3 +448,8 @@ template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_HeapMemory,         
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_StackMemory,         TR::DataType, uint32_t, RecognizedField);
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_HeapMemory,          TR::DataType, uint32_t, RecognizedField);
 
+template TR::Symbol * J9::Symbol::createPossiblyRecognizedShadowWithFlags(TR_StackMemory,         TR::DataType, bool, bool, bool, RecognizedField);
+template TR::Symbol * J9::Symbol::createPossiblyRecognizedShadowWithFlags(TR_HeapMemory,          TR::DataType, bool, bool, bool, RecognizedField);
+
+template TR::Symbol * J9::Symbol::createPossiblyRecognizedShadowFromCP(TR::Compilation*, TR_StackMemory,         TR_ResolvedMethod*, int32_t, TR::DataType*, uint32_t*, bool);
+template TR::Symbol * J9::Symbol::createPossiblyRecognizedShadowFromCP(TR::Compilation*, TR_HeapMemory,          TR_ResolvedMethod*, int32_t, TR::DataType*, uint32_t*, bool);

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -376,9 +376,7 @@ J9::Symbol::createRecognizedShadow(AllocatorType m, TR::DataType d, uint32_t s, 
 
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_StackMemory,         TR::DataType, RecognizedField);
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_HeapMemory,          TR::DataType, RecognizedField);
-template TR::Symbol * J9::Symbol::createRecognizedShadow(PERSISTENT_NEW_DECLARE, TR::DataType, RecognizedField);
 
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_StackMemory,         TR::DataType, uint32_t, RecognizedField);
 template TR::Symbol * J9::Symbol::createRecognizedShadow(TR_HeapMemory,          TR::DataType, uint32_t, RecognizedField);
-template TR::Symbol * J9::Symbol::createRecognizedShadow(PERSISTENT_NEW_DECLARE, TR::DataType, uint32_t, RecognizedField);
 

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -138,6 +138,7 @@
        {r(TR::Symbol::Java_lang_Throwable_stackTrace,                 "java/lang/Throwable", "stackTrace", "[Ljava/lang/StackTraceElement;")},
        {r(TR::Symbol::Java_lang_invoke_BruteArgumentMoverHandle_extra,"java/lang/invoke/BruteArgumentMoverHandle", "extra", "[Ljava/lang/Object;")},
        {r(TR::Symbol::Java_lang_invoke_DynamicInvokerHandle_site,     "java/lang/invoke/DynamicInvokerHandle", "site", "Ljava/lang/invoke/CallSite;")},
+       {r(TR::Symbol::Java_lang_invoke_CallSite_target,               "java/lang/invoke/CallSite", "target", "Ljava/lang/invoke/MethodHandle;")},
        {r(TR::Symbol::Java_lang_invoke_MutableCallSite_target,        "java/lang/invoke/MutableCallSite", "target", "Ljava/lang/invoke/MethodHandle;")},
        {r(TR::Symbol::Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,"java/lang/invoke/MutableCallSiteDynamicInvokerHandle", "mutableSite", "Ljava/lang/invoke/MutableCallSite;")},
        {r(TR::Symbol::Java_lang_invoke_MethodHandle_thunks,           "java/lang/invoke/MethodHandle", "thunks", "Ljava/lang/invoke/ThunkTuple;")},

--- a/runtime/compiler/il/J9Symbol.hpp
+++ b/runtime/compiler/il/J9Symbol.hpp
@@ -198,6 +198,30 @@ private:
    RecognizedField _recognizedField;
    /** @} */
 
+public:
+
+   // These two methods are primarily for direct analysis of bytecode. If
+   // generating trees, use SymbolReferenceTable instead.
+
+   template <typename AllocatorType>
+   static TR::Symbol * createPossiblyRecognizedShadowWithFlags(
+      AllocatorType m,
+      TR::DataType type,
+      bool isVolatile,
+      bool isFinal,
+      bool isPrivate,
+      RecognizedField recognizedField);
+
+   template <typename AllocatorType>
+   static TR::Symbol * createPossiblyRecognizedShadowFromCP(
+      TR::Compilation *comp,
+      AllocatorType m,
+      TR_ResolvedMethod *owningMethod,
+      int32_t cpIndex,
+      TR::DataType *type,
+      uint32_t *offset,
+      bool needsAOTValidation);
+
    };
 }
 

--- a/runtime/compiler/il/J9Symbol.hpp
+++ b/runtime/compiler/il/J9Symbol.hpp
@@ -148,6 +148,7 @@ public:
       Java_lang_Throwable_stackTrace,
       Java_lang_invoke_BruteArgumentMoverHandle_extra,
       Java_lang_invoke_DynamicInvokerHandle_site,
+      Java_lang_invoke_CallSite_target,
       Java_lang_invoke_MutableCallSite_target,
       Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,
       Java_lang_invoke_MethodHandle_thunks,

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -290,12 +290,12 @@ void
 InterpreterEmulator::maintainStackForGetField()
    {
    TR_ASSERT_FATAL(_iteratorWithState, "has to be called when the iterator has state!");
-   bool isVolatile, isPrivate, isUnresolvedInCP, isFinal;
    TR::DataType type = TR::NoType;
    uint32_t fieldOffset;
    int32_t cpIndex = next2Bytes();
    Operand *newOperand = _unknownOperand;
-   bool resolved = _calltarget->_calleeMethod->fieldAttributes(comp(), cpIndex, &fieldOffset, &type, &isVolatile, &isFinal, &isPrivate, false, &isUnresolvedInCP, false);
+   TR::Symbol *fieldSymbol = TR::Symbol::createPossiblyRecognizedShadowFromCP(
+      comp(), trStackMemory(), _calltarget->_calleeMethod, cpIndex, &type, &fieldOffset, false);
 
    TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
    if (knot &&
@@ -303,16 +303,7 @@ InterpreterEmulator::maintainStackForGetField()
        !knot->isNull(top()->getKnownObjectIndex())
        && type == TR::Address)
       {
-      TR::Symbol::RecognizedField recognizedField = TR::Symbol::searchRecognizedField(comp(), _calltarget->_calleeMethod, cpIndex, false);
-      TR::Symbol *fieldSymbol = NULL;
-      if (recognizedField != TR::Symbol::UnknownField)
-         fieldSymbol = TR::Symbol::createRecognizedShadow(trStackMemory(),type, recognizedField);
-      else
-         fieldSymbol = TR::Symbol::createShadow(trStackMemory(),type);
-      if (isFinal)
-         fieldSymbol->setFinal();
-
-      if (!resolved && isUnresolvedInCP)
+      if (fieldSymbol == NULL)
          {
          debugTrace(tracer(), "field is unresolved");
          }

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -312,7 +312,15 @@ InterpreterEmulator::maintainStackForGetField()
       if (isFinal)
          fieldSymbol->setFinal();
 
-      if ((resolved || !isUnresolvedInCP) && comp()->fej9()->canDereferenceAtCompileTimeWithFieldSymbol(fieldSymbol, cpIndex, _calltarget->_calleeMethod))
+      if (!resolved && isUnresolvedInCP)
+         {
+         debugTrace(tracer(), "field is unresolved");
+         }
+      else if (!comp()->fej9()->canDereferenceAtCompileTimeWithFieldSymbol(fieldSymbol, cpIndex, _calltarget->_calleeMethod))
+         {
+         debugTrace(tracer(), "field is not foldable");
+         }
+      else
          {
          TR::KnownObjectTable::Index baseObjectIndex = top()->getKnownObjectIndex();
          TR::KnownObjectTable::Index resultIndex = TR::KnownObjectTable::UNKNOWN;
@@ -366,8 +374,6 @@ InterpreterEmulator::maintainStackForGetField()
                   fieldOffset, baseObjectIndex, baseObjectAddress);
             }
          }
-      else
-         debugTrace(tracer(), "unresolved field or can't derefence in thunk archetype resolved %d isUnresolvedInCP %d\n", resolved, isUnresolvedInCP);
       }
    pop();
    push(newOperand);


### PR DESCRIPTION
In the `LambdaForm`-based JSR292 implementation, `CallSite` declares a target field to be inherited by all subclasses, including `MutableCallSite`, and that field is declared final even though it's actually mutable in instances of MCS.

Because it is a final field declared in a trusted JCL package, loads of this field would normally be folded to a known object. However, folding the target in the case of a MCS can result in the spurious removal of the MCS target guard, so refuse to fold in that case.

Folding is prevented in `transformIndirectLoadChain` and `InterpreterEmulator`.

This is a prerequisite to `MutableCallSite` inlining with `LambdaForm`.

----

There are a few refactoring/cleanup commits leading up to the main commit.