### PR TITLE
Add API to check J9ClassHasIdentity class flag

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -435,12 +435,12 @@ J9::CodeGenerator::lowerCompressedRefs(
       // object references they will have decompression or compression sequence for
       // the child being loaded or stored respectively. In case of storing
       // object reference, in some cases it might need actual object decompressed
-      // address. 
+      // address.
       // Due to above assumptions made by the codegen we should not do any
       // optimization here on compression/decompression sequence which could
       // break this assumption and lead to undefined behaviour.
       // See openj9#12597 for more details
-      
+
       // -J9JIT_COMPRESSED_POINTER-
       // if the value is known to be null or if using lowMemHeap, do not
       // generate a compression sequence
@@ -5111,6 +5111,10 @@ J9::CodeGenerator::isMonitorValueBasedOrValueType(TR::Node* monNode)
 
       //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
       if (clazz == self()->comp()->getObjectClassPointer())
+         return TR_no;
+
+      // J9ClassIsValueType is mutually exclusive to J9ClassHasIdentity
+      if (!TR::Compiler->om.areValueBasedMonitorChecksEnabled() && TR::Compiler->cls.classHasIdentity(clazz))
          return TR_no;
 
       if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,6 +94,18 @@ public:
    bool isValueTypeClass(TR_OpaqueClassBlock *);
    bool isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz);
    bool isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *);
+   /** \brief
+    *	    Checks whether a class implements `IdentityObject`/`IdentityInterface`
+    *
+    *  \param clazz
+    *     The class that is to be checked
+    *
+    *  \return
+    *    `true` if the class implements `IdentityObject`/`IdentityInterface`;
+    *    `false` otherwise (that is, if the class could be a value type,
+    *    or some abstract class, interface, or java/lang/Object)
+    */
+   bool classHasIdentity(TR_OpaqueClassBlock *clazz);
 
    /**
     * \brief

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -613,30 +613,19 @@ static TR_YesNoMaybe isValue(TR::VPConstraint *constraint)
    TR::Compilation *comp = TR::comp();
    TR_OpaqueClassBlock *clazz = type->getClass();
 
+   // No need to check array class type because array classes should be marked as having identity.
+   if (TR::Compiler->cls.classHasIdentity(clazz))
+      {
+      return TR_no;
+      }
+
    if (clazz == comp->getObjectClassPointer())
       {
       return type->isFixedClass() ? TR_no : TR_maybe;
       }
 
-   // Array types are never value types
-   //
-   if (TR::Compiler->cls.isClassArray(comp, clazz))
-      {
-      return TR_no;
-      }
-
    // Is the type either an abstract class or an interface (i.e., not a
    // concrete class)?  If so, it might be a value type.
-   //
-   // Future refinements:
-   //   The JVM will have classes whose instances must be identity
-   //   objects implement the java/lang/IdentityObject interface, including
-   //   array classes.  Once that happens, the check for isClassArray can
-   //   be replaced with a test of whether the component class implements
-   //   IdentityObject, and the test of !isConcreteClass can be refined
-   //   to distinguish abstract classes that implement IdentityObject from
-   //   those that do not, as well as interfaces that extend IdentityObject.
-   //
    if (!TR::Compiler->cls.isConcreteClass(comp, clazz))
       {
       return TR_maybe;
@@ -1560,40 +1549,28 @@ J9::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint
    //
    //   - Is no information available about the component type of the array?
    //     If not, assume it might be a value type.
+   //   - Is the component type definitely a identity type?
    //   - Is the component type definitely a value type?
-   //   - Is the component type an array class (i.e., is this an array of
-   //     arrays)?  If so, it's definitely not a value type.
    //   - Is the component type either an abstract class or an interface
    //     (i.e., not a concrete class)?  If so, it might be a value type.
    //   - Is the array an array of java/lang/Object?  See below.
    //   - Otherwise, it must be a concrete class known not to be a value
    //     type
    //
-   // Future refinements:
-   //   The JVM will have classes whose instances must be identity
-   //   objects implement the java/lang/IdentityObject interface, including
-   //   array classes.  Once that happens, the check for isClassArray can
-   //   be replaced with a test of whether the component class implements
-   //   IdentityObject, and the test of !isConcreteClass can be refined
-   //   to distinguish abstract classes that implement IdentityObject from
-   //   those that do not, as well as interfaces that extend IdentityObject.
-   //
-   //   Another potential improvement would be to look for fixed class
-   //   arrays of an interface type
-   //
    if (!arrayComponentClass)
       {
       return TR_maybe;
       }
 
+   // No need to check array class type because array classes should be marked as having identity.
+   if (TR::Compiler->cls.classHasIdentity(arrayComponentClass))
+      {
+      return TR_no;
+      }
+
    if (TR::Compiler->cls.isValueTypeClass(arrayComponentClass))
       {
       return TR_yes;
-      }
-
-   if (TR::Compiler->cls.isClassArray(comp(), arrayComponentClass))
-      {
-      return TR_no;
       }
 
    if (!TR::Compiler->cls.isConcreteClass(comp(), arrayComponentClass))


### PR DESCRIPTION
`J9ClassIsValueType` is mutually exclusive to `J9ClassHasIdentity`.  If the class implements `IdentityInterface`, it is not a value type.

Related to #12581