### PR TITLE
Fix close scope test failure jdk17

### DIFF
--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -35,6 +35,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<property name="module_src_root" location="modules" />
 	<property name="module_bin_root" location="module_bin" />
 	<property name="dest_module_bin" location="${DEST}/module_bin" />
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="LIB" value="asm,testng,jcommander" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 
@@ -95,6 +96,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${src_160}" />
+			<src path="${TestUtilities}" />
 			<exclude name="**/modules/**" />
 			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
 			<compilerarg line='--add-modules jdk.incubator.foreign' />

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -128,12 +128,6 @@
 	</test>
 	<test>
 		<testCaseName>CloseScope0Tests</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/13195</comment>
-				<version>17</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -143,7 +137,7 @@
 			--add-opens java.base/java.lang=ALL-UNNAMED \
 			--add-modules jdk.incubator.foreign \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_160.xml$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 			-testnames CloseScope0Tests \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
@@ -156,7 +150,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>16</version>
+			<version>16+</version>
 		</versions>
 	</test>
 	<test>

--- a/test/functional/Java16andUp/testng.xml
+++ b/test/functional/Java16andUp/testng.xml
@@ -29,4 +29,9 @@
             <class name="org.openj9.test.java.lang.Test_Class"/>
         </classes>
     </test>
+    <test name="CloseScope0Tests">
+        <classes>
+            <class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
+        </classes>
+    </test>
 </suite>

--- a/test/functional/Java16andUp/testng_160.xml
+++ b/test/functional/Java16andUp/testng_160.xml
@@ -35,9 +35,4 @@
 			<class name="org.openj9.test.jep389.downcall.PrimitiveTypeTests"/>
 		</classes>
 	</test>
-	<test name="CloseScope0Tests">
-		<classes>
-			<class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
-		</classes>
-	</test>
 </suite>


### PR DESCRIPTION
Class changes in the jdk17 extensions repo (e.g. MemoryScope ->
ResourceScope)
Move test from Java16andUp/src_160 (where only JDK16 can run it) to
Java16andUp/src to enable for JDK16+.

Fixes: #13195
Signed-off-by: Eric Yang <eric.yang@ibm.com>