### PR TITLE
(0.28.0) AArch64: Remove unnecessary regdep from reference array copy

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3818,7 +3818,7 @@ J9::ARM64::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node *node, TR::Code
       snippet->gcMap().setGCRegisterMask(0xFFFFFFFF);
       }
 
-   gcPoint = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, exceptionSnippetLabel, TR::CC_NE, deps);
+   gcPoint = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, exceptionSnippetLabel, TR::CC_NE);
    gcPoint->ARM64NeedsGCMap(cg, 0xFFFFFFFF);
 
    // ARM64HelperCallSnippet generates "bl" instruction


### PR DESCRIPTION
Remove unnecessary regdep from condition branch instruction to
ArrayStoreException JIT helper.
The unnecessary regdep keeps otherwise dead registers alive and
assigned to real registers, which results in GC error if instantiation
of ArrayStoreException triggers GC.

Master PR: https://github.com/eclipse-openj9/openj9/pull/13507

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>