### PR TITLE
 Ensure consistency in the ClassLoader hash table 

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -274,18 +274,6 @@ resolveNativeAddress(J9VMThread *currentThread, J9Method *nativeMethod, UDATA ru
 /* ---------------- classallocation.c ---------------- */
 
 /**
-* @brief Get Package ID for the ROM class. NOTE: You must own the class table mutex before calling this function.
-* @param *classLoader Classloader for the class
-* @param *romClass ROM class with package name
-* @param *vmThread J9VMThread instance
-* @param entryIndex classpath index
-* @param locationType location type of class
-* @return UDATA Package ID
-*/
-UDATA
-initializePackageID(J9ClassLoader *classLoader, J9ROMClass *romClass, J9VMThread *vmThread, IDATA entryIndex, I_32 locationType);
-
-/**
 * @brief
 * @param *javaVM
 * @param *classLoaderObject
@@ -2132,6 +2120,7 @@ cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor*
 
 /**
 * @brief Find the package ID for the given name and length
+* @note Must own the classTableMutex.
 * @param *vmThread J9VMThread instance
 * @param *classLoader Classloader for the class
 * @param *romClass ROM class with the package name
@@ -2144,13 +2133,25 @@ hashPkgTableIDFor(J9VMThread *vmThread, J9ClassLoader *classLoader, J9ROMClass* 
 
 /**
 * @brief Look up the package information given a ROM class.
-* @note the ROM class may be a dummy with only  the package name.
+* @note Must own the classTableMutex.
+* @note The ROM class may be a dummy with only  the package name.
 * @param *classLoader Classloader for the class
 * @param *romClass ROM class with the package name
 * @return J9PackageIDTableEntry* ROM class representing a package
 */
 J9PackageIDTableEntry *
 hashPkgTableAt(J9ClassLoader* classLoader, J9ROMClass* romClass);
+
+/**
+* @brief Delete the package ID for a ROM class.
+* @note Must own the classTableMutex.
+* @note The entry is only deleted if it came from the given ROM class.
+* @param *classLoader Classloader for the class
+* @param *romClass ROM class with the package name
+*/
+void
+hashPkgTableDelete(J9ClassLoader* classLoader, J9ROMClass* romClass);
+
 
 /**
 * @brief Iterate over the package IDs used by the specified class loader

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,14 +50,6 @@
 #define J9DYNAMIC_ONUNLOAD              "JNI_OnUnload"
 
 static void cleanPackage(J9Package *package);
-
-UDATA
-initializePackageID(J9ClassLoader *classLoader, J9ROMClass *romClass, J9VMThread *vmThread, IDATA entryIndex, I_32 locationType)
-{
-	UDATA id = hashPkgTableIDFor(vmThread, classLoader, romClass, entryIndex, locationType);
-
-	return id;
-}
 
 #define CLASS_PROPAGATION_TABLE_SIZE 3
 


### PR DESCRIPTION
Ensure that both the package ID and the class defining it are in the
class loader hash table, or that neither are.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>