### PR TITLE
Remove disabling HW Prefetch by default for AIX

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2606,9 +2606,6 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					goto _memParseError;
 				}
 			}
-		} else {
-			/* default behavior (jvm disable HWPrefetch) */
-			setHWPrefetch(XXSETHWPREFETCH_NONE_VALUE);
 		}
 #endif /*if defined(J9OS_I5)*/
 #endif /*if defined(AIXPPC)*/


### PR DESCRIPTION
Given the new project AIX system target, it is safe to assume the processor is at least POWER7 and there's no need to disable HW prefetch by default.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>