### PR TITLE
Add ExcludeTestAnnotationTransformer listener to testUnreflect

### DIFF
--- a/test/functional/Java9andUp/playlist.xml
+++ b/test/functional/Java9andUp/playlist.xml
@@ -54,7 +54,7 @@
 	<test>
 		<testCaseName>UnreflectTests</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.unnamed$(Q) \
+		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.unnamed$(Q) \
 		--module-path $(Q)$(TEST_RESROOT)$(D)module_bin$(Q) \
 		--add-modules org.openj9test.modularity.testUnreflect,org.openj9test.modularity.dummy \
 		--add-exports org.openj9test.modularity.testUnreflect/org.openj9.test.modularity.tests=ALL-UNNAMED \

--- a/test/functional/Java9andUp/testUnreflect.xml
+++ b/test/functional/Java9andUp/testUnreflect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- Copyright (c) 2018, 2018 IBM Corp. and others This program and the accompanying 
+<!-- Copyright (c) 2018, 2021 IBM Corp. and others This program and the accompanying
 	materials are made available under the terms of the Eclipse Public License 
 	2.0 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ 
 	or the Apache License, Version 2.0 which accompanies this distribution and 
@@ -17,6 +17,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <!--  We need a separate file because the classes mentioned in the normal testng.xml are not visible. -->
 <suite name="Java9andUp suite" parallel="none" verbose="2">
+	<listeners>
+		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer"/>
+	</listeners>
 	<test name="UnreflectTests">
 		<classes>
 			<class name="org.openj9.test.modularity.tests.UnreflectTests" />


### PR DESCRIPTION
Related: #11935 & #12779 & https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/29

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>