### PR TITLE
Memory leak in internalFindClassString

### DIFF
--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -339,9 +339,9 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 			}
 
 			result = internalFindClassInModule(currentThread, j9module, utf8Name, utf8Length, classLoader, options);
-			if (utf8Name != localBuf) {
-				j9mem_free_memory(utf8Name);
-			}
+		}
+		if (utf8Name != localBuf) {
+			j9mem_free_memory(utf8Name);
 		}
 	}
 	return result;


### PR DESCRIPTION
As part of running Kafka traffic we hit a condition where both the Kerberos servers and Kafka broker go down and the client continues to send traffic over a long running connection.  An exception is thrown:
org.apache.kafka.common.errors.SaslAuthenticationException: Failed to configure SaslClientAuthenticator
Caused by: org.apache.kafka.common.KafkaException: Principal could not be determined from Subject, this may be a transient failure due to Kerberos re-login

Diagnostics are showing at least a native memory leak for some allocation which contains the following string (on the order of 10k's times):
"org.apache.kafka.common.network.SaslChannelBuilder$$Lambda$7/0x0000000000000000"

Further analysis shows the allocation coming from copyStringToUTF8WithMemAlloc called from internalFindClassString.

Propose moving the free to unconditionally be checked and freed when appropriate outside of a conditional block which appears to be skipped in the condition described above.

