### PR TITLE
Spelling `a`

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -355,7 +355,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 When enabled, a contiguous block of memory is created for each array which data surpasses the size of a region. This contiguous block represents the array as
 if the data was stored in a contiguous region of memory. All of the array data will be stored at their own region (not with spine); hence, all arraylets
 become discontiguous whenever this flag is enabled. Since there won’t be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
-all data is stored in their own region. It additionaly reduces footprint, mainly for JNI primitive array critical.</description>
+all data is stored in their own region. It additionally reduces footprint, mainly for JNI primitive array critical.</description>
 		<ifRemoved></ifRemoved>
 		<requires>
 			<require flag="gc_vlhgc"/>

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -377,7 +377,7 @@ public class StructureReader {
 				String fieldType = infoMap.remove(fieldName);
 
 				if (fieldType == null) {
-					// No auxilliary information for this field.
+					// No auxiliary information for this field.
 				} else if (fieldType.equals("required")) {
 					field.required = true;
 				} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/UnwindTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/UnwindTable.java
@@ -376,7 +376,7 @@ public class UnwindTable {
 				// One operand, register
 				long registerId = readUnsignedLEB128(instructionStream);
 				// This rule needs the offset from the last rule
-				// that affeted the CFA so we need to walk the list and find the
+				// that affected the CFA so we need to walk the list and find the
 				// last instance of CFARule.
 				out.printf("def_cfa_register: r%d", registerId);
 				break;
@@ -586,7 +586,7 @@ public class UnwindTable {
 				// One operand, register
 				long registerId = readUnsignedLEB128(instructionStream);
 				// This rule needs the offset from the last rule
-				// that affeted the CFA so we need to walk the list and find the
+				// that affected the CFA so we need to walk the list and find the
 				// last instance of CFARule.
 				CFARule lastRule = (CFARule)currentState.cfaRule;
 				currentState.cfaRule = new RegisterOffsetCFARule(CFA_RULE_ID, (int)registerId, lastRule.getOffset());
@@ -599,7 +599,7 @@ public class UnwindTable {
 //				out.printf("def_cfa_offset: offset: %d", offset);
 
 				// This rule needs the register number from the last rule
-				// that affeted the CFA so we need to walk the list and find the
+				// that affected the CFA so we need to walk the list and find the
 				// last instance of CFARule.
 				CFARule lastRule = (CFARule)currentState.cfaRule;
 				currentState.cfaRule = new RegisterOffsetCFARule(CFA_RULE_ID, lastRule.getBaseRegister(), offset);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/UnwindTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/UnwindTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corp. and others
+ * Copyright (c) 2014, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
@@ -322,7 +322,7 @@ public class MemorySourceTable {
 		public IMemorySource getRangeForAddress(long address);
 	}
 
-	/* Class used for debugging misbehaving addres resolver strategies */
+	/* Class used for debugging misbehaving address resolver strategies */
 	@SuppressWarnings("unused")
 	private static class DebugAddressResolverStrategy implements IAddressResolverStrategy {
 		private final IAddressResolverStrategy trusted;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corp. and others
+ * Copyright (c) 2009, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -113,7 +113,7 @@ public class PointerGenerator {
 		opts.put("-u", "true");  // flag to control if user code is supported or not, default is true
 		opts.put("-c", "");      // optional value to provide a cache properties file
 		opts.put("-l", "false"); // flag to determine if legacy DDR is used, default is false
-		opts.put("-a", null);    // auxilliary field information
+		opts.put("-a", null);    // auxiliary field information
 	}
 
 	public static void main(String[] args) throws Exception {

--- a/doc/compiler/aot/InlinedMethods.md
+++ b/doc/compiler/aot/InlinedMethods.md
@@ -96,7 +96,7 @@ pool, and `bar` is named in `foo`'s constant pool. Therefore, in order to
 materialize the `J9Method` of `baz`, one first needs the `J9Method` of `bar`,
 which first requires the `J9Method` of `foo`.
 
-If the inlined method has a guard assocated with it, then the Inlined Method
+If the inlined method has a guard associated with it, then the Inlined Method
 with NOP Guard / Profiled Inlined Method with Guard relocations are 
 generated. If not, then the Inlined Method / Profiled Inlined Method
 relocations are generated. Additionally, unless the 

--- a/doc/compiler/jitserver/Caching.md
+++ b/doc/compiler/jitserver/Caching.md
@@ -25,7 +25,7 @@ Caching is an important aspect of `JITServer` and one of the main reasons for wh
 ## Why caching is important
 When server is compiling a method, it needs to know a lot of information that is located on the client side, e.g. the addresses of RAM classes, GC mode, class hierarchy information, interpreter profiling data and much more. To obtain this information, server will make a remote call over the network to the client, client will find it, and send it back to the server. During the course of a compilation server will make hundreds of such calls (on average), assuming no caching is involved.
 Why is it bad? First of all, remote calls are expensive, both in terms of latency and CPU, especially in terms of CPU. If the server makes hundreds of requests to the client just for one compilation, client will spend more CPU time just sending and receiving data over the network than it would take for it to compile a method locally. What makes it worse is that in order for the client to fetch the requested data it needs to do some work, which additionally increases CPU consumption.
-Caching helps alleviate this problem by storing the result of frequent remote calls on the server, so that if the same data is needed again, it can accesss it from the cache, instead of making a remote call.
+Caching helps alleviate this problem by storing the result of frequent remote calls on the server, so that if the same data is needed again, it can access it from the cache, instead of making a remote call.
 
 ## Types of caching
 There are 2 types of caching that `JITServer` does:

--- a/doc/compiler/memory/MemoryManager.md
+++ b/doc/compiler/memory/MemoryManager.md
@@ -226,7 +226,7 @@ calling it `TR::PersistentSegmentProvider`, and have it use
 
 The mechanism for limiting the memory usage during compilation can be summarized as:
 
-Default size of system segments allocatd by `J9::SystemSegmentProvider` is 16 MB. 
+Default size of system segments allocated by `J9::SystemSegmentProvider` is 16 MB. 
 These system segments are then carved into smaller segments based on the size requested
 which is rounded up to 64 KB. The cumulative memory usage of these system segments is limited 
 by the value of the option `scratchSpaceLimit`. When the scratch space limit is not a multiple

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1466,7 +1466,7 @@ public class MethodHandles {
 		 * Check whether the target class is accessible to the lookup class.
 		 * 
 		 * @param targetClass The {@link Class} being accessed.
-		 * @return true if the accessiblity check is passed; otherwise return false.
+		 * @return true if the accessibility check is passed; otherwise return false.
 		 */
 		private boolean isClassAccessible(Class<?> targetClass) {
 			try {

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -421,7 +421,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 			AttachNotSupportedException {
 		Reply replyFile = null;
 		AttachHandler.waitForAttachApiInitialization(); /* ignore result: we can still attach to another target if API is disabled */
-		IPC.logMessage("VirtualMachineImpl.tryAttachtarget"); //$NON-NLS-1$
+		IPC.logMessage("VirtualMachineImpl.tryAttachTarget"); //$NON-NLS-1$
 		Object myIn = AttachHandler.getMainHandler().getIgnoreNotification();
 
 		synchronized (myIn) {

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -58,7 +58,7 @@ j9vm_shadowed_option(J9VM_GC_DEBUG_ASSERTS "Specialized GC assertions are used i
 # When enabled, a contiguous block of memory is created for each array in which data surpasses the size of a region. This contiguous block represents the array as
 # if the data was stored in a contiguous region of memory. All of the array data is stored in a unique region (not with spine); hence, all arraylets
 # become discontiguous whenever this flag is enabled. Since there won’t be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
-# all data is stored in a unique region. It additionaly reduces footprint, mainly for JNI primitive array critical.
+# all data is stored in a unique region. It additionally reduces footprint, mainly for JNI primitive array critical.
 j9vm_shadowed_option(J9VM_GC_ENABLE_DOUBLE_MAP OMR_GC_DOUBLE_MAP_ARRAYLETS "Allows LINUX and OSX systems to double map arrays that are stored as arraylets.")
 j9vm_shadowed_option(J9VM_GC_LARGE_OBJECT_AREA "Enable large object area (LOA) support")
 j9vm_shadowed_option(J9VM_GC_LEAF_BITS "Add leaf bit instance descriptions to classes")

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2586,7 +2586,7 @@ old_slow_jitRetranslateMethod(J9VMThread *currentThread)
 		 *	- interpreter submits target for compilation
 		 *	- during compilation, a decomp is added for the caller
 		 *	- target is successfully compiled
-		 *	- decomp record is updated such that the savedPCAddres points to where the jitted method would save the RA
+		 *	- decomp record is updated such that the savedPCAddress points to where the jitted method would save the RA
 		 *	- interp transitions to the newly-compiled method with the return address pointing to a decompilation
 		 *
 		 * The decompilation assumes that the target method would run (so it's jitDecompileOnReturn*).

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 # This target is created so that various subdirectories can add dependencies to it.
 # The j9jit target will then depend on it, propagating the dependencies.
 # This is required because at the time we include the subdirectories, the j9jit target
-# does not yet exist (and as such can't have dependencies addded to it).
+# does not yet exist (and as such can't have dependencies added to it).
 add_custom_target(j9jit_generate)
 
 # On windows exceptions are controlled via a the preprocessor define _HAS_EXCEPTIONS

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1796,7 +1796,7 @@ J9::SymbolReferenceTable::checkUserField(TR::SymbolReference *symRef)
       // At the moment this is conservative. i.e. any field in any of the above packages will not be considered
       // a user field in any of the other packages. However it is possible to have fields from one package (or class) that we
       // may want to consider as a user field in another package (class) in which case having the different array elements
-      // below would then be the way to acomplish this. The population of the array would need to be more selective.
+      // below would then be the way to accomplish this. The population of the array would need to be more selective.
       //
       }
    else

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -574,7 +574,7 @@ TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
       else if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT && JITServerHelpers::isServerAvailable())
          {
          
-         // For JITClient let's be more agressive with compilation thread activation
+         // For JITClient let's be more aggressive with compilation thread activation
          // because the latencies are larger. Beyond 'numProc-1' we will use the
          // 'starvation activation schedule', but accelerated (divide those thresholds by 2)
          // NOTE: compilation thread activation policy is AGGRESSIVE if we reached this point

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6342,7 +6342,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
          {
          void *currOldStartPC = startPCIfAlreadyCompiled(vmThread, details, startPC);
          // If currOldStartPC is NULL, the method body defined by startPC has not been
-         // recompiled. We will queue the second remote aync compilation here. Otherwise,
+         // recompiled. We will queue the second remote async compilation here. Otherwise,
          // another thread is doing the recompilation and will take care of queueing
          // the second compilation.
          if (!currOldStartPC)

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1671,7 +1671,7 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
    // When the side table entry is unresolved, this object is unknown, thus, the JIT
    // doesn't know what method to call at compile time. To represent the unresolved
    // case, the JIT uses MethodHandle.linkToStatic to represent the call.
-   // In addtion to the appendixObject, the MemberName object is also needed, thus
+   // In addition to the appendixObject, the MemberName object is also needed, thus
    // the call requires two more arguments that what's on the stack.
    //
    // Resolved case:

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -5018,7 +5018,7 @@ TR_CISCTransformer::areAllNodesIncluded(TR_CISCNodeRegion *r)
          bv.reset(p->getID());
       }
 
-   // If the bit vector bv is empty, alll nodes are included in the region r.
+   // If the bit vector bv is empty, all nodes are included in the region r.
    if (trace())
       {
       if (!bv.isEmpty())

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4400,7 +4400,7 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
 
    if (!comp()->getOption(TR_DisableInlinerFanIn))  // TODO: make the default for everybody
       {
-      // In JIT, having low caller information is equivalent to lack of information.  We want to exclude only cases where we know we have alot of fan-in
+      // In JIT, having low caller information is equivalent to lack of information.  We want to exclude only cases where we know we have a lot of fan-in
       if (j9InlinerPolicy->adjustFanInSizeInExceedsSizeThreshold(bytecodeSize, calculatedSize, calleeResolvedMethod, callerResolvedMethod, bcInfo.getByteCodeIndex()))
          {
          return true;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1288,7 +1288,7 @@ InterpreterEmulator::isCurrentCallUnresolvedOrCold(TR_ResolvedMethod *resolvedMe
    // Since bytecodes in a thunk archetype are never interpreted,
    // most of the cp entries may appear unresolved, and we always
    // compile-time resolve the cp entries. Thus ignore resolution
-   // status of cp entries of thunk arthetype
+   // status of cp entries of thunk archetype
    //
    if (_callerIsThunkArchetype)
       return resolvedMethod->isCold(comp(), isIndirectCall);

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -599,7 +599,7 @@ static bool changeIndirectLoadIntoConst(TR::Node *node, TR::ILOpCodes opCode, TR
    }
 
 /** \brief
- *     Entry point for folding allowlist'd static final fields.
+ *     Entry point for folding allow listed static final fields.
  *     These typically belong to fundamental system/bootstrap classes.
  *
  *  \param comp
@@ -657,7 +657,7 @@ J9::TransformUtil::foldStaticFinalFieldAssumingProtection(TR::Compilation *comp,
  *     The node which is a load of a static final field.
  *
  *  \return
- *    True TR_yes if the field is allowlisted and can be folded.
+ *    True TR_yes if the field is allow listed and can be folded.
  *    True TR_maybe if the field is a generic static final and can be folded with protection.
  *    True TR_no if the field is cannot be folded due to being unresolved, already been written post initialization, or owning class uninitialized, etc.
  */

--- a/runtime/compiler/optimizer/MethodHandleTransformer.hpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.hpp
@@ -42,7 +42,7 @@
  *  2. Nodes with known object index
  *  3. Nodes whose value can be compile-time inferred and is a known object
  *
- * We'd like the object info be avaliable at places where we want to do transformation,
+ * We'd like the object info be available at places where we want to do transformation,
  * however, the objects will be stored into autos and autos will be used instead of
  * nodes with known object index. Thus we need to track the object info while walking
  * the trees.

--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -348,7 +348,7 @@ class AcmpTransformer: public TR::TreeLowering::Transformer
  * with the exception of any register (x, above) holding the result of the compare
  *
  * @param node is the current node in the tree walk
- * @param tt is the treetop at the root of the tree ancoring the current node
+ * @param tt is the treetop at the root of the tree anchoring the current node
  *
  */
 void
@@ -608,7 +608,7 @@ class ArrayStoreCHKTransformer: public TR::TreeLowering::Transformer
  * of whether the array's component type is a value type.
  *
  * @param node is the current node in the tree walk
- * @param tt is the treetop at the root of the tree ancoring the current node
+ * @param tt is the treetop at the root of the tree anchoring the current node
  */
 void
 ArrayStoreCHKTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -939,7 +939,7 @@ J9::Power::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::
    // Setup Dependencies
    // dataSnippetRegister is always used during OOL sequence.
    // Requires two argument registers: resultReg and cpIndexReg.
-   // Static requires an extra arugment fieldClassReg
+   // Static requires an extra argument fieldClassReg
    // jumpReg used by trampoline
    uint8_t numOfConditions = isStatic? 5 : 4;
    TR::RegisterDependencyConditions  *deps =  new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numOfConditions, numOfConditions, cg->trMemory());
@@ -1091,7 +1091,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
 
    /*
     * For reporting field write, reference to the valueNode is needed so we need to store
-    * the value on to a stack location first and pass the stack location address as an arguement
+    * the value on to a stack location first and pass the stack location address as an argument
     * to the VM helper
     */
    if (isWrite)

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -597,7 +597,7 @@ _interpreterUnresolvedInstanceDataGlue:
 	stw     r3, 0(r9)                                       ! replace isync with noop
 	bl      .__code_synchronization
 .L.normal_patching:
-	ori     r3, r30, 0                                      ! restore resolved field addre
+	ori     r3, r30, 0                                      ! restore resolved field address
 .L11.common_code:						!   not modified, r3 is result
 	laddr	r6, 0(r7)					! Load code cache RA
 	rlwinm  r17, r3, 0, 31, 31                              ! keep in r17 if r3 last bit is set: <clinit> is being executed

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -491,7 +491,7 @@ private:
 
    This indirection is needed so that we can cache the value of the pointer so
    that we can access client session data without going through the hashtable.
-   Accesss to this hashtable must be protected by the compilation monitor.
+   Access to this hashtable must be protected by the compilation monitor.
    Compilation threads may purge old entries periodically at the beginning of a
    compilation. The StatistcisThread can also perform purging duties.
    Entried with inUse > 0 must not be purged.

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12406,7 +12406,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
 
    /*
     * For reporting field write, reference to the valueNode (valueNode is evaluated in valueReg) is needed so we need to store
-    * the value on to a stack location first and pass the stack location address as an arguement
+    * the value on to a stack location first and pass the stack location address as an argument
     * to the VM helper
     */
    if (isWrite)

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -2690,7 +2690,7 @@ void J9::Z::JNILinkage::acquireVMAccessMask(TR::Node * callNode, TR::Register * 
    self()->cg()->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(self()->cg(), callNode, longAcquireSnippetLabel,
                               comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getJittedMethodSymbol()), acquireDoneLabel));
    generateS390LabelInstruction(self()->cg(), TR::InstOpCode::label, callNode, acquireDoneLabel);
-   // end of acquire vm accessa
+   // end of acquire vm access
    }
 
 #ifdef J9VM_INTERP_ATOMIC_FREE_JNI

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -220,7 +220,7 @@ public:
 	 * Called when an allocation context replenishment request fails in order to invoke a GC.
 	 * 
 	 * @param[in] env The current thread
-	 * @param[in] replenishingSpace The subspace which was initially asked to fill the replenishment request and which will be aksed to replenish it once the GC is complete
+	 * @param[in] replenishingSpace The subspace which was initially asked to fill the replenishment request and which will be asked to replenish it once the GC is complete
 	 * @param[in] context The allocation context which the sender failed to replenish
 	 * @param[in] allocateDescription The allocation request which initiated the allocation failure
 	 * @param[in] allocationType The type of allocation request we eventually must satisfy

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/ReclaimDelegate.cpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.cpp
@@ -364,7 +364,7 @@ MM_ReclaimDelegate::rebuildRegionsSortedByEmptinessArray(MM_EnvironmentVLHGC *en
 			if (region->getRememberedSetCardList()->isAccurate() && (!regionHasCriticalRegions)) {
 				/* Don't want to double-count regions that would be selected by other collection set algorithms 
 				 * (i.e. nursery or DCSS) when calculating optimalEmptinessRegionThreshold.
-				 * Going to only filter out nursery for now as with exponential aging, there may be alot of objects
+				 * Going to only filter out nursery for now as with exponential aging, there may be a lot of objects
 				 * that might never reach maximum age.
 				 */
 				 if (!MM_CompactGroupManager::isRegionInNursery(env, region)) {

--- a/runtime/j9vm31/jnimisc.cpp
+++ b/runtime/j9vm31/jnimisc.cpp
@@ -229,7 +229,7 @@ void* JNICALL
 getArrayElements(JNIEnv *env, jarray array, jboolean *isCopy)
 {
 	/* This routine is used for all Get*ArrayElements and GetPrimitiveArrayCritical. The latter because
-	 * the Java heap is not addressible in AMODE 31, as such, will always return a copy.
+	 * the Java heap is not addressable in AMODE 31, as such, will always return a copy.
 	 */
 	const jint NUM_ARGS = 3;
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_uint32_ptr };

--- a/runtime/libffi/bfin/sysv.S
+++ b/runtime/libffi/bfin/sysv.S
@@ -72,7 +72,7 @@ _ffi_call_SYSV:
 	[FP+16] = R2;
 
 .allocate_stack:
-	//alocate cif->bytes into the stack
+	//allocate cif->bytes into the stack
 	R1 = [FP+8];
 	R0 = SP;
 	R0 = R0 - R1;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2522,7 +2522,7 @@ typedef struct J9StackWalkState {
 	void* stackMap;
 	void* inlineMap;
 	/* The size of J9StackWalkState must be a multiple of 8 because it is inlined into
-	 * J9VMThread where alignment assumotions are being made.
+	 * J9VMThread where alignment assumptions are being made.
 	 */
 #if 1 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 padTo8;

--- a/runtime/port/common/j9prt.tdf
+++ b/runtime/port/common/j9prt.tdf
@@ -683,7 +683,7 @@ TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_unsupported_page_size Obsolete
 // TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_Exit4 Obsolete Group=j9mem Overhead=1 Level=3 NoEnv Template="j9vmem_reserve_memory (failure)" */
 TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_failure Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory (failure)"
 TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_shmget_failed Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory (shmget_failed) byteAmount=%u shmgetFlags=%i"
-TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_shmat_failed Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory (shmat failed) byteAmout=%u address=%p"
+TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_shmat_failed Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory (shmat failed) byteAmount=%u address=%p"
 
 // TraceExit=Trc_PRT_vmem_j9vmem_reserve_memory_Exit Group=j9mem Overhead=1 Level=5 NoEnv Template="j9vmem_reserve_memory returns %p"
 TraceExit=Trc_PRT_vmem_j9vmem_reserve_memory_Exit_replacement Obsolete Group=j9mem Overhead=1 Level=5 NoEnv Template="j9vmem_reserve_memory returns %p requestedAddress=%p"

--- a/runtime/port/zos390/j9guardedstorage.mc
+++ b/runtime/port/zos390/j9guardedstorage.mc
@@ -47,7 +47,7 @@
  *   http://publibz.boulder.ibm.com/epubs/pdf/ccrug120.pdf
  * 
  * Specifically, page 24 has the sample macros for re-entrant code
- * that is used below (wAtuh and lAuth) stuff.
+ * that is used below (wAuth and lAuth) stuff.
  */
 #include <stdint.h>
 

--- a/runtime/port/zos390/j9guardedstorage.mc
+++ b/runtime/port/zos390/j9guardedstorage.mc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -493,7 +493,7 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			}
 		}
 
-		/* Normal exit - its not safe to free this stuff if we are ab'ending.
+		/* Normal exit - its not safe to free this stuff if we are abending.
 		 * Blank global pointer before freeing struct (safer?)
 		 */
 		if (vm->j9rasGlobalStorage != NULL) {

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -6003,7 +6003,7 @@ SH_CacheMap::shutdownForStats(J9VMThread* currentThread)
 		SH_CompositeCacheImpl* ccNext = ccToUse->getNext();
 		if (_ccHead != ccToUse) {
 			PORT_ACCESS_FROM_VMC(currentThread);
-			/* _ccHead is alloacated together with the SH_CacheMap instance, it will be free together with the SH_CacheMap instance */
+			/* _ccHead is allocated together with the SH_CacheMap instance, it will be free together with the SH_CacheMap instance */
 			ccToUse->cleanup(currentThread);
 			j9mem_free_memory(ccToUse);
 		}

--- a/runtime/verbose/errormessageframeworkcfr.c
+++ b/runtime/verbose/errormessageframeworkcfr.c
@@ -181,7 +181,7 @@ printReasonForInvalidStackMapAttribute(MessageBuffer* msgBuf, J9CfrError* error,
 			printMessage(msgBuf, "(Stack Map Frame offset overflow. bci=%u, bytecode length=%u)", errorFrameBCI, codeLength);
 		}
 
-		/* Walk through the stackmap for the specified stackmap frame and set alll data to stackMapFrame for 'Current Frame'.
+		/* Walk through the stackmap for the specified stackmap frame and set all data to stackMapFrame for 'Current Frame'.
 		 * Note: it only prints out the content existing in the error message uffer even if out-out-memory.
 		 */
 		if (FALSE == prepareVerificationTypeBuffer(stackMapFrame, methodInfo)) {

--- a/runtime/verbose/errormessageframeworkcfr.c
+++ b/runtime/verbose/errormessageframeworkcfr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/growstack.cpp
+++ b/runtime/vm/growstack.cpp
@@ -207,7 +207,7 @@ poolElementAllocFailed:
 		UDATA *newStackOverflowMark = J9JAVASTACK_STACKOVERFLOWMARK(newStack);
 		UDATA currentStackOverflowMark = (UDATA)vmThread->stackOverflowMark;
 		if (J9_EVENT_SOM_VALUE != currentStackOverflowMark) {
-			/* Use an atomic here to ensure we don't lose an aynsc message post.
+			/* Use an atomic here to ensure we don't lose an async message post.
 			 * Only the current thread can ever write a value other than
 			 * J9_EVENT_SOM_VALUE into stackOverflowMark.
 			 */

--- a/runtime/vm/growstack.cpp
+++ b/runtime/vm/growstack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
@@ -34,7 +34,7 @@ public class TestCommandLineOptionXscmx01 extends TestUtils {
 	
 	/* Note: AOT is turned off for the below tests. In some cases the JIT has 
 	 * enough time to store information in the already small cache. During this 
-	 * test this may cause the alredy to small cache to be marked as full 
+	 * test this may cause the already to small cache to be marked as full 
 	 * (when this is not expected to occur).
 	 */
 	

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
@@ -43,7 +43,7 @@ public class TestZipCacheStoresAllBootstrapJar extends TestUtils {
 
 		String bootClassPath = System.getProperty("sun.boot.class.path");
 		
-		// Assumimg that the sun.boot.class.path is of the following format:
+		// Assuming that the sun.boot.class.path is of the following format:
 		// full_path_to_file1.jar;full_path_to_file2.jar
 		String[] bootClassPathSplit = bootClassPath.split(";");
 		

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Class.java
@@ -190,7 +190,7 @@ import org.openj9.test.utilities.CustomClassLoader;
             AssertJUnit.assertNull(rc.getAccessor());
         }
 
-        /* check signature attribte */
+        /* check signature attribute */
         AssertJUnit.assertEquals(signature, rc.getGenericSignature());
 
         /* check annotations attributes */

--- a/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Class.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/RasapiTest/src/com/ibm/jvm/ras/tests/DumpAPIQuerySetReset.java
+++ b/test/functional/RasapiTest/src/com/ibm/jvm/ras/tests/DumpAPIQuerySetReset.java
@@ -544,7 +544,7 @@ public class DumpAPIQuerySetReset extends TestCase {
 					String options = type + ":events=" + event + ",filter=" + filter + ",label=" + type + count++;
 					try {
 						com.ibm.jvm.Dump.setDumpOptions(options);
-						fail("Expected not to be ablel to set these dump options: " + options);
+						fail("Expected not to be able to set these dump options: " + options);
 					} catch (InvalidDumpOptionException e) {
 						// TODO Auto-generated catch block
 					} catch (DumpConfigurationUnavailableException e) {


### PR DESCRIPTION
This PR should be changes for word families `a`:

To make my life easier, there are 2 types of commits:
* one which is the fixes
* and one which is the copyright bumping

I've split this family into a bunch of commits -- separated by copyright bumps to distinguish categories, I'm happy to drop any which seem problematic (we can revisit at a later round), or split categories into distinct PRs. I'd encourage reviewing on a commit-by-commit basis (or at least diffs between copyright bumps) as opposed to looking at the flattened PR. (The easiest thing for me to drop is a whole commit.)

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `rs` / and guided by [check-spelling/check-spelling](https://github.com/marketplace/actions/check-spelling) #12866. That branch should eventually shrink as I update it to reflect that I've merged a portion of its content.