### PR TITLE
Recognize new product name Semeru

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
@@ -697,7 +697,7 @@
 	<test id="Verify whether VM successfully runs in read-only shared cache with testBadBuildID and nonfatal option specified" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xint -Xshareclasses:testBadBuildID,verbose,readonly,nonfatal -version</command>
 		<output type="required" caseSensitive="yes" regex="no">Continue without using it as -Xshareclasses:nonfatal is specified</output>
-		<output type="success"  caseSensitive="yes" regex="yes" javaUtilPattern="yes">(OpenJDK|Java\(TM\) SE) Runtime Environment</output>
+		<output type="success"  caseSensitive="yes" regex="yes" javaUtilPattern="yes">(Semeru|OpenJDK|Java\(TM\) SE) Runtime Environment</output>
 		
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/xlogTests/xlog.xml
+++ b/test/functional/cmdLineTests/xlogTests/xlog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,8 +29,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -38,8 +37,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog: -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -47,8 +45,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:all">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:all -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -56,8 +53,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:all=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:all=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -65,8 +61,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:any,gc">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:any,gc -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -74,8 +69,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc,any">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc,any -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -83,8 +77,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc,any=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc,any=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -92,8 +85,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -101,8 +93,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc: -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -110,8 +101,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:stderr">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:stderr -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -119,8 +109,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:stderr">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:stderr: -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -128,8 +117,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:stderr:any">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:stderr:any -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -137,8 +125,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:stdout">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:stdout -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">verbosegc</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -146,8 +133,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:gclog">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:gclog -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -162,8 +148,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:gclog:">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:gclog: -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -178,8 +163,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc:file=gclog">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc:file=gclog -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
 		<output regex="no" type="failure">JVMJ9VM007</output>
@@ -194,8 +178,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -203,8 +186,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:any+gc=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:any+gc=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -212,8 +194,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc+any=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc+any=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -221,8 +202,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc=off,any">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=off,any -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -230,8 +210,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:any,gc=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:any,gc=off -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -239,8 +218,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:disable">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:disable -version</command>
-		<output regex="no" type="success">openjdk version</output>
-		<output regex="no" type="success">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM085</output>
@@ -249,8 +227,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test id="-Xlog:disable:">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:disable: -version</command>
 		<output regex="no" type="success">JVMJ9VM085E</output>
-		<output regex="no" type="failure">openjdk version</output>
-		<output regex="no" type="failure">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM007W</output>
 	</test>
@@ -258,8 +235,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test id="-Xlog:disable,any">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:disable,any -version</command>
 		<output regex="no" type="success">JVMJ9VM085E</output>
-		<output regex="no" type="failure">openjdk version</output>
-		<output regex="no" type="failure">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM007W</output>
 	</test>
@@ -267,8 +243,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test id="-Xlog:disable+any">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:disable+any -version</command>
 		<output regex="no" type="success">JVMJ9VM085E</output>
-		<output regex="no" type="failure">openjdk version</output>
-		<output regex="no" type="failure">java version</output>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(openjdk|java|semeru) version</output>
 		<output regex="no" type="failure">verbosegc</output>
 		<output regex="no" type="failure">JVMJ9VM007W</output>
 	</test>


### PR DESCRIPTION
Note: this is an addition of https://github.com/eclipse-openj9/openj9/pull/13156 to fix test failures such as following:

`Test_openjdk8_j9_extended.functional_ppc64le_linux_testList_0/83/`
```
[2021-07-20T03:49:28.409Z] Testing: Verify whether VM successfully runs in read-only shared cache with testBadBuildID and nonfatal option specified
"/home/jenkins/workspace/Test_openjdk8_j9_extended.functional_ppc64le_linux_testList_0/openjdkbinary/j2sdk-image/bin/java"  -Xjit -Xgcpolicy:gencon -Xnocompressedrefs  -Xint -Xshareclasses:testBadBuildID,verbose,readonly,nonfatal -version
[2021-07-20T03:49:30.374Z] Test result: FAILED
[2021-07-20T03:49:30.374Z]  [ERR] semeru version "1.8.0_302-beta"
[2021-07-20T03:49:30.374Z]  [ERR] Semeru Runtime Environment (build 1.8.0_302-beta-202107200233-b07)
[2021-07-20T03:49:30.374Z]  [ERR] Eclipse OpenJ9 VM (build master-88dbf3b34, JRE 1.8.0 Linux ppc64le-64-Bit 20210719_163 (JIT disabled, AOT disabled)
[2021-07-20T03:49:30.374Z]  [ERR] OpenJ9   - 88dbf3b34
[2021-07-20T03:49:30.374Z]  [ERR] OMR      - 88427d642
[2021-07-20T03:49:30.374Z]  [ERR] JCL      - 4b45aeb5 based on jdk8u302-b07)
[2021-07-20T03:49:30.374Z] >> Success condition was not found: [Output match: (OpenJDK|Java\(TM\) SE) Runtime Environment]
[2021-07-20T03:49:30.375Z] testSCCMLTests4_0_FAILED
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>