### PR TITLE
Fix off-by-one error in String.indexOf acceleration on z15

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
@@ -904,6 +904,9 @@ public class Test_JITHelpers {
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("ab12345678901234567cdefghijklmnopq"), 34, valueField.get("def"), 3, 5), 20);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("ab12345678901234567cdefghijklmnopq"), 34, valueField.get("defghijklmn"), 11, 5), 20);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghiklmnopqrstwyzabcdefghikabcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 71, valueField.get("abcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 39, 0), 32);
+				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghiklmnopqrstwyzabcdefghikabcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 37, valueField.get("zabcdefghikabcdefg"), 17, 5), -1);
+				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghiklmnopqrstwyzabcdefghikabcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 37, valueField.get("zabcdefghikabcdefg"), 17, 2), -1);
+				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghiklmnopqrstwyzabcdefghikabcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 38, valueField.get("zabcdefghikabcdefg"), 17, 5), 21);
 			}
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException(e);
@@ -1140,6 +1143,9 @@ public class Test_JITHelpers {
 			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 34, valueField.get("\u0196e"), 2, 5), 20);
 			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 34, valueField.get("\u0196ef"), 3, 5), 20);
 			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 34, valueField.get("\u0196efghijklmn"), 11, 5), 20);
+			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 29, valueField.get("\u0196efghijklmn"), 10, 3), -1);
+			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 29, valueField.get("\u0196efghijklmn"), 10, 5), -1);
+			Assert.assertEquals(helpers.intrinsicIndexOfStringUTF16(valueField.get("\u0190\u019112\u0199456789012\u01994567c\u0196efghijklmn\u0194\u0197\u0198"), 30, valueField.get("\u0196efghijklmn"), 10, 5), 20);
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException(e);
 		} catch (NoSuchFieldException e) {


### PR DESCRIPTION
- `stringIndexReg` contains the current index into the search string
  that we will start the search on
- `maxIndexReg = searchString.length() - patternString.length()`
  and this value does not change at all
- `loadLenReg` is the minimum of the number of characters left to load
  from the search string or 16. That is `loadLenReg` <= 16.

The problem here is that due to the comparison we are making we break
the assumption that the remaining number of characters we have left to
examine is always greater than or equal to the length of the pattern.
The code snippet being changed has two branches:

- The first branch branches if `stringIndexReg >= maxIndexReg`
- The second branch branches if `stringIndexReg >= searchString.length()`

There are two problems with the first branch. First problem is that
`stringIndexReg` is updated after the branch, when it should be updated
before the branch. Second issue is that we can have a false negative
result because we branch on equality when we really shouldn't.

The second branch is actually not needed since it will never be executed
because `maxIndexReg` is always <= `searchString.length()`. This branch
is removed.

There is another issue in case there is a full pattern match. In the
full pattern match case, the first character of the match will be at
index 0, but the path following `labelPatternHeadFullMatch` in the code
assumes we have enough characters left in the search string to search
for the entire pattern. This may not be the case. To cover this scenario
we add another check in this path to ensure we have enough characters
left to carry out the full pattern search.

The above problem with the full pattern match does not exist for the
partial pattern match because the partial pattern match handling code
updates the search index so that we begin the match at index 0 and 
we re-run the matching (VSTRS) code again. After re-running we will
either get a full match or no match. Both of these cases have been
fixed up as per above notes. Thus we are fully covered.