### PR TITLE
(0.28.0) Update 0.28 release notes with JITServer info

### DIFF
--- a/doc/release-notes/0.28/0.28.md
+++ b/doc/release-notes/0.28/0.28.md
@@ -48,6 +48,12 @@ The following table covers notable changes in v0.28.0. Further information about
 </thead>
 <tbody>
 
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/13492">#13492</a></td>
+<td valign="top">JITServer technology is now a supported feature for Linux on x86-64 and Power</td>
+<td valign="top">OpenJDK8, 11, and 17 (Linux on x86-64, Linux on Power)</td>
+<td valign="top">JITServer decouples the JIT compiler from the OpenJ9 VM, freeing up CPU and memory for an application. JITServer then runs in its own process, either locally or on a remote machine, where resources can be separately managed.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
The release notes now reflect that JITServer is fully
available on select platforms.