### PR TITLE
delete getDependentLibs in lockWordAlignment build.xml

### DIFF
--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -40,7 +40,7 @@
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init,getDependentLibs" description="Using java ${JDK_VERSION} to compile the source ">
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>


### PR DESCRIPTION
fixes: #13056
[ci skip]

Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>