### PR TITLE
JITServer support for ``TR_J9VMBase::delegatingMethodHandleTarget``

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1129,6 +1129,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->vTableOrITableIndexFromMemberName(comp, std::get<0>(recv)));
          }
          break;
+      case MessageType::VM_delegatingMethodHandleTarget:
+         {
+         auto recv = client->getRecvData<TR::KnownObjectTable::Index, TR_OpaqueClassBlock *>();
+         TR::KnownObjectTable::Index idx = fe->delegatingMethodHandleTargetHelper(comp, std::get<0>(recv), std::get<1>(recv));
+         client->write(response, idx, knot->getPointerLocation(idx));
+         }
+         break;
       case MessageType::VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex:
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index, std::string>();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -895,6 +895,8 @@ public:
     */
    TR::KnownObjectTable::Index delegatingMethodHandleTarget(
       TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, bool trace);
+   virtual TR::KnownObjectTable::Index delegatingMethodHandleTargetHelper(
+      TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass);
 #endif
 
    // JSR292 }}}

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2242,6 +2242,21 @@ TR_J9ServerVM::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::Know
       }
    return -1;
    }
+
+TR::KnownObjectTable::Index
+TR_J9ServerVM::delegatingMethodHandleTargetHelper(TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass)
+   {
+   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
+   if (!knot) return TR::KnownObjectTable::UNKNOWN;
+
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_delegatingMethodHandleTarget, dmhIndex, cwClass);
+   auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
+
+   TR::KnownObjectTable::Index idx = std::get<0>(recv);
+   knot->updateKnownObjectTableAtServer(idx, std::get<1>(recv));
+   return idx;
+   }
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 TR::KnownObjectTable::Index

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -233,6 +233,7 @@ public:
    virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
    virtual int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName) override;
    virtual int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual TR::KnownObjectTable::Index delegatingMethodHandleTargetHelper( TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass) override;
 #endif
    virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName) override;
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 28;
+   static const uint16_t MINOR_NUMBER = 29;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -190,6 +190,7 @@ enum MessageType : uint16_t
    VM_vTableOrITableIndexFromMemberName,
    VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex,
    VM_isStable,
+   VM_delegatingMethodHandleTarget,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,
@@ -435,6 +436,7 @@ static const char *messageNames[] =
    "VM_vTableOrITableIndexFromMemberName",
    "VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex",
    "VM_isStable",
+   "VM_delegatingMethodHandleTarget",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",


### PR DESCRIPTION
overrode the ```TR_J9VMBase::delegatingMethodHandleTarget``` method in ``VMJ9Server.cpp``.
The server will send the message ```VM_delegatingMethodHandleTarget``` to the client with
the ``cwClass``, ``dmhIndex`` and ``knot``. The client will then receive the message and
call the frontend method in ``VMJ9.cpp``.
issue: #13361 

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>