### PR TITLE
(v0.28.0-release) Cleanup stale directories and files of attach API properly

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -206,7 +206,7 @@ public class AttachHandler extends Thread {
 			if (isAttachApiTerminated()) { 
 				return false; /* abort if we decided to shut down */
 			}
-			String myId = TargetDirectory.createMyDirectory(pidProperty, false);
+			String myId = TargetDirectory.createMyDirectory(pidProperty, true);
 			/*[PR RTC 80844 problem in initialization, or we are shutting down ]*/
 			if (null == myId) { 
 				return false;

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -349,6 +349,9 @@ public abstract class CommonDirectory {
 	 */
 	static void deleteStaleDirectories(String myId) {
 		long myUid = IPC.getUid();
+		if (LOGGING_DISABLED != loggingStatus) {
+			IPC.logMessage("deleting stale dirs, myId = " + myId + ", myUid = " + myUid); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		File[] vmDirs = getCommonDirFileObject().listFiles(new DirectorySampler());
 		if (null == vmDirs) {
 			return;
@@ -356,6 +359,7 @@ public abstract class CommonDirectory {
 		for (File dirMember: vmDirs) {
 			/*[PR 169137 abort if we shutting down while checking]*/
 			if (AttachHandler.isAttachApiTerminated()) {
+				IPC.logMessage("deleteStaleDirectories aborted due to AttachAPI is terminated"); //$NON-NLS-1$
 				break;
 			}
 
@@ -445,7 +449,7 @@ public abstract class CommonDirectory {
 		pid = advert.getProcessId();
 		long uid = advert.getUid();
 		if (LOGGING_DISABLED != loggingStatus) {
-			IPC.logMessage("getPidFromFile pid = ", (int) pid, dirMember.getName()); //$NON-NLS-1$
+			IPC.logMessage("getPidFromFile pid = ", (int) pid, ", fileNmae = " + dirMember.getName()); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		/*advertisement is from an older version or is corrupt, or claims to be owned by root.  Get the owner via file stat ]*/
 		if (0 == uid) {

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -570,18 +570,6 @@ public class TestAttachAPI extends AttachApiTest {
 				checkTargetPid(targets[i]);
 			}
 			assertTrue(vmIdExists(testName));
-			for (int i = 1; i < NUM_TARGETS; ++i) {
-				String tgtId = testName + "-" + (i - 1);
-				String tgtId2 = testName + "_" + (i - 1);
-				String tgtName = testName;
-				logger.debug("check for " + tgtId + " or " + tgtId2);
-				if (!vmIdExists(tgtId, tgtName) && !vmIdExists(tgtId2, tgtName)) {
-					targets[i].terminateTarget();
-					fail("target VM id " + tgtId + " or " + tgtId2 + " name "
-							+ tgtName + " not found");
-				}
-				assertTrue(vmIdExists(tgtId, tgtId2, tgtName));
-			}
 		} finally {
 			for (int i = 0; i < NUM_TARGETS; ++i) {
 				targets[i].terminateTarget();


### PR DESCRIPTION
When restarts the docker container, which the java application
does not catch some signals like SIGTERM to shutdown gracefully:
- leave some stale file there.
- it's possible(mostly) that the java application is assigned the same
process ID as before.

As a result, the jps/jstack could not work as expected due to
these stale and conflict VM target files.

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/13331 for 0.28 release

Signed-off-by: Xia Wood <xiazhongwu@gmail.com>