### PR TITLE
Fold Stable fields

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2640,7 +2640,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             TR_OpaqueClassBlock *fieldDeclaringClass = calleeMethod->getDeclaringClassFromFieldOrStatic(comp, cpIndex);
 
             avoidFolding = TR::TransformUtil::avoidFoldingInstanceField(
-               baseObjectAddress, fieldSymbol, cpIndex, calleeMethod, comp);
+                           baseObjectAddress, fieldSymbol, fieldOffset, cpIndex, calleeMethod, comp);
 
             if (fieldDeclaringClass && fe->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
                {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4015,6 +4015,10 @@ bool
 TR_J9VMBase::canDereferenceAtCompileTimeWithFieldSymbol(TR::Symbol * fieldSymbol, int32_t cpIndex, TR_ResolvedMethod *owningMethod)
    {
    TR::Compilation *comp = TR::comp();
+
+   if (isStable(cpIndex, owningMethod, comp))
+      return true;
+
    switch (fieldSymbol->getRecognizedField())
       {
       case TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers:
@@ -4086,6 +4090,35 @@ TR_J9VMBase::canDereferenceAtCompileTime(TR::SymbolReference *fieldRef, TR::Comp
       return false;
    }
 
+bool
+TR_J9VMBase::isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp)
+   {
+   // NOTE: the field must be resolved!
+
+   if (comp->getOption(TR_DisableStableAnnotations))
+      return false;
+   
+   if (cpIndex < 0)
+      return false;
+   
+   J9Class *fieldClass = (J9Class*)owningMethod->classOfMethod();
+   if (!fieldClass)
+      return false;
+
+   bool isStable = jitIsFieldStable(comp->fej9()->vmThread(), fieldClass, cpIndex);
+
+   if (isStable && comp->getOption(TR_TraceOptDetails))
+      {
+      int classLen;
+      const char * className= owningMethod->classNameOfFieldOrStatic(cpIndex, classLen);
+      int fieldLen;
+      const char * fieldName = owningMethod->fieldNameChars(cpIndex, fieldLen);
+      traceMsg(comp, "   Found stable field: %.*s.%.*s\n", classLen, className, fieldLen, fieldName);
+      }
+
+   // Not checking for JCL classes since @Stable annotation only visible inside JCL
+   return isStable; 
+   }
 
 // Creates a node to initialize the local object flags field
 //

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -898,22 +898,35 @@ public:
     * \brief
     *    tell whether it's possible to dereference a field given the field symbol reference at compile time
     *
-    * \fieldRef
+    * \param fieldRef
     *    symbol reference of the field
     */
    virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp);
 
    /*
     * \brief
+    *    tell whether a field was annotated as @Stable. Field must be resolved.
+    *
+    * \param cpIndex
+    *    field's constant pool index
+    *
+    * \param owningMethod
+    *    the method accessing the field
+    *
+    */
+   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp);
+
+   /*
+    * \brief
     *    tell whether it's possible to dereference a field given the field symbol at compile time
     *
-    * \fieldSymbol
+    * \param fieldSymbol
     *    symbol of the field
     *
-    * \cpIndex
+    * \param cpIndex
     *    constant pool index
     *
-    * \owningMethod
+    * \param owningMethod
     *    the method accessing the field
     */
    virtual bool canDereferenceAtCompileTimeWithFieldSymbol(TR::Symbol *fieldSymbol, int32_t cpIndex, TR_ResolvedMethod *owningMethod);
@@ -1311,6 +1324,7 @@ public:
    virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
    virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
    virtual bool               needRelocatableTarget()                          { return true; }
+   virtual bool               isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) { return false; }
    virtual bool               shouldDelayAotLoad();
 
    virtual bool               isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -184,6 +184,7 @@ public:
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptr_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
    virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
+   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp)  { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -406,7 +406,7 @@ InterpreterEmulator::maintainStackForGetField()
             TR_OpaqueClassBlock *fieldDeclaringClass = _calltarget->_calleeMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
 
             avoidFolding = TR::TransformUtil::avoidFoldingInstanceField(
-               baseObjectAddress, fieldSymbol, cpIndex, _calltarget->_calleeMethod, comp());
+                           baseObjectAddress, fieldSymbol, fieldOffset, cpIndex, _calltarget->_calleeMethod, comp());
 
             if (fieldDeclaringClass && comp()->fej9()->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
                {

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -190,6 +190,7 @@ static bool isFieldOfJavaObject(TR::SymbolReference *symRef, TR::Compilation *co
 bool J9::TransformUtil::avoidFoldingInstanceField(
    uintptr_t object,
    TR::Symbol *field,
+   uint32_t fieldOffset,
    int cpIndex,
    TR_ResolvedMethod *owningMethod,
    TR::Compilation *comp)
@@ -208,6 +209,57 @@ bool J9::TransformUtil::avoidFoldingInstanceField(
       "avoidFoldingInstanceField: symbol %p is never foldable (expected possibly foldable)\n",
       field);
 
+   if (fej9->isStable(cpIndex, owningMethod, comp) && !field->isFinal())
+      {
+      uintptr_t fieldAddress = object + fieldOffset;
+
+      TR::DataType loadType = field->getDataType();
+      switch (loadType)
+         {
+         case TR::Int32:
+            {
+            int32_t value = *(int32_t*)fieldAddress;
+            if (value == 0)
+               return true;
+            }
+            break;
+         case TR::Int64:
+            {
+            int64_t value = *(int64_t*)fieldAddress;
+            if (value == 0)
+               return true;
+            }
+            break;
+         case TR::Float:
+            {
+            float value = *(float*)fieldAddress;
+            // This will not fold -0.0 but will fold NaN
+            if (value == 0.0)
+               return true;
+            }
+            break;
+         case TR::Double:
+            {
+            double value = *(double*)fieldAddress;
+            // This will not fold -0.0 but will fold NaN
+            if (value == 0.0)
+               return true;
+            }
+            break;
+         case TR::Address:
+            {
+            TR_ASSERT_FATAL(field->isCollectedReference(), "Expecting a collectable reference\n");
+            uintptr_t value = fej9->getReferenceFieldAtAddress((uintptr_t)fieldAddress);
+            if (value == 0)
+               return true;
+            }
+            break;
+         default:
+            TR_ASSERT_FATAL(false, "Unknown type of field being dereferenced\n");
+            break;
+         }
+      }
+   
    switch (field->getRecognizedField())
       {
       // In the LambdaForm-based JSR292 implementation, CallSite declares a
@@ -264,6 +316,7 @@ bool J9::TransformUtil::avoidFoldingInstanceField(
    return TR::TransformUtil::avoidFoldingInstanceField(
       object,
       field->getSymbol(),
+      field->getOffset(),
       field->getCPIndex(),
       field->getOwningMethod(comp),
       comp);

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -92,6 +92,7 @@ public:
    static bool avoidFoldingInstanceField(
       uintptr_t object,
       TR::Symbol *field,
+      uint32_t fieldOffset,       
       int cpIndex,
       TR_ResolvedMethod *owningMethod,
       TR::Compilation *comp);


### PR DESCRIPTION
   - recognize stable fields using jitIsFieldStable() VM helper
   - make canDereferenceAtCompileTimeWithFieldSymbol() return true if field is stable
   - check if value can be actually folded using avoidFoldingInstanceField()
   - disable using disableStableAnnotations -Xjit option