### PR TITLE
Disable tests known to fail with forceAOT

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -558,6 +558,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<aot>nonapplicable</aot>
 	</test>
 	<test>
 		<testCaseName>jit_hwWarm</testCaseName>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
@@ -49,6 +49,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<aot>nonapplicable</aot>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_SCHelperCompatTests_unix</testCaseName>

--- a/test/functional/cmdLineTests/verbosetest/playlist.xml
+++ b/test/functional/cmdLineTests/verbosetest/playlist.xml
@@ -46,6 +46,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<aot>nonapplicable</aot>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_verbosetest_11</testCaseName>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/6057 tracks known issues when running functional and extended tests with `-Xscmx400M -Xscmaxaot256m -Xjit:forceAOT -Xaot:forceAOT`. This PR temporarily disables them (only under forceAOT) until they are fixed so that new bugs don't get lost in the noise.