### PR TITLE
Move java specific evaluators from OMR

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3713,19 +3713,6 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
    return false;
    }
 
-/* extern TreeEvaluator functions */
-
-extern TR::Register* inlineStringHashCode(TR::Node *node, TR::CodeGenerator *cg, bool isCompressed);
-extern TR::Register* inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register* inlineUTF16BEEncode    (TR::Node *node, TR::CodeGenerator *cg);
-
-extern TR::Register *inlineHighestOneBit(TR::Node *node, TR::CodeGenerator *cg, bool isLong);
-extern TR::Register *inlineNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator * cg, bool isLong);
-extern TR::Register *inlineNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg, int32_t subfconst);
-extern TR::Register *inlineTrailingZerosQuadWordAtATime(TR::Node *node, TR::CodeGenerator *cg);
-
-
-
 #define IS_OBJ      true
 #define IS_NOT_OBJ  false
 
@@ -3905,20 +3892,20 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_lang_String_hashCodeImplDecompressed:
          if (cg->getSupportsInlineStringHashCode())
             {
-            return resultReg = inlineStringHashCode(node, cg, false);
+            return resultReg = TR::TreeEvaluator::inlineStringHashCode(node, cg, false);
             }
          break;
 
       case TR::java_lang_String_hashCodeImplCompressed:
          if (cg->getSupportsInlineStringHashCode())
             {
-            return resultReg = inlineStringHashCode(node, cg, true);
+            return resultReg = TR::TreeEvaluator::inlineStringHashCode(node, cg, true);
             }
         break;
 
       case TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Big:
-         return resultReg = comp->getOption(TR_DisableUTF16BEEncoder) ? inlineUTF16BEEncodeSIMD(node, cg)
-                                                                      : inlineUTF16BEEncode    (node, cg);
+         return resultReg = comp->getOption(TR_DisableUTF16BEEncoder) ? TR::TreeEvaluator::inlineUTF16BEEncodeSIMD(node, cg)
+                                                                      : TR::TreeEvaluator::inlineUTF16BEEncode    (node, cg);
          break;
 
       default:
@@ -3929,22 +3916,22 @@ J9::Z::CodeGenerator::inlineDirectCall(
    switch (methodSymbol->getRecognizedMethod())
       {
       case TR::java_lang_Integer_highestOneBit:
-         resultReg = inlineHighestOneBit(node, cg, false);
+         resultReg = TR::TreeEvaluator::inlineHighestOneBit(node, cg, false);
          return true;
       case TR::java_lang_Integer_numberOfLeadingZeros:
-         resultReg = inlineNumberOfLeadingZeros(node, cg, false);
+         resultReg = TR::TreeEvaluator::inlineNumberOfLeadingZeros(node, cg, false);
          return true;
       case TR::java_lang_Integer_numberOfTrailingZeros:
-         resultReg = inlineNumberOfTrailingZeros(node, cg, 32);
+         resultReg = TR::TreeEvaluator::inlineNumberOfTrailingZeros(node, cg, 32);
          return true;
       case TR::java_lang_Long_highestOneBit:
-         resultReg = inlineHighestOneBit(node, cg, true);
+         resultReg = TR::TreeEvaluator::inlineHighestOneBit(node, cg, true);
          return true;
       case TR::java_lang_Long_numberOfLeadingZeros:
-         resultReg = inlineNumberOfLeadingZeros(node, cg, true);
+         resultReg = TR::TreeEvaluator::inlineNumberOfLeadingZeros(node, cg, true);
          return true;
       case TR::java_lang_Long_numberOfTrailingZeros:
-         resultReg = inlineNumberOfTrailingZeros(node, cg, 64);
+         resultReg = TR::TreeEvaluator::inlineNumberOfTrailingZeros(node, cg, 64);
          return true;
       default:
          break;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3714,14 +3714,6 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
    }
 
 /* extern TreeEvaluator functions */
-extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::Node* node);
-extern TR::Register* inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register* VMinlineCompareAndSwap( TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj);
-extern TR::Register* inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8_t size, TR::MethodSymbol *method, bool isArray = false);
-extern TR::Register* inlineAtomicFieldUpdater(TR::Node *node, TR::CodeGenerator *cg, TR::MethodSymbol *method);
-extern TR::Register* inlineKeepAlive(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register* inlineConcurrentLinkedQueueTMOffer(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register* inlineConcurrentLinkedQueueTMPoll(TR::Node *node, TR::CodeGenerator *cg);
 
 extern TR::Register* inlineStringHashCode(TR::Node *node, TR::CodeGenerator *cg, bool isCompressed);
 extern TR::Register* inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg);
@@ -3732,17 +3724,7 @@ extern TR::Register *inlineNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerato
 extern TR::Register *inlineNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg, int32_t subfconst);
 extern TR::Register *inlineTrailingZerosQuadWordAtATime(TR::Node *node, TR::CodeGenerator *cg);
 
-extern TR::Register *toUpperIntrinsic(TR::Node * node, TR::CodeGenerator * cg, bool isCompressedString);
-extern TR::Register *toLowerIntrinsic(TR::Node * node, TR::CodeGenerator * cg, bool isCompressedString);
 
-extern TR::Register* inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isCompressed);
-
-extern TR::Register *inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isLatin1);
-
-extern TR::Register *inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register *inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg);
-
-extern TR::Register *inlineMathFma(TR::Node *node, TR::CodeGenerator *cg);
 
 #define IS_OBJ      true
 #define IS_NOT_OBJ  false
@@ -3771,12 +3753,12 @@ J9::Z::CodeGenerator::inlineDirectCall(
    //
    if (comp->getSymRefTab()->isNonHelper(node->getSymbolReference(), TR::SymbolReferenceTable::currentTimeMaxPrecisionSymbol))
       {
-      resultReg = inlineCurrentTimeMaxPrecision(cg, node);
+      resultReg = TR::TreeEvaluator::inlineCurrentTimeMaxPrecision(cg, node);
       return true;
       }
    else if (comp->getSymRefTab()->isNonHelper(node->getSymbolReference(), TR::SymbolReferenceTable::singlePrecisionSQRTSymbol))
       {
-      resultReg = inlineSinglePrecisionSQRT(node, cg);
+      resultReg = TR::TreeEvaluator::inlineSinglePrecisionSQRT(node, cg);
       return true;
       }
    else if (comp->getSymRefTab()->isNonHelper(node->getSymbolReference(), TR::SymbolReferenceTable::synchronizedFieldLoadSymbol))
@@ -3797,7 +3779,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
 
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ);
+            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ);
             return true;
             }
 
@@ -3808,7 +3790,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
 
          if (comp->target().is64Bit() && (!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ);
+            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ);
             return true;
             }
          // Too risky to do Long-31bit version now.
@@ -3821,7 +3803,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
 
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ);
+            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ);
             return true;
             }
          break;
@@ -3841,7 +3823,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_atomic_AtomicInteger_addAndGet:
       case TR::java_util_concurrent_atomic_AtomicInteger_incrementAndGet:
       case TR::java_util_concurrent_atomic_AtomicInteger_decrementAndGet:
-         resultReg = inlineAtomicOps(node, cg, 4, methodSymbol);
+         resultReg = TR::TreeEvaluator::inlineAtomicOps(node, cg, 4, methodSymbol);
          return true;
          break;
 
@@ -3852,7 +3834,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_atomic_AtomicIntegerArray_addAndGet:
       case TR::java_util_concurrent_atomic_AtomicIntegerArray_incrementAndGet:
       case TR::java_util_concurrent_atomic_AtomicIntegerArray_decrementAndGet:
-         resultReg = inlineAtomicOps(node, cg, 4, methodSymbol, true);
+         resultReg = TR::TreeEvaluator::inlineAtomicOps(node, cg, 4, methodSymbol, true);
          return true;
          break;
 
@@ -3866,7 +3848,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
             {
             // TODO: I'm not sure we need the z196 restriction here given that the function already checks for z196 and
             // has a compare and swap fallback path
-            resultReg = inlineAtomicOps(node, cg, 8, methodSymbol);
+            resultReg = TR::TreeEvaluator::inlineAtomicOps(node, cg, 8, methodSymbol);
             return true;
             }
          break;
@@ -3881,7 +3863,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
             {
             // TODO: I'm not sure we need the z196 restriction here given that the function already checks for z196 and
             // has a compare and swap fallback path
-            resultReg = inlineAtomicOps(node, cg, 8, methodSymbol);
+            resultReg = TR::TreeEvaluator::inlineAtomicOps(node, cg, 8, methodSymbol);
             return true;
             }
          break;
@@ -3894,20 +3876,20 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_getAndAdd:
          if (cg->getSupportsAtomicLoadAndAdd())
             {
-            resultReg = inlineAtomicFieldUpdater(node, cg, methodSymbol);
+            resultReg = TR::TreeEvaluator::inlineAtomicFieldUpdater(node, cg, methodSymbol);
             return true;
             }
          break;
 
       case TR::java_nio_Bits_keepAlive:
       case TR::java_lang_ref_Reference_reachabilityFence:
-         resultReg = inlineKeepAlive(node, cg);
+         resultReg = TR::TreeEvaluator::inlineKeepAlive(node, cg);
          return true;
 
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer:
          if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
-            resultReg = inlineConcurrentLinkedQueueTMOffer(node, cg);
+            resultReg = TR::TreeEvaluator::inlineConcurrentLinkedQueueTMOffer(node, cg);
             return true;
             }
          break;
@@ -3915,7 +3897,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll:
          if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
-            resultReg = inlineConcurrentLinkedQueueTMPoll(node, cg);
+            resultReg = TR::TreeEvaluator::inlineConcurrentLinkedQueueTMPoll(node, cg);
             return true;
             }
          break;
@@ -3980,16 +3962,16 @@ J9::Z::CodeGenerator::inlineDirectCall(
       switch (methodSymbol->getRecognizedMethod())
          {
          case TR::com_ibm_jit_JITHelpers_toUpperIntrinsicUTF16:
-            resultReg = toUpperIntrinsic(node, cg, false);
+            resultReg = TR::TreeEvaluator::toUpperIntrinsic(node, cg, false);
             return true;
          case TR::com_ibm_jit_JITHelpers_toUpperIntrinsicLatin1:
-            resultReg = toUpperIntrinsic(node, cg, true);
+            resultReg = TR::TreeEvaluator::toUpperIntrinsic(node, cg, true);
             return true;
          case TR::com_ibm_jit_JITHelpers_toLowerIntrinsicUTF16:
-            resultReg = toLowerIntrinsic(node, cg, false);
+            resultReg = TR::TreeEvaluator::toLowerIntrinsic(node, cg, false);
             return true;
          case TR::com_ibm_jit_JITHelpers_toLowerIntrinsicLatin1:
-            resultReg = toLowerIntrinsic(node, cg, true);
+            resultReg = TR::TreeEvaluator::toLowerIntrinsic(node, cg, true);
             return true;
          default:
             break;
@@ -4001,18 +3983,18 @@ J9::Z::CodeGenerator::inlineDirectCall(
       switch (methodSymbol->getRecognizedMethod())
          {
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
-            resultReg = inlineIntrinsicIndexOf(node, cg, true);
+            resultReg = TR::TreeEvaluator::inlineIntrinsicIndexOf(node, cg, true);
             return true;
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
-            resultReg = inlineIntrinsicIndexOf(node, cg, false);
+            resultReg = TR::TreeEvaluator::inlineIntrinsicIndexOf(node, cg, false);
             return true;
          case TR::java_lang_StringLatin1_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
-               resultReg = inlineVectorizedStringIndexOf(node, cg, false);
+               resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);
                return true;
          case TR::java_lang_StringUTF16_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
-               resultReg = inlineVectorizedStringIndexOf(node, cg, true);
+               resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, true);
                return true;
          default:
             break;
@@ -4024,10 +4006,10 @@ J9::Z::CodeGenerator::inlineDirectCall(
          switch (methodSymbol->getRecognizedMethod())
             {
             case TR::java_lang_Math_max_D:
-               resultReg = inlineDoubleMax(node, cg);
+               resultReg = TR::TreeEvaluator::inlineDoubleMax(node, cg);
                return true;
             case TR::java_lang_Math_min_D:
-               resultReg = inlineDoubleMin(node, cg);
+               resultReg = TR::TreeEvaluator::inlineDoubleMin(node, cg);
                return true;
             default:
                break;
@@ -4039,14 +4021,14 @@ J9::Z::CodeGenerator::inlineDirectCall(
             {
             case TR::java_lang_Math_fma_D:
             case TR::java_lang_StrictMath_fma_D:
-               resultReg = inlineMathFma(node, cg);
+               resultReg = TR::TreeEvaluator::inlineMathFma(node, cg);
                return true;
 
             case TR::java_lang_Math_fma_F:
             case TR::java_lang_StrictMath_fma_F:
                if (comp->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1))
                   {
-                  resultReg = inlineMathFma(node, cg);
+                  resultReg = TR::TreeEvaluator::inlineMathFma(node, cg);
                   return true;
                   }
                break;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -616,7 +616,7 @@ doubleMaxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool isMaxOp)
  * \return a register for that contains the indexOf() result.
 */
 TR::Register*
-inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF16)
+J9::Z::TreeEvaluator::inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF16)
    {
    #define iComment(str) if (compDebug) compDebug->addInstructionComment(cursor, (const_cast<char*>(str)));
    TR::Compilation *comp = cg->comp();
@@ -1295,8 +1295,8 @@ TR::Register * caseConversionHelper(TR::Node* node, TR::CodeGenerator* cg, bool 
    return node->getRegister();
    }
 
-extern TR::Register *
-inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
+TR::Register *
+J9::Z::TreeEvaluator::inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    {
    cg->generateDebugCounter("z13/simd/indexOf", 1, TR::DebugCounter::Free);
 
@@ -1445,36 +1445,36 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    return indexRegister;
    }
 
-extern TR::Register *
-toUpperIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString)
+TR::Register*
+J9::Z::TreeEvaluator::toUpperIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString)
    {
    cg->generateDebugCounter("z13/simd/toUpper", 1, TR::DebugCounter::Free);
    return caseConversionHelper(node, cg, true, isCompressedString);
    }
 
-extern TR::Register *
-toLowerIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString)
+TR::Register*
+J9::Z::TreeEvaluator::toLowerIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString)
    {
    cg->generateDebugCounter("z13/simd/toLower", 1, TR::DebugCounter::Free);
    return caseConversionHelper(node, cg, false, isCompressedString);
    }
 
-extern TR::Register *
-inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg)
    {
    cg->generateDebugCounter("z13/simd/doubleMax", 1, TR::DebugCounter::Free);
    return doubleMaxMinHelper(node, cg, true);
    }
 
-extern TR::Register *
-inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg)
    {
    cg->generateDebugCounter("z13/simd/doubleMin", 1, TR::DebugCounter::Free);
    return doubleMaxMinHelper(node, cg, false);
    }
 
-extern TR::Register *
-inlineMathFma(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *
+J9::Z::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT_FATAL(node->getNumChildren() == 3,
    "In function inlineMathFma, the node at address %p should have exactly 3 children, but got %u instead", node, node->getNumChildren());
@@ -10152,8 +10152,8 @@ void J9::Z::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register *s
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
    }
 
-extern TR::Register *
-VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj)
+TR::Register*
+J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj)
    {
    TR::Register *scratchReg = NULL;
    TR::Register *objReg, *oldVReg, *newVReg;
@@ -10479,7 +10479,8 @@ extern "C" void _getSTCKLSOOffset(int32_t* offsetArray);  /* 390 asm stub */
 /**
  * generate a single precision sqrt instruction
  */
-extern TR::Register * inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * targetRegister = NULL;
@@ -10511,7 +10512,8 @@ extern TR::Register * inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerato
  *  \return
  *     A register (or register pair for 31-bit) containing the current time in terms of 1/2048 of micro-seconds.
  */
-extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::Node* node)
+TR::Register*
+J9::Z::TreeEvaluator::inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::Node* node)
    {
    // STCKF is an S instruction and requires a 64-bit memory reference
    TR::SymbolReference* reusableTempSlot = cg->allocateReusableTempSlot();
@@ -10571,12 +10573,8 @@ extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::No
    return targetRegister;
    }
 
-extern TR::Register *inlineAtomicOps(
-      TR::Node *node,
-      TR::CodeGenerator *cg,
-      int8_t size,
-      TR::MethodSymbol *method,
-      bool isArray = false)
+TR::Register*
+J9::Z::TreeEvaluator::inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8_t size, TR::MethodSymbol *method, bool isArray)
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
@@ -10973,11 +10971,8 @@ evaluateTwo32BitLoadsInAConsecutiveEvenOddPair(
    return newRegisterPair;
    }
 
-extern TR::Register *
-inlineAtomicFieldUpdater(
-      TR::Node *node,
-      TR::CodeGenerator *cg,
-      TR::MethodSymbol *method)
+TR::Register*
+J9::Z::TreeEvaluator::inlineAtomicFieldUpdater(TR::Node *node, TR::CodeGenerator *cg, TR::MethodSymbol *method)
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
@@ -11123,10 +11118,8 @@ inlineAtomicFieldUpdater(
    return resultReg;
    }
 
-extern TR::Register *
-inlineKeepAlive(
-      TR::Node *node,
-      TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineKeepAlive(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *paramNode = node->getFirstChild();
    TR::Register *paramReg = cg->evaluate(paramNode);
@@ -11212,10 +11205,8 @@ genWrtBarForTM(
       }
    }
 
-extern TR::Register *
-inlineConcurrentLinkedQueueTMOffer(
-      TR::Node *node,
-      TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineConcurrentLinkedQueueTMOffer(TR::Node *node, TR::CodeGenerator *cg)
    {
    int32_t offsetTail = 0;
    int32_t offsetNext = 0;
@@ -11400,10 +11391,8 @@ inlineConcurrentLinkedQueueTMOffer(
    return rReturn;
    }
 
-extern TR::Register *
-inlineConcurrentLinkedQueueTMPoll(
-      TR::Node *node,
-      TR::CodeGenerator *cg)
+TR::Register*
+J9::Z::TreeEvaluator::inlineConcurrentLinkedQueueTMPoll(TR::Node *node, TR::CodeGenerator *cg)
    {
    int32_t offsetHead = 0;
    int32_t offsetNext = 0;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -49,6 +49,21 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
+   static TR::Register *inlineCurrentTimeMaxPrecision(TR::CodeGenerator *cg, TR::Node *node);
+   static TR::Register *inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *VMinlineCompareAndSwap( TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj);
+   static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8_t size, TR::MethodSymbol *method, bool isArray = false);
+   static TR::Register *inlineAtomicFieldUpdater(TR::Node *node, TR::CodeGenerator *cg, TR::MethodSymbol *method);
+   static TR::Register *inlineKeepAlive(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineConcurrentLinkedQueueTMOffer(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineConcurrentLinkedQueueTMPoll(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *toUpperIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString);
+   static TR::Register *toLowerIntrinsic(TR::Node *node, TR::CodeGenerator *cg, bool isCompressedString);
+   static TR::Register *inlineVectorizedStringIndexOf(TR::Node *node, TR::CodeGenerator *cg, bool isCompressed);
+   static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *cg, bool isLatin1);
+   static TR::Register *inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineMathFma(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Many extern evaluators declarations in z/J9CodeGenerator.cpp are defined in OMR. These evaluators should be in OpenJ9 instead. As part of this commit, all extern declarations of evaluators are removed from J9CodeGenerator.cpp and function definitions are imported over from OMR where applicable.

Closes: #12911