### PR TITLE
Add JDK17+ SecurityManager warning messages

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -478,7 +478,7 @@ K0A01="Constant_Dynamic references bootstrap method '{0}' does not have java.lan
 K0A02="Bootstrap method returned null."
 
 #java.lang.System
-K0B00="`-Djava.security.manager=disallow` has been specified."
+K0B00="The Security Manager is deprecated and will be removed in a future release"
 
 #java.lang.Throwable
 K0C00="Non-standard List class not permitted in suppressedExceptions serial stream"

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -290,6 +290,10 @@ public abstract class ClassLoader {
 			&& !javaSecurityManager.equals("allow") //$NON-NLS-1$ /* special token to allow SecurityManager */
 			/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 		) {
+			/*[IF JAVA_SPEC_VERSION >= 17]*/
+			System.initialErr.println("WARNING: A command line option has enabled the Security Manager"); //$NON-NLS-1$
+			System.initialErr.println("WARNING: The Security Manager is deprecated and will be removed in a future release"); //$NON-NLS-1$
+			/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) { //$NON-NLS-1$
 				System.setSecurityManager(new SecurityManager());
 			} else {

--- a/test/functional/Java8andUp/src/org/openj9/test/support/Support_Exec.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/support/Support_Exec.java
@@ -1,7 +1,7 @@
 package org.openj9.test.support;
 
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,7 +113,10 @@ public class Support_Exec {
 				String line;
 				try {
 					while ((line = reader.readLine()) != null) {
-						if (line.indexOf("switch to IFA processor") != -1) {
+						/* Ignore WARNING: message on stderr - https://github.com/eclipse-openj9/openj9/issues/12760 */
+						if ((line.indexOf("switch to IFA processor") != -1)
+							|| (line.indexOf("WARNING:") != -1)
+						) {
 							continue;
 						}
 						if (checkExpectedErr && line.indexOf(expectedErr) != -1) {


### PR DESCRIPTION
Add `System.initialErr` to match RI behaviours;
Add/update `warning`/`error` `SecurityManager` messages;
Adjust the test to ignore warning messages in `stderr`.

Note: 
1. The warnings are always printed to the original `System.err` and will not be swallowed [1];
2. `@Deprecated(since="17", forRemoval=true)` is decorated with `OPENJDK_METHODHANDLES` to avoid compilation warning as error in `openj9` branch (`openj9-staging` branch has latest openjdk code to suppress the warning);
3. `K0B00` exception message change wasn't decorated with `JAVA_SPEC_VERSION >= 17` since it doesn't affect `JDK11` and no more `JDK16` release build.

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk17/blob/96df588a3eef5a6d1082ade6d11d632c24f9f4be/test/jdk/java/lang/System/SecurityManagerWarnings.java#L73-L75

Related to https://github.com/eclipse-openj9/openj9/issues/12760 https://github.com/eclipse-openj9/openj9/issues/13157

Signed-off-by: Jason Feng <fengj@ca.ibm.com>