### PR TITLE
Allow Value Propagation to transform an array store if the value assigned is known not to be a value type

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2427,6 +2427,18 @@ J9::SymbolReferenceTable::findOrCreateObjectEqualityComparisonSymbolRef()
    return symRef;
    }
 
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateNonNullableArrayNullStoreCheckSymbolRef()
+   {
+   TR::SymbolReference *symRef = element(nonNullableArrayNullStoreCheckSymbol);
+   if (symRef != NULL)
+      return symRef;
+
+   symRef = self()->findOrCreateCodeGenInlinedHelper(nonNullableArrayNullStoreCheckSymbol);
+   symRef->setCanGCandExcept();
+   return symRef;
+   }
+
 TR::ParameterSymbol *
 J9::SymbolReferenceTable::createParameterSymbol(
       TR::ResolvedMethodSymbol *owningMethodSymbol,

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -313,6 +313,16 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    /**
     * \brief
+    *    Finds the <nonNullableArrayNullStoreCheck> "nonhelper" symbol
+    *    reference, creating it if necessary.
+    *
+    *  \return
+    *     The <nonNullableArrayNullStoreCheck> symbol reference.
+    */
+   TR::SymbolReference *findOrCreateNonNullableArrayNullStoreCheckSymbolRef();
+
+   /**
+    * \brief
     *    Creates a new symbol for a parameter within the supplied owning method of the
     *    specified type and slot index.
     *

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -761,19 +761,26 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
          }
 
       bool arrayRefGlobal;
+      bool storeValueGlobal;
+      const int storeValueOpIndex = isLoadFlattenableArrayElement ? -1 : 0;
       const int elementIndexOpIndex = isLoadFlattenableArrayElement ? 0 : 1;
       const int arrayRefOpIndex = elementIndexOpIndex+1;
 
       TR::Node *indexNode = node->getChild(elementIndexOpIndex);
       TR::Node *arrayRefNode = node->getChild(arrayRefOpIndex);
+      TR::Node *storeValueNode = isStoreFlattenableArrayElement ? node->getChild(storeValueOpIndex) : NULL;
       TR::VPConstraint *arrayConstraint = getConstraint(arrayRefNode, arrayRefGlobal);
       TR_YesNoMaybe isCompTypeVT = isArrayCompTypeValueType(arrayConstraint);
 
-      // If the array's component type is definitely not a value type, add a delayed
-      // transformation to replace the helper call with inline code to perform the
-      // array element access
+      TR_YesNoMaybe isStoreValueVT = isStoreFlattenableArrayElement ? isValue(getConstraint(storeValueNode, storeValueGlobal)) : TR_maybe;
+
+      // If the array's component type is definitely not a value type, or if the value
+      // being assigned in an array store operation is definitely not a value type, add
+      // a delayed transformation to replace the helper call with inline code to
+      // perform the array element access.
       //
-      if (arrayConstraint != NULL && isCompTypeVT == TR_no)
+      if ((arrayConstraint != NULL && isCompTypeVT == TR_no)
+          || (isStoreFlattenableArrayElement && isStoreValueVT == TR_no))
          {
          flags8_t flagsForTransform(isLoadFlattenableArrayElement ? ValueTypesHelperCallTransform::IsArrayLoad
                                                                   : ValueTypesHelperCallTransform::IsArrayStore);
@@ -781,7 +788,20 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 
          if (isStoreFlattenableArrayElement && !owningMethodDoesNotContainStoreChecks(this, node))
             {
-            flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreCheck);
+            // If storing to an array whose component type is or might be a value type
+            // and the value that's being assigned is or might null, both a run-time
+            // NULLCHK of the value is required (guarded by a check of whether the
+            // component type is a value type) and an ArrayStoreCHK are required;
+            // otherwise, only the ArrayStoreCHK is required.
+            //
+            if ((isCompTypeVT != TR_no) && !storeValueNode->isNonNull())
+               {
+               flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreAndNullCheck);
+               }
+            else
+               {
+               flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreCheck);
+               }
             }
 
          if (!owningMethodDoesNotContainBoundChecks(this, node))
@@ -1666,6 +1686,7 @@ J9::ValuePropagation::doDelayedTransformations()
       const bool isStore = callToTransform->_flags.testAny(ValueTypesHelperCallTransform::IsArrayStore);
       const bool isCompare = callToTransform->_flags.testAny(ValueTypesHelperCallTransform::IsRefCompare);
       const bool needsStoreCheck = callToTransform->_flags.testAny(ValueTypesHelperCallTransform::RequiresStoreCheck);
+      const bool needsStoreAndNullCheck = callToTransform->_flags.testAny(ValueTypesHelperCallTransform::RequiresStoreAndNullCheck);
       const bool needsBoundCheck = callToTransform->_flags.testAny(ValueTypesHelperCallTransform::RequiresBoundCheck);
 
       // performTransformation was already checked for comparison non-helper call
@@ -1742,12 +1763,21 @@ J9::ValuePropagation::doDelayedTransformations()
          TR::Node *elementStoreNode = TR::Node::recreateWithoutProperties(callNode, TR::awrtbari, 3, elementAddressNode,
                                                    valueNode, arrayRefNode, elementSymRef);
 
-         if (needsStoreCheck)
+         if (needsStoreCheck || needsStoreAndNullCheck)
             {
             TR::ResolvedMethodSymbol *methodSym = comp()->getMethodSymbol();
             TR::SymbolReference *storeCheckSymRef = comp()->getSymRefTab()->findOrCreateTypeCheckArrayStoreSymbolRef(methodSym);
             TR::Node *storeCheckNode = TR::Node::createWithRoomForThree(TR::ArrayStoreCHK, elementStoreNode, 0, storeCheckSymRef);
+            storeCheckNode->setByteCodeInfo(elementStoreNode->getByteCodeInfo());
             callTree->setNode(storeCheckNode);
+
+            if (needsStoreAndNullCheck)
+               {
+               TR::SymbolReference *nonNullableArrayNullStoreCheckSymRef = comp()->getSymRefTab()->findOrCreateNonNullableArrayNullStoreCheckSymbolRef();
+               TR::Node *nullCheckNode = TR::Node::createWithSymRef(TR::call, 2, 2, valueNode, arrayRefNode, nonNullableArrayNullStoreCheckSymRef);
+               nullCheckNode->setByteCodeInfo(elementStoreNode->getByteCodeInfo());
+               callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1,  nullCheckNode)));
+               }
             }
          else
             {

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1738,6 +1738,11 @@ J9::ValuePropagation::doDelayedTransformations()
          TR::Node *bndChkNode = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, arrayLengthNode, indexNode,
                                              comp()->getSymRefTab()->findOrCreateArrayBoundsCheckSymbolRef(comp()->getMethodSymbol()));
          callTree->insertBefore(TR::TreeTop::create(comp(), bndChkNode));
+
+         // This might be the first time the array bounds check symbol reference is used
+         // Need to ensure aliasing for them is correctly constructed
+         //
+         optimizer()->setAliasSetsAreValid(false);
          }
 
       TR::SymbolReference *elementSymRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::Address, arrayRefNode);
@@ -1778,6 +1783,11 @@ J9::ValuePropagation::doDelayedTransformations()
                nullCheckNode->setByteCodeInfo(elementStoreNode->getByteCodeInfo());
                callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1,  nullCheckNode)));
                }
+
+            // This might be the first time the various checking symbol references are used
+            // Need to ensure aliasing for them is correctly constructed
+            //
+            optimizer()->setAliasSetsAreValid(false);
             }
          else
             {

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -151,7 +151,7 @@ class ValuePropagation : public OMR::ValuePropagation
          IsRefCompare       = 0x08,
          InsertDebugCounter = 0x10,
          RequiresBoundCheck = 0x20,
-         Unused2            = 0x40,
+         RequiresStoreAndNullCheck = 0x40,
          Unused1            = 0x80,
          };
    };

--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -1095,6 +1095,11 @@ LoadArrayElementTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
       arraylengthNode->setArrayStride(dataWidth);
 
       elementLoadTT->insertBefore(TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, arraylengthNode, anchoredElementIndexNode, comp->getSymRefTab()->findOrCreateArrayBoundsCheckSymbolRef(comp->getMethodSymbol()))));
+
+      // This might be the first time the various checking symbol references are used
+      // Need to ensure aliasing for them is correctly constructed
+      //
+      this->optimizer()->setAliasSetsAreValid(false);
       }
 
 
@@ -1401,6 +1406,11 @@ StoreArrayElementTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
       arrayStoreTT = originalBlock->append(TR::TreeTop::create(comp, arrayStoreCHKNode));
       if (enableTrace)
          traceMsg(comp, "Created arrayStoreCHK treetop n%dn arrayStoreCHKNode n%dn\n", arrayStoreTT->getNode()->getGlobalIndex(), arrayStoreCHKNode->getGlobalIndex());
+
+      // This might be the first time the various checking symbol references are used
+      // Need to ensure aliasing for them is correctly constructed
+      //
+      this->optimizer()->setAliasSetsAreValid(false);
       }
    else
       {
@@ -1446,6 +1456,11 @@ StoreArrayElementTransformer::lower(TR::Node* const node, TR::TreeTop* const tt)
          {
          arrayStoreTT->insertBefore(TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, arraylengthNode, anchoredElementIndexNode, comp->getSymRefTab()->findOrCreateArrayBoundsCheckSymbolRef(comp->getMethodSymbol()))));
          }
+
+      // This might be the first time the various checking symbol references are used
+      // Need to ensure aliasing for them is correctly constructed
+      //
+      this->optimizer()->setAliasSetsAreValid(false);
       }
 
    if (comp->useCompressedPointers())

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -67,6 +67,8 @@ class TreeLowering : public TR::Optimization
 
       TR::Compilation* comp() { return _comp; }
 
+      TR::Optimizer* optimizer() { return _treeLoweringOpt->optimizer(); }
+
       bool trace() { return _treeLoweringOpt->trace(); }
 
       const char* optDetailString() { return _treeLoweringOpt->optDetailString(); }


### PR DESCRIPTION
If the value stored in a call to `jitStoreFlattenableArrayElement` is known not to be a value type, the call can be transformed by Value Propagation to inline IL for an ordinary array store even if the component type of the array is not known not to be a value type.  That's because, if the component type of the array actually is a value type, the `ArrayStoreCHK` added as part of the array element store sequence would throw an `ArrayStoreException` - there is no need to deal with a potential store to a flattened value type array element.

The one special case that needs to be handled in the inline IL that's generated is the case where the value that is being stored could be a null reference.  The prototype support for value types does not permit a null reference to be stored into an element of a value type array, and `ArrayStoreCHK` never throws an exception if the value is a null reference.  A call to a non-helper symbol, `<nonNullableArrayNullStoreCheck>`, is added to the IL to handle that case.  During the Tree Lowering optimization, the call to that non-helepr is expanded to IL that will throw a `NullPointerException` if the value is a null reference and the component type of the array is a value type.

Some older prototype code in Tree Lowering that overloaded `ArrayStoreCHK` to do this special handling to check for a null reference is now redundant, and removed.

Delivering these changes on behalf of Annabelle Huo @a7ehuo and myself.