### PR TITLE
Add jit ct helpers to detect method annotations

### DIFF
--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -29,10 +29,16 @@
 
 extern "C" {
 
+#if JAVA_SPEC_VERSION >= 16
+J9_DECLARE_CONSTANT_UTF8(ojdk_intrinsicCandidate, "Ljdk/internal/vm/annotation/IntrinsicCandidate;");
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
 #if JAVA_SPEC_VERSION >= 11
 J9_DECLARE_CONSTANT_UTF8(ojdk_stable, "Ljdk/internal/vm/annotation/Stable;");
+J9_DECLARE_CONSTANT_UTF8(ojdk_forceInline, "Ljdk/internal/vm/annotation/ForceInline;");
 #else /* JAVA_SPEC_VERSION >= 11 */
 J9_DECLARE_CONSTANT_UTF8(ojdk_stable, "Ljava/lang/invoke/Stable;");
+J9_DECLARE_CONSTANT_UTF8(ojdk_forceInline, "Ljava/lang/invoke/ForceInline;");
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
 void*
@@ -199,6 +205,36 @@ BOOLEAN
 jitIsFieldStable(J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex)
 {
 	return fieldContainsRuntimeAnnotation(currentThread, clazz, cpIndex, (J9UTF8 *)&ojdk_stable);
+}
+
+/**
+ * Queries if the method contains the @ForceInline annotation
+ *
+ * @param currentThread currentThread
+ * @param method the queried method
+ * @return true if method contains @ForceInline, false otherwise
+ */
+BOOLEAN
+jitIsMethodTaggedWithForceInline(J9VMThread *currentThread, J9Method *method)
+{
+	return FALSE != methodContainsRuntimeAnnotation(currentThread, method, (J9UTF8 *)&ojdk_forceInline);
+}
+
+/**
+ * Queries if the method contains the @IntrinsicCandidate annotation
+ *
+ * @param currentThread currentThread
+ * @param method the queried method
+ * @return true if method contains @IntrinsicCandidate, false otherwise
+ */
+BOOLEAN
+jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *method)
+{
+#if JAVA_SPEC_VERSION >= 16
+	return FALSE != methodContainsRuntimeAnnotation(currentThread, method, (J9UTF8 *)&ojdk_intrinsicCandidate);
+#else /* JAVA_SPEC_VERSION >= 16 */
+	return FALSE;
+#endif /* JAVA_SPEC_VERSION >= 16 */
 }
 
 }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4790,6 +4790,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*objectIsBeingWaitedOn)(struct J9VMThread *currentThread, struct J9VMThread *targetThread, j9object_t obj);
 	BOOLEAN (*areValueBasedMonitorChecksEnabled)(struct J9JavaVM *vm);
 	BOOLEAN (*fieldContainsRuntimeAnnotation)(struct J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex, J9UTF8 *annotationName);
+	BOOLEAN (*methodContainsRuntimeAnnotation)(struct J9VMThread *currentThread, J9Method *method, J9UTF8 *annotationName);
 	J9ROMFieldShape* (*findFieldExt)(struct J9VMThread *vmStruct, J9Class *clazz, U_8 *fieldName, UDATA fieldNameLength, U_8 *signature, UDATA signatureLength, J9Class **definingClass, UDATA *offsetOrAddress, UDATA options);
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	BOOLEAN (*jvmCheckpointHooks)(struct J9VMThread *currentThread);

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1133,6 +1133,8 @@ extern J9_CFUNC struct J9Method* jitResolveStaticMethodRef(J9VMThread *vmStruct,
 extern J9_CFUNC struct J9Method* jitResolveSpecialMethodRef(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpOrSplitIndex, UDATA resolveFlags);
 extern J9_CFUNC struct J9Class * jitGetDeclaringClassOfROMField(J9VMThread *vmStruct, J9Class *clazz, J9ROMFieldShape *romField);
 extern J9_CFUNC BOOLEAN jitIsFieldStable(J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex);
+extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithForceInline(J9VMThread *currentThread, J9Method *method);
+extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *method);
 
 typedef struct J9MethodFromSignatureWalkState {
 	const char *className;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -83,6 +83,17 @@ alignedBackwardsMemcpy(J9VMThread *vmStruct, void *dest, void *source, UDATA byt
 BOOLEAN
 fieldContainsRuntimeAnnotation(J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex, J9UTF8 *annotationName);
 
+/**
+ * Check if a method contains the specified Runtime Visible annotation.
+ *
+ * @param currentThread Thread token
+ * @param method The method to be queried
+ * @param annotationName The annotation name
+ * @return TRUE if the annotation is found, FALSE otherwise.
+ */
+BOOLEAN
+methodContainsRuntimeAnnotation(J9VMThread *currentThread, J9Method *method, J9UTF8 *annotationName);
+
 /* ---------------- argbits.c ---------------- */
 
 /**

--- a/runtime/tests/annotationtests/CMakeLists.txt
+++ b/runtime/tests/annotationtests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(anntests
 
 omr_add_exports(anntests
 	Java_org_openj9_test_annotation_ContainsRuntimeAnnotationTest_containsRuntimeAnnotation
+	Java_org_openj9_test_annotation_ContainsRuntimeAnnotationTest_methodContainsRuntimeAnnotation
 )
 
 install(

--- a/runtime/tests/annotationtests/module.xml
+++ b/runtime/tests/annotationtests/module.xml
@@ -23,6 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<exports group="all">
 		<export name="Java_org_openj9_test_annotation_ContainsRuntimeAnnotationTest_containsRuntimeAnnotation"/>
+		<export name="Java_org_openj9_test_annotation_ContainsRuntimeAnnotationTest_methodContainsRuntimeAnnotation"/>
 	</exports>
 
 	<artifact type="shared" name="anntests" appendrelease="false">
@@ -33,7 +34,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>
-		</includes>		
+		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="UMA_DISABLE_DDRGEN=1"/>

--- a/runtime/util/annhelp.c
+++ b/runtime/util/annhelp.c
@@ -220,6 +220,38 @@ fieldContainsRuntimeAnnotation(J9VMThread *currentThread, J9Class *clazz, UDATA 
 }
 
 /**
+ * Check if a method contains the specified Runtime Visible annotation.
+ *
+ * @param currentThread Thread token
+ * @param method The method to be queried
+ * @param annotationName The annotation name
+ * @return TRUE if the annotation is found, FALSE otherwise.
+ */
+BOOLEAN
+methodContainsRuntimeAnnotation(J9VMThread *currentThread, J9Method *method, J9UTF8 *annotationName)
+{
+	BOOLEAN annotationFound = FALSE;
+	J9ROMMethod *romMethod = NULL;
+
+	Assert_VMUtil_true(NULL != annotationName);
+	Assert_VMUtil_true(NULL != method);
+	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	Assert_VMUtil_true(NULL != romMethod);
+	
+	U_32 *methodAnnotationData = getMethodAnnotationsDataFromROMMethod(romMethod);
+	if (NULL != methodAnnotationData) {
+		U_32 len = *methodAnnotationData;
+		U_8 *data = (U_8 *)(methodAnnotationData + 1);
+
+		annotationFound = findRuntimeVisibleAnnotation(currentThread, data, len, annotationName, J9_CP_FROM_METHOD(method)->romConstantPool);
+	}
+
+	Trc_Util_annhelp_SearchForMethodAnnotation(currentThread, (UDATA)J9UTF8_LENGTH(annotationName), J9UTF8_DATA(annotationName), romMethod, (UDATA)annotationFound);
+
+	return annotationFound;
+}
+
+/**
  * Check if the provided Runtime Visible annotation data contains the specified annotation.
  *
  * @param data The Runtime Visible annotation data.

--- a/runtime/util/vmutil.tdf
+++ b/runtime/util/vmutil.tdf
@@ -58,4 +58,5 @@ TraceExit=Trc_VMUtil_getOriginalROMMethodUnchecked_Exit Overhead=1 Level=3 Noenv
 TraceException=Trc_VMUtil_getOriginalROMMethodUnchecked_getMethodIndexFailed Overhead=1 Level=1 Noenv Template="getOriginalROMMethodUnchecked: Unable to get methodIndex for method=%p"
 
 TraceEvent=Trc_Util_annhelp_SearchForFieldAnnotation Overhead=1 Level=5 Template="Search for field annotation: annotation=%.*s cpIndex=%zu clazz=%p romFieldShape=%p result=%zu"
+TraceEvent=Trc_Util_annhelp_SearchForMethodAnnotation Overhead=1 Level=5 Template="Search for method annotation: annotation=%.*s romMethod=%p result=%zu"
 TraceEvent=Trc_Util_annhelp_skipAnnotationElementError Overhead=1 Level=5 Template="Error when skipping annotation: annotation=%.*s targetAnnotation=%.*s index=%p constantPool=%p"

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -398,6 +398,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	objectIsBeingWaitedOn,
 	areValueBasedMonitorChecksEnabled,
 	fieldContainsRuntimeAnnotation,
+	methodContainsRuntimeAnnotation,
 	findFieldExt,
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	jvmCheckpointHooks,

--- a/test/functional/Java8andUp/src_80/org/openj9/test/annotation/ContainsRuntimeAnnotationTest.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/annotation/ContainsRuntimeAnnotationTest.java
@@ -27,6 +27,7 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 
+import java.lang.reflect.*;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -79,11 +80,20 @@ public class ContainsRuntimeAnnotationTest {
 	@Single(a="second")
 	int skipAnnotationMembers = 0;
 
+	@MyMethodAnnotation
+	void myMethod() {}
+
+	void myMethod2() {}
+
+	@MyMethodAnnotation
+	final static void fsMethod() {}
+
 	public ContainsRuntimeAnnotationTest() {
 		thisClassConstantPool = SharedSecrets.getJavaLangAccess().getConstantPool(this.getClass());
 	}
 
 	private static native boolean containsRuntimeAnnotation(Class clazz, int cpIndex, String annotationName, boolean isField, int type);
+	private static native boolean methodContainsRuntimeAnnotation(Method method, String annotationName);
 
 	@Test
 	public void test_stable_annotation() throws Exception {
@@ -201,6 +211,57 @@ public class ContainsRuntimeAnnotationTest {
 		Assert.assertFalse(annotationFound, "skipAnnotationMembers has Stable annotation");
 	}
 
+	@Test
+	public void test_method_annotation() throws Exception {
+		boolean annotationFound = false;
+		Method m = ContainsRuntimeAnnotationTest.class.getDeclaredMethod("myMethod");
+		Method m2 = ContainsRuntimeAnnotationTest.class.getDeclaredMethod("myMethod2");
+		final String mAnnotation = "Lorg/openj9/test/annotation/MyMethodAnnotation;";
+
+		annotationFound = methodContainsRuntimeAnnotation(m, mAnnotation);
+		Assert.assertTrue(annotationFound, "myMethod does not have MyMethodAnnotation annotation");
+
+		annotationFound = methodContainsRuntimeAnnotation(m2, mAnnotation);
+		Assert.assertFalse(annotationFound, "myMethod2 has MyMethodAnnotation annotation");
+	}
+
+	@Test
+	public void test_finalStaticMethod_annotation() throws Exception {
+		boolean annotationFound = false;
+		Method m = ContainsRuntimeAnnotationTest.class.getDeclaredMethod("fsMethod");
+		final String mAnnotation = "Lorg/openj9/test/annotation/MyMethodAnnotation;";
+
+		annotationFound = methodContainsRuntimeAnnotation(m, mAnnotation);
+		Assert.assertTrue(annotationFound, "fsMethod does not have MyMethodAnnotation annotation");
+	}
+
+	@Test
+	public void test_overridden_methods() throws Exception {
+		boolean annotationFound = false;
+		Method b1 = B.class.getDeclaredMethod("method1");
+		Method b2 = B.class.getDeclaredMethod("method2");
+		Method i3 = I.class.getDeclaredMethod("method3");
+		Method i4 = I.class.getDeclaredMethod("method4");
+		Method b3 = B.class.getDeclaredMethod("method3");
+		Method b4 = B.class.getDeclaredMethod("method4");
+		final String mAnnotation = "Lorg/openj9/test/annotation/MyMethodAnnotation;";
+
+		annotationFound = methodContainsRuntimeAnnotation(b1, mAnnotation);
+		Assert.assertFalse(annotationFound, "B.method1 has MyMethodAnnotation annotation");
+		annotationFound = methodContainsRuntimeAnnotation(b2, mAnnotation);
+		Assert.assertTrue(annotationFound, "B.method2 doesn't have MyMethodAnnotation annotation");
+
+		annotationFound = methodContainsRuntimeAnnotation(b3, mAnnotation);
+		Assert.assertFalse(annotationFound, "B.method3 has MyMethodAnnotation annotation");
+		annotationFound = methodContainsRuntimeAnnotation(b4, mAnnotation);
+		Assert.assertTrue(annotationFound, "B.method4 doesn't have MyMethodAnnotation annotation");
+
+		annotationFound = methodContainsRuntimeAnnotation(i4, mAnnotation);
+		Assert.assertFalse(annotationFound, "I.method4 has MyMethodAnnotation annotation");
+		annotationFound = methodContainsRuntimeAnnotation(i3, mAnnotation);
+		Assert.assertTrue(annotationFound, "I.method3 doesn't have MyMethodAnnotation annotation");
+	}
+
 	private int getMemberCPIndex(ConstantPool constantPool, String className, String memberName, String memberType) {
 		int cpIndex = -1;
 		int size = constantPool.getSize();
@@ -234,9 +295,14 @@ class A {
 
 	@MyStableAnnotation
 	static int sfield1;
+
+	@MyMethodAnnotation
+	void method1() {}
+
+	void method2() {}
 }
 
-class B extends A {
+class B extends A implements I {
 	B() {}
 
 	@MyStableAnnotation
@@ -244,6 +310,16 @@ class B extends A {
 
 	@MyStableAnnotation
 	static int sfield2;
+
+	void method1() {}
+
+	@MyMethodAnnotation
+	void method2() {}
+
+	public void method3() {}
+
+	@MyMethodAnnotation
+	public void method4() {}
 }
 
 class C {
@@ -266,6 +342,13 @@ class C {
 		int field2 = B.sfield2;
 		int field3 = C.sfield3;
 	}
+}
+
+interface I {
+	@MyMethodAnnotation
+	void method3();
+
+	void method4();
 }
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -330,3 +413,7 @@ enum En {
 @interface Multiple {
 	Single[] value();
 }
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface MyMethodAnnotation {}


### PR DESCRIPTION
Helpers to detect `@ForceInline` and `@IntrinsicCandidate`, general
helper `methodContainsRuntimeAnnotation`

Fixes: #11993
Signed-off-by: Eric Yang <eric.yang@ibm.com>