### PR TITLE
Delete comment referring to obsolete J9VMJavaLangClassNativesCDLC

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
@@ -400,7 +400,6 @@ public class J9ClassHelper
 	/**
 	 * Returns "raw" modifiers
 	 * 
-	 * Derived from logic in J9VMJavaLangClassNativesCDLC.getModifiersImpl
 	 * @param j9class
 	 * @return
 	 * @throws CorruptDataException


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/12818