### PR TITLE
Update jit_jitt_array_compress unit test to set -Xmx

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -147,10 +147,10 @@
 	<test>
 		<testCaseName>jit_jitt_array_compress</testCaseName>
 		<variations>
-			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=1</variation>
-			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=2</variation>
-			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=3</variation>
-			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=4</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=1 -Xmx512m</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=2 -Xmx512m</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=3 -Xmx512m</variation>
+			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=4 -Xmx512m</variation>
 		</variations>
 		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \


### PR DESCRIPTION
The new test added via
https://github.com/eclipse-openj9/openj9/pull/12905 uses the
-XXgc:forcedShiftingCompressionAmount option to force shifting to 1, 2,
3, 4, but doesn't set -Xmx. The default -Xmx is 25% of the available
memory up to 25G. The default value on some machines may be too big for
smaller shift values.

Fixes https://github.com/eclipse-openj9/openj9/issues/12947

Tested this test only change via grinder, just one platform but that should be sufficient.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/87/