### PR TITLE
Implement missing front-end queries for JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -495,6 +495,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._osrGlobalBufferSize = javaVM->osrGlobalBufferSize;
          vmInfo._needsMethodTrampolines = TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines();
          vmInfo._objectAlignmentInBytes = TR::Compiler->om.objectAlignmentInBytes();
+         vmInfo._isGetImplInliningSupported = fe->isGetImplInliningSupported();
+         vmInfo._isAllocateZeroedTLHPagesEnabled = fe->tlhHasBeenCleared();
+         vmInfo._staticObjectAllocateFlags = fe->getStaticObjectFlags();
+         vmInfo._referenceArrayCopyHelperAddress = fe->getReferenceArrayCopyHelperAddress();
 
          client->write(response, vmInfo, listOfCacheDescriptors);
          }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -630,6 +630,14 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
    }
 
 bool
+TR_J9ServerVM::isGetImplInliningSupported()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_isGetImplInliningSupported;
+   }
+
+bool
 TR_J9ServerVM::compiledAsDLTBefore(TR_ResolvedMethod *method)
    {
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
@@ -648,6 +656,34 @@ TR_J9ServerVM::getOverflowSafeAllocSize()
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return static_cast<uintptr_t>(vmInfo->_overflowSafeAllocSize);
+   }
+
+void*
+TR_J9ServerVM::getReferenceArrayCopyHelperAddress()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_referenceArrayCopyHelperAddress;
+   }
+
+bool
+TR_J9ServerVM::tlhHasBeenCleared()
+   {
+#if defined(J9VM_GC_BATCH_CLEAR_TLH)
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_isAllocateZeroedTLHPagesEnabled;
+#else
+   return false;
+#endif
+   }
+
+uint32_t
+TR_J9ServerVM::getStaticObjectFlags()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_staticObjectAllocateFlags;
    }
 
 bool

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -86,8 +86,12 @@ public:
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass) override;
    virtual bool classHasBeenReplaced(TR_OpaqueClassBlock *) override;
    virtual bool classHasBeenExtended(TR_OpaqueClassBlock *) override;
+   virtual bool isGetImplInliningSupported() override;
    virtual bool compiledAsDLTBefore(TR_ResolvedMethod *) override;
+   virtual bool tlhHasBeenCleared() override;
+   virtual uint32_t getStaticObjectFlags() override;
    virtual uintptr_t getOverflowSafeAllocSize() override;
+   virtual void *getReferenceArrayCopyHelperAddress() override;
    virtual bool isThunkArchetype(J9Method * method) override;
    virtual int32_t printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method) override;
    virtual bool isClassInitialized(TR_OpaqueClassBlock * clazz) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 27;
+   static const uint16_t MINOR_NUMBER = 28;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -293,6 +293,10 @@ public:
       UDATA _osrGlobalBufferSize;
       bool _needsMethodTrampolines;
       int32_t _objectAlignmentInBytes;
+      bool _isGetImplInliningSupported;
+      bool _isAllocateZeroedTLHPagesEnabled;
+      uint32_t _staticObjectAllocateFlags;
+      void *_referenceArrayCopyHelperAddress;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
There is a number of GC-related front-end queries that
were not implemented for JITServer, which was causing
a number of bugs in tests running metronome GC policy.

All of the new queries access information initialized at
JVM startup, so we cache it inside server's VM info.