### PR TITLE
Update the documentation for new boot jdk location

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -146,7 +146,7 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-11
+bash configure --with-boot-jdk=/home/jenkins/bootjdks/jdk11
 ```
 :warning: The path in the example --with-boot-jdk= option is appropriate for the Docker installation. If not using the Docker environment, set the path appropriate for your setup, such as "<my_home_dir>/bootjdk11" as setup in the previous instructions.
 

--- a/doc/build-instructions/Build_Instructions_V16.md
+++ b/doc/build-instructions/Build_Instructions_V16.md
@@ -137,7 +137,7 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-15
+bash configure --with-boot-jdk=/home/jenkins/bootjdks/jdk16
 ```
 :warning: The path in the example `--with-boot-jdk= option` is appropriate for the Docker installation. If you're not using the Docker environment, set the path that's appropriate for your setup, such as `<my_home_dir>/bootjdk15`.
 

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -147,7 +147,7 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-80
+bash configure --with-boot-jdk=/home/jenkins/bootjdks/jdk8
 ```
 :warning: The path in the example --with-boot-jdk= option is appropriate for the Docker installation. If not using the Docker environment, set the path appropriate for your setup, such as "<my_home_dir>/bootjdk8" as setup in the previous instructions.
 


### PR DESCRIPTION
The location of the boot jdk in the documented configure command in the
Build_Instructions_V*.md files  doesn't match the current behaviour of
the mkdocker.sh script. This PR updates the documentation to match the
current locations.

Hopefully this addresses https://github.com/eclipse-openj9/openj9/issues/13459