### PR TITLE
Fix a number of issues related to runtime resolution of methods

### DIFF
--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1797,7 +1797,7 @@ TR_ResolvedJ9JITServerMethod::cacheResolvedMethodsCallees(int32_t ttlForUnresolv
 
    // 2. Send a remote query to mirror all uncached resolved methods
    _stream->write(JITServer::MessageType::ResolvedMethod_getMultipleResolvedMethods, (TR_ResolvedJ9Method *) _remoteMirror, methodTypes, cpIndices);
-   auto recv = _stream->read<std::vector<J9Method *>, std::vector<uint32_t>, std::vector<TR_ResolvedJ9JITServerMethodInfo>>();
+   auto recv = _stream->read<std::vector<TR_OpaqueMethodBlock *>, std::vector<uint32_t>, std::vector<TR_ResolvedJ9JITServerMethodInfo>>();
 
    // 3. Cache all received resolved methods
    auto &ramMethods = std::get<0>(recv);
@@ -1816,10 +1816,11 @@ TR_ResolvedJ9JITServerMethod::cacheResolvedMethodsCallees(int32_t ttlForUnresolv
          {
          compInfoPT->cacheResolvedMethod(
             key,
-            (TR_OpaqueMethodBlock *) ramMethods[i],
+            ramMethods[i],
             vTableOffsets[i],
             methodInfos[i],
-            ttlForUnresolved);
+            ttlForUnresolved
+            );
          }
       }
    }


### PR DESCRIPTION
The client-side handler of `ResolvedMethod_getMultipleResolvedMethods`
did not check the value of `J9JIT_RUNTIME_RESOLVE` flag for some of
the methods it created, which resulted in bugs when `-Xjit:rtResolve`
option is specified.

This commit refactors `ResolvedMethod_getMultipleResolvedMethods`
and `TR_ResolvedJ9JITServerMethod::cacheResolvedMethodCallees` to
call resolved method creation routine on the client directly, instead
of copy-pasting the code from that routine, which fixes the problem.

The code here is a small chunk of PR #12147, which should fully refactor
resolved methods creation, when it is merged at a later date.