### PR TITLE
Add a flag to method metadata indicating a remote compilation

### DIFF
--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1524,6 +1524,11 @@ createMethodMetaData(
    if (*comp->getMetadataAssumptionList())
       static_cast<TR::SentinelRuntimeAssumption *>(*(comp->getMetadataAssumptionList()))->setOwningMetadata(data);
 
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isOutOfProcessCompilation())
+      data->flags |= JIT_METADATA_IS_REMOTE_COMP;
+#endif
+
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
    if (vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -554,6 +554,7 @@ typedef struct J9JITExceptionTable {
 #define JIT_METADATA_GC_MAP_32_BIT_OFFSETS 0x2
 #define JIT_METADATA_IS_STUB 0x4
 #define JIT_METADATA_NOT_INITIALIZED 0x8
+#define JIT_METADATA_IS_REMOTE_COMP 0x10
 
 typedef struct J9JIT16BitExceptionTableEntry {
 	U_16 startPC;


### PR DESCRIPTION
When `TR_MethodMetaData` is created on the server, set a flag
to indicate that the compilation was done remotely.
This is useful for diagnostic purposes.

Closes: #12921