### PR TITLE
Clean up softmx logic in MemorySubSpaceTarok

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1347,12 +1347,12 @@ MM_MemorySubSpaceTarok::calculateExpandSize(MM_EnvironmentBase *env, UDATA bytes
 	/* Adjust within -XsoftMx limit */
 	if (expandToSatisfy){
 		/* we need at least bytesRequired or we will get an OOM */
-		expandSize = adjustExpansionWithinSoftMax(env, expandSize, bytesRequired);
+		expandSize = adjustExpansionWithinSoftMx(env, expandSize, bytesRequired);
 	} else {
 		/* we are adjusting based on other command line options, so fully respect softmx,
 		 * the minimum expand it can allow in this case is 0
 		 */
-		expandSize = adjustExpansionWithinSoftMax(env, expandSize, 0);
+		expandSize = adjustExpansionWithinSoftMx(env, expandSize, 0);
 	}
 	
 	Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit1(env->getLanguageVMThread(), desiredFree, currentFree, expandSize);
@@ -1369,7 +1369,7 @@ MM_MemorySubSpaceTarok::calculateCollectorExpandSize(MM_EnvironmentBase *env)
 	UDATA expandSize = _heapRegionManager->getRegionSize(); 
 	
 	/* Adjust within -XsoftMx limit */
-	expandSize = adjustExpansionWithinSoftMax(env, expandSize,0);
+	expandSize = adjustExpansionWithinSoftMx(env, expandSize,0);
 	
 	Trc_MM_MemorySubSpaceTarok_calculateCollectorExpandSize_Exit1(env->getLanguageVMThread(), expandSize);
 
@@ -1511,7 +1511,7 @@ MM_MemorySubSpaceTarok::adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env,
  * @return Updated expand size
  */		
 MMINLINE UDATA		
-MM_MemorySubSpaceTarok::adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired)
+MM_MemorySubSpaceTarok::adjustExpansionWithinSoftMx(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired)
 {
 	MM_Heap * heap = env->getExtensions()->getHeap();
 	UDATA actualSoftMx = heap->getActualSoftMxSize(env);

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,7 @@ public:
 private:
 	bool initialize(MM_EnvironmentBase *env);
 	UDATA adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, UDATA expandSize);
-	UDATA adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired);
+	UDATA adjustExpansionWithinSoftMx(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired);
 	UDATA checkForRatioExpand(MM_EnvironmentBase *env, UDATA bytesRequired);	
 	bool checkForRatioContract(MM_EnvironmentBase *env);
 	UDATA calculateExpandSize(MM_EnvironmentBase *env, UDATA bytesRequired, bool expandToSatisfy);
@@ -110,8 +110,8 @@ protected:
 public:
 	static MM_MemorySubSpaceTarok *newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize, UDATA memoryType, U_32 objectFlags);
 	
-	virtual const char *getName() { return MEMORY_SUBSPACE_NAME_GENERIC; }
-	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_GENERIC; }
+	virtual const char *getName() { return "Tarok"; }
+	virtual const char *getDescription() { return "Tarok MemorySubSpace Description"; }
 
 	virtual MM_MemoryPool *getMemoryPool();
 	virtual MM_MemoryPool *getMemoryPool(void *addr);


### PR DESCRIPTION
- rename `adjustExpansionWithinSoftMax` to `adjustExpansionWithinSoftMx`

The purpose of doing this is to allow better code sharing between `MemorySubSpace::adjustExpansionWithinSoftMax` which is being introduced eclipse/omr#6141
Additionally, changing name/description of MemorySubSpaceTarok to better reflect true description.

A follow up PR should be done (once OMR side goes through), which does the following:
- Remove `MemorySubSpaceTarok::adjustExpansionWithinSoftMx`. All of these function calls should be changed to `adjustExpansionWithinSoftMax` (inherited from `MemorySubSpace`)
- Use `SOFT_MX_CONTRACT` flag for contraction in `MemorySubSpaceTarok` in the appropriate place in `MemorySubSpaceTarok::timeForHeapContract` (this flag will be introduced in OMR side)

Signed-off-by: Cedric Hansen cedric.hansen@ibm.com