### PR TITLE
Change uses of snprintf() to use infra/String.hpp instead

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -161,6 +161,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/infra/OMRMonitorTable.cpp \
     omr/compiler/infra/Random.cpp \
     omr/compiler/infra/SimpleRegex.cpp \
+    omr/compiler/infra/String.cpp \
     omr/compiler/infra/Timer.cpp \
     omr/compiler/infra/TreeServices.cpp \
     omr/compiler/optimizer/AsyncCheckInsertion.cpp \

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -24,11 +24,6 @@
  * Support code for TR::CodeGenerator.  Code related to generating GPU
  */
 
-#if defined (_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
-
-#include <stdio.h>
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/RecognizedMethods.hpp"
@@ -39,6 +34,7 @@
 #include "il/ParameterSymbol.hpp"
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
+#include "infra/String.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/annotations/GPUAnnotation.hpp"
@@ -547,25 +543,18 @@ static const char* getVarTypeName(TR::DataType type) {
 
 static void getParmName(int32_t slot, char * s, bool addr = true)
    {
-   int32_t len = 0;
-
-   len = snprintf(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", slot,  addr ? ".addr" : "");
-
-   TR_ASSERT(len < MAX_NAME, "Auto's or parm's name is too long\n");
+   TR::snprintfNoTrunc(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", slot,  addr ? ".addr" : "");
    }
 
 
 static void getAutoOrParmName(TR::Symbol *sym, char * s, bool addr = true)
    {
-   int32_t len = 0;
    TR_ASSERT(sym->isAutoOrParm(), "expecting auto or parm");
 
    if (sym->isParm())
-      len = snprintf(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", sym->castToParmSymbol()->getSlot(),  addr ? ".addr" : "");
+      TR::snprintfNoTrunc(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", sym->castToParmSymbol()->getSlot(),  addr ? ".addr" : "");
    else
-      len = snprintf(s, MAX_NAME, "%%a%" OMR_PRId32 "%s", sym->castToAutoSymbol()->getLiveLocalIndex(), addr ? ".addr" : "");
-
-   TR_ASSERT(len < MAX_NAME, "Auto's or parm's name is too long\n");
+      TR::snprintfNoTrunc(s, MAX_NAME, "%%a%" OMR_PRId32 "%s", sym->castToAutoSymbol()->getLiveLocalIndex(), addr ? ".addr" : "");
    }
 
 
@@ -626,7 +615,6 @@ class NVVMIRBuffer
 
 static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
    {
-   int32_t len = 0;
    if (node->getOpCode().isLoadConst())
       {
       bool isUnsigned = node->getOpCode().isUnsigned();
@@ -634,24 +622,24 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
          {
          case TR::Int8:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, "%" OMR_PRIu8, node->getUnsignedByte());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRIu8, node->getUnsignedByte());
             else
-               len = snprintf(s, MAX_NAME, "%" OMR_PRId8, node->getByte());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRId8, node->getByte());
             break;
          case TR::Int16:
-            len = snprintf(s, MAX_NAME, "%" OMR_PRIu16, node->getConst<uint16_t>());
+            TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRIu16, node->getConst<uint16_t>());
             break;
          case TR::Int32:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, "%" OMR_PRIu32, node->getUnsignedInt());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRIu32, node->getUnsignedInt());
             else
-               len = snprintf(s, MAX_NAME, "%" OMR_PRId32, node->getInt());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRId32, node->getInt());
             break;
          case TR::Int64:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, "%" OMR_PRIu64, node->getUnsignedLongInt());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRIu64, node->getUnsignedLongInt());
             else
-               len = snprintf(s, MAX_NAME, "%" OMR_PRId64, node->getLongInt());
+               TR::snprintfNoTrunc(s, MAX_NAME, "%" OMR_PRId64, node->getLongInt());
             break;
          case TR::Float:
             union
@@ -660,14 +648,14 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
                int64_t                 doubleBits;
                };
             doubleValue = node->getFloat();
-            len = snprintf(s, MAX_NAME, "0x%016" OMR_PRIx64, doubleBits);
+            TR::snprintfNoTrunc(s, MAX_NAME, "0x%016" OMR_PRIx64, doubleBits);
             break;
          case TR::Double:
-            len = snprintf(s, MAX_NAME, "0x%016" OMR_PRIx64, node->getDoubleBits());
+            TR::snprintfNoTrunc(s, MAX_NAME, "0x%016" OMR_PRIx64, node->getDoubleBits());
             break;
          case TR::Address:
             if (node->getAddress() == 0)
-               len = snprintf(s, MAX_NAME, "null");
+               TR::snprintfNoTrunc(s, MAX_NAME, "null");
             else
                TR_ASSERT(0, "Non-null Address constants should not occur.\n");
             break;
@@ -677,10 +665,8 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
       }
    else
       {
-      len = snprintf(s, MAX_NAME, "%%%" OMR_PRIu32, node->getLocalIndex());
+      TR::snprintfNoTrunc(s, MAX_NAME, "%%%" OMR_PRIu32, node->getLocalIndex());
       }
-
-   TR_ASSERT(len < MAX_NAME, "Node's name is too long\n");
    }
 
 char* getNVVMMathFunctionName(TR::Node *node)
@@ -1309,8 +1295,7 @@ J9::CodeGenerator::printNVVMIR(
          }
       else
          {
-         int32_t len = snprintf(name0, MAX_NAME, "%" OMR_PRId32, smsize);
-         TR_ASSERT(len < MAX_NAME, "Node's name is too long\n");
+         TR::snprintfNoTrunc(name0, MAX_NAME, "%" OMR_PRId32, smsize);
          }
 
       getNodeName(node->getChild(1), name1, self()->comp());

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -49,18 +49,13 @@
 #include "infra/Assert.hpp"
 #include "infra/BitVector.hpp"
 #include "infra/List.hpp"
+#include "infra/String.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "optimizer/TransformUtil.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "env/j9methodServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
-
-#include <stdio.h>
-
-#if defined (_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 
 namespace J9
 {
@@ -786,7 +781,7 @@ J9::SymbolReferenceTable::findOrFabricateShadowSymbol(
 
    int qualifiedFieldNameSize = classNameLen + 1 + strlen(name) + 1 + strlen(signature) + 1;
    char *qualifiedFieldName = (char*)trHeapMemory().allocate(qualifiedFieldNameSize);
-   snprintf(
+   TR::snprintfNoTrunc(
       qualifiedFieldName,
       qualifiedFieldNameSize,
       "%.*s.%s %s",

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -29,10 +29,6 @@
 #define J9OS_STRNCMP strncmp
 #endif
 
-#if defined (_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 #include "control/CompilationThread.hpp"
 
 #include <exception>
@@ -80,6 +76,7 @@
 #include "infra/CriticalSection.hpp"
 #include "infra/MonitorTable.hpp"
 #include "infra/Monitor.hpp"
+#include "infra/String.hpp"
 #include "ras/InternalFunctions.hpp"
 #include "runtime/asmprotos.h"
 #include "runtime/CodeCache.hpp"
@@ -6941,8 +6938,8 @@ TR::CompilationInfoPerThreadBase::generatePerfToolEntry()
       static const int maxPerfFilenameSize = 15 + sizeof(jvmPid)* 3; // "/tmp/perf-%ld.map"
       char perfFilename[maxPerfFilenameSize] = { 0 };
 
-      int numCharsWritten = snprintf(perfFilename, maxPerfFilenameSize, "/tmp/perf-%ld.map", jvmPid);
-      if (numCharsWritten > 0 && numCharsWritten < maxPerfFilenameSize)
+      bool truncated = TR::snprintfTrunc(perfFilename, maxPerfFilenameSize, "/tmp/perf-%ld.map", jvmPid);
+      if (!truncated)
          {
          TR::CompilationInfoPerThreadBase::_perfFile = j9jit_fopen(perfFilename, "a", true, false);
          }
@@ -9307,7 +9304,7 @@ TR::CompilationInfoPerThreadBase::compile(
       if (TR::Options::isAnyVerboseOptionSet(TR_VerbosePerformance, TR_VerboseCompileStart))
          {
          char compilationTypeString[15]={0};
-         snprintf(compilationTypeString, sizeof(compilationTypeString), "%s%s",
+         TR::snprintfNoTrunc(compilationTypeString, sizeof(compilationTypeString), "%s%s",
                  vm.isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
                  compiler->isProfilingCompilation() ? "profiled " : ""
                 );
@@ -10472,7 +10469,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
       else
          {
          char compilationTypeString[15] = { 0 };
-         snprintf(compilationTypeString, sizeof(compilationTypeString), "%s%s",
+         TR::snprintfNoTrunc(compilationTypeString, sizeof(compilationTypeString), "%s%s",
             vm.isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
             compiler->isProfilingCompilation() ? "profiled " : "");
 
@@ -10688,7 +10685,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
             }
 
          char compilationAttributes[40] = { 0 };
-         snprintf(compilationAttributes, sizeof(compilationAttributes), "%s %s %s %s %s %s %s",
+         TR::snprintfNoTrunc(compilationAttributes, sizeof(compilationAttributes), "%s %s %s %s %s %s %s",
                       prexString,
                       (_compInfo.useSeparateCompilationThread() && !_methodBeingCompiled->_async) ? "sync" : "",
                       compilee->isJNINative()? "JNI" : "",
@@ -10697,11 +10694,6 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                       compiler->isDLT() ? "DLT" : "",
                       TR::CompilationInfo::isJSR292(method) ? "JSR292" : ""
                       );
-#if defined (_MSC_VER) && _MSC_VER < 1900
-         // Microsoft has a compliant version of snprintf only starting with Visual Studio 2015
-         // We should add the null terminator just in case
-         * (compilationAttributes + sizeof(compilationAttributes)-1) = '\0';
-#endif
 
          Trc_JIT_compileEnd15(vmThread, compilationTypeString, hotnessString, compiler->signature(),
                                startPC, endWarmPC, startColdPC, endPC,
@@ -11037,7 +11029,7 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
       uintptr_t translationTime = j9time_usec_clock() - getTimeWhenCompStarted(); //get the time it took to fail the compilation
       
       char compilationTypeString[15] = { 0 };
-      snprintf(compilationTypeString, sizeof(compilationTypeString), "%s%s",
+      TR::snprintfNoTrunc(compilationTypeString, sizeof(compilationTypeString), "%s%s",
          compiler->fej9()->isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
          compiler->isProfilingCompilation() ? "profiled " : "");
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -20,10 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined (_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
-
 #include "env/J9SharedCache.hpp"
 
 #include <algorithm>

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -26,10 +26,6 @@
 #include "env/VMJ9Server.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-#if defined (_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
-
 #include "env/VMJ9.h"
 
 #include <algorithm>
@@ -130,6 +126,7 @@
 #include "infra/Bit.hpp"               //for trailingZeroes
 #include "VMHelpers.hpp"
 #include "env/JSR292Methods.h"
+#include "infra/String.hpp"
 
 #ifdef LINUX
 #include <signal.h>
@@ -4365,8 +4362,8 @@ TR_J9VMBase::getOverflowSafeAllocSize()
 void
 TR_J9VMBase::unsupportedByteCode(TR::Compilation * comp, U_8 opcode)
    {
-   char errMsg[40];
-   snprintf(errMsg, 40, "bytecode %d not supported by JIT", opcode);
+   char errMsg[64];
+   TR::snprintfNoTrunc(errMsg, sizeof (errMsg), "bytecode %d not supported by JIT", opcode);
    comp->failCompilation<TR::CompilationException>(errMsg);
    }
 
@@ -4988,9 +4985,8 @@ getSignatureForLinkToStatic(
 
    const char * const origSignature = utf8Data(romMethodSignature);
    const int origSignatureLength = J9UTF8_LENGTH(romMethodSignature);
-   signatureLength = origSignatureLength + extraParamsLength;
 
-   const int32_t signatureAllocSize = signatureLength + 1; // +1 for NUL terminator
+   const int32_t signatureAllocSize = origSignatureLength + extraParamsLength + 1; // +1 for NUL terminator
    char * linkToStaticSignature =
       (char *)comp->trMemory()->allocateMemory(signatureAllocSize, heapAlloc);
 
@@ -5030,7 +5026,7 @@ getSignatureForLinkToStatic(
       origSignature);
 
    // Put together the new signature.
-   const int formattedLength = snprintf(
+   signatureLength = TR::snprintfNoTrunc(
       linkToStaticSignature,
       signatureAllocSize,
       "(%s%.*s%s)%.*s",
@@ -5040,20 +5036,6 @@ getSignatureForLinkToStatic(
       extraParamsAfter,
       (int)(returnTypeEnd - returnType),
       returnType);
-
-   // This condition implies that (formattedLength < signatureAllocSize), so
-   // given that the assertion passes, we can be sure that the signature was
-   // not truncated.
-   TR_ASSERT_FATAL(
-      formattedLength == signatureLength,
-      "expected linkToStatic signature length %d but got %d "
-      "(origSignature `%.*s', extraParamsBefore `%s', extraParamsAfter `%s')",
-      signatureLength,
-      formattedLength,
-      origSignatureLength,
-      origSignature,
-      extraParamsBefore,
-      extraParamsAfter);
 
    return linkToStaticSignature;
    }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -20,10 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined (_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
-
 #include "env/j9method.h"
 
 #include <stddef.h>

--- a/runtime/compiler/optimizer/StringBuilderTransformer.cpp
+++ b/runtime/compiler/optimizer/StringBuilderTransformer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,12 +29,9 @@
 #include "env/VMJ9.h"
 #include "il/Block.hpp"
 #include "il/StaticSymbol.hpp"
+#include "infra/String.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "ras/DebugCounter.hpp"
-
-#if defined (_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 
 #define OPT_DETAILS "O^O STRINGBUILDER TRANSFORMER: "
 
@@ -504,17 +501,7 @@ int32_t TR_StringBuilderTransformer::computeHeuristicStringBuilderInitCapacity(L
             {
             if (argument->getOpCodeValue() == TR::dconst)
                {
-               char printed[32];
-
-               // The C Standard Library guarantees the printed array to be null-terminated except on certain versions of MSVC++
-               snprintf(printed, sizeof(printed) / sizeof(printed[0]), "%g", argument->getDouble());
-
-#if defined (_MSC_VER) && _MSC_VER < 1900
-               // Explicitly null terminate as null termination is not guaranteed
-               printed[(sizeof(printed) / sizeof(printed[0])) - 1] = '\0';
-#endif
-
-               capacity += strlen(printed);
+               capacity += TR::printfLen("%g", argument->getDouble());
                }
             else
                {
@@ -527,17 +514,7 @@ int32_t TR_StringBuilderTransformer::computeHeuristicStringBuilderInitCapacity(L
             {
             if (argument->getOpCodeValue() == TR::fconst)
                {
-               char printed[32];
-
-               // The C Standard Library guarantees the printed array to be null-terminated except on certain versions of MSVC++
-               snprintf(printed, sizeof(printed) / sizeof(printed[0]), "%g", argument->getFloat());
-
-#if defined (_MSC_VER) && _MSC_VER < 1900
-               // Explicitly null terminate as null termination is not guaranteed
-               printed[(sizeof(printed) / sizeof(printed[0])) - 1] = '\0';
-#endif
-
-               capacity += strlen(printed);
+               capacity += TR::printfLen("%g", argument->getFloat());
                }
             else
                {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -29,6 +29,7 @@
 #include "compile/Compilation.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
+#include "infra/String.hpp"
 #include "runtime/RelocationRuntime.hpp"
 #include "runtime/SymbolValidationManager.hpp"
 
@@ -37,10 +38,6 @@
 #endif
 
 #include "j9protos.h"
-
-#if defined (_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 
 TR::SymbolValidationManager::SystemClassNotWorthRemembering
 TR::SymbolValidationManager::_systemClassesNotWorthRemembering[] = {
@@ -197,8 +194,7 @@ TR::SymbolValidationManager::getSystemClassNotWorthRemembering(int idx)
 void
 TR::SymbolValidationManager::getWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses)
    {
-   int len = snprintf(buffer, size, "AOTWellKnownClasses:%x", includedClasses);
-   TR_ASSERT(len <= size, "Buffer too small");
+   TR::snprintfNoTrunc(buffer, size, "AOTWellKnownClasses:%x", includedClasses);
    }
 
 void


### PR DESCRIPTION
This eliminates all instances of the MSVC conditional `snprintf` `#define` (outside of String.cpp), and it deduplicates and in some instances corrects truncation detection logic.

Closes https://github.com/eclipse-openj9/openj9/issues/11884