### PR TITLE
Remove incorrect casting while calculating block frequency

### DIFF
--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2100,8 +2100,8 @@ TR_BlockFrequencyInfo::getRawCount(TR_ByteCodeInfo &bci, TR_CallSiteInfo *callSi
             if (comp->getOption(TR_TraceBFGeneration))
                traceMsg(comp, "   Slot %d has raw frequency %d\n", i, rawCount);
 
-            if (maxCount > 0)
-               rawCount = ((10000 * (uintptr_t)rawCount) / maxCount);
+            if (maxCount > 0 && rawCount > 0)
+               rawCount = ((10000 * rawCount) / maxCount);
             else
                rawCount = 0;
             }


### PR DESCRIPTION
In TR_BlockFrequencyInfo while calculating the rawCount of matched
blocks to the given bytecode info, it was incorrectly casting a 64-Bit
signed integer to uintptr_t. This conversion was forcing the function to
return very high frequency for the blocks for which we calculated
negative rawCount (cold blocks), which eventually causes compiler to
optimize cold code leaving with sub-optimal compiled code.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>