### PR TITLE
Store field signature for TypeLayoutEntry on heap

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -572,9 +572,15 @@ static void addEntryForFieldImpl(TR_VMField *field, TR::TypeLayoutBuilder &tlb, 
       bool isVolatile = (field->modifiers & J9AccVolatile) ? true : false;
       bool isPrivate = (field->modifiers & J9AccPrivate) ? true : false;
       bool isFinal = (field->modifiers & J9AccFinal) ? true : false;
+
+      int sigLen = strlen(signature);
+      char *fieldSignature = new (region) char[sigLen+1];
+      memcpy(fieldSignature, signature, sigLen);
+      fieldSignature[sigLen] = '\0';
+
       if (trace)
-         traceMsg(comp, "type layout definingClass %p field: %s, field offset: %d offsetBase %d\n", definingClass, fieldName, field->offset, offsetBase);
-      tlb.add(TR::TypeLayoutEntry(dataType, offset, fieldName, isVolatile, isPrivate, isFinal, signature));
+         traceMsg(comp, "type layout definingClass %p field: %s signature: %s field offset: %d offsetBase %d\n", definingClass, fieldName, fieldSignature, field->offset, offsetBase);
+      tlb.add(TR::TypeLayoutEntry(dataType, offset, fieldName, isVolatile, isPrivate, isFinal, fieldSignature));
       }
    }
 


### PR DESCRIPTION
`TypeLayoutEntry` needs to be valid throughout the whole compilation.
When the typeLayout is constructed in ILGen, the field signature is
from `TR_VMFieldsInfo` which is stack allocated in `enumerateFields` in
the stack region for ILGen. The` stackMemoryRegion` for ILGen will be
released after genIL().

Fixes #13484

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>