### PR TITLE
Change SCC default directory to /tmp on z/OS

### DIFF
--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -208,7 +208,7 @@ SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDA
 		flags |= J9SHMEM_GETDIR_APPEND_BASEDIR;
 	}
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	if ((NULL == ctrlDirName)
 		&& J9_ARE_NO_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_GROUP_ACCESS)
 	) {
@@ -218,7 +218,7 @@ SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDA
 
 		flags |= J9SHMEM_GETDIR_USE_USERHOME;
 	}
-#endif /*defined(OPENJ9_BUILD) */
+#endif /*defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	rc = j9shmem_getDir(ctrlDirName, flags, buffer, bufferSize);
 

--- a/runtime/tests/shared/CacheDirPerm.cpp
+++ b/runtime/tests/shared/CacheDirPerm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,16 +41,21 @@ extern "C" {
 
 #define EXISTING_DIR_PERM         NEW_DIR_PERM
 #if defined(OPENJ9_BUILD)
-#define NON_EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM
-#define EXISTING_DEFAULT_DIR_PERM	NEW_DIR_PERM
-#else
-#define NON_EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM_DEFAULT_TMP
-#if defined(J9ZOS390)
-/* on z/OS permission of existing default directory under /tmp is not changed to J9SH_DIRPERM_DEFAULT_TMP. */
-#define EXISTING_DEFAULT_DIR_PERM	NEW_DIR_PERM
-#else /* defined(J9ZOS390) */
-#define EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM_DEFAULT_TMP
-#endif /* defined(J9ZOS390) */
+	#define EXISTING_DEFAULT_DIR_PERM	NEW_DIR_PERM
+	#if defined(J9ZOS390)
+	/* on z/OS permission of new default directory under /tmp is J9SH_DIRPERM_DEFAULT_TMP */
+		#define NON_EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM_DEFAULT_TMP
+	#else /* defined(J9ZOS390) */
+		#define NON_EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM
+	#endif /* defined(J9ZOS390) */
+#else /* defined(OPENJ9_BUILD) */
+	#define NON_EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM_DEFAULT_TMP
+	#if defined(J9ZOS390)
+		/* on z/OS permission of existing default directory under /tmp is not changed to J9SH_DIRPERM_DEFAULT_TMP. */
+		#define EXISTING_DEFAULT_DIR_PERM	NEW_DIR_PERM
+	#else /* defined(J9ZOS390) */
+		#define EXISTING_DEFAULT_DIR_PERM	J9SH_DIRPERM_DEFAULT_TMP
+	#endif /* defined(J9ZOS390) */
 #endif /* defined(OPENJ9_BUILD) */
 
 extern "C" IDATA removeTempDir(J9JavaVM *vm, char *dir);
@@ -83,11 +88,11 @@ CacheDirPerm::getTempCacheDir(J9JavaVM *vm, I_32 cacheType, bool useDefaultDir, 
 
 	if (useDefaultDir) {
 		flags |= J9SHMEM_GETDIR_APPEND_BASEDIR;
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 		if (!groupAccess) {
 			flags |= J9SHMEM_GETDIR_USE_USERHOME;
 		}
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	}
 
 	memset(cacheDir, 0, J9SH_MAXPATH);

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -777,9 +777,9 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	rc = j9shmem_getDir(NULL, flags, baseDir, J9SH_MAXPATH);
 	if (rc < 0) {
@@ -843,9 +843,9 @@ truncateCache(J9JavaVM *vm, I_32 cacheType)
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	rc = j9shmem_getDir(NULL, flags, baseDir, J9SH_MAXPATH);
 	if (rc < 0) {

--- a/runtime/tests/shared/OSCacheTestMmap.cpp
+++ b/runtime/tests/shared/OSCacheTestMmap.cpp
@@ -55,9 +55,9 @@ SH_OSCacheTestMmap::testBasic(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -142,9 +142,9 @@ SH_OSCacheTestMmap::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -214,9 +214,9 @@ SH_OSCacheTestMmap::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -313,9 +313,9 @@ SH_OSCacheTestMmap::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -460,9 +460,9 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 	}
 	piconfig->sharedClassDebugAreaBytes = -1;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /*  defined(OPENJ9_BUILD) */
+#endif /*  defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	ret = j9shmem_getDir(ctrlDirName, flags, cacheDirName, J9SH_MAXPATH);
 	if (0 > ret) {
@@ -570,9 +570,9 @@ SH_OSCacheTestMmap::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -663,9 +663,9 @@ SH_OSCacheTestMmap::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
@@ -757,9 +757,9 @@ SH_OSCacheTestMmap::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -58,9 +58,9 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	void* allocatedMem = NULL;
 	UDATA memSize = 0;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
@@ -205,9 +205,9 @@ SH_OSCacheTestSysv::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	UDATA memSize = SH_OSCache::getRequiredConstrBytes();
 	void* allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /*  defined(OPENJ9_BUILD) */
+#endif /*  defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	
@@ -362,9 +362,9 @@ SH_OSCacheTestSysv::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	UDATA memSize = 0;
 	void* allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /*  defined(OPENJ9_BUILD) */
+#endif /*  defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
@@ -453,9 +453,9 @@ SH_OSCacheTestSysv::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	UDATA memSize = 0;
 	void* allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
@@ -550,9 +550,9 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	}
 	memset(piconfig, 0 , sizeof(J9SharedClassPreinitConfig));
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= (J9SHMEM_GETDIR_USE_USERHOME | J9SHMEM_GETDIR_APPEND_BASEDIR);
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	ret = j9shmem_getDir(ctrlDirName, flags, cacheDirName, J9SH_MAXPATH);
 	if (0 > ret) {
@@ -673,9 +673,9 @@ SH_OSCacheTestSysv::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	UDATA memSize = 0;
 	void* allocatedMem = NULL;
 
-#if	defined(OPENJ9_BUILD)
+#if	defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
@@ -774,9 +774,9 @@ SH_OSCacheTestSysv::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	UDATA memSize = 0;
 	void* allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
@@ -872,9 +872,9 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	UDATA memSize = 0;
 	void* allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
@@ -1033,9 +1033,9 @@ SH_OSCacheTestSysv::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	UDATA memSize = 0;
 	void *allocatedMem = NULL;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 

--- a/runtime/tests/shared/SharedCacheAPITest.cpp
+++ b/runtime/tests/shared/SharedCacheAPITest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,9 +50,9 @@ getCacheDir(J9JavaVM *vm, char *cacheDir)
 	char cacheDirNoTestBasedir[J9SH_MAXPATH];
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-#if defined(OPENJ9_BUILD)
+#if defined(OPENJ9_BUILD) && !defined(J9ZOS390)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
-#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(OPENJ9_BUILD) && !defined(J9ZOS390) */
 
 	rc = j9shmem_getDir(NULL, flags, cacheDirNoTestBasedir, J9SH_MAXPATH);
 	if (rc < 0) {

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,7 +165,7 @@ public class TestUtils {
 		    }
 		    else
 		    {
-		    	if (false == isIbmJava8()) {
+				if (false == isDefaultDirTmp()) {
 		    		config.put("defaultCacheGroupAccessLocation","/tmp/");
 			    } 
 		    	config.put("defaultCacheLocation","/tmp/"); 
@@ -605,7 +605,7 @@ public class TestUtils {
 		//NOTE: use above statics to save some time when running tests ...
 		
 		String cmd = "";
-		if ( false == isIbmJava8() && cachename.indexOf("groupaccess") != -1 ) {
+		if ( false == isDefaultDirTmp() && cachename.indexOf("groupaccess") != -1 ) {
 			if (persistent==true)
 			{
 				cmd = getCommand("getCacheFileNameGroupAccess",cachename);
@@ -1528,9 +1528,9 @@ public class TestUtils {
 		return RunCommand.lastCommandStderrLines;
 	}
 	
-	public static boolean isIbmJava8() {
+	public static boolean isDefaultDirTmp() {
 		// ibm 11+ has the same -DOPENJ9_BUILD as openj9
-		return System.getProperty("java.vm.vendor").toLowerCase().contains("ibm") && System.getProperty("java.specification.version").contains("1.8");
+		return System.getProperty("java.vm.vendor").toLowerCase().contains("ibm") && System.getProperty("java.specification.version").contains("1.8") || isMVS();
 	}
 	
 	public static String removeJavaSharedResourcesDir(String dir) {

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 	  }
 	  String currentCacheDir = getCacheDir();
 
-	  if ( null == currentCacheDir && false == isIbmJava8() ) {
+	  if ( null == currentCacheDir && false == isDefaultDirTmp() ) {
 		  // Persistent cachefile without groupaccess are generated under HOME directory
 		  // Current directory is under /tmp. Move a file from HOME directory to /tmp may not succeed on some platforms. 
 		return;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			persistentList = new ArrayList<String>();
 			persistentList.add("cache1");
 			if (isWindows() == false) {
-				if (false == isIbmJava8()) {
+				if (false == isDefaultDirTmp()) {
 					persistentGroupAccessList = new ArrayList<String>();
 					persistentGroupAccessList.add("cache1_groupaccess");
 				} else {
@@ -56,7 +56,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			nonpersistentList = new ArrayList<String>();
 			nonpersistentList.add("cache2");
 			if (isWindows() == false) {
-				if (false == isIbmJava8()) {
+				if (false == isDefaultDirTmp()) {
 					nonpersistentGroupAccessList = new ArrayList<String>();
 					nonpersistentGroupAccessList.add("cache2_groupaccess");
 				} else {
@@ -89,7 +89,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
     	runDestroyAllCaches();
     	if (false == isWindows()) {
     		runDestroyAllSnapshots();
-        	if (false == isIbmJava8()) {
+			if (false == isDefaultDirTmp()) {
         		runDestroyAllGroupAccessCaches();
             }
     	}
@@ -110,7 +110,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	    		oldCacheCount = cacheList.size();
 	    	}
 
-	    	if (dir == null && false == isWindows() && false == isMVS() && false == isIbmJava8()) {
+			if (dir == null && false == isWindows() && false == isMVS() && false == isDefaultDirTmp()) {
 	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
 	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
 	    		cacheGroupAccessList = SharedClassUtilities.getSharedCacheInfo(dirGroupAccess, SharedClassUtilities.NO_FLAGS, false);
@@ -605,7 +605,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			runDestroyAllCaches();
 			if (false == isWindows()) {
 				runDestroyAllSnapshots();
-				if (false == isIbmJava8()) {
+				if (false == isDefaultDirTmp()) {
 					runDestroyAllGroupAccessCaches();
 				}
 			}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corp. and others
+ * Copyright (c) 2010, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
         runDestroyAllCaches();
         if (false == isWindows()) {
         	runDestroyAllSnapshots();
-        	if (false == isIbmJava8()) {
+			if (false == isDefaultDirTmp()) {
         		runDestroyAllGroupAccessCaches();
         	}
         }
@@ -63,7 +63,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
 		    	fail("iterateSharedCacheFunction failed with dir " + dir);
 		    }
 	    	
-	    	if (dir == null && false == isWindows() && false == isIbmJava8()) {
+			if (dir == null && false == isWindows() && false == isDefaultDirTmp()) {
 	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
 	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
 	    		oldCacheGroupAccessCount = iterateSharedCache(dirGroupAccess, NO_FLAGS, false) + iterateSharedCache(dirRemoveJavaSharedResources, NO_FLAGS, false);
@@ -156,7 +156,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
 			runDestroyAllCaches();
 			if (false == isWindows()) {
 				runDestroyAllSnapshots();
-				if (false == isIbmJava8()) {
+				if (false == isDefaultDirTmp()) {
 					runDestroyAllGroupAccessCaches();
 				}
 			}

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/SCCOptionTestSetting.mk
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/SCCOptionTestSetting.mk
@@ -1,0 +1,26 @@
+##############################################################################
+#  Copyright (c) 2021, 2021 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
+
+EXCLUDE_FILE=exclude_11.xml
+ifeq (8, $(JDK_VERSION))
+ EXCLUDE_FILE=exclude.xml
+endif

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/exclude_11.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/exclude_11.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+<suite id="CommandLineOption Excluded Test Case List">
+	<exclude id="nameOption" platform="zos_390-64.*" shouldFix="false">
+			<reason>The default cache is in use, which cannot be removed on zOS systems</reason>
+	</exclude>
+	<exclude id="nameOption11" platform="all" shouldFix="true">
+			<reason>CMVC 169666 : nameOption11 test fails on zOS systems</reason>
+	</exclude>
+	<exclude id="nameOption15" platform="win_x86-64_cr" shouldFix="false">
+			<reason>%g modifier not valid on Windows</reason>
+	</exclude>
+	<exclude id="nameOption19" platform="win_x86-64_cr" shouldFix="false">
+			<reason>%g modifier not valid on Windows</reason>
+	</exclude>
+</suite>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
@@ -22,6 +22,7 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<!-- Exclude it on windows for issue https://github.com/eclipse-openj9/openj9/issues/1814 -->
+	<include>SCCOptionTestSetting.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_SCCommandLineOptionTests</testCaseName>
 		<variations>
@@ -34,7 +35,7 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DTEST_JDK_HOME=$(Q)$(TEST_JDK_HOME)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)CommandLineOptionTests.xml$(Q) \
-	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)$(EXCLUDE_FILE)$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
1. Change the shared cache directory to /tmp on z/OS.
2. Update tests.

Depends on eclipse-openj9/openj9-docs#829
Close #13312

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>