### PR TITLE
Inline MutableCallSite targets with LambdaForm

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -993,6 +993,7 @@
    java_lang_invoke_InterfaceHandle_invokeExact,
    java_lang_invoke_Invokers_checkCustomized,
    java_lang_invoke_Invokers_checkExactType,
+   java_lang_invoke_Invokers_getCallSiteTarget,
    java_lang_invoke_MethodHandle_doCustomizationLogic,
    java_lang_invoke_MethodHandle_asType,
    java_lang_invoke_MethodHandle_asType_instance,

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2516,6 +2516,126 @@ void jitIllegalFinalFieldModification(J9VMThread *currentThread, J9Class *fieldC
    reportHookFinished(currentThread, "jitIllegalFinalFieldModification");
    }
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+// JIT hook called by the VM to update the target of a MutableCallSite.
+void jitSetMutableCallSiteTarget(J9VMThread *vmThread, j9object_t mcs, j9object_t newTarget)
+   {
+   J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(jitConfig, vmThread);
+   TR_RuntimeAssumptionTable *rat = compInfo->getPersistentInfo()->getRuntimeAssumptionTable();
+
+   bool verbose = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseHooks);
+   bool details = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseHookDetails);
+   verbose = verbose || details;
+
+   TR_OpaqueClassBlock *mcsClass = fej9->getObjectClass((uintptr_t)mcs);
+   uintptr_t targetOffset = fej9->getInstanceFieldOffset(
+      mcsClass, "target", "Ljava/lang/invoke/MethodHandle;");
+
+   TR::ClassTableCriticalSection commit(fej9);
+
+   // There are no concurrent modifications because target is only modified
+   // while holding the CH table lock.
+   uintptr_t prevTarget = fej9->getReferenceFieldAt((uintptr_t)mcs, targetOffset);
+   if ((uintptr_t)newTarget == prevTarget)
+      return; // Nothing to do.
+
+   // The CH table lock must be acquired before reading the cookie. Otherwise,
+   // a nonzero value written by another thread (in the compiler's CH table
+   // commit phase) won't necessarily be observed; and worse, if this MCS
+   // object were first inlined in a compilation that is committing
+   // concurrently, the following would be possible even with strong memory
+   // ordering:
+   //
+   // 1. jitSetMutableCallSiteTarget() reads the cookie, which is zero, so no
+   //    assumptions will be invalidated; then
+   //
+   // 2. the compilation reads the MCS target during CH table commit, which
+   //    matches what it saw during inlining, so it considers its assumption
+   //    valid; then
+   //
+   // 3. in any order, the compilation finishes and the MCS target is updated,
+   //    resulting in a compiled body that has inlined the wrong target.
+
+   uintptr_t cookie = fej9->mutableCallSiteCookie((uintptr_t)mcs);
+   if (cookie == 0)
+      {
+      if (verbose)
+         {
+         TR_VerboseLog::writeLineLocked(
+            TR_Vlog_HD, "%p skipping nonexistent cookie", vmThread);
+         }
+      }
+   else
+      {
+      // There may be assumptions to invalidate. Any such assumptions must be
+      // invalidated before updating the target field. Otherwise, another
+      // thread concurrently running JIT-compiled code where the previous
+      // target is inlined could read the new target object from the field and
+      // still pass the MCS target guard into the inlined body, even though the
+      // freshly loaded target differs from the known object used during
+      // optimization.
+      //
+      // While it would actually be OK to continue using the old target until
+      // syncAll() is called, code optimized based on known object information
+      // does not keep using the original reference it had when it was
+      // compiled. Instead, it retrieves the reference at runtime using the
+      // original chain of loads. The compiler will have transformed some but
+      // not necessarily all of the uses of this reference, so if a different
+      // reference is found at runtime, inconsistencies will result.
+      //
+      // For example, suppose the compiled code gets the mutable call site MCS
+      // and then updates ((Foo)((Species_L)MCS.target).argL0).f. Making use of
+      // the known object information, the compiler has likely improved the
+      // code so that it stores to MCS.target.argL0.f without any casts, but
+      // (crucially) the object reference MCS.target.argL0 is not truly
+      // constant-folded, so it must be found by chasing pointers at runtime.
+      // If MCS.target is changed to e.g. an instance of Species_I, and if the
+      // optimized code is still allowed to run, then the load of argL0 will
+      // reinterpret the bound integer as a reference, and the subsequent store
+      // will dereference it. Kaboom!
+
+      if (verbose)
+         {
+         TR_VerboseLog::writeLineLocked(
+            TR_Vlog_HD, "%p notifying cookie %p", vmThread, (void*)cookie);
+         }
+
+      rat->notifyMutableCallSiteChangeEvent(fej9, cookie);
+
+      if (verbose)
+         {
+         TR_VerboseLog::writeLineLocked(
+            TR_Vlog_HD, "%p finished notifying cookie %p", vmThread, (void*)cookie);
+         }
+      }
+
+   // Finally, update the target. This must be done while the CH table lock is
+   // still held. Otherwise, it would be possible for a concurrent compilation
+   // to inline the wrong target without invalidating its guard:
+   //
+   // 1. jitSetMutableCallSiteTarget() invalidates MCS target guards for this
+   //    call site and releases the CH table lock; then
+   //
+   // 2. the compilation gets the CH table lock and starts its CH table commit,
+   //    wherein it observes the previous target, which matches what it saw
+   //    during inlining, so it considers its assumption valid; then
+   //
+   // 3. finally, the target is updated.
+   //
+   // Note that it's fine to use a regular (non-volatile) store here. For other
+   // threads loading the target at runtime / in the interpreter, they are not
+   // required to see the update before syncAll() is called. For compilations
+   // in other threads, any subsequent CH table commit is guaranteed to see the
+   // update due to synchronization via the CH table lock.
+
+   targetOffset += TR::Compiler->om.objectHeaderSizeInBytes();
+   vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectStoreObject(
+      vmThread, mcs, targetOffset, newTarget, 0);
+   }
+#endif
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 static void jitHookInterruptCompilation(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
    {

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2597,12 +2597,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             if (mcsObject && knotEnabled && knot)
                {
                TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe);
-               uintptr_t currentEpoch = fej9->getVolatileReferenceField(mcsObject, "epoch", "Ljava/lang/invoke/MethodHandle;");
-               if (currentEpoch)
-                  {
-                  knotIndex = knot->getOrCreateIndex(currentEpoch);
+               knotIndex = fej9->mutableCallSiteEpoch(comp, mcsObject);
+               if (knotIndex != TR::KnownObjectTable::UNKNOWN)
                   objectPointerReference = knot->getPointerLocation(knotIndex);
-                  }
                }
             }
 

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -579,11 +579,7 @@ TR_CHTable::commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> 
             {
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
             TR::VMAccessCriticalSection invalidateMCSTargetGuards(fej9);
-            // TODO: Code duplication with TR_InlinerBase::findInlineTargets
-            currentIndex = TR::KnownObjectTable::UNKNOWN;
-            uintptr_t currentEpoch = fej9->getVolatileReferenceField(*mcsReferenceLocation, "epoch", "Ljava/lang/invoke/MethodHandle;");
-            if (currentEpoch)
-               currentIndex = knot->getOrCreateIndex(currentEpoch);
+            currentIndex = fej9->mutableCallSiteEpoch(comp, *mcsReferenceLocation);
             if (info->mutableCallSiteEpoch() == currentIndex)
                cookie = fej9->mutableCallSiteCookie(*mcsReferenceLocation, potentialCookie);
             else

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -430,11 +430,7 @@ JITClientCommitVirtualGuard(const VirtualGuardInfoForCHTable *info, std::vector<
             // However, JITClientCHTableCommit() is called at the end of compilation,
             // and therefore it cannot cause any issues.
             TR::VMAccessCriticalSection invalidateMCSTargetGuards(fej9);
-            // TODO: Code duplication with TR_InlinerBase::findInlineTargets
-            currentIndex = TR::KnownObjectTable::UNKNOWN;
-            uintptr_t currentEpoch = fej9->getVolatileReferenceField(*mcsReferenceLocation, "epoch", "Ljava/lang/invoke/MethodHandle;");
-            if (currentEpoch)
-               currentIndex = knot->getOrCreateIndex(currentEpoch);
+            currentIndex = fej9->mutableCallSiteEpoch(comp, *mcsReferenceLocation);
             if (info->_mutableCallSiteEpoch == currentIndex)
                cookie = fej9->mutableCallSiteCookie(*mcsReferenceLocation, potentialCookie);
             else

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4763,6 +4763,20 @@ uintptr_t TR_J9VMBase::mutableCallSiteCookie(uintptr_t mutableCallSite, uintptr_
    return result;
    }
 
+TR::KnownObjectTable::Index TR_J9VMBase::mutableCallSiteEpoch(TR::Compilation *comp, uintptr_t mutableCallSite)
+   {
+   TR_ASSERT_FATAL(haveAccess(), "mutableCallSiteEpoch requires VM access");
+
+   TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+   if (knot == NULL)
+      return TR::KnownObjectTable::UNKNOWN;
+
+   uintptr_t mh = getVolatileReferenceField(
+      mutableCallSite, "epoch", "Ljava/lang/invoke/MethodHandle;");
+
+   return mh == 0 ? TR::KnownObjectTable::UNKNOWN : knot->getOrCreateIndex(mh);
+   }
+
 bool
 TR_J9VMBase::hasMethodTypesSideTable()
    {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4755,11 +4755,22 @@ TR_J9VMBase::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptr_t 
 
 uintptr_t TR_J9VMBase::mutableCallSiteCookie(uintptr_t mutableCallSite, uintptr_t potentialCookie)
    {
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   uint32_t offset = _jitConfig->javaVM->mutableCallSiteInvalidationCookieOffset;
+   // The *FieldAt() functions below will add the header size, but that's
+   // already included in mutableCallSiteInvalidationCookieOffset.
+   offset -= getObjectHeaderSizeInBytes();
+#else
+   uint32_t offset = getInstanceFieldOffset(
+      getObjectClass(mutableCallSite), "invalidationCookie", "J");
+#endif
+
    uintptr_t result=0;
-   if (potentialCookie && compareAndSwapInt64Field(mutableCallSite, "invalidationCookie", 0, potentialCookie))
+   if (potentialCookie && compareAndSwapInt64FieldAt(mutableCallSite, offset, 0, potentialCookie))
       result =  potentialCookie;
    else
-      result = (uintptr_t)getInt64Field(mutableCallSite, "invalidationCookie");
+      result = (uintptr_t)getInt64FieldAt(mutableCallSite, offset);
+
    return result;
    }
 
@@ -4771,8 +4782,15 @@ TR::KnownObjectTable::Index TR_J9VMBase::mutableCallSiteEpoch(TR::Compilation *c
    if (knot == NULL)
       return TR::KnownObjectTable::UNKNOWN;
 
+   // getVolatileReferenceField() doesn't accept const char*
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   char *fieldName = "target"; // There is no separate epoch field.
+#else
+   char *fieldName = "epoch";
+#endif
+
    uintptr_t mh = getVolatileReferenceField(
-      mutableCallSite, "epoch", "Ljava/lang/invoke/MethodHandle;");
+      mutableCallSite, fieldName, "Ljava/lang/invoke/MethodHandle;");
 
    return mh == 0 ? TR::KnownObjectTable::UNKNOWN : knot->getOrCreateIndex(mh);
    }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -761,6 +761,7 @@ public:
    virtual TR_ResolvedMethod    *createMethodHandleArchetypeSpecimen(TR_Memory *, TR_OpaqueMethodBlock *archetype, uintptr_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0); // more efficient if you already know the archetype
 
    virtual uintptr_t mutableCallSiteCookie(uintptr_t mutableCallSite, uintptr_t potentialCookie=0);
+   TR::KnownObjectTable::Index mutableCallSiteEpoch(TR::Compilation *comp, uintptr_t mutableCallSite);
 
    bool hasMethodTypesSideTable();
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3647,6 +3647,7 @@ void TR_ResolvedJ9Method::construct()
       {
       {x(TR::java_lang_invoke_Invokers_checkCustomized,                    "checkCustomized",             "(Ljava/lang/invoke/MethodHandle;)V")},
       {x(TR::java_lang_invoke_Invokers_checkExactType,                     "checkExactType",              "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V")},
+      {x(TR::java_lang_invoke_Invokers_getCallSiteTarget,                  "getCallSiteTarget",           "(Ljava/lang/invoke/CallSite;)Ljava/lang/invoke/MethodHandle;")},
       {TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1100,6 +1100,7 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
 
       _currentCallSite = NULL;
       _currentCallMethod = NULL;
+      _currentCallMethodUnrefined = NULL;
 
       if (_InterpreterEmulatorFlags[_bcIndex].testAny(InterpreterEmulator::BytecodePropertyFlag::bbStart))
          {
@@ -1210,6 +1211,7 @@ InterpreterEmulator::visitInvokedynamic()
       // Add callsite handle to known object table
       knot->getOrCreateIndexAt((uintptr_t*)entryLocation);
       _currentCallMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(this->trMemory(), entryLocation, owningMethod);
+      _currentCallMethodUnrefined = _currentCallMethod;
       bool allconsts= false;
 
       heuristicTrace(tracer(),"numberOfExplicitParameters = %d  _pca.getNumPrevConstArgs = %d\n", _currentCallMethod->numberOfExplicitParameters() , _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()));
@@ -1364,6 +1366,7 @@ InterpreterEmulator::visitInvokevirtual()
    // Calls in thunk archetype won't be executed by interpreter, so they may appear as unresolved
    bool ignoreRtResolve = _callerIsThunkArchetype;
    _currentCallMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, ignoreRtResolve, &isUnresolvedInCP);
+   _currentCallMethodUnrefined = _currentCallMethod;
    Operand *result = NULL;
    if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
@@ -1454,6 +1457,7 @@ InterpreterEmulator::visitInvokespecial()
    int32_t cpIndex = next2Bytes();
    bool isUnresolvedInCP;
    _currentCallMethod = _calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (current() == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
+   _currentCallMethodUnrefined = _currentCallMethod;
    if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
       debugUnresolvedOrCold(_currentCallMethod);
@@ -1486,6 +1490,7 @@ InterpreterEmulator::visitInvokestatic()
    int32_t cpIndex = next2Bytes();
    bool isUnresolvedInCP;
    _currentCallMethod = _calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (current() == J9BCinvokestaticsplit) ? cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
+   _currentCallMethodUnrefined = _currentCallMethod;
    if (isCurrentCallUnresolvedOrCold(_currentCallMethod, isUnresolvedInCP))
       {
       debugUnresolvedOrCold(_currentCallMethod);
@@ -1564,6 +1569,7 @@ InterpreterEmulator::visitInvokeinterface()
    int32_t cpIndex = next2Bytes();
    auto calleeMethod = (TR_ResolvedJ9Method*)_calltarget->_calleeMethod;
    _currentCallMethod = calleeMethod->getResolvedImproperInterfaceMethod(comp(), cpIndex);
+   _currentCallMethodUnrefined = _currentCallMethod;
    bool isIndirectCall = true;
    bool isInterface = true;
    if (_currentCallMethod)

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1099,6 +1099,7 @@ InterpreterEmulator::findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessf
       heuristicTrace(tracer(), "%4d: %s\n", _bcIndex, comp()->fej9()->getByteCodeName(_code[_bcIndex]));
 
       _currentCallSite = NULL;
+      _currentCallMethod = NULL;
 
       if (_InterpreterEmulatorFlags[_bcIndex].testAny(InterpreterEmulator::BytecodePropertyFlag::bbStart))
          {

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -253,6 +253,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
          _localObjectInfos = NULL;
          _currentCallSite = NULL;
          _currentCallMethod = NULL;
+         _currentCallMethodUnrefined = NULL;
          _numSlots = 0;
          _callerIsThunkArchetype = _calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen();
          }
@@ -445,6 +446,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       TR_CallSite ** _callSites;
       TR_CallSite * _currentCallSite; // Store created callsite if visiting invoke* bytecodes
       TR_ResolvedMethod * _currentCallMethod; // Resolved method for invoke* bytecodes, some calls won't have call site created due to coldness info
+      TR_ResolvedMethod * _currentCallMethodUnrefined; // Call method without any refinement applied to it
       TR::CFG* _cfg;
       TR_ByteCodeInfo *_newBCInfo;
       int32_t _recursionDepth;

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -252,6 +252,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
          _currentLocalObjectInfo = NULL;
          _localObjectInfos = NULL;
          _currentCallSite = NULL;
+         _currentCallMethod = NULL;
          _numSlots = 0;
          _callerIsThunkArchetype = _calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen();
          }

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -780,12 +780,11 @@ bool TR_J9MutableCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inlin
          TR_ASSERT(target , "There should be only one target for TR_MutableCallSite");
          target->_calleeMethodKind = TR::MethodSymbol::ComputedVirtual;
 
-         // The following dereferences pointers to heap references, which is technically not valid,
-         // but it's only a debug trace, and it won't crash (only return garbage).
-         //
-         heuristicTrace(inliner->tracer(),"  addTarget: MutableCallSite.epoch is %p.obj%d (%p.%p)",
-             vgs->_mutableCallSiteObject, vgs->_mutableCallSiteEpoch,
-            *vgs->_mutableCallSiteObject, knot->getPointer(vgs->_mutableCallSiteEpoch));
+         heuristicTrace(
+            inliner->tracer(),
+            "  addTarget: MutableCallSite %p epoch is obj%d",
+            vgs->_mutableCallSiteObject,
+            vgs->_mutableCallSiteEpoch);
 
          return true;
          }

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -763,9 +763,7 @@ bool TR_J9MutableCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inlin
          if (mcsObject && knot)
             {
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fej9());
-            uintptr_t currentEpoch = fej9->getVolatileReferenceField(mcsObject, "epoch", "Ljava/lang/invoke/MethodHandle;");
-            if (currentEpoch)
-               vgs->_mutableCallSiteEpoch = knot->getOrCreateIndex(currentEpoch);
+            vgs->_mutableCallSiteEpoch = fej9->mutableCallSiteEpoch(comp(), mcsObject);
             }
          else
             {

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -198,6 +198,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
       virtual bool inlineMethodEvenForColdBlocks(TR_ResolvedMethod *method);
       virtual bool willBeInlinedInCodeGen(TR::RecognizedMethod method);
       virtual bool canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method);
+      virtual bool shouldRemoveDifferingTargets(TR::Node *callNode);
       virtual bool skipHCRGuardForCallee(TR_ResolvedMethod* callee);
       virtual bool dontPrivatizeArgumentsForRecognizedMethod(TR::RecognizedMethod recognizedMethod);
       virtual bool replaceSoftwareCheckWithHardwareCheck(TR_ResolvedMethod *calleeMethod);

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -110,6 +110,10 @@ extern "C" void jitDiscardPendingCompilationsOfNatives(J9VMThread *vmThread, J9C
 extern "C" void *jitLookupDLT(J9VMThread *currentThread, J9Method *method, UDATA bcIndex);
 #endif
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+extern "C" void jitSetMutableCallSiteTarget(J9VMThread *vmThread, j9object_t mcs, j9object_t newTarget);
+#endif
+
 }
 
 static void codertOnBootstrap(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
@@ -483,6 +487,9 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
    jitConfig->jitDiscardPendingCompilationsOfNatives = jitDiscardPendingCompilationsOfNatives;
    jitConfig->jitMethodBreakpointed = jitMethodBreakpointed;
    jitConfig->jitIllegalFinalFieldModification = jitIllegalFinalFieldModification;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   jitConfig->jitSetMutableCallSiteTarget = jitSetMutableCallSiteTarget;
+#endif
 
    initializeCodertFunctionTable(javaVM);
 

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -622,6 +622,10 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/invoke/MemberName", "vmtarget", "J", &vm->vmtargetOffset)) {
 		return 1;
 	}
+
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/invoke/MutableCallSite", "invalidationCookie", "J", &vm->mutableCallSiteInvalidationCookieOffset)) {
+		return 1;
+	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4027,6 +4027,9 @@ typedef struct J9JITConfig {
 	void ( *jitMethodBreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitMethodUnbreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	void ( *jitSetMutableCallSiteTarget)(struct J9VMThread *vmThread, j9object_t mcs, j9object_t newTarget) ;
+#endif /* J9VM_OPT_OPENJDK_METHODHANDLE */
 	U_8* (*codeCacheWarmAlloc)(void *codeCache);
 	U_8* (*codeCacheColdAlloc)(void *codeCache);
 	void ( *printAOTHeaderProcessorFeatures)(struct TR_AOTHeader * aotHeaderAddress, char * buff, const size_t BUFF_SIZE);
@@ -5508,6 +5511,7 @@ typedef struct J9JavaVM {
 #ifdef J9VM_OPT_OPENJDK_METHODHANDLE
 	UDATA vmindexOffset;
 	UDATA vmtargetOffset;
+	UDATA mutableCallSiteInvalidationCookieOffset;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY)
 	U_32 javaVM31;


### PR DESCRIPTION
This series inlines `MutableCallSite` targets when the MCS is used directly via `invokedynamic`. Inlining for MCS dynamic invoker handles will be implemented afterward.

The bulk of the inlining logic is in the last commit, but there are a few additional commits to help set the stage:
- Deduplicate logic to read `MutableCallSite.epoch` (so that it can be changed in one place)
- Forget stale call methods in `InterpreterEmulator` (cleanup)
- Remember the pre-refinement method in `InterpreterEmulator` (needed to find the receiver of refined `invokeBasic()` calls and create `TR_J9MutableCallSite`, and will also be used in a later PR to recognize `invokeBasic()` in `getReturnValue()`)
- Remove dereference that crashes in out-of-process compilation (in a path that is now exercised due to MCS inlining)

----

The compiler will find the target (in `mutableCallSiteEpoch()`) directly from the target field rather than "epoch," which doesn't exist in the `LambdaForm`-based implementation.

`Invokers.getCallSiteTarget()` is recognized and `InterpreterEmulator` treats it in much the same way as `MutableCallSite.getTarget()`, except that it's necessary to check that the call site is in fact an instance of `MutableCallSite` (which is always guaranteed for the latter method).

`InterpreterEmulator` already knows the MCS reference location when it creates the `TR_J9MutableCallSite`, so it sets it right away. This stops inliner from looking through the trees later in an attempt to find the MCS again.

The inliner policy's `shouldRemoveDifferingTargets()` is overridden to avoid removing the refined targets from `invokeBasic()` even though the `invokeBasic()` call is direct. The method symbol can't be refined in the call node because the known object information is only reliable after passing the MCS target guard, i.e. only within the inlined body, once the call has already been inlined.

To that end, make sure to give the callee's `LambdaForm` method a known object prex argument for the target handle. Previously the logic to do so applied only to archetype specimens, i.e. only to the original OpenJ9 implementation of `MethodHandle`.

When the target of a `MutableCallSite` changes, if its previous target has been inlined anywhere, then all guards protecting the inlined body must be invalidated. This invalidation is combined with the actual update of the target handle in `jitSetMutableCallSiteTarget()`, which the VM will now call rather than set the target directly. The reason for combining the update with the invalidation is to do them both as part of a single critical section, which ensures that all guards are patched correctly. For more details, see the comments in `jitSetMutableCallSiteTarget()`.

A hidden `invalidationCookie` field is added to `MutableCallSite`, which allows mutable call site guards' runtime assumptions to be keyed in the same way as they were in the original OpenJ9 JSR292 implementation.