### PR TITLE
Use Portable AOT setting for JIT compiles in CRIU mode

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -844,6 +844,12 @@ J9::Compilation::compileRelocatableCode()
    return self()->fej9()->isAOT_DEPRECATED_DO_NOT_USE();
    }
 
+bool
+J9::Compilation::compilePortableCode()
+   {
+   return self()->fej9()->inSnapshotMode();
+   }
+
 
 int32_t
 J9::Compilation::maxInternalPointers()

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -198,6 +198,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool compileRelocatableCode();
 
+   bool compilePortableCode();
+
    int32_t maxInternalPointers();
 
    bool compilationShouldBeInterrupted(TR_CallingContext);

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1257,7 +1257,11 @@ void J9::Options::preProcessMmf(J9JavaVM *vm, J9JITConfig *jitConfig)
       self()->setIsVariableActiveCardTableBase(true);
       }
 
-   if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))
+   if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE)
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+       || vm->internalVMFunctions->isCheckpointAllowed(vmThread)
+#endif
+       )
       {
       // Disable any fixed-size heap optimizations under portable shared cache mode
       self()->setIsVariableHeapSizeForBarrierRange0(true);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2045,6 +2045,19 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       }
 #endif
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be
+    * limited to the same processor features as those used in Portable AOT mode. This
+    * is because, the restore run may not be on the same machine as the one that created
+    * the snapshot; thus the JIT code must be portable.
+    */
+   if (javaVM->internalVMFunctions->isCheckpointAllowed(curThread))
+      {
+      TR::Compiler->target.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
+      jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
+      }
+#endif
+
    #if defined(TR_TARGET_S390)
       uintptr_t * tocBase = (uintptr_t *)jitConfig->pseudoTOC;
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9319,6 +9319,16 @@ TR_J9VMBase::classNameChars(TR::Compilation *comp, TR::SymbolReference * symRef,
    return n;
    }
 
+bool
+TR_J9VMBase::inSnapshotMode()
+   {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   return getJ9JITConfig()->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread());
+#else
+   return false;
+#endif
+   }
+
 
 // Native method bodies
 //

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1209,6 +1209,8 @@ public:
    virtual bool isStringCompressionEnabledVM();
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);
 
+   bool inSnapshotMode();
+
 protected:
 
    enum // _flags

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -97,8 +97,8 @@ J9::X86::CodeGenerator::initialize()
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsNewInstanceImplOpt();
 
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -558,7 +558,7 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    TR::Instruction *instr = NULL;
 
    static const char *prefetch = feGetEnv("TR_EnableSoftwarePrefetch");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
    if (prefetch && comp->getMethodHotness()>=scorching && comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2))
       {
       int32_t fieldOffset = 0;

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -206,7 +206,7 @@ J9::X86::CPU::is_test(OMRProcessorArchitecture p)
    if (TR::CompilationInfo::getStream())
       return true;
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   if (TR::comp()->compileRelocatableCode())
+   if (TR::comp()->compileRelocatableCode() || TR::comp()->compilePortableCode())
       return true;
 
    switch(p)
@@ -254,7 +254,7 @@ J9::X86::CPU::supports_feature_test(uint32_t feature)
    if (TR::CompilationInfo::getStream())
       return true;
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   if (TR::comp()->compileRelocatableCode())
+   if (TR::comp()->compileRelocatableCode() || TR::comp()->compilePortableCode())
       return true;
 
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2907,7 +2907,12 @@ gcInitializeDefaults(J9JavaVM* vm)
 
 				if (hwSupported) {
 					/* Software Barrier request overwrites HW usage on supported HW */
-					extensions->concurrentScavengerHWSupport = hwSupported && !extensions->softwareRangeCheckReadBarrier && !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
+					extensions->concurrentScavengerHWSupport = hwSupported 
+						&& !extensions->softwareRangeCheckReadBarrier 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+						&& !vm->internalVMFunctions->isCRIUSupportEnabled(vm->internalVMFunctions->currentVMThread(vm))
+#endif
+						&& !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
 					extensions->concurrentScavenger = hwSupported || extensions->softwareRangeCheckReadBarrier;
 				} else {
 					extensions->concurrentScavengerHWSupport = false;


### PR DESCRIPTION
If the JVM Is in CRIU mode, then the JIT should be limited to the same
processor features as those used in Portable AOT mode. This is because,
the restore run may not be on the same machine as the one that created
the snapshot; thus the JIT code must be portable.

Depends on https://github.com/eclipse/omr/pull/6091

Closes https://github.com/eclipse-openj9/openj9/issues/12482