### PR TITLE
Re-add MIN_PROFILED_CALL_FREQUENCY to inliner

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -50,6 +50,7 @@
 #include "codegen/CodeGenerator.hpp"
 
 #define OPT_DETAILS "O^O INLINER: "
+const float MIN_PROFILED_CALL_FREQUENCY = (.65f); // lowered this from .80f since opportunities were being missed in WAS; in those cases getting rid of the call even in 65% of the cases was beneficial probably due to the improved icache impact
 
 extern int32_t          *NumInlinedMethods;  // Defined in Inliner.cpp
 extern int32_t          *InlinedSizes;       // Defined in Inliner.cpp


### PR DESCRIPTION
This constant was removed from OMR and readded
inside `J9Inliner.cpp` as it is the only file that uses it.