### PR TITLE
Add explicit assignment to workaround JDK8 zOS 64bit compiler issue

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -549,7 +549,11 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
-	translationFlags |= BCT_JavaMajorVersionShifted(JAVA_SPEC_VERSION);
+	{
+		/* majorVer is introduced to workaround JDK8 zOS 64bit compiler issue. */
+		U_32 majorVer = BCT_JavaMajorVersionShifted(JAVA_SPEC_VERSION);
+		translationFlags |= majorVer;
+	}
 #endif
 
 	/* TODO toss tracepoint?? Trc_BCU_internalLoadROMClass_AttemptExisting(vmThread, segment, romAvailable, bytesRequired); */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2048,7 +2048,7 @@ typedef struct J9BCTranslationData {
 #define BCT_MajorClassFileVersionMaskShift  24
 
 /* A given Java feature version uses class-file format (version) + 44. */
-#define BCT_JavaMajorVersionShifted(java_version)  ((44 + (I_32)(java_version)) << BCT_MajorClassFileVersionMaskShift)
+#define BCT_JavaMajorVersionShifted(java_version)  ((44 + (U_32)(java_version)) << BCT_MajorClassFileVersionMaskShift)
 /* When adding support for a new Java feature version, update this appropriately. */
 #define BCT_JavaMaxMajorVersionShifted  BCT_JavaMajorVersionShifted(18)
 


### PR DESCRIPTION
Add explicit assignment to workaround `JDK8` `zOS` `64bit` compiler issue.

Fixes an internal failure `RTC 145584`.

Related https://github.com/eclipse-openj9/openj9/pull/12935

Signed-off-by: Jason Feng <fengj@ca.ibm.com>