### PR TITLE
Use client's object alignment value on the JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -482,6 +482,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._isHotReferenceFieldRequired = TR::Compiler->om.isHotReferenceFieldRequired();
          vmInfo._osrGlobalBufferSize = javaVM->osrGlobalBufferSize;
          vmInfo._needsMethodTrampolines = TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines();
+         vmInfo._objectAlignmentInBytes = TR::Compiler->om.objectAlignmentInBytes();
 
          client->write(response, vmInfo, listOfCacheDescriptors);
          }

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -485,6 +485,14 @@ J9::ObjectModel::objectAlignmentInBytes()
    if (!javaVM)
       return 0;
 
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_objectAlignmentInBytes;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    J9MemoryManagerFunctions * mmf = javaVM->memoryManagerFunctions;
    uintptr_t result = 0;
    result = mmf->j9gc_modron_getConfigurationValueForKey(javaVM, j9gc_modron_configuration_objectAlignment, &result) ? result : 0;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -292,6 +292,7 @@ public:
       bool _isHotReferenceFieldRequired;
       UDATA _osrGlobalBufferSize;
       bool _needsMethodTrampolines;
+      int32_t _objectAlignmentInBytes;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
`J9::ObjectModel::objectAlignmentInBytes` returns a GC
configuration parameter. This value is stored on the client
and can differ between clients. Therefore, we need to fetch
and cache this value in the VMInfo on the server.

Fixes: #12934 