### PR TITLE
Implement isStable() query for JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1137,6 +1137,16 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          }
          break;
 #endif // J9VM_OPT_OPENJDK_METHODHANDLE
+      case MessageType::VM_isStable:
+         {
+         auto recv = client->getRecvData<J9Class *, int>();
+         J9Class *fieldClass = std::get<0>(recv);
+         int cpIndex = std::get<1>(recv);
+
+         bool isStable = fe->isStable(fieldClass, cpIndex);
+         client->write(response, isStable);
+         }
+         break;
       case MessageType::mirrorResolvedJ9Method:
          {
          // allocate a new TR_ResolvedJ9Method on the heap, to be used as a mirror for performing actions which are only

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4105,9 +4105,9 @@ TR_J9VMBase::isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilat
    if (!fieldClass)
       return false;
 
-   bool isStable = jitIsFieldStable(comp->fej9()->vmThread(), fieldClass, cpIndex);
+   bool isFieldStable = isStable(fieldClass, cpIndex);
 
-   if (isStable && comp->getOption(TR_TraceOptDetails))
+   if (isFieldStable && comp->getOption(TR_TraceOptDetails))
       {
       int classLen;
       const char * className= owningMethod->classNameOfFieldOrStatic(cpIndex, classLen);
@@ -4117,7 +4117,14 @@ TR_J9VMBase::isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilat
       }
 
    // Not checking for JCL classes since @Stable annotation only visible inside JCL
-   return isStable; 
+   return isFieldStable;
+   }
+
+bool
+TR_J9VMBase::isStable(J9Class *fieldClass, int cpIndex)
+   {
+   TR_ASSERT_FATAL(fieldClass, "fieldClass must not be NULL");
+   return jitIsFieldStable(vmThread(), fieldClass, cpIndex);
    }
 
 // Creates a node to initialize the local object flags field

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -915,6 +915,7 @@ public:
     *
     */
    virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp);
+   virtual bool isStable(J9Class *fieldClass, int cpIndex);
 
    /*
     * \brief

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2235,6 +2235,14 @@ TR_J9ServerVM::isLambdaFormGeneratedMethod(TR_ResolvedMethod *method)
    }
 
 bool
+TR_J9ServerVM::isStable(J9Class *fieldClass, int cpIndex)
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_isStable, fieldClass, cpIndex);
+   return std::get<0>(stream->read<bool>());
+   }
+
+bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    TR_ASSERT(vettedForAOT, "The TR_J9SharedCacheServerVM version of this method is expected to be called only from isClassLibraryMethod.\n"

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -151,6 +151,7 @@ public:
    virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock * clazz) override;
    virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass) override;
+   virtual bool isStable(J9Class *fieldClass, int cpIndex) override;
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual void markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart) override;
    virtual void reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency) override;
@@ -184,7 +185,6 @@ public:
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptr_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
    virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
-   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp)  { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
@@ -287,6 +287,7 @@ public:
    virtual bool       needsContiguousCodeAndDataCacheAllocation() override     { return true; }
 
    virtual bool shouldDelayAotLoad() override                                  { return true; }
+   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) override { return false; }
    virtual bool isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueClassBlock * destClass) override;
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 26;
+   static const uint16_t MINOR_NUMBER = 27;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -189,6 +189,7 @@ enum MessageType : uint16_t
    VM_isLambdaFormGeneratedMethod,
    VM_vTableOrITableIndexFromMemberName,
    VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex,
+   VM_isStable,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,
@@ -433,6 +434,7 @@ static const char *messageNames[] =
    "VM_isLambdaFormGeneratedMethod",
    "VM_vTableOrITableIndexFromMemberName",
    "VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex",
+   "VM_isStable",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",


### PR DESCRIPTION
PR #13178 introduced a new front-end query: `TR_J9VMBase::isStable()`.
This commit adds a JITServer version of this method, which also requires
adding a new message type - `VM_isStable`.

Closes: #12953