### PR TITLE
Fix AttachAPI long delay case

### DIFF
--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -126,7 +126,8 @@ public class OpenJ9AttachProvider extends AttachProvider {
 		}
 
 		try {
-			CommonDirectory.obtainControllerLock(); /*[PR 164751 avoid scanning the directory when an attach API is launching ]*/
+			/*[PR 164751 avoid scanning the directory when an attach API is launching ]*/
+			CommonDirectory.obtainControllerLock("OpenJ9AttachProvider.listVirtualMachinesImp"); //$NON-NLS-1$
 		} catch (IOException e) { /*[PR 164751 avoid scanning the directory when an attach API is launching ]*/
 			/* 
 			 * IOException is thrown if we already have the lock. The only other cases where we lock this file are during startup and shutdown.
@@ -182,7 +183,8 @@ public class OpenJ9AttachProvider extends AttachProvider {
 				}
 			}
 		} finally {
-			CommonDirectory.releaseControllerLock(); /* guarantee that we unlock the file */
+			/* guarantee that we unlock the file */
+			CommonDirectory.releaseControllerLock("OpenJ9AttachProvider.listVirtualMachinesImp"); //$NON-NLS-1$
 		}
 		return descriptors;
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,9 +42,9 @@ public class NativeFileLock extends GenericFileLock {
 		nflConstructor.setAccessible(true);
 		fileLockObject = nflConstructor.newInstance(lockFile.getAbsolutePath(), Integer.valueOf(mode));
 		lockFileMethod = nativeFileLock.getDeclaredMethod("lockFile",
-				boolean.class);
+				boolean.class, String.class);
 		lockFileMethod.setAccessible(true);
-		unlockFileMethod = nativeFileLock.getDeclaredMethod("unlockFile");
+		unlockFileMethod = nativeFileLock.getDeclaredMethod("unlockFile", String.class);
 		unlockFileMethod.setAccessible(true);
 		TestFileLocking.logger.debug("exit NativeFileLock");
 	}
@@ -53,12 +53,12 @@ public class NativeFileLock extends GenericFileLock {
 	public boolean lockFile(boolean blocking) throws Exception {
 		Boolean result = Boolean.valueOf(true);
 		TestFileLocking.logger.debug("lockfile blocking =" + blocking);
-		result = (Boolean) lockFileMethod.invoke(fileLockObject, Boolean.valueOf(blocking));
+		result = (Boolean) lockFileMethod.invoke(fileLockObject, Boolean.valueOf(blocking), "NativeFileLock.lockFile()");
 		return result.booleanValue();
 	}
 
 	@Override
 	public void unlockFile() throws Exception {
-		unlockFileMethod.invoke(fileLockObject);
+		unlockFileMethod.invoke(fileLockObject, "NativeFileLock.unlockFile()");
 	}
 }


### PR DESCRIPTION
Ensure `lockFileRAF.close()` is called even there is an exception during `lockObject.release()`;
Reduce some timeout for error recovery;
Add more message logs. (`IPC.logMessage()` checks `isLoggingEnabled()` internally).

Note: this reduces the worst delay from up to 18min to ~1min in a customer use case.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>