### PR TITLE
Set J9ClassHasIdentity for arrays

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3012,9 +3012,9 @@ fail:
 			 *                     + J9ClassCanSupportFastSubstitutability
 			 *
 			 *                   + J9ClassHasReferences
-			 *                  + J9ClassIsValueBased
-			 *                 + J9ClassHasIdentity (inherited)
-			 *                + Unused
+			 *                  + J9ClassRequiresPrePadding
+			 *                 + J9ClassIsValueBased
+			 *                + J9ClassHasIdentity (inherited)
 			 *
 			 *              + Unused
 			 *             + Unused
@@ -3266,8 +3266,10 @@ fail:
 					 * elements may be flattened arrays.
 					 */
 					ramArrayClass->classFlags |= (elementClass->classFlags & arrayFlags);
-
 				}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				ramArrayClass->classFlags |= J9ClassHasIdentity; 
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				ramArrayClass->leafComponentType = leafComponentType;
 				ramArrayClass->arity = arity;
 				ramArrayClass->componentType = elementClass;


### PR DESCRIPTION
1. Set J9ClassHasIdentity into array ramClass classFlags
2. Add the missing J9ClassRequiresPrePadding in the documentation of
ramClass classFlags. 

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>