### PR TITLE
Increase JITClient socket default timeout to 10 seconds

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2048,7 +2048,7 @@ J9::Options::fePreProcess(void * base)
          J9::PersistentInfo::_remoteCompilationMode = JITServer::SERVER;
          // Increase the default timeout value for JITServer.
          // It can be overridden with -XX:JITServerTimeout= option in JITServerParseCommonOptions().
-         compInfo->getPersistentInfo()->setSocketTimeout(30000);
+         compInfo->getPersistentInfo()->setSocketTimeout(DEFAULT_JITSERVER_TIMEOUT);
          }
       else
          {
@@ -2064,6 +2064,7 @@ J9::Options::fePreProcess(void * base)
          if (xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex)
             {
             J9::PersistentInfo::_remoteCompilationMode = JITServer::CLIENT;
+            compInfo->getPersistentInfo()->setSocketTimeout(DEFAULT_JITCLIENT_TIMEOUT);
 
             // Check if the technology preview message should be displayed.
             const char *xxJITServerTechPreviewMessageOption = "-XX:+JITServerTechPreviewMessage";

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -269,6 +269,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int64_t _timeBetweenPurges;
    static bool _shareROMClasses;
    static int32_t _sharedROMClassCacheNumPartitions;
+   const static uint32_t DEFAULT_JITCLIENT_TIMEOUT = 10000; // ms
+   const static uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _waitTimeToEnterIdleMode;


### PR DESCRIPTION
Issue: #12845

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>