### PR TITLE
AArch64: Add suppressInliningOfRecognizedMethod to code generator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -200,3 +200,9 @@ J9::ARM64::CodeGenerator::supportsInliningOfIsInstance()
    {
    return !self()->comp()->getOption(TR_DisableInlineIsInstance);
    }
+
+bool
+J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+   return false;
+   }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -105,6 +105,12 @@ public:
     * @return true if isInstance inline fast helper is supported
     */
    bool supportsInliningOfIsInstance();
+
+   /**
+    * @brief Answers whether inlining of the specified recognized method should be suppressed
+    * @return true if inlining of the method should be suppressed
+    */
+   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
    };
 
 }


### PR DESCRIPTION
Add suppressInliningOfRecognizedMethod to aarch64 code generator as the default implementation of this method now always returns true as described in https://github.com/eclipse/omr/issues/6049.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>