### PR TITLE
 Store ROM Method arg slot count in floatTemp1 for linkToStatic

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -780,23 +780,60 @@ J9::CodeGenerator::lowerTreeIfNeeded(
          {
          // invokeBasic and linkTo* are signature-polymorphic, so the VM needs to know the number of argument slots
          // for the INL call in order to locate the start of the arguments on the stack. The arg slot count is stored
-         // in vmThread.tempSlot
-         TR::SymbolReference *vmThreadTempSlotSymRef = self()->comp()->getSymRefTab()->findOrCreateVMThreadTempSlotFieldSymbolRef();
-         int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
+         // in vmThread.tempSlot.
+         //
+         // Furthermore, for unresolved invokedynamic and invokehandle bytecodes, we create a dummy TR_ResolvedMethod call to
+         // linkToStatic. The appendix object in the invoke cache array entry could be NULL, which we cannot determine at compile
+         // time when the callSite/invokeCache table entries are unresolved. The VM would have to remove the appendix
+         // object, which would require knowing the number of stack slots of the ROM method signature plus the slots occupied
+         // by the receiver object (for invokehandle only) and appendix object. This would be equivalent to the number of
+         // parameter slots of the linkToStatic call - 1.
+         // To pass that information, we store to vmThread.floatTemp1 field. The name of the field is
+         // misleading, as it is an lconst/iconst being stored. If the linkToStatic call is not for an unresolved
+         // invokedynamic/invokehandle, then the JIT would not create a push of a null appendix object, so the VM would not
+         // need to do any stack adjustments. In those cases, -1 is stored in floatTemp1. This is also done for linkToSpecial,
+         // as it shares the same handling mechanism in the VM. No stack adjustments are necessary for linkToSpecial, so the value
+         // stored in floatTemp1 will always be -1.
          TR::Node * numArgsNode = NULL;
-         TR::Node * storeNode = NULL;
-         if (self()->comp()->target().is64Bit())
+         TR::Node * numArgSlotsNode = NULL;
+         TR::Node * tempSlotStoreNode = NULL;
+         TR::Node * floatTemp1StoreNode = NULL;
+         bool is64Bit = self()->comp()->target().is64Bit();
+         TR::ILOpCodes storeOpCode;
+         int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
+         if (is64Bit)
             {
-            numArgsNode = TR::Node::lconst(node, numParameterStackSlots);
-            storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::lstore);
+            storeOpCode = TR::lstore;
+            numArgSlotsNode = TR::Node::lconst(node, numParameterStackSlots);
             }
          else
             {
-            numArgsNode = TR::Node::iconst(node, numParameterStackSlots);
-            storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::istore);
+            storeOpCode = TR::istore;
+            numArgSlotsNode = TR::Node::iconst(node, numParameterStackSlots);
             }
-         storeNode->setByteCodeIndex(node->getByteCodeIndex());
-         TR::TreeTop::create(self()->comp(), tt->getPrevTreeTop(), storeNode);
+         tempSlotStoreNode = TR::Node::createStore(self()->comp()->getSymRefTab()->findOrCreateVMThreadTempSlotFieldSymbolRef(),
+                                                   numArgSlotsNode,
+                                                   storeOpCode);
+         tempSlotStoreNode->setByteCodeIndex(node->getByteCodeIndex());
+         TR::TreeTop::create(self()->comp(), tt->getPrevTreeTop(), tempSlotStoreNode);
+
+         if (rm == TR::java_lang_invoke_MethodHandle_linkToStatic || rm ==  TR::java_lang_invoke_MethodHandle_linkToSpecial)
+            {
+            int32_t numArgs;
+            if (node->getSymbolReference()->getSymbol()->isDummyResolvedMethod())
+               numArgs = numParameterStackSlots - 1 ;
+            else
+               numArgs = -1;
+
+            numArgsNode = is64Bit ? TR::Node::lconst(node, numArgs) :
+                                    TR::Node::iconst(node, numArgs);
+
+            floatTemp1StoreNode = TR::Node::createStore(self()->comp()->getSymRefTab()->findOrCreateVMThreadFloatTemp1SymbolRef(),
+                                                      numArgsNode,
+                                                      storeOpCode);
+            floatTemp1StoreNode->setByteCodeIndex(node->getByteCodeIndex());
+            TR::TreeTop::create(self()->comp(), tt->getPrevTreeTop(), floatTemp1StoreNode);
+            }
          }
       }
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2400,6 +2400,21 @@ J9::SymbolReferenceTable::findOrCreateArrayComponentTypeSymbolRef()
    }
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateVMThreadFloatTemp1SymbolRef()
+   {
+   if (!element(j9VMThreadFloatTemp1Symbol))
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+      TR::Symbol * sym = TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(), "j9VMThreadFloatTemp1");
+      sym->setDataType(TR::Address);
+      element(j9VMThreadFloatTemp1Symbol) = new (trHeapMemory()) TR::SymbolReference(self(), j9VMThreadFloatTemp1Symbol, sym);
+      element(j9VMThreadFloatTemp1Symbol)->setOffset(fej9->thisThreadGetFloatTemp1Offset());
+      aliasBuilder.addressStaticSymRefs().set(getNonhelperIndex(j9VMThreadFloatTemp1Symbol));
+      }
+   return element(j9VMThreadFloatTemp1Symbol);
+   }
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateObjectEqualityComparisonSymbolRef()
    {
    TR::SymbolReference *symRef = element(objectEqualityComparisonSymbol);
@@ -2493,4 +2508,3 @@ J9::SymbolReferenceTable::getNonHelperSymbolName(CommonNonhelperSymbol nonHelper
    return NULL;
 #endif
    }
-

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -85,6 +85,14 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     */
    TR::SymbolReference * findOrCreateVMThreadTempSlotFieldSymbolRef();
 
+   /** \brief
+    * Find or create VMThread.floatTemp1 symbol reference. J9VMThread.floatTemp1 provides an additional
+    * mechanism for the compiler to provide information that the VM can use for various reasons
+    *
+    * \return TR::SymbolReference* the VMThread.floatTemp1 symbol reference
+    */
+   TR::SymbolReference * findOrCreateVMThreadFloatTemp1SymbolRef();
+
    // CG linkage
    TR::SymbolReference * findOrCreateAcquireVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework
    TR::SymbolReference * findOrCreateReleaseVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3329,6 +3329,8 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    // ------------------------------------------------------
    bool isUnresolved;
    TR::SymbolReference * targetMethodSymRef = symRefTab()->findOrCreateDynamicMethodSymbol(_methodSymbol, callSiteIndex, &isUnresolved);
+   if (isUnresolved)
+      targetMethodSymRef->getSymbol()->setDummyResolvedMethod(); // linkToStatic is a dummy TR_ResolvedMethod
    TR::SymbolReference *callSiteTableEntrySymRef = symRefTab()->findOrCreateCallSiteTableEntrySymbol(_methodSymbol, callSiteIndex);
    TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
    uintptr_t * invokeCacheArray = (uintptr_t *) owningMethod->callSiteTableEntryAddress(callSiteIndex);
@@ -3411,6 +3413,8 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    // ------------------------------------------------------
    bool isUnresolved;
    TR::SymbolReference * targetMethodSymRef = symRefTab()->findOrCreateHandleMethodSymbol(_methodSymbol, cpIndex, &isUnresolved);
+   if (isUnresolved)
+      targetMethodSymRef->getSymbol()->setDummyResolvedMethod(); // linkToStatic is a dummy TR_ResolvedMethod
    TR::SymbolReference *methodTypeTableEntrySymRef = symRefTab()->findOrCreateMethodTypeTableEntrySymbol(_methodSymbol, cpIndex);
    TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
    uintptr_t * invokeCacheArray = (uintptr_t *) owningMethod->methodTypeTableEntryAddress(cpIndex);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4861,6 +4861,24 @@ typedef struct J9VMThread {
 #if 1 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 paddingToAlignFloatTemp;
 #endif
+	/**
+	 * floatTemp1 is an overloaded field used for multiple purposes.
+	 *
+	 * Note: Listed below is one such use, and the other uses of this field still need to be
+	 * documented.
+	 *
+	 * 1. OpenJDK MethodHandle implementation
+	 *		For signature-polymorphic INL calls from compiled code for the following methods:
+	 *		* java/lang/invoke/MethodHandle.linkToStatic
+	 *		* java/lang/invoke/MethodHandle.linkToSpecial
+	 *		the compiled code performs a store to this field right before the INL call. The
+	 *		stored value represents the number of args for the unresolved invokedynamic/invokehandle
+	 *		call. This is required because linkToStatic calls are generated for unresolved
+	 *		invokedynamic/invokehandle, where the JIT cannot determine whether the appendix object of
+	 *		the callSite/invokeCache table entry is valid. As a result, the JIT code may push NULL
+	 *		appendix objects on the stack which the interpreter must remove. To determine that, the
+	 *		interpreter would need to know the number of arguments of method.
+	 */
 	void* floatTemp1;
 	void* floatTemp2;
 	void* floatTemp3;


### PR DESCRIPTION
This changeset includes the following:
 * Add functionality to lookup/create j9VMThreadFloatTemp1Symbol
 * Insert trees to store num args to VMThread.floatTemp1 for
   linkToStatic/Special
 * Document this added use case of the floatTemp1 field

Required for: #12522 

Depends: eclipse/omr#6045

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>