### PR TITLE
Look through DelegatingMethodHandle.getTarget() during inlining

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1010,6 +1010,7 @@
    java_lang_invoke_MethodHandle_linkToSpecial,
    java_lang_invoke_MethodHandle_linkToVirtual,
    java_lang_invoke_MethodHandle_linkToInterface,
+   java_lang_invoke_DelegatingMethodHandle_getTarget,
    java_lang_invoke_DirectMethodHandle_internalMemberName,
    java_lang_invoke_DirectMethodHandle_internalMemberNameEnsureInit,
    java_lang_invoke_DirectMethodHandle_constructorMethod,

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -879,6 +879,22 @@ public:
     * \return char * the signature for linkToStatic
     */
    char * getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature, int32_t &signatureLength);
+
+   /**
+    * \brief
+    *    Get the target of a DelegatingMethodHandle
+    *
+    * If the target cannot be determined (including any cases where dmhIndex
+    * does not indicate an instance of DelegatingMethodHandle), the result is
+    * TR::KnownObjectTable::UNKNOWN.
+    *
+    * \param comp the compilation object
+    * \param dmhIndex the known object index of the (purported) DelegatingMethodHandle
+    * \param trace whether to enable trace messages
+    * \return the known object index of the target, or TR::KnownObjectTable::UNKNOWN
+    */
+   TR::KnownObjectTable::Index delegatingMethodHandleTarget(
+      TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, bool trace);
 #endif
 
    // JSR292 }}}

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3733,6 +3733,12 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+   static X DelegatingMethodHandleMethods[] =
+      {
+      {x(TR::java_lang_invoke_DelegatingMethodHandle_getTarget,   "getTarget",  "()Ljava/lang/invoke/MethodHandle;")},
+      {  TR::unknownMethod}
+      };
+
    static X DirectHandleMethods[] =
       {
       {x(TR::java_lang_invoke_DirectHandle_isAlreadyCompiled,   "isAlreadyCompiled",  "(J)Z")},
@@ -4126,6 +4132,7 @@ void TR_ResolvedJ9Method::construct()
    static Y class39[] =
       {
       { "com/ibm/jit/crypto/JITFullHardwareCrypt", ZCryptoMethods },
+      { "java/lang/invoke/DelegatingMethodHandle", DelegatingMethodHandleMethods },
       { 0 }
       };
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -935,6 +935,23 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
       case TR::java_lang_invoke_ILGenMacros_isShareableThunk:
          result = new (trStackMemory()) IconstOperand(0);
          break;
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      case TR::java_lang_invoke_DelegatingMethodHandle_getTarget:
+         {
+         TR::KnownObjectTable::Index dmhIndex = top()->getKnownObjectIndex();
+         bool trace = tracer()->debugLevel();
+         TR::KnownObjectTable::Index targetIndex =
+            comp()->fej9()->delegatingMethodHandleTarget(comp(), dmhIndex, trace);
+
+         if (targetIndex == TR::KnownObjectTable::UNKNOWN)
+            return NULL;
+
+         result = new (trStackMemory()) KnownObjOperand(targetIndex);
+         break;
+         }
+#endif
+
       case TR::java_lang_invoke_MutableCallSite_getTarget:
       case TR::java_lang_invoke_Invokers_getCallSiteTarget:
          {

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -387,6 +387,17 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
               }
            }
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+         case TR::java_lang_invoke_DelegatingMethodHandle_getTarget:
+            {
+            TR::KnownObjectTable::Index dmhIndex =
+               getObjectInfoOfNode(node->getArgument(0));
+
+            return comp()->fej9()->delegatingMethodHandleTarget(
+               comp(), dmhIndex, trace());
+            }
+#endif
+
          default:
             break;
         }


### PR DESCRIPTION
Recognize `DelegatingMethodHandle.getTarget()` and determine its result as a known object in:

- `InterpreterEmulator`, which can now find the call target of a later `invokeBasic()` call whose receiver is the result; and

- Method handle transformer, which can now refine such an `invokeBasic()` call to match the target found by `InterpreterEmulator`.

With this, the compiler can inline the `DelegatingMethodHandle` target.

Because `DelegatingMethodHandle.getTarget()` is abstract, the target must be determined based on the concrete type of the `DelegatingMethodHandle`. So far only `java/lang/invoke/MethodHandleImpl$CountingWrapper` has been observed.