### PR TITLE
Define JVMTI_VERSION dynamically according to JAVA_SPEC_VERSION

### DIFF
--- a/runtime/include/jvmti.h.m4
+++ b/runtime/include/jvmti.h.m4
@@ -54,7 +54,8 @@ ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [#define JVMTI_VERSION_15 0x300f0000], 
 #define JVMTI_1_2_SPEC_VERSION           (JVMTI_VERSION_1_2 + 1)	/* Spec version is 1.2.1 */
 #define JVMTI_1_2_3_SPEC_VERSION         (JVMTI_VERSION_1_2 + 3)  /* Spec version is 1.2.3 */
 
-ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [#define JVMTI_VERSION JVMTI_VERSION_15], [
+dnl /* JVMTI_VERSION = 0x30000000 + majorversion * 0x10000 + minorversion (always 0) * 0x100 */
+ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [[#]define JVMTI_VERSION (0x30000000 + (JAVA_SPEC_VERSION * 0x10000))], [
 ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [#define JVMTI_VERSION JVMTI_VERSION_11], [
 #define JVMTI_VERSION JVMTI_1_2_SPEC_VERSION])])
 

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -185,13 +185,11 @@ jvmtiGetVersionNumber(jvmtiEnv* env,
 
 done:
 	if (NULL != version_ptr) {
-#if JAVA_SPEC_VERSION >= 15
-		*version_ptr = JVMTI_VERSION_15;
-#elif JAVA_SPEC_VERSION >= 11 /* JAVA_SPEC_VERSION >= 15 */
-		*version_ptr = JVMTI_VERSION_11;
-#else /* JAVA_SPEC_VERSION >= 15 */
+#if JAVA_SPEC_VERSION >= 11
+		*version_ptr = JVMTI_VERSION;
+#else /* JAVA_SPEC_VERSION >= 11 */
 		*version_ptr = JVMTI_1_2_3_SPEC_VERSION;
-#endif /* JAVA_SPEC_VERSION >= 15 */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetVersionNumber);
 }

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1579,20 +1579,20 @@ jvmtiHookGetEnv(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 
 	Trc_JVMTI_jvmtiHookGetEnv_Entry();
 
-	if (data->rc == JNI_EVERSION) {
-		jint version = data->version & ~JVMTI_VERSION_MASK_MICRO;
+	if (JNI_EVERSION == data->rc) {
+		jint version = (data->version & ~JVMTI_VERSION_MASK_MICRO);
+		jboolean isValidVersion = ((JVMTI_VERSION_1_0 == version) || (JVMTI_VERSION_1_1 == version) || (JVMTI_VERSION_1_2 == version)); 
 
-		if ((JVMTI_VERSION_1_0 == version)
-			|| (JVMTI_VERSION_1_1 == version)
-			|| (JVMTI_VERSION_1_2 == version)
 #if JAVA_SPEC_VERSION > 8
-			|| (JVMTI_VERSION_9 == version)
-			|| (JVMTI_VERSION_11 == version)
-#if JAVA_SPEC_VERSION >= 15
-			|| (JVMTI_VERSION_15 == version)
-#endif /* JAVA_SPEC_VERSION >= 15 */
+		if (!isValidVersion) {
+			/* JVMTI 9+ with minor/micro versions are not accepted, this could change if such support is added explicitly. */
+			jint majorVersion = ((version & JVMTI_VERSION_MASK_MAJOR) >> JVMTI_VERSION_SHIFT_MAJOR);
+			isValidVersion = ((majorVersion > 8)
+				&& (majorVersion <= JAVA_SPEC_VERSION)
+				&& (JVMTI_VERSION_INTERFACE_JVMTI == (version & ~JVMTI_VERSION_MASK_MAJOR)));
+		}
 #endif /* JAVA_SPEC_VERSION > 8 */
-		) {
+		if (isValidVersion) {
 			J9JVMTIData * jvmtiData = userData;
 
 			if ((NULL != jvmtiData) && (JVMTI_PHASE_DEAD != jvmtiData->phase)) {

--- a/runtime/tests/jvmtitests/agent/agent.c
+++ b/runtime/tests/jvmtitests/agent/agent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ Agent_Prepare(JavaVM * vm, char *phase, char * options, void * reserved)
 		rc = JNI_ERR;
 		goto done;
 	}
-	tprintf(env, 100, "JVMTI version: %p\n", version, getVersionName(env, version));
+	tprintf(env, 100, "JVMTI version: %x\n", version);
 	env->jvmtiVersion = version;
 
 	/* Take the options and run the testcase */

--- a/runtime/tests/jvmtitests/agent/version.c
+++ b/runtime/tests/jvmtitests/agent/version.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,57 +23,13 @@
 
 #include "jvmti_test.h"
 
-const static char *versionNames[] =
-{
-	"JVMTI 1.0",
-	"JVMTI 1.1",
-	"JVMTI 1.2",
-	"JVMTI 9.0",
-	"JVMTI 11",
-	"JVMTI 15",
-	"unknown"
-};
-
-
 jboolean
 ensureVersion(agentEnv * agent_env, jint version)
 {
-
 	if ((agent_env->jvmtiVersion & ~JVMTI_VERSION_MASK_MICRO) == version) {
-		const char *versionName = getVersionName(agent_env, version);
-
-		error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Test requires %s",
-				versionName ? versionName : "Unknown Version");
-
+		error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Test requires %x", version);
 		return JNI_FALSE;
 	}
 
 	return JNI_TRUE;
-}
-
-const char *
-getVersionName(agentEnv * agent_env, jint version)
-{
-	switch ((version & ~JVMTI_VERSION_MASK_MICRO)) {
-		case JVMTI_VERSION_1_0:
-			return versionNames[0];
-		case JVMTI_VERSION_1_1:
-			return versionNames[1];
-		case JVMTI_VERSION_1_2:
-			return versionNames[2];
-#if JAVA_SPEC_VERSION > 8
-		case JVMTI_VERSION_9:
-			return versionNames[3];
-		case JVMTI_VERSION_11:
-			return versionNames[4];
-#if JAVA_SPEC_VERSION >= 15
-		case JVMTI_VERSION_15:
-			return versionNames[5];
-#endif /* JAVA_SPEC_VERSION >= 15 */
-#endif /* JAVA_SPEC_VERSION > 8 */
-		default:
-			error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Query for an unknown version");
-	}
-
-	return NULL;
 }

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,7 +149,6 @@ void printHelp(void);
 
 /* version.c */
 jboolean ensureVersion(agentEnv * agent_env, jint version);
-const char * getVersionName(agentEnv * agent_env, jint version);
 
 /* util.c */
 void jvmtitest_usleep(UDATA millis);


### PR DESCRIPTION
`JVMTI_VERSION = 0x30000000 + majorversion * 0x10000 + minorversion (always 0) * 0x100`
Update `jniVersionIsValid()` to accept `JVMTI_VERSION`;
Update references to `JVMTI_VERSION_15`.

Note: `changecom()dnl` is required to generate `#define JVMTI_VERSION (0x30000000 + 16 * 0x10000)` instead of `#define JVMTI_VERSION (0x30000000 + JAVA_SPEC_VERSION * 0x10000)` which won't compile in OpenJDK JCL natives such as `jdk.jdwp.agent/share/native/libjdwp/debugInit.c` where `JAVA_SPEC_VERSION` is not defined.

This fixes AGCT unit testing error:
```
Error: wrong result of a valid call to GetEnv!
JVMJ9TI064E Agent initialization function Agent_OnLoad failed for library AsyncGetCallTraceTest, return code -1
JVMJ9VM015W Initialization error for library j9jvmti29(-3): JVMJ9VM009E J9VMDllMain failed
```

Additional note: running `test/hotspot/jtreg/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java` requires `libAsyncGetCallTraceTest.so` is copied into `test-images/openj9` otherwise following error occurs:
```
JVMJ9TI001E Agent library AsyncGetCallTraceTest could not be opened (libAsyncGetCallTraceTest.so: cannot open shared object file: No such file or directory)
JVMJ9VM015W Initialization error for library j9jvmti29(-3): JVMJ9VM009E J9VMDllMain failed
```

related to https://github.com/eclipse-openj9/openj9/issues/12276

fyi @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>