### PR TITLE
Fix follow up local compilations on JITServer client

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3443,15 +3443,17 @@ remoteCompile(
          // As a debugging feature, a local compilation can be performed immediately after a remote compilation.
          // Each of them has logs with the same compilationSequenceNumber
          int compilationSequenceNumber = compiler->getOptions()->writeLogFileFromServer(logFileStr);
-         if (TR::Options::getCmdLineOptions()->getOption(TR_JITServerFollowRemoteCompileWithLocalCompile) && compilationSequenceNumber)
+         if (compiler->getOption(TR_JITServerFollowRemoteCompileWithLocalCompile) && compilationSequenceNumber)
             {
             intptr_t rtn = 0;
             compiler->getOptions()->setLogFileForClientOptions(compilationSequenceNumber);
+            releaseVMAccess(vmThread);
             if ((rtn = compiler->compile()) != COMPILATION_SUCCEEDED)
                {
                TR_ASSERT(false, "Compiler returned non zero return code %d\n", rtn);
                compiler->failCompilation<TR::CompilationException>("Compilation Failure");
                }
+            acquireVMAccessNoSuspend(vmThread);
             compiler->getOptions()->closeLogFileForClientOptions();
             }
 


### PR DESCRIPTION
The option `TR_JITServerFollowRemoteCompileWithLocalCompile`
should be retrieved from a compilation object, instead of command line options.
Otherwise, the option is ignored when it's limited to
a single compilation/set of compilations.

VM access should be released before performing a local compile,
to avoid deadlocks during compilation,
e.g. in `TR_J9VMBase::compilationShouldBeInterrupted`.