### PR TITLE
Add MN_TRUSTED_FINAL to MemberName flags

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -133,6 +133,9 @@ initImpl(J9VMThread *currentThread, j9object_t membernameObject, j9object_t refO
 		flags = fieldID->field->modifiers & CFR_FIELD_ACCESS_MASK;
 		flags |= MN_IS_FIELD;
 		flags |= (J9_ARE_ANY_BITS_SET(flags, J9AccStatic) ? MH_REF_GETSTATIC : MH_REF_GETFIELD) << MN_REFERENCE_KIND_SHIFT;
+		if (VM_VMHelpers::isTrustedFinalField(fieldID->field, fieldID->declaringClass->romClass)) {
+			flags |= MN_TRUSTED_FINAL;
+		}
 
 		nameObject = J9VMJAVALANGREFLECTFIELD_NAME(currentThread, refObject);
 		typeObject = J9VMJAVALANGREFLECTFIELD_TYPE(currentThread, refObject);
@@ -961,6 +964,10 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 
 					new_clazz = J9VM_J9CLASS_TO_HEAPCLASS(declaringClass);
 					new_flags = MN_IS_FIELD | (fieldID->field->modifiers & CFR_FIELD_ACCESS_MASK);
+					if (VM_VMHelpers::isTrustedFinalField(fieldID->field, fieldID->declaringClass->romClass)) {
+						new_flags |= MN_TRUSTED_FINAL;
+					}
+
 					romField = fieldID->field;
 
 					if (J9_ARE_ANY_BITS_SET(romField->modifiers, J9AccStatic)) {

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1812,6 +1812,28 @@ exit:
 		return result;
 	}
 
+	/**
+	 * Determine if the field is a trusted final field.
+	 *
+	 * A trusted final field must have be a static final field or
+	 * a final field defined in either a hidden class or Record class
+	 *
+	 * @param field the field to be checked
+	 * @param romClass the declaring class of the field
+	 * @return true if the field is trusted final. Otherwise, return false.
+	 */
+	static VMINLINE bool
+	isTrustedFinalField(J9ROMFieldShape *field, J9ROMClass *romClass)
+	{
+		bool result = false;
+		if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccFinal)) {
+			if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic) || J9ROMCLASS_IS_HIDDEN(romClass) || J9ROMCLASS_IS_RECORD(romClass)) {
+				result = true;
+			}
+		}
+		return result;
+	}
+
 	static VMINLINE void *
 	buildJITResolveFrameWithPC(J9VMThread *currentThread, UDATA flags, UDATA parmCount, UDATA spAdjust, void *oldPC)
 	{

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2243,6 +2243,7 @@ typedef struct J9ROMMethodHandleRef {
 #define MN_IS_FIELD			0x00040000
 #define MN_IS_TYPE			0x00080000
 #define MN_CALLER_SENSITIVE	0x00100000
+#define MN_TRUSTED_FINAL	0x00200000
 
 typedef struct J9ROMMethodRef {
 	U_32 classRefCPIndex;


### PR DESCRIPTION
This change fixes: 
`java/lang/invoke/unreflect/UnreflectTest.java`
`java/lang/invoke/VarHandles/accessibility/TestFieldLookupAccessibility.java`
in https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/29

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>