### PR TITLE
Use MemorySegment intrusive list for SystemSegmentProvider free list

### DIFF
--- a/runtime/compiler/env/SystemSegmentProvider.cpp
+++ b/runtime/compiler/env/SystemSegmentProvider.cpp
@@ -36,7 +36,7 @@ J9::SystemSegmentProvider::SystemSegmentProvider(size_t defaultSegmentSize, size
    _freeSegments(&_freeSegmentsEmpty),
    _currentSystemSegment( TR::ref(_systemSegmentAllocator.request(systemSegmentSize) ) )
    {
-   TR_ASSERT(defaultSegmentSize <= systemSegmentSize, "defaultSegmentSize should be smaller than or equal to systemSegmentSize");
+   TR_ASSERT_FATAL(defaultSegmentSize <= systemSegmentSize, "defaultSegmentSize should be smaller than or equal to systemSegmentSize");
 
    // We cannot simply assign systemSegmentSize to _systemSegmentSize because:
    // We want to make sure that _currentSystemSegment is always a small system segment, i.e. its size <= _systemSegmentSize. When
@@ -97,14 +97,14 @@ J9::SystemSegmentProvider::request(size_t requiredSize)
    if (remaining(_currentSystemSegment) >= roundedSize)
       {
       // Only allocate small segments from _currentSystemSegment
-      TR_ASSERT(!isLargeSegment(remaining(_currentSystemSegment)), "_currentSystemSegment must be a small segment");
+      TR_ASSERT_FATAL(!isLargeSegment(remaining(_currentSystemSegment)), "_currentSystemSegment must be a small segment");
       return allocateNewSegment(roundedSize, _currentSystemSegment);
       }
 
    size_t systemSegmentSize = std::max(roundedSize, _systemSegmentSize);
 
    J9MemorySegment &newSegment = _systemSegmentAllocator.request(systemSegmentSize);
-   TR_ASSERT(
+   TR_ASSERT_FATAL(
       newSegment.heapAlloc == newSegment.heapBase,
       "Segment @ %p { heapBase: %p, heapAlloc: %p, heapTop: %p } is stale",
       &newSegment,
@@ -234,7 +234,7 @@ J9::SystemSegmentProvider::bytesAllocated() const throw()
 TR::MemorySegment &
 J9::SystemSegmentProvider::allocateNewSegment(size_t size, TR::reference_wrapper<J9MemorySegment> systemSegment)
    {
-   TR_ASSERT( (size % defaultSegmentSize()) == 0, "Misaligned segment");
+   TR_ASSERT_FATAL( (size % defaultSegmentSize()) == 0, "Misaligned segment");
    void *newSegmentArea = operator new(size, systemSegment);
    if (!newSegmentArea) throw std::bad_alloc();
    try
@@ -254,8 +254,8 @@ TR::MemorySegment &
 J9::SystemSegmentProvider::createSegmentFromArea(size_t size, void *newSegmentArea)
    {
    auto result = _segments.insert( TR::MemorySegment(newSegmentArea, size) );
-   TR_ASSERT(result.first != _segments.end(), "Bad iterator");
-   TR_ASSERT(result.second, "Insertion failed");
+   TR_ASSERT_FATAL(result.first != _segments.end(), "Bad iterator");
+   TR_ASSERT_FATAL(result.second, "Insertion failed");
    return const_cast<TR::MemorySegment &>(*(result.first));
    }
 

--- a/runtime/compiler/env/SystemSegmentProvider.hpp
+++ b/runtime/compiler/env/SystemSegmentProvider.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,15 +83,8 @@ private:
       SegmentSetAllocator
       > _segments;
 
-   typedef TR::typed_allocator<
-      TR::reference_wrapper<TR::MemorySegment>,
-      TR::RawAllocator
-      > FreeSegmentDequeAllocator;
-
-   std::deque<
-      TR::reference_wrapper<TR::MemorySegment>,
-      FreeSegmentDequeAllocator
-      > _freeSegments;
+   TR::MemorySegment _freeSegmentsEmpty;
+   TR::MemorySegment *_freeSegments;
 
    // Current active System segment from where memory might be allocated.
    // A segment with space larger than _systemSegmentSize is used for only one request,


### PR DESCRIPTION
This avoids allocation within `J9::SystemSegmentProvider::release()`, which previously would push onto a `std::deque`.

Also, for segments that are larger than default but smaller than the system segment size, skip carving them into default-sized segments. The carving logic was allocating during `release()` for no benefit.

It's desirable to `release()` without allocating because we may already be trying to clean up due to an out-of-memory condition. If so, allocations may fail, throwing `std::bad_alloc()`, and furthermore, an exception throw operation itself can allocate on the heap, and if that fails, the C++ runtime library can call `std::terminate()`. That is, if there is little enough heap memory available, it won't be possible to recover from allocation failures in `release()`.

Also (in a separate commit) change `TR_ASSERT` to `TR_ASSERT_FATAL` within `J9::SystemSegmentProvider` so that the assertions will be checked