### PR TITLE
Update release notes for 0.27 for Balanced GC Optimization

### DIFF
--- a/doc/release-notes/0.27/0.27.md
+++ b/doc/release-notes/0.27/0.27.md
@@ -63,6 +63,13 @@ The following table covers notable changes in v0.27.0. Further information about
 <td valign="top">Two new fields are included, the date and time in UTC (<strong>1TIDATETIMEUTC</strong>) and the time zone according to the local system (<strong>1TITIMEZONE</strong>).</td>
 </tr>
 
+<tr><td valign="top">
+<a href="https://github.com/eclipse/openj9/issues/7552">#7552</a></td>
+<td valign="top">New default garbage collection (GC) scan ordering mode for the <tt>balanced</tt> policy</td>
+<td valign="top">All versions</td>
+<td valign="top">For performance improvements, GC copy forward operations in the <tt>balanced</tt> policy now use <i>dynamic breadth first scan mode</i>. To revert to the behavior in earlier releases, set <tt>-Xgc:breadthFirstScanOrdering</tt> on the command line when you start your application.</td>
+</tr>
+
 </table>
 
 ## Known Issues


### PR DESCRIPTION
Update release notes for 0.27 to include the change in behavior for `balanced` to use a dynamic breadth-first scan ordering policy.

Related to: https://github.com/eclipse-openj9/openj9-docs/pull/793

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>