### PR TITLE
JDK17 requires JavaLangAccess.exit(status) implementation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -506,12 +506,10 @@ final class Access implements JavaLangAccess {
 		return ClassLoader.findNative(loader, entryName);
 	}
 
-	/*[IF JAVA_SPEC_VERSION >= 18]*/
 	@Override
 	public void exit(int status) {
 		Shutdown.exit(status);
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
 	/*[ENDIF] OPENJDK_METHODHANDLES*/
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */


### PR DESCRIPTION
Removed `JAVA_SPEC_VERSION >= 18` `JPP` decoration to make it available for `JDK17` as well.

`JDK17` builds w/ this PR, and produces `-version` output:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk17)
Eclipse OpenJ9 VM (build jdk17access-5f07ceea2a, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210618_000000 (JIT enabled, AOT enabled)
OpenJ9   - 5f07ceea2a
OMR      - b7eb96336
JCL      - 3b15ac03333 based on jdk-17+27)
```

closes https://github.com/eclipse-openj9/openj9/issues/13006

Signed-off-by: Jason Feng <fengj@ca.ibm.com>