### PR TITLE
Tweaks to Value Propagation for value types prototype support

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -618,6 +618,13 @@ static TR_YesNoMaybe isValue(TR::VPConstraint *constraint)
       return type->isFixedClass() ? TR_no : TR_maybe;
       }
 
+   // Array types are never value types
+   //
+   if (TR::Compiler->cls.isClassArray(comp, clazz))
+      {
+      return TR_no;
+      }
+
    // Is the type either an abstract class or an interface (i.e., not a
    // concrete class)?  If so, it might be a value type.
    //

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -807,6 +807,20 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
          TR::DebugCounter::incStaticDebugCounter(comp(), counterName);
          }
 
+      // If there is information available about the component type of the array for a call to
+      // jitLoadFlattenableArrayElement, mark the result of the call with the component type
+      //
+      if (isLoadFlattenableArrayElement && arrayConstraint && arrayConstraint->getClass()
+          && arrayConstraint->getClassType()->isArray() == TR_yes)
+         {
+         TR_OpaqueClassBlock *arrayComponentClass = fe()->getComponentClassFromArrayClass(arrayConstraint->getClass());
+
+         if (arrayComponentClass && arrayConstraint->asResolvedClass())
+            {
+            addBlockOrGlobalConstraint(node, TR::VPResolvedClass::create(this, arrayComponentClass), arrayRefGlobal);
+            }
+         }
+
       return;
       }
 


### PR DESCRIPTION
This covers a pair of minor improvements to value propagation for the prototype support for value types.

The `isValue` static method in `J9ValuePropagation.cpp` did not take into account that an array cannot be an instance of a value type.  That could prevent reference comparisons involving an array from being recognized as not needing to use the <objectEqualityComparison> non-helper.  Added a check to return `TR_no` in that case.

Also, in `J9::ValuePropagation::constrainRecognizedMethod`, a call to the `jitLoadFlattenableArrayElement` helper can be marked with the component type of the array whose element is being accessed.  That can allow the current pass of value propagation to recognize additional opportunities based on that type constraint.