### PR TITLE
Revert "Remove limit on number of JITServer compilation threads"

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1044,8 +1044,8 @@ public:
    uint32_t getLastCriticalSeqNo() const { return _lastCriticalCompReqSeqNo; }
    void setLastCriticalSeqNo(uint32_t seqNo) { _lastCriticalCompReqSeqNo = seqNo; }
 
-   void markCHTableUpdateDone(int32_t threadId) { _chTableUpdateFlags |= (1 << threadId); }
-   void resetCHTableUpdateDone(int32_t threadId) { _chTableUpdateFlags &= ~(1 << threadId); }
+   void markCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags |= (1 << threadId); }
+   void resetCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags &= ~(1 << threadId); }
    uint8_t getCHTableUpdateDone() const { return _chTableUpdateFlags; }
 
    const PersistentVector<std::string> &getJITServerSslKeys() const { return _sslKeys; }
@@ -1088,7 +1088,7 @@ public:
    // Must be less than 8 at the JITClient or non-JITServer mode.
    // Because in some parts of the code (CHTable) we keep flags on a byte variable.
    static const uint32_t MAX_CLIENT_USABLE_COMP_THREADS = 7;  // For JITClient and non-JITServer mode
-   static const uint32_t DEFAULT_SERVER_USABLE_COMP_THREADS = 63; // JITServer
+   static const uint32_t MAX_SERVER_USABLE_COMP_THREADS = 63; // JITServer
    static const uint32_t MAX_DIAGNOSTIC_COMP_THREADS = 1;
 
 private:

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -459,7 +459,7 @@ TR::CompilationInfoPerThread *
 TR::CompilationInfo::findFirstLowPriorityCompilationInProgress(CompilationPriority priority) // needs compilationQueueMonitor in hand
    {
    TR::CompilationInfoPerThread *lowPriorityCompInProgress = NULL;
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1216,7 +1216,7 @@ TR::CompilationInfoPerThreadBase *TR::CompilationInfo::getCompInfoWithID(int32_t
    if (_compInfoForCompOnAppThread)
       return _compInfoForCompOnAppThread;
 
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1235,7 +1235,7 @@ TR::CompilationInfoPerThread *TR::CompilationInfo::getFirstSuspendedCompilationT
    if (_compInfoForCompOnAppThread)
       return NULL;
 
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1261,7 +1261,7 @@ void TR::CompilationInfo::setAllCompilationsShouldBeInterrupted()
       _compInfoForCompOnAppThread->setCompilationShouldBeInterrupted(GC_COMP_INTERRUPT);
    else
       {
-      for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+      for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
          {
          TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
          TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1753,7 +1753,7 @@ bool TR::CompilationInfo::canProcessLowPriorityRequest()
       }
 
    // Cycle through all the compilation threads
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1770,7 +1770,7 @@ int64_t
 TR::CompilationInfo::getCpuTimeSpentInCompilation()
    {
    I_64 totalTime = 0;
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -1893,7 +1893,7 @@ void TR::CompilationInfo::invalidateRequestsForNativeMethods(J9Class * clazz, J9
       TR_VerboseLog::writeLineLocked(TR_Vlog_HK, "invalidateRequestsForNativeMethods class=%p vmThread=%p", clazz, vmThread);
 
    // Cycle through all the compilation threads
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_MethodToBeCompiled *methodBeingCompiled = curCompThreadInfoPT->getMethodBeingCompiled();
@@ -1983,7 +1983,7 @@ void TR::CompilationInfo::invalidateRequestsForUnloadedMethods(TR_OpaqueClassBlo
    if (verbose)
       TR_VerboseLog::writeLineLocked(TR_Vlog_HK, "invalidateRequestsForUnloadedMethods class=%p vmThread=%p hotCodeReplacement=%d", clazz, vmThread, hotCodeReplacement);
 
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -2479,7 +2479,7 @@ void TR::CompilationInfo::suspendCompilationThread()
 
       // Must visit all compilation threads
       bool stoppedOneCompilationThread = false;
-      for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+      for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
          {
          TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
          TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -2560,7 +2560,7 @@ void TR::CompilationInfo::resumeCompilationThread()
       int32_t numActiveCompThreads = 0; // RAS purposes
       int32_t numHot = 0;
       TR::CompilationInfoPerThread *compInfoPTHot = NULL;
-      for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+      for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
          {
          TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
          TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -2614,7 +2614,7 @@ void TR::CompilationInfo::resumeCompilationThread()
 
       // If dynamicThreadActivation is used, wake compilation threads only as
       // many as required; otherwise wake them all
-      for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+      for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
          {
          TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
          TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -2659,7 +2659,7 @@ int TR::CompilationInfo::computeCompilationThreadPriority(J9JavaVM *vm)
 
 TR::CompilationInfoPerThread* TR::CompilationInfo::getCompInfoForThread(J9VMThread *vmThread)
    {
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -2680,8 +2680,9 @@ void TR::CompilationInfo::updateNumUsableCompThreads(int32_t &numUsableCompThrea
 #if defined(J9VM_OPT_JITSERVER)
    if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
-      numUsableCompThreads = (numUsableCompThreads <= 0) ? DEFAULT_SERVER_USABLE_COMP_THREADS
-                             : numUsableCompThreads;
+      numUsableCompThreads = ((numUsableCompThreads <= 0) ||
+                              (numUsableCompThreads > MAX_SERVER_USABLE_COMP_THREADS)) ?
+                               MAX_SERVER_USABLE_COMP_THREADS : numUsableCompThreads;
       }
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -2710,7 +2711,8 @@ TR::CompilationInfo::allocateCompilationThreads(int32_t numUsableCompThreads)
 #if defined(J9VM_OPT_JITSERVER)
    if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
-      TR_ASSERT(0 < numUsableCompThreads, "numUsableCompThreads %d is negative", numUsableCompThreads);
+      TR_ASSERT((0 < numUsableCompThreads) && (numUsableCompThreads <= MAX_SERVER_USABLE_COMP_THREADS),
+               "numUsableCompThreads %d is greater than supported %d", numUsableCompThreads, MAX_SERVER_USABLE_COMP_THREADS);
       }
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -3433,7 +3435,7 @@ void TR::CompilationInfo::stopCompilationThreads()
    acquireCompMonitor(vmThread);
 
    // Cycle through all non-diagnostic threads and stop them
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
 
@@ -3449,7 +3451,7 @@ void TR::CompilationInfo::stopCompilationThreads()
    // compilation thread has crashed and is going through the JitDump process. The reason we skipped terminating the
    // diagnostic threads in the above loop is because the JitDump logic will activate the diagnostic thread to generate
    // the JitDump, so the diagnostic thread must not be in a terminated state at that point.
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
 
@@ -3470,7 +3472,7 @@ void TR::CompilationInfo::stopCompilationThreads()
    // for the crashed thread in the loop above. However because the diagnostic data is generated on the crashed 
    // thread this thread will never return to execute the state processing loop, and thus will never terminate.
    // This is ok, because following the dump process in the JVM we will terminate the entire JVM process.
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
 
@@ -3480,7 +3482,7 @@ void TR::CompilationInfo::stopCompilationThreads()
 
    // Wake up the diagnostic thread and stop it. If it is currently active then we will block here until the JitDump
    // process is complete (see #11860).
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
 
@@ -4650,7 +4652,7 @@ TR::CompilationInfo::addMethodToBeCompiled(TR::IlGeneratorMethodDetails & detail
    TR_J9VMBase * fe = TR_J9VMBase::get(_jitConfig, vmThread);
 
    // search among the threads
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -4980,7 +4982,7 @@ TR::CompilationInfo::adjustCompilationEntryAndRequeue(
                             CompilationPriority priority,
                             TR_J9VMBase *fe)
    {
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -5034,7 +5036,7 @@ int32_t TR::CompilationInfo::promoteMethodInAsyncQueue(J9Method * method, void *
    {
    // See if the method is already in the queue or is already being compiled
    //
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -5094,7 +5096,7 @@ void TR::CompilationInfo::changeCompReqFromAsyncToSync(J9Method * method)
    TR_MethodToBeCompiled *cur = NULL, *prev = NULL;
    // See if the method is already in the queue or is already being compiled
    //
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -5157,7 +5159,7 @@ TR_MethodToBeCompiled * TR::CompilationInfo::requestExistsInCompilationQueue(TR:
    {
    // See if the method is already in the queue or under compilation
    //
-   for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -5289,7 +5291,7 @@ TR::CompilationInfo::getNextMethodToBeCompiled(TR::CompilationInfoPerThread *com
                // make sure there is at least one thread that is not jobless
                TR::CompilationInfoPerThread * const * arrayOfCompInfoPT = getArrayOfCompilationInfoPerThread();
                int32_t numActive = 0, numHot = 0, numLowPriority = 0;
-               for (int32_t i = 0; i < getNumUsableCompilationThreads(); i++)
+               for (uint8_t i = 0; i < getNumUsableCompilationThreads(); i++)
                   {
                   TR::CompilationInfoPerThread *curCompThreadInfoPT = arrayOfCompInfoPT[i];
                   TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -11204,7 +11206,7 @@ TR::CompilationInfo::printQueue()
    fprintf(stderr, "\t\t\tActive: ");
    bool activeMethods = false;
 
-   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -477,7 +477,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
             TR_ASSERT(arrayOfCompInfoPT, "TR::CompilationInfo::_arrayOfCompilationInfoPerThread is null\n");
 
-            for (int32_t i = 0; i < compInfo->getNumTotalCompilationThreads(); i++)
+            for (uint8_t i = 0; i < compInfo->getNumTotalCompilationThreads(); i++)
                {
                TR::CompilationInfoPerThread *curCompThreadInfoPT = arrayOfCompInfoPT[i];
                TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4966,7 +4966,7 @@ static void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, 
    //TODO: Is getArrayOfCompilationInfoPerThread() called after setupCompilationThreads()
    TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
 
-   for (int32_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+   for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
       {
       const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
       if (cpuUtil.isFunctional())
@@ -4993,7 +4993,7 @@ static void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, 
       TR_VerboseLog::vlogAcquire();
       TR_VerboseLog::write(TR_Vlog_INFO, "t=%6u TotalCompCpuUtil=%3d%%.", static_cast<uint32_t>(crtTime), totalCompCPUUtilization);
       TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
-      for (int32_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+      for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
          {
          const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
          TR_VerboseLog::write(" compThr%d:%3d%% (%2d%%, %2d%%) ", i, cpuUtilizationValues[i], cpuUtil.getThreadLastCpuUtil(), cpuUtil.getThreadPrevCpuUtil());

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1530,16 +1530,7 @@ onLoadInternal(
       // Address the case where the number of compilation threads is higher than the
       // maximum number of code caches
       if (TR::Options::_numUsableCompilationThreads > maxNumberOfCodeCaches)
-         {
-#if defined(J9VM_OPT_JITSERVER)
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
-               "ERROR: Requested number of compilation threads larger than maximum number of code caches: %d > %d",
-               TR::Options::_numUsableCompilationThreads, maxNumberOfCodeCaches
-            );
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         TR::Options::_numUsableCompilationThreads = maxNumberOfCodeCaches;
-         }
+         TR::Options::_numUsableCompilationThreads =  maxNumberOfCodeCaches;
 
       compInfo->updateNumUsableCompThreads(TR::Options::_numUsableCompilationThreads);
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -341,7 +341,7 @@ public:
 
    void incInUse() { _inUse++; }
    void decInUse() { _inUse--; TR_ASSERT(_inUse >= 0, "_inUse=%d must be positive\n", _inUse); }
-   int32_t getInUse() const { return _inUse; }
+   bool getInUse() const { return _inUse; }
 
    uint64_t getClientUID() const { return _clientUID; }
    void updateTimeOfLastAccess();
@@ -362,7 +362,7 @@ public:
       if (seqNo > _maxReceivedSeqNo)
          _maxReceivedSeqNo = seqNo;
       }
-   int32_t getNumActiveThreads() const { return _numActiveThreads; }
+   int8_t getNumActiveThreads() const { return _numActiveThreads; }
    void incNumActiveThreads() { ++_numActiveThreads; }
    void decNumActiveThreads() { --_numActiveThreads; }
    void printStats();
@@ -443,11 +443,11 @@ private:
 
    uint32_t _lastProcessedCriticalSeqNo; // highest seqNo processed request carrying info that needs to be applied in order
 
-   int32_t  _inUse; // Number of concurrent compilations from the same client
+   int8_t  _inUse;  // Number of concurrent compilations from the same client
                     // Accessed with compilation monitor in hand
-   int32_t _numActiveThreads; // Number of threads working on compilations for this client
-                              // This is smaller or equal to _inUse because some threads
-                              // could be just starting or waiting in _OOSequenceEntryList
+   int8_t _numActiveThreads; // Number of threads working on compilations for this client
+                             // This is smaller or equal to _inUse because some threads
+                             // could be just starting or waiting in _OOSequenceEntryList
    VMInfo *_vmInfo; // info specific to a client VM that does not change, NULL means not set
    bool _markedForDeletion; //Client Session is marked for deletion. When the inUse count will become zero this will be deleted.
    TR_AddressSet *_unloadedClassAddresses; // Per-client versions of the unloaded class and method addresses kept in J9PersistentInfo


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#12913

I merged 12913 by mistake, before having performed Jenkins tests on it.