### PR TITLE
JDK17+ : Try BootLoader if bootstrapClassLoader didn't find the native

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -64,6 +64,7 @@ import sun.reflect.CallerSensitive;
 /*[ENDIF]*/
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
+import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.NativeLibraries;
 import jdk.internal.loader.NativeLibrary;
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
@@ -2042,9 +2043,12 @@ static void loadLibrary(Class<?> caller, String libName) {
 static long findNative(ClassLoader loader, String entryName) {
 	long result = 0;
 	if (loader == null) {
-		result = bootstrapClassLoader.nativelibs.find(entryName);
-	} else {
-		result = loader.nativelibs.find(entryName);
+		loader = bootstrapClassLoader;
+	}
+	result = loader.nativelibs.find(entryName);
+	if ((result == 0) && (loader == bootstrapClassLoader)) {
+		// Try BootLoader if bootstrapClassLoader didn't find the native.
+		result = BootLoader.getNativeLibraries().find(entryName);
 	}
 	return result;
 }

--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2020 IBM Corp. and others
+// Copyright (c) 2006, 2021 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -185,7 +185,7 @@ TraceExit=Trc_SC_Listen_Exit NoEnv Overhead=1 Level=1 Template="JVM_Listen -- re
 
 TraceEntry=Trc_SC_LoadLibrary_Entry NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary(name=%s)"
 TraceExit-Exception=Trc_SC_LoadLibrary_Error Obsolete NoEnv Overhead=1 Level=1 Template="JVM_LoadLibrary -- error. Return %d"
-TraceExit=Trc_SC_LoadLibrary_Exit NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary -- return %d"
+TraceExit=Trc_SC_LoadLibrary_Exit Obsolete NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary -- return %d"
 
 TraceEntry=Trc_SC_Lseek_Entry NoEnv Overhead=1 Level=3 Template="JVM_Lseek(descriptor=%d, bytesToSeek=%lld, origin=%d)"
 TraceExit-Exception=Trc_SC_Lseek_bad_descriptor NoEnv Overhead=1 Level=1 Template="invalid descriptor"
@@ -348,3 +348,5 @@ TraceEntry=Trc_SC_UnloadLibrary_Entry NoEnv Overhead=1 Level=2 Template="JVM_Unl
 TraceEvent=Trc_SC_LoadLibrary_BootStrap NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) Bootstrap library"
 TraceEvent=Trc_SC_LoadLibrary_OpenShared NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) j9sl_open_shared_library"
 TraceEvent=Trc_SC_LoadLibrary_OpenShared_Decorate NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) j9sl_open_shared_library J9PORT_SLOPEN_DECORATE"
+
+TraceExit=Trc_SC_LoadLibrary_Exit NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary -- return 0x%zx"

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -810,10 +810,10 @@ TraceEntry=Trc_VM_lookupJNINative_Entry Overhead=1 Level=3 Template="lookupJNINa
 TraceEvent=Trc_VM_lookupJNINative_NullNativeLibrary Overhead=1 Level=3 Template="lookupJNINative (null native library) - nativeMethod (%p) symbolName (%s) signature (%s) functionAddress (%p)"
 TraceExit=Trc_VM_lookupJNINative_Exit Overhead=1 Level=3 Template="lookupJNINative - nativeLibrary (%p) nativeMethod (%p) nativeMethod->extra (%p) symbolName (%s) signature (%s) lookupResult (%zu)"
 TraceEntry=Trc_VM_lookupNativeAddress_Entry Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) shortJNI (%s) functionArgCount (%zu) bindJNINative (%zu)"
-TraceExit=Trc_VM_lookupNativeAddress_inlIntercept_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) rc (%zu)"
-TraceExit=Trc_VM_lookupNativeAddress_bindmethod_shortJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) shortJNI (%s) argSignature (%s)"
-TraceExit=Trc_VM_lookupNativeAddress_bindmethod_longJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) argSignature (%s)"
-TraceExit=Trc_VM_lookupNativeAddress_fail_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) argSignature (%s)"
+TraceExit=Trc_VM_lookupNativeAddress_inlIntercept_Exit Overhead=1 Level=3 Template="lookupNativeAddress : inlIntercept exit - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) rc (%zu)"
+TraceExit=Trc_VM_lookupNativeAddress_bindmethod_shortJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress : bind success - nativeLibrary (%p) nativeMethod (%p) shortJNI (%s) argSignature (%s)"
+TraceExit=Trc_VM_lookupNativeAddress_bindmethod_longJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress : bind success - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) argSignature (%s)"
+TraceExit=Trc_VM_lookupNativeAddress_fail_Exit Overhead=1 Level=3 Template="lookupNativeAddress : failed exit - nativeLibrary (%p) nativeMethod (%p) argSignature (%s)"
 
 TraceEntry=Trc_VM_registerBootstrapLibrary_Entry Overhead=1 Level=3 Template="registerBootstrapLibrary - libName (%s) libraryPtr (%p)"
 TraceExit=Trc_VM_registerBootstrapLibrary_Exit Overhead=1 Level=3 Template="registerBootstrapLibrary - libName (%s) libraryPtr (%p) result (%zu)"
@@ -880,3 +880,4 @@ TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentPackage
 
 TraceEvent=Trc_VM_callin_stackFree Overhead=1 Level=5 Template="OS Stack free=%zi, current native sp=%p"
 
+TraceEvent=Trc_VM_classLoaderRegisterLibrary_newNativeLibrary Overhead=1 Level=5 Template="classLoaderRegisterLibrary -- newNativeLibrary (0x%p) handle (0x%zx) logicalName (%s) name (%s) rc (0x%zx)"


### PR DESCRIPTION
Try `BootLoader.getNativeLibraries().find(entryName)` if `bootstrapClassLoader.nativelibs.find(entryName)` didn't succeed;
Add trace points;
Refactoring methods affected.

This fixes an internal test failure with following stack trace
```
java.lang.UnsatisfiedLinkError: apple/security/KeychainStore._scanKeychain()V
	at java.base/apple.security.KeychainStore.engineLoad(KeychainStore.java:769)
	at java.base/java.security.KeyStoreSpi.engineLoad(KeyStoreSpi.java:439)
	at java.base/java.security.KeyStoreSpi.engineLoad(KeyStoreSpi.java:403)
	at java.base/java.security.KeyStore.load(KeyStore.java:1506)
	at java.base/java.security.KeyStore$Builder$2$1.run(KeyStore.java:2193)
	at java.base/java.security.KeyStore$Builder$2$1.run(KeyStore.java:2182)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:774)
	at java.base/java.security.KeyStore$Builder$2.getKeyStore(KeyStore.java:2228)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>