### PR TITLE
Update CachedRowSet create method for illegal-access error

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1010,7 +1010,7 @@
 			<variation>-XX:+CompactStrings</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
-	--illegal-access=permit -Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
 	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \
@@ -1110,7 +1110,7 @@
 			<variation>-Xshareclasses:none -XX:RecreateClassfileOnload</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
-	--illegal-access=permit -Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
 	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \

--- a/test/functional/Java8andUp/src/org/openj9/test/annotationClassLoader/Test_ClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/annotationClassLoader/Test_ClassLoader.java
@@ -30,6 +30,7 @@ import java.net.URLClassLoader;
 import java.sql.SQLException;
 
 import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetProvider;
 import javax.sql.rowset.spi.SyncProvider;
 
 @Test(groups = { "level.sanity" })
@@ -79,7 +80,7 @@ public class Test_ClassLoader {
 	@Test
 	public void test_latestUserDefinedLoader() throws Exception {
 		String customSyncProviderClassName = CustomSyncProvider.class.getName();
-		CachedRowSet crs = (CachedRowSet)Class.forName("com.sun.rowset.CachedRowSetImpl").newInstance();
+		CachedRowSet crs = RowSetProvider.newFactory().createCachedRowSet();
 		crs.setSyncProvider(customSyncProviderClassName);
 		SyncProvider syncProvider = crs.getSyncProvider();
 	


### PR DESCRIPTION
- Update CachedRowSet create method to solve illegal-access error for JCL_Test and JCL_Test_none_SCC
- Relate Issue: https://github.com/eclipse-openj9/openj9/issues/12727
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>