### PR TITLE
Replace hard-code JAVA_MODULE_VERSION with JAVA_SPEC_VERSION_STRING

### DIFF
--- a/runtime/ddr/j9ddr.h
+++ b/runtime/ddr/j9ddr.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef J9_STR
-#define J9_STR_(x) #x
-#define J9_STR(x) J9_STR_(x)
 #endif
 
 struct OMRPortLibrary;

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -41,8 +41,6 @@ dumpCapabilities(J9JavaVM * vm, const jvmtiCapabilities *capabilities, const cha
 
 	j9tty_printf(PORTLIB, "%s\n", caption);
 
-#define J9_STR_(x) #x
-#define J9_STR(x) J9_STR_(x)
 #define PRINT_CAPABILITY(capability) if (capabilities->capability) j9tty_printf(PORTLIB, "\t%s\n", J9_STR(capability));
 
 	PRINT_CAPABILITY(can_tag_objects);

--- a/runtime/oti/j9comp.h
+++ b/runtime/oti/j9comp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,9 @@
 #define J9_ARE_ANY_BITS_SET(value, bits) OMR_ARE_ANY_BITS_SET((value), (bits))
 #define J9_ARE_ALL_BITS_SET(value, bits) OMR_ARE_ALL_BITS_SET((value), (bits))
 #define J9_ARE_NO_BITS_SET(value, bits) OMR_ARE_NO_BITS_SET((value), (bits))
+
+#define J9_STR_(x) #x
+#define J9_STR(x) J9_STR_(x)
 
 #if defined(RS6000) || defined(LINUX) || defined(OSX)
 #define J9UNIX

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -616,7 +616,6 @@ enum INIT_STAGE {
 #define SYSPROP_JDK_MODULE_PATCH "jdk.module.patch."
 #define SYSPROP_JDK_MODULE_ILLEGALACCESS "jdk.module.illegalAccess"
 #define JAVA_BASE_MODULE "java.base"
-#define JAVA_MODULE_VERSION "9"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."
 

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -575,9 +575,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	if (JAVA_SPEC_VERSION == 8) {
 		specificationVersion = "1.8";
 	} else {
-#define J9_STR_(x) #x
-#define J9_STR(x) J9_STR_(x)
-		specificationVersion = J9_STR(JAVA_SPEC_VERSION);
+		specificationVersion = JAVA_SPEC_VERSION_STRING;
 	}
 
 	/* Some properties (*.vm.*) are owned by the VM and need to be set early for all


### PR DESCRIPTION
Consolidate macro `J9_STR_`/`J9_STR` into `j9comp.h`;
Format refactoring within the methods affected.

close #13048 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>