### PR TITLE
Teach InterpreterEmulator about foldable statics

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -51,7 +51,7 @@
 #include "infra/List.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/PersistentCHTable.hpp"
-#include "optimizer/J9TransformUtil.hpp"
+#include "optimizer/TransformUtil.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "env/j9methodServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -1721,72 +1721,12 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       symRef->setReallySharesSymbol();
 
    TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
-   TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-   if (knot
-       && resolved
-       && isFinal
-       && type == TR::Address
-       && !comp()->compileRelocatableCode())
+   if (resolved && isFinal && type == TR::Address)
       {
-#if defined(J9VM_OPT_JITSERVER)
-      if (comp()->isOutOfProcessCompilation())
-         {
-         TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod*>(owningMethod);
-         TR_ResolvedMethod *clientMethod = serverMethod->getRemoteMirror();
-
-         auto stream = TR::CompilationInfo::getStream();
-         stream->write(JITServer::MessageType::KnownObjectTable_symbolReferenceTableCreateKnownObject, dataAddress, clientMethod, cpIndex);
-
-         auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*>();
-         knownObjectIndex = std::get<0>(recv);
-         uintptr_t *objectPointerReference = std::get<1>(recv);
-
-         if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
-            {
-            knot->updateKnownObjectTableAtServer(knownObjectIndex, objectPointerReference);
-            }
-         }
-      else
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         {
-         TR::VMAccessCriticalSection getObjectReferenceLocation(comp());
-         if (*((uintptr_t*)dataAddress) != 0)
-            {
-            TR_J9VMBase *fej9 = comp()->fej9();
-            TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
-            if (declaringClass && fej9->isClassInitialized(declaringClass))
-               {
-               static const char *foldVarHandle = feGetEnv("TR_FoldVarHandleWithoutFear");
-               int32_t clazzNameLength = 0;
-               char *clazzName = fej9->getClassNameChars(declaringClass, clazzNameLength);
-               bool createKnownObject = false;
-
-               if (J9::TransformUtil::foldFinalFieldsIn(declaringClass, clazzName, clazzNameLength, true, comp()))
-                  {
-                  createKnownObject = true;
-                  }
-               else if (foldVarHandle
-                        && (clazzNameLength != 16 || strncmp(clazzName, "java/lang/System", 16)))
-                  {
-                  TR_OpaqueClassBlock *varHandleClass =  fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", 26);
-                  TR_OpaqueClassBlock *objectClass = TR::Compiler->cls.objectClass(comp(), *((uintptr_t*)dataAddress));
-
-                  if (varHandleClass != NULL
-                      && objectClass != NULL
-                      && fej9->isInstanceOf(objectClass, varHandleClass, true, true))
-                     {
-                     createKnownObject = true;
-                     }
-                  }
-
-               if (createKnownObject)
-                  {
-                  knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)dataAddress);
-                  }
-               }
-            }
-         }
+      knownObjectIndex = TR::TransformUtil::knownObjectFromFinalStatic(
+         comp(), owningMethod, cpIndex, dataAddress);
       }
+
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, knownObjectIndex);
 
    checkUserField(symRef);

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -421,6 +421,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       void debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod);
       void maintainStackForAstore(int slotIndex);
       void maintainStackForldc(int32_t cpIndex);
+      void maintainStackForGetStatic();
       /*
        * \brief Check if a block has predecessors whose bytecodes haven't been visited
        */

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -215,6 +215,28 @@ public:
     *    Doesn't support `MethodHandle.linkToInterface` right now
     */
    static bool refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* treetop, TR::Node* node, TR::KnownObjectTable::Index mnIndex, bool trace = false);
+
+   /*
+    * \brief
+    *    Determine the known-object index to use for a reference-typed final
+    *    static field that is foldable in the walker.
+    *
+    *    The caller must check in advance that the field is a final reference.
+    *    This method does not verify.
+    *
+    * \param comp the compilation object
+    * \param owningMethod the owning method of the static field reference
+    * \param cpIndex the constant pool index of the static field reference
+    * \param dataAddress The static field address from \c staticAttributes()
+    *
+    * \return the known object index, or \c UNKNOWN if disallowed
+    */
+   static TR::KnownObjectTable::Index knownObjectFromFinalStatic(
+      TR::Compilation *comp,
+      TR_ResolvedMethod *owningMethod,
+      int32_t cpIndex,
+      void *dataAddress);
+
 protected:
    /**
     * \brief


### PR DESCRIPTION
In particular, push a known object operand whenever stateful iteration encounters a `getstatic` bytecode instruction that loads an object from a static final field declared by an allowlisted class (or any other reference-typed static final field that would be treated as a known object in `findOrCreateStaticSymbol()`).

This allows the inliner to find the `MethodHandle` for which a specialized `LambdaForm` was generated. Such a `LambdaForm` loads its `MethodHandle` from a static final field and replaces the corresponding argument, which would previously result in an unknown `MethodHandle` even when the `MethodHandle` argument is already a known object due to inlining.

Thanks to @liqunl for the original version of this change.

There is a preparatory commit to reduce code duplication.