### PR TITLE
Add JPP flag OPENJDK_METHODHANDLES to match OpenJDK content

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -572,9 +572,9 @@ public static int activeCount(){
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  */
-/*[IF JAVA_SPEC_VERSION >= 17]*/
+/*[IF (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES]*/
 @Deprecated(since="17", forRemoval=true)
-/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES */
 public final void checkAccess() {
 	@SuppressWarnings("removal")
 	SecurityManager currentManager = System.getSecurityManager();

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -253,9 +253,9 @@ public boolean allowThreadSuspension(boolean b) {
  * If there is a SecurityManager installed, call <code>checkAccess</code>
  * in it passing the receiver as parameter, otherwise do nothing.
  */
-/*[IF JAVA_SPEC_VERSION >= 17]*/
+/*[IF (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES]*/
 @Deprecated(since="17", forRemoval=true)
-/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES */
 public final void checkAccess() {
 	// Forwards the message to the SecurityManager (if there's one)
 	// passing the receiver as parameter

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -41,9 +41,9 @@ import sun.security.util.SecurityConstants;
  * @author  OTI
  * @version initial
  */
-/*[IF JAVA_SPEC_VERSION >= 17]*/
+/*[IF (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES]*/
 @Deprecated(since="17", forRemoval=true)
-/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES */
 public final class AccessControlContext {
 
 	static final int STATE_NOT_AUTHORIZED = 0; // It has been confirmed that the ACC is NOT authorized

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -39,9 +39,9 @@ import sun.reflect.CallerSensitive;
  * @author      OTI
  * @version     initial
  */
-/*[IF JAVA_SPEC_VERSION >= 17]*/
+/*[IF (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES]*/
 @Deprecated(since="17", forRemoval=true)
-/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 17) & OPENJDK_METHODHANDLES */
 public final class AccessController {
 	static {
 		// Initialize vm-internal caches


### PR DESCRIPTION
`OPENJDK_METHODHANDLES` is enabled in `JDK18` extension repo `openj9-staging` branch which has latest OpenJDK content but not promoted into `openj9` branch yet;
Added this JPP flag to ensure OpenJ9 methods marked as `Deprecated` matching those OpenJDK references.

This fixes PR build failure https://github.com/eclipse-openj9/openj9/pull/13395#issuecomment-906690576

Signed-off-by: Jason Feng <fengj@ca.ibm.com>