### PR TITLE
Exclude CloseScope0 test jdk17 temporarily

### DIFF
--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -128,6 +128,12 @@
 	</test>
 	<test>
 		<testCaseName>CloseScope0Tests</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13195</comment>
+				<version>17</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>


### PR DESCRIPTION
jdk17 staging branch has changes to classes that this test depends on.
Will revert this change and fix the test when the staging branch is
merged.

Issue: #13195
Signed-off-by: Eric Yang <eric.yang@ibm.com>