### PR TITLE
Enable getCallerClass optimization for JITServer

### DIFF
--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,3 +112,19 @@ J9::VMMethodEnv::bytecodeSize(TR_OpaqueMethodBlock *method)
                      J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
    }
 
+bool
+J9::VMMethodEnv::isFrameIteratorSkipMethod(J9Method *method)
+   {
+   J9ROMMethod *romMethod = NULL;
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      {
+      romMethod = JITServerHelpers::romMethodOfRamMethod(method);
+      }
+   else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+      }
+   return _J9ROMMETHOD_J9MODIFIER_IS_SET(romMethod, J9AccMethodFrameIteratorSkip);
+   }

--- a/runtime/compiler/env/J9VMMethodEnv.hpp
+++ b/runtime/compiler/env/J9VMMethodEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,6 +53,8 @@ public:
    uintptr_t bytecodeStart(TR_OpaqueMethodBlock *method);
 
    uint32_t bytecodeSize(TR_OpaqueMethodBlock *method);
+
+   bool isFrameIteratorSkipMethod(J9Method *method);
 
    };
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7494,13 +7494,6 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
 
       case TR::sun_reflect_Reflection_getCallerClass:
          {
-#if defined(J9VM_OPT_JITSERVER)
-         // TODO (#13098): Enable getCallerClass optimization for JITServer
-         if (comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER ||
-             comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-            return 0;
-#endif
-
          // We need to bail out since we create a class pointer const with cpIndex of -1
          if (isAOT_DEPRECATED_DO_NOT_USE() && !comp->getOption(TR_UseSymbolValidationManager))
             {
@@ -7547,7 +7540,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                // and we want to skip the callerIndex == -1 frame, but we cannot because the JIT cannot statically
                // determine the caller of the top-level method being compiled. We cannot perform this optimization
                // in such a case, so we make skipFrameAtDepth0 at this point and proceed.
-               if ((J9_ROM_METHOD_FROM_RAM_METHOD(callerMethod)->modifiers & J9AccMethodFrameIteratorSkip) == J9AccMethodFrameIteratorSkip)
+               if (TR::Compiler->mtd.isFrameIteratorSkipMethod(callerMethod))
                   skipFrameAtDepth0 = true;
                }
             else
@@ -7560,7 +7553,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                break;
 
             // Skip methods with java.lang.invoke.FrameIteratorSkip annotation
-            if ((J9_ROM_METHOD_FROM_RAM_METHOD(callerMethod)->modifiers & J9AccMethodFrameIteratorSkip) != J9AccMethodFrameIteratorSkip)
+            if (!TR::Compiler->mtd.isFrameIteratorSkipMethod(callerMethod))
                {
                if (targetInlineDepth == 0)
                   {


### PR DESCRIPTION
This commit enables the optimization by adding a new
method `J9::VMMethodEnv::isFrameIteratorSkipMethod` that
checks whether a ROM method has `J9AccMethodFrameIteratorSkip`
flag set.

Closes: #13098