### PR TITLE
Clean up `MemorySubSpaceTarok` softmx heap resizing

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -68,7 +68,6 @@ public:
 private:
 	bool initialize(MM_EnvironmentBase *env);
 	UDATA adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, UDATA expandSize);
-	UDATA adjustExpansionWithinSoftMx(MM_EnvironmentBase *env, UDATA expandSize, UDATA minimumBytesRequired);
 	UDATA checkForRatioExpand(MM_EnvironmentBase *env, UDATA bytesRequired);	
 	bool checkForRatioContract(MM_EnvironmentBase *env);
 	UDATA calculateExpandSize(MM_EnvironmentBase *env, UDATA bytesRequired, bool expandToSatisfy);
@@ -110,8 +109,8 @@ protected:
 public:
 	static MM_MemorySubSpaceTarok *newInstance(MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_GlobalAllocationManagerTarok *gamt, bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize, UDATA memoryType, U_32 objectFlags);
 	
-	virtual const char *getName() { return "Tarok"; }
-	virtual const char *getDescription() { return "Tarok MemorySubSpace Description"; }
+	virtual const char *getName() { return MEMORY_SUBSPACE_NAME_TAROK; }
+	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_TAROK; }
 
 	virtual MM_MemoryPool *getMemoryPool();
 	virtual MM_MemoryPool *getMemoryPool(void *addr);


### PR DESCRIPTION
Please see related PR link for motivations behind this change.

Changes include:
- remove `MemorySubSpaceTarok::adjustExpansionWithinSoftMx()` in favour of `adjustExpansionWithinSoftMax()`. The latter of the two, is inherited from `MemorySubSpace` and has no functional differences. This allows better code sharing/consistency
- Use `SOFT_MX_CONTRACT` contraction flag in `MemorySubSpaceTarok`. This better reflects the reason for contraction due to softmx. This depends on the linked OMR PR.
- Use `MEMORY_SUBSPACE_NAME_TAROK` and `MEMORY_SUBSPACE_DESCRIPTION_TAROK` flags instead of hard coded value for `getName()` and `getDescription()` in `MemorySubSpaceTarok`

This PR is related to, and is a follow up on: https://github.com/eclipse-openj9/openj9/pull/13308
This PR depends on: https://github.com/eclipse/omr/pull/6141

Signed-off-by: Cedric Hansen cedric.hansen@ibm.com