### PR TITLE
Increase maximum number of JIT client compilation threads

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1089,9 +1089,10 @@ public:
    struct CompilationStatsPerInterval _intervalStats;
    TR_PersistentArray<TR_SignatureCountPair *> *_persistedMethods;
 
-   // Must be less than 8 at the JITClient or non-JITServer mode.
-   // Because in some parts of the code (CHTable) we keep flags on a byte variable.
-   static const uint32_t MAX_CLIENT_USABLE_COMP_THREADS = 7;  // For JITClient and non-JITServer mode
+   // Must be less than 16 at the JITClient or non-JITServer mode because
+   // in some parts of the code (CHTable) we keep flags on a 2-byte variable.
+   static const uint32_t MAX_CLIENT_USABLE_COMP_THREADS = 15; // For JITClient and non-JITServer mode
+   static const uint32_t DEFAULT_CLIENT_USABLE_COMP_THREADS = 7; // For JITClient and non-JITServer mode
 #if defined(J9VM_OPT_JITSERVER)
    static const uint32_t MAX_SERVER_USABLE_COMP_THREADS = 999; // JITServer
    static const uint32_t DEFAULT_SERVER_USABLE_COMP_THREADS = 63; // JITServer

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2697,8 +2697,18 @@ void TR::CompilationInfo::updateNumUsableCompThreads(int32_t &numUsableCompThrea
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      numUsableCompThreads = (numUsableCompThreads <= 0) ? DEFAULT_CLIENT_USABLE_COMP_THREADS
-                             : std::min(numUsableCompThreads, (int32_t)MAX_CLIENT_USABLE_COMP_THREADS);
+      if (numUsableCompThreads <= 0)
+         {
+         numUsableCompThreads = DEFAULT_CLIENT_USABLE_COMP_THREADS;
+         }
+      else if (numUsableCompThreads > MAX_CLIENT_USABLE_COMP_THREADS)
+         {
+         fprintf(stderr,
+            "Requested number of compilation threads is over the limit of %u. Will use %u threads.\n",
+            MAX_CLIENT_USABLE_COMP_THREADS, MAX_CLIENT_USABLE_COMP_THREADS
+         );
+         numUsableCompThreads = MAX_CLIENT_USABLE_COMP_THREADS;
+         }
       }
    }
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2697,9 +2697,8 @@ void TR::CompilationInfo::updateNumUsableCompThreads(int32_t &numUsableCompThrea
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      numUsableCompThreads = ((numUsableCompThreads <= 0) ||
-                              (numUsableCompThreads > MAX_CLIENT_USABLE_COMP_THREADS)) ?
-                               MAX_CLIENT_USABLE_COMP_THREADS : numUsableCompThreads;
+      numUsableCompThreads = (numUsableCompThreads <= 0) ? DEFAULT_CLIENT_USABLE_COMP_THREADS
+                             : std::min(numUsableCompThreads, (int32_t)MAX_CLIENT_USABLE_COMP_THREADS);
       }
    }
 

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -309,11 +309,10 @@ FlatPersistentClassInfo::serializeClass(TR_PersistentClassInfo *clazz, FlatPersi
    info->_visitedStatus = clazz->_visitedStatus;
    info->_prexAssumptions = clazz->_prexAssumptions;
    info->_timeStamp = clazz->_timeStamp;
-   info->_nameLength = clazz->_nameLength;
+   info->_shouldNotBeNewlyExtended = clazz->_shouldNotBeNewlyExtended;
    info->_flags = clazz->_flags;
    TR_ASSERT(clazz->_flags.getValue() < 0x40, "corrupted flags");
    TR_ASSERT(!clazz->getFieldInfo(), "field info not supported");
-   info->_shouldNotBeNewlyExtended = clazz->_shouldNotBeNewlyExtended;
    int idx = 0;
    for (TR_SubClass *c = clazz->getFirstSubclass(); c; c = c->getNext())
       {
@@ -354,9 +353,8 @@ FlatPersistentClassInfo::deserializeClassSimple(TR_PersistentClassInfo *clazz, F
    clazz->_classId = info->_classId;
    clazz->_visitedStatus = info->_visitedStatus;
    clazz->_timeStamp = info->_timeStamp;
-   clazz->_nameLength = info->_nameLength;
-   clazz->_flags = info->_flags;
    clazz->_shouldNotBeNewlyExtended = info->_shouldNotBeNewlyExtended;
+   clazz->_flags = info->_flags;
    clazz->_fieldInfo = NULL;
    return sizeof(FlatPersistentClassInfo) + info->_numSubClasses * sizeof(TR_OpaqueClassBlock*);
    }
@@ -644,10 +642,4 @@ void TR_JITClientPersistentClassInfo::setClassHasBeenRedefined(bool v)
    {
    TR_JITClientPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setClassHasBeenRedefined(v);
-   }
-
-void TR_JITClientPersistentClassInfo::setNameLength(int32_t length)
-   {
-   TR_JITClientPersistentClassInfo::_chTable->markDirty(getClassId());
-   TR_PersistentClassInfo::setNameLength(length);
    }

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -162,21 +162,20 @@ public:
    static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info);
    static size_t deserializeClassSimple(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo *info);
 
-   TR_OpaqueClassBlock                *_classId;
+   TR_OpaqueClassBlock *_classId;
 
    union
       {
       uintptr_t _visitedStatus;
       TR_PersistentClassInfoForFields *_fieldInfo;
       };
-   int16_t                             _prexAssumptions;
-   uint16_t                            _timeStamp;
-   int32_t                             _nameLength;
-   flags8_t                            _flags;
-   flags8_t                            _shouldNotBeNewlyExtended; // one bit for each possible compilation thread
+   int16_t   _prexAssumptions;
+   uint16_t  _timeStamp;
+   flags16_t _shouldNotBeNewlyExtended; // one bit for each possible compilation thread
+   flags8_t  _flags;
 
-   uint32_t                            _numSubClasses;
-   TR_OpaqueClassBlock                *_subClasses[0];
+   uint32_t             _numSubClasses;
+   TR_OpaqueClassBlock *_subClasses[0];
    };
 
 
@@ -217,7 +216,6 @@ public:
    virtual void setAlreadyCheckedForAnnotations(bool v = true) override;
    virtual void setCannotTrustStaticFinal(bool v = true) override;
    virtual void setClassHasBeenRedefined(bool v = true) override;
-   virtual void setNameLength(int32_t length) override;
 private:
    static JITClientPersistentCHTable *_chTable;
    };

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -246,8 +246,8 @@ TR_PersistentCHTable::classGotExtended(
    if (cl->shouldNotBeNewlyExtended())
       {
       TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
-      uint8_t mask = cl->getShouldNotBeNewlyExtendedMask().getValue();
-      for (int32_t ID = 0; mask; mask>>=1, ++ID)
+      uint16_t mask = cl->getShouldNotBeNewlyExtendedMask().getValue();
+      for (int32_t ID = 0; mask; mask >>= 1, ++ID)
          {
          if (mask & 0x1)
             {


### PR DESCRIPTION
Having more usable compilation threads at the JIT client than the current maximum of 7 improves performance when the network connection to the JITServer has high latency. The user can now specify up to 15 threads with `-XcompilationThreads<N>`, while the default is unchanged.