### PR TITLE
Update command line tests compilation dependency

### DIFF
--- a/test/functional/CacheManagement/build.xml
+++ b/test/functional/CacheManagement/build.xml
@@ -27,7 +27,7 @@
 		Build CacheManagement Tests 
 	</description>
 	<import file="${TEST_ROOT}/functional/build.xml"/>
-	
+
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/CacheManagement" />
 	<property name="src" location="./src"/>

--- a/test/functional/JIT_Test/build.xml
+++ b/test/functional/JIT_Test/build.xml
@@ -35,6 +35,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
+	<property name="jarfile" value="${DEST}/jitt.jar" />
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
 	<property name="LIB" value="jcommander,testng"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
@@ -65,7 +66,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/jitt.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
 		</jar>
@@ -80,7 +81,11 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/VM_Test/build.xml
+++ b/test/functional/VM_Test/build.xml
@@ -33,6 +33,7 @@
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/VM_Test" />
+	<property name="jarfile" value="${DEST}/VM_Test.jar" />
 	<property name="excludeFiles" location="../J9 Exclude File Support/src"/>
 	<property name="data" location="./data" />
 	<property name="databin" location="./data/bin" />
@@ -171,7 +172,7 @@
 		<jar jarfile="${databin}/JarFileUpdateTestRunnerResource2.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
 			<fileset dir="${databin}/JarFileUpdateTestRunnerResource2"/>
 		</jar>
-		<jar jarfile="${DEST}/VM_Test.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
+		<jar jarfile="${jarfile}" filesonly="true" manifest="./META-INF/MANIFEST.MF">
 			<fileset dir="${build}" />
 			<fileset dir="${excludeFiles}"/>
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
@@ -204,7 +205,11 @@
 		<delete dir="${classUnloadingBin}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/CDSAdaptorTest/build.xml
+++ b/test/functional/cmdLineTests/CDSAdaptorTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2001, 2020 IBM Corp. and others
+  Copyright (c) 2001, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build CDSAdaptorTest 
 	</description>
 	
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/CDSAdaptorTest" />
 	<property name="dist" location="${DEST}"/>
@@ -102,7 +104,7 @@
 		<delete dir="${build_resource_weavinghookTest}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/J9security/build.xml
+++ b/test/functional/cmdLineTests/J9security/build.xml
@@ -28,6 +28,8 @@
 		Build cmdLineTests_J9security
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/J9security" />
 	<property name="PROJECT_ROOT" location="." />
@@ -105,7 +107,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTester_SystemPropertiesTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/SystemPropertiesTest" />
@@ -65,7 +67,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build DataHelperTests   
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/URLClassLoaderTests" />
@@ -317,7 +319,7 @@
 		<!-- Delete the ${build} directory trees -->
 		<delete dir="${build.dir}" />
 	</target>
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
@@ -28,6 +28,8 @@
 		Build cmdLineTester_ValueBasedClassTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/ValueBasedClassTest" />
 	<property name="src" location="./src"/>
@@ -67,7 +69,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
+++ b/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests bootStrapStaticVerify
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/bootStrapStaticVerify" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2019, 2020 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build bootstrapMethodArgumentTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/bootstrapMethodArgumentTest" />
@@ -83,7 +85,7 @@
 		</delete>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/build.xml
+++ b/test/functional/cmdLineTests/build.xml
@@ -28,6 +28,7 @@
 		Build cmdLineTests
 	</description>
 	<import file="${TEST_ROOT}/functional/build.xml"/>
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests" />
@@ -36,7 +37,7 @@
 		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist">
+	<target name="build" depends="dist,buildCmdLineTestTools">
 		<subant target="">
 			<fileset dir="." includes="*/build.xml" />
 		</subant>

--- a/test/functional/cmdLineTests/buildTools.xml
+++ b/test/functional/cmdLineTests/buildTools.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2021, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,26 +22,23 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>
-		Build cmdLineTests
-	</description>
-
-	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/ignoreUnrecognizedVMOptions" />
-	<property name="src" location="." />
-
-	<target name="dist" description="generate the distribution">
-		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml"/>
-			<fileset dir="${src}" includes="*.mk"/>
-		</copy>
+<project name="cmdLineTests" default="buildCmdLineTestTools" basedir=".">
+	<target name="buildCmdLineTestTools" description="build command line test tools">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdline_options_tester/" includes="build.xml" />
+			<fileset dir="${TEST_ROOT}/functional/cmdline_options_testresources/" includes="build.xml" />
+		</subant>
 	</target>
-	
-	<target name="build" depends="buildCmdLineTestTools">
-		<antcall target="dist" inheritall="true" />
+
+	<target name="buildCmdLineTestUtils" description="build command line test utils">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdLineTests/utils" includes="build.xml" />
+		</subant>
+	</target>
+
+	<target name="buildCmdLineTestUtils2" description="build command line test utils">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdLineTests/utils2" includes="build.xml" />
+		</subant>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/callsitedbgddrext/build.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests callsitedbgddrext
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/callsitedbgddrext" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/classLoaderTest/build.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_EnableAssertionStatusTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/classLoaderTest" />
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/classesdbgddrext/build.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests classesddrtests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/classesdbgddrext" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTest_J9tests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/cmdLineTest_J9tests" />
@@ -66,7 +68,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/cmdlinetestertests/build.xml
+++ b/test/functional/cmdLineTests/cmdlinetestertests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/cmdlinetestertests" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests defaultLazySymbolResolution
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/defaultLazySymbolResolution" />
 	<property name="src" location="." />
@@ -50,7 +52,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests doProtectedAccessCheck
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/doProtectedAccessCheck" />
@@ -71,7 +73,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/dscr/build.xml
+++ b/test/functional/cmdLineTests/dscr/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests dscr
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/dscr" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/dumpromtests/build.xml
+++ b/test/functional/cmdLineTests/dumpromtests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests GCCheck
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/dumpromtests" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/fastClassHashTable/build.xml
+++ b/test/functional/cmdLineTests/fastClassHashTable/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests fastClassHashTable
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/fastClassHashTable" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests forceLazySymbolResolution
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/forceLazySymbolResolution" />
 	<property name="src" location="." />
@@ -50,7 +52,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/gcCheck/build.xml
+++ b/test/functional/cmdLineTests/gcCheck/build.xml
@@ -27,7 +27,9 @@
 		Build cmdLineTests GCCheck
 	</description>
 
-    <!-- set properties for this build -->
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
+	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gcCheck" />
 	<property name="src" location="./src"/>
 	<property name="allocator" location="${TEST_ROOT}/functional/Java8andUp/src/org/openj9/test/nogc"/>
@@ -66,7 +68,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/gcRegressionTests/build.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_GCRegressionTests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gcRegressionTests" />
@@ -73,7 +75,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/gcsuballoctests/build.xml
+++ b/test/functional/cmdLineTests/gcsuballoctests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests gcsuballoctests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gcsuballoctests" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/getCallerClassTests/build.xml
+++ b/test/functional/cmdLineTests/getCallerClassTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/getCallerClassTests" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/gptest/build.xml
+++ b/test/functional/cmdLineTests/gptest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests gptest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gptest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/javaAssertions/build.xml
+++ b/test/functional/cmdLineTests/javaAssertions/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2019 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_javaAssertions
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/javaAssertions" />
@@ -65,7 +67,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_libpathTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jep178staticLinkingTest" />
@@ -71,7 +73,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/jimageinterface/build.xml
+++ b/test/functional/cmdLineTests/jimageinterface/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jimageinterface" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/jrvTest/build.xml
+++ b/test/functional/cmdLineTests/jrvTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests jrvTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jrvTest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build JVMTI tests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jvmtitests" />
@@ -128,7 +130,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/jython/build.xml
+++ b/test/functional/cmdLineTests/jython/build.xml
@@ -28,6 +28,8 @@
 		Build jython hello
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jython" />
 	<property name="src" location="./src"/>
@@ -70,7 +72,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
+++ b/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_lazyClassLoading
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/lazyClassLoadingTest" />
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/libpathTest/build.xml
+++ b/test/functional/cmdLineTests/libpathTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_libpathTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/libpathTest" />
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/loadLibraryTest/build.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_loadLibraryTest
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/loadLibraryTest" />
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/locales/build.xml
+++ b/test/functional/cmdLineTests/locales/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests locales
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/locales" />
 	<property name="src" location="." />
@@ -49,7 +51,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -28,6 +28,8 @@
 		Build cmdLineTests_lockWordAlignment
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/lockWordAlignment" />
 	<property name="PROJECT_ROOT" location="." />
@@ -107,7 +109,7 @@
 		</delete>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/loopReduction/build.xml
+++ b/test/functional/cmdLineTests/loopReduction/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build loopReduction
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/loopReduction" />
 	<property name="src" location="." />
@@ -38,8 +40,11 @@
 			<fileset dir="${src}" includes="*.mk"/>
 		</copy>
 	</target>
-	
-	<target name="build" >
+
+	<target name="build" depends="buildCmdLineTestTools">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/JIT_Test/" includes="build.xml" />
+		</subant>
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/modularityddrtests/build.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests modularityddrtests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/modularityddrtests" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/openssl/build.xml
+++ b/test/functional/cmdLineTests/openssl/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_OpenSSL
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/openssl" />
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/pageAlignDirectMemory/build.xml
+++ b/test/functional/cmdLineTests/pageAlignDirectMemory/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/pageAlignDirectMemory" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/pltest/build.xml
+++ b/test/functional/cmdLineTests/pltest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build pltest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/pltest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/proxyFieldAccess/build.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_proxyFieldAccess
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/proxyFieldAccess" />
@@ -81,7 +83,7 @@
 		<delete dir="${build}" />
 	</target>
 	
-	<target name="build">
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/reflectCache/build.xml
+++ b/test/functional/cmdLineTests/reflectCache/build.xml
@@ -28,6 +28,8 @@
 		Build cmdLineTests reflectCache
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/reflectCache" />
 	<property name="src" location="./src"/>
@@ -85,7 +87,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2020 IBM Corp. and others
+  Copyright (c) 2017, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_runtimemxbeanTests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/runtimemxbeanTests" />
@@ -80,7 +82,7 @@
 		</delete>
 	</target>
 
-	<target name="build">
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9)$$" />

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests badStackMap
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/BadStackMap" />
@@ -63,7 +65,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,11 @@
 		Build DataHelperTests   
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/DataHelperTests" />
+	<property name="jarfile" value="${DEST}/DataHelperTests.jar" />
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="."/>
 	<property name="build" location="./bin"/>
@@ -111,7 +114,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/DataHelperTests.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}" />
 		</jar>
 		<copy todir="${DEST}">
@@ -125,7 +128,11 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,10 @@
 		Build ShareClassesListAllCachesTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!--Properties for this particular build-->
-    <property name="src" location="./"/>
+	<property name="src" location="./"/>
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/ListAllCachesTests" />
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="."/>
@@ -64,7 +66,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build ShareClassesCMLTEST
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/SCCMLTests" />
 	<property name="src" location="." />
@@ -39,7 +41,19 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils,buildCmdLineTestUtils2">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/VM_Test/" includes="build.xml" />
+		</subant>
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdLineTests/shareClassTests/URLHelperTests" includes="build.xml" />
+		</subant>
+				<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdLineTests/shareClassTests/TokenHelperTests" includes="build.xml" />
+		</subant>
+				<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/cmdLineTests/shareClassTests/DataHelperTests" includes="build.xml" />
+		</subant>
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build SCCommandLineOptionTests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests" />
@@ -71,7 +73,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build SCHelperCompatTests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/SCHelperCompatTests" />
@@ -145,7 +147,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build ShareClassesSimpleSanity
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity" />
@@ -67,7 +69,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests locales
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/StorageKey" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build StoreFilterTests
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/StoreFilterTests" />
@@ -114,7 +116,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (c) 2005, 2019 IBM Corp. and others
+  Copyright (c) 2005, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,12 @@
 	<description>
 		Build TokenHelperTests
 	</description>
-		
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/TokenHelperTests" />
+	<property name="jarfile" value="${DEST}/TokenHelperTests.jar" />
 	<property name="src" location="."/>
 	<property name="build" location="./bin"/>
 
@@ -116,21 +119,25 @@
 	</target>
 	
 	<target name="dist" depends="compile" description="generate the distribution">
- 		<jar jarfile="${DEST}/TokenHelperTests.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}"/>
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}" />
 			<fileset dir="${src}" includes="*.mk" />
 		</copy>
-  	</target>
+	</target>
 	
 	<target name="clean" depends="dist" description="clean up">
 		<!-- Delete the ${build} directory trees -->
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,12 @@
 		Build URLHelperTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/URLHelperTests" />
+	<property name="jarfile" value="${DEST}/URLHelperTests.jar" />
+
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="."/>
 	<property name="build" location="./bin"/>
@@ -153,7 +157,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/URLHelperTests.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}" />
 		</jar>
 		<copy todir="${DEST}">
@@ -167,7 +171,11 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shareClassTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build shareClassTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests" />
 
@@ -35,7 +37,7 @@
 		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist">
+	<target name="build" depends="dist,buildCmdLineTestTools">
 		<subant target="">
 			<fileset dir="." includes="*/build.xml" />
 		</subant>

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 	<description>
        Build sharedClass testClasses  
     </description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!--Properties for this particular build-->
 	<property name="build" location="build" />
@@ -326,7 +328,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/shrcdbgddrext/build.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests shrcdbgddrext
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shrcdbgddrext" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests sigabrtHandlingTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigabrtHandlingTest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests sigxfszHandlingTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigxfszHandlingTest" />
 	<property name="src" location="." />
@@ -50,7 +52,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/softmxCmdOptTest/build.xml
+++ b/test/functional/cmdLineTests/softmxCmdOptTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/softmxCmdOptTest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/stackSizeInfoTest/build.xml
+++ b/test/functional/cmdLineTests/stackSizeInfoTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests stackSizeInfoTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/stackSizeInfoTest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/utils/build.xml
+++ b/test/functional/cmdLineTests/utils/build.xml
@@ -28,8 +28,11 @@
 		Build utils
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/utils" />
+	<property name="jarfile" value="${DEST}/utils.jar" />
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
 	<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
@@ -65,7 +68,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/utils.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}" />
 		</jar>
@@ -80,10 +83,14 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<if>
 			<or>
-				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
 			<then>

--- a/test/functional/cmdLineTests/utils2/build.xml
+++ b/test/functional/cmdLineTests/utils2/build.xml
@@ -28,8 +28,11 @@
 		Build utils2. It only contains the modified AnonClassAndUnsafeClassTest.java and the duplicated ClassTest.java which are used on the ShareClassesCMLTests-1 test 62-d.
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/utils2" />
+	<property name="jarfile" value="${DEST}/utils2.jar" />
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
 	<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
@@ -65,7 +68,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/utils2.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}" />
 		</jar>
@@ -80,7 +83,11 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />

--- a/test/functional/cmdLineTests/valuetypeddrtests/build.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build valuetype ddr tests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/valuetypeddrtests" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
 			<then>

--- a/test/functional/cmdLineTests/verboseVerification/build.xml
+++ b/test/functional/cmdLineTests/verboseVerification/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2010, 2018 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build verboseVerification
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/verboseVerification" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/verbosetest/build.xml
+++ b/test/functional/cmdLineTests/verbosetest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build verbosetest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/verbosetest" />
 	<property name="src" location="." />
@@ -38,8 +40,11 @@
 			<fileset dir="${src}" includes="*.mk"/>
 		</copy>
 	</target>
-	
-	<target name="build" >
+
+	<target name="build" depends="buildCmdLineTestTools">
+		<subant target="build">
+			<fileset dir="${TEST_ROOT}/functional/JIT_Test/" includes="build.xml" />
+		</subant>
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/vmRuntimeState/build.xml
+++ b/test/functional/cmdLineTests/vmRuntimeState/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 	<description>
 		Build cmdLineTests_vmRuntimeState
 	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/vmRuntimeState" />
@@ -71,7 +73,7 @@
 		</delete>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/xcheckjni/build.xml
+++ b/test/functional/cmdLineTests/xcheckjni/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTester_XcheckJNI
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/xcheckjni" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/xlogTests/build.xml
+++ b/test/functional/cmdLineTests/xlogTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		Build cmdLineTests xlogTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/xlogTests" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/xlpCMLTests/build.xml
+++ b/test/functional/cmdLineTests/xlpCMLTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTests xlpCMLTests
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/xlpCMLTests" />
 	<property name="src" location="." />
@@ -38,7 +40,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/xxargtest/build.xml
+++ b/test/functional/cmdLineTests/xxargtest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 		Build cmdLineTest_XXArgtest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/xxargtest" />
 	<property name="src" location="." />
@@ -39,7 +41,7 @@
 		</copy>
 	</target>
 	
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools">
 		<antcall target="dist" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdline_options_tester/build.xml
+++ b/test/functional/cmdline_options_tester/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdline_options_tester" />
+	<property name="jarfile" value="${DEST}/cmdlinetester.jar" />
 
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
@@ -58,7 +59,7 @@
 
 	<target name="dist" depends="compile" description="Generate the distribution">
 		<!-- Store all class files in cmdlinetester.jar file -->
-		<jar jarfile="${DEST}/cmdlinetester.jar" filesonly="true" duplicate="fail">
+		<jar jarfile="${jarfile}" filesonly="true" duplicate="fail">
 			<manifest>
 				<attribute name="Main-Class" value="MainTester"/>
 			</manifest>
@@ -76,7 +77,11 @@
 		<delete dir="${build}"/>
 	</target>
 
-	<target name="build" >
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdline_options_testresources/build.xml
+++ b/test/functional/cmdline_options_testresources/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdline_options_testresources" />
+	<property name="jarfile" value="${DEST}/cmdlinetestresources.jar" />
 
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
@@ -80,7 +81,7 @@
 
 	<target name="dist" depends="compile" description="generate the distribution" >
 		<!-- Store all class files in cmdlinetestresources.jar file -->
-		<jar jarfile="${DEST}/cmdlinetestresources.jar" filesonly="true">
+		<jar jarfile="${jarfile}" filesonly="true">
 			<fileset dir="${build}"/>
 			<fileset dir="${src}"/>
 		</jar>
@@ -89,12 +90,16 @@
 		</copy>
 	</target>
 
+	<target name="check-jar">
+		<available file="${jarfile}" property="jar.exist"/>
+	</target>
+
 	<target name="clean" depends="dist" description="clean up" >
 		<!-- Delete the ${build} directory trees -->
 		<delete dir="${build}"/>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="check-jar" unless="jar.exist">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
@@ -103,6 +108,6 @@
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>
-		</if>		
+		</if>
 	</target>
 </project>


### PR DESCRIPTION
- add check-jar to compile dependencies only if jar doesn't exit
- add dependency to compile tools in each test build.xml
- add dependency to compile JIT_Test in loopReduction build.xml
- add dependency to compile JIT_Test in verbosettest build.xml
- add dependency to compile VM_Test in SCCMLTests build.xml
- add dependency to compile utils and utils2 in multiple build.xml
- add dependency to compile URL/Token/DataHelperTests in SCCMLTest

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>