### PR TITLE
Remove isMonitorValueType

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5079,27 +5079,6 @@ J9::CodeGenerator::getMonClass(TR::Node* monNode)
    }
 
 TR_YesNoMaybe
-J9::CodeGenerator::isMonitorValueType(TR::Node* monNode)
-   {
-   TR_OpaqueClassBlock *clazz = self()->getMonClass(monNode);
-
-   if (!clazz)
-      return TR_maybe;
-
-   //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
-   if (clazz == self()->comp()->getObjectClassPointer())
-      return TR_no;
-
-   if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))
-      return TR_maybe;
-
-   if (TR::Compiler->cls.isValueTypeClass(clazz))
-      return TR_yes;
-
-   return TR_no;
-   }
-
-TR_YesNoMaybe
 J9::CodeGenerator::isMonitorValueBasedOrValueType(TR::Node* monNode)
    {
    if (TR::Compiler->om.areValueTypesEnabled() || TR::Compiler->om.areValueBasedMonitorChecksEnabled())

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -317,16 +317,6 @@ public:
 
    /*
     * \brief
-    *    Whether a monitor object is of value type
-    *
-    * \return
-    *    TR_yes The monitor object is definitely value type
-    *    TR_no The monitor object is definitely identity type
-    *    TR_maybe It is unknown whether the monitor object is identity type or value type
-    */
-   TR_YesNoMaybe isMonitorValueType(TR::Node* monNode);
-   /*
-    * \brief
     *    Whether a monitor object is of value based class type or value type.
     *    This API checks if value based or value type is enabled first.
     *

--- a/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -286,8 +286,10 @@ ReduceSynchronizedFieldLoad::performOnTreeTops(TR::TreeTop* startTreeTop, TR::Tr
          TR::Node* monentNode = iter.currentNode()->getOpCodeValue() == TR::monent ?
             iter.currentNode() :
             iter.currentNode()->getFirstChild();
-         // Locking on value types is prohibited by the spec., so this optimization can only be performed if we are certain (at compile time) the locking object is not a value type
-         if (TR::Compiler->om.areValueTypesEnabled() && cg->isMonitorValueType(monentNode) != TR_no)
+         // Locking on value types or value based classes is prohibited by the spec.,
+         // so this optimization can only be performed if we are certain (at compile time)
+         // the locking object is not a value type or value based
+         if (cg->isMonitorValueBasedOrValueType(monentNode) != TR_no)
             continue;
          if (comp->getOption(TR_TraceCG))
             {


### PR DESCRIPTION
`isMonitorValueType` has been replaced by `isMonitorValueBasedOrValueType`. `isMonitorValueType` is no longer required. 

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>