### PR TITLE
Use exceptions instead of return codes for CRIU

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCRIUException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCRIUException.java
@@ -1,3 +1,4 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2021 IBM Corp. and others
  *
@@ -19,20 +20,35 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.eclipse.openj9.criu;
 
-#ifndef _Included_org_eclipse_openj9_criu_CRIUSupport
-#define _Included_org_eclipse_openj9_criu_CRIUSupport
+/**
+ * Abstract CRIU exception superclass. Contains an error code returned from a failed operation.
+ */
+public abstract class JVMCRIUException extends RuntimeException {
+    private static final long serialVersionUID = 4486137934620495516L;
+    protected int errorCode;
 
-#include <jni.h>
-#include "j9.h"
+    protected JVMCRIUException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
 
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
+    /**
+     * Returns the error code.
+     *
+     * @return errorCode
+     */
+    public int getErrorCode() {
+        return errorCode;
+    }
 
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused);
-
-void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir);
-
-#endif
+    /**
+     * Sets the error code.
+     *
+     * @param errorCode the value to set to
+     */
+    public void setErrorCode(int errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
@@ -1,3 +1,4 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2021 IBM Corp. and others
  *
@@ -19,20 +20,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.eclipse.openj9.criu;
 
-#ifndef _Included_org_eclipse_openj9_criu_CRIUSupport
-#define _Included_org_eclipse_openj9_criu_CRIUSupport
+/**
+ * A CRIU exception representing a failure in the JVM before checkpoint.
+ */
+public final class JVMCheckpointException extends JVMCRIUException {
+    private static final long serialVersionUID = 3729891178366898261L;
 
-#include <jni.h>
-#include "j9.h"
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused);
-
-void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir);
-
-#endif
+    /**
+     * Creates a JVMCheckpointException with the specified message and error code.
+     *
+     * @param message the message
+     * @param errorCode the error code
+     */
+    public JVMCheckpointException(String message, int errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/RestoreException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/RestoreException.java
@@ -1,3 +1,4 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2021 IBM Corp. and others
  *
@@ -19,20 +20,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.eclipse.openj9.criu;
 
-#ifndef _Included_org_eclipse_openj9_criu_CRIUSupport
-#define _Included_org_eclipse_openj9_criu_CRIUSupport
+/**
+ * A CRIU exception representing a failure after restore.
+ */
+public final class RestoreException extends JVMCRIUException {
+    private static final long serialVersionUID = 1539393473417716292L;
 
-#include <jni.h>
-#include "j9.h"
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused);
-
-void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir);
-
-#endif
+    /**
+     * Creates a RestoreException with the specified message and error code.
+     *
+     * @param message the message
+     * @param errorCode the error code
+     */
+    public RestoreException(String message, int errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/SystemCheckpointException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/SystemCheckpointException.java
@@ -1,3 +1,4 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2021 IBM Corp. and others
  *
@@ -19,20 +20,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.eclipse.openj9.criu;
 
-#ifndef _Included_org_eclipse_openj9_criu_CRIUSupport
-#define _Included_org_eclipse_openj9_criu_CRIUSupport
+/**
+ * A CRIU exception representing a failed CRIU operation.
+ */
+public final class SystemCheckpointException extends JVMCRIUException {
+    private static final long serialVersionUID = 1262214147293662586L;
 
-#include <jni.h>
-#include "j9.h"
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
-
-jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused);
-
-void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir);
-
-#endif
+    /**
+     * Creates a SystemCheckpointException with the specified message and error code.
+     *
+     * @param message the message
+     * @param errorCode the error code
+     */
+    public SystemCheckpointException(String message, int errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -29,3 +29,6 @@ TraceAssert=Assert_CRIU_false noEnv Overhead=1 Level=1 Assert="!(P1)"
 TraceAssert=Assert_CRIU_notNull noEnv Overhead=1 Level=1 Assert="(P1) != NULL"
 TraceAssert=Assert_CRIU_mustHaveVMAccess noEnv Overhead=1 Level=1 Assert="(P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS"
 TraceAssert=Assert_CRIU_mustNotHaveVMAccess noEnv Overhead=1 Level=1 Assert="0 == ((P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)"
+
+TraceException=Trc_CRIU_getNativeString_getStringSizeFail Overhead=1 Level=1 Template="Failed to get Java string size: mutf8String=%s mutf8StringSize=%zu"
+TraceException=Trc_CRIU_getNativeString_convertFail Overhead=1 Level=1 Template="Failed to convert Java string: mutf8String=%s mutf8StringSize=%zu requiredConvertedStringSize=%zd"

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -449,7 +449,15 @@ J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR=Could not open the checkpoint data directory, 
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.sample_input_1=1
 J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.explanation=An error occured when the JVM attempted to open the specified directory.
-J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.system_action=The JVM will throw an InternalError.
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.system_action=The JVM will throw a JVMCheckpointException.
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.user_response=Ensure the specified directory is accessible.
+# END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_WORK_DIR=Could not open the work directory, errno=%li
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.sample_input_1=1
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.explanation=An error occured when the JVM attempted to open the specified directory.
+J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.system_action=The JVM will throw a JVMCheckpointException.
 J9NLS_JCL_CRIU_FAILED_TO_OPEN_DIR.user_response=Ensure the specified directory is accessible.
 # END NON-TRANSLATABLE
 
@@ -457,7 +465,7 @@ J9NLS_JCL_CRIU_INIT_FAILED=Could not init CRIU options, err=%li
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_INIT_FAILED.sample_input_1=1
 J9NLS_JCL_CRIU_INIT_FAILED.explanation=An error occured when the JVM attempted to initialize CRIU options.
-J9NLS_JCL_CRIU_INIT_FAILED.system_action=The JVM will throw an InternalError.
+J9NLS_JCL_CRIU_INIT_FAILED.system_action=The JVM will throw a SystemCheckpointException.
 J9NLS_JCL_CRIU_INIT_FAILED.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
 
@@ -465,7 +473,7 @@ J9NLS_JCL_CRIU_DUMP_FAILED=Could not dump the JVM processs, err=%li
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_DUMP_FAILED.sample_input_1=1
 J9NLS_JCL_CRIU_DUMP_FAILED.explanation=An error occured when the JVM attempted to dump the process via criu_dump.
-J9NLS_JCL_CRIU_DUMP_FAILED.system_action=The JVM will throw an InternalError.
+J9NLS_JCL_CRIU_DUMP_FAILED.system_action=The JVM will throw a SystemCheckpointException.
 J9NLS_JCL_CRIU_DUMP_FAILED.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
 
@@ -473,7 +481,15 @@ J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR=Could not close the checkpoint data directory
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.sample_input_1=1
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.explanation=An error occured when the JVM attempted to close the specified directory.
-J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.system_action=The JVM will throw an InternalError.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.system_action=The JVM will throw a RestoreException or SystemCheckpointException.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.user_response=Ensure the specified directory is accessible.
+# END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR=Could not close the work directory, errno=%li
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.sample_input_1=1
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.explanation=An error occured when the JVM attempted to close the specified directory.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.system_action=The JVM will throw a RestoreException or SystemCheckpointException.
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_DIR.user_response=Ensure the specified directory is accessible.
 # END NON-TRANSLATABLE
 
@@ -481,6 +497,6 @@ J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING=Could not convert java string to na
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING.sample_input_1=1
 J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING.explanation=An error occured when the JVM attempted to convert a java string to native encoding.
-J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING.system_action=The JVM will throw an InternalError.
+J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING.system_action=The JVM will throw a JVMCheckpointException.
 J9NLS_JCL_CRIU_FAILED_TO_CONVERT_JAVA_STRING.user_response=Ensure the specified input strings are valid.
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5535,15 +5535,12 @@ typedef struct J9JavaVM {
 	U_32 javaVM31PadTo8; /* Possible to optimize with future guarded U_32 member in ENV_DATA64. */
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	jclass criuResultTypeClass;
-	jfieldID criuSupportSuccess;
-	jfieldID criuSupportUnsupportedOperation;
-	jfieldID criuSupportInvalidArguments;
-	jfieldID criuSupportSystemCheckpointFailure;
-	jfieldID criuSupportJVMCheckpointFailure;
-	jfieldID criuSupportJVMRestoreFailure;
-	jclass criuResultClass;
-	jmethodID criuResultInit;
+	jclass criuJVMCheckpointExceptionClass;
+	jclass criuSystemCheckpointExceptionClass;
+	jclass criuRestoreExceptionClass;
+	jmethodID criuJVMCheckpointExceptionInit;
+	jmethodID criuSystemCheckpointExceptionInit;
+	jmethodID criuRestoreExceptionInit;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	J9CRIUCheckpointState *checkpointState;
 } J9JavaVM;


### PR DESCRIPTION
`checkpointJVM` should throw exceptions instead of setting return codes.
`JVMCheckpointException`: issue with the JVM
`SystemCheckpointException`: issue with CRIU
`RestoreException`: issue upon CRIU restore

Closes: #13137
Signed-off-by: Eric Yang <eric.yang@ibm.com>