### PR TITLE
SealedClassGenerator adopts JDK17+

### DIFF
--- a/test/functional/Java15andUp/build.xml
+++ b/test/functional/Java15andUp/build.xml
@@ -34,6 +34,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="LIB" value="asm,testng,jcommander"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
@@ -52,6 +53,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<src path="${TestUtilities}" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
 			<classpath>

--- a/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
@@ -23,28 +23,20 @@ package org.openj9.test.utilities;
  *******************************************************************************/
 
  import org.objectweb.asm.*;
+ import org.openj9.test.util.VersionCheck;
 
  public class SealedClassGenerator implements Opcodes {
 	private static String dummySubclassName = "TestSubclassGen";
 	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
 	 * major version match the latest supported version when --enable-preview flag is active
+	 *
+	 * It is a feature since JDK17.
 	 */
-	private static int latestPreviewVersion;
+	private static int classVersion;
 	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 15:
-				latestPreviewVersion = V15;
-				break;
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
+		classVersion = VersionCheck.classFile();
+		if (VersionCheck.major() < 17) {
+			classVersion |= V_PREVIEW;
 		}
 	}
 
@@ -52,7 +44,7 @@ package org.openj9.test.utilities;
 		int accessFlags = ACC_FINAL | ACC_SUPER;
 
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, accessFlags, className, null, "java/lang/Object", null);
+		cw.visit(classVersion, accessFlags, className, null, "java/lang/Object", null);
 
 		/* Sealed class must have a PermittedSubclasses attribute */
 		cw.visitPermittedSubclass(dummySubclassName);
@@ -64,7 +56,7 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubclassIllegallyExtendingSealedSuperclass(String className, Class<?> superClass) {
 		String superName = superClass.getName().replace('.', '/');
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, superName, null);
+		cw.visit(classVersion, ACC_SUPER, className, null, superName, null);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
@@ -72,14 +64,14 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubinterfaceIllegallyExtendingSealedSuperinterface(String className, Class<?> superInterface) {
 		String[] interfaces = { superInterface.getName().replace('.', '/') };
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", interfaces);
+		cw.visit(classVersion, ACC_SUPER, className, null, "java/lang/Object", interfaces);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
 
 	public static byte[] generateSealedClass(String className, String[] permittedSubclassNames) {
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", null);
+		cw.visit(classVersion, ACC_SUPER, className, null, "java/lang/Object", null);
 
 		for (String psName : permittedSubclassNames) {
 			cw.visitPermittedSubclass(psName);

--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -37,6 +37,7 @@
 	<property name="module_src_root" location="./modules"/>
 	<property name="module_bin_root" location="./module_bin"/>
 	<property name="dest_module_bin" location="${DEST}/module_bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="LIB" value="asm,testng,jcommander"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
@@ -58,9 +59,22 @@
 				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
 				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
 				<mkdir dir="${module_bin_dir}" />
+				<if>
+					<equals arg1="@{mod}" arg2="moduleY"/>
+					<then>
+						<var name="TestUtilitiesModule" value="${TestUtilities}" />
+						<var name="moduleCompilerarg" value="--add-modules java.management,jdk.management,jdk.attach,java.instrument --add-reads ${MODULE_NAME_ROOT}.@{mod}=java.management --add-reads ${MODULE_NAME_ROOT}.@{mod}=jdk.management --add-reads ${MODULE_NAME_ROOT}.@{mod}=jdk.attach --add-reads ${MODULE_NAME_ROOT}.@{mod}=java.instrument" />
+					</then>
+					<else>
+						<var name="TestUtilitiesModule" value=""/>
+						<var name="moduleCompilerarg" value="" />
+					</else>
+				</if>
 				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir}" />
 				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${module_src_dir}" />
+					<src path="${TestUtilitiesModule}" />
+					<compilerarg line="${moduleCompilerarg}" />
 					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
 					<compilerarg line="${modpath}" />
@@ -85,6 +99,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<src path="${TestUtilities}" />
 			<exclude name="**/modules/**" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
@@ -42,22 +42,9 @@ public class Test_SubClass {
 	
 	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
 	 * major version match the latest supported version when --enable-preview flag is active
+	 *
+	 * It is a feature since JDK17.
 	 */
-	private static int latestPreviewVersion;
-	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
-		}
-	}
 	
 	@Test
 	public void test_subClassInTheDifferentPackageFromSealedSuperClass() throws ClassNotFoundException {

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/org/openj9/test/modularity/pkgB/Test_SubClass.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/org/openj9/test/modularity/pkgB/Test_SubClass.java
@@ -32,6 +32,7 @@ import static org.objectweb.asm.Opcodes.V16;
 import org.openj9.test.modularity.pkgA.SuperClassSealed;
 import org.openj9.test.modularity.pkgA.SuperInterfaceSealed;
 import org.openj9.test.modularity.pkgB.SuperClassFromPkgB;
+import org.openj9.test.util.VersionCheck;
 
 /**
  * Test cases for JEP 397: Sealed Classes (Second Preview)
@@ -44,20 +45,14 @@ import org.openj9.test.modularity.pkgB.SuperClassFromPkgB;
 public class Test_SubClass {
 	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
 	 * major version match the latest supported version when --enable-preview flag is active
+	 *
+	 * It is a feature since JDK17.
 	 */
-	private static int latestPreviewVersion;
+	private static int classVersion;
 	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
+		classVersion = VersionCheck.classFile();
+		if (VersionCheck.major() < 17) {
+			classVersion |= V_PREVIEW;
 		}
 	}
 	
@@ -86,7 +81,7 @@ public class Test_SubClass {
 		}
 		
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_PUBLIC, className, null, superClassName, superInterfaceNames);
+		cw.visit(classVersion, ACC_PUBLIC, className, null, superClassName, superInterfaceNames);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}


### PR DESCRIPTION
Sealed classes becomes a feature since JDK17, `V_PREVIEW` is not required.

This PR fixes JDK18 sealed class test failures:
```
[2021-09-15T15:23:43.397Z] Caused by: java.lang.UnsupportedClassVersionError: JVMCFRE163 Class file is a preview version but has the wrong major version or preview is not enabled.; class=TestIllegalSealedClass, offset=6
[2021-09-15T15:23:43.397Z] 	at java.base/java.lang.ClassLoader.defineClassInternal(ClassLoader.java:493)
[2021-09-15T15:23:43.397Z] 	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:454)
[2021-09-15T15:23:43.397Z] 	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:406)
[2021-09-15T15:23:43.397Z] 	at org.openj9.test.utilities.CustomClassLoader.getClass(CustomClassLoader.java:27)
[2021-09-15T15:23:43.397Z] 	at org.openj9.test.sealedclasses.SealedClassesTests.test_loadIllegalSubinterfaceOfSealedInterface(SealedClassesTests.java:66)
```
Note: kept `V_PREVIEW` for earlier Java levels particularly Java 16 which might be useful for behaviour comparison.


Signed-off-by: Jason Feng <fengj@ca.ibm.com>