### PR TITLE
Update graph_req.os value in win_x86.spec

### DIFF
--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -65,7 +65,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_req.build2" value="{$common.req.build.java8$}"/>
 		<property name="graph_req.machine" value=""/>
 		<property name="graph_req.machine.test" value="{$spec.property.graph_req.machine$}"/>
-		<property name="graph_req.os" value="{$machine_mapping.win$}"/>
+		<property name="graph_req.os" value="os:win"/>
 		<property name="graph_req.os.build" value="os:win"/>
 		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
 		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -403,6 +403,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</test>
 	<test>
 		<testCaseName>shrtest_aix_SE80</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5965</comment>
+				<impl>ibm</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>


### PR DESCRIPTION
- The original value {$machine_mapping.win$} is win, but there is no machine labeled win in vmfarm.
- Temporarily exclude shrtest_aix_SE80 on vmfarm

related: runtimes/test/pull/445
related: runtimes/backlog/issues/560

Signed-off-by: lanxia <lan_xia@ca.ibm.com>