### PR TITLE
Fix segmentation fault when shareROMClasses is enabled

### DIFF
--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -96,7 +96,8 @@ JITServerSharedROMClassCache::JITServerSharedROMClassCache(size_t numPartitions)
    _numPartitions(numPartitions), _persistentMemory(NULL),
    _partitions((Partition *)TR::Compiler->persistentGlobalMemory()->allocatePersistentMemory(
                numPartitions * sizeof(Partition), TR_Memory::ROMClass)),
-   _monitors(new (TR::Compiler->persistentGlobalMemory()) TR::Monitor *[numPartitions])
+   _monitors((TR::Monitor **) TR::Compiler->persistentGlobalMemory()->allocatePersistentMemory(
+               numPartitions * sizeof(TR::Monitor *), TR_Memory::ROMClass))
    {
    if (!_partitions || !_monitors)
       throw std::bad_alloc();


### PR DESCRIPTION
Allocate the array of JITServer ROM cache partition monitors
by invoking allocator directly, instead of using operator new[].

Fixes: #13210