### PR TITLE
JDK17 add Access.findNative(loader, entryName)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -501,6 +501,11 @@ final class Access implements JavaLangAccess {
 	public Module addEnableNativeAccess(Module mod) {
 		return mod.implAddEnableNativeAccess();
 	}
+	
+	public long findNative(ClassLoader loader, String entryName) {
+		return ClassLoader.findNative(loader, entryName);
+	}
+
 	/*[ENDIF] OPENJDK_METHODHANDLES*/
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2035,7 +2035,7 @@ static void loadLibrary(Class<?> caller, String libName) {
 	}
 }
 
-private static long findNative(ClassLoader loader, String entryName) {
+static long findNative(ClassLoader loader, String entryName) {
 	long result = 0;
 	if (loader == null) {
 		result = bootstrapClassLoader.nativelibs.find(entryName);


### PR DESCRIPTION
It is required by OpenJDK update b25.

With this PR, `JDK17` `openj9-staging` branch can be built and `-version` output is as following:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.mergetmp)
Eclipse OpenJ9 VM (build attachlog-2894a3ca34, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210605_000000 (JIT enabled, AOT enabled)
OpenJ9   - 2894a3ca34
OMR      - a5a0eca5a
JCL      - 6b4c146221b based on jdk-17+25)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>