### PR TITLE
Move f2i, f2l, d2i, d2l evaluators from OMR to OpenJ9

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,7 +154,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *generateConcurrentScavengeSequence(TR::Node *node, TR::CodeGenerator *cg);
-
+   static TR::Register *fpConvertToLong(TR::Node *node, TR::SymbolReference *helperSymRef, TR::CodeGenerator *cg);
+   static TR::Register *f2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    class CaseConversionManager;
    static TR::Register *stringCaseConversionHelper(TR::Node *node, TR::CodeGenerator *cg, CaseConversionManager& manager);
 


### PR DESCRIPTION
Move f2i, f2l, d2i, d2l evaluators from OMR to OpenJ9

Signed-off-by: BradleyWood <bradley.wood@ibm.com>