### PR TITLE
Add bound check before accessing flags array of InterpreterEmulator

### DIFF
--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1240,7 +1240,7 @@ InterpreterEmulator::findNextByteCodeToVisit()
       else next();
       }
 
-   if (_InterpreterEmulatorFlags[_bcIndex].testAny(InterpreterEmulator::BytecodePropertyFlag::bbStart))
+   if (_bcIndex < _maxByteCodeIndex && _InterpreterEmulatorFlags[_bcIndex].testAny(InterpreterEmulator::BytecodePropertyFlag::bbStart))
       {
       if (isGenerated(_bcIndex))
          setIndex(Base::findNextByteCodeToGen());


### PR DESCRIPTION
`InterpreterEmulator::findNextByteCodeToVisit()` accesses `_InterpreterEmulatorFlags`
twice. Before the second one, `_bcIndex` can be modified with the value returned
by `findNextByteCodeToGen()`. The value can be larger than `_maxByteCodeIndex`,
which causes an out of bounds access as seen in https://github.com/eclipse-openj9/openj9/issues/13096.
This commit adds a bound check before the second access to `_InterpreterEmulatorFlags`.

Closes: #13096

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>