### PR TITLE
JDK17 update : add JavaLangAccess methods & @SuppressWarnings("removal") for SecurityManager

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/AbstractClassLoader.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/AbstractClassLoader.java
@@ -1,9 +1,6 @@
-/*[INCLUDE-IF Sidecar16 & !Sidecar19-SE]*/
-
-package com.ibm.oti.vm;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +20,7 @@ package com.ibm.oti.vm;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- 
+package com.ibm.oti.vm;
 
 import java.lang.ref.SoftReference;
 import java.net.URL;
@@ -194,6 +191,7 @@ protected URL findResource(final String res) {
 			return null;
 		}});
 	if (result != null) {
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm != null) {
 			try {
@@ -260,6 +258,7 @@ protected Enumeration findResources(final String res) throws IOException {
 			}
 			return resources;
 		}});
+	@SuppressWarnings("removal")
 	SecurityManager sm;
 	int length = result.size();
 	if (length > 0 && (sm = System.getSecurityManager()) != null) {
@@ -324,6 +323,7 @@ public InputStream getResourceAsStream(String resName) {
 					final ZipFile zf = (ZipFile)cache[i];
 					ZipEntry entry;
 					if ((entry = zf.getEntry(resName)) != null) {
+						@SuppressWarnings("removal")
 						SecurityManager security = System.getSecurityManager();
 						if (security != null) {
 							initalizePermissions();

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -477,20 +477,31 @@ final class Access implements JavaLangAccess {
 		StringLatin1.inflate(srcBytes, srcOffset, dstChars, dstOffset, length);
 	}
 
-	/*[IF OPENJDK_METHODHANDLES]*/
-	// This JPP flag is used to workaround the issue that latest 
-	// String update hasn't been promoted into openj9 branch. 
-	public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
-		return String.join(prefix, suffix, delimiter, elements, size);
-	}
-	/*[ENDIF] OPENJDK_METHODHANDLES*/
-	
 	// The method findBootstrapClassOrNull(ClassLoader classLoader, String name) can be removed
 	// after following API change is promoted into extension repo openj9 branch.
 	public Class<?> findBootstrapClassOrNull(String name) {
 		return VMAccess.findClassOrNull(name, ClassLoader.bootstrapClassLoader);
 	}
 
+	/*[IF OPENJDK_METHODHANDLES]*/
+	// This JPP flag is used to workaround the issue that latest 
+	// String update hasn't been promoted into openj9 branch. 
+	public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
+		return String.join(prefix, suffix, delimiter, elements, size);
+	}
+	
+	public boolean isEnableNativeAccess(Module mod) {
+		return mod.implIsEnableNativeAccess();
+	}
+	
+	public void addEnableNativeAccessAllUnnamed() {
+		Module.implAddEnableNativeAccessAllUnnamed();
+	}
+	
+	public Module addEnableNativeAccess(Module mod) {
+		return mod.implAddEnableNativeAccess();
+	}
+	/*[ENDIF] OPENJDK_METHODHANDLES*/
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 /*[ENDIF] Sidecar19-SE */

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -389,6 +389,7 @@ private static void forNameAccessCheck(final SecurityManager sm, final Class<?> 
  */
 @CallerSensitive
 public static Class<?> forName(String className) throws ClassNotFoundException {
+	@SuppressWarnings("removal")
 	SecurityManager sm = null;
 	/**
 	 * Get the SecurityManager from System.  If the VM has not yet completed bootstrapping (i.e., J9VMInternals.initialized is still false)
@@ -467,6 +468,7 @@ boolean casAnnotationType(AnnotationType oldType, AnnotationType newType) {
 public static Class<?> forName(String className, boolean initializeBoolean, ClassLoader classLoader)
 	throws ClassNotFoundException
 {
+	@SuppressWarnings("removal")
 	SecurityManager sm = null;
 	if (J9VMInternals.initialized) {
 		sm = System.getSecurityManager();
@@ -516,6 +518,7 @@ public static Class<?> forName(String className, boolean initializeBoolean, Clas
 @CallerSensitive
 public static Class<?> forName(Module module, String name)
 {
+	@SuppressWarnings("removal")
 	SecurityManager sm = null;
 	ClassLoader classLoader;
 	Class<?> c;
@@ -598,6 +601,7 @@ private static native Class<?> forNameImpl(String className,
 @CallerSensitive
 public Class<?>[] getClasses() {
 	/*[PR CMVC 82311] Spec is incorrect before 1.5, RI has this behavior since 1.2 */
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -635,6 +639,7 @@ public ClassLoader getClassLoader() {
 		if (classLoader == ClassLoader.bootstrapClassLoader)	{
 			return null;
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
 			ClassLoader callersClassLoader = ClassLoader.callerClassLoader();
@@ -722,6 +727,7 @@ private NoSuchMethodException newNoSuchMethodException(String name, Class<?>[] t
  */
 @CallerSensitive
 public Constructor<T> getConstructor(Class<?>... parameterTypes) throws NoSuchMethodException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -778,6 +784,7 @@ private native Constructor<T> getConstructorImpl(Class<?> parameterTypes[], Stri
  */
 @CallerSensitive
 public Constructor<?>[] getConstructors() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -822,6 +829,7 @@ private native Constructor<T>[] getConstructorsImpl();
  */
 @CallerSensitive
 public Class<?>[] getDeclaredClasses() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -857,6 +865,7 @@ private native Class<?>[] getDeclaredClassesImpl();
  */
 @CallerSensitive
 public Constructor<T> getDeclaredConstructor(Class<?>... parameterTypes) throws NoSuchMethodException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -914,6 +923,7 @@ private native Constructor<T> getDeclaredConstructorImpl(Class<?>[] parameterTyp
  */
 @CallerSensitive
 public Constructor<?>[] getDeclaredConstructors() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -960,6 +970,7 @@ private native Constructor<T>[] getDeclaredConstructorsImpl();
  */
 @CallerSensitive
 public Field getDeclaredField(String name) throws NoSuchFieldException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1033,6 +1044,7 @@ private native Field getDeclaredFieldImpl(String name) throws NoSuchFieldExcepti
  */
 @CallerSensitive
 public Field[] getDeclaredFields() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1181,6 +1193,7 @@ static void reflectCacheDebugHelper(Class<?>[] parameters, int posInsert, String
  */
 @CallerSensitive
 public Method getDeclaredMethod(String name, Class<?>... parameterTypes) throws NoSuchMethodException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1220,6 +1233,7 @@ private native Method getDeclaredMethodImpl(String name, Class<?>[] parameterTyp
  */
 @CallerSensitive
 public Method[] getDeclaredMethods() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1280,6 +1294,7 @@ public Class<?> getDeclaringClass() {
 		return declaringClass;
 	}
 	if (declaringClass.isClassADeclaredClass(this)) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1348,6 +1363,7 @@ private native Class<?> getDeclaringClassImpl();
  */
 @CallerSensitive
 public Field getField(String name) throws NoSuchFieldException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1397,6 +1413,7 @@ private native Field getFieldImpl(String name) throws NoSuchFieldException;
  */
 @CallerSensitive
 public Field[] getFields() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1466,6 +1483,7 @@ public Class<?>[] getInterfaces() {
  */
 @CallerSensitive
 public Method getMethod(String name, Class<?>... parameterTypes) throws NoSuchMethodException, SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -1791,6 +1809,7 @@ private native Method getMethodImpl(String name, Class<?>[] parameterTypes, Stri
  */
 @CallerSensitive
 public Method[] getMethods() throws SecurityException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -2047,6 +2066,7 @@ public String getName() {
  * @see			java.lang.Class
  */
 public ProtectionDomain getProtectionDomain() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		security.checkPermission(sun.security.util.SecurityConstants.GET_PD_PERMISSION);
@@ -2408,6 +2428,7 @@ public native boolean isPrimitiveClass();
 @Deprecated(forRemoval=false, since="9")
 /*[ENDIF]*/
 public T newInstance() throws IllegalAccessException, InstantiationException {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -3636,6 +3657,7 @@ public Constructor<?> getEnclosingConstructor() throws SecurityException {
 	Object enclosing = getEnclosingObject();
 	if (enclosing instanceof Constructor<?>) {
 		constructor = (Constructor<?>) enclosing;
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -3663,6 +3685,7 @@ public Method getEnclosingMethod() throws SecurityException {
 	Object enclosing = getEnclosingObject();
 	if (enclosing instanceof Method) {
 		method = (Method)enclosing;
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -3711,6 +3734,7 @@ public Class<?> getEnclosingClass() throws SecurityException {
 		enclosingClass = cachedEnclosingClass == ClassReflectNullPlaceHolder.class ? null: cachedEnclosingClass;
 	}
 	if (enclosingClass != null) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -4901,6 +4925,7 @@ public Class<?> getNestHost() throws SecurityException {
 	 * then throw a SecurityException.
 	 */
 	if (nestHost != this) {
+		@SuppressWarnings("removal")
 		SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null) {
 			ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
@@ -4963,6 +4988,7 @@ SecurityException {
 	Class<?>[] members = getNestMembersImpl();
 	/* Skip security check for the Class object that belongs to the nest consisting only of itself */
 	if (members.length > 1) {
+		@SuppressWarnings("removal")
 		SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null) {
 			/* All classes in a nest must be in the same runtime package and therefore same classloader */
@@ -5121,6 +5147,7 @@ SecurityException {
 	 */
 	@CallerSensitive
 	public RecordComponent[] getRecordComponents() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			ClassLoader callerClassLoader = ClassLoader.getStackClassLoader(1);
@@ -5211,6 +5238,7 @@ SecurityException {
 			getUnsafe().putObjectRelease(this, localPermittedSubclassesCacheOffset, localPermittedSubclasses);
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (null != sm) {
 			HashSet<String> packages = new HashSet<>();

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -339,6 +339,7 @@ protected ClassLoader() {
  * @return Void a unused reference passed to the Constructor
  */
 private static Void checkSecurityPermission() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		security.checkCreateClassLoader();
@@ -844,6 +845,7 @@ protected final Class<?> findSystemClass (String className) throws ClassNotFound
  */
 @CallerSensitive
 public final ClassLoader getParent() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {	
 		ClassLoader callersClassLoader = callerClassLoader();
@@ -1068,6 +1070,7 @@ static ClassLoader getClassLoader(Class<?> clz) {
  */
 @CallerSensitive
 public static ClassLoader getPlatformClassLoader() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	ClassLoader platformClassLoader = ClassLoaders.platformClassLoader();
 	if (security != null) {
@@ -1148,6 +1151,7 @@ public static ClassLoader getSystemClassLoader () {
 	}
 	
 	ClassLoader sysLoader = applicationClassLoader;
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {	
 		ClassLoader callersClassLoader = callerClassLoader();

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2021 IBM Corp. and others
  *
@@ -323,6 +323,7 @@ final class J9VMInternals {
 
 	/*[PR CVMC 124584] checkPackageAccess(), not defineClassImpl(), should use ProtectionDomain */
 	private static void checkPackageAccess(final Class clazz, ProtectionDomain pd) {
+		@SuppressWarnings("removal")
 		final SecurityManager sm = System.getSecurityManager();
 		if (sm != null) {
 			ProtectionDomain[] pdArray = (pd == null) ? new ProtectionDomain[]{} : new ProtectionDomain[]{pd};

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION > 8]*/
 /*******************************************************************************
  * Copyright (c) 2016, 2021 IBM Corp. and others
  *
@@ -70,6 +70,7 @@ public final class StackWalker {
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0641")); //$NON-NLS-1$
 		}
 		if (options.contains(Option.RETAIN_CLASS_REFERENCE)) {
+			@SuppressWarnings("removal")
 			SecurityManager securityMgr = System.getSecurityManager();
 			if (null != securityMgr) {
 				securityMgr.checkPermission(PermissionSingleton.perm);

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -456,6 +456,7 @@ private static void initGPUAssist() {
  * @param		newIn 		the new value for in.
  */
 public static void setIn(InputStream newIn) {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
@@ -471,6 +472,7 @@ public static void setIn(InputStream newIn) {
  * @param		newOut 		the new value for out.
  */
 public static void setOut(java.io.PrintStream newOut) {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
@@ -485,6 +487,7 @@ public static void setOut(java.io.PrintStream newOut) {
  * @param		newErr  	the new value for err.
  */
 public static void setErr(java.io.PrintStream newErr) {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
@@ -713,6 +716,7 @@ public static void gc() {
 @SuppressWarnings("dep-ann")
 public static String getenv(String var) {
 	if (var == null) throw new NullPointerException();
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv." + var)); //$NON-NLS-1$
@@ -733,6 +737,7 @@ public static String getenv(String var) {
  */
 public static Properties getProperties() {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init"); //$NON-NLS-1$
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertiesAccess();
@@ -797,6 +802,7 @@ public static String getProperty(String prop) {
 public static String getProperty(String prop, String defaultValue) {
 	if (prop.length() == 0) throw new IllegalArgumentException();
 
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertyAccess(prop);
@@ -831,6 +837,7 @@ public static String setProperty(String prop, String value) {
 	/*[PR CMVC 80288] should check for empty key */
 	if (prop.length() == 0) throw new IllegalArgumentException();
 
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(
@@ -894,6 +901,7 @@ public static int identityHashCode(Object anObject) {
  */
 @CallerSensitive
 public static void load(String pathName) {
+	@SuppressWarnings("removal")
 	SecurityManager smngr = System.getSecurityManager();
 	if (smngr != null) {
 		smngr.checkLink(pathName);
@@ -921,6 +929,7 @@ public static void load(String pathName) {
  */
 @CallerSensitive
 public static void loadLibrary(String libName) {
+	@SuppressWarnings("removal")
 	SecurityManager smngr = System.getSecurityManager();
 	if (smngr != null) {
 		smngr.checkLink(libName);
@@ -974,6 +983,7 @@ public static void runFinalizersOnExit(boolean flag) {
  * @param		p			the property to set
  */
 public static void setProperties(Properties p) {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertiesAccess();
@@ -1000,6 +1010,7 @@ public static void setProperties(Properties p) {
  */
 public static void setSecurityManager(final SecurityManager s) {
 	/*[PR 113606] security field could be modified by another Thread */
+	@SuppressWarnings("removal")
 	final SecurityManager currentSecurity = security;
 
 	if (s != null) {
@@ -1103,6 +1114,7 @@ public static String clearProperty(String prop) {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
 
 	if (prop.length() == 0) throw new IllegalArgumentException();
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new PropertyPermission(prop, "write")); //$NON-NLS-1$
@@ -1115,6 +1127,7 @@ public static String clearProperty(String prop) {
  * @return	an unmodifiable Map containing all of the system environment variables.
  */
 public static Map<String, String> getenv() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv.*")); //$NON-NLS-1$
@@ -1533,6 +1546,7 @@ public abstract static class LoggerFinder {
 	}
 
 	private static void verifyPermissions() {
+		@SuppressWarnings("removal")
 		SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null)	{
 			securityManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionLoggerFinder);

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -423,6 +423,7 @@ private Thread(ThreadGroup group, Runnable runnable, String threadName, AccessCo
 
 /*[PR 1FEO92F] (dup of 1FC0TRN) */
 	if (group == null) {
+		@SuppressWarnings("removal")
 		SecurityManager currentManager = System.getSecurityManager();
 		 // if there is a security manager...
 		if (currentManager != null)
@@ -473,6 +474,7 @@ private void initialize(boolean booting, ThreadGroup threadGroup, Thread parentT
 		}
 
 		/*[PR CMVC 90230] enableContextClassLoaderOverride check added in 1.5 */
+		@SuppressWarnings("removal")
 		final SecurityManager sm = System.getSecurityManager();
 		final Class implClass = getClass();
 		final Class thisClass = Thread.class;
@@ -571,6 +573,7 @@ public static int activeCount(){
  * @see			java.lang.SecurityManager
  */
 public final void checkAccess() {
+	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();
 	if (currentManager != null) currentManager.checkAccess(this);
 }
@@ -664,6 +667,7 @@ public static int enumerate(Thread[] threads) {
 public ClassLoader getContextClassLoader() {
 /*[PR 1FCA807]*/
 /*[PR 1FDTAMT] use callerClassLoader()*/
+	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();
 	 // if there is a security manager...
 	if (currentManager != null) {
@@ -722,6 +726,7 @@ public final ThreadGroup getThreadGroup() {
  * @see			Thread#isInterrupted
  */
 public void interrupt() {
+	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();
 
 	if (currentManager != null) {
@@ -993,6 +998,7 @@ public void run() {
  */
 public void setContextClassLoader(ClassLoader cl) {
 /*[PR 1FCA807]*/
+	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();
 	 // if there is a security manager...
 	if (currentManager != null) {
@@ -1366,6 +1372,7 @@ private native Throwable getStackTraceImpl();
  */
 public StackTraceElement[] getStackTrace() {
 	if (Thread.currentThread() != this) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null)
 			security.checkPermission(SecurityConstants.GET_STACK_TRACE_PERMISSION); //$NON-NLS-1$
@@ -1393,6 +1400,7 @@ public StackTraceElement[] getStackTrace() {
  * @see #getStackTrace()
  */
 public static Map<Thread, StackTraceElement[]> getAllStackTraces() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
 		security.checkPermission(SecurityConstants.GET_STACK_TRACE_PERMISSION);

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -256,7 +256,7 @@ public boolean allowThreadSuspension(boolean b) {
 public final void checkAccess() {
 	// Forwards the message to the SecurityManager (if there's one)
 	// passing the receiver as parameter
-
+	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();
 	if (currentManager != null) currentManager.checkAccess(this);
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1892,6 +1892,7 @@ public class MethodHandles {
 			}
 			
 			if (performSecurityCheck) {
+				@SuppressWarnings("removal")
 				SecurityManager secmgr = System.getSecurityManager();
 				if (secmgr != null) {
 					/* Use leaf-class in the case of arrays for security check */
@@ -2094,6 +2095,7 @@ public class MethodHandles {
 				throw new IllegalAccessException(com.ibm.oti.util.Msg.getString("K065Y1", Integer.toHexString(accessMode), Integer.toHexString(Lookup.PACKAGE))); //$NON-NLS-1$
 			}
 			
+			@SuppressWarnings("removal")
 			SecurityManager secmgr = System.getSecurityManager();
 			if ((null != secmgr)
 				/*[IF JAVA_SPEC_VERSION >= 14]*/
@@ -2553,6 +2555,7 @@ public class MethodHandles {
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 
+		@SuppressWarnings("removal")
 		SecurityManager secmgr = System.getSecurityManager();
 		if (null != secmgr) {
 			secmgr.checkPermission(com.ibm.oti.util.ReflectPermissions.permissionSuppressAccessChecks);
@@ -2594,6 +2597,7 @@ public class MethodHandles {
 		if ((null == expected) || (null == target)) {
 			throw new NullPointerException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager secmgr = System.getSecurityManager();
 		if (null != secmgr) {
 			secmgr.checkPermission(com.ibm.oti.util.ReflectPermissions.permissionSuppressAccessChecks);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -336,6 +336,7 @@ public final class MethodType implements Serializable
 		ClassLoader classLoader = loader; 
 		if (classLoader == null) {
 			/*[IF JAVA_SPEC_VERSION >= 14]*/
+			@SuppressWarnings("removal")
 			SecurityManager security = System.getSecurityManager();
 			if (security != null) {
 				security.checkPermission(sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION);

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -376,6 +376,7 @@ public AccessControlContext(AccessControlContext acc, DomainCombiner combiner) {
  */
 AccessControlContext(AccessControlContext acc, DomainCombiner combiner, boolean preauthorized) {
 	if (!preauthorized) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
 			security.checkPermission(SecurityConstants.CREATE_ACC_PERMISSION);
@@ -894,6 +895,7 @@ public int hashCode() {
  *      when the caller doesn't have the  "getDomainCombiner" SecurityPermission
  */
 public DomainCombiner getDomainCombiner() {
+	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(SecurityConstants.GET_COMBINER_PERMISSION);

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,6 +118,7 @@ public final class ClassLoadingMXBeanImpl implements ClassLoadingMXBean {
 	 */
 	@Override
 	public void setVerbose(boolean value) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corp. and others
+ * Copyright (c) 2008, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -444,6 +444,7 @@ public final class ManagementUtils {
 		int i = name.lastIndexOf('.');
 
 		if (i != -1) {
+			@SuppressWarnings("removal")
 			SecurityManager sm = System.getSecurityManager();
 			if (sm != null) {
 				sm.checkPackageAccess(name.substring(0, i));

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -464,6 +464,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	 */
 	@Override
 	public void setVerbose(boolean value) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -522,6 +523,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (size < this.getMinHeapSize() || size > this.getMaxHeapSizeLimit()) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -657,6 +659,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (value < 0) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -671,6 +674,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (value < 0) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -685,6 +689,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (value < 0) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -699,6 +704,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (value < 0) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -713,6 +719,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		if (value < 0) {
 			throw new IllegalArgumentException();
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -360,6 +360,7 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 	 */
 	@Override
 	public void resetPeakUsage() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -385,6 +386,7 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -419,6 +421,7 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -237,6 +237,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 	}
 
 	public static void checkMonitorPermission() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2020 IBM Corp. and others
+ * Copyright (c) 2007, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,6 +84,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public long[] findMonitorDeadlockedThreads() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -103,6 +104,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public long[] getAllThreadIds() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -245,6 +247,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public ThreadInfo[] getThreadInfo(long[] ids, int maxDepth) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -330,6 +333,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05FB")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -353,6 +357,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public ThreadInfo getThreadInfo(long id, int maxDepth) {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -545,6 +550,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public void resetPeakThreadCount() {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -569,6 +575,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05FA")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -593,6 +600,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05F9")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
@@ -639,6 +647,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05FB")); //$NON-NLS-1$
 		}
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -672,6 +681,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 			/*[MSG "K05FB", "Monitoring of ownable synchronizer usage is not supported on this virtual machine"]*/
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05FB")); //$NON-NLS-1$
 		}
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -736,6 +746,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 * To satisfy com.ibm.lang.management.ThreadMXBean.
 	 */
 	public long[] getNativeThreadIds(long[] threadIDs) throws IllegalArgumentException, SecurityException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
@@ -758,6 +769,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 * To satisfy com.ibm.lang.management.
 	 */
 	public long getNativeThreadId(long threadId) throws IllegalArgumentException, SecurityException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);

--- a/jcl/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17 & !Sidecar19-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,6 +240,7 @@ public class ManagementFactory {
 	 */
 	public static MBeanServer getPlatformMBeanServer() {
 		/*[PR CMVC 93006]*/
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -1,8 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-package com.ibm.tools.attach.attacher;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corp. and others
+ * Copyright (c) 2009, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +20,7 @@ package com.ibm.tools.attach.attacher;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.tools.attach.attacher;
 
 import java.io.File;
 import java.io.IOException;
@@ -217,6 +216,7 @@ public class OpenJ9AttachProvider extends AttachProvider {
 	}
 
 	private static void checkAttachSecurity() {
+		@SuppressWarnings("removal")
 		final SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null) {
 			securityManager.checkPermission(Permissions.ATTACH_VM);

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -308,6 +308,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 
 	private static void checkManagementSecurityPermission() {
 		/* Check the caller has Management Permission. */
+		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkPermission(ManagementPermissionHelper.MPCONTROL);

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaDevice.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaDevice.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -525,6 +525,7 @@ public final class CudaDevice {
 	 *          does not have permission to disable peer access
 	 */
 	public void disablePeerAccess(CudaDevice peerDevice) throws CudaException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {
@@ -546,6 +547,7 @@ public final class CudaDevice {
 	 *          does not have permission to enable peer access
 	 */
 	public void enablePeerAccess(CudaDevice peerDevice) throws CudaException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {
@@ -736,6 +738,7 @@ public final class CudaDevice {
 	 *          does not have permission to set device cache configurations
 	 */
 	public void setCacheConfig(CacheConfig config) throws CudaException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {
@@ -759,6 +762,7 @@ public final class CudaDevice {
 	 *          does not have permission to set device limits
 	 */
 	public void setLimit(Limit limit, long value) throws CudaException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {
@@ -780,6 +784,7 @@ public final class CudaDevice {
 	 *          not have permission to set device shared memory configurations
 	 */
 	public void setSharedMemConfig(SharedMemConfig config) throws CudaException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaModule.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaModule.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,7 @@ public final class CudaModule {
 			throws CudaException {
 		super();
 
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/CUDAManager.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/CUDAManager.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corp. and others
+ * Copyright (c) 2014, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -270,6 +270,7 @@ public final class CUDAManager {
 	 *          have permission to access the CUDAManager instance.
 	 */
 	public static CUDAManager instance() throws SecurityException {
+		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 
 		if (security != null) {

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corp. and others
+ * Copyright (c) 2006, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -496,6 +496,7 @@ public class Dump {
 
 	private static void checkDumpSecurityPermssion() throws SecurityException {
 		/* Check the caller has DumpPermission. */
+		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
 		if( manager != null ) {
 			manager.checkPermission(DUMP_PERMISSION);
@@ -504,6 +505,7 @@ public class Dump {
 
 	private static void checkToolSecurityPermssion() throws SecurityException {
 		/* Check the caller has DumpPermission. */
+		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
 		if( manager != null ) {
 			manager.checkPermission(TOOL_DUMP_PERMISSION);

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
@@ -1,8 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-package com.ibm.jvm;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corp. and others
+ * Copyright (c) 2006, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +20,7 @@ package com.ibm.jvm;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.jvm;
 
 import java.util.Objects;
 
@@ -77,6 +76,7 @@ public class Log {
 	
     private static void checkLogSecurityPermssion() throws SecurityException {
 		/* Check the caller has LogPermission. */
+		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
 		if( manager != null ) {
 			manager.checkPermission(LOG_PERMISSION);

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
@@ -1,7 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -291,6 +290,7 @@ public final class Trace {
 	
     private static void checkTraceSecurityPermssion() throws SecurityException {
 		/* Check the caller has TracePermission. */
+		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkPermission(TRACE_PERMISSION);

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelper.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelper.java
@@ -77,6 +77,7 @@ public abstract class SharedAbstractHelper implements SharedHelper {
 	}
 
 	static boolean checkReadPermission(ClassLoader loader) {
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm!=null) {
 			return checkPermission(sm, loader, "read"); //$NON-NLS-1$
@@ -85,6 +86,7 @@ public abstract class SharedAbstractHelper implements SharedHelper {
 	}
 	
 	static boolean checkWritePermission(ClassLoader loader) {
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm!=null) {
 			return checkPermission(sm, loader, "write"); //$NON-NLS-1$

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelperFactory.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelperFactory.java
@@ -45,6 +45,7 @@ public abstract class SharedAbstractHelperFactory {
 	
 	static boolean checkPermission(ClassLoader loader, String type) {
 		boolean result = true;
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm!=null) {
 			try {

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassUtilities.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassUtilities.java
@@ -112,6 +112,7 @@ public class SharedClassUtilities {
 	 * 					have SharedClassesNamedPermission("getSharedCacheInfo")
 	 */
 	static public List<SharedClassCacheInfo> getSharedCacheInfo(String cacheDir, int flags, boolean useCommandLineValues) {
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm != null) {
 			sm.checkPermission(SharedPermissions.getSharedCacheInfo);
@@ -182,6 +183,7 @@ public class SharedClassUtilities {
 	 * 					have SharedClassesNamedPermission("destroySharedCache")
 	 */
 	static public int destroySharedCache(String cacheDir, int cacheType, String cacheName, boolean useCommandLineValues) {
+		@SuppressWarnings("removal")
 		SecurityManager sm = System.getSecurityManager();
 		if (sm != null) {
 			sm.checkPermission(SharedPermissions.destroySharedCache);


### PR DESCRIPTION
Added `JavaLangAccess` method implementations for `isEnableNativeAccess(mod)`, `addEnableNativeAccessAllUnnamed()` and `addEnableNativeAccess(mod)`;
Added `@SuppressWarnings("removal")` before `SecurityManager` to fix `error: warnings found and -Werror specified` for `warning: [removal] SecurityManager in java.lang has been deprecated and marked for removal`.

With this PR, `JDK17` `openj9-staging` branch can be built and `-version` output is as following:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.mergetmp)
Eclipse OpenJ9 VM (build jdk17update-199ad9188d, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210603_000000 (JIT enabled, AOT enabled)
OpenJ9   - 199ad9188d
OMR      - a5a0eca5a
JCL      - 0920b4bc912 based on jdk-17+24)
```

Related https://github.com/eclipse-openj9/openj9/issues/12760 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/320

Signed-off-by: Jason Feng <fengj@ca.ibm.com>