### PR TITLE
Fix jdk/internal/misc/Unsafe.copyMemory crash without value propagation

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11486,50 +11486,6 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             }
          break;
          }
-      case TR::jdk_internal_misc_Unsafe_copyMemory0:
-      case TR::sun_misc_Unsafe_copyMemory:
-         if (comp->canTransformUnsafeCopyToArrayCopy()
-            && methodSymbol->isNative()
-            && performTransformation(comp,
-                  "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
-            {
-            TR::Node *src = node->getChild(1);
-            TR::Node *srcOffset = node->getChild(2);
-            TR::Node *dest = node->getChild(3);
-            TR::Node *destOffset = node->getChild(4);
-            TR::Node *len = node->getChild(5);
-
-            if (comp->target().is32Bit())
-               {
-               srcOffset = TR::Node::create(TR::l2i, 1, srcOffset);
-               destOffset = TR::Node::create(TR::l2i, 1, destOffset);
-               len = TR::Node::create(TR::l2i, 1, len);
-               src = TR::Node::create(TR::aiadd, 2, src, srcOffset);
-               dest = TR::Node::create(TR::aiadd, 2, dest, destOffset);
-               }
-            else
-               {
-               src = TR::Node::create(TR::aladd, 2, src, srcOffset);
-               dest = TR::Node::create(TR::aladd, 2, dest, destOffset);
-               }
-
-            TR::Node *arraycopyNode = TR::Node::createArraycopy(src, dest, len);
-            TR::TreeEvaluator::arraycopyEvaluator(arraycopyNode,cg);
-
-            if (node->getChild(0)->getRegister())
-               cg->decReferenceCount(node->getChild(0));
-            else
-               node->getChild(0)->recursivelyDecReferenceCount();
-
-            cg->decReferenceCount(node->getChild(1));
-            cg->decReferenceCount(node->getChild(2));
-            cg->decReferenceCount(node->getChild(3));
-            cg->decReferenceCount(node->getChild(4));
-            cg->decReferenceCount(node->getChild(5));
-
-            return true;
-            }
-         break;
 
       case TR::sun_misc_Unsafe_setMemory:
          if (comp->canTransformUnsafeSetMemory())

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10149,51 +10149,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
                return true;
                }
             return false; // Call the native version of NativeThread.current()
-         case TR::jdk_internal_misc_Unsafe_copyMemory0:
-         case TR::sun_misc_Unsafe_copyMemory:
-            {
-            if (comp->canTransformUnsafeCopyToArrayCopy()
-               && methodSymbol->isNative()
-               && performTransformation(comp, "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
-               {
-               TR::Node *src = node->getChild(1);
-               TR::Node *srcOffset = node->getChild(2);
-               TR::Node *dest = node->getChild(3);
-               TR::Node *destOffset = node->getChild(4);
-               TR::Node *len = node->getChild(5);
-
-               if (comp->target().is32Bit())
-                  {
-                  srcOffset = TR::Node::create(TR::l2i, 1, srcOffset);
-                  destOffset = TR::Node::create(TR::l2i, 1, destOffset);
-                  len = TR::Node::create(TR::l2i, 1, len);
-                  src = TR::Node::create(TR::aiadd, 2, src, srcOffset);
-                  dest = TR::Node::create(TR::aiadd, 2, dest, destOffset);
-                  }
-               else
-                  {
-                  src = TR::Node::create(TR::aladd, 2, src, srcOffset);
-                  dest = TR::Node::create(TR::aladd, 2, dest, destOffset);
-                  }
-
-               TR::Node *arraycopyNode = TR::Node::createArraycopy(src, dest, len);
-               TR::TreeEvaluator::arraycopyEvaluator(arraycopyNode,cg);
-
-               if (node->getChild(0)->getRegister())
-                  cg->decReferenceCount(node->getChild(0));
-               else
-                  node->getChild(0)->recursivelyDecReferenceCount();
-
-               cg->decReferenceCount(node->getChild(1));
-               cg->decReferenceCount(node->getChild(2));
-               cg->decReferenceCount(node->getChild(3));
-               cg->decReferenceCount(node->getChild(4));
-               cg->decReferenceCount(node->getChild(5));
-
-               return true;
-               }
-               return false; // Perform the original Unsafe.copyMemory call
-            }
          case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
             {
             if(node->isSafeForCGToFastPathUnsafeCall())
@@ -11881,7 +11836,6 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
       case TR::java_util_concurrent_atomic_Fences_orderWrites:
       case TR::java_util_concurrent_atomic_Fences_reachabilityFence:
       case TR::sun_nio_ch_NativeThread_current:
-      case TR::sun_misc_Unsafe_copyMemory:
          if (TR::TreeEvaluator::VMinlineCallEvaluator(node, false, cg))
             {
             returnRegister = node->getRegister();

--- a/test/functional/UnsafeTest/playlist.xml
+++ b/test/functional/UnsafeTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 		<variations>
 			<variation>-DScenario=Regular</variation>
 			<variation>-DScenario=Compiled</variation>
+			<variation>-DScenario=Compiled -Xjit:optLevel=noOpt</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
  	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
@@ -53,6 +54,7 @@
 		<variations>
 			<variation>-DScenario=Regular</variation>
 			<variation>-DScenario=Compiled</variation>
+			<variation>-DScenario=Compiled -Xjit:optLevel=noOpt</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-opens java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \


### PR DESCRIPTION
Running with optLevel=noOpt or disableLocalVP causes VM crash on startup when Unsafe.copyMemory is called. This fix ensures that the intrinsic is inlined.

Closes #13314 

Signed-off-by: BradleyWood <bradley.wood@ibm.com>