### PR TITLE
Fix deadlock when crashed thread holds onto the class unload mutex

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -383,6 +383,12 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
             }
          }
 #endif
+
+      // Release the class unload RW mutex
+      while (TR::MonitorTable::get()->getClassUnloadMonitorHoldCount(threadCompInfo->getCompThreadId()) > 0)
+         {
+         TR::MonitorTable::get()->readReleaseClassUnloadMonitor(threadCompInfo->getCompThreadId());
+         }
       }
 
    TR::CompilationInfoPerThread *recompilationThreadInfo = compInfo->getCompilationInfoForDiagnosticThread();


### PR DESCRIPTION
When a compilation thread is holding onto the class unload mutex and it
crashes, we must make sure to release the class unload mutex prior to
queuing the compilation, because we could encounter a deadlock.

The deadlock scenario occurs when the crashed thread holds onto the
class unload mutex, we proceed to queue a recompilation of the method
via the JitDump mechanism. When the diagnostic thread is printing a
class name for example, it will attempt to acquire VM access. The GC
could have asked for exclusive at some previous point which means the
compile thread will have to yield and wait for GC to finish. If the
GC attempts to unload classes it cannot because our crashed thread
still holds onto the class unload mutex, hence we get in a deadlock
situation.

The fix here is to simply release the class unload mutex on the crashed
thread prior to queuing a recompilaton.