### PR TITLE
AArch64: Enable ArrayCopyOpts and primitive arraycopy

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -65,6 +65,8 @@ J9::ARM64::CodeGenerator::initialize()
    cg->setSupportsDivCheck();
    if (!comp()->getOption(TR_FullSpeedDebug))
       cg->setSupportsDirectJNICalls();
+
+   cg->setSupportsPrimitiveArrayCopy();
    }
 
 TR::Linkage *

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1822,13 +1822,6 @@ onLoadInternal(
       }
 #endif
 
-#if defined(TR_HOST_ARM64)
-   // ArrayCopy transformations are not available in AArch64 yet.
-   // OpenJ9 issue #6438 tracks the work to enable.
-   //
-   TR::Options::getCmdLineOptions()->setOption(TR_DisableArrayCopyOpts);
-#endif
-
 #ifdef J9VM_RAS_DUMP_AGENTS
    jitConfig->runJitdump = runJitdump;
 #endif


### PR DESCRIPTION
This commit enables ArrayCopyOpts and primitive arraycopy on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>