### PR TITLE
31/64 Interop: Exploit CEEPCB_3164 bit and fix va_list_64 arg for NewObjectV

### DIFF
--- a/runtime/j9vm31/j9cel4ro64.c
+++ b/runtime/j9vm31/j9cel4ro64.c
@@ -28,6 +28,16 @@ typedef void cel4ro64_cwi_func(void*);
 #pragma linkage (cel4ro64_cwi_func,OS_UPSTACK)
 #define CEL4RO64_FNPTR ((cel4ro64_cwi_func *)(*(int*)((char*)(*(int*)(((char*)__gtca())+1024))+8)))
 
+/* CEEPCB_3164 indicator is the 6th bit of PCB's CEEPCBFLAG6 field (byte 84).
+ * CEECAAPCB field is byte 756 of CAA.
+ *
+ * References for AMODE31:
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=conventions-language-environment-process-control-block
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=conventions-language-environment-common-anchor-area
+ */
+#define CEL4RO64_CEEPCBFLAG6_VALUE *((char *)(*(int *)(((char *)__gtca())+756))+84)
+#define CEL4RO64_CEEPCB_3164_MASK 0x4
+
 #pragma linkage (J9VM_STE,OS)
 float J9VM_STE(void);
 #pragma linkage (J9VM_STD,OS)
@@ -328,7 +338,7 @@ j9_cel4ro64_load_query_call_function(
 jboolean
 j9_cel4ro64_isSupported(void)
 {
-	return (NULL != CEL4RO64_FNPTR);
+	return (CEL4RO64_CEEPCB_3164_MASK == (CEL4RO64_CEEPCBFLAG6_VALUE & CEL4RO64_CEEPCB_3164_MASK));
 }
 
 const char*

--- a/runtime/j9vm31/jnicsup.cpp
+++ b/runtime/j9vm31/jnicsup.cpp
@@ -496,8 +496,6 @@ jobject JNICALL
 NewObject(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
 {
 	va_list_64 parms;
-
-	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
 	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
 
 	return NewObjectV_64(env, clazz, methodID, parms);
@@ -508,8 +506,9 @@ NewObjectV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args)
 {
 	va_list_64 parms;
 
-	long long value = *((int *)(((int *)(args))[1]));
-	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+	// Extract the arguments pointer from 31-bit va_list.
+	char *arguments = (char *)((int *)args)[1];
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = arguments );
 
 	return NewObjectV_64(env, clazz, methodID, parms);
 }

--- a/runtime/libffi/z/ffi64.c
+++ b/runtime/libffi/z/ffi64.c
@@ -134,6 +134,16 @@ typedef void cel4ro31_cwi_func(void*);
 typedef void celqgipb_cwi_func(uint32_t*, ffi_cel4ro31_control_block**, uint32_t*);
 #define FFI390_CELQGIPB_FNPTR ((celqgipb_cwi_func*)((char*)(*(int*)(((char*)__gtca())+1096))+96))
 
+/* CEEPCB_3164 indicator is the 6th bit of PCB's CEEPCBFLAG6 field (byte 344).
+ * CEECAAPCB field is byte 912 of CAA.
+ *
+ * References for AMODE64:
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=mappings-language-environment-process-control-block
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=mappings-language-environment-common-anchor-area
+ */
+#define FFI390_CEL4RO31_CEEPCBFLAG6_VALUE *((char *)(*(long *)(((char *)__gtca())+912))+344)
+#define FFI390_CEL4RO31_CEEPCB_3164_MASK 0x4
+
 /*====================== End of Externals ============================*/
  
 /*====================================================================*/
@@ -336,7 +346,7 @@ ffi_prep_cif_machdep_cel4ro31(ffi_cif *cif)
   int i;
 
   /* Check if LE APIs are available. */
-  if ((NULL == FFI390_CEL4RO31_FNPTR) || (NULL == FFI390_CELQGIPB_FNPTR))
+  if (0 == (FFI390_CEL4RO31_CEEPCBFLAG6_VALUE & FFI390_CEL4RO31_CEEPCB_3164_MASK))
   {
     return FFI_BAD_ABI;
   }


### PR DESCRIPTION
Two fixes related to zOS 31/64 bit interoperability:

- LE added a new CEEPCB_3164 bit on CEEPCBFLAG6 flag within Process
Control Block (PCB) to indicate support for CEL4RO31/64. Update
both libffi and libjvm31 usage of CEL4RO31/64 checks, as previous checks
were not sufficient on older zOS releases.
- NewObjectV did not set up the arguments pointer properly
from the incoming va_list (31-bit) arg parameter.
Updated va_list_64 argument parameter to directly
reference the corresponding parameter from the 31-bit va_list.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>
