### PR TITLE
Add a JITServer option to do cold sync compiles locally

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7507,9 +7507,11 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          if (!doLocalCompilation &&
              !entry->_async &&
              !entry->isJNINative() &&
+             entry->_optimizationPlan->getOptLevel() > cold &&
              !details.isNewInstanceThunk() &&
              !details.isMethodHandleThunk() &&
-             TR::Options::getCmdLineOptions()->getOption(TR_EnableJITServerHeuristics) &&
+             (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITServerHeuristics) ||
+             _compInfo.getPersistentInfo()->isLocalSyncCompiles()) &&
              !TR::Options::getCmdLineOptions()->getOption(TR_DisableUpgradingColdCompilations) &&
              TR::Options::getCmdLineOptions()->allowRecompilation())
             {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2028,6 +2028,17 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                GET_OPTION_VALUE(xxJITServerAddressArgIndex, '=', &address);
                compInfo->getPersistentInfo()->setJITServerAddress(address);
                }
+
+            const char *xxJITServerLocalSyncCompilesOption = "-XX:+JITServerLocalSyncCompiles";
+            const char *xxDisableJITServerLocalSyncCompilesOption = "-XX:-JITServerLocalSyncCompiles";
+
+            int32_t xxJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLocalSyncCompilesOption, 0);
+            int32_t xxDisableJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLocalSyncCompilesOption, 0);
+
+            if (xxJITServerLocalSyncCompilesArgIndex > xxDisableJITServerLocalSyncCompilesArgIndex)
+               {
+               compInfo->getPersistentInfo()->setLocalSyncCompiles(true);
+               }
             }
          }
       if (!JITServerParseCommonOptions(vm, compInfo))

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -165,6 +165,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _clientUID(0),
          _JITServerUseAOTCache(false),
          _requireJITServer(false),
+         _localSyncCompiles(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -344,6 +345,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
    bool getRequireJITServer() const { return _requireJITServer; }
    void setRequireJITServer(bool requireJITServer) { _requireJITServer = requireJITServer; }
+   bool isLocalSyncCompiles() const { return _localSyncCompiles; }
+   void setLocalSyncCompiles(bool localSyncCompiles) { _localSyncCompiles = localSyncCompiles; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -436,6 +439,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
    bool        _JITServerUseAOTCache;
    bool        _requireJITServer;
+   bool        _localSyncCompiles;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 


### PR DESCRIPTION
This commit adds a new command-line option
`-XX:[+|-]JITServerLocalAsyncCompiles`.
When enabled, JITServer client will perform downgraded
sync compilations locally.