### PR TITLE
(0.27) Account for array header alignment for multianewarray evaluator

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -145,6 +145,34 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>jit_jitt_array_compress</testCaseName>
+		<variations>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=1</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=2</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=3</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=4</variation>
+		</variations>
+		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	arrayTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>bits.64,^vm.xl</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jit_compareAndBranch</testCaseName>
 		<variations>
 			<variation>-Xjit:count=1,limit={*testAddressCompare*},optlevel=hot,disableCFGSimplification,disableGRA,disableAsyncCompilation</variation>


### PR DESCRIPTION
The array header size recently increased from 16 bytes to 24 bytes on 64-bit platforms.  With a 16 byte header size, inline code generated by the JIT to allocate a multidimensional array on the thread-local heap didn't need to account for alignment of the array headers, as they would be aligned for any shift compression amount.  With a size of 24 bytes,
headers will not be automatically aligned for a shift compression amount of four, which requires a heap alignment of 16 bytes.

The problem can be reproduced with this simple test:

```
public class Bar {
    public static final Integer[][] sub(int dim1, int dim2) {
        return new Integer[dim1][dim2];
    }

    public static final void main(String[] args) {
        sub(3, 0);
    }
}
```

Running with this command:

```
java -XXgc:forcedShiftingCompressionAmount=4 -Xjit:limit={Bar.sub*},count=0 Bar
```

Adjusted `multianewarray` evaluators for x and z platforms to account for array header alignment requirements.

These changes were merged to the OpenJ9 master branch under pull request #12905.