### PR TITLE
Fix jsr inliner for zero indexes (0.28)

### DIFF
--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -183,6 +183,7 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 	bcIndex = bcStart;
 	bcInstructionStart = bcIndex;
 	while (bcIndex < bcEnd) {
+		BOOLEAN noZeroIndex = FALSE;
 		bcInstructionStart = bcIndex;
 		/* Don't need to check that an instruction is in the code range here as method entries
 			have 4 extra bytes at the end - exception and attribute counts so we won't exceed
@@ -608,6 +609,8 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 		case CFR_BC_jsr:
 			method->j9Flags |= CFR_J9FLAG_HAS_JSR;
 			classfile->j9Flags |= CFR_J9FLAG_HAS_JSR;
+			noZeroIndex = TRUE;
+
 			/* fall through */
 
 		case CFR_BC_goto:
@@ -636,6 +639,10 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			}
 			if (!map[target]) {
 				errorType = J9NLS_CFR_ERR_BC_JUMP_TARGET__ID;
+				goto _verifyError;
+			}
+			if (noZeroIndex && (0 == index)) {
+				errorType = J9NLS_CFR_ERR_BC_JUMP_RECURSIVE__ID;
 				goto _verifyError;
 			}
 			break;
@@ -1166,6 +1173,8 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 		case CFR_BC_jsr_w:
 			method->j9Flags |= CFR_J9FLAG_HAS_JSR;
 			classfile->j9Flags |= CFR_J9FLAG_HAS_JSR;
+			noZeroIndex = TRUE;
+
 			/* fall through */
 
 		case CFR_BC_goto_w:
@@ -1178,6 +1187,10 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			}
 			if (!map[target]) {
 				errorType = J9NLS_CFR_ERR_BC_JUMP_TARGET__ID;
+				goto _verifyError;
+			}
+			if (noZeroIndex && (0 == index)) {
+				errorType = J9NLS_CFR_ERR_BC_JUMP_RECURSIVE__ID;
 				goto _verifyError;
 			}
 			break;

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1559,3 +1559,10 @@ J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.explanation=ValueTypes is an exper
 J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.user_response=Contact the provider of the class file for a corrected version, or remove the -XX:+EnableValhalla option and retry.
 # END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_BC_JUMP_RECURSIVE=A jsr instruction illegally points to its own bytecode index
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.explanation=The JVM is unable to flatten the code block for a jsr instruction that refers to its own bytecode index.
+J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED_V1.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
Fix jsr inliner for zero indexes (0.28)

back port of #13412 

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>