### PR TITLE
Ensure linkToStatic/Special ignores rtResolve

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6329,6 +6329,12 @@ TR_ResolvedJ9Method::getResolvedStaticMethod(TR::Compilation * comp, I_32 cpInde
          }
       }
 
+   // With rtResolve option, INL calls that are required to be compile time
+   // resolved are left as unresolved.
+   if (shouldCompileTimeResolveMethod(cpIndex))
+      skipForDebugging = false;
+
+
    if (ramMethod && !skipForDebugging)
       {
       TR_AOTInliningStats *aotStats = NULL;


### PR DESCRIPTION
linkToStatic/Special are VM INL calls that are required to be
resolved at compile time, which results in the call node not
being handled by tree lowering in order to insert additional
info needed by the interpreter.

Needed for: #13345

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>