### PR TITLE
Enable `make all` on z/OS Jenkins builds

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -271,8 +271,7 @@ def checkoutRef (REF) {
 
 def build() {
     stage('Compile') {
-        // 'all' target dependencies broken for zos, use 'images test-image-openj9'
-        def make_target = SPEC.contains('zos') ? 'images test-image-openj9 debug-image' : 'all'
+        def make_target = 'all'
         OPENJDK_CLONE_DIR = "${env.WORKSPACE}/${OPENJDK_CLONE_DIR}"
 
         withEnv(BUILD_ENV_VARS_LIST) {


### PR DESCRIPTION
`make all` is broken on z/OS. Recent experiments show that it is
only the javadoc generation that is failing builds triggered by
`make all`. While we investigate the reasons for that, I've
proposed that we disable javadoc generation and start using
`make all` to build on z/OS.

Signed-off-by: Pushkar N Kulkarni <pushkar.nk@in.ibm.com>