### PR TITLE
Fix ValueTypeTests throwing NoSuchMethod exception

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -297,10 +297,11 @@ public class ValueTypeTests {
 		
 		makePoint2D = lookup.findStatic(point2DClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
 		
-		getX = generateGetter(point2DClass, "x", int.class);
-		withX = generateWither(point2DClass, "x", int.class);
-		getY = generateGetter(point2DClass, "y", int.class);
-		withY = generateWither(point2DClass, "y", int.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getX = generateGenericGetter(point2DClass, "x");
+		withX = generateGenericWither(point2DClass, "x");
+		getY = generateGenericGetter(point2DClass, "y");
+		withY = generateGenericWither(point2DClass, "y");
 
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
@@ -460,10 +461,11 @@ public class ValueTypeTests {
 		
 		MethodHandle makePoint2DComplex = lookup.findStatic(point2DComplexClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
 
-		MethodHandle getD = generateGetter(point2DComplexClass, "d", double.class);
-		MethodHandle withD = generateWither(point2DComplexClass, "d", double.class);
-		MethodHandle getJ = generateGetter(point2DComplexClass, "j", long.class);
-		MethodHandle withJ = generateWither(point2DComplexClass, "j", long.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		MethodHandle getD = generateGenericGetter(point2DComplexClass, "d");
+		MethodHandle withD = generateGenericWither(point2DComplexClass, "d");
+		MethodHandle getJ = generateGenericGetter(point2DComplexClass, "j");
+		MethodHandle withJ = generateGenericWither(point2DComplexClass, "j");
 		
 		double d = Double.MAX_VALUE;
 		long j = Long.MAX_VALUE;
@@ -507,11 +509,12 @@ public class ValueTypeTests {
 		
 		makeLine2D = lookup.findStatic(line2DClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
 		
-		MethodHandle getSt = generateGetter(line2DClass, "st", point2DClass);
- 		MethodHandle withSt = generateWither(line2DClass, "st", point2DClass);
- 		MethodHandle getEn = generateGetter(line2DClass, "en", point2DClass);
- 		MethodHandle withEn = generateWither(line2DClass, "en", point2DClass);
- 		
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		MethodHandle getSt = generateGenericGetter(line2DClass, "st");
+		MethodHandle withSt = generateGenericWither(line2DClass, "st");
+		MethodHandle getEn = generateGenericGetter(line2DClass, "en");
+		MethodHandle withEn = generateGenericWither(line2DClass, "en");
+
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
 		int xNew = 0x11223344;
@@ -564,11 +567,12 @@ public class ValueTypeTests {
 				
 		makeFlattenedLine2D = lookup.findStatic(flattenedLine2DClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
 		
-		getFlatSt = generateGetter(flattenedLine2DClass, "st", point2DClass);
- 		withFlatSt = generateWither(flattenedLine2DClass, "st", point2DClass);
- 		getFlatEn = generateGetter(flattenedLine2DClass, "en", point2DClass);
- 		withFlatEn = generateWither(flattenedLine2DClass, "en", point2DClass);
- 		
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getFlatSt = generateGenericGetter(flattenedLine2DClass, "st");
+		withFlatSt = generateGenericWither(flattenedLine2DClass, "st");
+		getFlatEn = generateGenericGetter(flattenedLine2DClass, "en");
+		withFlatEn = generateGenericWither(flattenedLine2DClass, "en");
+
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
 		int xNew = 0x11223344;
@@ -1278,12 +1282,13 @@ public class ValueTypeTests {
 
 		makeTriangle2D = lookup.findStatic(triangle2DClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class));
 
-		getV1 = generateGetter(triangle2DClass, "v1", flattenedLine2DClass);
-		MethodHandle withV1 = generateWither(triangle2DClass, "v1", flattenedLine2DClass);
-		getV2 = generateGetter(triangle2DClass, "v2", flattenedLine2DClass);
-		MethodHandle withV2 = generateWither(triangle2DClass, "v2", flattenedLine2DClass);
-		getV3 = generateGetter(triangle2DClass, "v3", flattenedLine2DClass);
-		MethodHandle withV3 = generateWither(triangle2DClass, "v3", flattenedLine2DClass);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getV1 = generateGenericGetter(triangle2DClass, "v1");
+		MethodHandle withV1 = generateGenericWither(triangle2DClass, "v1");
+		getV2 = generateGenericGetter(triangle2DClass, "v2");
+		MethodHandle withV2 = generateGenericWither(triangle2DClass, "v2");
+		getV3 = generateGenericGetter(triangle2DClass, "v3");
+		MethodHandle withV3 = generateGenericWither(triangle2DClass, "v3");
 
 		MethodHandle[][] getterAndWither = {{getV1, withV1}, {getV2, withV2}, {getV3, withV3}};
 		Object triangle2D = createTriangle2D(defaultTrianglePositions);
@@ -1341,8 +1346,9 @@ public class ValueTypeTests {
 		makeValueLong = lookup.findStatic(valueLongClass, "makeValueGeneric",
 				MethodType.methodType(Object.class, Object.class));
 
-		getLong = generateGetter(valueLongClass, "j", long.class);
-		withLong = generateWither(valueLongClass, "j", long.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getLong = generateGenericGetter(valueLongClass, "j");
+		withLong = generateGenericWither(valueLongClass, "j");
 
 		long j = Long.MAX_VALUE;
 		long jNew = Long.MIN_VALUE;
@@ -1368,8 +1374,9 @@ public class ValueTypeTests {
 
 		makeValueInt = lookup.findStatic(valueIntClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class));
 
-		getInt = generateGetter(valueIntClass, "i", int.class);
-		withInt = generateWither(valueIntClass, "i", int.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getInt = generateGenericGetter(valueIntClass, "i");
+		withInt = generateGenericWither(valueIntClass, "i");
 
 		int i = Integer.MAX_VALUE;
 		int iNew = Integer.MIN_VALUE;
@@ -1396,8 +1403,9 @@ public class ValueTypeTests {
 		makeValueDouble = lookup.findStatic(valueDoubleClass, "makeValueGeneric",
 				MethodType.methodType(Object.class, Object.class));
 
-		getDouble = generateGetter(valueDoubleClass, "d", double.class);
-		withDouble = generateWither(valueDoubleClass, "d", double.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getDouble = generateGenericGetter(valueDoubleClass, "d");
+		withDouble = generateGenericWither(valueDoubleClass, "d");
 
 		double d = Double.MAX_VALUE;
 		double dNew = Double.MIN_VALUE;
@@ -1424,8 +1432,9 @@ public class ValueTypeTests {
 		makeValueFloat = lookup.findStatic(valueFloatClass, "makeValueGeneric",
 				MethodType.methodType(Object.class, Object.class));
 
-		getFloat = generateGetter(valueFloatClass, "f", float.class);
-		withFloat = generateWither(valueFloatClass, "f", float.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getFloat = generateGenericGetter(valueFloatClass, "f");
+		withFloat = generateGenericWither(valueFloatClass, "f");
 
 		float f = Float.MAX_VALUE;
 		float fNew = Float.MIN_VALUE;
@@ -1456,8 +1465,9 @@ public class ValueTypeTests {
 		Object val = (Object)0xEEFFEEFF;
 		Object valNew = (Object)0xFFEEFFEE;
 
-		getObject = generateGetter(valueObjectClass, "val", Object.class);
-		withObject = generateWither(valueObjectClass, "val", Object.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getObject = generateGenericGetter(valueObjectClass, "val");
+		withObject = generateGenericWither(valueObjectClass, "val");
 
 		Object valueObject = makeValueObject.invoke(val);
 
@@ -1569,15 +1579,17 @@ public class ValueTypeTests {
 		String singleBackfill[] = {"l:J", "o:Ljava/lang/Object;", "i:I"};
 		singleBackfillClass = ValueTypeGenerator.generateValueClass("SingleBackfill", singleBackfill);
 		makeSingleBackfillClass = lookup.findStatic(singleBackfillClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class));
-		getSingleI = generateGetter(singleBackfillClass, "i", int.class);
-		getSingleO = generateGetter(singleBackfillClass, "o", Object.class);
-		getSingleL = generateGetter(singleBackfillClass, "l", long.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getSingleI = generateGenericGetter(singleBackfillClass, "i");
+		getSingleO = generateGenericGetter(singleBackfillClass, "o");
+		getSingleL = generateGenericGetter(singleBackfillClass, "l");
 		
 		String objectBackfill[] = {"l:J", "o:Ljava/lang/Object;"};
 		objectBackfillClass = ValueTypeGenerator.generateValueClass("ObjectBackfill", objectBackfill);
 		makeObjectBackfillClass = lookup.findStatic(objectBackfillClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
-		getObjectO = generateGetter(objectBackfillClass, "o", Object.class);
-		getObjectL = generateGetter(objectBackfillClass, "l", long.class);
+		/* Replace typed getters/setters/withers to generic due to current lack of support for ValueTypes and OJDK method handles */
+		getObjectO = generateGenericGetter(objectBackfillClass, "o");
+		getObjectL = generateGenericGetter(objectBackfillClass, "l");
 	}
 	
 	@Test(priority=3, invocationCount=2)


### PR DESCRIPTION
Changed typed getters/setters/withers to generic as there is currently
no support for OJDK method handles for value types.

Fixes: #13547
See #13549
Signed-off-by: Eric Yang <eric.yang@ibm.com>