### PR TITLE
Document Global Lock Reservtion now on by default

### DIFF
--- a/doc/release-notes/0.27/0.27.md
+++ b/doc/release-notes/0.27/0.27.md
@@ -78,6 +78,13 @@ The following table covers notable changes in v0.27.0. Further information about
 The <tt>_JAVA_OPTIONS</tt> environment variable (with different behavior) is added for compatibility.</td>
 </tr>
 
+<tr><td valign="top">
+<a href="https://github.com/eclipse-openj9/openj9/issues/12125">#12125</a></td>
+<td valign="top">Global lock reservation is now enabled by default on Power</td>
+<td valign="top">AIX and Linux on Power</td>
+<td valign="top">Global lock reservation is now enabled by default on Power. This is an optimization targeted towards more efficient handling of locking and unlocking Java&trade; objects. The older locking behavior can be restored via the <tt>-XX:-GlobalLockReservation</tt> option.</td>
+</tr>
+
 </table>
 
 ## Known Issues


### PR DESCRIPTION
Updated 0.27.md to indicate that Global lock reservation is now enabled by
default on Power and that the -XX:-GlobalLockReservation option can be used to
restore older behavior.

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>