### PR TITLE
Fix build error due to missing javadoc

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,8 @@
 package java.lang.management;
 
 /**
+ * Distinguishes various kinds of memory used by the virtual machine.
+ *
  * @since 1.5
  */
 public enum MemoryType {
@@ -34,6 +36,7 @@ public enum MemoryType {
 	 * threads in the virtual machine.
 	 */
 	HEAP,
+
 	/**
 	 * Memory that is not on the heap. This encompasses all other storage used
 	 * by the virtual machine at runtime.


### PR DESCRIPTION
JDKnext builds fail, e.g. [for xLinux](https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/65/console):
```
02:12:40  === Output from failing command(s) repeated here ===
02:12:40  * For target jdk_modules_java.management__the.java.management_batch:
02:12:40  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_OpenJDK/build/linux-x86_64-server-release/support/j9jcl/java.management/share/classes/java/lang/management/MemoryType.java:25: warning: no initial description
02:12:40   * @since 1.5
02:12:40     ^
02:12:40  error: warnings found and -Werror specified
02:12:40  1 error
02:12:40  1 warning
```