### PR TITLE
Add option -Xaot:disableSharedCacheHints in SCC CML tests

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2019 IBM Corp. and others
+  Copyright (c) 2012, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,13 @@
  	
 	<variable name="NON_WINDOWS_PLATFORMS" value="aix.*,linux.*,zos.*,osx.*" />
 	<variable name="WINDOWS_PLATFORMS" value="win.*" />
+	
+	<variable name="EXTRA_OPT_FOR_MPROTECT_NONE" value=" " />
+	<!-- memory protection is across processes on zos_390-31. If the cache is not created with -Xshareclasses:mprotect=none,
+		 it cannot be reused with -Xshareclasses:mprotect=none. Any update to it may lead to segmentation fault. Disable update
+		 using -Xaot:disableSharedCacheHints.
+	--> 
+	<variable name="EXTRA_OPT_FOR_MPROTECT_NONE" value="-Xaot:disableSharedCacheHints" platforms="zos_390-31.*" />
 		
 	<if testVariable="SCMODE" testValue="204" resultVariable="currentMode" resultValue="$mode204$"/>
 	
@@ -682,7 +689,7 @@
 	</test>
 	
 	<test id="Test 206-g: Reuse the cache with -Xshareclasses:mprotect=none option." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose -version</command>
+		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose $EXTRA_OPT_FOR_MPROTECT_NONE$ -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<!-- On linux and windows verify cache is being used with partial page protection enabled. -->
 		<output type="required" caseSensitive="yes" regex="no" platforms="linux.*,win.*">The JVM has enabled shared cache partial page protection as the existing shared cache was created with partial page protection enabled</output>
@@ -752,7 +759,7 @@
 	</test>
 	
 	<test id="Test 206-m: Reuse the cache with -Xshareclasses:mprotect=none option." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose -version</command>
+		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose $EXTRA_OPT_FOR_MPROTECT_NONE$ -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="required" caseSensitive="yes" regex="no">The JVM has enabled shared cache partial page protection on startup as the existing shared cache was created with partial page protection enabled on startup</output>
 		<output type="required" caseSensitive="yes" regex="no">The JVM has enabled shared cache partial page protection as the existing shared cache was created with partial page protection enabled</output>
@@ -828,7 +835,7 @@
 	</test>
 	
 	<test id="Test 206-t: Reuse the cache with -Xshareclasses:mprotect=none option." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose -version</command>
+		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose $EXTRA_OPT_FOR_MPROTECT_NONE$ -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="required" caseSensitive="yes" regex="no">The JVM has enabled shared cache partial page protection as the existing shared cache was created with partial page protection enabled</output>
 		<output type="required" caseSensitive="yes" regex="no" platforms="linux.*,win.*">Memory page protection on runtime data, string read-write data and partially filled pages is successfully enabled</output>
@@ -904,7 +911,7 @@
 	</test>
 	
 	<test id="Test 206-aa: Reuse the cache with -Xshareclasses:mprotect=none option and verify that memory protection is disabled." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose -version</command>
+		<command>$JAVA_EXE$ $currentMode$,mprotect=none,verbose $EXTRA_OPT_FOR_MPROTECT_NONE$ -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="required" caseSensitive="yes" regex="no">Memory page protection disabled for cache</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>


### PR DESCRIPTION
Add option -Xaot:disableSharedCacheHints for tests reusing cache 
with mprotect=none on zos_390-31. Memory protection is across process
there. Disable update to the cache if running with mprotect=none. 

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>