### PR TITLE
Fix MemberName fields after Fast HCR and FSD

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -44,11 +44,6 @@ extern "C" {
  * These constants are validated by the MethodHandleNatives$Constants.verifyConstants()
  * method when Java assertions are enabled
  */
-#define MN_IS_METHOD		0x00010000
-#define MN_IS_CONSTRUCTOR	0x00020000
-#define MN_IS_FIELD			0x00040000
-#define MN_IS_TYPE			0x00080000
-#define MN_CALLER_SENSITIVE	0x00100000
 
 #define MN_REFERENCE_KIND_SHIFT	24
 #define MN_REFERENCE_KIND_MASK	0xF		/* (flag >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK */

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1197,7 +1197,7 @@ redefineClassesCommon(jvmtiEnv* env,
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 			/* Fix MemberNames (vmtarget) */
-			fixMemberNames(vm, classPairs);
+			fixMemberNames(currentThread, classPairs);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 			/* Fix resolved constant pool references to point to new methods. */
@@ -1261,7 +1261,7 @@ redefineClassesCommon(jvmtiEnv* env,
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 			/* Fix MemberNames (vmtarget) */
-			fixMemberNames(vm, classPairs);
+			fixMemberNames(currentThread, classPairs);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 			/* Restore breakpoints in the implicitly replaced classes */

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1195,6 +1195,11 @@ redefineClassesCommon(jvmtiEnv* env,
 			/* Fix JNI */
 			fixJNIRefs(currentThread, classPairs, TRUE, extensionsUsed);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			/* Fix MemberNames (vmtarget) */
+			fixMemberNames(vm, classPairs);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
 			/* Fix resolved constant pool references to point to new methods. */
 			fixConstantPoolsForFastHCR(currentThread, classPairs, methodPairs);
 
@@ -1253,6 +1258,11 @@ redefineClassesCommon(jvmtiEnv* env,
 			if (!extensionsUsed) {
 				fixVTables_forNormalRedefine(currentThread, classPairs, methodPairs, FALSE, &methodEquivalences);
 			}
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			/* Fix MemberNames (vmtarget) */
+			fixMemberNames(vm, classPairs);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 			/* Restore breakpoints in the implicitly replaced classes */
 			restoreBreakpointsInClasses(currentThread, classPairs);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2247,6 +2247,16 @@ typedef struct J9ROMMethodHandleRef {
 #define MH_REF_INVOKEVIRTUAL  5
 #define MH_REF_PUTFIELD  3
 
+/* Constants mapped from java.lang.invoke.MethodHandleNatives$Constants
+ * These constants are validated by the MethodHandleNatives$Constants.verifyConstants()
+ * method when Java assertions are enabled
+ */
+#define MN_IS_METHOD		0x00010000
+#define MN_IS_CONSTRUCTOR	0x00020000
+#define MN_IS_FIELD			0x00040000
+#define MN_IS_TYPE			0x00080000
+#define MN_CALLER_SENSITIVE	0x00100000
+
 typedef struct J9ROMMethodRef {
 	U_32 classRefCPIndex;
 	J9SRP nameAndSignature;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2176,7 +2176,7 @@ fixJNIRefs (J9VMThread * currentThread, J9HashTable* classHashTable, BOOLEAN fas
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void
-fixMemberNames(J9JavaVM * vm, J9HashTable * classHashTable);
+fixMemberNames(J9VMThread * currentThread, J9HashTable * classHashTable);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 void

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2175,6 +2175,9 @@ void
 fixJNIRefs (J9VMThread * currentThread, J9HashTable* classHashTable, BOOLEAN fastHCR, UDATA extensionsUsed);
 
 void
+fixMemberNames(J9JavaVM * vm, J9HashTable * classHashTable);
+
+void
 fixConstantPoolsForFastHCR(J9VMThread *currentThread, J9HashTable *classPairs, J9HashTable *methodPair);
 
 void

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2174,8 +2174,10 @@ fixArrayClasses(J9VMThread * currentThread, J9HashTable* classHashTable);
 void
 fixJNIRefs (J9VMThread * currentThread, J9HashTable* classHashTable, BOOLEAN fastHCR, UDATA extensionsUsed);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void
 fixMemberNames(J9JavaVM * vm, J9HashTable * classHashTable);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 void
 fixConstantPoolsForFastHCR(J9VMThread *currentThread, J9HashTable *classPairs, J9HashTable *methodPair);

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -90,7 +90,9 @@ static int compareClassDepth (const void *leftPair, const void *rightPair);
 static UDATA utfsAreIdentical(J9UTF8 * utf1, J9UTF8 * utf2);
 static UDATA areUTFPairsIdentical(J9UTF8 * leftUtf1, J9UTF8 * leftUtf2, J9UTF8 * rightUtf1, J9UTF8 * rightUtf2);
 static jvmtiError fixJNIMethodID(J9VMThread *currentThread, J9Method *oldMethod, J9Method *newMethod, BOOLEAN equivalent, UDATA extensionsUsed);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 static jvmtiIterationControl fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor *objectDesc, void *userData);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 static jvmtiIterationControl fixHeapRefsHeapIteratorCallback(J9JavaVM *vm, J9MM_IterateHeapDescriptor *heapDesc, void *userData);
 static jvmtiIterationControl fixHeapRefsSpaceIteratorCallback(J9JavaVM *vm, J9MM_IterateSpaceDescriptor *spaceDesc, void *userData);
@@ -1702,6 +1704,7 @@ fixJNIRefs(J9VMThread * currentThread, J9HashTable * classPairs, BOOLEAN fastHCR
 }
 
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void
 fixMemberNames(J9JavaVM * vm, J9HashTable * classHashTable)
 {
@@ -1755,6 +1758,7 @@ fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor 
 
 	return JVMTI_ITERATION_CONTINUE;
 }
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 
 /**

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1704,34 +1704,46 @@ fixJNIRefs(J9VMThread * currentThread, J9HashTable * classPairs, BOOLEAN fastHCR
 }
 
 
+typedef struct J9ThreadHashPair {
+	J9VMThread *currentThread;
+	void *userData;
+} J9ThreadHashPair;
+
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void
-fixMemberNames(J9JavaVM * vm, J9HashTable * classHashTable)
+fixMemberNames(J9VMThread * currentThread, J9HashTable * classHashTable)
 {
-	PORT_ACCESS_FROM_JAVAVM(vm);
+	PORT_ACCESS_FROM_JAVAVM(currentThread->javaVM);
+
+	J9ThreadHashPair data;
+	data.currentThread = currentThread;
+	data.userData = classHashTable;
 
 	/* iterate over all objects fixing up vmtarget refs if object is a MemberName */
-	vm->memoryManagerFunctions->j9mm_iterate_all_objects(vm, PORTLIB, 0, fixMemberNamesObjectIteratorCallback, classHashTable);
+	currentThread->javaVM->memoryManagerFunctions->j9mm_iterate_all_objects(currentThread->javaVM, PORTLIB, 0, fixMemberNamesObjectIteratorCallback, &data);
 }
 
 static jvmtiIterationControl
 fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor *objectDesc, void *userData)
 {
-	J9HashTable *classHashTable = userData;
+	J9ThreadHashPair *data = userData;
+	J9VMThread *currentThread = data->currentThread;
+	J9HashTable *classHashTable = data->userData;
 	j9object_t object = objectDesc->object;
 	J9Class *clazz = J9OBJECT_CLAZZ_VM(vm, object);
 
 	if (NULL != classHashTable) {
-		if (clazz == J9VMJAVALANGINVOKEMEMBERNAME(vm) && NULL != J9OBJECT_U64_LOAD(vm->currentThread, object, vm->vmindexOffset)) {
-			jlong vmindex = J9OBJECT_U64_LOAD(vm->currentThread, object, vm->vmindexOffset);
+		if (clazz == J9VMJAVALANGINVOKEMEMBERNAME(vm) && 0 != J9OBJECT_U64_LOAD(currentThread, object, vm->vmindexOffset)) {
+			jlong vmindex = J9OBJECT_U64_LOAD(currentThread, object, vm->vmindexOffset);
 
 			J9JVMTIClassPair exemplar;
 			J9JVMTIClassPair *result = NULL;
 
-			exemplar.replacementClass.ramClass = J9VM_J9CLASS_FROM_HEAPCLASS(J9VMJAVALANGINVOKEMEMBERNAME_CLAZZ(vm->currentThread, object));
+			j9object_t membernameClazz = J9VMJAVALANGINVOKEMEMBERNAME_CLAZZ(currentThread, object);
+			exemplar.replacementClass.ramClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, membernameClazz);
 			result = hashTableFind(classHashTable, &exemplar);
 			if (NULL != result) {
-				jint flags = J9VMJAVALANGINVOKEMEMBERNAME_FLAGS(vm->currentThread, object);
+				jint flags = J9VMJAVALANGINVOKEMEMBERNAME_FLAGS(currentThread, object);
 				if (J9_ARE_ANY_BITS_SET(flags, MN_IS_FIELD)) {
 					/* Update vmtarget to vmindex->offset */
 					J9JNIFieldID *fieldID = (J9JNIFieldID *)vmindex;
@@ -1744,12 +1756,12 @@ fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor 
 							offset |= J9_SUN_FINAL_FIELD_OFFSET_TAG;
 						}
 					}
-					J9OBJECT_U64_STORE(vm->currentThread, object, vm->vmtargetOffset, (U_64)offset));
+					J9OBJECT_U64_STORE(currentThread, object, vm->vmtargetOffset, (U_64)offset);
 				
 				} else if (J9_ARE_ANY_BITS_SET(flags, MN_IS_METHOD | MN_IS_CONSTRUCTOR)) {
 					/* Update vmtarget to vmindex->method */
 					J9JNIMethodID *methodID = (J9JNIMethodID *)vmindex;
-					J9OBJECT_U64_STORE(vm->currentThread, object, vm->vmtargetOffset, vmindex->method));
+					J9OBJECT_U64_STORE(currentThread, object, vm->vmtargetOffset, methodID->method);
 
 				}
 			}

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1734,7 +1734,7 @@ fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor 
 
 	if (NULL != classHashTable) {
 		if (clazz == J9VMJAVALANGINVOKEMEMBERNAME(vm) && 0 != J9OBJECT_U64_LOAD(currentThread, object, vm->vmindexOffset)) {
-			jlong vmindex = J9OBJECT_U64_LOAD(currentThread, object, vm->vmindexOffset);
+			U_64 vmindex = J9OBJECT_U64_LOAD(currentThread, object, vm->vmindexOffset);
 
 			J9JVMTIClassPair exemplar;
 			J9JVMTIClassPair *result = NULL;

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -90,6 +90,7 @@ static int compareClassDepth (const void *leftPair, const void *rightPair);
 static UDATA utfsAreIdentical(J9UTF8 * utf1, J9UTF8 * utf2);
 static UDATA areUTFPairsIdentical(J9UTF8 * leftUtf1, J9UTF8 * leftUtf2, J9UTF8 * rightUtf1, J9UTF8 * rightUtf2);
 static jvmtiError fixJNIMethodID(J9VMThread *currentThread, J9Method *oldMethod, J9Method *newMethod, BOOLEAN equivalent, UDATA extensionsUsed);
+static jvmtiIterationControl fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor *objectDesc, void *userData);
 
 static jvmtiIterationControl fixHeapRefsHeapIteratorCallback(J9JavaVM *vm, J9MM_IterateHeapDescriptor *heapDesc, void *userData);
 static jvmtiIterationControl fixHeapRefsSpaceIteratorCallback(J9JavaVM *vm, J9MM_IterateSpaceDescriptor *spaceDesc, void *userData);

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1761,7 +1761,7 @@ fixMemberNamesObjectIteratorCallback(J9JavaVM *vm, J9MM_IterateObjectDescriptor 
 				} else if (J9_ARE_ANY_BITS_SET(flags, MN_IS_METHOD | MN_IS_CONSTRUCTOR)) {
 					/* Update vmtarget to vmindex->method */
 					J9JNIMethodID *methodID = (J9JNIMethodID *)vmindex;
-					J9OBJECT_U64_STORE(currentThread, object, vm->vmtargetOffset, methodID->method);
+					J9OBJECT_U64_STORE(currentThread, object, vm->vmtargetOffset, (U_64)methodID->method);
 
 				}
 			}


### PR DESCRIPTION
`fixMemberNames` called after HCR to do a heap walk to fix all `MemberName` objects' `vmtarget`. `MemberName->clazz` and `MemberName->vmindex` have already been fixed by existing mechanisms.

- If the object is a fieldID, set vmtarget to the field offset + modifiers. If it is a method/constructor ID, set vmtarget to the ID's method
- Move needed MemberName macros to j9nonbuilder.h
- Define struct consisting of J9VMThread * and void * to be passed into the callback function as it needs the current thread and the class hash table

Issue: #11528
Signed-off-by: Eric Yang <eric.yang@ibm.com>