### PR TITLE
Move all ARM mnemonics into the TR::InstOpCode class

### DIFF
--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -130,7 +130,7 @@ TR::Register *J9::ARM::JNILinkage::pushFloatArgForJNI(TR::Node *child)
    if (pushRegister->getKind() == TR_GPR)
       {
       TR::Register *trgReg = cg()->allocateSinglePrecisionRegister();
-      generateTrg1Src1Instruction(cg(), ARMOp_fmsr, child, trgReg, pushRegister);
+      generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_fmsr, child, trgReg, pushRegister);
       return trgReg;
       }
 
@@ -148,7 +148,7 @@ TR::Register *J9::ARM::JNILinkage::pushDoubleArgForJNI(TR::Node *child)
       {
       TR::Register *trgReg = cg()->allocateRegister(TR_FPR);
       TR::RegisterPair *pair = pushRegister->getRegisterPair();
-      generateTrg1Src2Instruction(cg(), ARMOp_fmdrr, child, trgReg, pair->getLowOrder(), pair->getHighOrder());
+      generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_fmdrr, child, trgReg, pair->getLowOrder(), pair->getHighOrder());
       return trgReg;
       }
    return pushRegister;
@@ -369,13 +369,13 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
       uint32_t base, rotate;
       if (constantIsImmed8r(numStackParmSlots, &base, &rotate))
          {
-         generateTrg1Src1ImmInstruction(codeGen, ARMOp_sub, callNode, sp, sp, base, rotate);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub, callNode, sp, sp, base, rotate);
          }
       else
          {
          TR::Register *tmpReg = codeGen->allocateRegister();
          armLoadConstant(callNode, numStackParmSlots, tmpReg, codeGen);
-         generateTrg1Src2Instruction(codeGen, ARMOp_sub, callNode, sp, sp, tmpReg);
+         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_sub, callNode, sp, sp, tmpReg);
          codeGen->stopUsingRegister(tmpReg);
          }
       }
@@ -419,7 +419,7 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
                      tempReg = codeGen->allocateCollectedReferenceRegister();
                   else
                      tempReg = codeGen->allocateRegister();
-                  generateTrg1Src1Instruction(codeGen, ARMOp_mov, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg);
                   reg = tempReg;
                   }
                if (numIntegerArgRegIndex == 0 &&
@@ -449,7 +449,7 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing 32-bit arg %d %d\n", numIntegerArgRegIndex, memArg); fflush(stdout);
 #endif
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, ARMOp_str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
                stackOffset += 4;
                }
             numIntegerArgRegIndex++;
@@ -478,12 +478,12 @@ printf("skipping one argument slot\n"); fflush(stdout);
 
                   if (bigEndian)
                      {
-                     generateTrg1Src1Instruction(codeGen, ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
+                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
                      reg = codeGen->allocateRegisterPair(reg->getRegisterPair()->getLowOrder(), tempReg);
                      }
                   else
                      {
-                     generateTrg1Src1Instruction(codeGen, ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
+                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
                      reg = codeGen->allocateRegisterPair(tempReg, reg->getRegisterPair()->getHighOrder());
                      }
                   }
@@ -501,12 +501,12 @@ printf("skipping one argument slot\n"); fflush(stdout);
                      tempReg = codeGen->allocateRegister();
                      if (bigEndian)
                         {
-                        generateTrg1Src1Instruction(codeGen, ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
+                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
                         reg->getRegisterPair()->setLowOrder(tempReg, codeGen);
                         }
                      else
                         {
-                        generateTrg1Src1Instruction(codeGen, ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
+                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
                         reg->getRegisterPair()->setHighOrder(tempReg, codeGen);
                         }
                      }
@@ -518,7 +518,7 @@ printf("skipping one argument slot\n"); fflush(stdout);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing %s word of 64-bit arg %d %d\n", bigEndian ? "low" : "high", numIntegerArgRegIndex, memArg); fflush(stdout);
 #endif
-                  tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), ARMOp_str, pushToMemory[memArg++]);
+                  tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
                   stackOffset += 4;
                   }
                }
@@ -529,8 +529,8 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
 #endif
                if (isEABI)
                   stackOffset = (stackOffset + 4) & (~7);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getHighOrder() : reg->getRegisterPair()->getLowOrder(), ARMOp_str, pushToMemory[memArg++]);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset + 4, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), ARMOp_str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getHighOrder() : reg->getRegisterPair()->getLowOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset + 4, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
                stackOffset += 8;
                }
             numIntegerArgRegIndex += 2;
@@ -543,7 +543,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                if (!cg()->canClobberNodesRegister(child, 0))
                   {
                   tempReg = codeGen->allocateSinglePrecisionRegister();
-                  generateTrg1Src1Instruction(codeGen, ARMOp_fcpys, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fcpys, child, tempReg, reg);
                   reg = tempReg;
                   }
                if ((numFloatArgRegIndex == 0) && resType.isFloatingPoint())
@@ -579,7 +579,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                }
             else
                {
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, ARMOp_fsts, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_fsts, pushToMemory[memArg++]);
                stackOffset += 4;
 
                numFloatArgRegIndex++;
@@ -596,7 +596,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                if (!cg()->canClobberNodesRegister(child, 0))
                   {
                   tempReg = cg()->allocateRegister(TR_FPR);
-                  generateTrg1Src1Instruction(codeGen, ARMOp_fcpyd, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fcpyd, child, tempReg, reg);
                   reg = tempReg;
                   }
                if ((numFloatArgRegIndex == 0) && resType.isFloatingPoint())
@@ -617,7 +617,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                {
                if (isEABI)
                    stackOffset = (stackOffset + 4) & (~7);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, ARMOp_fstd, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_fstd, pushToMemory[memArg++]);
                stackOffset += 8;
                }
             numFloatArgRegIndex++;
@@ -864,9 +864,9 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    // mask out the magic bit that indicates JIT frames below
-   generateTrg1ImmInstruction(codeGen, ARMOp_mov, callNode, gr5Reg, 0, 0);
+   generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr5Reg, 0, 0);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaFrameFlagsOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr5Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr5Reg);
 
    // push tag bits (savedA0 slot)
    // if the current method is simply a wrapper for the JNI call, hide the call-out stack frame
@@ -878,52 +878,52 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    armLoadConstant(callNode, tagBits, gr4Reg, codeGen);
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)sizeof(uintptr_t)), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
 
    // skip unused savedPC slot and push return address (savedCP slot)
    //
    TR::LabelSymbol *returnAddrLabel               = generateLabelSymbol(codeGen);
-   generateLabelInstruction(codeGen, ARMOp_add, callNode, returnAddrLabel, NULL, gr4Reg, instrPtr);
+   generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, returnAddrLabel, NULL, gr4Reg, instrPtr);
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -2 * ((int)sizeof(uintptr_t)), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
 
    // push frame flags
    intParts flags((int32_t)fej9->constJNICallOutFrameFlags());
    TR_ASSERT((flags.getValue() & ~0x7FFF0000) == 0, "JNI call-out frame flags have more than 15 bits");
-   generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte3(), 24));
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte2(), 16));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte3(), 24));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte2(), 16));
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)TR::Compiler->om.sizeofReferenceAddress()), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
 
    // push the RAM method for the native
    intParts ramMethod((int32_t)resolvedMethod->resolvedMethodAddress());
-   generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte3(), 24));
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte2(), 16));
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte1(), 8));
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte0(), 0));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte3(), 24));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte2(), 16));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte1(), 8));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte0(), 0));
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)TR::Compiler->om.sizeofReferenceAddress()), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
 
    // store the Java SP
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaSPOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, stackPtr);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, stackPtr);
 
    // store the PC and literals values indicating the call-out frame
    intParts frameType((int32_t)fej9->constJNICallOutFrameType());
    TR_ASSERT((frameType.getValue() & ~0xFFFF) == 0, "JNI call-out frame type has more than 16 bits");
-   generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte1(), 8));
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte0(), 0));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte1(), 8));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte0(), 0));
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaPCOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaLiteralsOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, ARMOp_str, callNode, tempMR, gr5Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr5Reg);
 
    // the Java arguments for the native method are all in place already; now
    // pass the vmThread pointer as the hidden first argument to a JNI call
-   generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr0Reg, metaReg);
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr0Reg, metaReg);
 
    // release VM access (go to internalReleaseVMAccess directly)
    TR::ResolvedMethodSymbol *callerSym    = comp()->getJittedMethodSymbol();
@@ -931,13 +931,13 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    TR::SymbolReference      *helperSymRef = symRefTab->findOrCreateReleaseVMAccessSymbolRef(callerSym);
 
    TR::ARMMultipleMoveInstruction *instr;
-   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(ARMOp_stmdb, callNode, gr13Reg, 0x0f, codeGen);
+   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::ARMOp_stmdb, callNode, gr13Reg, 0x0f, codeGen);
    instr->setWriteBack();
 
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   TR::Instruction *gcPoint = generateImmSymInstruction(codeGen, ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
+   TR::Instruction *gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
    gcPoint->ARMNeedsGCMap(~(jniLinkageProperties.getPreservedRegisterMapForGC()));
-   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(ARMOp_ldmia, callNode, gr13Reg, 0x0f, codeGen);
+   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::ARMOp_ldmia, callNode, gr13Reg, 0x0f, codeGen);
    instr->setWriteBack();
 
    // split dependencies to prevent register assigner from inserting code. Any generated
@@ -948,7 +948,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    // get the target method address and dispatch JNI method directly
    uintptr_t methodAddress = (uintptr_t)resolvedMethod->startAddressForJNIMethod(comp());
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, ARMOp_bl, callNode, methodAddress, deps, callSymRef);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, methodAddress, deps, callSymRef);
    codeGen->getJNICallSites().push_front(new (trHeapMemory()) TR_Pair<TR_ResolvedMethod, TR::Instruction>(calleeSym->getResolvedMethod(), gcPoint));
    gcPoint->ARMNeedsGCMap(jniLinkageProperties.getPreservedRegisterMapForGC());
 
@@ -960,7 +960,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       {
       case TR::Int8:
         if (resolvedMethod->returnTypeIsUnsigned())
-           generateTrg1Src1ImmInstruction(codeGen, ARMOp_and, callNode, returnRegister, returnRegister, 0xFF, 0);
+           generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_and, callNode, returnRegister, returnRegister, 0xFF, 0);
         else
            {
            generateShiftLeftImmediate(codeGen, callNode, returnRegister, returnRegister, 24);
@@ -970,8 +970,8 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       case TR::Int16:
          if (resolvedMethod->returnTypeIsUnsigned())
             {
-            generateTrg1ImmInstruction(codeGen, ARMOp_mvn, callNode, gr4Reg, 0xFF, 0);
-            generateTrg1Src2Instruction(codeGen, ARMOp_and, callNode, returnRegister, returnRegister,
+            generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mvn, callNode, gr4Reg, 0xFF, 0);
+            generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_and, callNode, returnRegister, returnRegister,
                                         new (trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, gr4Reg, 16));
             }
          else
@@ -993,8 +993,8 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
             TR::RealRegister *fpReg   = machine->getRealRegister(jniLinkageProperties.getFloatReturnRegister());
             fpReg->setAssignedRegister(fpReg);
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
-            generateMemSrc1Instruction(codeGen, ARMOp_fsts, callNode, tempMR, fpReg);
-            generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, returnRegister, tempMR);
+            generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fsts, callNode, tempMR, fpReg);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, returnRegister, tempMR);
             break;
             }
          case TR::Double:
@@ -1003,11 +1003,11 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
             fdReg->setAssignedRegister(fdReg);
             TR_ASSERT(fej9->thisThreadGetFloatTemp2Offset() - fej9->thisThreadGetFloatTemp1Offset() == 4,"floatTemp1 and floatTemp2 not contiguous");
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
-            generateMemSrc1Instruction(codeGen, ARMOp_fstd, callNode, tempMR, fdReg);
+            generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fstd, callNode, tempMR, fdReg);
             bool bigEndian = codeGen->comp()->target().cpu.isBigEndian();
-            generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, bigEndian ? returnRegister->getHighOrder() : returnRegister->getLowOrder(), tempMR);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, bigEndian ? returnRegister->getHighOrder() : returnRegister->getLowOrder(), tempMR);
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp2Offset(), codeGen);
-            generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, bigEndian ? returnRegister->getLowOrder() : returnRegister->getHighOrder(), tempMR);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, bigEndian ? returnRegister->getLowOrder() : returnRegister->getHighOrder(), tempMR);
             break;
             }
          }
@@ -1020,20 +1020,20 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       uint32_t base, rotate;
       if (constantIsImmed8r(spSize, &base, &rotate))
          {
-         generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, callNode, sp, sp, base, rotate);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, sp, sp, base, rotate);
          }
       else
          {
          TR::Register *tmpReg = codeGen->allocateRegister();
          armLoadConstant(callNode, spSize, gr4Reg, codeGen);
-         generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, sp, sp, gr4Reg);
+         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, sp, sp, gr4Reg);
          }
       }
 
    // re-acquire VM access
    helperSymRef = symRefTab->findOrCreateAcquireVMAccessSymbolRef(callerSym);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
    gcPoint->ARMNeedsGCMap(1 << (jniLinkageProperties.getIntegerReturnRegister() - TR::RealRegister::FirstGPR));
 
    // JNI methods return objects with an extra level of indirection (unless
@@ -1043,49 +1043,49 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    if (resolvedMethod->returnType() == TR::Address)
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(returnRegister, 0, codeGen);
-      generateSrc1ImmInstruction(codeGen, ARMOp_cmp, callNode, returnRegister, 0, 0);
-      gcPoint = generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, returnRegister, tempMR);
+      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_cmp, callNode, returnRegister, 0, 0);
+      gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, returnRegister, tempMR);
       gcPoint->setConditionCode(ARMConditionCodeNE);
       }
 
    // restore stack pointer and deal with possibly grown stack
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaLiteralsOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr4Reg, tempMR);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaSPOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, stackPtr, tempMR);
-   generateTrg1Src2Instruction(codeGen, ARMOp_add, callNode, stackPtr, stackPtr, gr4Reg);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, stackPtr, tempMR);
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, stackPtr, stackPtr, gr4Reg);
 
    // see if the reference pool was used and, if used, clean it up; otherwise we can
    // leave a bunch of pinned garbage behind that screws up the GC quality forever
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, fej9->constJNICallOutFrameFlagsOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr4Reg, tempMR);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
 
    uint32_t flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
    uint32_t base, rotate;
    if (constantIsImmed8r(flagValue, &base, &rotate))
       {
-      generateSrc1ImmInstruction(codeGen, ARMOp_tst, callNode, gr4Reg, base, rotate);
+      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_tst, callNode, gr4Reg, base, rotate);
       }
    else
       {
       armLoadConstant(callNode, flagValue, gr5Reg, codeGen);
-      generateSrc2Instruction(codeGen, ARMOp_tst, callNode, gr4Reg, gr5Reg);
+      generateSrc2Instruction(codeGen, TR::InstOpCode::ARMOp_tst, callNode, gr4Reg, gr5Reg);
       }
 
    helperSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_ARMjitCollapseJNIReferenceFrame);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   generateImmSymInstruction(codeGen, ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeEQ);
+   generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeEQ);
 
    // restore the JIT frame
-   generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, callNode, stackPtr, stackPtr, 20, 0);
+   generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, stackPtr, stackPtr, 20, 0);
 
    // check exceptions
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetCurrentExceptionOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr4Reg, tempMR);
-   generateSrc1ImmInstruction(codeGen, ARMOp_cmp, callNode, gr4Reg, 0, 0);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
+   generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_cmp, callNode, gr4Reg, 0, 0);
    helperSymRef = symRefTab->findOrCreateThrowCurrentExceptionSymbolRef(callerSym);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeNE);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeNE);
    gcPoint->ARMNeedsGCMap(1 << (jniLinkageProperties.getIntegerReturnRegister() - TR::RealRegister::FirstGPR));
 
    TR::LabelSymbol *doneLabel = generateLabelSymbol(codeGen);

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -860,7 +860,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       {
       spillDeps->addPostCondition(codeGen->allocateRegister(TR_FPR), (TR::RealRegister::RegNum)((uint32_t)TR::RealRegister::fs0 + i));
       }
-   generateLabelInstruction(codeGen, ARMOp_label, callNode, spillLabel, spillDeps);
+   generateLabelInstruction(codeGen, TR::InstOpCode::label, callNode, spillLabel, spillDeps);
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    // mask out the magic bit that indicates JIT frames below
@@ -952,7 +952,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    codeGen->getJNICallSites().push_front(new (trHeapMemory()) TR_Pair<TR_ResolvedMethod, TR::Instruction>(calleeSym->getResolvedMethod(), gcPoint));
    gcPoint->ARMNeedsGCMap(jniLinkageProperties.getPreservedRegisterMapForGC());
 
-   generateLabelInstruction(codeGen, ARMOp_label, callNode, returnAddrLabel);
+   generateLabelInstruction(codeGen, TR::InstOpCode::label, callNode, returnAddrLabel);
 
    // JNI methods may not return a full register in some cases so we need to
    // sign- or zero-extend the narrower integer return types properly.
@@ -1089,7 +1089,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    gcPoint->ARMNeedsGCMap(1 << (jniLinkageProperties.getIntegerReturnRegister() - TR::RealRegister::FirstGPR));
 
    TR::LabelSymbol *doneLabel = generateLabelSymbol(codeGen);
-   generateLabelInstruction(codeGen, ARMOp_label, callNode, doneLabel, postDeps);
+   generateLabelInstruction(codeGen, TR::InstOpCode::label, callNode, doneLabel, postDeps);
 
    return callNode->setRegister(returnRegister);
    }

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -130,7 +130,7 @@ TR::Register *J9::ARM::JNILinkage::pushFloatArgForJNI(TR::Node *child)
    if (pushRegister->getKind() == TR_GPR)
       {
       TR::Register *trgReg = cg()->allocateSinglePrecisionRegister();
-      generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_fmsr, child, trgReg, pushRegister);
+      generateTrg1Src1Instruction(cg(), TR::InstOpCode::fmsr, child, trgReg, pushRegister);
       return trgReg;
       }
 
@@ -148,7 +148,7 @@ TR::Register *J9::ARM::JNILinkage::pushDoubleArgForJNI(TR::Node *child)
       {
       TR::Register *trgReg = cg()->allocateRegister(TR_FPR);
       TR::RegisterPair *pair = pushRegister->getRegisterPair();
-      generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_fmdrr, child, trgReg, pair->getLowOrder(), pair->getHighOrder());
+      generateTrg1Src2Instruction(cg(), TR::InstOpCode::fmdrr, child, trgReg, pair->getLowOrder(), pair->getHighOrder());
       return trgReg;
       }
    return pushRegister;
@@ -369,13 +369,13 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
       uint32_t base, rotate;
       if (constantIsImmed8r(numStackParmSlots, &base, &rotate))
          {
-         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub, callNode, sp, sp, base, rotate);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::sub, callNode, sp, sp, base, rotate);
          }
       else
          {
          TR::Register *tmpReg = codeGen->allocateRegister();
          armLoadConstant(callNode, numStackParmSlots, tmpReg, codeGen);
-         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_sub, callNode, sp, sp, tmpReg);
+         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::sub, callNode, sp, sp, tmpReg);
          codeGen->stopUsingRegister(tmpReg);
          }
       }
@@ -419,7 +419,7 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
                      tempReg = codeGen->allocateCollectedReferenceRegister();
                   else
                      tempReg = codeGen->allocateRegister();
-                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, child, tempReg, reg);
                   reg = tempReg;
                   }
                if (numIntegerArgRegIndex == 0 &&
@@ -449,7 +449,7 @@ printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing 32-bit arg %d %d\n", numIntegerArgRegIndex, memArg); fflush(stdout);
 #endif
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::str, pushToMemory[memArg++]);
                stackOffset += 4;
                }
             numIntegerArgRegIndex++;
@@ -478,12 +478,12 @@ printf("skipping one argument slot\n"); fflush(stdout);
 
                   if (bigEndian)
                      {
-                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
+                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
                      reg = codeGen->allocateRegisterPair(reg->getRegisterPair()->getLowOrder(), tempReg);
                      }
                   else
                      {
-                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
+                     generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
                      reg = codeGen->allocateRegisterPair(tempReg, reg->getRegisterPair()->getHighOrder());
                      }
                   }
@@ -501,12 +501,12 @@ printf("skipping one argument slot\n"); fflush(stdout);
                      tempReg = codeGen->allocateRegister();
                      if (bigEndian)
                         {
-                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
+                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, child, tempReg, reg->getRegisterPair()->getLowOrder());
                         reg->getRegisterPair()->setLowOrder(tempReg, codeGen);
                         }
                      else
                         {
-                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
+                        generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, child, tempReg, reg->getRegisterPair()->getHighOrder());
                         reg->getRegisterPair()->setHighOrder(tempReg, codeGen);
                         }
                      }
@@ -518,7 +518,7 @@ printf("skipping one argument slot\n"); fflush(stdout);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing %s word of 64-bit arg %d %d\n", bigEndian ? "low" : "high", numIntegerArgRegIndex, memArg); fflush(stdout);
 #endif
-                  tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
+                  tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::str, pushToMemory[memArg++]);
                   stackOffset += 4;
                   }
                }
@@ -529,8 +529,8 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
 #endif
                if (isEABI)
                   stackOffset = (stackOffset + 4) & (~7);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getHighOrder() : reg->getRegisterPair()->getLowOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset + 4, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::ARMOp_str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, bigEndian ? reg->getRegisterPair()->getHighOrder() : reg->getRegisterPair()->getLowOrder(), TR::InstOpCode::str, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset + 4, bigEndian ? reg->getRegisterPair()->getLowOrder() : reg->getRegisterPair()->getHighOrder(), TR::InstOpCode::str, pushToMemory[memArg++]);
                stackOffset += 8;
                }
             numIntegerArgRegIndex += 2;
@@ -543,7 +543,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                if (!cg()->canClobberNodesRegister(child, 0))
                   {
                   tempReg = codeGen->allocateSinglePrecisionRegister();
-                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fcpys, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::fcpys, child, tempReg, reg);
                   reg = tempReg;
                   }
                if ((numFloatArgRegIndex == 0) && resType.isFloatingPoint())
@@ -579,7 +579,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                }
             else
                {
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_fsts, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::fsts, pushToMemory[memArg++]);
                stackOffset += 4;
 
                numFloatArgRegIndex++;
@@ -596,7 +596,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                if (!cg()->canClobberNodesRegister(child, 0))
                   {
                   tempReg = cg()->allocateRegister(TR_FPR);
-                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fcpyd, child, tempReg, reg);
+                  generateTrg1Src1Instruction(codeGen, TR::InstOpCode::fcpyd, child, tempReg, reg);
                   reg = tempReg;
                   }
                if ((numFloatArgRegIndex == 0) && resType.isFloatingPoint())
@@ -617,7 +617,7 @@ printf("pushing 64-bit JNI arg %d %d %d\n", numIntegerArgs, memArg, totalSize); 
                {
                if (isEABI)
                    stackOffset = (stackOffset + 4) & (~7);
-               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::ARMOp_fstd, pushToMemory[memArg++]);
+               tempMR = getOutgoingArgumentMemRef(0, stackOffset, reg, TR::InstOpCode::fstd, pushToMemory[memArg++]);
                stackOffset += 8;
                }
             numFloatArgRegIndex++;
@@ -864,9 +864,9 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    // mask out the magic bit that indicates JIT frames below
-   generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr5Reg, 0, 0);
+   generateTrg1ImmInstruction(codeGen, TR::InstOpCode::mov, callNode, gr5Reg, 0, 0);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaFrameFlagsOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr5Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr5Reg);
 
    // push tag bits (savedA0 slot)
    // if the current method is simply a wrapper for the JNI call, hide the call-out stack frame
@@ -878,52 +878,52 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    armLoadConstant(callNode, tagBits, gr4Reg, codeGen);
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)sizeof(uintptr_t)), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr4Reg);
 
    // skip unused savedPC slot and push return address (savedCP slot)
    //
    TR::LabelSymbol *returnAddrLabel               = generateLabelSymbol(codeGen);
-   generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, returnAddrLabel, NULL, gr4Reg, instrPtr);
+   generateLabelInstruction(codeGen, TR::InstOpCode::add, callNode, returnAddrLabel, NULL, gr4Reg, instrPtr);
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -2 * ((int)sizeof(uintptr_t)), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr4Reg);
 
    // push frame flags
    intParts flags((int32_t)fej9->constJNICallOutFrameFlags());
    TR_ASSERT((flags.getValue() & ~0x7FFF0000) == 0, "JNI call-out frame flags have more than 15 bits");
-   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte3(), 24));
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte2(), 16));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte3(), 24));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(flags.getByte2(), 16));
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)TR::Compiler->om.sizeofReferenceAddress()), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr4Reg);
 
    // push the RAM method for the native
    intParts ramMethod((int32_t)resolvedMethod->resolvedMethodAddress());
-   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte3(), 24));
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte2(), 16));
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte1(), 8));
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte0(), 0));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte3(), 24));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte2(), 16));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte1(), 8));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(ramMethod.getByte0(), 0));
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -((int)TR::Compiler->om.sizeofReferenceAddress()), codeGen);
    tempMR->setImmediatePreIndexed();
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr4Reg);
 
    // store the Java SP
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaSPOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, stackPtr);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, stackPtr);
 
    // store the PC and literals values indicating the call-out frame
    intParts frameType((int32_t)fej9->constJNICallOutFrameType());
    TR_ASSERT((frameType.getValue() & ~0xFFFF) == 0, "JNI call-out frame type has more than 16 bits");
-   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte1(), 8));
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte0(), 0));
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte1(), 8));
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, gr4Reg, gr4Reg, new (trHeapMemory()) TR_ARMOperand2(frameType.getByte0(), 0));
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaPCOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr4Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr4Reg);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaLiteralsOffset(), codeGen);
-   generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, callNode, tempMR, gr5Reg);
+   generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, callNode, tempMR, gr5Reg);
 
    // the Java arguments for the native method are all in place already; now
    // pass the vmThread pointer as the hidden first argument to a JNI call
-   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr0Reg, metaReg);
+   generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr0Reg, metaReg);
 
    // release VM access (go to internalReleaseVMAccess directly)
    TR::ResolvedMethodSymbol *callerSym    = comp()->getJittedMethodSymbol();
@@ -931,13 +931,13 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    TR::SymbolReference      *helperSymRef = symRefTab->findOrCreateReleaseVMAccessSymbolRef(callerSym);
 
    TR::ARMMultipleMoveInstruction *instr;
-   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::ARMOp_stmdb, callNode, gr13Reg, 0x0f, codeGen);
+   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::stmdb, callNode, gr13Reg, 0x0f, codeGen);
    instr->setWriteBack();
 
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   TR::Instruction *gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
+   TR::Instruction *gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
    gcPoint->ARMNeedsGCMap(~(jniLinkageProperties.getPreservedRegisterMapForGC()));
-   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::ARMOp_ldmia, callNode, gr13Reg, 0x0f, codeGen);
+   instr = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(TR::InstOpCode::ldmia, callNode, gr13Reg, 0x0f, codeGen);
    instr->setWriteBack();
 
    // split dependencies to prevent register assigner from inserting code. Any generated
@@ -948,7 +948,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    // get the target method address and dispatch JNI method directly
    uintptr_t methodAddress = (uintptr_t)resolvedMethod->startAddressForJNIMethod(comp());
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, methodAddress, deps, callSymRef);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::bl, callNode, methodAddress, deps, callSymRef);
    codeGen->getJNICallSites().push_front(new (trHeapMemory()) TR_Pair<TR_ResolvedMethod, TR::Instruction>(calleeSym->getResolvedMethod(), gcPoint));
    gcPoint->ARMNeedsGCMap(jniLinkageProperties.getPreservedRegisterMapForGC());
 
@@ -960,7 +960,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       {
       case TR::Int8:
         if (resolvedMethod->returnTypeIsUnsigned())
-           generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_and, callNode, returnRegister, returnRegister, 0xFF, 0);
+           generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::and_, callNode, returnRegister, returnRegister, 0xFF, 0);
         else
            {
            generateShiftLeftImmediate(codeGen, callNode, returnRegister, returnRegister, 24);
@@ -970,8 +970,8 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       case TR::Int16:
          if (resolvedMethod->returnTypeIsUnsigned())
             {
-            generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mvn, callNode, gr4Reg, 0xFF, 0);
-            generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_and, callNode, returnRegister, returnRegister,
+            generateTrg1ImmInstruction(codeGen, TR::InstOpCode::mvn, callNode, gr4Reg, 0xFF, 0);
+            generateTrg1Src2Instruction(codeGen, TR::InstOpCode::and_, callNode, returnRegister, returnRegister,
                                         new (trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, gr4Reg, 16));
             }
          else
@@ -993,8 +993,8 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
             TR::RealRegister *fpReg   = machine->getRealRegister(jniLinkageProperties.getFloatReturnRegister());
             fpReg->setAssignedRegister(fpReg);
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
-            generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fsts, callNode, tempMR, fpReg);
-            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, returnRegister, tempMR);
+            generateMemSrc1Instruction(codeGen, TR::InstOpCode::fsts, callNode, tempMR, fpReg);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, returnRegister, tempMR);
             break;
             }
          case TR::Double:
@@ -1003,11 +1003,11 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
             fdReg->setAssignedRegister(fdReg);
             TR_ASSERT(fej9->thisThreadGetFloatTemp2Offset() - fej9->thisThreadGetFloatTemp1Offset() == 4,"floatTemp1 and floatTemp2 not contiguous");
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
-            generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fstd, callNode, tempMR, fdReg);
+            generateMemSrc1Instruction(codeGen, TR::InstOpCode::fstd, callNode, tempMR, fdReg);
             bool bigEndian = codeGen->comp()->target().cpu.isBigEndian();
-            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, bigEndian ? returnRegister->getHighOrder() : returnRegister->getLowOrder(), tempMR);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, bigEndian ? returnRegister->getHighOrder() : returnRegister->getLowOrder(), tempMR);
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp2Offset(), codeGen);
-            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, bigEndian ? returnRegister->getLowOrder() : returnRegister->getHighOrder(), tempMR);
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, bigEndian ? returnRegister->getLowOrder() : returnRegister->getHighOrder(), tempMR);
             break;
             }
          }
@@ -1020,20 +1020,20 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       uint32_t base, rotate;
       if (constantIsImmed8r(spSize, &base, &rotate))
          {
-         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, sp, sp, base, rotate);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, callNode, sp, sp, base, rotate);
          }
       else
          {
          TR::Register *tmpReg = codeGen->allocateRegister();
          armLoadConstant(callNode, spSize, gr4Reg, codeGen);
-         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, sp, sp, gr4Reg);
+         generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, sp, sp, gr4Reg);
          }
       }
 
    // re-acquire VM access
    helperSymRef = symRefTab->findOrCreateAcquireVMAccessSymbolRef(callerSym);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef);
    gcPoint->ARMNeedsGCMap(1 << (jniLinkageProperties.getIntegerReturnRegister() - TR::RealRegister::FirstGPR));
 
    // JNI methods return objects with an extra level of indirection (unless
@@ -1043,49 +1043,49 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    if (resolvedMethod->returnType() == TR::Address)
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(returnRegister, 0, codeGen);
-      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_cmp, callNode, returnRegister, 0, 0);
-      gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, returnRegister, tempMR);
+      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::cmp, callNode, returnRegister, 0, 0);
+      gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, returnRegister, tempMR);
       gcPoint->setConditionCode(ARMConditionCodeNE);
       }
 
    // restore stack pointer and deal with possibly grown stack
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaLiteralsOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr4Reg, tempMR);
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetJavaSPOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, stackPtr, tempMR);
-   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, stackPtr, stackPtr, gr4Reg);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, stackPtr, tempMR);
+   generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, callNode, stackPtr, stackPtr, gr4Reg);
 
    // see if the reference pool was used and, if used, clean it up; otherwise we can
    // leave a bunch of pinned garbage behind that screws up the GC quality forever
    tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, fej9->constJNICallOutFrameFlagsOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr4Reg, tempMR);
 
    uint32_t flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
    uint32_t base, rotate;
    if (constantIsImmed8r(flagValue, &base, &rotate))
       {
-      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_tst, callNode, gr4Reg, base, rotate);
+      generateSrc1ImmInstruction(codeGen, TR::InstOpCode::tst, callNode, gr4Reg, base, rotate);
       }
    else
       {
       armLoadConstant(callNode, flagValue, gr5Reg, codeGen);
-      generateSrc2Instruction(codeGen, TR::InstOpCode::ARMOp_tst, callNode, gr4Reg, gr5Reg);
+      generateSrc2Instruction(codeGen, TR::InstOpCode::tst, callNode, gr4Reg, gr5Reg);
       }
 
    helperSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_ARMjitCollapseJNIReferenceFrame);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeEQ);
+   generateImmSymInstruction(codeGen, TR::InstOpCode::bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeEQ);
 
    // restore the JIT frame
-   generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, stackPtr, stackPtr, 20, 0);
+   generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, callNode, stackPtr, stackPtr, 20, 0);
 
    // check exceptions
    tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetCurrentExceptionOffset(), codeGen);
-   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr4Reg, tempMR);
-   generateSrc1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_cmp, callNode, gr4Reg, 0, 0);
+   generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr4Reg, tempMR);
+   generateSrc1ImmInstruction(codeGen, TR::InstOpCode::cmp, callNode, gr4Reg, 0, 0);
    helperSymRef = symRefTab->findOrCreateThrowCurrentExceptionSymbolRef(callerSym);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
-   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeNE);
+   gcPoint = generateImmSymInstruction(codeGen, TR::InstOpCode::bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeNE);
    gcPoint->ARMNeedsGCMap(1 << (jniLinkageProperties.getIntegerReturnRegister() - TR::RealRegister::FirstGPR));
 
    TR::LabelSymbol *doneLabel = generateLabelSymbol(codeGen);

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -494,24 +494,24 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
        machine->getLinkRegisterKilled())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -4, codeGen);
-      cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr14, cursor);
+      cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, tempMR, gr14, cursor);
       }
 
    if (constantIsImmed8r(totalFrameSize, &base, &rotate))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub, firstNode, stackPtr, stackPtr, base, rotate, cursor);
+      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::sub, firstNode, stackPtr, stackPtr, base, rotate, cursor);
       }
    else
       {
       cursor = armLoadConstant(firstNode, totalFrameSize, gr11, codeGen, cursor);
-      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_sub, firstNode, stackPtr, stackPtr, gr11, cursor);
+      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::sub, firstNode, stackPtr, stackPtr, gr11, cursor);
       }
 
    if (!comp()->isDLT())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(metaBase, codeGen->getStackLimitOffset(), codeGen);
-      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, firstNode, gr4, tempMR, cursor);
-      cursor = generateSrc2Instruction(codeGen, TR::InstOpCode::ARMOp_cmp, firstNode, stackPtr, gr4, cursor);
+      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, firstNode, gr4, tempMR, cursor);
+      cursor = generateSrc2Instruction(codeGen, TR::InstOpCode::cmp, firstNode, stackPtr, gr4, cursor);
 
       TR::LabelSymbol *snippetLabel = generateLabelSymbol(codeGen);
       TR::LabelSymbol *restartLabel = generateLabelSymbol(codeGen);
@@ -533,14 +533,14 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          {
          TR::Register *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
-         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, tempMR, reg, cursor);
          }
       else
          {
          constantIsImmed8r(outgoingArgSize, &base, &rotate);
-         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
+         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, firstNode, gr4, stackPtr, base, rotate, cursor);
          // FIXME Need generateMultiMoveInstruction().
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_stm, firstNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::stm, firstNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
          }
       }
 
@@ -558,25 +558,25 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          else
             {
             cursor = armLoadConstant(firstNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, firstNode, gr4, stackPtr, gr4, cursor);
             tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, 0, codeGen);
             }
-         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fstd, firstNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::fstd, firstNode, tempMR, reg, cursor);
          }
       else
          {
          if (constantIsImmed8r(outgoingArgSize, &base, &rotate))
             {
-            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
+            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, firstNode, gr4, stackPtr, base, rotate, cursor);
             }
          else
             {
             cursor = armLoadConstant(firstNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, firstNode, gr4, stackPtr, gr4, cursor);
             }
          // FIXME Need generateMultiMoveInstruction().
          uint16_t offset = ((TR::RealRegister::fp8 - TR::RealRegister::FirstFPR) << 12) | (fpRegistersSaved << 1);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_fstmd, firstNode, gr4, offset, codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::fstmd, firstNode, gr4, offset, codeGen);
          ((TR::ARMMultipleMoveInstruction *)cursor)->setIncrement();
          }
       }
@@ -606,12 +606,12 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                {
                TR::LabelSymbol *loopLabel = generateLabelSymbol(codeGen);
                cursor = armLoadConstant(firstNode, offset, gr4, codeGen, cursor);
-               cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, gr4, stackPtr, cursor);
+               cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, firstNode, gr4, gr4, stackPtr, cursor);
                cursor = armLoadConstant(firstNode, (numLocalsToBeInitialized - 1) << 2, gr5, codeGen, cursor);
                cursor = generateLabelInstruction(codeGen, TR::InstOpCode::label, firstNode, loopLabel, cursor);
                tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, gr5, codeGen);
-               cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
-               cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub_r, firstNode, gr5, gr5, 4, 0, cursor);
+               cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, tempMR, gr11, cursor);
+               cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::sub_r, firstNode, gr5, gr5, 4, 0, cursor);
                cursor = generateConditionalBranchInstruction(codeGen, firstNode, ARMConditionCodeGE, loopLabel, cursor);
                }
             else
@@ -619,7 +619,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                for (uint32_t i = 0; i < numLocalsToBeInitialized; i++, offset += 4)
                   {
                   tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen);
-                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
+                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, tempMR, gr11, cursor);
                   }
                }
             }
@@ -684,7 +684,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          for (i = 0; i < numSlotsToBeInitialized; i++, offset += TR::Compiler->om.sizeofReferenceAddress())
             {
             tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen);
-            cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
+            cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, tempMR, gr11, cursor);
             }
          }
 
@@ -761,14 +761,14 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
          {
          TR::RealRegister *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
-         cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, lastNode, reg, tempMR, cursor);
+         cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, lastNode, reg, tempMR, cursor);
          }
       else
          {
          TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
          constantIsImmed8r(outgoingArgSize, &base, &rotate);
-         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_ldm, lastNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
+         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, lastNode, gr4, stackPtr, base, rotate, cursor);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ldm, lastNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
          }
       }
 
@@ -786,25 +786,25 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
          else
             {
             cursor = armLoadConstant(lastNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, lastNode, gr4, stackPtr, gr4, cursor);
             tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, 0, codeGen);
             }
-         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fldd, lastNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::fldd, lastNode, tempMR, reg, cursor);
          }
       else
          {
          if (constantIsImmed8r(outgoingArgSize, &base, &rotate))
             {
-            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
+            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, lastNode, gr4, stackPtr, base, rotate, cursor);
             }
          else
             {
             cursor = armLoadConstant(lastNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, lastNode, gr4, stackPtr, gr4, cursor);
             }
          // FIXME Need generateMultiMoveInstruction().
          uint16_t offset = ((TR::RealRegister::fp8 - TR::RealRegister::FirstFPR) << 12) | (fpRegistersSaved << 1);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_fldmd, lastNode, gr4, offset, codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::fldmd, lastNode, gr4, offset, codeGen);
          ((TR::ARMMultipleMoveInstruction *)cursor)->setIncrement();
          }
       }
@@ -819,22 +819,22 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
        machine->getLinkRegisterKilled())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, totalFrameSize + properties.getOffsetToFirstLocal(), codeGen);
-      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, lastNode, gr14, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, lastNode, gr14, tempMR, cursor);
       }
 
    // Collapse stack frame and return.
    if (constantIsImmed8r(totalFrameSize, &base, &rotate))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, stackPtr, stackPtr, base, rotate, cursor);
+      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, lastNode, stackPtr, stackPtr, base, rotate, cursor);
       }
    else
       {
       TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
       cursor = armLoadConstant(lastNode, totalFrameSize, gr4, codeGen, cursor);
-      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, stackPtr, stackPtr, gr4, cursor);
+      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::add, lastNode, stackPtr, stackPtr, gr4, cursor);
       }
 
-   cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, lastNode, gr15, gr14, cursor);
+   cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, lastNode, gr15, gr14, cursor);
    }
 
 TR::MemoryReference *J9::ARM::PrivateLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
@@ -932,13 +932,13 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          targetAddress = targetAddress->getLowOrder();
          }
       doneLabel = generateLabelSymbol(codeGen);
-      generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4, targetAddress);
+      generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr4, targetAddress);
 
-      TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
+      TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr14, gr15);
       instr->setDependencyConditions(dependencies);
       dependencies->incRegisterTotalUseCounts(codeGen);
 
-      gcPoint = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr15, gr4);
+      gcPoint = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr15, gr4);
 
       gcPoint->ARMNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
 
@@ -959,7 +959,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          if (TR::Compiler->cls.classesOnHeap())
             {
             classReg = gr11;
-            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr11, new (trHeapMemory()) TR::MemoryReference(gr0, fej9->getOffsetOfClassFromJavaLangClassField(), codeGen));
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr11, new (trHeapMemory()) TR::MemoryReference(gr0, fej9->getOffsetOfClassFromJavaLangClassField(), codeGen));
             }
          else
             classReg = gr0;
@@ -985,39 +985,39 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          // method pointer and move return address to link register.
          // The 4 instruction before branch should be a no-op if the offset turns
          // out to be within range (for most cases).
-         generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr11, 0, 0);
-         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 8);
-         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 16);
-         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 24);
+         generateTrg1ImmInstruction(codeGen, TR::InstOpCode::mov, callNode, gr11, 0, 0);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, callNode, gr11, gr11, 0, 8);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, callNode, gr11, gr11, 0, 16);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::add, callNode, gr11, gr11, 0, 24);
 
-         generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_b, callNode, snippetLabel, dependencies);
+         generateLabelInstruction(codeGen, TR::InstOpCode::b, callNode, snippetLabel, dependencies);
 
          tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, 0, codeGen);
-         gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
+         gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr15, tempMR);
          }
       else
          {
          int32_t offset = methodSymRef->getOffset();
          if (constantIsImmed12(offset))
             {
-            TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
+            TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr14, gr15);
             instr->setDependencyConditions(dependencies);
             dependencies->incRegisterTotalUseCounts(codeGen);
 
             tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, offset, codeGen);
-            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
+            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr15, tempMR);
             gcPoint->setDependencyConditions(postDeps);
             postDeps->incRegisterTotalUseCounts(codeGen);
             }
          else
             {
             TR::Instruction *instr = armLoadConstant(callNode, offset, gr11, codeGen);
-            instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
+            instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::mov, callNode, gr14, gr15);
             instr->setDependencyConditions(dependencies);
             dependencies->incRegisterTotalUseCounts(codeGen);
 
             tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, gr11, 0, codeGen);
-            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
+            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, callNode, gr15, tempMR);
             gcPoint->setDependencyConditions(postDeps);
             postDeps->incRegisterTotalUseCounts(codeGen);
             }
@@ -1036,7 +1036,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
                                                          doneLabel,
                                                          thunk));
 
-      gcPoint = generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_b, callNode, snippetLabel, dependencies);
+      gcPoint = generateLabelInstruction(codeGen, TR::InstOpCode::b, callNode, snippetLabel, dependencies);
       }
 
    gcPoint->ARMNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
@@ -1118,7 +1118,7 @@ TR::Register *J9::ARM::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          if (resType.isFloatingPoint())
             {
             TR::Register *tempReg = codeGen->allocateSinglePrecisionRegister();
-            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fmsr, callNode, tempReg, returnRegister);
+            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::fmsr, callNode, tempReg, returnRegister);
             returnRegister = tempReg;
             }
          break;
@@ -1133,7 +1133,7 @@ TR::Register *J9::ARM::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          if (resType.isDouble())
             {
             TR::Register *tempReg = codeGen->allocateRegister(TR_FPR);
-            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_fmdrr, callNode, tempReg, lowReg, highReg);
+            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::fmdrr, callNode, tempReg, lowReg, highReg);
             returnRegister = tempReg;
             }
 

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -522,7 +522,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
       snippet->resetNeedsExceptionTableEntry();
       codeGen->addSnippet(snippet);
 
-      cursor = generateLabelInstruction(codeGen, ARMOp_label, firstNode, restartLabel, cursor);
+      cursor = generateLabelInstruction(codeGen, TR::InstOpCode::label, firstNode, restartLabel, cursor);
       }
 
    // Save preserved registers.
@@ -608,7 +608,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                cursor = armLoadConstant(firstNode, offset, gr4, codeGen, cursor);
                cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, firstNode, gr4, gr4, stackPtr, cursor);
                cursor = armLoadConstant(firstNode, (numLocalsToBeInitialized - 1) << 2, gr5, codeGen, cursor);
-               cursor = generateLabelInstruction(codeGen, ARMOp_label, firstNode, loopLabel, cursor);
+               cursor = generateLabelInstruction(codeGen, TR::InstOpCode::label, firstNode, loopLabel, cursor);
                tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, gr5, codeGen);
                cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, gr11, cursor);
                cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_sub_r, firstNode, gr5, gr5, 4, 0, cursor);
@@ -942,7 +942,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
 
       gcPoint->ARMNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
 
-      generateLabelInstruction(codeGen, ARMOp_label, callNode, doneLabel, postDeps);
+      generateLabelInstruction(codeGen, TR::InstOpCode::label, callNode, doneLabel, postDeps);
 
       return;
       }
@@ -1045,7 +1045,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
    // pre-conditions must be anchored on the branch out, and the post-
    // conditions must be anchored on the return label.
    if (doneLabel)
-      generateLabelInstruction(codeGen, ARMOp_label, callNode, doneLabel, postDeps);
+      generateLabelInstruction(codeGen, TR::InstOpCode::label, callNode, doneLabel, postDeps);
 
    return;
    }

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -469,7 +469,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
    if (comp()->getOption(TR_EntryBreakPoints))
       {
-      cursor = new (trHeapMemory()) TR::Instruction(cursor, ARMOp_bad, firstNode, codeGen);
+      cursor = new (trHeapMemory()) TR::Instruction(cursor, TR::InstOpCode::bad, firstNode, codeGen);
       }
 
    // TODO Only save arguments if full-speed debugging is enabled; otherwise, they

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -494,24 +494,24 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
        machine->getLinkRegisterKilled())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, -4, codeGen);
-      cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, gr14, cursor);
+      cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr14, cursor);
       }
 
    if (constantIsImmed8r(totalFrameSize, &base, &rotate))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_sub, firstNode, stackPtr, stackPtr, base, rotate, cursor);
+      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub, firstNode, stackPtr, stackPtr, base, rotate, cursor);
       }
    else
       {
       cursor = armLoadConstant(firstNode, totalFrameSize, gr11, codeGen, cursor);
-      cursor = generateTrg1Src2Instruction(codeGen, ARMOp_sub, firstNode, stackPtr, stackPtr, gr11, cursor);
+      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_sub, firstNode, stackPtr, stackPtr, gr11, cursor);
       }
 
    if (!comp()->isDLT())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(metaBase, codeGen->getStackLimitOffset(), codeGen);
-      cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, gr4, tempMR, cursor);
-      cursor = generateSrc2Instruction(codeGen, ARMOp_cmp, firstNode, stackPtr, gr4, cursor);
+      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, firstNode, gr4, tempMR, cursor);
+      cursor = generateSrc2Instruction(codeGen, TR::InstOpCode::ARMOp_cmp, firstNode, stackPtr, gr4, cursor);
 
       TR::LabelSymbol *snippetLabel = generateLabelSymbol(codeGen);
       TR::LabelSymbol *restartLabel = generateLabelSymbol(codeGen);
@@ -533,14 +533,14 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          {
          TR::Register *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
-         cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, reg, cursor);
          }
       else
          {
          constantIsImmed8r(outgoingArgSize, &base, &rotate);
-         cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
+         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
          // FIXME Need generateMultiMoveInstruction().
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, ARMOp_stm, firstNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_stm, firstNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
          }
       }
 
@@ -558,25 +558,25 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          else
             {
             cursor = armLoadConstant(firstNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
             tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, 0, codeGen);
             }
-         cursor = generateMemSrc1Instruction(codeGen, ARMOp_fstd, firstNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fstd, firstNode, tempMR, reg, cursor);
          }
       else
          {
          if (constantIsImmed8r(outgoingArgSize, &base, &rotate))
             {
-            cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
+            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, base, rotate, cursor);
             }
          else
             {
             cursor = armLoadConstant(firstNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, stackPtr, gr4, cursor);
             }
          // FIXME Need generateMultiMoveInstruction().
          uint16_t offset = ((TR::RealRegister::fp8 - TR::RealRegister::FirstFPR) << 12) | (fpRegistersSaved << 1);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, ARMOp_fstmd, firstNode, gr4, offset, codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_fstmd, firstNode, gr4, offset, codeGen);
          ((TR::ARMMultipleMoveInstruction *)cursor)->setIncrement();
          }
       }
@@ -606,12 +606,12 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                {
                TR::LabelSymbol *loopLabel = generateLabelSymbol(codeGen);
                cursor = armLoadConstant(firstNode, offset, gr4, codeGen, cursor);
-               cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, firstNode, gr4, gr4, stackPtr, cursor);
+               cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, firstNode, gr4, gr4, stackPtr, cursor);
                cursor = armLoadConstant(firstNode, (numLocalsToBeInitialized - 1) << 2, gr5, codeGen, cursor);
                cursor = generateLabelInstruction(codeGen, TR::InstOpCode::label, firstNode, loopLabel, cursor);
                tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, gr5, codeGen);
-               cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, gr11, cursor);
-               cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_sub_r, firstNode, gr5, gr5, 4, 0, cursor);
+               cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
+               cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_sub_r, firstNode, gr5, gr5, 4, 0, cursor);
                cursor = generateConditionalBranchInstruction(codeGen, firstNode, ARMConditionCodeGE, loopLabel, cursor);
                }
             else
@@ -619,7 +619,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                for (uint32_t i = 0; i < numLocalsToBeInitialized; i++, offset += 4)
                   {
                   tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen);
-                  cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, gr11, cursor);
+                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
                   }
                }
             }
@@ -684,7 +684,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          for (i = 0; i < numSlotsToBeInitialized; i++, offset += TR::Compiler->om.sizeofReferenceAddress())
             {
             tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen);
-            cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, gr11, cursor);
+            cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_str, firstNode, tempMR, gr11, cursor);
             }
          }
 
@@ -761,14 +761,14 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
          {
          TR::RealRegister *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
-         cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, lastNode, reg, tempMR, cursor);
+         cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, lastNode, reg, tempMR, cursor);
          }
       else
          {
          TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
          constantIsImmed8r(outgoingArgSize, &base, &rotate);
-         cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, ARMOp_ldm, lastNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
+         cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_ldm, lastNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
          }
       }
 
@@ -786,25 +786,25 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
          else
             {
             cursor = armLoadConstant(lastNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
             tempMR = new (trHeapMemory()) TR::MemoryReference(gr4, 0, codeGen);
             }
-         cursor = generateMemSrc1Instruction(codeGen, ARMOp_fldd, lastNode, tempMR, reg, cursor);
+         cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::ARMOp_fldd, lastNode, tempMR, reg, cursor);
          }
       else
          {
          if (constantIsImmed8r(outgoingArgSize, &base, &rotate))
             {
-            cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
+            cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
             }
          else
             {
             cursor = armLoadConstant(lastNode, outgoingArgSize, gr4, codeGen, cursor);
-            cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
+            cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, gr4, stackPtr, gr4, cursor);
             }
          // FIXME Need generateMultiMoveInstruction().
          uint16_t offset = ((TR::RealRegister::fp8 - TR::RealRegister::FirstFPR) << 12) | (fpRegistersSaved << 1);
-         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, ARMOp_fldmd, lastNode, gr4, offset, codeGen);
+         cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, TR::InstOpCode::ARMOp_fldmd, lastNode, gr4, offset, codeGen);
          ((TR::ARMMultipleMoveInstruction *)cursor)->setIncrement();
          }
       }
@@ -819,22 +819,22 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
        machine->getLinkRegisterKilled())
       {
       tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, totalFrameSize + properties.getOffsetToFirstLocal(), codeGen);
-      cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, lastNode, gr14, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, lastNode, gr14, tempMR, cursor);
       }
 
    // Collapse stack frame and return.
    if (constantIsImmed8r(totalFrameSize, &base, &rotate))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, lastNode, stackPtr, stackPtr, base, rotate, cursor);
+      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, stackPtr, stackPtr, base, rotate, cursor);
       }
    else
       {
       TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
       cursor = armLoadConstant(lastNode, totalFrameSize, gr4, codeGen, cursor);
-      cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, lastNode, stackPtr, stackPtr, gr4, cursor);
+      cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_add, lastNode, stackPtr, stackPtr, gr4, cursor);
       }
 
-   cursor = generateTrg1Src1Instruction(codeGen, ARMOp_mov, lastNode, gr15, gr14, cursor);
+   cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, lastNode, gr15, gr14, cursor);
    }
 
 TR::MemoryReference *J9::ARM::PrivateLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
@@ -932,13 +932,13 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          targetAddress = targetAddress->getLowOrder();
          }
       doneLabel = generateLabelSymbol(codeGen);
-      generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr4, targetAddress);
+      generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr4, targetAddress);
 
-      TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr14, gr15);
+      TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
       instr->setDependencyConditions(dependencies);
       dependencies->incRegisterTotalUseCounts(codeGen);
 
-      gcPoint = generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr15, gr4);
+      gcPoint = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr15, gr4);
 
       gcPoint->ARMNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
 
@@ -959,7 +959,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          if (TR::Compiler->cls.classesOnHeap())
             {
             classReg = gr11;
-            generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr11, new (trHeapMemory()) TR::MemoryReference(gr0, fej9->getOffsetOfClassFromJavaLangClassField(), codeGen));
+            generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr11, new (trHeapMemory()) TR::MemoryReference(gr0, fej9->getOffsetOfClassFromJavaLangClassField(), codeGen));
             }
          else
             classReg = gr0;
@@ -985,39 +985,39 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          // method pointer and move return address to link register.
          // The 4 instruction before branch should be a no-op if the offset turns
          // out to be within range (for most cases).
-         generateTrg1ImmInstruction(codeGen, ARMOp_mov, callNode, gr11, 0, 0);
-         generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, callNode, gr11, gr11, 0, 8);
-         generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, callNode, gr11, gr11, 0, 16);
-         generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, callNode, gr11, gr11, 0, 24);
+         generateTrg1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr11, 0, 0);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 8);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 16);
+         generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::ARMOp_add, callNode, gr11, gr11, 0, 24);
 
-         generateLabelInstruction(codeGen, ARMOp_b, callNode, snippetLabel, dependencies);
+         generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_b, callNode, snippetLabel, dependencies);
 
          tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, 0, codeGen);
-         gcPoint = generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr15, tempMR);
+         gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
          }
       else
          {
          int32_t offset = methodSymRef->getOffset();
          if (constantIsImmed12(offset))
             {
-            TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr14, gr15);
+            TR::Instruction *instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
             instr->setDependencyConditions(dependencies);
             dependencies->incRegisterTotalUseCounts(codeGen);
 
             tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, offset, codeGen);
-            gcPoint = generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr15, tempMR);
+            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
             gcPoint->setDependencyConditions(postDeps);
             postDeps->incRegisterTotalUseCounts(codeGen);
             }
          else
             {
             TR::Instruction *instr = armLoadConstant(callNode, offset, gr11, codeGen);
-            instr = generateTrg1Src1Instruction(codeGen, ARMOp_mov, callNode, gr14, gr15);
+            instr = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_mov, callNode, gr14, gr15);
             instr->setDependencyConditions(dependencies);
             dependencies->incRegisterTotalUseCounts(codeGen);
 
             tempMR = new (trHeapMemory()) TR::MemoryReference(classReg, gr11, 0, codeGen);
-            gcPoint = generateTrg1MemInstruction(codeGen, ARMOp_ldr, callNode, gr15, tempMR);
+            gcPoint = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ARMOp_ldr, callNode, gr15, tempMR);
             gcPoint->setDependencyConditions(postDeps);
             postDeps->incRegisterTotalUseCounts(codeGen);
             }
@@ -1036,7 +1036,7 @@ void J9::ARM::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
                                                          doneLabel,
                                                          thunk));
 
-      gcPoint = generateLabelInstruction(codeGen, ARMOp_b, callNode, snippetLabel, dependencies);
+      gcPoint = generateLabelInstruction(codeGen, TR::InstOpCode::ARMOp_b, callNode, snippetLabel, dependencies);
       }
 
    gcPoint->ARMNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
@@ -1118,7 +1118,7 @@ TR::Register *J9::ARM::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          if (resType.isFloatingPoint())
             {
             TR::Register *tempReg = codeGen->allocateSinglePrecisionRegister();
-            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, ARMOp_fmsr, callNode, tempReg, returnRegister);
+            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::ARMOp_fmsr, callNode, tempReg, returnRegister);
             returnRegister = tempReg;
             }
          break;
@@ -1133,7 +1133,7 @@ TR::Register *J9::ARM::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          if (resType.isDouble())
             {
             TR::Register *tempReg = codeGen->allocateRegister(TR_FPR);
-            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, ARMOp_fmdrr, callNode, tempReg, lowReg, highReg);
+            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::ARMOp_fmdrr, callNode, tempReg, lowReg, highReg);
             returnRegister = tempReg;
             }
 

--- a/runtime/compiler/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,8 +87,8 @@ TR::Instruction *TR_ARMRecompilation::generatePrePrologue()
       // gr4 must contain the saved LR; see Recompilation.s
       if(useSampling())
          {
-         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, TR::InstOpCode::ARMOp_mov, firstNode, gr4, lr, cg());
-         cursor = generateImmSymInstruction(cg(), TR::InstOpCode::ARMOp_bl, firstNode, (uintptr_t)recompileMethodSymRef->getMethodAddress(), new (cg()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg()->trMemory()), recompileMethodSymRef, NULL, cursor);
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, TR::InstOpCode::mov, firstNode, gr4, lr, cg());
+         cursor = generateImmSymInstruction(cg(), TR::InstOpCode::bl, firstNode, (uintptr_t)recompileMethodSymRef->getMethodAddress(), new (cg()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg()->trMemory()), recompileMethodSymRef, NULL, cursor);
          }
       cursor = new (cg()->trHeapMemory()) TR::ARMImmInstruction(cursor, TR::InstOpCode::dd, firstNode, (int32_t)(intptr_t)info, cg());
       cursor->setNeedsAOTRelocation();
@@ -118,17 +118,17 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
       TR_ARMOperand2 *op2_2 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte2(), 16);
       TR_ARMOperand2 *op2_1 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte1(), 8);
       TR_ARMOperand2 *op2_0 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte0(), 0);
-      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_mov, firstNode, gr5, op2_3, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_2, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_1, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_0, cursor);
+      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::mov, firstNode, gr5, op2_3, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::add, firstNode, gr5, gr5, op2_2, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::add, firstNode, gr5, gr5, op2_1, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::add, firstNode, gr5, gr5, op2_0, cursor);
 
-      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ARMOp_ldr, firstNode, gr4, new (cg()->trHeapMemory()) TR::MemoryReference(gr5, 0, cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldr, firstNode, gr4, new (cg()->trHeapMemory()) TR::MemoryReference(gr5, 0, cg()), cursor);
 
       if (!isProfilingCompilation())
          {
-         cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::ARMOp_sub_r, firstNode, gr4, gr4, 1, 0, cursor);
-         cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::ARMOp_str, firstNode,
+         cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::sub_r, firstNode, gr4, gr4, 1, 0, cursor);
+         cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::str, firstNode,
                                 new (cg()->trHeapMemory()) TR::MemoryReference(gr5, (int32_t)0, cg()), gr4, cursor);
          }
       else
@@ -136,15 +136,15 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
          // This only applies to JitProfiling, as JProfiling uses sampling
          TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
 
-         cursor = generateSrc1ImmInstruction(cg(), TR::InstOpCode::ARMOp_cmp, firstNode, gr4, 0, 0, cursor);
+         cursor = generateSrc1ImmInstruction(cg(), TR::InstOpCode::cmp, firstNode, gr4, 0, 0, cursor);
          // this is just padding for consistent code length
-         cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
+         cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::orr, firstNode, gr5, gr5, gr5, cursor);
          }
 
       // gr4 must contain the saved LR; see Recompilation.s
-      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_mov, firstNode, gr4, lr, cursor);
+      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::mov, firstNode, gr4, lr, cursor);
       // the instruction below is replaced after successful recompilation
-      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::orr, firstNode, gr5, gr5, gr5, cursor);
       cursor = generateConditionalBranchInstruction(cg(), firstNode, ARMConditionCodeLT, snippetLabel, cursor);
 
       TR::Snippet     *snippet = new (cg()->trHeapMemory()) TR::ARMRecompilationSnippet(snippetLabel, cursor, cg());

--- a/runtime/compiler/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilation.cpp
@@ -90,11 +90,11 @@ TR::Instruction *TR_ARMRecompilation::generatePrePrologue()
          cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, ARMOp_mov, firstNode, gr4, lr, cg());
          cursor = generateImmSymInstruction(cg(), ARMOp_bl, firstNode, (uintptr_t)recompileMethodSymRef->getMethodAddress(), new (cg()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg()->trMemory()), recompileMethodSymRef, NULL, cursor);
          }
-      cursor = new (cg()->trHeapMemory()) TR::ARMImmInstruction(cursor, ARMOp_dd, firstNode, (int32_t)(intptr_t)info, cg());
+      cursor = new (cg()->trHeapMemory()) TR::ARMImmInstruction(cursor, TR::InstOpCode::dd, firstNode, (int32_t)(intptr_t)info, cg());
       cursor->setNeedsAOTRelocation();
       ((TR::ARMImmInstruction *)cursor)->setReloKind(TR_BodyInfoAddress);
 
-      cursor = generateImmInstruction(cg(), ARMOp_dd, firstNode, 0, cursor);
+      cursor = generateImmInstruction(cg(), TR::InstOpCode::dd, firstNode, 0, cursor);
       }
    return(cursor);
    }

--- a/runtime/compiler/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilation.cpp
@@ -87,8 +87,8 @@ TR::Instruction *TR_ARMRecompilation::generatePrePrologue()
       // gr4 must contain the saved LR; see Recompilation.s
       if(useSampling())
          {
-         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, ARMOp_mov, firstNode, gr4, lr, cg());
-         cursor = generateImmSymInstruction(cg(), ARMOp_bl, firstNode, (uintptr_t)recompileMethodSymRef->getMethodAddress(), new (cg()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg()->trMemory()), recompileMethodSymRef, NULL, cursor);
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, TR::InstOpCode::ARMOp_mov, firstNode, gr4, lr, cg());
+         cursor = generateImmSymInstruction(cg(), TR::InstOpCode::ARMOp_bl, firstNode, (uintptr_t)recompileMethodSymRef->getMethodAddress(), new (cg()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg()->trMemory()), recompileMethodSymRef, NULL, cursor);
          }
       cursor = new (cg()->trHeapMemory()) TR::ARMImmInstruction(cursor, TR::InstOpCode::dd, firstNode, (int32_t)(intptr_t)info, cg());
       cursor->setNeedsAOTRelocation();
@@ -118,17 +118,17 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
       TR_ARMOperand2 *op2_2 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte2(), 16);
       TR_ARMOperand2 *op2_1 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte1(), 8);
       TR_ARMOperand2 *op2_0 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte0(), 0);
-      cursor = generateTrg1Src1Instruction(cg(), ARMOp_mov, firstNode, gr5, op2_3, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), ARMOp_add, firstNode, gr5, gr5, op2_2, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), ARMOp_add, firstNode, gr5, gr5, op2_1, cursor);
-      cursor = generateTrg1Src2Instruction(cg(), ARMOp_add, firstNode, gr5, gr5, op2_0, cursor);
+      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_mov, firstNode, gr5, op2_3, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_2, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_1, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_add, firstNode, gr5, gr5, op2_0, cursor);
 
-      cursor = generateTrg1MemInstruction(cg(), ARMOp_ldr, firstNode, gr4, new (cg()->trHeapMemory()) TR::MemoryReference(gr5, 0, cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ARMOp_ldr, firstNode, gr4, new (cg()->trHeapMemory()) TR::MemoryReference(gr5, 0, cg()), cursor);
 
       if (!isProfilingCompilation())
          {
-         cursor = generateTrg1Src1ImmInstruction(cg(), ARMOp_sub_r, firstNode, gr4, gr4, 1, 0, cursor);
-         cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode,
+         cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::ARMOp_sub_r, firstNode, gr4, gr4, 1, 0, cursor);
+         cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::ARMOp_str, firstNode,
                                 new (cg()->trHeapMemory()) TR::MemoryReference(gr5, (int32_t)0, cg()), gr4, cursor);
          }
       else
@@ -136,15 +136,15 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
          // This only applies to JitProfiling, as JProfiling uses sampling
          TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
 
-         cursor = generateSrc1ImmInstruction(cg(), ARMOp_cmp, firstNode, gr4, 0, 0, cursor);
+         cursor = generateSrc1ImmInstruction(cg(), TR::InstOpCode::ARMOp_cmp, firstNode, gr4, 0, 0, cursor);
          // this is just padding for consistent code length
-         cursor = generateTrg1Src2Instruction(cg(), ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
+         cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
          }
 
       // gr4 must contain the saved LR; see Recompilation.s
-      cursor = generateTrg1Src1Instruction(cg(), ARMOp_mov, firstNode, gr4, lr, cursor);
+      cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::ARMOp_mov, firstNode, gr4, lr, cursor);
       // the instruction below is replaced after successful recompilation
-      cursor = generateTrg1Src2Instruction(cg(), ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
+      cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);
       cursor = generateConditionalBranchInstruction(cg(), firstNode, ARMConditionCodeLT, snippetLabel, cursor);
 
       TR::Snippet     *snippet = new (cg()->trHeapMemory()) TR::ARMRecompilationSnippet(snippetLabel, cursor, cg());

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
             if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkageProperties.getRightToLeft())
@@ -78,10 +78,10 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
             if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                if (intArgNum < linkageProperties.getNumIntArgRegs()-1)
            	  {
-           	  buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+           	  buffer = storeArgumentItem(TR::InstOpCode::str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
            	  }
                }
             intArgNum += 2;
@@ -95,7 +95,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
                if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_stfs, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::stfs, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkageProperties.getRightToLeft())
@@ -108,7 +108,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
                if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_stfd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::stfd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkageProperties.getRightToLeft())

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -64,7 +64,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
             if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkageProperties.getRightToLeft())
@@ -78,10 +78,10 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
             if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                if (intArgNum < linkageProperties.getNumIntArgRegs()-1)
            	  {
-           	  buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+           	  buffer = storeArgumentItem(TR::InstOpCode::ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
            	  }
                }
             intArgNum += 2;
@@ -95,7 +95,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
                if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfs, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_stfs, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkageProperties.getRightToLeft())
@@ -108,7 +108,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
                if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::ARMOp_stfd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkageProperties.getRightToLeft())

--- a/runtime/compiler/arm/codegen/Instruction.hpp
+++ b/runtime/compiler/arm/codegen/Instruction.hpp
@@ -66,7 +66,7 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
 TR::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
    : J9::InstructionConnector(cg, InstOpCode::bad, node)
    {
-   self()->setOpCodeValue(ARMOp_bad);
+   self()->setOpCodeValue(TR::InstOpCode::bad);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(NULL);
    }

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -314,7 +314,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
       implicitExceptionPointInstr->setNode(implicitExceptionPointNode);
       }
 
-   generateLabelInstruction(cg, ARMOp_label, node, doneLabel, deps);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
    deps->stopAddingConditions();
 
    cg->decReferenceCount(objNode);
@@ -528,7 +528,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          }
 
       iCursor = cg->getAppendInstruction();
-      generateLabelInstruction(cg, ARMOp_label, node, doneLabel, conditions);
+      generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
       conditions->stopAddingConditions();
       cg->decReferenceCount(objectNode);
       cg->decReferenceCount(castClassNode);
@@ -603,7 +603,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          }
       else
          {
-         iCursor = generateLabelInstruction(cg, ARMOp_label, node, trueLabel, iCursor);
+         iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
          iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
          }
 
@@ -655,7 +655,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
 
       if (doneLabel != NULL)
          {
-         generateLabelInstruction(cg, ARMOp_label, node, doneLabel, newDeps);
+         generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, newDeps);
          newDeps->stopAddingConditions();
          }
 
@@ -778,7 +778,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
 
       iCursor = cg->getAppendInstruction();
-      generateLabelInstruction(cg, ARMOp_label, node, doneLabel, conditions);
+      generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
       cg->decReferenceCount(objectNode);
       cg->decReferenceCount(castClassNode);
       }
@@ -826,7 +826,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
 
       if (trueLabel != NULL)
          {
-         iCursor = generateLabelInstruction(cg, ARMOp_label, node, trueLabel, iCursor);
+         iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
          }
       iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
       iCursor->setConditionCode(ARMConditionCodeEQ);
@@ -842,7 +842,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
       else
          {
          generateTrg1Src1Instruction(cg, ARMOp_mov, node, resultReg, callResult);
-         generateLabelInstruction(cg, ARMOp_label, node, doneLabel, conditions->cloneAndFix(cg));
+         generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions->cloneAndFix(cg));
          }
       }
    if (resultReg != node->getRegister())
@@ -905,7 +905,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Co
 
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, decLabel);
 
-   generateLabelInstruction(cg, ARMOp_label, node, doneLabel, deps);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
    cg->addSnippet(snippet);
    doneLabel->setEndInternalControlFlow();
 
@@ -1160,10 +1160,10 @@ static void genAlignDoubleArray(TR::CodeGenerator  *cg,
 
    // the slop bytes are at the start of the allocation
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)0, cg);
-   iCursor = generateLabelInstruction(cg, ARMOp_label, node, slotAtStart, iCursor);
+   iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, slotAtStart, iCursor);
    iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp2Reg, iCursor);
    iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, resReg, resReg, 4, 0, iCursor);
-   iCursor = generateLabelInstruction(cg, ARMOp_label, node, doneAlign, iCursor);
+   iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneAlign, iCursor);
    }
 
 
@@ -1358,7 +1358,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
 
             iCursor = armLoadConstant(node, loopCnt, temp1Reg, cg, iCursor);
             iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, temp2Reg, resReg, dataBegin, 0, iCursor);
-            iCursor = generateLabelInstruction(cg, ARMOp_label, node, initLoop, iCursor);
+            iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 0, cg);
             iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 4, cg);
@@ -1397,7 +1397,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
          iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, temp2Reg, resReg, dataBegin - 4, 0, iCursor);
 
          TR::LabelSymbol *initLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         iCursor = generateLabelInstruction(cg, ARMOp_label, node, initLoop, iCursor);
+         iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
          tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, temp1Reg, 4, cg);
          iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
          iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
@@ -1407,14 +1407,14 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeAL, doneLabel);
 
    // TODO:  using snippet to better use of branch prediction facility
-   generateLabelInstruction(cg, ARMOp_label, node, callLabel);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, callLabel);
    generateTrg1Src1Instruction(cg, ARMOp_mov, node, resReg, classReg);
    if (secondChild != NULL)
       generateTrg1Src1Instruction(cg, ARMOp_mov, node, temp2Reg, enumReg);
    iCursor = generateImmSymInstruction(cg, ARMOp_bl, node, (uint32_t)node->getSymbolReference()->getMethodAddress(), deps, node->getSymbolReference());
    iCursor->ARMNeedsGCMap(0xFFFFFFFE);  // mask off gr0
    cg->machine()->setLinkRegisterKilled(true);
-   generateLabelInstruction(cg, ARMOp_label, node, doneLabel, deps);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
    deps->stopAddingConditions();
 
    cg->decReferenceCount(firstChild);
@@ -1469,7 +1469,7 @@ OMR::ARM::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg
    TR::LabelSymbol *doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
    generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, addrReg, objReg, lwOffset, 0);
-   generateLabelInstruction(cg, ARMOp_label, node, loopLabel);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
    generateTrg1MemInstruction(cg, ARMOp_ldrex, node, dataReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg));
    generateSrc1ImmInstruction(cg, ARMOp_cmp, node, dataReg, 0, 0);
    TR::Instruction *cursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, incLabel);
@@ -1483,7 +1483,7 @@ OMR::ARM::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
 
-   generateLabelInstruction(cg, ARMOp_label, node, doneLabel, deps);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
 
    TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARMMonitorEnterSnippet(cg, node, lwOffset, incLabel, callLabel, doneLabel);
    cg->addSnippet(snippet);
@@ -1699,7 +1699,7 @@ void OMR::ARM::TreeEvaluator::VMwrtbarEvaluator(TR::Node *node, TR::Register *sr
       }
 
    // place label that marks work was done.
-   generateLabelInstruction(cg, ARMOp_label, node, doneLabel, deps);
+   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
 
    if (flagReg == NULL)
       cg->stopUsingRegister(tempReg);

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -64,12 +64,12 @@ static inline TR::Instruction *genNullTest(TR::CodeGenerator *cg,
    uint32_t base, rotate;
    if (constantIsImmed8r(NULLVALUE, &base, &rotate))
       {
-      instr = generateSrc1ImmInstruction(cg, ARMOp_cmp, node, objectReg, base, rotate, cursor);
+      instr = generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, objectReg, base, rotate, cursor);
       }
    else
       {
       instr = armLoadConstant(node, NULLVALUE, scratchReg, cg, cursor);
-      instr = generateSrc2Instruction(cg, ARMOp_cmp, node, objectReg, scratchReg, instr);
+      instr = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objectReg, scratchReg, instr);
       }
 
    return instr;
@@ -127,7 +127,7 @@ TR::Instruction *OMR::ARM::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGen
       }
    else
       {
-      return generateTrg1Src1ImmInstruction(cg, ARMOp_bic, node, dstReg, srcReg, ~mask, 0, prev);
+      return generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, dstReg, srcReg, ~mask, 0, prev);
       }
    }
 
@@ -154,21 +154,21 @@ static TR::Instruction *genTestIsSuper(TR::CodeGenerator *cg,
    bool     regDepth         = !constantIsImmed8r(castClassDepth, &base, &rotate);
 
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objClassReg, offsetof(J9Class, classDepthAndFlags), cg);
-   cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
 
-   cursor = generateTrg1ImmInstruction(cg, ARMOp_mvn, node, scratch2Reg, 0, 0, cursor);
+   cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mvn, node, scratch2Reg, 0, 0, cursor);
 
    TR_ARMOperand2 *operand2 = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, scratch2Reg, shiftAmount);
-   cursor = generateTrg1Src2Instruction(cg, ARMOp_and, node, scratch1Reg, scratch1Reg, operand2, cursor);
+   cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and, node, scratch1Reg, scratch1Reg, operand2, cursor);
 
    if (outOfBound || regDepth)
       {
       cursor = armLoadConstant(node, castClassDepth, scratch2Reg, cg, cursor);
-      cursor = generateSrc2Instruction(cg, ARMOp_cmp, node, scratch1Reg, scratch2Reg, cursor);
+      cursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, scratch2Reg, cursor);
       }
    else
       {
-      cursor = generateSrc1ImmInstruction(cg, ARMOp_cmp, node, scratch1Reg, base, rotate, cursor);
+      cursor = generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, base, rotate, cursor);
       }
 
    if (failLabel)
@@ -178,27 +178,27 @@ static TR::Instruction *genTestIsSuper(TR::CodeGenerator *cg,
    else
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
-      cursor = generateImmSymInstruction(cg, ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeLE);
+      cursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeLE);
       cursor->ARMNeedsGCMap(0xFFFFFFFF);
       cg->machine()->setLinkRegisterKilled(true);
       }
 
 
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objClassReg, offsetof(J9Class,superclasses), cg);
-   cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
 
    if (outOfBound || regDepth)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(scratch1Reg, scratch2Reg, 4, cg);
-      cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(scratch1Reg, superClassOffset, cg);
-      cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
       }
 
-   cursor = generateSrc2Instruction(cg, ARMOp_cmp, node, scratch1Reg, castClassReg, cursor);
+   cursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, castClassReg, cursor);
    return cursor;
    }
 
@@ -247,7 +247,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
    if (!testEqualClass && !testCastClassIsSuper)
       {
       TR::SymbolReference *symRef  = node->getSymbolReference();
-      TR::Instruction     *gcPoint = generateImmSymInstruction(cg, ARMOp_bl, node, (uint32_t)symRef->getMethodAddress(), deps, symRef);
+      TR::Instruction     *gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uint32_t)symRef->getMethodAddress(), deps, symRef);
       gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
       deps->stopAddingConditions();
       cg->decReferenceCount(objNode);
@@ -271,7 +271,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
          }
       }
 
-   implicitExceptionPointInstr = generateTrg1MemInstruction(cg, ARMOp_ldr, node, objClassReg,
+   implicitExceptionPointInstr = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg,
                                  new (cg->trHeapMemory()) TR::MemoryReference(objReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg));
    generateVFTMaskInstruction(cg, node, objClassReg);
 
@@ -279,12 +279,12 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
 
    if (testEqualClass)
       {
-      generateSrc2Instruction(cg, ARMOp_cmp, node, objClassReg, castClassReg);
+      generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg);
       if (testCastClassIsSuper)
          generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel);
       else
          {
-         gcPoint = generateImmSymInstruction(cg, ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
+         gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
          gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
          }
       }
@@ -298,7 +298,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
 
       genTestIsSuper(cg, node, objClassReg, castClassReg, scratch1Reg,
                      scratch2Reg, castClassDepth, NULL, NULL, doneLabel);
-      gcPoint = generateImmSymInstruction(cg, ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
+      gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
       gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
       }
 
@@ -424,7 +424,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
       TR::Node::recreate(instanceOfNode, childOpCode);
 
       iCursor = cg->getAppendInstruction();
-      while (iCursor->getOpCodeValue() != ARMOp_bl)
+      while (iCursor->getOpCodeValue() != TR::InstOpCode::ARMOp_bl)
          iCursor = iCursor->getPrev();
       conditions = iCursor->getDependencyConditions();
       iCursor = iCursor->getPrev();
@@ -445,7 +445,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          if (needResult)
             {
             resultReg = conditions->searchPreConditionRegister(TR::RealRegister::gr5);
-            iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 0, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0, iCursor);
             }
          if (!objectNode->isNonNull())
             {
@@ -503,7 +503,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
 
       if (needResult)
          {
-         generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 0, 0);
+         generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0);
          }
 
       if (!objectNode->isNonNull())
@@ -537,13 +537,13 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
    if (testEqualClass || testCastClassIsSuper)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objectReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, objClassReg, tempMR, iCursor);
+      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg, tempMR, iCursor);
       iCursor = generateVFTMaskInstruction(cg, node, objClassReg, iCursor);
       }
 
    if (testEqualClass)
       {
-      iCursor = generateSrc2Instruction(cg, ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
+      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
 
       if (testCastClassIsSuper)
          {
@@ -561,7 +561,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
             }
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, res1Label, iCursor);
          }
@@ -569,7 +569,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
             iCursor->setConditionCode(ARMConditionCodeEQ);
             }
 
@@ -598,18 +598,18 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
             }
          }
       else
          {
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
-         iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
          }
 
       if (branchOn1)
          {
-         iCursor = generateLabelInstruction(cg, ARMOp_b, node, res1Label, iCursor);
+         iCursor = generateLabelInstruction(cg, TR::InstOpCode::ARMOp_b, node, res1Label, iCursor);
          }
       }
 
@@ -624,10 +624,10 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          }
       else
          {
-         generateTrg1Src1Instruction(cg, ARMOp_mov, node, resultReg, callResult);
+         generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, callResult);
          }
 
-      generateSrc1ImmInstruction(cg, ARMOp_cmp, node, resultReg, 0, 0);
+      generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, resultReg, 0, 0);
 
       if (depNode != NULL)
          {
@@ -709,7 +709,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
       TR::Node::recreate(node, opCode);
 
       iCursor = cg->getAppendInstruction();
-      while (iCursor->getOpCodeValue() != ARMOp_bl)
+      while (iCursor->getOpCodeValue() != TR::InstOpCode::ARMOp_bl)
          iCursor = iCursor->getPrev();
       conditions = iCursor->getDependencyConditions();
       iCursor = iCursor->getPrev();
@@ -731,7 +731,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          resultReg = conditions->searchPreConditionRegister(
                        TR::RealRegister::gr5);
 
-         iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 0, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0, iCursor);
          if (!objectNode->isNonNull())
             {
             iCursor = genNullTest(cg, objectNode, objectReg, scratch1Reg, iCursor);
@@ -758,7 +758,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
 
       doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 0, 0);
+      generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0);
       if (!objectNode->isNonNull())
          {
          genNullTest(cg, objectNode, objectReg, objClassReg, NULL);
@@ -786,13 +786,13 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
    if (testEqualClass || testCastClassIsSuper)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objectReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, objClassReg, tempMR, iCursor);
+      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg, tempMR, iCursor);
       iCursor = generateVFTMaskInstruction(cg, node, objClassReg, iCursor);
       }
 
    if (testEqualClass)
       {
-      iCursor = generateSrc2Instruction(cg, ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
+      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
 
       if (testCastClassIsSuper)
          {
@@ -801,12 +801,12 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
       else if (needsHelperCall)
          {
-         iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel, iCursor);
          }
       else
          {
-         iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
          iCursor->setConditionCode(ARMConditionCodeEQ);
          }
       }
@@ -828,7 +828,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          {
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
          }
-      iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, resultReg, 1, 0, iCursor);
+      iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
       iCursor->setConditionCode(ARMConditionCodeEQ);
       }
 
@@ -841,7 +841,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
       else
          {
-         generateTrg1Src1Instruction(cg, ARMOp_mov, node, resultReg, callResult);
+         generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, callResult);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions->cloneAndFix(cg));
          }
       }
@@ -880,21 +880,21 @@ TR::Register *OMR::ARM::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Co
    TR::addDependency(deps, flagReg, TR::RealRegister::NoReg, TR_GPR, cg);
 
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objReg, lwOffset, cg);
-   generateTrg1MemInstruction(cg, ARMOp_ldr, node, monitorReg, tempMR);
-   generateSrc2Instruction(cg, ARMOp_cmp, node, monitorReg, metaReg);
+   generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, monitorReg, tempMR);
+   generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, monitorReg, metaReg);
 
-   TR::Instruction *instr = generateTrg1ImmInstruction(cg, ARMOp_mov, node, flagReg, 0, 0);
+   TR::Instruction *instr = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, flagReg, 0, 0);
    instr->setConditionCode(ARMConditionCodeEQ);
 
    if (cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      //instr = generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
-      instr = generateInstruction(cg, ARMOp_dmb_v6 , node); // v7 version is unconditional
+      //instr = generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::ARMOp_dmb_v6 : TR::InstOpCode::ARMOp_dmb, node);
+      instr = generateInstruction(cg, TR::InstOpCode::ARMOp_dmb_v6 , node); // v7 version is unconditional
       instr->setConditionCode(ARMConditionCodeEQ);
       }
 
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objReg, lwOffset, cg);
-   instr  = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, flagReg);
+   instr  = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, flagReg);
    instr->setConditionCode(ARMConditionCodeEQ);
 
    // Branch to decLabel in snippet first
@@ -943,22 +943,22 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
    if (isVariableLen)
       {
       // This is coming from the cg setting: less than 0x10000000 will not wrap around
-      iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_and_r, node, zeroReg, enumReg, 0x000000FF, 24, iCursor);
+      iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_and_r, node, zeroReg, enumReg, 0x000000FF, 24, iCursor);
       iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, callLabel, iCursor);
 
       if (isArrayAlloc)
          {
          // Zero length arrays are discontiguous
-         iCursor = generateSrc2Instruction(cg, ARMOp_tst, node, enumReg, enumReg, iCursor);
+         iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_tst, node, enumReg, enumReg, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, callLabel, iCursor);
          }
       }
 
    TR::MemoryReference *tempMR;
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapAlloc), cg);
-   iCursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, resReg, tempMR, iCursor);
+   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, resReg, tempMR, iCursor);
    //tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapTop), cg);
-   //iCursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
+   //iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
 
    if (sizeInReg)
       {
@@ -971,25 +971,25 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
          if (elementSize >= 4)
             {
             TR_ARMOperand2 *operand2 = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSLImmed, enumReg, trailingZeroes(elementSize));
-            iCursor = generateTrg1Src1Instruction(cg, ARMOp_mov, node, dataSizeReg, operand2, iCursor);
+            iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, dataSizeReg, operand2, iCursor);
             }
          else
             {
             // Round the data area to a multiple of 4
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, dataSizeReg, enumReg, 3, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, dataSizeReg, enumReg, 3, 0, iCursor);
             if (elementSize == 2)
                {
-               iCursor = generateTrg1Src2Instruction(cg, ARMOp_add, node, dataSizeReg, dataSizeReg, enumReg, iCursor);
+               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, dataSizeReg, dataSizeReg, enumReg, iCursor);
                }
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_bic, node, dataSizeReg, dataSizeReg, 3, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, dataSizeReg, dataSizeReg, 3, 0, iCursor);
             }
          if ((round != 0 && round != 4) || !headerAligned)
             {
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, sizeReg, dataSizeReg, allocSize+round-1, 0, iCursor);
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_bic, node, sizeReg, sizeReg, round-1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, dataSizeReg, allocSize+round-1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, sizeReg, sizeReg, round-1, 0, iCursor);
             }
          else
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, sizeReg, dataSizeReg, allocSize, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, dataSizeReg, allocSize, 0, iCursor);
          }
       else
          iCursor = armLoadConstant(node, allocSize, sizeReg, cg, iCursor);
@@ -997,7 +997,7 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
 
    // Borrowing heapTopReg
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapTop), cg);
-   iCursor = generateTrg1MemInstruction(cg, ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
+   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
 
    // Calculate the after-allocation heapAlloc: if the size is huge,
    //   we need to check address wrap-around also. This is unsigned
@@ -1008,11 +1008,11 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
       {
       if (sizeInReg)
          {
-         iCursor = generateTrg1Src2Instruction(cg, ARMOp_add_r, node, sizeReg, resReg, sizeReg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add_r, node, sizeReg, resReg, sizeReg, iCursor);
          }
       else
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add_r, node, sizeReg, resReg, base, rotate, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add_r, node, sizeReg, resReg, base, rotate, iCursor);
          }
       iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeCS, callLabel, iCursor);
       }
@@ -1020,19 +1020,19 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
       {
       if (sizeInReg)
          {
-         iCursor = generateTrg1Src2Instruction(cg, ARMOp_add, node, sizeReg, resReg, sizeReg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, resReg, sizeReg, iCursor);
          }
       else
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, sizeReg, resReg, base, rotate, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, resReg, base, rotate, iCursor);
          }
       }
 
-   iCursor = generateSrc2Instruction(cg, ARMOp_cmp, node, sizeReg, heapTopReg, iCursor);
+   iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, sizeReg, heapTopReg, iCursor);
    iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeHI, callLabel, iCursor);
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapAlloc), cg);
-   iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, sizeReg, iCursor);
-   iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, zeroReg, 0, 0, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, sizeReg, iCursor);
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, zeroReg, 0, 0, iCursor);
    }
 
 
@@ -1057,12 +1057,12 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
       iCursor = armLoadConstant(node, (int32_t)clazz, temp1Reg, cg, iCursor);
 
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp1Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp1Reg, iCursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, classReg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, classReg, iCursor);
       }
 
    // If the object flags cannot be determined at compile time, we have to add a load
@@ -1087,10 +1087,10 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
    //   I can only think of 4 instructions sequence which takes advantage of the fact
    //   that resReg itself is at least dword-aligned. Need to revisit whether there is
    //   better sequence.
-   iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, temp1Reg, 2, 16, iCursor);
-   iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_sub, node, temp1Reg, temp1Reg, 1, 0, iCursor);
-   iCursor = generateTrg1Src2Instruction(cg, ARMOp_and, node, temp1Reg, resReg, temp1Reg, iCursor);
-   iCursor = generateTrg1Src1Instruction(cg, ARMOp_mov, node, temp1Reg,
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, temp1Reg, 2, 16, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+   iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and, node, temp1Reg, resReg, temp1Reg, iCursor);
+   iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, temp1Reg,
                 new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSLImmed, temp1Reg, 14), iCursor);
 
    if (isStaticFlag != 0)
@@ -1099,19 +1099,19 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
       uint32_t  val1, val2;
       if (constantIsImmed8r(staticFlag, &val1, &val2))
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_orr, node, temp1Reg, temp1Reg, val1, val2, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_orr, node, temp1Reg, temp1Reg, val1, val2, iCursor);
          }
       else
          {
          iCursor = armLoadConstant(node, staticFlag, temp2Reg, cg, iCursor);
-         iCursor = generateTrg1Src2Instruction(cg, ARMOp_orr, node, temp1Reg, temp1Reg, temp2Reg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_orr, node, temp1Reg, temp1Reg, temp2Reg, iCursor);
          }
       }
 #endif /* J9VM_OPT_NEW_OBJECT_HASH */
 
    // Store the flags
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfHeaderFlags(), cg);
-   iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp1Reg, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp1Reg, iCursor);
 #endif /* J9VM_INTERP_FLAGS_IN_CLASS_SLOT */
    }
 
@@ -1130,8 +1130,8 @@ static void genAlignDoubleArray(TR::CodeGenerator  *cg,
    TR::LabelSymbol *slotAtStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol *doneAlign = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-   iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_and_r, node, temp1Reg, resReg, 7, 0, iCursor);
-   iCursor = generateTrg1ImmInstruction(cg, ARMOp_mov, node, temp2Reg, 3, 0, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_and_r, node, temp1Reg, resReg, 7, 0, iCursor);
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, temp2Reg, 3, 0, iCursor);
    iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, slotAtStart, iCursor);
 
    // Should be able to have branch-less sequence here ... but we need to change armLoadConstant for that.
@@ -1142,27 +1142,27 @@ static void genAlignDoubleArray(TR::CodeGenerator  *cg,
    if (isVariableLen)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(temp1Reg, dataBegin, cg);
-      iCursor = generateTrg1Src2Instruction(cg, ARMOp_add, node, temp1Reg, resReg, dataSizeReg, iCursor);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, temp1Reg, resReg, dataSizeReg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
       }
    else if (objectSize > UPPER_IMMED12)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, temp1Reg, cg);
       iCursor = armLoadConstant(node, objectSize, temp1Reg, cg, iCursor);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, objectSize, cg);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
       }
-   iCursor = generateLabelInstruction(cg, ARMOp_b, node, doneAlign, iCursor);
+   iCursor = generateLabelInstruction(cg, TR::InstOpCode::ARMOp_b, node, doneAlign, iCursor);
 
    // the slop bytes are at the start of the allocation
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)0, cg);
    iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, slotAtStart, iCursor);
-   iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp2Reg, iCursor);
-   iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, resReg, resReg, 4, 0, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, resReg, resReg, 4, 0, iCursor);
    iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneAlign, iCursor);
    }
 
@@ -1189,7 +1189,7 @@ static void genInitArrayHeader(TR::CodeGenerator  *cg,
 
    // Store the array size
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)(fej9->getOffsetOfContiguousArraySizeField()), cg);
-   iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, instanceSizeReg, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, instanceSizeReg, iCursor);
    }
 
 
@@ -1239,7 +1239,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
       if (firstChild->getReferenceCount() > 1)
          {
          TR::Register *copyReg = cg->allocateRegister();
-         iCursor = generateTrg1Src1Instruction(cg, ARMOp_mov, node, copyReg, classReg, iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, copyReg, classReg, iCursor);
          classReg = copyReg;
          }
       dataBegin = TR::Compiler->om.objectHeaderSizeInBytes();
@@ -1271,7 +1271,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
       if (secondChild->getReferenceCount() > 1)
          {
          TR::Register *copyReg = cg->allocateRegister();
-         iCursor = generateTrg1Src1Instruction(cg, ARMOp_mov, node, copyReg, classReg, iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, copyReg, classReg, iCursor);
          classReg = copyReg;
          }
       }
@@ -1344,7 +1344,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             while (bvi.hasMoreElements())
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(resReg, bvi.getNextElement() * 4 + dataBegin, cg);
-               iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
                }
             }
          else if (objectSize > 48)
@@ -1357,26 +1357,26 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             TR::LabelSymbol *initLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
             iCursor = armLoadConstant(node, loopCnt, temp1Reg, cg, iCursor);
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, temp2Reg, resReg, dataBegin, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, resReg, dataBegin, 0, iCursor);
             iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 0, cg);
-            iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 4, cg);
-            iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 8, cg);
-            iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 12, cg);
-            iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
 
             // TODO: add the update form instruction, we will not need the following instruction
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, temp2Reg, temp2Reg, 16, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, temp2Reg, 16, 0, iCursor);
 
-            iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
             iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, initLoop, iCursor);
             for (idx = 0; idx < residue; idx++)
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, idx << 2, cg);
-               iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
                }
             }
          else
@@ -1384,7 +1384,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             for (idx = dataBegin; idx < objectSize; idx += 4)
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(resReg, idx, cg);
-               iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
                }
             }
          }
@@ -1392,15 +1392,15 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
          {
          // Test for zero length array: also set up loop count
 
-         iCursor = generateTrg1Src1Instruction(cg, ARMOp_mov_r, node, temp1Reg, new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, dataSizeReg, 2), iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov_r, node, temp1Reg, new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, dataSizeReg, 2), iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel, iCursor);
-         iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, temp2Reg, resReg, dataBegin - 4, 0, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, resReg, dataBegin - 4, 0, iCursor);
 
          TR::LabelSymbol *initLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
          tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, temp1Reg, 4, cg);
-         iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
-         iCursor = generateTrg1Src1ImmInstruction(cg, ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+         iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, initLoop, iCursor);
          }
       }
@@ -1408,10 +1408,10 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
 
    // TODO:  using snippet to better use of branch prediction facility
    generateLabelInstruction(cg, TR::InstOpCode::label, node, callLabel);
-   generateTrg1Src1Instruction(cg, ARMOp_mov, node, resReg, classReg);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resReg, classReg);
    if (secondChild != NULL)
-      generateTrg1Src1Instruction(cg, ARMOp_mov, node, temp2Reg, enumReg);
-   iCursor = generateImmSymInstruction(cg, ARMOp_bl, node, (uint32_t)node->getSymbolReference()->getMethodAddress(), deps, node->getSymbolReference());
+      generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, temp2Reg, enumReg);
+   iCursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uint32_t)node->getSymbolReference()->getMethodAddress(), deps, node->getSymbolReference());
    iCursor->ARMNeedsGCMap(0xFFFFFFFE);  // mask off gr0
    cg->machine()->setLinkRegisterKilled(true);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
@@ -1468,19 +1468,19 @@ OMR::ARM::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg
    TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol *doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-   generateTrg1Src1ImmInstruction(cg, ARMOp_add, node, addrReg, objReg, lwOffset, 0);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, addrReg, objReg, lwOffset, 0);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
-   generateTrg1MemInstruction(cg, ARMOp_ldrex, node, dataReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg));
-   generateSrc1ImmInstruction(cg, ARMOp_cmp, node, dataReg, 0, 0);
+   generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldrex, node, dataReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg));
+   generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, dataReg, 0, 0);
    TR::Instruction *cursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, incLabel);
 
-   generateTrg1MemSrc1Instruction(cg, ARMOp_strex, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg), metaReg);
-   generateSrc1ImmInstruction(cg, ARMOp_cmp, node, tempReg, 0, 0);
+   generateTrg1MemSrc1Instruction(cg, TR::InstOpCode::ARMOp_strex, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg), metaReg);
+   generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, tempReg, 0, 0);
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, loopLabel);
 
    if (cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::ARMOp_dmb_v6 : TR::InstOpCode::ARMOp_dmb, node);
       }
 
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
@@ -1675,7 +1675,7 @@ void OMR::ARM::TreeEvaluator::VMwrtbarEvaluator(TR::Node *node, TR::Register *sr
 
    // todo check for _isSourceNonNull in PPC gen to see possible opt?
    // nullcheck store - skip write barrier if null being written in
-   generateSrc2Instruction(cg, ARMOp_tst, node, srcReg, srcReg);
+   generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_tst, node, srcReg, srcReg);
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel);
 
    if (gcMode != gc_modron_wrtbar_always)
@@ -1683,11 +1683,11 @@ void OMR::ARM::TreeEvaluator::VMwrtbarEvaluator(TR::Node *node, TR::Register *sr
       // check to see if colour bits give hint (read FLAGS field of J9Object).
 // @@ getWordOffsetToGCFlags() and getWriteBarrierGCFlagMaskAsByte() are missing in TR_FrontEnd
 // @@      if (flagReg == NULL)
-// @@         generateTrg1MemInstruction(cg, ARMOp_ldr, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(dstReg, fej9->getWordOffsetToGCFlags(), cg));
-// @@      generateTrg1Src2Instruction(cg, ARMOp_and_r, node, tempReg, tempReg, new (cg->trHeapMemory()) TR_ARMOperand2(fej9->getWriteBarrierGCFlagMaskAsByte(), 8));
+// @@         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(dstReg, fej9->getWordOffsetToGCFlags(), cg));
+// @@      generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and_r, node, tempReg, tempReg, new (cg->trHeapMemory()) TR_ARMOperand2(fej9->getWriteBarrierGCFlagMaskAsByte(), 8));
       }
 
-   TR::Instruction *cursor = generateImmSymInstruction(cg, ARMOp_bl,
+   TR::Instruction *cursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl,
                                         node, (uintptr_t)wbref->getMethodAddress(),
                                         new (cg->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg->trMemory()),
                                         wbref, NULL);

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -64,12 +64,12 @@ static inline TR::Instruction *genNullTest(TR::CodeGenerator *cg,
    uint32_t base, rotate;
    if (constantIsImmed8r(NULLVALUE, &base, &rotate))
       {
-      instr = generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, objectReg, base, rotate, cursor);
+      instr = generateSrc1ImmInstruction(cg, TR::InstOpCode::cmp, node, objectReg, base, rotate, cursor);
       }
    else
       {
       instr = armLoadConstant(node, NULLVALUE, scratchReg, cg, cursor);
-      instr = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objectReg, scratchReg, instr);
+      instr = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, objectReg, scratchReg, instr);
       }
 
    return instr;
@@ -127,7 +127,7 @@ TR::Instruction *OMR::ARM::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGen
       }
    else
       {
-      return generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, dstReg, srcReg, ~mask, 0, prev);
+      return generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::bic, node, dstReg, srcReg, ~mask, 0, prev);
       }
    }
 
@@ -154,21 +154,21 @@ static TR::Instruction *genTestIsSuper(TR::CodeGenerator *cg,
    bool     regDepth         = !constantIsImmed8r(castClassDepth, &base, &rotate);
 
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objClassReg, offsetof(J9Class, classDepthAndFlags), cg);
-   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, scratch1Reg, tempMR, cursor);
 
-   cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mvn, node, scratch2Reg, 0, 0, cursor);
+   cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mvn, node, scratch2Reg, 0, 0, cursor);
 
    TR_ARMOperand2 *operand2 = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, scratch2Reg, shiftAmount);
-   cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and, node, scratch1Reg, scratch1Reg, operand2, cursor);
+   cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::and_, node, scratch1Reg, scratch1Reg, operand2, cursor);
 
    if (outOfBound || regDepth)
       {
       cursor = armLoadConstant(node, castClassDepth, scratch2Reg, cg, cursor);
-      cursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, scratch2Reg, cursor);
+      cursor = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, scratch1Reg, scratch2Reg, cursor);
       }
    else
       {
-      cursor = generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, base, rotate, cursor);
+      cursor = generateSrc1ImmInstruction(cg, TR::InstOpCode::cmp, node, scratch1Reg, base, rotate, cursor);
       }
 
    if (failLabel)
@@ -178,27 +178,27 @@ static TR::Instruction *genTestIsSuper(TR::CodeGenerator *cg,
    else
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
-      cursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeLE);
+      cursor = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeLE);
       cursor->ARMNeedsGCMap(0xFFFFFFFF);
       cg->machine()->setLinkRegisterKilled(true);
       }
 
 
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objClassReg, offsetof(J9Class,superclasses), cg);
-   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+   cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, scratch1Reg, tempMR, cursor);
 
    if (outOfBound || regDepth)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(scratch1Reg, scratch2Reg, 4, cg);
-      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, scratch1Reg, tempMR, cursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(scratch1Reg, superClassOffset, cg);
-      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, scratch1Reg, tempMR, cursor);
+      cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, scratch1Reg, tempMR, cursor);
       }
 
-   cursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, scratch1Reg, castClassReg, cursor);
+   cursor = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, scratch1Reg, castClassReg, cursor);
    return cursor;
    }
 
@@ -247,7 +247,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
    if (!testEqualClass && !testCastClassIsSuper)
       {
       TR::SymbolReference *symRef  = node->getSymbolReference();
-      TR::Instruction     *gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uint32_t)symRef->getMethodAddress(), deps, symRef);
+      TR::Instruction     *gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uint32_t)symRef->getMethodAddress(), deps, symRef);
       gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
       deps->stopAddingConditions();
       cg->decReferenceCount(objNode);
@@ -271,7 +271,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
          }
       }
 
-   implicitExceptionPointInstr = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg,
+   implicitExceptionPointInstr = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, objClassReg,
                                  new (cg->trHeapMemory()) TR::MemoryReference(objReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg));
    generateVFTMaskInstruction(cg, node, objClassReg);
 
@@ -279,12 +279,12 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
 
    if (testEqualClass)
       {
-      generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg);
+      generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, objClassReg, castClassReg);
       if (testCastClassIsSuper)
          generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel);
       else
          {
-         gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
+         gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
          gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
          }
       }
@@ -298,7 +298,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::
 
       genTestIsSuper(cg, node, objClassReg, castClassReg, scratch1Reg,
                      scratch2Reg, castClassDepth, NULL, NULL, doneLabel);
-      gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
+      gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)symRef->getMethodAddress(), NULL, symRef, NULL, NULL, ARMConditionCodeNE);
       gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
       }
 
@@ -424,7 +424,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
       TR::Node::recreate(instanceOfNode, childOpCode);
 
       iCursor = cg->getAppendInstruction();
-      while (iCursor->getOpCodeValue() != TR::InstOpCode::ARMOp_bl)
+      while (iCursor->getOpCodeValue() != TR::InstOpCode::bl)
          iCursor = iCursor->getPrev();
       conditions = iCursor->getDependencyConditions();
       iCursor = iCursor->getPrev();
@@ -445,7 +445,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          if (needResult)
             {
             resultReg = conditions->searchPreConditionRegister(TR::RealRegister::gr5);
-            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 0, 0, iCursor);
             }
          if (!objectNode->isNonNull())
             {
@@ -503,7 +503,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
 
       if (needResult)
          {
-         generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0);
+         generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 0, 0);
          }
 
       if (!objectNode->isNonNull())
@@ -537,13 +537,13 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
    if (testEqualClass || testCastClassIsSuper)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objectReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg, tempMR, iCursor);
+      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, objClassReg, tempMR, iCursor);
       iCursor = generateVFTMaskInstruction(cg, node, objClassReg, iCursor);
       }
 
    if (testEqualClass)
       {
-      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
+      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, objClassReg, castClassReg, iCursor);
 
       if (testCastClassIsSuper)
          {
@@ -561,7 +561,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
             }
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, res1Label, iCursor);
          }
@@ -569,7 +569,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
             iCursor->setConditionCode(ARMConditionCodeEQ);
             }
 
@@ -598,18 +598,18 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          {
          if (needResult)
             {
-            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+            iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
             }
          }
       else
          {
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
-         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
          }
 
       if (branchOn1)
          {
-         iCursor = generateLabelInstruction(cg, TR::InstOpCode::ARMOp_b, node, res1Label, iCursor);
+         iCursor = generateLabelInstruction(cg, TR::InstOpCode::b, node, res1Label, iCursor);
          }
       }
 
@@ -624,10 +624,10 @@ TR::Register *OMR::ARM::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, T
          }
       else
          {
-         generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, callResult);
+         generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, resultReg, callResult);
          }
 
-      generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, resultReg, 0, 0);
+      generateSrc1ImmInstruction(cg, TR::InstOpCode::cmp, node, resultReg, 0, 0);
 
       if (depNode != NULL)
          {
@@ -709,7 +709,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
       TR::Node::recreate(node, opCode);
 
       iCursor = cg->getAppendInstruction();
-      while (iCursor->getOpCodeValue() != TR::InstOpCode::ARMOp_bl)
+      while (iCursor->getOpCodeValue() != TR::InstOpCode::bl)
          iCursor = iCursor->getPrev();
       conditions = iCursor->getDependencyConditions();
       iCursor = iCursor->getPrev();
@@ -731,7 +731,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          resultReg = conditions->searchPreConditionRegister(
                        TR::RealRegister::gr5);
 
-         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 0, 0, iCursor);
          if (!objectNode->isNonNull())
             {
             iCursor = genNullTest(cg, objectNode, objectReg, scratch1Reg, iCursor);
@@ -758,7 +758,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
 
       doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 0, 0);
+      generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 0, 0);
       if (!objectNode->isNonNull())
          {
          genNullTest(cg, objectNode, objectReg, objClassReg, NULL);
@@ -786,13 +786,13 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
    if (testEqualClass || testCastClassIsSuper)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objectReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, objClassReg, tempMR, iCursor);
+      iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, objClassReg, tempMR, iCursor);
       iCursor = generateVFTMaskInstruction(cg, node, objClassReg, iCursor);
       }
 
    if (testEqualClass)
       {
-      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, objClassReg, castClassReg, iCursor);
+      iCursor = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, objClassReg, castClassReg, iCursor);
 
       if (testCastClassIsSuper)
          {
@@ -801,12 +801,12 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
       else if (needsHelperCall)
          {
-         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel, iCursor);
          }
       else
          {
-         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+         iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
          iCursor->setConditionCode(ARMConditionCodeEQ);
          }
       }
@@ -828,7 +828,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          {
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, trueLabel, iCursor);
          }
-      iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, 1, 0, iCursor);
+      iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, resultReg, 1, 0, iCursor);
       iCursor->setConditionCode(ARMConditionCodeEQ);
       }
 
@@ -841,7 +841,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR:
          }
       else
          {
-         generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resultReg, callResult);
+         generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, resultReg, callResult);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions->cloneAndFix(cg));
          }
       }
@@ -880,21 +880,21 @@ TR::Register *OMR::ARM::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Co
    TR::addDependency(deps, flagReg, TR::RealRegister::NoReg, TR_GPR, cg);
 
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objReg, lwOffset, cg);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, monitorReg, tempMR);
-   generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, monitorReg, metaReg);
+   generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, monitorReg, tempMR);
+   generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, monitorReg, metaReg);
 
-   TR::Instruction *instr = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, flagReg, 0, 0);
+   TR::Instruction *instr = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, flagReg, 0, 0);
    instr->setConditionCode(ARMConditionCodeEQ);
 
    if (cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      //instr = generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::ARMOp_dmb_v6 : TR::InstOpCode::ARMOp_dmb, node);
-      instr = generateInstruction(cg, TR::InstOpCode::ARMOp_dmb_v6 , node); // v7 version is unconditional
+      //instr = generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
+      instr = generateInstruction(cg, TR::InstOpCode::dmb_v6 , node); // v7 version is unconditional
       instr->setConditionCode(ARMConditionCodeEQ);
       }
 
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(objReg, lwOffset, cg);
-   instr  = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, flagReg);
+   instr  = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, flagReg);
    instr->setConditionCode(ARMConditionCodeEQ);
 
    // Branch to decLabel in snippet first
@@ -943,22 +943,22 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
    if (isVariableLen)
       {
       // This is coming from the cg setting: less than 0x10000000 will not wrap around
-      iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_and_r, node, zeroReg, enumReg, 0x000000FF, 24, iCursor);
+      iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::and_r, node, zeroReg, enumReg, 0x000000FF, 24, iCursor);
       iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, callLabel, iCursor);
 
       if (isArrayAlloc)
          {
          // Zero length arrays are discontiguous
-         iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_tst, node, enumReg, enumReg, iCursor);
+         iCursor = generateSrc2Instruction(cg, TR::InstOpCode::tst, node, enumReg, enumReg, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, callLabel, iCursor);
          }
       }
 
    TR::MemoryReference *tempMR;
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapAlloc), cg);
-   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, resReg, tempMR, iCursor);
+   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, resReg, tempMR, iCursor);
    //tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapTop), cg);
-   //iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
+   //iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, heapTopReg, tempMR, iCursor);
 
    if (sizeInReg)
       {
@@ -971,25 +971,25 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
          if (elementSize >= 4)
             {
             TR_ARMOperand2 *operand2 = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSLImmed, enumReg, trailingZeroes(elementSize));
-            iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, dataSizeReg, operand2, iCursor);
+            iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, dataSizeReg, operand2, iCursor);
             }
          else
             {
             // Round the data area to a multiple of 4
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, dataSizeReg, enumReg, 3, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, dataSizeReg, enumReg, 3, 0, iCursor);
             if (elementSize == 2)
                {
-               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, dataSizeReg, dataSizeReg, enumReg, iCursor);
+               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dataSizeReg, dataSizeReg, enumReg, iCursor);
                }
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, dataSizeReg, dataSizeReg, 3, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::bic, node, dataSizeReg, dataSizeReg, 3, 0, iCursor);
             }
          if ((round != 0 && round != 4) || !headerAligned)
             {
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, dataSizeReg, allocSize+round-1, 0, iCursor);
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_bic, node, sizeReg, sizeReg, round-1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, sizeReg, dataSizeReg, allocSize+round-1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::bic, node, sizeReg, sizeReg, round-1, 0, iCursor);
             }
          else
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, dataSizeReg, allocSize, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, sizeReg, dataSizeReg, allocSize, 0, iCursor);
          }
       else
          iCursor = armLoadConstant(node, allocSize, sizeReg, cg, iCursor);
@@ -997,7 +997,7 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
 
    // Borrowing heapTopReg
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapTop), cg);
-   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, heapTopReg, tempMR, iCursor);
+   iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, heapTopReg, tempMR, iCursor);
 
    // Calculate the after-allocation heapAlloc: if the size is huge,
    //   we need to check address wrap-around also. This is unsigned
@@ -1008,11 +1008,11 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
       {
       if (sizeInReg)
          {
-         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add_r, node, sizeReg, resReg, sizeReg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::add_r, node, sizeReg, resReg, sizeReg, iCursor);
          }
       else
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add_r, node, sizeReg, resReg, base, rotate, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add_r, node, sizeReg, resReg, base, rotate, iCursor);
          }
       iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeCS, callLabel, iCursor);
       }
@@ -1020,19 +1020,19 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
       {
       if (sizeInReg)
          {
-         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, resReg, sizeReg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, sizeReg, resReg, sizeReg, iCursor);
          }
       else
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, sizeReg, resReg, base, rotate, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, sizeReg, resReg, base, rotate, iCursor);
          }
       }
 
-   iCursor = generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, sizeReg, heapTopReg, iCursor);
+   iCursor = generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, sizeReg, heapTopReg, iCursor);
    iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeHI, callLabel, iCursor);
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapAlloc), cg);
-   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, sizeReg, iCursor);
-   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, zeroReg, 0, 0, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, sizeReg, iCursor);
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, zeroReg, 0, 0, iCursor);
    }
 
 
@@ -1057,12 +1057,12 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
       iCursor = armLoadConstant(node, (int32_t)clazz, temp1Reg, cg, iCursor);
 
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp1Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp1Reg, iCursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), cg);
-      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, classReg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, classReg, iCursor);
       }
 
    // If the object flags cannot be determined at compile time, we have to add a load
@@ -1087,10 +1087,10 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
    //   I can only think of 4 instructions sequence which takes advantage of the fact
    //   that resReg itself is at least dword-aligned. Need to revisit whether there is
    //   better sequence.
-   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, temp1Reg, 2, 16, iCursor);
-   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub, node, temp1Reg, temp1Reg, 1, 0, iCursor);
-   iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and, node, temp1Reg, resReg, temp1Reg, iCursor);
-   iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, temp1Reg,
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, temp1Reg, 2, 16, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sub, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+   iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::and_, node, temp1Reg, resReg, temp1Reg, iCursor);
+   iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, temp1Reg,
                 new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSLImmed, temp1Reg, 14), iCursor);
 
    if (isStaticFlag != 0)
@@ -1099,19 +1099,19 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
       uint32_t  val1, val2;
       if (constantIsImmed8r(staticFlag, &val1, &val2))
          {
-         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_orr, node, temp1Reg, temp1Reg, val1, val2, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::orr, node, temp1Reg, temp1Reg, val1, val2, iCursor);
          }
       else
          {
          iCursor = armLoadConstant(node, staticFlag, temp2Reg, cg, iCursor);
-         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_orr, node, temp1Reg, temp1Reg, temp2Reg, iCursor);
+         iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::orr, node, temp1Reg, temp1Reg, temp2Reg, iCursor);
          }
       }
 #endif /* J9VM_OPT_NEW_OBJECT_HASH */
 
    // Store the flags
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfHeaderFlags(), cg);
-   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp1Reg, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp1Reg, iCursor);
 #endif /* J9VM_INTERP_FLAGS_IN_CLASS_SLOT */
    }
 
@@ -1130,8 +1130,8 @@ static void genAlignDoubleArray(TR::CodeGenerator  *cg,
    TR::LabelSymbol *slotAtStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol *doneAlign = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_and_r, node, temp1Reg, resReg, 7, 0, iCursor);
-   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::ARMOp_mov, node, temp2Reg, 3, 0, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::and_r, node, temp1Reg, resReg, 7, 0, iCursor);
+   iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::mov, node, temp2Reg, 3, 0, iCursor);
    iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, slotAtStart, iCursor);
 
    // Should be able to have branch-less sequence here ... but we need to change armLoadConstant for that.
@@ -1142,27 +1142,27 @@ static void genAlignDoubleArray(TR::CodeGenerator  *cg,
    if (isVariableLen)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(temp1Reg, dataBegin, cg);
-      iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_add, node, temp1Reg, resReg, dataSizeReg, iCursor);
-      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, temp1Reg, resReg, dataSizeReg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp2Reg, iCursor);
       }
    else if (objectSize > UPPER_IMMED12)
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, temp1Reg, cg);
       iCursor = armLoadConstant(node, objectSize, temp1Reg, cg, iCursor);
-      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp2Reg, iCursor);
       }
    else
       {
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, objectSize, cg);
-      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
+      iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp2Reg, iCursor);
       }
-   iCursor = generateLabelInstruction(cg, TR::InstOpCode::ARMOp_b, node, doneAlign, iCursor);
+   iCursor = generateLabelInstruction(cg, TR::InstOpCode::b, node, doneAlign, iCursor);
 
    // the slop bytes are at the start of the allocation
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)0, cg);
    iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, slotAtStart, iCursor);
-   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, temp2Reg, iCursor);
-   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, resReg, resReg, 4, 0, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, temp2Reg, iCursor);
+   iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, resReg, resReg, 4, 0, iCursor);
    iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneAlign, iCursor);
    }
 
@@ -1189,7 +1189,7 @@ static void genInitArrayHeader(TR::CodeGenerator  *cg,
 
    // Store the array size
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)(fej9->getOffsetOfContiguousArraySizeField()), cg);
-   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, instanceSizeReg, iCursor);
+   iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, instanceSizeReg, iCursor);
    }
 
 
@@ -1239,7 +1239,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
       if (firstChild->getReferenceCount() > 1)
          {
          TR::Register *copyReg = cg->allocateRegister();
-         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, copyReg, classReg, iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, copyReg, classReg, iCursor);
          classReg = copyReg;
          }
       dataBegin = TR::Compiler->om.objectHeaderSizeInBytes();
@@ -1271,7 +1271,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
       if (secondChild->getReferenceCount() > 1)
          {
          TR::Register *copyReg = cg->allocateRegister();
-         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, copyReg, classReg, iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, copyReg, classReg, iCursor);
          classReg = copyReg;
          }
       }
@@ -1344,7 +1344,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             while (bvi.hasMoreElements())
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(resReg, bvi.getNextElement() * 4 + dataBegin, cg);
-               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
                }
             }
          else if (objectSize > 48)
@@ -1357,26 +1357,26 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             TR::LabelSymbol *initLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
             iCursor = armLoadConstant(node, loopCnt, temp1Reg, cg, iCursor);
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, resReg, dataBegin, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, temp2Reg, resReg, dataBegin, 0, iCursor);
             iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 0, cg);
-            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 4, cg);
-            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 8, cg);
-            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
             tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, 12, cg);
-            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+            iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
 
             // TODO: add the update form instruction, we will not need the following instruction
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, temp2Reg, 16, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, temp2Reg, temp2Reg, 16, 0, iCursor);
 
-            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+            iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
             iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, initLoop, iCursor);
             for (idx = 0; idx < residue; idx++)
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, idx << 2, cg);
-               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
                }
             }
          else
@@ -1384,7 +1384,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
             for (idx = dataBegin; idx < objectSize; idx += 4)
                {
                tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(resReg, idx, cg);
-               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
+               iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
                }
             }
          }
@@ -1392,15 +1392,15 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
          {
          // Test for zero length array: also set up loop count
 
-         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov_r, node, temp1Reg, new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, dataSizeReg, 2), iCursor);
+         iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mov_r, node, temp1Reg, new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2RegLSRImmed, dataSizeReg, 2), iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel, iCursor);
-         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, temp2Reg, resReg, dataBegin - 4, 0, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, temp2Reg, resReg, dataBegin - 4, 0, iCursor);
 
          TR::LabelSymbol *initLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, initLoop, iCursor);
          tempMR  = new (cg->trHeapMemory()) TR::MemoryReference(temp2Reg, temp1Reg, 4, cg);
-         iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_str, node, tempMR, zeroReg, iCursor);
-         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
+         iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, node, tempMR, zeroReg, iCursor);
+         iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sub_r, node, temp1Reg, temp1Reg, 1, 0, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, initLoop, iCursor);
          }
       }
@@ -1408,10 +1408,10 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
 
    // TODO:  using snippet to better use of branch prediction facility
    generateLabelInstruction(cg, TR::InstOpCode::label, node, callLabel);
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, resReg, classReg);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, resReg, classReg);
    if (secondChild != NULL)
-      generateTrg1Src1Instruction(cg, TR::InstOpCode::ARMOp_mov, node, temp2Reg, enumReg);
-   iCursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uint32_t)node->getSymbolReference()->getMethodAddress(), deps, node->getSymbolReference());
+      generateTrg1Src1Instruction(cg, TR::InstOpCode::mov, node, temp2Reg, enumReg);
+   iCursor = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uint32_t)node->getSymbolReference()->getMethodAddress(), deps, node->getSymbolReference());
    iCursor->ARMNeedsGCMap(0xFFFFFFFE);  // mask off gr0
    cg->machine()->setLinkRegisterKilled(true);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
@@ -1468,19 +1468,19 @@ OMR::ARM::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg
    TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol *doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ARMOp_add, node, addrReg, objReg, lwOffset, 0);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::add, node, addrReg, objReg, lwOffset, 0);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldrex, node, dataReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg));
-   generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, dataReg, 0, 0);
+   generateTrg1MemInstruction(cg, TR::InstOpCode::ldrex, node, dataReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg));
+   generateSrc1ImmInstruction(cg, TR::InstOpCode::cmp, node, dataReg, 0, 0);
    TR::Instruction *cursor = generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, incLabel);
 
-   generateTrg1MemSrc1Instruction(cg, TR::InstOpCode::ARMOp_strex, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg), metaReg);
-   generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_cmp, node, tempReg, 0, 0);
+   generateTrg1MemSrc1Instruction(cg, TR::InstOpCode::strex, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(addrReg, (int32_t)0, cg), metaReg);
+   generateSrc1ImmInstruction(cg, TR::InstOpCode::cmp, node, tempReg, 0, 0);
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeNE, loopLabel);
 
    if (cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::ARMOp_dmb_v6 : TR::InstOpCode::ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
 
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
@@ -1675,7 +1675,7 @@ void OMR::ARM::TreeEvaluator::VMwrtbarEvaluator(TR::Node *node, TR::Register *sr
 
    // todo check for _isSourceNonNull in PPC gen to see possible opt?
    // nullcheck store - skip write barrier if null being written in
-   generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_tst, node, srcReg, srcReg);
+   generateSrc2Instruction(cg, TR::InstOpCode::tst, node, srcReg, srcReg);
    generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, doneLabel);
 
    if (gcMode != gc_modron_wrtbar_always)
@@ -1683,11 +1683,11 @@ void OMR::ARM::TreeEvaluator::VMwrtbarEvaluator(TR::Node *node, TR::Register *sr
       // check to see if colour bits give hint (read FLAGS field of J9Object).
 // @@ getWordOffsetToGCFlags() and getWriteBarrierGCFlagMaskAsByte() are missing in TR_FrontEnd
 // @@      if (flagReg == NULL)
-// @@         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(dstReg, fej9->getWordOffsetToGCFlags(), cg));
-// @@      generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_and_r, node, tempReg, tempReg, new (cg->trHeapMemory()) TR_ARMOperand2(fej9->getWriteBarrierGCFlagMaskAsByte(), 8));
+// @@         generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(dstReg, fej9->getWordOffsetToGCFlags(), cg));
+// @@      generateTrg1Src2Instruction(cg, TR::InstOpCode::and_r, node, tempReg, tempReg, new (cg->trHeapMemory()) TR_ARMOperand2(fej9->getWriteBarrierGCFlagMaskAsByte(), 8));
       }
 
-   TR::Instruction *cursor = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl,
+   TR::Instruction *cursor = generateImmSymInstruction(cg, TR::InstOpCode::bl,
                                         node, (uintptr_t)wbref->getMethodAddress(),
                                         new (cg->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0, 0, cg->trMemory()),
                                         wbref, NULL);

--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -82,7 +82,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
 
    _incLabel->setCodeLocation(buffer);
 
-   opcode.setOpCodeValue(ARMOp_mvn);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_mvn);
    buffer = opcode.copyBinaryToBuffer(buffer);
    tempReg->setRegisterFieldRD((uint32_t *)buffer);
    // OBJECT_HEADER_LOCK_BITS_MASK          is 0xFF
@@ -92,7 +92,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | 0x1 << 25 | (OBJECT_HEADER_LOCK_BITS_MASK - OBJECT_HEADER_LOCK_LAST_RECURSION_BIT));
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(ARMOp_and);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_and);
    buffer = opcode.copyBinaryToBuffer(buffer);
    tempReg->setRegisterFieldRD((uint32_t *)buffer);
    dataReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -100,21 +100,21 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(ARMOp_cmp);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_cmp);
    buffer = opcode.copyBinaryToBuffer(buffer);
    metaReg->setRegisterFieldRN((uint32_t *)buffer);
    tempReg->setRegisterFieldRM((uint32_t *)buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(ARMOp_add);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_add);
    buffer = opcode.copyBinaryToBuffer(buffer);
    dataReg->setRegisterFieldRD((uint32_t *)buffer);
    dataReg->setRegisterFieldRN((uint32_t *)buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 25 | LOCK_INC_DEC_VALUE);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(ARMOp_str);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_str);
    buffer = opcode.copyBinaryToBuffer(buffer);
    dataReg->setRegisterFieldRD((uint32_t *)buffer);
    addrReg->setRegisterFieldRN((uint32_t *)buffer); // offset_12 = 0, U = X, B = 0, L = 0
@@ -122,7 +122,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    // No modification needed
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(ARMOp_b);
+   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
    buffer = opcode.copyBinaryToBuffer(buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | ((getRestartLabel()->getCodeLocation() - buffer - 8) >> 2) & 0x00FFFFFF);
    buffer += ARM_INSTRUCTION_LENGTH;
@@ -279,7 +279,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= 8;
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_b);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
       buffer = opcode.copyBinaryToBuffer(buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | ((getRestoreAndCallLabel()->getCodeLocation()-buffer) >> 2) & 0x00FFFFFF);
       buffer += ARM_INSTRUCTION_LENGTH;
@@ -387,7 +387,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    else
 #endif
       {
-      opcode.setOpCodeValue(ARMOp_mvn);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_mvn);
       buffer = opcode.copyBinaryToBuffer(buffer);
       threadReg->setRegisterFieldRD((uint32_t *)buffer);
       // 32-bit immediate shifter_operand
@@ -396,7 +396,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | 0x1 << 25 | OBJECT_HEADER_LOCK_RECURSION_MASK);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_and);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_and);
       buffer = opcode.copyBinaryToBuffer(buffer);
       threadReg->setRegisterFieldRD((uint32_t *)buffer);
       monitorReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -404,21 +404,21 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_cmp);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_cmp);
       buffer = opcode.copyBinaryToBuffer(buffer);
       metaReg->setRegisterFieldRN((uint32_t *)buffer);
       threadReg->setRegisterFieldRM((uint32_t *)buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_sub);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_sub);
       buffer = opcode.copyBinaryToBuffer(buffer);
       monitorReg->setRegisterFieldRD((uint32_t *)buffer);
       monitorReg->setRegisterFieldRN((uint32_t *)buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 25 | (LOCK_INC_DEC_VALUE & 0xFFFF));
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_str);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_str);
       buffer = opcode.copyBinaryToBuffer(buffer);
       monitorReg->setRegisterFieldRD((uint32_t *)buffer);
       objReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -427,7 +427,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 24 | 0x1 << 23 | _lwOffset & 0xFFF);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(ARMOp_b);
+      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
       buffer = opcode.copyBinaryToBuffer(buffer);
       // Back to restartLabel
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 |((getRestartLabel()->getCodeLocation() - buffer - 8) >> 2) & 0x00FFFFFF);

--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -82,7 +82,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
 
    _incLabel->setCodeLocation(buffer);
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_mvn);
+   opcode.setOpCodeValue(TR::InstOpCode::mvn);
    buffer = opcode.copyBinaryToBuffer(buffer);
    tempReg->setRegisterFieldRD((uint32_t *)buffer);
    // OBJECT_HEADER_LOCK_BITS_MASK          is 0xFF
@@ -92,7 +92,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | 0x1 << 25 | (OBJECT_HEADER_LOCK_BITS_MASK - OBJECT_HEADER_LOCK_LAST_RECURSION_BIT));
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_and);
+   opcode.setOpCodeValue(TR::InstOpCode::and_);
    buffer = opcode.copyBinaryToBuffer(buffer);
    tempReg->setRegisterFieldRD((uint32_t *)buffer);
    dataReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -100,21 +100,21 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_cmp);
+   opcode.setOpCodeValue(TR::InstOpCode::cmp);
    buffer = opcode.copyBinaryToBuffer(buffer);
    metaReg->setRegisterFieldRN((uint32_t *)buffer);
    tempReg->setRegisterFieldRM((uint32_t *)buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_add);
+   opcode.setOpCodeValue(TR::InstOpCode::add);
    buffer = opcode.copyBinaryToBuffer(buffer);
    dataReg->setRegisterFieldRD((uint32_t *)buffer);
    dataReg->setRegisterFieldRN((uint32_t *)buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 25 | LOCK_INC_DEC_VALUE);
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_str);
+   opcode.setOpCodeValue(TR::InstOpCode::str);
    buffer = opcode.copyBinaryToBuffer(buffer);
    dataReg->setRegisterFieldRD((uint32_t *)buffer);
    addrReg->setRegisterFieldRN((uint32_t *)buffer); // offset_12 = 0, U = X, B = 0, L = 0
@@ -122,7 +122,7 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    // No modification needed
    buffer += ARM_INSTRUCTION_LENGTH;
 
-   opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
+   opcode.setOpCodeValue(TR::InstOpCode::b);
    buffer = opcode.copyBinaryToBuffer(buffer);
    *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | ((getRestartLabel()->getCodeLocation() - buffer - 8) >> 2) & 0x00FFFFFF);
    buffer += ARM_INSTRUCTION_LENGTH;
@@ -279,7 +279,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= 8;
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
+      opcode.setOpCodeValue(TR::InstOpCode::b);
       buffer = opcode.copyBinaryToBuffer(buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | ((getRestoreAndCallLabel()->getCodeLocation()-buffer) >> 2) & 0x00FFFFFF);
       buffer += ARM_INSTRUCTION_LENGTH;
@@ -387,7 +387,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    else
 #endif
       {
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_mvn);
+      opcode.setOpCodeValue(TR::InstOpCode::mvn);
       buffer = opcode.copyBinaryToBuffer(buffer);
       threadReg->setRegisterFieldRD((uint32_t *)buffer);
       // 32-bit immediate shifter_operand
@@ -396,7 +396,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28 | 0x1 << 25 | OBJECT_HEADER_LOCK_RECURSION_MASK);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_and);
+      opcode.setOpCodeValue(TR::InstOpCode::and_);
       buffer = opcode.copyBinaryToBuffer(buffer);
       threadReg->setRegisterFieldRD((uint32_t *)buffer);
       monitorReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -404,21 +404,21 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_cmp);
+      opcode.setOpCodeValue(TR::InstOpCode::cmp);
       buffer = opcode.copyBinaryToBuffer(buffer);
       metaReg->setRegisterFieldRN((uint32_t *)buffer);
       threadReg->setRegisterFieldRM((uint32_t *)buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeAL) << 28);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_sub);
+      opcode.setOpCodeValue(TR::InstOpCode::sub);
       buffer = opcode.copyBinaryToBuffer(buffer);
       monitorReg->setRegisterFieldRD((uint32_t *)buffer);
       monitorReg->setRegisterFieldRN((uint32_t *)buffer);
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 25 | (LOCK_INC_DEC_VALUE & 0xFFFF));
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_str);
+      opcode.setOpCodeValue(TR::InstOpCode::str);
       buffer = opcode.copyBinaryToBuffer(buffer);
       monitorReg->setRegisterFieldRD((uint32_t *)buffer);
       objReg->setRegisterFieldRN((uint32_t *)buffer);
@@ -427,7 +427,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 | 0x1 << 24 | 0x1 << 23 | _lwOffset & 0xFFF);
       buffer += ARM_INSTRUCTION_LENGTH;
 
-      opcode.setOpCodeValue(TR::InstOpCode::ARMOp_b);
+      opcode.setOpCodeValue(TR::InstOpCode::b);
       buffer = opcode.copyBinaryToBuffer(buffer);
       // Back to restartLabel
       *(int32_t *)buffer |= ((uint32_t)(ARMConditionCodeEQ) << 28 |((getRestartLabel()->getCodeLocation() - buffer - 8) >> 2) & 0x00FFFFFF);

--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -186,7 +186,7 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
    bool skipOneReturn = false;
    while (cursorInstruction)
       {
-      if (cursorInstruction->getOpCodeValue() == ARMOp_ret)
+      if (cursorInstruction->getOpCodeValue() == TR::InstOpCode::retn)
          {
          if (skipOneReturn == false)
             {

--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -170,7 +170,7 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
 
    cursorInstruction = cg->getFirstInstruction();
 
-   while (cursorInstruction && cursorInstruction->getOpCodeValue() != ARMOp_proc)
+   while (cursorInstruction && cursorInstruction->getOpCodeValue() != TR::InstOpCode::proc)
       {
       estimate          = cursorInstruction->estimateBinaryLength(estimate);
       cursorInstruction = cursorInstruction->getNext();

--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -245,7 +245,7 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
       armLoadConstant(node, CARD_DIRTY, temp2Reg, cg);
       generateMemSrc1Instruction(cg, ARMOp_strb, node, new (cg->trHeapMemory()) TR::MemoryReference(temp1Reg, temp3Reg, 1, cg), temp2Reg);
 
-      generateLabelInstruction(cg, ARMOp_label, node, noChkLabel, deps);
+      generateLabelInstruction(cg, TR::InstOpCode::label, node, noChkLabel, deps);
       }
 
    }
@@ -332,7 +332,7 @@ void J9::ARM::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register 
 
       if (gcMode != gc_modron_wrtbar_always)
          {
-         generateLabelInstruction(cg, ARMOp_label, node, doneLabel, conditions);
+         generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
          }
 
       cg->machine()->setLinkRegisterKilled(true);

--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,10 +106,10 @@ J9::ARM::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool 
 
       TR::Register    *targetRegister = cg->evaluate(reference);
 
-      generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_tst, node, targetRegister, targetRegister);
+      generateSrc2Instruction(cg, TR::InstOpCode::tst, node, targetRegister, targetRegister);
 
       TR::SymbolReference *NULLCHKException = node->getSymbolReference();
-      TR::Instruction *instr1 = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)NULLCHKException->getMethodAddress(), NULL, NULLCHKException, NULL, NULL, ARMConditionCodeEQ);
+      TR::Instruction *instr1 = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)NULLCHKException->getMethodAddress(), NULL, NULLCHKException, NULL, NULL, ARMConditionCodeEQ);
       instr1->ARMNeedsGCMap(0xFFFFFFFF);
       cg->machine()->setLinkRegisterKilled(true);
       }
@@ -208,7 +208,7 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
          {
          uint32_t base, rotate;
 
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp1Reg,
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp1Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, privateFlags), cg));
 
          // The value for J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE is a generated value when VM code is created
@@ -218,32 +218,32 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
          TR_ASSERT(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >= 0x00010000 && J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE <= 0x80000000,
                "Concurrent mark active Value assumption broken.");
          constantIsImmed8r(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, &base, &rotate);
-         generateSrc1ImmInstruction(cg, TR::InstOpCode::ARMOp_tst, node, temp1Reg, base, rotate);
+         generateSrc1ImmInstruction(cg, TR::InstOpCode::tst, node, temp1Reg, base, rotate);
          generateConditionalBranchInstruction(cg, node, ARMConditionCodeEQ, noChkLabel);
          }
 
       uintptr_t card_size_shift = trailingZeroes((uint32_t) options->getGcCardSize());
 
       // temp3Reg = dstReg - heapBaseForBarrierRange0
-      generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp3Reg,
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp3Reg,
             new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapBaseForBarrierRange0), cg));
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_sub, node, temp3Reg, dstReg, temp3Reg);
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::sub, node, temp3Reg, dstReg, temp3Reg);
 
       if (!definitelyHeapObject)
          {
          // if (temp3Reg >= heapSizeForBarrierRange0), object not in the heap
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp1Reg,
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp1Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapSizeForBarrierRange0), cg));
-         generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, temp3Reg, temp1Reg);
+         generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, temp3Reg, temp1Reg);
          generateConditionalBranchInstruction(cg, node, ARMConditionCodeCS, noChkLabel);
          }
 
       // dirty(activeCardTableBase + temp3Reg >> card_size_shift)
-      generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp1Reg,
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp1Reg,
             new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, activeCardTableBase), cg));
       generateShiftRightImmediate(cg, node, temp3Reg, temp3Reg, card_size_shift, true);
       armLoadConstant(node, CARD_DIRTY, temp2Reg, cg);
-      generateMemSrc1Instruction(cg, TR::InstOpCode::ARMOp_strb, node, new (cg->trHeapMemory()) TR::MemoryReference(temp1Reg, temp3Reg, 1, cg), temp2Reg);
+      generateMemSrc1Instruction(cg, TR::InstOpCode::strb, node, new (cg->trHeapMemory()) TR::MemoryReference(temp1Reg, temp3Reg, 1, cg), temp2Reg);
 
       generateLabelInstruction(cg, TR::InstOpCode::label, node, noChkLabel, deps);
       }
@@ -310,14 +310,14 @@ void J9::ARM::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register 
          TR::Register *metaReg = cg->getMethodMetaDataRegister();
 
          // temp1Reg = dstObjReg - heapBaseForBarrierRange0
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp1Reg,
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp1Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapBaseForBarrierRange0), cg));
-         generateTrg1Src2Instruction(cg, TR::InstOpCode::ARMOp_sub, node, temp1Reg, dstObjReg, temp1Reg);
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::sub, node, temp1Reg, dstObjReg, temp1Reg);
 
          // if (temp1Reg >= heapSizeForBarrierRange0), object not in the tenured area
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ARMOp_ldr, node, temp2Reg,
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, node, temp2Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapSizeForBarrierRange0), cg));
-         generateSrc2Instruction(cg, TR::InstOpCode::ARMOp_cmp, node, temp1Reg, temp2Reg);
+         generateSrc2Instruction(cg, TR::InstOpCode::cmp, node, temp1Reg, temp2Reg);
          generateConditionalBranchInstruction(cg, node, ARMConditionCodeCS, doneLabel);
          }
       else
@@ -327,7 +327,7 @@ void J9::ARM::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register 
 
       TR::addDependency(conditions, dstObjReg, TR::RealRegister::gr0, TR_GPR, cg);
 
-      TR::Instruction *gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::ARMOp_bl, node, (uintptr_t)wbRef->getSymbol()->castToMethodSymbol()->getMethodAddress(), NULL, wbRef);
+      TR::Instruction *gcPoint = generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)wbRef->getSymbol()->castToMethodSymbol()->getMethodAddress(), NULL, wbRef);
       gcPoint->ARMNeedsGCMap(0xFFFFFFFF);
 
       if (gcMode != gc_modron_wrtbar_always)


### PR DESCRIPTION
This is a continuation of #12897 which eliminates the ".temp.defines" file and finishes off moving all the ARM instruction mnemonics inside the TR::InstOpCode class. See each commit comment to understand what was done. Each individual commit builds on its own.

Depends on eclipse/omr#6070