### PR TITLE
JDK17 - add missed annotations

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -572,6 +572,9 @@ public static int activeCount(){
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@Deprecated(since="17", forRemoval=true)
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final void checkAccess() {
 	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -253,6 +253,9 @@ public boolean allowThreadSuspension(boolean b) {
  * If there is a SecurityManager installed, call <code>checkAccess</code>
  * in it passing the receiver as parameter, otherwise do nothing.
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@Deprecated(since="17", forRemoval=true)
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final void checkAccess() {
 	// Forwards the message to the SecurityManager (if there's one)
 	// passing the receiver as parameter

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -41,6 +41,9 @@ import sun.security.util.SecurityConstants;
  * @author  OTI
  * @version initial
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@Deprecated(since="17", forRemoval=true)
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class AccessControlContext {
 
 	static final int STATE_NOT_AUTHORIZED = 0; // It has been confirmed that the ACC is NOT authorized

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -39,6 +39,9 @@ import sun.reflect.CallerSensitive;
  * @author      OTI
  * @version     initial
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@Deprecated(since="17", forRemoval=true)
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class AccessController {
 	static {
 		// Initialize vm-internal caches

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,9 @@ public final class LoggingMXBeanImpl
 
 	private static final LoggingMXBeanImpl instance = createInstance();
 
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
+	@SuppressWarnings("removal")
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	private static LoggingMXBeanImpl createInstance() {
 		/*[IF Sidecar19-SE]*/
 		final Optional<Module> java_logging = ModuleLayer.boot().findModule("java.logging"); //$NON-NLS-1$

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -41,6 +41,9 @@ import openj9.management.internal.ThreadInfoBase;
  *
  * @since 1.5
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public class ThreadMXBeanImpl implements ThreadMXBean {
 
 	private static final ThreadMXBeanImpl instance = new ThreadMXBeanImpl();

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,9 @@ import java.util.Map;
  *  
  * @since 1.5
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public interface RuntimeMXBean extends PlatformManagedObject {
 
 	/**

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -45,6 +45,9 @@ import com.sun.tools.attach.spi.AttachProvider;
  * Concrete subclass of the class that lists the available target VMs
  * 
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public class OpenJ9AttachProvider extends AttachProvider {
 
 	/**

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -65,6 +65,9 @@ import com.sun.tools.attach.spi.AttachProvider;
  * Handles the initiator end of an attachment to a target VM
  * 
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 
 	/* 

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/Cuda.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/Cuda.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corp. and others
+ * Copyright (c) 2013, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The {@code Cuda} class provides general CUDA utilities.
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class Cuda {
 
 	private static final class Cleaner implements Runnable {

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/CUDAManager.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/CUDAManager.java
@@ -48,6 +48,9 @@ import sun.misc.Unsafe;
 /**
  * This class contains information important to IBM GPU enabled functions.
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class CUDAManager {
 
 	private static final class Configuration {

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/SortNetwork.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/SortNetwork.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corp. and others
+ * Copyright (c) 2013, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,9 @@ import com.ibm.oti.vm.VM;
  * This class provides access to a GPU implementation of the bitonic sort
  * network.
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 final class SortNetwork {
 
 	private static final class LoadKey {

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/internal/CudaGPUAssistProvider.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/internal/CudaGPUAssistProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,9 @@ public final class CudaGPUAssistProvider implements GPUAssist.Provider {
 	}
 
 	@Override
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
+	@SuppressWarnings("removal")
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	public GPUAssist getGPUAssist() {
 		PrivilegedAction<CUDAManager> getInstance = () -> CUDAManager.instance();
 		CUDAManager manager = AccessController.doPrivileged(getInstance);


### PR DESCRIPTION
Added `@Deprecated(since="17", forRemoval=true)` annotation:
```
java.lang.Thread.checkAccess();
java.lang.ThreadGroup.checkAccess();
java.security.AccessControlContext;
java.security.AccessController;
```
Also added `@SuppressWarnings("removal")` to avoid warning causing compilation failure when `-Werror` is specified.

This fixes an internal test failure.

Related to https://github.com/eclipse-openj9/openj9/issues/12760

Signed-off-by: Jason Feng <fengj@ca.ibm.com>