### PR TITLE
AArch64: Set correct instruction as implicit exception point

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9InstructionDelegate.cpp
+++ b/runtime/compiler/aarch64/codegen/J9InstructionDelegate.cpp
@@ -32,6 +32,13 @@ J9::ARM64::InstructionDelegate::encodeBranchToLabel(TR::CodeGenerator *cg, TR::A
    ((TR::ARM64CallSnippet *)ins->getCallSnippet())->setCallRA(cursor + ARM64_INSTRUCTION_LENGTH);
    }
 
+static bool
+isNPEThrowingInstruction(TR::InstOpCode::Mnemonic opCodeValue)
+{
+   return (opCodeValue != TR::InstOpCode::addimmx) && (opCodeValue != TR::InstOpCode::addx)
+      && (opCodeValue != TR::InstOpCode::prfm) && (opCodeValue != TR::InstOpCode::prfmimm) && (opCodeValue != TR::InstOpCode::prfmoff);
+}
+
 static void
 setupImplicitNullPointerExceptionImpl(TR::CodeGenerator *cg, TR::Instruction *instr, TR::Node *node, TR::MemoryReference *mr)
    {
@@ -47,14 +54,16 @@ setupImplicitNullPointerExceptionImpl(TR::CodeGenerator *cg, TR::Instruction *in
       // this instruction throws an implicit null check if:
       // 1. The treetop node is a NULLCHK node
       // 2. The memory reference of this instruction can cause a null pointer exception
-      // 3. The null check reference node must be a child of this node
-      // 4. This memory reference uses the same register as the null check reference
-      // 5. This is the first instruction in the evaluation of this null check node to have met all the conditions
+      // 3. The instruction throws NPE (prefetch or add does not throw it).
+      // 4. The null check reference node must be a child of this node
+      // 5. This memory reference uses the same register as the null check reference
+      // 6. This is the first instruction in the evaluation of this null check node to have met all the conditions
 
-      // Test conditions 1, 2, and 5
+      // Test conditions 1, 2, 3, and 6
       if(node != NULL & mr != NULL &&
          mr->getCausesImplicitNullPointerException() &&
          treeTopNode->getOpCode().isNullCheck() &&
+         isNPEThrowingInstruction(instr->getOpCodeValue()) &&
          cg->getImplicitExceptionPoint() == NULL)
          {
          // determine what the NULLcheck reference node is


### PR DESCRIPTION
Instructions which do not trigger NPE (such as `add` or `prfm`) must not be
marked as an implicit exception point.
For instruction sequence for read barrier, we need to manually
set a load instruction as an implicit exception point.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>