### PR TITLE
Enable runaqa PR build

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -1,0 +1,239 @@
+###############################################################################
+# Copyright (c) 2021, 2021 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################/
+
+name: "PR Comment Build Action for openj9"
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  parseComment:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, 'run aqa') && github.event.issue.pull_request
+    outputs:
+      workflow_url: ${{ steps.workflow_run_info.outputs.url }}
+      workflow_id: ${{ steps.workflow_run_info.outputs.id }}
+      build_parameters: ${{ steps.argparse.outputs.build_parameters }}
+      failed: ${{ steps.failure_report.outputs.failed }} # For reportStatus to check if parseComment has already reported a failure (in parsing).
+    steps:
+    - name: Get workflow run info
+      run: |
+        echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        echo ::set-output name=id::$GITHUB_RUN_ID
+      id: workflow_run_info
+    # Checkout current repo to access the repo-specific config file `.github/workflows/runAqaConfig.json`
+    - name: Checkout current repo
+      uses: actions/checkout@v2
+      with:
+        path: 'main'
+    # Checkout the main TKG repo to access the shared script `scripts/testRepo/runAqaArgParse.py`
+    - name: Checkout main TKG repo
+      uses: actions/checkout@v2
+      with:
+        repository: 'adoptium/TKG.git'
+        ref: 'master'
+        path: 'TKG'
+    - name: Parse parameters
+      env:
+        args: ${{ github.event.comment.body }}
+      run: python3 TKG/scripts/testBot/runAqaArgParse.py $args 2> log.txt
+      id: argparse
+    - name: Output log
+      if: failure()
+      # Store the contents of log.txt into an environment variable and escape characters to preserve newlines and other symbols.
+      run: |
+        log=$(cat log.txt)
+        log="${log//'%'/'%25'}"
+        log="${log//$'\n'/'%0A'}"
+        log="${log//$'\r'/'%0D'}"
+        log="${log/$'`'/'\`'}"
+        echo ::set-output name=log::$log
+      id: output_log
+    - name: Create error comment
+      if: failure()
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }}
+          \`\`\`
+          ${{ steps.output_log.outputs.log }}
+          \`\`\`
+          No builds were started.
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+    - name: Failure report
+      if: failure()
+      run: echo ::set-output name=failed::true
+      id: failure_report
+    - name: Create success comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) started with the following parameters:
+          - sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+          - customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
+          - archive_extension: ${{ steps.argparse.outputs.archive_extension }}
+          - build_list: ${{ steps.argparse.outputs.build_list }}
+          - target: ${{ steps.argparse.outputs.target }}
+          - platform: ${{ steps.argparse.outputs.platform }}
+          - jdk_version: ${{ steps.argparse.outputs.jdk_version }}
+          - jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+          - openjdk_testrepo: ${{ steps.argparse.outputs.openjdk_testrepo }}
+          - tkg_repo: ${{ steps.argparse.outputs.tkg_repo }}
+
+          Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+    - name: Echo parameters
+      run: |
+        echo ${{ steps.argparse.outputs.build_parameters }}
+
+  runBuild:
+    runs-on: ${{ matrix.platform }}
+    needs: parseComment
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parseComment.outputs.build_parameters) }}
+    steps:
+    - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource != 'customized'
+      with:
+        version: ${{ matrix.jdk_version }}
+        source: ${{ matrix.sdk_resource }}
+        sourceType: 'buildType'
+        impl: ${{ matrix.jdk_impl }}
+    - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource == 'customized'
+      with:
+        version: ${{ matrix.jdk_version }}
+        source: ${{ matrix.customized_sdk_url }}
+        archiveExtension: ${{ matrix.archive_extension }}
+        sourceType: 'url'
+        impl: ${{ matrix.jdk_impl }}
+    # get-pr step by @Simran-B https://github.com/actions/checkout/issues/331#issuecomment-707103442
+    - uses: actions/github-script@v3
+      id: get-pr
+      with:
+        script: |
+          const request = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          }
+          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          try {
+            const result = await github.pulls.get(request)
+            return result.data
+          } catch (err) {
+            core.setFailed(`Request failed with error ${err}`)
+          }
+    - name: AQA
+      uses: adoptium/run-aqa@v1
+      with:
+         build_list: ${{ matrix.build_list }}
+         target: ${{ matrix.target }}
+         jdksource: 'install-jdk'
+         version: ${{ matrix.jdk_version }}
+         openj9_repo: '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}:${{ fromJSON(steps.get-pr.outputs.result).head.ref }}'
+         openjdk_testRepo: ${{ matrix.openjdk_testrepo }}
+         tkg_Repo: ${{ matrix.tkg_repo }}
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test_output
+        path: ./**/output_*/
+
+  reportFailure:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: failure() && !needs.parseComment.outputs.failed
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) failed.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+
+  reportCancelled:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: cancelled()
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) cancelled.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+
+  reportSuccess:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: success()
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) successful.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })

--- a/.github/workflows/runAqaConfig.json
+++ b/.github/workflows/runAqaConfig.json
@@ -1,0 +1,4 @@
+{
+    "custom_openjdk_testrepo": true,
+    "custom_tkg_repo": true
+}


### PR DESCRIPTION
- tailor runaqa action and workflow files for openj9
- current runaqa version doesn't support build openj9

[ci skip]

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>