### PR TITLE
CMake: apply OMR_EXE_LAUNCHER when launching jilgen

### DIFF
--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ target_link_libraries(constgen
 add_custom_command(
 	OUTPUT ${j9vm_BINARY_DIR}/oti/jilconsts.inc ${j9vm_BINARY_DIR}/oti/jilvalues.m4
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${j9vm_BINARY_DIR}/oti
-	COMMAND $<TARGET_FILE:constgen>
+	COMMAND ${OMR_EXE_LAUNCHER} $<TARGET_FILE:constgen>
 	VERBATIM
 	WORKING_DIRECTORY ${j9vm_BINARY_DIR}
 )


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>