### PR TITLE
JDK17+ recognize --enable-native-access option

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -586,6 +586,7 @@ enum INIT_STAGE {
 #define VMOPT_ADD_OPENS "--add-opens"
 #define VMOPT_PATCH_MODULE "--patch-module"
 #define VMOPT_ILLEGAL_ACCESS "--illegal-access="
+#define VMOPT_ENABLE_NATIVE_ACCESS "--enable-native-access"
 
 #define ENVVAR_IBM_MIXED_MODE_THRESHOLD "IBM_MIXED_MODE_THRESHOLD"
 #define ENVVAR_JAVA_COMPILER "JAVA_COMPILER"
@@ -615,6 +616,7 @@ enum INIT_STAGE {
 #define SYSPROP_JDK_MODULE_ADDEXPORTS "jdk.module.addexports."
 #define SYSPROP_JDK_MODULE_PATCH "jdk.module.patch."
 #define SYSPROP_JDK_MODULE_ILLEGALACCESS "jdk.module.illegalAccess"
+#define SYSPROP_JDK_MODULE_ENABLENATIVEACCESS "jdk.module.enable.native.access."
 #define JAVA_BASE_MODULE "java.base"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -343,6 +343,7 @@ _end:
  * --add-opens,
  * --add-reads,
  * --patch-module
+ * --enable-native-access --- JDK17+
  *
  * For every occurrence of the option, a new system property is created by appending index
  * to the base property name. The index corresponds to the number of times that option is used.
@@ -480,6 +481,15 @@ addModularitySystemProperties(J9JavaVM * vm)
 			vm->jclFlags |= J9_JCL_FLAG_JDK_MODULE_PATCH_PROP;
 		}
 	}
+
+#if JAVA_SPEC_VERSION >= 17
+	/* Find all --enable-native-access options */
+	rc = addPropertiesForOptionWithAssignArg(vm, VMOPT_ENABLE_NATIVE_ACCESS, LITERAL_STRLEN(VMOPT_ENABLE_NATIVE_ACCESS),
+		SYSPROP_JDK_MODULE_ENABLENATIVEACCESS, LITERAL_STRLEN(SYSPROP_JDK_MODULE_ENABLENATIVEACCESS), NULL);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto _end;
+	}
+#endif /* JAVA_SPEC_VERSION >= 17 */
 
 	/* Find last --illegal-access */
 	rc = addPropertyForOptionWithEqualsArg(vm, VMOPT_ILLEGAL_ACCESS, LITERAL_STRLEN(VMOPT_ILLEGAL_ACCESS), SYSPROP_JDK_MODULE_ILLEGALACCESS);


### PR DESCRIPTION
`--enable-native-access` option is converted to system properties `jdk.module.enable.native.access.*` [1].

closes https://github.com/eclipse-openj9/openj9/issues/13088

This fixes the error like `JVMJ9VM007E Command-line option unrecognised: --enable-native-access=ALL-UNNAMED`.

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk17/blob/acf5b4f41829774008033d189c88272983297b2d/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java#L804-L808

Signed-off-by: Jason Feng <fengj@ca.ibm.com>