### PR TITLE
Fix a memory leak in runtime assumption list

### DIFF
--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -269,6 +269,15 @@ void OMR::RuntimeAssumption::dequeueFromListOfAssumptionsForJittedBody()
          OMR::RuntimeAssumption *next = crt->getNextAssumptionForSameJittedBodyEvenIfDead();
          prev->setNextAssumptionForSameJittedBody(next);
          crt->setNextAssumptionForSameJittedBody(NULL);
+
+         // Sentinel is not a part of RAT so it will not be deleted normally.
+         // Need to explicitly free it here
+         if (crt->getAssumptionKind() == RuntimeAssumptionSentinel)
+            {
+            crt->paint();
+            TR_PersistentMemory::jitPersistentFree(crt);
+            }
+
          crt = next;
          }
       else


### PR DESCRIPTION
The mark-and-sweep assumption reclamation algorithm will free
marked for detach entries in
`TR_RuntimeAssumptionTable::reclaimMarkedAssumptionsFromRAT`.
The method iterates through the runtime assumption table and
frees all entries that are marked for detach, after dequeing
them from the per-compilation runtime assumption list.

However, sentinel runtime assumptions (i.e. heads of assumption lists)
are detached but never freed, since they are not part of the RAT.
The fix to this memory leak is to delete sentinels the moment they
are dequeued from the runtime assumption list.