### PR TITLE
AArch64: Fix getLoadOpCodeFromDataType()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -4467,7 +4467,10 @@ getLoadOpCodeFromDataType(TR::CodeGenerator *cg, TR::DataType dt, int32_t elemen
    switch (dt)
       {
       case TR::Int8:
-         return useIdxReg ? TR::InstOpCode::ldrboff : TR::InstOpCode::ldrbimm;
+         if (isUnsigned)
+            return useIdxReg ? TR::InstOpCode::ldrboff : TR::InstOpCode::ldrbimm;
+         else
+            return useIdxReg ? TR::InstOpCode::ldrsboffw : TR::InstOpCode::ldrsbimmw;
       case TR::Int16:
          if (isUnsigned)
             return useIdxReg ? TR::InstOpCode::ldrhoff : TR::InstOpCode::ldrhimm;
@@ -4781,7 +4784,7 @@ J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGe
                TR_ASSERT(loadOrStoreChild->getOpCode().isConversion() || loadOrStoreChild->getOpCode().isLoad(), "Unexpected op");
 
                bool isUnsigned = loadOrStoreChild->getOpCode().isUnsigned();
-               TR::InstOpCode::Mnemonic loadOp = getLoadOpCodeFromDataType(cg, dt, isUnsigned, elementSize, indexReg != NULL);
+               TR::InstOpCode::Mnemonic loadOp = getLoadOpCodeFromDataType(cg, dt, elementSize, isUnsigned, indexReg != NULL);
 
                TR::MemoryReference *arrayletMR = indexReg ?
                   new (cg->trHeapMemory()) TR::MemoryReference(arrayletReg, arrayletOffsetReg, cg) :


### PR DESCRIPTION
This commit fixes two coding errors with getLoadOpCodeFromDataType():
- Use different opcodes in the case of signed Int8.
- Correct the order of arguments.

Fixes: #12831

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>