### PR TITLE
Improve known object propagation for MethodHandles

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5365,7 +5365,13 @@ TR_J9InlinerUtil::computePrexInfo(TR_InlinerBase *inliner, TR_CallSite* site, TR
          {
          prexArg = new (inliner->trHeapMemory()) TR_PrexArgument(symRef->getKnownObjectIndex(), comp);
          if (tracePrex)
-            traceMsg(comp, "PREX.inl:      %p: is known object obj%d\n", prexArg, symRef->getKnownObjectIndex());
+            traceMsg(comp, "PREX.inl:      %p: is symref known object obj%d\n", prexArg, symRef->getKnownObjectIndex());
+         }
+      else if (argument->hasKnownObjectIndex())
+         {
+         prexArg = new (inliner->trHeapMemory()) TR_PrexArgument(argument->getKnownObjectIndex(), comp);
+         if (tracePrex)
+            traceMsg(comp, "PREX.inl:      %p: is node known object obj%d\n", prexArg, argument->getKnownObjectIndex());
          }
       else if (argument->getOpCodeValue() == TR::aload)
          {

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -350,9 +350,15 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
    if (node->getOpCode().isLoadDirect() &&
        symbol->isAutoOrParm())
       {
+      TR::KnownObjectTable::Index koi = (*_currentObjectInfo)[symbol->getLocalIndex()];
+      node->setKnownObjectIndex(koi);
+
       if (trace())
-         traceMsg(comp(), "getObjectInfoOfNode n%dn is load from auto or parm, local #%d\n", node->getGlobalIndex(), symbol->getLocalIndex());
-      return (*_currentObjectInfo)[symbol->getLocalIndex()];
+         {
+         traceMsg(comp(), "getObjectInfoOfNode n%dn is load from auto or parm, local #%d, set node known object=%d\n", node->getGlobalIndex(), symbol->getLocalIndex(), koi);
+         }
+
+      return koi;
       }
 
    auto knot = comp()->getKnownObjectTable();
@@ -371,7 +377,8 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
               {
               auto mnIndex = comp()->fej9()->getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(comp(), mhIndex, "member");
               if (trace())
-                 traceMsg(comp(), "Get DirectMethodHandle.member known object %d\n", mnIndex);
+                 traceMsg(comp(), "Get DirectMethodHandle.member known object %d, update node n%dn known object\n", mnIndex, node->getGlobalIndex());
+              node->setKnownObjectIndex(mnIndex);
               return mnIndex;
               }
            }
@@ -382,7 +389,8 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
               {
               auto mnIndex = comp()->fej9()->getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(comp(), mhIndex, "initMethod");
               if (trace())
-                 traceMsg(comp(), "Get DirectMethodHandle.initMethod known object %d\n", mnIndex);
+                 traceMsg(comp(), "Get DirectMethodHandle.initMethod known object %d, update node n%dn known object\n", mnIndex, node->getGlobalIndex());
+              node->setKnownObjectIndex(mnIndex);
               return mnIndex;
               }
            }


### PR DESCRIPTION
Populate known object info on nodes based on MethodHandle transformer analysis.
The node information supplements the information on "improved symbol references"
that are refined with known object info.  Storing known object info in symbol
references will eventually be deprecated and moved to nodes.