### PR TITLE
Move Linux aarch64 compiles to Adoptium docker container

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -645,7 +645,7 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     if ("${DOCKER_IMAGE}") {
                         prepare_docker_environment()
-                        docker.image(DOCKER_IMAGE_ID).inside {
+                        docker.image(DOCKER_IMAGE_ID).inside("-v /home/jenkins/openjdk_cache:/home/jenkins/openjdk_cache:rw,z") {
                             _build_all()
                         }
                     } else {

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1579,7 +1579,7 @@ def download_boot_jdk(bootJDKVersion, bootJDK) {
         sh """
             curl -LJkO ${sdkUrl}
             mkdir -p ${bootJDK}
-            sdkFile=`ls | grep OpenJDK`
+            sdkFile=`ls | grep semeru`
             if [[ "\$sdkFile" == *zip ]]; then
                 unzip "\$sdkFile" -d .
                 sdkFolder=`ls -d */`

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -495,9 +495,12 @@ aarch64_linux:
     8: 'linux-aarch64-normal-server-release'
     11: 'linux-aarch64-normal-server-release'
   node_labels:
-    build: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
+    build:
+      11: 'ci.role.build && hw.arch.aarch64 && sw.tool.docker'
+    docker_image:
+      11: 'adoptopenjdk/centos7_build_image@sha256:b2cc072a5c6196461a0993c6817d7540b8c8fcbce40f63cd5bb49eb6d7d61d89'
   build_env:
-    vars: 'PATH+TOOLS=/usr/local/gcc-7.5.0/bin'
+    vars: 'CC=/usr/local/gcc/bin/gcc-7.5 CXX=/usr/local/gcc/bin/g++-7.5'
 #========================================#
 # Linux Aarch 64bits Compressed Pointers /w cmake
 #========================================#


### PR DESCRIPTION
* update the download name expected from Adopt API; OpenJDK->semeru
* modify build requirement for aarch64_linux to use docker and an
    Adoptium docker container
* set CC/CXX values for specific gcc-7.5 location
* add openjdk_cache directory from the docker host to container

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>