### PR TITLE
Remove casts related to `reservedSize` and `freeTenure`

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1085,8 +1085,8 @@ double MM_MemorySubSpaceTarok::mapMemoryPercentageToGcOverhead(MM_EnvironmentBas
 	double memoryScore = 0.0;
 
 	/* At this point, eden is full, so all the free space is all part of tenure */
-	uintptr_t tenureSize = getActiveMemorySize() - (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.reservedSize;
-	uintptr_t freeTenure = (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.freeTenure;
+	uintptr_t tenureSize = getActiveMemorySize() - _extensions->globalVLHGCStats._heapSizingData.reservedSize;
+	uintptr_t freeTenure = _extensions->globalVLHGCStats._heapSizingData.freeTenure;
 
 	if (0 == heapSizeChange) {
 		Trc_MM_MemorySubSpaceTarok_mapMemoryPercentageToGcOverhead_1(env->getLanguageVMThread(), tenureSize, freeTenure);
@@ -1562,7 +1562,7 @@ MM_MemorySubSpaceTarok::calculateGcPctForHeapChange(MM_EnvironmentBase *env, int
 				 * Determine what the gc cpu % would be if we changed the heap by heapSizeChange bytes
 				 * Main idea is that the change in number of pgc's (per gmp) will be proportional to how much free tenure changes;
 				 */
-				uintptr_t currentFreeTenure = (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.freeTenure;
+				uintptr_t currentFreeTenure = _extensions->globalVLHGCStats._heapSizingData.freeTenure;
 				uintptr_t potentialFreeTenure = 0;
 				if (heapSizeChange <= (-1 * (intptr_t)currentFreeTenure) ) {
 					/* If we try to shrink too much, too fast, tenure will be way too small, causing lots of GC work */

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -1031,8 +1031,8 @@ MM_SchedulingDelegate::updateHeapSizingData(MM_EnvironmentVLHGC *env)
 	_extensions->globalVLHGCStats._heapSizingData.reservedSize = reservedFreeMemory;
 
 	if (_extensions->globalVLHGCStats._heapSizingData.reservedSize + _liveSetBytesAfterPartialCollect < totalHeapSize) {
-		uintptr_t freeTenureEstimate = totalHeapSize - (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.reservedSize - _liveSetBytesAfterPartialCollect;
-		uintptr_t freeTenureEstimateFromBeforePgc = (uintptr_t)_extensions->globalVLHGCStats._heapSizingData.freeTenure;
+		uintptr_t freeTenureEstimate = totalHeapSize - _extensions->globalVLHGCStats._heapSizingData.reservedSize - _liveSetBytesAfterPartialCollect;
+		uintptr_t freeTenureEstimateFromBeforePgc = _extensions->globalVLHGCStats._heapSizingData.freeTenure;
 
 		/*
 		 * Until a GMP occurs, and _estimatedFreeTenure is set, use the most conservative estimate between the free tenure estimate recorded before a PGC,


### PR DESCRIPTION
The data types of the 2 variables mentioned above, have changed from `uint64_t` to `uintptr_t`.
With that, several explicit casts were removed, to increase code readability.

Depends on: https://github.com/eclipse/omr/pull/6184

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>