### PR TITLE
Adopt TR::InstOpCode on ARM

### DIFF
--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -158,7 +158,7 @@ TR::Register *J9::ARM::JNILinkage::pushDoubleArgForJNI(TR::Node *child)
 TR::MemoryReference *J9::ARM::JNILinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
                                                                        int32_t               offset,
                                                                        TR::Register          *argReg,
-                                                                       TR_ARMOpCodes         opCode,
+                                                                       TR::InstOpCode::Mnemonic         opCode,
                                                                        TR::ARMMemoryArgument &memArg)
    {
 /* totalSize does not matter */

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ class JNILinkage : public PrivateLinkage
    virtual TR::MemoryReference *getOutgoingArgumentMemRef(int32_t               totalParmAreaSize,
                                                             int32_t               argOffset,
                                                             TR::Register          *argReg,
-                                                            TR_ARMOpCodes         opCode,
+                                                            TR::InstOpCode::Mnemonic         opCode,
                                                             TR::ARMMemoryArgument &memArg);
 
    virtual TR::ARMLinkageProperties& getProperties();

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -840,7 +840,7 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 TR::MemoryReference *J9::ARM::PrivateLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
                                                                        int32_t               offset,
                                                                        TR::Register          *argReg,
-                                                                       TR_ARMOpCodes         opCode,
+                                                                       TR::InstOpCode::Mnemonic         opCode,
                                                                        TR::ARMMemoryArgument &memArg)
    {
 #ifdef DEBUG_ARM_LINKAGE

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ class PrivateLinkage : public J9::PrivateLinkage
    virtual TR::MemoryReference *getOutgoingArgumentMemRef(int32_t               totalParmAreaSize,
                                                             int32_t               argOffset,
                                                             TR::Register          *argReg,
-                                                            TR_ARMOpCodes         opCode,
+                                                            TR::InstOpCode::Mnemonic         opCode,
                                                             TR::ARMMemoryArgument &memArg);
 
    virtual TR::ARMLinkageProperties& getProperties();

--- a/runtime/compiler/arm/codegen/Instruction.hpp
+++ b/runtime/compiler/arm/codegen/Instruction.hpp
@@ -64,7 +64,7 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
 #include "codegen/J9Instruction_inlines.hpp"
 
 TR::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
-   : J9::InstructionConnector(cg, InstOpCode::BAD, node)
+   : J9::InstructionConnector(cg, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(ARMOp_bad);
    self()->setConditionCode(ARMConditionCodeAL);
@@ -72,7 +72,7 @@ TR::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Instruction::Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
-   : J9::InstructionConnector(cg, InstOpCode::BAD, node)
+   : J9::InstructionConnector(cg, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
@@ -83,7 +83,7 @@ TR::Instruction::Instruction(TR::Instruction   *precedingInstruction,
                          TR_ARMOpCodes     op,
                          TR::Node          *node,
                          TR::CodeGenerator *cg)
-   : J9::InstructionConnector(cg, precedingInstruction, InstOpCode::BAD, node)
+   : J9::InstructionConnector(cg, precedingInstruction, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
@@ -94,7 +94,7 @@ TR::Instruction::Instruction(TR_ARMOpCodes                       op,
                          TR::Node                            *node,
                          TR::RegisterDependencyConditions    *cond,
                          TR::CodeGenerator                   *cg)
-   : J9::InstructionConnector(cg, InstOpCode::BAD, node)
+   : J9::InstructionConnector(cg, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
@@ -109,7 +109,7 @@ TR::Instruction::Instruction(TR::Instruction                     *precedingInstr
                          TR::Node                            *node,
                          TR::RegisterDependencyConditions    *cond,
                          TR::CodeGenerator                   *cg)
-   : J9::InstructionConnector(cg, precedingInstruction, InstOpCode::BAD, node)
+   : J9::InstructionConnector(cg, precedingInstruction, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);

--- a/runtime/compiler/arm/codegen/Instruction.hpp
+++ b/runtime/compiler/arm/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,20 +40,20 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
    // TODO: need to fix the InstOpCode initialization
    inline Instruction(TR::Node *node, TR::CodeGenerator *cg);
 
-   inline Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg);
+   inline Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg);
 
    inline Instruction(TR::Instruction   *precedingInstruction,
-               TR_ARMOpCodes     op,
+               TR::InstOpCode::Mnemonic     op,
                TR::Node          *node,
                TR::CodeGenerator *cg);
 
-   inline Instruction(TR_ARMOpCodes                       op,
+   inline Instruction(TR::InstOpCode::Mnemonic                       op,
                TR::Node                            *node,
                TR::RegisterDependencyConditions    *cond,
                TR::CodeGenerator                   *cg);
 
    inline Instruction(TR::Instruction                     *precedingInstruction,
-               TR_ARMOpCodes                       op,
+               TR::InstOpCode::Mnemonic                       op,
                TR::Node                            *node,
                TR::RegisterDependencyConditions    *cond,
                TR::CodeGenerator                   *cg);
@@ -71,7 +71,7 @@ TR::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
    self()->setDependencyConditions(NULL);
    }
 
-TR::Instruction::Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
+TR::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
    : J9::InstructionConnector(cg, InstOpCode::bad, node)
    {
    self()->setOpCodeValue(op);
@@ -80,7 +80,7 @@ TR::Instruction::Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator
    }
 
 TR::Instruction::Instruction(TR::Instruction   *precedingInstruction,
-                         TR_ARMOpCodes     op,
+                         TR::InstOpCode::Mnemonic     op,
                          TR::Node          *node,
                          TR::CodeGenerator *cg)
    : J9::InstructionConnector(cg, precedingInstruction, InstOpCode::bad, node)
@@ -90,7 +90,7 @@ TR::Instruction::Instruction(TR::Instruction   *precedingInstruction,
    self()->setDependencyConditions(NULL);
    }
 
-TR::Instruction::Instruction(TR_ARMOpCodes                       op,
+TR::Instruction::Instruction(TR::InstOpCode::Mnemonic                       op,
                          TR::Node                            *node,
                          TR::RegisterDependencyConditions    *cond,
                          TR::CodeGenerator                   *cg)
@@ -105,7 +105,7 @@ TR::Instruction::Instruction(TR_ARMOpCodes                       op,
 
 
 TR::Instruction::Instruction(TR::Instruction                     *precedingInstruction,
-                         TR_ARMOpCodes                       op,
+                         TR::InstOpCode::Mnemonic                       op,
                          TR::Node                            *node,
                          TR::RegisterDependencyConditions    *cond,
                          TR::CodeGenerator                   *cg)

--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -75,7 +75,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    TR::RealRegister *addrReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
    TR::RealRegister *tempReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
 
-   TR_ARMOpCode opcode;
+   TR::InstOpCode opcode;
    TR_ARMOpCodes opCodeValue;
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();
@@ -226,7 +226,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
    TR::RealRegister *threadReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
-   TR_ARMOpCode opcode;
+   TR::InstOpCode opcode;
    TR_ARMOpCodes opCodeValue;
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();

--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    TR::RealRegister *tempReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
 
    TR::InstOpCode opcode;
-   TR_ARMOpCodes opCodeValue;
+   TR::InstOpCode::Mnemonic opCodeValue;
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();
 
@@ -227,7 +227,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    TR::RealRegister *threadReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    TR::InstOpCode opcode;
-   TR_ARMOpCodes opCodeValue;
+   TR::InstOpCode::Mnemonic opCodeValue;
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();
 #if 0

--- a/runtime/compiler/build/files/target/arm.mk
+++ b/runtime/compiler/build/files/target/arm.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/build/files/target/arm.mk
+++ b/runtime/compiler/build/files/target/arm.mk
@@ -30,6 +30,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/arm/codegen/ControlFlowEvaluator.cpp \
     omr/compiler/arm/codegen/FPTreeEvaluator.cpp \
     omr/compiler/arm/codegen/OMRCodeGenerator.cpp \
+    omr/compiler/arm/codegen/OMRInstOpCode.cpp \
     omr/compiler/arm/codegen/OMRInstruction.cpp \
     omr/compiler/arm/codegen/OMRLinkage.cpp \
     omr/compiler/arm/codegen/OMRMachine.cpp \
@@ -38,8 +39,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/arm/codegen/OMRRegisterDependency.cpp \
     omr/compiler/arm/codegen/OMRSnippet.cpp \
     omr/compiler/arm/codegen/OMRTreeEvaluator.cpp \
-    omr/compiler/arm/codegen/OpBinary.cpp \
-    omr/compiler/arm/codegen/OpProperties.cpp \
     omr/compiler/arm/codegen/StackCheckFailureSnippet.cpp \
     omr/compiler/arm/codegen/SubtractAnalyser.cpp \
     omr/compiler/arm/codegen/UnaryEvaluator.cpp \


### PR DESCRIPTION
Replicate the work done in #12729 on ARM. The changes here follow the exact same sequence of steps as on x86. There was no deviation from the sequence of steps performed.

Depends on eclipse/omr#6055