### PR TITLE
Re-enable Test_AccessController:test_doPrivilegedFrameStackWalking

### DIFF
--- a/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
+++ b/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
@@ -26,8 +26,6 @@ org.openj9.test.java.lang.invoke.Test_MethodHandleInfo:test_RevealDirect_TargetV
 
 org.openj9.test.modularity.tests.UnreflectTests:testLookupUnreflectSpecial AN-https://github.com/eclipse-openj9/openj9/issues/11935 generic-all
 
-org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking AN-https://github.com/eclipse-openj9/openj9/issues/12690 generic-all
-
 com.ibm.j9.jsr292.MethodHandleTest:testBindTo AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
 com.ibm.j9.jsr292.AsTypeTest:testAll AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
 com.ibm.j9.jsr292.PermuteTest:testPermuteArguments AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all


### PR DESCRIPTION
Re-enable `Test_AccessController:test_doPrivilegedFrameStackWalking`

Note: https://github.com/eclipse-openj9/openj9/pull/12716/ enabled stackwalking to find `InjectedInvoker` frame which carries the actual caller `protectiondomain` just like `OpenJ9` `SecurityFrame`. A sample stacktrace looks like:
```
java.security.AccessControlException: Access denied ("java.util.PropertyPermission" "user.home" "read")
	at java.base/java.security.AccessController.throwACE(AccessController.java:176)
	at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:238)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:385)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:408)
	at java.base/java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1152)
	at java.base/java.lang.System.getProperty(System.java:574)
	at java.base/java.lang.System.getProperty(System.java:557)
	at a.se.ojdkmh.bootpath.TrustedCodePA$1.run(TrustedCodePA.java:13)
	at a.se.ojdkmh.bootpath.TrustedCodePA$1.run(TrustedCodePA.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:682)
	at java.base/java.lang.invoke.LambdaForm$DMH/0x0000000000000000.invokeStatic(LambdaForm$DMH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invoke(LambdaForm$MH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invokeExact_MT(LambdaForm$MH)
	at a.se.ojdkmh.TestAccDoPriv$$InjectedInvoker/0x0000000000000000.invoke_V(Unknown Source)
	at java.base/java.lang.invoke.LambdaForm$DMH/0x0000000000000000.invokeStatic(LambdaForm$DMH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invoke(LambdaForm$MH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invoke_MT(LambdaForm$MH)
	at a.se.ojdkmh.TestAccDoPriv.testAccDoPriv(TestAccDoPriv.java:32)
```
Now `org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking` passes.

closes https://github.com/eclipse-openj9/openj9/issues/12690

fyi @fengxue-IS 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>