### PR TITLE
Exclude building riscvnathelp.m4 within codert_vm/modules.xml

### DIFF
--- a/runtime/codert_vm/module.xml
+++ b/runtime/codert_vm/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2020 IBM Corp. and others
+Copyright (c) 2006, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,6 +82,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</makefilestub>
 			<makefilestub data="UMA_OBJECTS:=$(filter-out znathelp%,$(UMA_OBJECTS))">
 				<exclude-if condition="spec.flags.arch_s390"/>
+			</makefilestub>
+			<makefilestub data="UMA_OBJECTS:=$(filter-out riscvnathelp%,$(UMA_OBJECTS))">
+				<exclude-if condition="spec.flags.arch_riscv and spec.flags.J9VM_ENV_DATA64"/>
 			</makefilestub>
 		</makefilestubs>
 	</artifact>


### PR DESCRIPTION
Required for pre-CMake UMA builds.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>