### PR TITLE
Simplify the logic for identifying minimum free size for sweeping

### DIFF
--- a/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
+++ b/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
@@ -22,13 +22,16 @@
 
 #include "j9.h"
 #include "j9cfg.h"
+#include "omrcomp.h"
 
 #include "SweepHeapSectioningVLHGC.hpp"
+#include "SweepPoolManager.hpp"
 
 #include "EnvironmentBase.hpp"
 #include "HeapRegionIteratorVLHGC.hpp"
 #include "HeapRegionDescriptorVLHGC.hpp"
 #include "HeapRegionManager.hpp"
+#include "MemoryPool.hpp"
 #include "MemorySubSpace.hpp"
 #include "ParallelDispatcher.hpp"
 
@@ -153,6 +156,8 @@ MM_SweepHeapSectioningVLHGC::reassignChunks(MM_EnvironmentBase *env)
 				chunk->chunkBase = (void *)heapChunkBase;
 				chunk->chunkTop = (void *)heapChunkTop;
 				chunk->memoryPool = pool;
+				Assert_MM_true(NULL != pool);
+				chunk->_minFreeSize = OMR_MAX(pool->getMinimumFreeEntrySize(), pool->getSweepPoolManager()->getMinimumFreeSize());
 				chunk->_coalesceCandidate = (heapChunkBase != region->getLowAddress());
 				chunk->_previous= previousChunk;
 				if(NULL != previousChunk) {

--- a/runtime/gc_vlhgc/SweepPoolManagerVLHGC.hpp
+++ b/runtime/gc_vlhgc/SweepPoolManagerVLHGC.hpp
@@ -40,7 +40,6 @@ class MM_MemoryPool;
 class MM_SweepPoolManagerVLHGC : public MM_SweepPoolManagerAddressOrderedList
 {
 private:
-	uintptr_t _minimumFreeSize;
 protected:
 public:
 
@@ -52,7 +51,6 @@ protected:
 	 * if the size of free memory is changed, oldAddrTop will be set.
 	 */
 	MMINLINE virtual void addFreeMemoryPostProcess(MM_EnvironmentBase *env, MM_MemoryPoolAddressOrderedListBase *memoryPool, void *addrBase, void *addrTop, bool needSync, void *oldAddrTop = NULL);
-	MMINLINE virtual bool isEligibleForFreeMemory(MM_EnvironmentBase *env, MM_MemoryPoolAddressOrderedListBase *memoryPool, void* address, uintptr_t size);
 
 public:
 	static MM_SweepPoolManagerVLHGC *newInstance(MM_EnvironmentBase *env);
@@ -62,7 +60,6 @@ public:
 	 */
 	MM_SweepPoolManagerVLHGC(MM_EnvironmentBase *env)
 		: MM_SweepPoolManagerAddressOrderedList(env)
-		, _minimumFreeSize(0)
 	{
 		_typeId = __FUNCTION__;
 	}


### PR DESCRIPTION
Avoid callback check and retrieve minimum free entry size from
memorypool every time.

for Balanced GC case:
minimum free entry size = max(memorypool.minimumFreeEntrySize,
minimumFreeSize for Survivor).

depends on https://github.com/eclipse/omr/pull/6081

Signed-off-by: Lin Hu <linhu@ca.ibm.com>