### PR TITLE
Disable inline script dump

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3402,11 +3402,6 @@ bool TR_MultipleCallTargetInliner::inlineCallTargets(TR::ResolvedMethodSymbol *c
                }
             }
          }
-
-      if (tracer()->heuristicLevel())
-         {
-         tracer()->dumpInline(&_callTargets, "inline script");
-         }
       }
 
    if (prevCallStack == 0)
@@ -5079,7 +5074,7 @@ bool TR_J9InlinerPolicy::isJSR292SmallHelperMethod(TR_ResolvedMethod *resolvedMe
       case TR::java_lang_invoke_MethodHandle_doCustomizationLogic:
       case TR::java_lang_invoke_MethodHandle_undoCustomizationLogic:
          return true;
-      
+
       default:
          break;
       }


### PR DESCRIPTION
The inline script appears to be a legacy feature useful for consumption
by a tool that does not exist anymore.  The dump is just consuming space
in the log file and does not provide any value over other tracing.  Disable
it.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>