### PR TITLE
JDK18 bringup - add JAVA18 JPP pConfig, Access.exit & MajorVersion

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -178,7 +178,34 @@
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
-	
+
+	<configuration
+		  label="JAVA18"
+		  outputpath="JAVA18/src"
+		  dependencies="JAVA17"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava17.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="JAVA_SPEC_VERSION=18"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
 	<configuration
 		  label="OPENJ9-RAWBUILD"
 		  outputpath="OPENJ9-RAWBUILD/src"

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -506,6 +506,13 @@ final class Access implements JavaLangAccess {
 		return ClassLoader.findNative(loader, entryName);
 	}
 
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	@Override
+	public void exit(int status) {
+		Shutdown.exit(status);
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+
 	/*[ENDIF] OPENJDK_METHODHANDLES*/
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -549,7 +549,9 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
-	if (J2SE_VERSION(vm) >= J2SE_V17) {
+	if (J2SE_VERSION(vm) >= J2SE_V18) {
+		translationFlags |= BCT_Java18MajorVersionShifted;
+	} else if (J2SE_VERSION(vm) >= J2SE_V17) {
 		translationFlags |= BCT_Java17MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_V16) {
 		translationFlags |= BCT_Java16MajorVersionShifted;

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,7 @@
 #define J2SE_V15  (15 << J2SE_JAVA_SPEC_VERSION_SHIFT)
 #define J2SE_V16  (16 << J2SE_JAVA_SPEC_VERSION_SHIFT)
 #define J2SE_V17  (17 << J2SE_JAVA_SPEC_VERSION_SHIFT)
+#define J2SE_V18  (18 << J2SE_JAVA_SPEC_VERSION_SHIFT)
 
 /* J2SE_CURRENT_VERSION is the current Java version supported by VM for a JCL level. */
 #define J2SE_CURRENT_VERSION (JAVA_SPEC_VERSION << J2SE_JAVA_SPEC_VERSION_SHIFT)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2062,8 +2062,9 @@ typedef struct J9BCTranslationData {
 #define BCT_Java15MajorVersionShifted 0x3B000000
 #define BCT_Java16MajorVersionShifted 0x3C000000
 #define BCT_Java17MajorVersionShifted 0x3D000000
+#define BCT_Java18MajorVersionShifted 0x3E000000
 
-#define BCT_JavaMaxMajorVersionShifted BCT_Java17MajorVersionShifted
+#define BCT_JavaMaxMajorVersionShifted BCT_Java18MajorVersionShifted
 
 typedef struct J9RAMClassFreeListBlock {
 	UDATA size;


### PR DESCRIPTION
Added `JPP pConfig JAVA18`;
Added `BCT_Java18MajorVersionShifted`;
Added `Access.exit(status)`;

With this PR, `-version` output for JDKnext `openj9-staging`:
```
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc.fengjcaibmcom.mergetmp)
Eclipse OpenJ9 VM (build master-d8104c46a0, JRE 18 Mac OS X amd64-64-Bit Compressed References 20210611_000000 (JIT enabled, AOT enabled)
OpenJ9   - d8104c46a0
OMR      - 99f008c99
JCL      - da7073a7c4b based on jdk-9+99)
```
The JCL version is a known issue due to merging script.

close https://github.com/eclipse-openj9/openj9/issues/12930

Signed-off-by: Jason Feng <fengj@ca.ibm.com>