### PR TITLE
Fix typo in Artifactory cleanup

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -562,7 +562,7 @@ def cleanup_artifactory(artifactory_manual_cleanup, job_name, artifactory_server
             def cleanup_job_params = [
                 string(name: 'JOB_TYPE', value: 'COUNT'),
                 string(name: 'JOB_TO_CHECK', value: job_name),
-                string(name: 'ARTIFACTORY_SERVER', value: artifactory_repo),
+                string(name: 'ARTIFACTORY_SERVER', value: artifactory_server),
                 string(name: 'ARTIFACTORY_REPO', value: artifactory_repo),
                 string(name: 'ARTIFACTORY_NUM_ARTIFACTS', value: artifactory_num_artifacts)]
 


### PR DESCRIPTION
I can't think of a reason the server would be set to repo.
I think this never surfaced before now because the name and
repo were always the same. Looking at the original commit I'd
say it was a mistake.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>