### PR TITLE
Add missing bytecodes to ROM class walk

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -480,6 +480,8 @@ public class RomClassWalker extends ClassWalker {
 				|| (bc == JBinvokestatic)
 				|| (bc == JBinvokehandle)
 				|| (bc == JBinvokehandlegeneric)
+				|| (bc == JBinvokedynamic)
+				|| (bc == JBinvokeinterface)
 				|| (bc == JBnew)
 				|| (bc == JBdefaultvalue)
 				|| (bc == JBnewdup)

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -514,12 +514,20 @@ static void allSlotsInBytecodesDo(J9ROMClass* romClass, J9ROMMethod* method, J9R
 			case JBputstatic:
 			case JBgetfield:
 			case JBputfield:
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			case JBwithfield:
+#endif
 			case JBinvokevirtual:
 			case JBinvokespecial:
 			case JBinvokestatic:
 			case JBinvokehandle:
 			case JBinvokehandlegeneric:
+			case JBinvokedynamic:
+			case JBinvokeinterface:
 			case JBnew:
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			case JBdefaultvalue:
+#endif
 			case JBnewdup:
 			case JBanewarray:
 			case JBcheckcast:


### PR DESCRIPTION
Function `allSlotsInBytecodesDo` in ROM class walk
code walks bytecodes in a method, calling a slot callback
function for each bytecode argument.
The bytecode iterator in this function and identical function
in ddr code are missing handlers for some bytecodes, resulting
in pc being incremented by an incorrect amount.

Missing bytecode handlers:
- `JBinvokedynamic`
- `JBinvokeinterface`
- `JBdefaultvalue`
- `JBwithfield`