### PR TITLE
Add envvar TR_DisableIndexOfStringIntrinsic

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3978,11 +3978,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
          case TR::java_lang_StringLatin1_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);
-               return true;
+               return resultReg != NULL;
          case TR::java_lang_StringUTF16_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, true);
-               return true;
+               return resultReg != NULL;
          default:
             break;
          }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -584,6 +584,10 @@ J9::Z::TreeEvaluator::inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGene
    TR_Debug *compDebug = comp->getDebug();
    TR::Instruction* cursor;
 
+   static bool disableIndexOfStringIntrinsic = feGetEnv("TR_DisableIndexOfStringIntrinsic") != NULL;
+   if (disableIndexOfStringIntrinsic)
+      return NULL;
+
    if (comp->getOption(TR_TraceCG))
       traceMsg(comp, "inlineVectorizedStringIndexOf. Is isUTF16 %d\n", isUTF16);
 


### PR DESCRIPTION
When specified this envvar will disable intrinsic inlining of the
`java/lang/String.indexOf(String)` API.