### PR TITLE
Fix TR_ValueProfiler initialization to allow arraycopy length profiling

### DIFF
--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -211,7 +211,7 @@ class TR_PersistentProfileInfo
    private:
    /**
     * This data structure contains all the fields required for serializing an object of TR_PersistentProfileInfo.
-    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are 
+    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are
     * represented as bool to indicate their absence/presence instead of storing the raw address.
     */
    struct SerializedPPI {
@@ -380,7 +380,7 @@ class TR_ValueProfiler : public TR_RecompilationProfiler
    {
    public:
    TR_ValueProfiler(TR::Compilation * c, TR::Recompilation * r, TR_ValueInfoSource profiler = LinkedListProfiler) :
-      TR_RecompilationProfiler(c, r, initialCompilation),
+      TR_RecompilationProfiler(c, r),
       _bdClass(NULL),
       _stringClass(NULL),
       _defaultProfiler(profiler),
@@ -750,7 +750,7 @@ class TR_BlockFrequencyInfo
 
    /**
     * This data structure contains all the fields required for serializing an object of TR_PersistentProfileInfo.
-    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are 
+    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are
     * represented as bool to indicate their absence/presence instead of storing the raw address.
     */
    struct SerializedBFI
@@ -913,7 +913,7 @@ class TR_CallSiteInfo
 
    /**
     * This data structure contains all the fields required for serializing an object of TR_PersistentProfileInfo.
-    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are 
+    * Members of primitive type are represented as it is, and the pointer types which can have NULL value are
     * represented as bool to indicate their absence/presence instead of storing the raw address.
     */
    struct SerializedCSI


### PR DESCRIPTION
The JIT no longer value profiles arraycopy lengths and I believe it is due to a subtle bug introduced when value profiling with JProfiling was first implemented.

Arraycopy length profiling was designed to not occur in the first compilation of a method, and checks a flag (`initialCompilation`) set in the `TR_RecompilationProfiler` object to determine that.   This flag is always `true`, however, due to what I believe is a bug during initialization of the `TR_RecompilationProfiler` class.  The flag is set in [1] and never changed.

However, I don't think this was intended.  The API prior to JProfiling being introduced looked like [2].  The flag `initialCompilation` was actually the name of an optional parameter to `TR_ValueProfiler` (defaults to `false`) in the original code that is simply passed into the superclass `TR_RecompilationProfiler`.  When the API was refactored for JProfiling the `initialCompilation` variable was retained, but this also happens to be the same name as the flag.

Prior to JProfiling, the `initialCompilation` flag was never set when creating a `TR_ValueProfiler`.  The flag was simply eaten by the constructor [3].  I suspect always setting this flag was a refactoring oversight when JProfiling was introduced as the fact that a profiling compile is the initial compile is simply not true.  The default setting of this flag should be removed.

With this fix, I verified that arraycopy length profiling is occurring and the results of that profiling are consumed in a subsequent compile.

[1] https://github.com/eclipse-openj9/openj9/blob/fa5a8b31b0db6c151ae3a72510aa58f095940087/runtime/compiler/runtime/J9Profiler.hpp#L382
[2] https://github.com/eclipse-openj9/openj9/blob/c891a1ec849af59092611b42b4d710926cb6546f/runtime/compiler/trj9/runtime/J9Profiler.hpp#L283
[3] https://github.com/eclipse-openj9/openj9/blob/c891a1ec849af59092611b42b4d710926cb6546f/runtime/compiler/trj9/runtime/J9Profiler.hpp#L186
