### PR TITLE
Remove unnecessary repeated call to get_docker_image_id()

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -611,8 +611,8 @@ def prepare_docker_environment() {
         docker.withRegistry("", "${dockerCredentialID}") {
             sh "docker pull ${DOCKER_IMAGE}"
         }
+        DOCKER_IMAGE_ID = get_docker_image_id(DOCKER_IMAGE)
     }
-    DOCKER_IMAGE_ID = get_docker_image_id(DOCKER_IMAGE)
     echo "Using ID ${DOCKER_IMAGE_ID} of ${DOCKER_IMAGE}"
 }
 
@@ -649,7 +649,7 @@ def build_all() {
                         docker.image(DOCKER_IMAGE_ID).inside {
                             _build_all()
                         }
-                    } else { 
+                    } else {
                         _build_all()
                     }
                 }


### PR DESCRIPTION
A second call is only needed if a `pull` was required.