### PR TITLE
Exclude New Problematic GC (Verbose) Regression Tests

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -330,10 +330,11 @@
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
 
+<!--
  <test id="GC rotating verbose log file name contains %s">
   <exec command="rm foo*.*" />
   <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s.005 is created -->
+  <!-- check a file with name foo%s%s%s%s%s%s.005 is created
   <command>cat foo%s%s%s%s%s%s.005</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
@@ -342,7 +343,7 @@
  <test id="GC rotating verbose log file name contains %s and other random symbols">
   <exec command="rm foo*.*" />
   <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
+  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created
   <command>cat foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
@@ -351,7 +352,7 @@
  <test id="GC rotating verbose log file name contains %s %c %i">
   <exec command="rm foo*.*" />
   <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005 is created -->
+  <!-- check a file with name foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005 is created
   <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
@@ -360,12 +361,12 @@
  <test id="GC rotating verbose log file name contains %s %c %i and other random symbols">
   <exec command="rm foo*.*" />
   <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
+  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created
   <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.005</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
-
+ -->
  <!-- CMVC 178000 - disable until a new version of the test can be added after the GC promotes
  <test id="-verbose:gc -Xverbosegclog:<invalid> - use a file name in a directory that doesn't exist">
   <exec command="rm foo.*.log" />

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
@@ -44,14 +44,18 @@
 <exclude id="Excessive GC appears in verbose log" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not use excessive GC</reason></exclude>
 
 <!-- Metronome does not cause multiple verboseGC logging files -->
+<!--
 <exclude id="GC rotating verbose log file name contains %s" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
 <exclude id="GC rotating verbose log file name contains %s and other random symbols" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
 <exclude id="GC rotating verbose log file name contains %s %c %i" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
 <exclude id="GC rotating verbose log file name contains %s %c %i and other random symbols" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
+-->
 
 <!-- The Windows system also does not support the * character in file or directory names.  -->
+<!--
 <exclude id="GC rotating verbose log file name contains %s and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
 <exclude id="GC rotating verbose log file name contains %s %c %i and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
+-->
 
 <!-- only Gencon GC is supported on RISC-V -->
 <exclude id="Excessive GC throws OOM" platform="linux_riscv.*" shouldFix="false"><reason>The initial memory setting does not work on RISC-V</reason></exclude>


### PR DESCRIPTION
Comment out GC Regression Tests introduced in https://github.com/eclipse-openj9/openj9/pull/12794

These tests are not being excluded as intended and as a result are causing failures.

Signed-off-by: Salman Rana <salman.rana@ibm.com>