### PR TITLE
Avoid using NULL pointer

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3567,11 +3567,10 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		if (enableCRIU > disableCRIU) {
 			PORT_ACCESS_FROM_JAVAVM(vm);
 			vm->checkpointState = (J9CRIUCheckpointState*) j9mem_allocate_memory(sizeof(J9CRIUCheckpointState), OMRMEM_CATEGORY_VM);
-			memset(vm->checkpointState, 0, sizeof(J9CRIUCheckpointState));
-
 			if (NULL == vm->checkpointState) {
 				return JNI_ENOMEM;
 			}
+			memset(vm->checkpointState, 0, sizeof(J9CRIUCheckpointState));
 			vm->checkpointState->isCheckPointAllowed = TRUE;
 		}
 	}


### PR DESCRIPTION
Delay call to `memset()` until validating pointer; see https://github.com/eclipse-openj9/openj9/pull/13113#discussion_r667899631.