### PR TITLE
Differentiate inlined frames in extended stack traces for JVMTI agents

### DIFF
--- a/runtime/include/ibmjvmti.h
+++ b/runtime/include/ibmjvmti.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,7 +165,8 @@ enum {
 
 enum {
 	COM_IBM_STACK_FRAME_EXTENDED_NOT_JITTED = 0,
-	COM_IBM_STACK_FRAME_EXTENDED_JITTED     = 1
+	COM_IBM_STACK_FRAME_EXTENDED_JITTED     = 1,
+	COM_IBM_STACK_FRAME_EXTENDED_INLINED    = 2
 };
 
 /**
@@ -174,7 +175,8 @@ enum {
 enum {
 	COM_IBM_GET_STACK_TRACE_PRUNE_UNREPORTED_METHODS	= 1,	/** Prunes methods for which method enter was not reported */
 	COM_IBM_GET_STACK_TRACE_ENTRY_LOCAL_STORAGE			= 2,	/** Returns ELS pointers */
-	COM_IBM_GET_STACK_TRACE_EXTRA_FRAME_INFO			= 4		/** Returns jitted vs non-jitted data */
+	COM_IBM_GET_STACK_TRACE_EXTRA_FRAME_INFO			= 4,	/** Returns jitted vs non-jitted data */
+	COM_IBM_GET_STACK_TRACE_MARK_INLINED_FRAMES			= 8		/** Distinguish between jitted (root) and inlined */
 };
 
 

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1780,6 +1780,8 @@ jvmtiInternalGetStackTraceIteratorExtended(J9VMThread * currentThread, J9StackWa
 #ifdef J9VM_INTERP_NATIVE_SUPPORT 
 			if (walkState->jitInfo == NULL) {
 				frame_buffer->type = COM_IBM_STACK_FRAME_EXTENDED_NOT_JITTED;
+			} else if (J9_ARE_ANY_BITS_SET(type, J9JVMTI_STACK_TRACE_MARK_INLINED_FRAMES) && (walkState->inlineDepth > 0)) {
+				frame_buffer->type = COM_IBM_STACK_FRAME_EXTENDED_INLINED;
 			} else {
 				frame_buffer->type = COM_IBM_STACK_FRAME_EXTENDED_JITTED;
 			}	

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,8 @@ typedef enum {
 typedef enum {
 	J9JVMTI_STACK_TRACE_PRUNE_UNREPORTED_METHODS	= COM_IBM_GET_STACK_TRACE_PRUNE_UNREPORTED_METHODS,
 	J9JVMTI_STACK_TRACE_ENTRY_LOCAL_STORAGE			= COM_IBM_GET_STACK_TRACE_ENTRY_LOCAL_STORAGE,
-	J9JVMTI_STACK_TRACE_EXTRA_FRAME_INFO			= COM_IBM_GET_STACK_TRACE_EXTRA_FRAME_INFO
+	J9JVMTI_STACK_TRACE_EXTRA_FRAME_INFO			= COM_IBM_GET_STACK_TRACE_EXTRA_FRAME_INFO,
+	J9JVMTI_STACK_TRACE_MARK_INLINED_FRAMES			= COM_IBM_GET_STACK_TRACE_MARK_INLINED_FRAMES
 } J9JVMTIStackTraceType;
 
 #define J9JVMTI_LOWEST_EXTENSION_EVENT (J9JVMTI_BEFORE_FIRST_EXTENSION_EVENT + 1)


### PR DESCRIPTION
Inlined frames may now be reported using the new frame type `COM_IBM_STACK_FRAME_EXTENDED_INLINED`, which allows agents to distinguish which compiled frames correspond to the root method of a JIT-compiled body and which do not.

For compatibility with any existing agents, this distinction is only made if explicitly requested by the agent via the new stack trace flag `COM_IBM_GET_STACK_TRACE_MARK_INLINED_FRAMES`.