### PR TITLE
z/OS jenkins build: Add a target to build JTreg test libraries

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -272,7 +272,7 @@ def checkoutRef (REF) {
 def build() {
     stage('Compile') {
         // 'all' target dependencies broken for zos, use 'images test-image-openj9'
-        def make_target = SPEC.contains('zos') ? 'images test-image-openj9 debug-image' : 'all'
+        def make_target = SPEC.contains('zos') ? 'images test-image-openj9 debug-image test-image-jdk-jtreg-native' : 'all'
         OPENJDK_CLONE_DIR = "${env.WORKSPACE}/${OPENJDK_CLONE_DIR}"
 
         withEnv(BUILD_ENV_VARS_LIST) {


### PR DESCRIPTION
Some of openjdk's JTreg tests falling under the `jdk` category also include
native libraries. These libraries need to be built for z/OS too, and be made
available in the test-images.tar.gz artifact generated by the builds. The
makefiles that build, link and copy these libraries have been suitably modified
on the z/OS repository. This pull request proposes the addition of the
`test-image-jdk-jtreg-native` target for z/OS JDK11 builds, to trigger
these makefile changes.

Please note that we cannot add the `test-images` target because it also
includes `test-image-hotspot-jtreg-native` - a target for building Hotspot
natives - which we wouldn't want to include for openj9.

Signed-off-by: Pushkar N Kulkarni <pushkar.nk@in.ibm.com>