### PR TITLE
Stop using unsafe sprintf() in InterpreterEmulator

### DIFF
--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -169,7 +169,7 @@ MutableCallsiteTargetOperand::merge1(Operand* other)
    MutableCallsiteTargetOperand* otherMutableCallsiteTarget = other->asMutableCallsiteTargetOperand();
    if (otherMutableCallsiteTarget &&
        this->mutableCallsiteIndex== otherMutableCallsiteTarget->mutableCallsiteIndex &&
-       this->methodHandleIndex && otherMutableCallsiteTarget->methodHandleIndex)
+       this->methodHandleIndex == otherMutableCallsiteTarget->methodHandleIndex)
       return this;
    else
       return NULL;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -190,7 +190,7 @@ InterpreterEmulator::printOperandArray(OperandArray* operands)
    }
 
 // Merge second OperandArray into the first one
-// The merge does an intersect
+// The merge does a union
 //
 void InterpreterEmulator::mergeOperandArray(OperandArray *first, OperandArray *second)
    {

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1069,7 +1069,6 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
    {
    heuristicTrace(tracer(),"Find and create callsite %s\n", withState ? "with state" : "without state");
 
-   TR::Region findCallsitesRegion(comp()->region());
    if (withState)
       initializeIteratorWithState();
    _wasPeekingSuccessfull = wasPeekingSuccessfull;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -513,9 +513,12 @@ InterpreterEmulator::setupMethodEntryLocalObjectState()
              else
                 (*_currentLocalObjectInfo)[slotIndex] = _unknownOperand;
              }
-         char buffer[OPERAND_STR_BUF_SIZE];
-         printToString(comp(), (*_currentLocalObjectInfo)[slotIndex], buffer, sizeof (buffer));
-         heuristicTrace(tracer(), "Creating operand %s for parm %d slot %d from PrexArgument %p", buffer, ordinal, slotIndex, prexArgument);
+         if (tracer()->heuristicLevel())
+            {
+            char buffer[OPERAND_STR_BUF_SIZE];
+            printToString(comp(), (*_currentLocalObjectInfo)[slotIndex], buffer, sizeof (buffer));
+            heuristicTrace(tracer(), "Creating operand %s for parm %d slot %d from PrexArgument %p", buffer, ordinal, slotIndex, prexArgument);
+            }
          }
       }
    }
@@ -875,6 +878,9 @@ InterpreterEmulator::maintainStackForCall()
 void
 InterpreterEmulator::dumpStack()
    {
+   if (!tracer()->debugLevel())
+      return;
+
    debugTrace(tracer(), "operandStack after bytecode %d : %s ", _bcIndex, comp()->fej9()->getByteCodeName(nextByte(0)));
    for (int i = 0; i < _stack->size(); i++ )
       {

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -36,6 +36,14 @@
 #include "env/j9methodServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+#include <stdio.h>
+
+#if defined (_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf _snprintf
+#endif
+
+#define OPERAND_STR_BUF_SIZE 128
+
 const char* Operand::KnowledgeStrings[] = {"NONE", "OBJECT", "MUTABLE_CALLSITE_TARGET", "PREEXISTENT", "FIXED_CLASS", "KNOWN_OBJECT", "ICONST" };
 
 char*
@@ -175,14 +183,64 @@ MutableCallsiteTargetOperand::merge1(Operand* other)
       return NULL;
    }
 
+int
+Operand::printToString(char *buffer, size_t size)
+   {
+   return snprintf(buffer, size, "(unknown)");
+   }
+
+int
+IconstOperand::printToString(char *buffer, size_t size)
+   {
+   return snprintf(buffer, size, "(iconst=%d)", intValue);
+   }
+
+int
+ObjectOperand::printToString(char *buffer, size_t size)
+   {
+   return snprintf(buffer, size, "(%s=clazz%p)", KnowledgeStrings[getKnowledgeLevel()], getClass());
+   }
+
+int
+KnownObjOperand::printToString(char *buffer, size_t size)
+   {
+   return snprintf(buffer, size, "(obj%d)", getKnownObjectIndex());
+   }
+
+int
+MutableCallsiteTargetOperand::printToString(char *buffer, size_t size)
+   {
+   return snprintf(buffer, size, "(mh=%d, mcs=%d)", getMethodHandleIndex(), getMutableCallsiteIndex());
+   }
+
+static void printToString(TR::Compilation *comp, Operand *operand, char *buffer, size_t size)
+   {
+   TR_ASSERT_FATAL(size >= 1, "undersized buffer has no space for the NUL terminator");
+
+   int len = operand->printToString(buffer, size);
+
+   // If the formatted length is > size, MSVC _snprintf() returns a negative
+   // value instead of the length, so check for len < 0 as well.
+   if (len < 0 || len >= size)
+      {
+      // When the formatted length is >= size, MSVC _snprintf() fails to
+      // NUL-terminate.
+      buffer[size - 1] = '\0';
+
+      // Warn that the output has been truncated. Do not assert here, since
+      // that risks producing less diagnostic information.
+      traceMsg(comp, "warning: Operand::printToString() result is truncated: %s\n", buffer);
+      }
+   }
+
 void
 InterpreterEmulator::printOperandArray(OperandArray* operands)
    {
    int32_t size = operands->size();
    for (int32_t i = 0; i < size; i++)
       {
-      char buffer[20];
-      (*operands)[i]->printToString(buffer);
+      char buffer[OPERAND_STR_BUF_SIZE];
+      printToString(comp(), (*operands)[i], buffer, sizeof (buffer));
       traceMsg(comp(), "[%d]=%s, ", i, buffer);
       }
    if (size > 0)
@@ -455,8 +513,8 @@ InterpreterEmulator::setupMethodEntryLocalObjectState()
              else
                 (*_currentLocalObjectInfo)[slotIndex] = _unknownOperand;
              }
-         char buffer[50];
-         (*_currentLocalObjectInfo)[slotIndex]->printToString(buffer);
+         char buffer[OPERAND_STR_BUF_SIZE];
+         printToString(comp(), (*_currentLocalObjectInfo)[slotIndex], buffer, sizeof (buffer));
          heuristicTrace(tracer(), "Creating operand %s for parm %d slot %d from PrexArgument %p", buffer, ordinal, slotIndex, prexArgument);
          }
       }
@@ -821,8 +879,8 @@ InterpreterEmulator::dumpStack()
    for (int i = 0; i < _stack->size(); i++ )
       {
       Operand *x = (*_stack)[i];
-      char buffer[50];
-      x->printToString(buffer);
+      char buffer[OPERAND_STR_BUF_SIZE];
+      printToString(comp(), x, buffer, sizeof (buffer));
       debugTrace(tracer(), "[%d]=%s", i, buffer);
       }
    }

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -88,10 +88,7 @@ class Operand
       virtual MutableCallsiteTargetOperand* asMutableCallsiteTargetOperand(){ return NULL;}
       virtual TR::KnownObjectTable::Index getKnownObjectIndex(){ return TR::KnownObjectTable::UNKNOWN;}
       virtual char* getSignature(TR::Compilation *comp, TR_Memory *trMemory) {return NULL;}
-      virtual void printToString( char *buffer)
-         {
-         sprintf(buffer, "(unknown)");
-         }
+      virtual int printToString(char *buffer, size_t size);
       virtual KnowledgeLevel getKnowledgeLevel() { return NONE; }
       Operand* merge(Operand* other);
       virtual Operand* merge1(Operand* other);
@@ -103,10 +100,7 @@ class IconstOperand : public Operand
       TR_ALLOC(TR_Memory::EstimateCodeSize);
       IconstOperand (int x): intValue(x) { }
       virtual IconstOperand *asIconst() { return this;}
-      virtual void printToString( char *buffer)
-         {
-         sprintf(buffer, "(iconst=%d)", intValue);
-         }
+      virtual int printToString(char *buffer, size_t size);
       int32_t intValue;
 
       virtual KnowledgeLevel getKnowledgeLevel() { return ICONST; }
@@ -130,10 +124,7 @@ class ObjectOperand : public Operand
       virtual TR_OpaqueClassBlock* getClass() { return _clazz;}
       virtual KnowledgeLevel getKnowledgeLevel() { return OBJECT; }
       virtual Operand* merge1(Operand* other);
-      virtual void printToString(char *buffer)
-         {
-         sprintf(buffer, "(%s=clazz%p)", KnowledgeStrings[getKnowledgeLevel()], getClass());
-         }
+      virtual int printToString(char *buffer, size_t size);
 
    protected:
       char* _signature;
@@ -188,10 +179,7 @@ class KnownObjOperand : public FixedClassOperand
       virtual TR::KnownObjectTable::Index getKnownObjectIndex(){ return knownObjIndex;}
       virtual KnowledgeLevel getKnowledgeLevel() { return KNOWN_OBJECT; }
       virtual Operand* merge1(Operand* other);
-      virtual void printToString( char *buffer)
-         {
-         sprintf(buffer, "(obj%d)", getKnownObjectIndex());
-         }
+      virtual int printToString(char *buffer, size_t size);
    private:
       TR::KnownObjectTable::Index knownObjIndex;
    };
@@ -217,10 +205,7 @@ class MutableCallsiteTargetOperand : public ObjectOperand
          mutableCallsiteIndex(mutableCallsiteIndex){}
       virtual MutableCallsiteTargetOperand* asMutableCallsiteTargetOperand(){ return this; }
       virtual Operand* merge1(Operand* other);
-      virtual void printToString(char *buffer)
-         {
-         sprintf(buffer, "(mh=%d, mcs=%d)", getMethodHandleIndex(), getMutableCallsiteIndex());
-         }
+      virtual int printToString(char *buffer, size_t size);
       virtual KnowledgeLevel getKnowledgeLevel() { return MUTABLE_CALLSITE_TARGET; }
       TR::KnownObjectTable::Index getMethodHandleIndex(){ return methodHandleIndex; }
       TR::KnownObjectTable::Index getMutableCallsiteIndex() { return mutableCallsiteIndex; }


### PR DESCRIPTION
In particular, in the debug tracing. The much safer `snprintf()` is now used instead, though with the usual caveat that only `_snprintf()` (with the underscore) is available in older versions of MSVC.

The implementations of `Operand::printToString()` are moved into InterpreterEmulator.cpp to avoid putting `#define snprintf ...` into a header file.

A wrapper is added that checks the result and prints a warning to the log when truncation is detected. It also ensures NUL-termination in case we are using `_snprintf()`.

Call sites are updated to call the wrapper instead of calling the method directly, and to use a larger buffer size. The old sizes were either barely large enough (50), or definitely too small (20). The new size is defined as a constant `OPERAND_STR_BUF_SIZE` to keep all of the call sites in sync.

----

There are a few additional minor cleanup commits.