### PR TITLE
Share common logic in SweepHeapSectioning base class

### DIFF
--- a/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
+++ b/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
@@ -29,40 +29,10 @@
 
 #include "EnvironmentBase.hpp"
 #include "HeapRegionIteratorVLHGC.hpp"
-#include "HeapRegionDescriptorVLHGC.hpp"
 #include "HeapRegionManager.hpp"
 #include "MemoryPool.hpp"
 #include "MemorySubSpace.hpp"
 #include "ParallelDispatcher.hpp"
-
-/**
- * Return the expected total sweep chunks that will be used in the system.
- * Called during initialization, this routine looks at the maximum size of the heap and expected
- * configuration (generations, regions, etc) and determines the approximate maximum number of chunks
- * that will be required for a sweep at any given time.  It is safe to underestimate the number of chunks,
- * as the sweep sectioning mechanism will compensate, but the expectation is that by having all
- * chunk memory allocated in one go will keep the data localized and fragment system memory less.
- * @return estimated upper bound number of chunks that will be required by the system.
- */
-UDATA
-MM_SweepHeapSectioningVLHGC::estimateTotalChunkCount(MM_EnvironmentBase *env)
-{
-	UDATA totalChunkCountEstimate;
-
-	if(0 == _extensions->parSweepChunkSize) {
-		/* -Xgc:sweepchunksize= has NOT been specified, so we set it heuristically.
-		 *
-		 *                  maxheapsize
-		 * chunksize =   ----------------   (rounded up to the nearest 256k)
-		 *               threadcount * 32
-		 */
-		_extensions->parSweepChunkSize = MM_Math::roundToCeiling(256*1024, _extensions->heap->getMaximumMemorySize() / (_extensions->dispatcher->threadCountMaximum() * 32));
-	}
-
-	totalChunkCountEstimate = MM_Math::roundToCeiling(_extensions->parSweepChunkSize, _extensions->heap->getMaximumMemorySize()) / _extensions->parSweepChunkSize;
-
-	return totalChunkCountEstimate;
-}
 
 /**
  * Walk all segments and calculate the maximum number of chunks needed to represent the current heap.
@@ -85,99 +55,6 @@ MM_SweepHeapSectioningVLHGC::calculateActualChunkNumbers() const
 	UDATA regionSize = regionManager->getRegionSize();
 	UDATA sweepChunkSize = _extensions->parSweepChunkSize;
 	UDATA totalChunkCount = regionCount * (MM_Math::roundToCeiling(sweepChunkSize, regionSize) / sweepChunkSize);
-
-	return totalChunkCount;
-}
-
-/**
- * Reset and reassign each chunk to a range of heap memory.
- * Given the current updated listed of chunks and the corresponding heap memory, walk the chunk
- * list reassigning each chunk to an appropriate range of memory.  This will clear each chunk
- * structure and then assign its basic values that connect it to a range of memory (base/top,
- * pool, segment, etc).
- * @return the total number of chunks in the system.
- */
-UDATA
-MM_SweepHeapSectioningVLHGC::reassignChunks(MM_EnvironmentBase *env)
-{
-	MM_ParallelSweepChunk *chunk; /* Sweep table chunk (global) */
-	MM_ParallelSweepChunk *previousChunk;
-	UDATA totalChunkCount;  /* Total chunks in system */
-
-	MM_SweepHeapSectioningIterator sectioningIterator(this);
-
-	totalChunkCount = 0;
-	previousChunk = NULL;
-
-	MM_HeapRegionManager *regionManager = _extensions->getHeap()->getHeapRegionManager();
-	GC_HeapRegionIteratorVLHGC regionIterator(regionManager);
-	MM_HeapRegionDescriptorVLHGC *region = NULL;
-
-	while (NULL != (region = regionIterator.nextRegion())) {
-		if (!region->_sweepData._alreadySwept && region->hasValidMarkMap()) {
-			/* TODO:  this must be rethought for Tarok since it treats all regions identically but some might require different sweep logic */
-			UDATA *heapChunkBase = (UDATA *)region->getLowAddress();  /* Heap chunk base pointer */
-			UDATA *regionHighAddress = (UDATA *)region->getHighAddress();
-
-			while (heapChunkBase < regionHighAddress) {
-				void *poolHighAddr;
-				UDATA *heapChunkTop;
-				MM_MemoryPool *pool;
-
-				chunk = sectioningIterator.nextChunk();
-				Assert_MM_true(chunk != NULL);  /* Should never return NULL */
-				totalChunkCount += 1;
-
-				/* Clear all data in the chunk (including sweep implementation specific information) */
-				chunk->clear();
-
-				if(((UDATA)regionHighAddress - (UDATA)heapChunkBase) < _extensions->parSweepChunkSize) {
-					/* corner case - we will wrap our address range */
-					heapChunkTop = regionHighAddress;
-				} else {
-					/* normal case - just increment by the chunk size */
-					heapChunkTop = (UDATA *)((UDATA)heapChunkBase + _extensions->parSweepChunkSize);
-				}
-
-				/* Find out if the range of memory we are considering spans 2 different pools.  If it does,
-				 * the current chunk can only be attributed to one, so we limit the upper range of the chunk
-				 * to the first pool and will continue the assignment at the upper address range.
-				 */
-				pool = region->getSubSpace()->getMemoryPool(env, heapChunkBase, heapChunkTop, poolHighAddr);
-				if (NULL == poolHighAddr) {
-					heapChunkTop = (heapChunkTop > regionHighAddress ? regionHighAddress : heapChunkTop);
-				} else {
-					/* Yes ..so adjust chunk boundaries */
-					assume0(poolHighAddr > heapChunkBase && poolHighAddr < heapChunkTop);
-					heapChunkTop = (UDATA *) poolHighAddr;
-				}
-
-				/* All values for the chunk have been calculated - assign them */
-				chunk->chunkBase = (void *)heapChunkBase;
-				chunk->chunkTop = (void *)heapChunkTop;
-				chunk->memoryPool = pool;
-				Assert_MM_true(NULL != pool);
-				chunk->_minFreeSize = OMR_MAX(pool->getMinimumFreeEntrySize(), pool->getSweepPoolManager()->getMinimumFreeSize());
-				chunk->_coalesceCandidate = (heapChunkBase != region->getLowAddress());
-				chunk->_previous= previousChunk;
-				if(NULL != previousChunk) {
-					previousChunk->_next = chunk;
-				}
-
-				/* Move to the next chunk */
-				heapChunkBase = heapChunkTop;
-
-				/* and remember address of previous chunk */
-				previousChunk = chunk;
-
-				assume0((UDATA)heapChunkBase == MM_Math::roundToCeiling(_extensions->heapAlignment,(UDATA)heapChunkBase));
-			}
-		}
-	}
-
-	if(NULL != previousChunk) {
-		previousChunk->_next = NULL;
-	}
 
 	return totalChunkCount;
 }

--- a/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.hpp
+++ b/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 #include "ParallelSweepChunk.hpp"
 #include "GCExtensions.hpp"
 #include "EnvironmentBase.hpp"
+#include "HeapRegionDescriptorVLHGC.hpp"
 
 class MM_ParallelSweepChunkArray;
 
@@ -41,13 +42,14 @@ class MM_SweepHeapSectioningVLHGC : public MM_SweepHeapSectioning
 {
 private:
 protected:
-	virtual UDATA estimateTotalChunkCount(MM_EnvironmentBase *env);
 	virtual UDATA calculateActualChunkNumbers() const;
+	virtual bool isReadyToSweep(MM_EnvironmentBase* env, MM_HeapRegionDescriptor* region)
+	{
+		return (!((MM_HeapRegionDescriptorVLHGC *)region)->_sweepData._alreadySwept && region->hasValidMarkMap());
+	}
 
 public:
 	static MM_SweepHeapSectioningVLHGC *newInstance(MM_EnvironmentBase *env);
-
-	virtual UDATA reassignChunks(MM_EnvironmentBase *env);
 
 	MM_SweepHeapSectioningVLHGC(MM_EnvironmentBase *env)
 		: MM_SweepHeapSectioning(env)


### PR DESCRIPTION
Avoid logic duplication between SweepHeapSectioning subclasses

depends on: https://github.com/eclipse/omr/pull/6089

Signed-off-by: Lin Hu <linhu@ca.ibm.com>