### PR TITLE
Restore space at end of J9NLS_VM_STACK_TRACE_EXCEPTION_IN message

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exception in thread \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exception in thread \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_ca.nls
+++ b/runtime/nls/j9vm/j9vm_ca.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Excepci\u00f3 al fil \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Excepci\u00f3 al fil \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_cs.nls
+++ b/runtime/nls/j9vm/j9vm_cs.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=V\u00fdjimka v podprocesu \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=V\u00fdjimka v podprocesu \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_de.nls
+++ b/runtime/nls/j9vm/j9vm_de.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Ausnahmebedingung in Thread \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Ausnahmebedingung in Thread \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_es.nls
+++ b/runtime/nls/j9vm/j9vm_es.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Excepci\u00f3n en hebra \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Excepci\u00f3n en hebra \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_fr.nls
+++ b/runtime/nls/j9vm/j9vm_fr.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exception dans l'unit\u00e9 d'ex\u00e9cution \"%.*s\"
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exception dans l'unit\u00e9 d'ex\u00e9cution \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_hu.nls
+++ b/runtime/nls/j9vm/j9vm_hu.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Kiv\u00e9tel a(z) \"%.*s\" sz\u00e1lban\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Kiv\u00e9tel a(z) \"%.*s\" sz\u00e1lban\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_it.nls
+++ b/runtime/nls/j9vm/j9vm_it.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Eccezione nel thread \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Eccezione nel thread \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_pl.nls
+++ b/runtime/nls/j9vm/j9vm_pl.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Wyj\u0105tek w w\u0105tku \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Wyj\u0105tek w w\u0105tku \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_pt_BR.nls
+++ b/runtime/nls/j9vm/j9vm_pt_BR.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exce\u00e7\u00e3o no encadeamento \"%.*s\"
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Exce\u00e7\u00e3o no encadeamento \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_ru.nls
+++ b/runtime/nls/j9vm/j9vm_ru.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=\u0418\u0441\u043a\u043b\u044e\u0447\u0438\u0442\u0435\u043b\u044c\u043d\u0430\u044f \u0441\u0438\u0442\u0443\u0430\u0446\u0438\u044f \u0432 \u043d\u0438\u0442\u0438 \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=\u0418\u0441\u043a\u043b\u044e\u0447\u0438\u0442\u0435\u043b\u044c\u043d\u0430\u044f \u0441\u0438\u0442\u0443\u0430\u0446\u0438\u044f \u0432 \u043d\u0438\u0442\u0438 \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_sk.nls
+++ b/runtime/nls/j9vm/j9vm_sk.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Do\u0161lo k v\u00fdnimke vo vl\u00e1kne \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Do\u0161lo k v\u00fdnimke vo vl\u00e1kne \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_sl.nls
+++ b/runtime/nls/j9vm/j9vm_sl.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Izjemno stanje v niti \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Izjemno stanje v niti \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred

--- a/runtime/nls/j9vm/j9vm_tr.nls
+++ b/runtime/nls/j9vm/j9vm_tr.nls
@@ -279,7 +279,7 @@ J9NLS_VM_CHECK_JAVA_HOME.user_response=Check that JAVA_HOME environment variable
 # This message will be followed by the exception's class name and
 # (if non-null) the exception's detail message
 # e.g. Exception in thread "main" java/lang/StackOverflowError: An overflow occurred
-J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Bu i\u015f par\u00e7ac\u0131\u011f\u0131nda kural d\u0131\u015f\u0131 durum - \"%.*s\"\
+J9NLS_VM_STACK_TRACE_EXCEPTION_IN=Bu i\u015f par\u00e7ac\u0131\u011f\u0131nda kural d\u0131\u015f\u0131 durum - \"%.*s\"\u0020
 # START NON-TRANSLATABLE
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_1=57
 J9NLS_VM_STACK_TRACE_EXCEPTION_IN.sample_input_2=\"main\" java/lang/StackOverflowError: An overflow occurred


### PR DESCRIPTION
Since there is a backslash without the trailing space, you get a message like:
Exception in thread "main"# START NON-TRANSLATABLEjava.lang.OutOfMemoryError: Java heap space

The trailing space was removed by https://github.com/eclipse-openj9/openj9/commit/328c0e433