### PR TITLE
Fix Java options for testDDRExt_SharedClasses

### DIFF
--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -186,12 +186,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>Using JVM : ${sdk.executable}${sdk.executable.ext}</echo>
 		<echo>classname = "j9vm.test.corehelper.StackMapCoreGenerator"</echo>
 		<echo>Java VM Args:</echo>
-		<echo>  jvmarg = -Xshareclasses:name=ddrextjunitSCC,reset -Xitsn1000</echo>
+		<echo>  jvmarg = -Xshareclasses:name=ddrextjunitSCC,reset -Xitsn1000 -Xmx512M </echo>
 		<echo>
 		</echo>
 		<java fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.corehelper.StackMapCoreGenerator" timeout="1200000" failonerror="true">
 			<jvmarg value="-Xshareclasses:name=ddrextjunitSCC,reset" />
 			<jvmarg value="-Xitsn1000" />
+			<jvmarg value="-Xmx512M" />
 			<classpath refid="tck.class.path" />
 		</java>
 	</target>


### PR DESCRIPTION
For the test testDDRExt_SharedClasses, add -Xmx512M to the TCK.cache.initialization step to match the TCK.generate.dump step. This ensures that the SCC AOT header matches the SCC AOT contents, and that the AOT code in the SCC is not ignored due to a compressedrefs shift mismatch.

Signed-off-by: midronij <jackie.midroni@ibm.com>