### PR TITLE
Checkout directly to OPENJSK_SHA if passed

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -78,10 +78,14 @@ def get_sources() {
             remote_config_parameters.put('credentialsId', "${USER_CREDENTIALS_ID}")
         }
 
+        def openjdkCheckoutRef = OPENJDK_BRANCH
+        if (OPENJDK_SHA) {
+            openjdkCheckoutRef = OPENJDK_SHA
+        }
         checkout changelog: false,
                 poll: false,
                 scm: [$class: 'GitSCM',
-                    branches: [[name: "${OPENJDK_BRANCH}"]],
+                    branches: [[name: "${openjdkCheckoutRef}"]],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[$class: 'CheckoutOption', timeout: 30],
                                 [$class: 'CloneOption',
@@ -100,7 +104,6 @@ def get_sources() {
         // Look for dependent changes and checkout PR(s)
         checkout_pullrequest()
     } else {
-        sh "git checkout ${OPENJDK_SHA}"
         sh "bash get_source.sh ${EXTRA_GETSOURCE_OPTIONS} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${OPENJ9_REFERENCE} ${OMR_REPO_OPTION} ${OMR_BRANCH_OPTION} ${OMR_SHA_OPTION} ${OMR_REFERENCE}"
     }
 }


### PR DESCRIPTION
On a Docker based compile, SCM checkout runs
using git from the host. Git checkout uses Git
from the container. This seems to produce an
incompatilibilty between the git metadata. When
'git checkout' runs (in the container) it can't
seem to process correctly and fails "fatal: reference
is not a tree: <sha>". Having the scm step checkout
directly to the SHA if it is passed should eliminate
the need to run the extra checkout. Note that
OPENJDK_SHA should be passed in 100% of the builds.
It would only not be passed if someone was launching
a build job direcly without filling in the param.

Test cases
- OpenJ9 PR
- OpenJDK PR
- OpenJ9 PR depends OpenJDK PR
- Non-PR build with OpenJDK_SHA passed
- Non-PR build without OPENJDK_SHA passed

Fixes #12881

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>