### PR TITLE
Fix a bug in assumption reclamation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10127,7 +10127,6 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                   // Delete any assumptions that might still exist in persistent memory
                   // The metadata parameter is NULL meaning that we want to delete ALL assumptions, including those for JBI
                   compInfo->getPersistentInfo()->getRuntimeAssumptionTable()->reclaimAssumptions(comp->getMetadataAssumptionList(), NULL);
-                  metaData->runtimeAssumptionList = NULL;
 
                   // reclaim code memory so we can use it for something else
                   TR::CodeCacheManager::instance()->addFreeBlock(static_cast<void *>(metaData), reinterpret_cast<uint8_t *>(metaData->startPC));
@@ -10194,7 +10193,6 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                if (metaData)
                   {
                   compInfo->getPersistentInfo()->getRuntimeAssumptionTable()->reclaimAssumptions(comp->getMetadataAssumptionList(), NULL);
-                  metaData->runtimeAssumptionList = NULL;
 
                   metaData->constantPool = 0; // mark metadata as unloaded
                   }

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -559,6 +559,15 @@ void TR_RuntimeAssumptionTable::reclaimAssumptions(OMR::RuntimeAssumption **sent
       else
          {
          sentry->markForDetach();
+         if (metaData)
+            {
+            reinterpret_cast<J9JITExceptionTable*>(metaData)->runtimeAssumptionList = NULL;
+            }
+         else if ((metaData = reinterpret_cast<TR::SentinelRuntimeAssumption *>(sentry)->getOwningMetadata()))
+            {
+            // metadata passed might be NULL, but it can still exist
+            reinterpret_cast<J9JITExceptionTable*>(metaData)->runtimeAssumptionList = NULL;
+            }
          *sentinel = NULL;
          }
       }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1521,6 +1521,9 @@ createMethodMetaData(
 
    data->registerSaveDescription = comp->cg()->getRegisterSaveDescription();
 
+   if (*comp->getMetadataAssumptionList())
+      static_cast<TR::SentinelRuntimeAssumption *>(*(comp->getMetadataAssumptionList()))->setOwningMetadata(data);
+
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
    if (vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -320,6 +320,7 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
             // having to allocate one at runtime and possibly running out of memory
             OMR::RuntimeAssumption * raList = new (PERSISTENT_NEW) TR::SentinelRuntimeAssumption();
             comp->setMetadataAssumptionList(raList); // copy this list to the compilation object as well (same view as for a JIT compilation)
+            static_cast<TR::SentinelRuntimeAssumption *>(*comp->getMetadataAssumptionList())->setOwningMetadata(_exceptionTable);
             _exceptionTable->runtimeAssumptionList = raList;
             // If we cannot allocate the memory, fail the compilation
             if (raList == NULL)


### PR DESCRIPTION
`TR_RuntimeAssumptionTable::reclaimAssumptions` marks assumptions
for detach and sets the head of the assumption list to NULL.
However, it has an issue where it does not guarantee that
`metaData->runtimeAssumptionList` will be set to NULL,
since the sentinel double pointer passed to it can be the address
of the list in the compilation object, instead of in the metadata.
It's also not always the case that the method is passed metadata
pointer when it exists.

This commit sets `_owningMetadata` attribute of a sentinel runtime
assumption when metadata is created.
At reclamation, we use the owning metadata to reset the assumption
list pointer, if metadata pointer is not directly available