### PR TITLE
AArch64: Add arraycopy helpers

### DIFF
--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@
 ################################################################################
 
 j9jit_files(
+	${omr_SOURCE_DIR}/compiler/aarch64/runtime/ARM64arrayCopy.spp
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/CodeSync.cpp
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 	aarch64/runtime/ARM64RelocationTarget.cpp

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -19,6 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
 JIT_PRODUCT_BACKEND_SOURCES+= \
+    omr/compiler/aarch64/runtime/ARM64arrayCopy.spp \
     omr/compiler/aarch64/runtime/CodeSync.cpp \
     omr/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -601,6 +601,9 @@ JIT_HELPER(_interpreterDoubleStaticGlue);
 JIT_HELPER(_interpreterSyncDoubleStaticGlue);
 JIT_HELPER(_nativeStaticHelper);
 JIT_HELPER(_interfaceDispatch);
+JIT_HELPER(__arrayCopy);
+JIT_HELPER(__forwardArrayCopy);
+JIT_HELPER(__backwardArrayCopy);
 
 #elif defined(TR_HOST_S390)
 JIT_HELPER(__double2Long);
@@ -1580,6 +1583,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARM64floatRemainder,                    (void *) helperCFloatRemainderFloat,       TR_Helper);
    SET(TR_ARM64doubleRemainder,                   (void *) helperCDoubleRemainderDouble,     TR_Helper);
    SET(TR_ARM64jitCollapseJNIReferenceFrame,      (void *) jitCollapseJNIReferenceFrame,     TR_Helper);
+   SET(TR_ARM64arrayCopy,                         (void *) __arrayCopy,                      TR_Helper);
+   SET(TR_ARM64forwardArrayCopy,                  (void *) __forwardArrayCopy,               TR_Helper);
+   SET(TR_ARM64backwardArrayCopy,                 (void *) __backwardArrayCopy,              TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390double2Long,                                (void *) 0,                                              TR_Helper);


### PR DESCRIPTION
This commit adds helper entries for arraycopy for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>