### PR TITLE
Add support for delayed start of JITServer

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -31,6 +31,7 @@
 #include "control/CompilationOperations.hpp"
 #include "control/CompilationTracingFacility.hpp"
 #include "control/ClassHolder.hpp"
+#include "control/MethodToBeCompiled.hpp"
 #include "env/CpuUtilization.hpp"
 #include "env/Processors.hpp"
 #include "env/ProcessorInfo.hpp"
@@ -121,7 +122,7 @@ class TR_LowPriorityCompQueue
       void enqueueCompReqToLPQ(TR_MethodToBeCompiled *compReq);
       bool createLowPriorityCompReqAndQueueIt(TR::IlGeneratorMethodDetails &details, void *startPC, uint8_t reason);
       bool addFirstTimeCompReqToLPQ(J9Method *j9method, uint8_t reason);
-      bool addUpgradeReqToLPQ(TR_MethodToBeCompiled*);
+      bool addUpgradeReqToLPQ(TR_MethodToBeCompiled*, uint8_t reason = TR_MethodToBeCompiled::REASON_UPGRADE);
       int32_t getLowPriorityQueueSize() const { return _sizeLPQ; }
       int32_t getLPQWeight() const { return _LPQWeight; }
       void increaseLPQWeightBy(uint8_t weight) { _LPQWeight += (int32_t)weight; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1745,13 +1745,13 @@ bool TR_LowPriorityCompQueue::addFirstTimeCompReqToLPQ(J9Method *j9method, uint8
 // This method is used when the JIT performs a low optimized compilation
 // and then schedules a low priority upgrade compilation for the same method
 //------------------------------------------------------------------
-bool TR_LowPriorityCompQueue::addUpgradeReqToLPQ(TR_MethodToBeCompiled *compReq)
+bool TR_LowPriorityCompQueue::addUpgradeReqToLPQ(TR_MethodToBeCompiled *compReq, uint8_t reason)
    {
    TR_ASSERT(!compReq->getMethodDetails().isNewInstanceThunk(), "classForNewInstance is sync req");
    // filter out DLT compilations and fixed opt level situations
    if (compReq->isDLTCompile() || !TR::Options::getCmdLineOptions()->allowRecompilation())
       return false;
-   return createLowPriorityCompReqAndQueueIt(compReq->getMethodDetails(), compReq->_newStartPC, TR_MethodToBeCompiled::REASON_UPGRADE);
+   return createLowPriorityCompReqAndQueueIt(compReq->getMethodDetails(), compReq->_newStartPC, reason);
    }
 
 bool TR::CompilationInfo::canProcessLowPriorityRequest()
@@ -1765,6 +1765,12 @@ bool TR::CompilationInfo::canProcessLowPriorityRequest()
    // If the main compilation queue has requests, we should serve those first
    if (getMethodQueueSize() != 0)
       return false;
+
+#if defined(J9VM_OPT_JITSERVER)
+   // If the first LPQ entry is REASON_SERVER_UNAVAILABLE, only attempt compilation if server is available by now
+   if (getLowPriorityCompQueue().getFirstLPQRequest()->_reqFromSecondaryQueue == TR_MethodToBeCompiled::REASON_SERVER_UNAVAILABLE)
+      return JITServerHelpers::isServerAvailable();
+#endif
 
    // To process a request from the low priority queue we need to have
    // (1) no other compilation in progress (not required if TR_ConcurrentLPQ is enabled)
@@ -4296,15 +4302,11 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
 #ifdef STATS
    statQueueSize.update(compInfo->getMethodQueueSize());
 #endif
-   bool shouldAddToUpgradeQueue = false;
-
    TR_ASSERT(entry._optimizationPlan, "Must have an optimization plan");
 
    // The server should not adjust the opt plan requested by the client.
    if (!entry.isOutOfProcessCompReq())
       TR::CompilationController::getCompilationStrategy()->adjustOptimizationPlan(&entry, 0);
-
-   shouldAddToUpgradeQueue = entry._optimizationPlan->shouldAddToUpgradeQueue();
 
    entry._tryCompilingAgain = false; // this field may be set by compile()
 
@@ -4346,18 +4348,33 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
       compInfo->debugPrint("\tcompilation succeeded for method", details, compThread);
       // Add upgrade request to secondary queue if we downgraded, this is not GCR and method
       // looks important enough that an upgrade is justified
-      if (shouldAddToUpgradeQueue && entry._compErrCode == compilationOK)
+      if (entry._compErrCode == compilationOK)
          {
-         // The flag could have been reset by GCR or other reasons
          if (entry._optimizationPlan->shouldAddToUpgradeQueue())
             {
             // clone this request, adjust its _oldStartPC to match the _newStartPC for the
             // this request, and insert it in the low upgrade queue
-            compInfo->getLowPriorityCompQueue().addUpgradeReqToLPQ(getMethodBeingCompiled());
+            compInfo->getLowPriorityCompQueue().addUpgradeReqToLPQ(getMethodBeingCompiled(), TR_MethodToBeCompiled::REASON_UPGRADE);
 #ifdef STATS
             fprintf(stderr, "Downgraded request will be added to upgrade queue\n");
 #endif
             }
+#if defined(J9VM_OPT_JITSERVER)
+         else if (entry.shouldUpgradeOutOfProcessCompilation())
+            {
+            // If it's a local cold downgraded compilation, add an upgrade request to the LPQ, hoping that
+            // the server will become available at some point in the future
+            if (TR::Options::isAnyVerboseOptionSet(
+                   TR_VerboseJITServer,
+                   TR_VerboseCompilationDispatch,
+                   TR_VerbosePerformance,
+                   TR_VerboseCompFailure))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "t=%6u Buffering an upgrade request into the LPQ: j9method=%p",
+                                              (uint32_t) compInfo->getPersistentInfo()->getElapsedTime(),
+                                              entry.getMethodDetails().getMethod());
+            compInfo->getLowPriorityCompQueue().addUpgradeReqToLPQ(getMethodBeingCompiled(), TR_MethodToBeCompiled::REASON_SERVER_UNAVAILABLE);
+            }
+#endif
          }
       }
    else // compilation failure
@@ -4417,7 +4434,6 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
       }
    else // compilation will not be retried
       {
-      //fprintf(stderr, "compilation thread will free optimization plan %p %d\n", entry->_optimizationPlan, entry->_optimizationPlan->creatorCanFreePlan());
       TR_OptimizationPlan::freeOptimizationPlan(entry._optimizationPlan); // we no longer need the optimization plan
       // decrease the queue weight
       compInfo->decreaseQueueWeightBy(entry._weight);
@@ -5374,7 +5390,11 @@ TR::CompilationInfo::getNextMethodToBeCompiled(TR::CompilationInfoPerThread *com
          // Check if we need to throttle
          if (exceedsCompCpuEntitlement() == TR_yes &&
             !compThreadCameOutOfSleep && // Don't throttle a comp thread that has just slept its share of time
-            (TR::Options::_compThreadCPUEntitlement < 100 || getNumCompThreadsActive() * 100 > (TR::Options::_compThreadCPUEntitlement + 50)))
+            (TR::Options::_compThreadCPUEntitlement < 100 || getNumCompThreadsActive() * 100 > (TR::Options::_compThreadCPUEntitlement + 50))
+#if defined(J9VM_OPT_JITSERVER)
+            && !getLowPriorityCompQueue().getFirstLPQRequest()->shouldUpgradeOutOfProcessCompilation() // Don't throttle if compilation will be done remotely
+#endif
+            )
             {
             // If at all possible suspend the compilation thread
             // Otherwise, perform a timed wait
@@ -7090,14 +7110,17 @@ TR::CompilationInfoPerThreadBase::isCPUCheapCompilation(uint32_t bcsz, TR_Hotnes
    }
 
 bool
-TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeCompiled *entry)
+TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeCompiled *entry, bool &forcedLocal)
    {
    // As a heuristic, cold compilations could be performed locally because
    // they are supposed to be cheap with respect to memory and CPU, but
    // only if we think we have enough resources
    if (!JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
        (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))))
-       return true; // I really cannot do a remote compilation
+      {
+      forcedLocal = true; // Inform the caller that remote compilation is not possible
+      return true; // I really cannot do a remote compilation
+      }
 
    // Do a local compile because the Power codegen is missing some FieldWatch relocation support.
    if (TR::Compiler->target.cpu.isPower() && _jitConfig->inlineFieldWatches)
@@ -7138,6 +7161,43 @@ TR::CompilationInfoPerThreadBase::exitPerClientAllocationRegion()
    if (_compiler)
       _compiler->switchToGlobalMemory();
    _perClientPersistentMemory = NULL;
+   }
+
+void
+TR::CompilationInfoPerThreadBase::downgradeLocalCompilationIfLowPhysicalMemory(TR_MethodToBeCompiled *entry)
+   {
+   TR_ASSERT_FATAL(_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT,
+                   "Must be called on JITServer client");
+
+   J9Method *method = entry->getMethodDetails().getMethod();
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableJITServerBufferedExpensiveCompilations) &&
+       TR::Options::getCmdLineOptions()->allowRecompilation() &&
+       !TR::CompilationInfo::isCompiled(method) &&  // do not downgrade recompilations
+       (entry->_optimizationPlan->getOptLevel() >= warm ||
+       // AOT compilations that are upgraded back to cheap-warm should be considered expensive
+       (entry->_useAotCompilation && !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableAotAtCheapWarm))))
+      {
+      // Downgrade a forced local compilation, if the available client memory is low.
+      bool incomplete;
+      uint64_t freePhysicalMemorySizeB = _compInfo.computeAndCacheFreePhysicalMemory(incomplete, 10);
+      int32_t numActiveThreads = _compInfo.getNumCompThreadsActive();
+      if (freePhysicalMemorySizeB != OMRPORT_MEMINFO_NOT_AVAILABLE &&
+         freePhysicalMemorySizeB <= (uint64_t)TR::Options::getSafeReservePhysicalMemoryValue() + (numActiveThreads + 4) * TR::Options::getScratchSpaceLowerBound())
+         {
+         if (TR::Options::isAnyVerboseOptionSet(
+                TR_VerboseJITServer,
+                TR_VerboseCompilationDispatch,
+                TR_VerbosePerformance,
+                TR_VerboseCompFailure))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "t=%6u Downgraded a forced local compilation to cold due to low memory: j9method=%p", 
+                                           (uint32_t)_compInfo.getPersistentInfo()->getElapsedTime(), method);
+         entry->_optimizationPlan->setOptLevel(cold);
+         entry->_optimizationPlan->setOptLevelDowngraded(true);
+         entry->_optimizationPlan->setDisableGCR(); // disable GCR to prevent aggressive recompilation
+         entry->_optimizationPlan->setUseSampling(false); // disable sampling to prevent spontaneous recompilation
+         entry->setShouldUpgradeOutOfProcessCompilation(); // ask for an upgrade if the server becomes available
+         }
+      }
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
@@ -7427,10 +7487,13 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
 #endif /* defined(J9VM_OPT_JITSERVER) */
          _vm = TR_J9VMBase::get(_jitConfig, vmThread, TR_J9VMBase::AOT_VM);
 #if defined(J9VM_OPT_JITSERVER)
-      if ((_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT) &&
-         !shouldPerformLocalComp(entry))
+      if (_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          {
-         entry->setRemoteCompReq();
+         bool forcedLocal = false;
+         if (!shouldPerformLocalComp(entry, forcedLocal))
+            entry->setRemoteCompReq();
+         else if (forcedLocal)
+            downgradeLocalCompilationIfLowPhysicalMemory(entry);
          }
 #endif /* defined(J9VM_OPT_JITSERVER) */
       }
@@ -7451,7 +7514,8 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       if ((_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT) &&
           TR::Options::canJITCompile())
          {
-         bool doLocalCompilation = shouldPerformLocalComp(entry);
+         bool forcedLocal = false;
+         bool doLocalCompilation = shouldPerformLocalComp(entry, forcedLocal);
 
          // If this is a remote sync compilation, change it to a local sync compilation.
          // After the local compilation is completed successfully, a remote async compilation
@@ -7494,7 +7558,13 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             }
 
          if (!doLocalCompilation)
+            {
             entry->setRemoteCompReq();
+            }
+         else if (forcedLocal)
+            {
+            downgradeLocalCompilationIfLowPhysicalMemory(entry);
+            }
          }
 #endif /* defined(J9VM_OPT_JITSERVER) */
       }
@@ -8201,7 +8271,13 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   (!TR::Compiler->target.cpu.isPower() && // Temporary change until we figure out the AOT bug on PPC
                    !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableAotAtCheapWarm))) &&
                   p->_optimizationPlan->isOptLevelDowngraded() &&
-                  p->_optimizationPlan->getOptLevel() == cold) // Is this test really needed?
+                  p->_optimizationPlan->getOptLevel() == cold // Is this test really needed?
+#if defined(J9VM_OPT_JITSERVER)
+                  // Do not reupgrade a compilation that was downgraded due to low memory
+                  && (TR::Options::getCmdLineOptions()->getOption(TR_DisableJITServerBufferedExpensiveCompilations) ||
+                      !that->_methodBeingCompiled->shouldUpgradeOutOfProcessCompilation())
+#endif
+                  )
                   {
                   p->_optimizationPlan->setOptLevel(warm);
                   p->_optimizationPlan->setOptLevelDowngraded(false);

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -341,9 +341,11 @@ class CompilationInfoPerThreadBase
              CPU relative to what the JVM has at its disposal
     */
    bool isCPUCheapCompilation(uint32_t bcsz, TR_Hotness optLevel);
-   bool shouldPerformLocalComp(const TR_MethodToBeCompiled *entry);
+   bool shouldPerformLocalComp(const TR_MethodToBeCompiled *entry, bool &forcedLocal);
 
    bool compilationCanBeInterrupted() const { return _compilationCanBeInterrupted; }
+
+   void downgradeLocalCompilationIfLowPhysicalMemory(TR_MethodToBeCompiled *entry);
 
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -88,6 +88,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
    _remoteCompReq = false;
    _stream = NULL;
    _origOptLevel = unknownHotness;
+   _shouldUpgradeOutOfProcessCompilation = false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR_ASSERT_FATAL(_freeTag & ENTRY_IN_POOL_FREE, "initializing an entry which is not free");


### PR DESCRIPTION
When JITServer clients are run in the containerized environment,
they are likely allocated a limited amount of memory that's sufficient
to run the application and support JITServer compilation, but not large
enough to perform expensive compilations locally.

If a server is temporarily unavailable, all compilations will be done
locally and we will see many failures due to low available memory.
If a compilation failed early due to insufficient memory, there will be
no recompilation attempts leading to bad performance even if server
becomes available or memory situation improves.

This commit addresses the above issue in 2 steps:
1. If the client is running low on memory, downgrade compilations to
cold, because they are typically much cheaper, making them less likely
to fail.
2. Once the downgraded compilation succeeds (or fails due to low memory),
add an upgrade request into the Low Priority Queue (LPQ).
Requests from the LPQ are processed when the main queue has no compilation requests left.
If by the time we get to processing requests from the LPQ the server is available, client will
send all upgrade requests to the server, potentially regaining all
of the performance lost.
If the server is still unavailable, the client will use the LPQ
as normal, i.e. conservatively attempt upgrades when resources allow.

Closes: #12375