### PR TITLE
(0.28.0) Do not reuse fabricated symrefs for relocatable compilations

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -699,20 +699,25 @@ J9::SymbolReferenceTable::findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol *
    //J9::SymbolReferenceTable::findOrCreateShadowSymbol
    TR::SymbolReference * symRef = NULL;
    TR::Symbol * sym = NULL;
-   symRef = findShadowSymbol(owningMethod, -1, type, &recognizedField);
 
-   if (symRef)
-      return symRef;
-   else
+   if (!comp()->compileRelocatableCode()
+#if defined(J9VM_OPT_JITSERVER)
+       && !comp()->isOutOfProcessCompilation()
+#endif
+       )
       {
-      sym = createShadowSymbol(
-         type,
-         isVolatile,
-         isPrivate,
-         isFinal,
-         name,
-         recognizedField);
+      symRef = findShadowSymbol(owningMethod, -1, type, &recognizedField);
+
+      if (symRef)
+         return symRef;
       }
+   sym = createShadowSymbol(
+      type,
+      isVolatile,
+      isPrivate,
+      isFinal,
+      name,
+      recognizedField);
 
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1);
    // isResolved = true, isUnresolvedInCP = false


### PR DESCRIPTION
This is a v0.28.0 backport of #13425