### PR TITLE
OJDK MHs test excludes + Process a list of test exclude files

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -966,6 +966,12 @@ initializeSystemProperties(J9JavaVM * vm)
 			goto fail;
 		}
 	}
+
+	/* TODO: https://github.com/eclipse-openj9/openj9/issues/12811 */
+	rc = addSystemProperty(vm, "openjdk.methodhandles", "true", J9SYSPROP_FLAG_WRITEABLE);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 	/* If we get here all is good */

--- a/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
+++ b/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright (c) 2021, 2021 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+##############################################################################
+
+# Exclude tests temporarily
+
+org.openj9.test.jsr335.defendersupersends.asm.TestDefenderMethodLookupAsm:test335DefenderSupersendsAsmAsMethodHandles AN-https://github.com/eclipse-openj9/openj9/issues/11924 generic-all
+org.openj9.test.jsr335.defendersupersends.asm.TestDefenderMethodLookupAsm:testConflictingDefinitionsInSuperInterface AN-https://github.com/eclipse-openj9/openj9/issues/11924 generic-all
+
+org.openj9.test.java.lang.invoke.Test_MethodHandleInfo:test_RevealDirect_TargetVarargsAdaptor AN-https://github.com/eclipse-openj9/openj9/issues/11927 generic-all
+
+org.openj9.test.modularity.tests.UnreflectTests:testLookupUnreflectSpecial AN-https://github.com/eclipse-openj9/openj9/issues/11935 generic-all
+
+org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking AN-https://github.com/eclipse-openj9/openj9/issues/12690 generic-all
+
+com.ibm.j9.jsr292.MethodHandleTest:testBindTo AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.AsTypeTest:testAll AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.PermuteTest:testPermuteArguments AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.VirtualHandleTest:testIfVirtualHandleTestIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.ConstructorHandleTest:testIfConstructorHandleIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.ReceiverBoundHandleTest:testIfRecieverBoundHandleTestIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.InterfaceHandleTest:testIfInterfaceHandleIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+com.ibm.j9.jsr292.DirectHandleTest:testIfDirectHandleTestIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
+

--- a/test/Utils/src/org/openj9/test/util/IncludeExcludeTestAnnotationTransformer.java
+++ b/test/Utils/src/org/openj9/test/util/IncludeExcludeTestAnnotationTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,50 +40,55 @@ public class IncludeExcludeTestAnnotationTransformer implements IAnnotationTrans
 	private static final Logger logger = Logger.getLogger(IncludeExcludeTestAnnotationTransformer.class);
 	static {
 		String line = null;
-		String excludeFile = System.getenv("EXCLUDE_FILE");
-		logger.info("exclude file is " + excludeFile);
-		if (excludeFile != null) {
-			String currentReadingFile = excludeFile;
-			File fileCheck = new File(currentReadingFile);
-			if(!fileCheck.exists()) {
-				int indexBeforeJDKVersion = excludeFile.lastIndexOf("_");
-				currentReadingFile = excludeFile.substring(0, indexBeforeJDKVersion) + "_base.txt";
-				logger.info("Unable to open file " + excludeFile + ", changed to read " + currentReadingFile);
-			}
-			try {
-				FileReader fileReader = new FileReader(currentReadingFile);
-				BufferedReader bufferedReader = new BufferedReader(fileReader);
-				while ((line = bufferedReader.readLine()) != null) {
-					if (line.startsWith("#") || line.matches("\\s") || line.isEmpty()) {
-						// comment to ignore - as the problems list from OpenJDK
-					} else {
-						// parse the line and populate the array lists
-						String[] lineParts = line.split("\\s+");
-						// expect to exclude all methods with the name that follows : at the start of a line
-						if (-1 != line.indexOf("*")) {
-							// TODO exclude all Test classes under the package?
-						} else {
-							String[] tests = lineParts[0].split(":");
-							String fileName = tests[0];
-							String methodsToExclude = "";
-							if (tests.length > 1) {
-								methodsToExclude = tests[1];
-							} else { //exclude class level
-								methodsToExclude = "ALL";
-							}
-							String defectNumber = lineParts[1];
-							String[] excludeGroups = lineParts[2].split(";");
-							for (int i = 0; i < excludeGroups.length; i++) {
-								excludeGroups[i] = "disabled." + excludeGroups[i];
-							}
-							ArrayList<String> excludeGroupNames = new ArrayList<String> (Arrays.asList(excludeGroups));
-							excludeDatas.add(new ExcludeData(methodsToExclude, fileName, defectNumber, excludeGroupNames));
-						}
-					}	
+		String excludeFilesEnv = System.getenv("EXCLUDE_FILE");
+		logger.info("EXCLUDE_FILE environment variable: " + excludeFilesEnv);
+		if (excludeFilesEnv != null) {
+			String[] excludeFiles = excludeFilesEnv.split(",");
+
+			for (String excludeFile : excludeFiles) {
+				String currentReadingFile = excludeFile;
+				File fileCheck = new File(currentReadingFile);
+				if(!fileCheck.exists()) {
+					int indexBeforeJDKVersion = excludeFile.lastIndexOf("_");
+					currentReadingFile = excludeFile.substring(0, indexBeforeJDKVersion) + "_base.txt";
+					logger.info("Unable to open file " + excludeFile + ", changed to read " + currentReadingFile);
 				}
-				bufferedReader.close();
-			} catch(IOException ex) {
-				logger.info("Error reading file " + currentReadingFile, ex);
+				try {
+					logger.info("Processing exclude file: " + currentReadingFile);
+					FileReader fileReader = new FileReader(currentReadingFile);
+					BufferedReader bufferedReader = new BufferedReader(fileReader);
+					while ((line = bufferedReader.readLine()) != null) {
+						if (line.startsWith("#") || line.matches("\\s") || line.isEmpty()) {
+							// comment to ignore - as the problems list from OpenJDK
+						} else {
+							// parse the line and populate the array lists
+							String[] lineParts = line.split("\\s+");
+							// expect to exclude all methods with the name that follows : at the start of a line
+							if (-1 != line.indexOf("*")) {
+								// TODO exclude all Test classes under the package?
+							} else {
+								String[] tests = lineParts[0].split(":");
+								String fileName = tests[0];
+								String methodsToExclude = "";
+								if (tests.length > 1) {
+									methodsToExclude = tests[1];
+								} else { //exclude class level
+									methodsToExclude = "ALL";
+								}
+								String defectNumber = lineParts[1];
+								String[] excludeGroups = lineParts[2].split(";");
+								for (int i = 0; i < excludeGroups.length; i++) {
+									excludeGroups[i] = "disabled." + excludeGroups[i];
+								}
+								ArrayList<String> excludeGroupNames = new ArrayList<String> (Arrays.asList(excludeGroups));
+								excludeDatas.add(new ExcludeData(methodsToExclude, fileName, defectNumber, excludeGroupNames));
+							}
+						}
+					}
+					bufferedReader.close();
+				} catch(IOException ex) {
+					logger.info("Error reading file " + currentReadingFile, ex);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Commit 1: Process a list of test exclude files

Currently, `IncludeExcludeTestAnnotationTransformer` only processes a single
exclude file.

It has been updated to process a list of exclude files.

The list can be provided via the `EXCLUDE_FILE` environment variable where the
exclude files are separated by commas.

The name of the environment variable is left unchanged. So, the existing
scripts do not need to be updated.

### Commit 2: Create a test exclude file for OJDK MHs

### Commit 3: Add a system property to check if OJDK MHs are enabled

The new system property can be checked through `-XshowSettings:properties`.

TODO: eclipse-openj9#12811

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>