### PR TITLE
Remove precision adjustments from floating-point math

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11878,25 +11878,12 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
    if (!callInlined && (symbol->isVMInternalNative() || symbol->isJITInternalNative()))
       {
       if (TR::TreeEvaluator::VMinlineCallEvaluator(node, false, cg))
-         returnRegister = node->getRegister();
+         return node->getRegister();
       else
-         returnRegister = TR::TreeEvaluator::performCall(node, false, true, cg);
-
-      callInlined = true;
+         return TR::TreeEvaluator::performCall(node, false, true, cg);
       }
-
-   if (callInlined)
+   else if (callInlined)
       {
-      // A strictfp caller needs to adjust double return values;
-      // a float callee always returns values that have correct precision.
-      //
-      if (returnRegister &&
-          returnRegister->needsPrecisionAdjustment() &&
-          comp->getCurrentMethod()->isStrictFP())
-         {
-         TR::TreeEvaluator::insertPrecisionAdjustment(returnRegister, node, cg);
-         }
-
       return returnRegister;
       }
 


### PR DESCRIPTION
All floating-point operations are assumed to be strict

See #12759 

Signed-off-by: BradleyWood <bradley.wood@ibm.com>