### PR TITLE
Add an option to log JITServer connections

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -921,6 +921,16 @@ JITServerHelpers::postStreamFailure(OMRPortLibrary *portLibrary, TR::Compilation
       _waitTimeMs *= 2; // Exponential backoff
       }
    _nextConnectionRetryTime = current_time + _waitTimeMs;
+
+   if (_serverAvailable && TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseJITServerConns))
+      {
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                     "t=%6u Lost connection to the server (serverUID=%llu)",
+                                     (uint32_t) compInfo->getPersistentInfo()->getElapsedTime(),
+                                     compInfo->getPersistentInfo()->getServerUID());
+      compInfo->getPersistentInfo()->setServerUID(0);
+      }
+
    _serverAvailable = false;
 
    // Reset the activation policy flag in case we never reconnect to the server

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -338,6 +338,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerPort(uint32_t port) { _JITServerPort = port; }
    uint64_t getClientUID() const { return _clientUID; }
    void setClientUID(uint64_t val) { _clientUID = val; }
+   uint64_t getServerUID() const { return _serverUID; }
+   void setServerUID(uint64_t val) { _serverUID = val; }
    bool getJITServerUseAOTCache() const { return _JITServerUseAOTCache; }
    void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
    bool getRequireJITServer() const { return _requireJITServer; }
@@ -431,6 +433,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint32_t    _JITServerPort;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    uint64_t    _clientUID;
+   uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
    bool        _JITServerUseAOTCache;
    bool        _requireJITServer;
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -822,8 +822,14 @@ ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, b
          {
          _clientSessionMap[clientUID] = clientData;
          *newSessionWasCreated = true;
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server allocated data for a new clientUID %llu", (unsigned long long)clientUID);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer) ||
+             TR::Options::getVerboseOption(TR_VerboseJITServerConns))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                           "t=%6u A new client (clientUID=%llu) connected. Server allocated a new client session.",
+                                           (uint32_t) _compInfo->getPersistentInfo()->getElapsedTime(),
+                                           (unsigned long long) clientUID);
+            }
          }
       else
          {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4030,6 +4030,7 @@ typedef struct J9JITConfig {
 	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);
 	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);
 	uint64_t clientUID;
+	uint64_t serverUID;
 #endif /* J9VM_OPT_JITSERVER */
 } J9JITConfig;
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1179,6 +1179,11 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 		_OutputStream.writeInteger64(jitConfig->clientUID, "%" OMR_PRIu64);
 		_OutputStream.writeCharacters("\n");
 	}
+	if (0 != jitConfig->serverUID) {
+		_OutputStream.writeCharacters("1CISERVERID    Server UID ");
+		_OutputStream.writeInteger64(jitConfig->serverUID, "%" OMR_PRIu64);
+		_OutputStream.writeCharacters("\n");
+	}
 #endif /* J9VM_OPT_JITSERVER */
 
 	_OutputStream.writeCharacters("1CIVMIDLESTATE VM Idle State: ");


### PR DESCRIPTION
This commit adds a new command line option `-XX:+LogJITServerConns`
which enables the newly added verbose option `TR_VerboseJITServerConns`.
The option can be enabled on both server and client.
When enabled, it logs connections/disconnections between server and client.

This commit also adds UID for the server. The client stores the latest
server UID to determine when a connection to a new server occurs.

Closes: #13055 

Depends on: eclipse/omr/pull/6090