### PR TITLE
Revert "Store number of arguments in vmThread.floatTemp1 for linkToStatic"

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2395,21 +2395,6 @@ J9::SymbolReferenceTable::findOrCreateVMThreadTempSlotFieldSymbolRef()
    }
 
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateVMThreadFloatTemp1SymbolRef()
-   {
-   if (!element(j9VMThreadFloatTemp1Symbol))
-      {
-      TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-      TR::Symbol * sym = TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(), "j9VMThreadFloatTemp1");
-      sym->setDataType(TR::Address);
-      element(j9VMThreadFloatTemp1Symbol) = new (trHeapMemory()) TR::SymbolReference(self(), j9VMThreadFloatTemp1Symbol, sym);
-      element(j9VMThreadFloatTemp1Symbol)->setOffset(fej9->thisThreadGetFloatTemp1Offset());
-      aliasBuilder.addressStaticSymRefs().set(getNonhelperIndex(j9VMThreadFloatTemp1Symbol));
-      }
-   return element(j9VMThreadFloatTemp1Symbol);
-   }
-
-TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateProfilingBufferSymbolRef(intptr_t offset)
    {
    if (!element(profilingBufferSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -85,14 +85,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     */
    TR::SymbolReference * findOrCreateVMThreadTempSlotFieldSymbolRef();
 
-   /** \brief
-    * Find or create VMThread.floatTemp1 symbol reference. J9VMThread.floatTemp1 provides an additional
-    * mechanism for the compiler to provide information that the VM can use for various reasons
-    *
-    * \return TR::SymbolReference* the VMThread.floatTemp1 symbol reference
-    */
-   TR::SymbolReference * findOrCreateVMThreadFloatTemp1SymbolRef();
-
    // CG linkage
    TR::SymbolReference * findOrCreateAcquireVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework
    TR::SymbolReference * findOrCreateReleaseVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5086,35 +5086,6 @@ TR_ResolvedJ9Method::isJITInternalNative()
    return isNative() && !isJNINative() && !isInterpreted();
    }
 
-uint32_t
-TR_ResolvedJ9Method::romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex)
-   {
-   J9ROMClass *romClass = romClassPtr();
-   J9SRP                 *namesAndSigs = (J9SRP*)J9ROMCLASS_CALLSITEDATA(romClass);
-   J9ROMNameAndSignature *nameAndSig   = NNSRP_GET(namesAndSigs[callSiteIndex], J9ROMNameAndSignature*);
-   J9UTF8                *signature    = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
-
-   U_8 paramBuffer[256];
-   uintptr_t    paramElements;
-   uintptr_t    paramSlots;
-   jitParseSignature(signature, paramBuffer, &paramElements, &paramSlots);
-   return paramElements;
-   }
-
-uint32_t
-TR_ResolvedJ9Method::romMethodArgCountAtCPIndex(int32_t cpIndex)
-   {
-   J9ROMMethodRef *romMethodRef = (J9ROMMethodRef *)(cp()->romConstantPool + cpIndex);
-   J9ROMNameAndSignature *nameAndSig = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
-   J9UTF8                *signature    = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
-
-   U_8 paramBuffer[256];
-   uintptr_t    paramElements;
-   uintptr_t    paramSlots;
-   jitParseSignature(signature, paramBuffer, &paramElements, &paramSlots);
-   return paramElements;
-   }
-
 bool
 TR_J9MethodBase::isUnsafeCAS(TR::Compilation * c)
    {

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -525,21 +525,6 @@ public:
     */
    virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
-   /**
-    * @brief Gets the number of arguments in the ROM method signature
-    *
-    * @param callSiteIndex the call site index of the ROM method
-    * @return uint32_t the number of arguments
-    */
-   virtual uint32_t romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex);
-   /**
-    * @brief Gets the number of arguments in the ROM method signature
-    *
-    * @param cpIndex the cpIndex to lookup the ROM method
-    * @return uint32_t the number of arguments
-    */
-   virtual uint32_t romMethodArgCountAtCPIndex(int32_t cpIndex);
-
 protected:
    virtual TR_J9MethodBase *       asJ9Method(){ return this; }
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4849,24 +4849,6 @@ typedef struct J9VMThread {
 #if 1 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 paddingToAlignFloatTemp;
 #endif
-	/**
-	 * floatTemp1 is an overloaded field used for multiple purposes.
-	 *
-	 * Note: Listed below is one such use, and the other uses of this field still need to be
-	 * documented.
-	 *
-	 * 1. OpenJDK MethodHandle implementation
-	 *		For signature-polymorphic INL calls from compiled code for the following methods:
-	 *		* java/lang/invoke/MethodHandle.linkToStatic
-	 *		* java/lang/invoke/MethodHandle.linkToSpecial
-	 *		the compiled code performs a store to this field right before the INL call. The
-	 *		stored value represents the number of args for the unresolved invokedynamic/invokehandle
-	 *		call. This is required because linkToStatic calls are generated for unresolved
-	 *		invokedynamic/invokehandle, where the JIT cannot determine whether the appendix object of
-	 *		the callSite/invokeCache table entry is valid. As a result, the JIT code may push NULL
-	 *		appendix objects on the stack which the interpreter must remove. To determine that, the
-	 *		interpreter would need to know the number of arguments of method.
-	 */
 	void* floatTemp1;
 	void* floatTemp2;
 	void* floatTemp3;


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#12549

#12549 causes some failures for the OpenJDK MH builds. Reverting this PR for now and a follow-up PR will address the issues faced.