### PR TITLE
JDK Path Update For AArch64 Build Documentation

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -780,11 +780,11 @@ Copy its contents to your AArch64 Linux device.
 For a simple test, try running the `java -version` command.
 Change to your jdk directory on AArch64 Linux:
 ```
-cd jdk
+cd build/linux-aarch64-normal-server-release/images/jdk
 ```
 Run:
 ```
-bin/java -version
+./bin/java -version
 ```
 
 Here is some sample output:

--- a/doc/build-instructions/Build_Instructions_V16.md
+++ b/doc/build-instructions/Build_Instructions_V16.md
@@ -774,11 +774,11 @@ Copy its contents to your AArch64 Linux device.
 For a simple test, try running the `java -version` command.
 Change to your jdk directory on AArch64 Linux:
 ```
-cd jdk
+cd build/linux-aarch64-normal-server-release/images/jdk
 ```
 Run:
 ```
-bin/java -version
+./bin/java -version
 ```
 
 Here is some sample output:


### PR DESCRIPTION
This commit corrects the paths mentioned for the version 11 and version
16 JDK build.

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>