### PR TITLE
Disable J9-specific HCR code in OJDK implementation

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1187,8 +1187,10 @@ redefineClassesCommon(jvmtiEnv* env,
 			/* Fix the vTables of all subclasses */
 			fixVTables_forNormalRedefine(currentThread, classPairs, methodPairs, TRUE, &methodEquivalences);
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 			/* Update method references in DirectHandles */
 			fixDirectHandles(currentThread, classPairs, methodPairs);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 			/* Fix JNI */
 			fixJNIRefs(currentThread, classPairs, TRUE, extensionsUsed);
@@ -1219,8 +1221,10 @@ redefineClassesCommon(jvmtiEnv* env,
 			/* Update heap references */
 			fixHeapRefs(vm, classPairs);
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 			/* Update method references in DirectHandles */
 			fixDirectHandles(currentThread, classPairs, methodPairs);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 			/* Copy preserved values */
 			copyPreservedValues(currentThread, classPairs, extensionsUsed);

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2183,8 +2183,10 @@ unresolveAllClasses (J9VMThread * currentThread, J9HashTable * classPairs, J9Has
 void
 fixHeapRefs (J9JavaVM * vm, J9HashTable * classPairs);
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 void
 fixDirectHandles(J9VMThread * currentThread, J9HashTable * classHashTable, J9HashTable * methodHashTable);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void
 copyPreservedValues (J9VMThread * currentThread, J9HashTable* classHashTable, UDATA extensionsUsed);

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2089,6 +2089,7 @@ fixHeapRefs(J9JavaVM * vm, J9HashTable * classHashTable)
 	vm->memoryManagerFunctions->j9mm_iterate_heaps(vm, PORTLIB, 0, fixHeapRefsHeapIteratorCallback, classHashTable);
 }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 void
 fixDirectHandles(J9VMThread * currentThread, J9HashTable * classHashTable, J9HashTable * methodHashTable)
 {
@@ -2139,6 +2140,7 @@ fixDirectHandles(J9VMThread * currentThread, J9HashTable * classHashTable, J9Has
 		}
 	}
 }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void
 copyPreservedValues(J9VMThread * currentThread, J9HashTable * classPairs, UDATA extensionsUsed)


### PR DESCRIPTION
Disable fixDirectHandles when building for OJDK method handles.

Issue: #11528
Signed-off-by: Eric Yang <eric.yang@ibm.com>