### PR TITLE
Show ignored options in java dumps

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -69,9 +69,9 @@
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_ENV_DATA64)
-#define SEGMENT_HEADER             "NULL           segment            start              alloc              end                type       size\n"
+#define SEGMENT_HEADER "NULL           segment            start              alloc              end                type       size\n"
 #else
-#define SEGMENT_HEADER             "NULL           segment    start      alloc      end        type       size\n"
+#define SEGMENT_HEADER "NULL           segment    start      alloc      end        type       size\n"
 #endif
 
 /* Format specifiers for printing memory quantities. */
@@ -178,22 +178,24 @@ typedef struct memcategory_total {
 	BOOLEAN codeMatched;
 } memcategory_total;
 
-typedef struct memcategory_data_frame
-{
+typedef struct memcategory_data_frame {
 	U_32 category;
 	UDATA liveBytes;
 	UDATA liveAllocations;
 } memcategory_data_frame;
 
-/* Macros for working with the category_bitmask in the memcategory_total structure. The range of category codes is not contiguous, so we have
- * to map entries from the end of the range (unknown & port library) onto the end of the entries from the start of the range*/
-#define MAP_CATEGORY_TO_BITMASK_ENTRY(category) ( ((category) > OMRMEM_LANGUAGE_CATEGORY_LIMIT) ? ((writer->_MaxCategoryBits - 1) - (OMRMEM_OMR_CATEGORY_INDEX_FROM_CODE(category))): (category) )
+/* Macros for working with the category_bitmask in the memcategory_total structure.
+ * The range of category codes is not contiguous, so we have to map entries from
+ * the end of the range (unknown & port library) onto the end of the entries from
+ * the start of the range.
+ */
+#define MAP_CATEGORY_TO_BITMASK_ENTRY(category) (((category) > OMRMEM_LANGUAGE_CATEGORY_LIMIT) ? ((writer->_MaxCategoryBits - 1) - (OMRMEM_OMR_CATEGORY_INDEX_FROM_CODE(category))) : (category))
 
 #define CATEGORY_WORD_INDEX(category) (MAP_CATEGORY_TO_BITMASK_ENTRY(category) / 32)
-#define CATEGORY_WORD_MASK(category) (1 << ( MAP_CATEGORY_TO_BITMASK_ENTRY(category) % 32 ))
+#define CATEGORY_WORD_MASK(category) (1 << (MAP_CATEGORY_TO_BITMASK_ENTRY(category) % 32))
 
-#define CATEGORY_IS_ANCESTOR(total, category) ( (total)->category_bitmask[CATEGORY_WORD_INDEX(category)] & CATEGORY_WORD_MASK(category) )
-#define SET_CATEGORY_AS_ANCESTOR(total, category) ( (total)->category_bitmask[CATEGORY_WORD_INDEX(category)] |= CATEGORY_WORD_MASK(category) )
+#define CATEGORY_IS_ANCESTOR(total, category) ((total)->category_bitmask[CATEGORY_WORD_INDEX(category)] & CATEGORY_WORD_MASK(category))
+#define SET_CATEGORY_AS_ANCESTOR(total, category) ((total)->category_bitmask[CATEGORY_WORD_INDEX(category)] |= CATEGORY_WORD_MASK(category))
 
 static const UDATA syncEventsMask =
 	J9RAS_DUMP_ON_CLASS_LOAD |
@@ -322,7 +324,7 @@ private :
 	void        writeObject                  (j9object_t obj);
 	void        writeThread                  (J9VMThread* vmThread, J9PlatformThread *nativeThread, UDATA vmstate, UDATA javaState, UDATA javaPriority, j9object_t lockObject, J9VMThread *lockOwnerThread);
 	void        writeThreadName              (J9VMThread* vmThread);
-	void        writeThreadBlockers          (J9VMThread* vmThread, UDATA vmstate, j9object_t lockObject, J9VMThread *lockOwnerThread );
+	void        writeThreadBlockers          (J9VMThread* vmThread, UDATA vmstate, j9object_t lockObject, J9VMThread *lockOwnerThread);
 	UDATA       writeFrame                   (J9StackWalkState* state);
 	UDATA       writeExceptionFrame          (void *userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber);
 	void        writeLoader                  (J9ClassLoader* classLoader);
@@ -418,9 +420,9 @@ struct walkClosure {
 #define CALL_PROTECT(section, retVal) \
 	do { \
 		sectionClosure closure(&JavaCoreDumpWriter::section, this); \
-		UDATA sink; \
-		retVal = j9sig_protect(protectedWriteSection, &closure, handlerWriteSection, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &sink) || retVal; \
-	} while (0);
+		UDATA sink = 0; \
+		(retVal) = j9sig_protect(protectedWriteSection, &closure, handlerWriteSection, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink) || (retVal); \
+	} while (0)
 
 /**************************************************************************************************/
 /*                                                                                                */
@@ -447,18 +449,18 @@ JavaCoreDumpWriter::JavaCoreDumpWriter(
 	_MaxCategoryBits(0)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
-	bool bufferWrites=false;
+	bool bufferWrites = false;
 	_AllocatedVMThreadCount = getAllocatedVMThreadCount(_VirtualMachine);
 
 	/* Determine whether getting further locks should be avoided
 	 * There is a small timing window where we can crash close to
 	 * startup and the vmThreadListMutex is NULL.
 	 * Failing to check for NULL leads to a endless spin.*/
-	if(NULL == _VirtualMachine->vmThreadListMutex) {
+	if (NULL == _VirtualMachine->vmThreadListMutex) {
 		_AvoidLocks = true;
 	} else if (omrthread_monitor_try_enter(_VirtualMachine->vmThreadListMutex)) {
 		/* Failed to get lock so avoid asking for further ones if it's a GPF or abort */
-		_AvoidLocks = ((_Context->eventFlags & (J9RAS_DUMP_ON_GP_FAULT | J9RAS_DUMP_ON_ABORT_SIGNAL)) != 0);
+		_AvoidLocks = J9_ARE_ANY_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_GP_FAULT | J9RAS_DUMP_ON_ABORT_SIGNAL);
 	} else {
 		/* Got the lock so release it */
 		omrthread_monitor_exit(_VirtualMachine->vmThreadListMutex);
@@ -466,12 +468,12 @@ JavaCoreDumpWriter::JavaCoreDumpWriter(
 	}
 
 	/* Write a message to standard error saying we are about to write a dump file */
-	reportDumpRequest(_PortLibrary,_Context,"Java",_FileName);
+	reportDumpRequest(_PortLibrary, _Context, "Java", _FileName);
 
 	/* don't buffer if we don't have the locks (incl exclusive) or it's a GP. */
 	bufferWrites = !_AvoidLocks
-	  && ((_Context->eventFlags & (J9RAS_DUMP_ON_GP_FAULT | J9RAS_DUMP_ON_ABORT_SIGNAL)) == 0)
-	  && ((_Agent->prepState & J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS) == J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS);
+			&& J9_ARE_NO_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_GP_FAULT | J9RAS_DUMP_ON_ABORT_SIGNAL)
+			&& J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS);
 
 	/* It's a single file so open it */
 	_OutputStream.open(_FileName, bufferWrites);
@@ -509,7 +511,7 @@ JavaCoreDumpWriter::JavaCoreDumpWriter(
 	omrthread_monitor_exit(_VirtualMachine->monitorTableMutex);
 
 	/* If request=preempt (for native stack collection) we attempt to acquire the mutex and note if we got it */
-	if (_Agent->requestMask & J9RAS_DUMP_DO_PREEMPT_THREADS) {
+	if (J9_ARE_ANY_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_PREEMPT_THREADS)) {
 		if (compareAndSwapUDATA(&rasDumpPreemptLock, 0, 1) == 0) {
 			_PreemptLocked = true; /* we got the lock */
 		}
@@ -609,11 +611,8 @@ JavaCoreDumpWriter::writeTitleSection(void)
 	char cset[64];
 	IDATA getCSet = j9file_get_text_encoding(cset, sizeof(cset));
 
-	if (getCSet != 0) {
-		strcpy(cset,"[not available]");
-	}
 	_OutputStream.writeCharacters("1TICHARSET     ");
-	_OutputStream.writeCharacters(cset);
+	_OutputStream.writeCharacters((0 == getCSet) ? cset : "[not available]");
 	_OutputStream.writeCharacters("\n");
 
 	if (J9RAS_DUMP_ON_USER_REQUEST == _Context->eventFlags) {
@@ -693,7 +692,7 @@ JavaCoreDumpWriter::writeTitleSection(void)
 			zoneSecondsEast += 60 * 60;
 		}
 	}
-#endif  /* defined(WIN32) */
+#endif /* defined(WIN32) */
 
 	_OutputStream.writeCharacters("1TITIMEZONE    Timezone: ");
 	if (!zoneAvailable) {
@@ -731,151 +730,127 @@ JavaCoreDumpWriter::writeTitleSection(void)
 	/* Record whether this is exclusive or not */
 	_OutputStream.writeCharacters("1TIREQFLAGS    Request Flags: ");
 	_OutputStream.writeInteger(_Agent->requestMask);
-	if (_Agent->requestMask) {
-		UDATA moreRequests = _Agent->requestMask;
+	if (0 != _Agent->requestMask) {
+		const char *prefix = " (";
 
-		_OutputStream.writeCharacters(" (");
-
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS) == J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("exclusive");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_COMPACT_HEAP) == J9RAS_DUMP_DO_COMPACT_HEAP) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_COMPACT_HEAP)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("compact");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_PREPARE_HEAP_FOR_WALK) == J9RAS_DUMP_DO_PREPARE_HEAP_FOR_WALK) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_PREPARE_HEAP_FOR_WALK)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("prepwalk");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_SUSPEND_OTHER_DUMPS) == J9RAS_DUMP_DO_SUSPEND_OTHER_DUMPS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_SUSPEND_OTHER_DUMPS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("serial");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_HALT_ALL_THREADS) == J9RAS_DUMP_DO_HALT_ALL_THREADS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_HALT_ALL_THREADS)) {
+			/* not yet implemented */
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_ATTACH_THREAD) == J9RAS_DUMP_DO_ATTACH_THREAD) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_ATTACH_THREAD)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("attach");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreRequests = moreRequests >> 1;
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_MULTIPLE_HEAPS) == J9RAS_DUMP_DO_MULTIPLE_HEAPS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_MULTIPLE_HEAPS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("multiple");
-			if (moreRequests) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		if ((_Agent->requestMask & J9RAS_DUMP_DO_PREEMPT_THREADS) == J9RAS_DUMP_DO_PREEMPT_THREADS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_PREEMPT_THREADS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("preempt");
+			prefix = "+";
 		}
 
-		_OutputStream.writeCharacters(")");
+		if (' ' != *prefix) {
+			_OutputStream.writeCharacters(")");
+		}
 	}
 
 	_OutputStream.writeCharacters("\n");
 
 	_OutputStream.writeCharacters("1TIPREPSTATE   Prep State: ");
 	_OutputStream.writeInteger(_Agent->prepState);
-	if (_Agent->prepState) {
-		UDATA moreState = _Agent->prepState;
+	if (0 != _Agent->prepState) {
+		const char *prefix = " (";
 
-		_OutputStream.writeCharacters(" (");
-
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_GOT_LOCK) == J9RAS_DUMP_GOT_LOCK) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_GOT_LOCK)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("rasdump_lock");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_GOT_VM_ACCESS) == J9RAS_DUMP_GOT_VM_ACCESS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_GOT_VM_ACCESS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("vm_access");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS) == J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("exclusive_vm_access");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_HEAP_COMPACTED) == J9RAS_DUMP_HEAP_COMPACTED) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_HEAP_COMPACTED)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("heap_compacted");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_HEAP_PREPARED) == J9RAS_DUMP_HEAP_PREPARED) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_HEAP_PREPARED)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("heap_prepared");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_THREADS_HALTED) == J9RAS_DUMP_THREADS_HALTED) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_THREADS_HALTED)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("threads_halted");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_ATTACHED_THREAD) == J9RAS_DUMP_ATTACHED_THREAD) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_ATTACHED_THREAD)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("attached_thread");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		moreState = moreState >> 1;
-		if ((_Agent->prepState & J9RAS_DUMP_PREEMPT_THREADS) == J9RAS_DUMP_PREEMPT_THREADS) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_PREEMPT_THREADS)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("preempt_threads");
-			if (moreState) {
-				_OutputStream.writeCharacters("+");
-			}
+			prefix = "+";
 		}
 
-		if ((_Agent->prepState & J9RAS_DUMP_TRACE_DISABLED) == J9RAS_DUMP_TRACE_DISABLED) {
+		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_TRACE_DISABLED)) {
 			_OutputStream.writeCharacters("trace_disabled");
 		}
-		_OutputStream.writeCharacters(")");
+
+		if (' ' != *prefix) {
+			_OutputStream.writeCharacters(")");
+		}
 	}
+
 	_OutputStream.writeCharacters("\n");
 
-	if ((_Agent->prepState & J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS) == 0) {
+	if (J9_ARE_NO_BITS_SET(_Agent->prepState, J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS)) {
 		_OutputStream.writeCharacters("1TIPREPINFO    Exclusive VM access not taken: data may not be consistent across javacore sections\n");
 	}
 
@@ -900,7 +875,7 @@ JavaCoreDumpWriter::writeEventDrivenTitle(void)
 
 	/* Write the event data */
 	J9RASdumpEventData* eventData = _Context->eventData;
-	if (eventData) {
+	if (NULL != eventData) {
 		_OutputStream.writeCharacters(" Detail \"");
 		_OutputStream.writeCharacters(eventData->detailData, eventData->detailLength);
 		_OutputStream.writeCharacters("\"");
@@ -925,7 +900,7 @@ JavaCoreDumpWriter::writeUserRequestedTitle(void)
 
 	/* Write the event data */
 	J9RASdumpEventData* eventData = _Context->eventData;
-	if (eventData) {
+	if (NULL != eventData) {
 		_OutputStream.writeCharacters(" Through ");
 		_OutputStream.writeCharacters(eventData->detailData, eventData->detailLength);
 	}
@@ -966,15 +941,15 @@ JavaCoreDumpWriter::writeProcessorSection(void)
 	const char* osArchitecture = j9sysinfo_get_CPU_architecture();
 	int         numberOfCpus   = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
 
-	if (osName == NULL) {
+	if (NULL == osName) {
 		osName = "[not available]";
 	}
 
-	if (osVersion == NULL) {
+	if (NULL == osVersion) {
 		osVersion = "[not available]";
 	}
 
-	if (osArchitecture == NULL) {
+	if (NULL == osArchitecture) {
 		osArchitecture = "[not available]";
 	}
 #endif /* !J9VM_RAS_EYECATCHERS */
@@ -1007,9 +982,7 @@ JavaCoreDumpWriter::writeProcessorSection(void)
 
 	/* Write the processor registers */
 	J9VMThread* vmThread = _Context->onThread;
-	if (vmThread && vmThread->gpInfo) {
-
-
+	if ((NULL != vmThread) && (NULL != vmThread->gpInfo)) {
 		_OutputStream.writeCharacters("NULL\n");
 		writeGPCategory(vmThread->gpInfo, "1XHEXCPCODE    ", J9PORT_SIG_SIGNAL);
 
@@ -1029,7 +1002,6 @@ JavaCoreDumpWriter::writeProcessorSection(void)
 		_OutputStream.writeCharacters("1XHFLAGS       VM flags:");
 		_OutputStream.writeVPrintf("%.*zX", sizeof(void *) * 2, vmThread->omrVMThread->vmState);
 		_OutputStream.writeCharacters("\n");
-
 	} else {
 		_OutputStream.writeCharacters(
 			"NULL\n"
@@ -1059,7 +1031,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	);
 
 	/* Write the Java version data */
-	if( _VirtualMachine->j9ras->serviceLevel != NULL ) {
+	if (NULL != _VirtualMachine->j9ras->serviceLevel) {
 		_OutputStream.writeCharacters("1CIJAVAVERSION ");
 		_OutputStream.writeCharacters(_VirtualMachine->j9ras->serviceLevel);
 		_OutputStream.writeCharacters("\n");
@@ -1086,9 +1058,9 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	_OutputStream.writeCharacters("1CIJITVERSION  ");
 
-	J9JITConfig* jitConfig = _VirtualMachine->jitConfig;
-	if (jitConfig) {
-		if (jitConfig->jitLevelName) {
+	J9JITConfig *jitConfig = _VirtualMachine->jitConfig;
+	if (NULL != jitConfig) {
+		if (NULL != jitConfig->jitLevelName) {
 			_OutputStream.writeCharacters(jitConfig->jitLevelName);
 		}
 	} else {
@@ -1124,13 +1096,13 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	_OutputStream.writeCharacters("1CIJITMODES    ");
 
-	if (jitConfig) {
-		if (jitConfig->runtimeFlags & J9JIT_JIT_ATTACHED) {
+	if (NULL != jitConfig) {
+		if (J9_ARE_ANY_BITS_SET(jitConfig->runtimeFlags, J9JIT_JIT_ATTACHED)) {
 			_OutputStream.writeCharacters("JIT enabled");
 		} else {
 			_OutputStream.writeCharacters("JIT disabled");
 		}
-		if (jitConfig->runtimeFlags & J9JIT_AOT_ATTACHED) {
+		if (J9_ARE_ANY_BITS_SET(jitConfig->runtimeFlags, J9JIT_AOT_ATTACHED)) {
 			_OutputStream.writeCharacters(", AOT enabled");
 		} else {
 			_OutputStream.writeCharacters(", AOT disabled");
@@ -1140,13 +1112,13 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 		} else {
 			_OutputStream.writeCharacters(", FSD disabled");
 		}
-		if (_VirtualMachine && (_VirtualMachine->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_CAN_REDEFINE_CLASSES)) {
+		if ((NULL != _VirtualMachine) && J9_ARE_ANY_BITS_SET(_VirtualMachine->requiredDebugAttributes, J9VM_DEBUG_ATTRIBUTE_CAN_REDEFINE_CLASSES)) {
 			_OutputStream.writeCharacters(", HCR enabled");
 		} else {
 			_OutputStream.writeCharacters(", HCR disabled");
 		}
 	} else {
-	_OutputStream.writeCharacters("unavailable (JIT disabled)");
+		_OutputStream.writeCharacters("unavailable (JIT disabled)");
 	}
 
 	_OutputStream.writeCharacters("\n");
@@ -1193,7 +1165,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	OMRPORT_ACCESS_FROM_J9PORT(_PortLibrary);
 	BOOLEAN inContainer = omrsysinfo_is_running_in_container();
 	_OutputStream.writeCharacters("1CICONTINFO    Running in container : ");
-	_OutputStream.writeCharacters( inContainer ? "TRUE\n" : "FALSE\n");
+	_OutputStream.writeCharacters(inContainer ? "TRUE\n" : "FALSE\n");
 	uint64_t availableSubsystems = omrsysinfo_cgroup_get_enabled_subsystems();
 	_OutputStream.writeCharacters("1CICGRPINFO    JVM support for cgroups enabled : ");
 	_OutputStream.writeCharacters((availableSubsystems > 0) ? "TRUE\n" : "FALSE\n");
@@ -1201,15 +1173,14 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	PORT_ACCESS_FROM_JAVAVM(_VirtualMachine);
 
 	/* Write the JVM start date and time */
-	RasDumpGlobalStorage* dump_storage;
-	struct J9StringTokens* stringTokens;
-
-	dump_storage = (RasDumpGlobalStorage*)_VirtualMachine->j9rasdumpGlobalStorage;
+	RasDumpGlobalStorage *dump_storage = (RasDumpGlobalStorage*)_VirtualMachine->j9rasdumpGlobalStorage;
 
 	/* lock access to the tokens */
 	omrthread_monitor_enter(dump_storage->dumpLabelTokensMutex);
-	stringTokens = (struct J9StringTokens*)dump_storage->dumpLabelTokens;
+
+	struct J9StringTokens *stringTokens = (struct J9StringTokens *)dump_storage->dumpLabelTokens;
 	j9str_set_time_tokens(stringTokens, _VirtualMachine->j9ras->startTimeMillis);
+
 	/* release access to the tokens */
 	omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 
@@ -1237,22 +1208,21 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	_OutputStream.writeCharacters(")\n");
 
 	/* Write the command line data */
-	char  commandLineBuffer[_MaximumCommandLineLength];
-	IDATA result;
+	char commandLineBuffer[_MaximumCommandLineLength];
+	IDATA result = 0;
 
 	result = j9sysinfo_get_env("IBM_JAVA_COMMAND_LINE", commandLineBuffer, _MaximumCommandLineLength);
-	if (result == 0) {
+	if (0 == result) {
 		/* Ensure null-terminated */
-		commandLineBuffer[_MaximumCommandLineLength-1] = '\0';
+		commandLineBuffer[_MaximumCommandLineLength - 1] = '\0';
 
 		_OutputStream.writeCharacters("1CICMDLINE     ");
 		_OutputStream.writeCharacters(commandLineBuffer);
 		_OutputStream.writeCharacters("\n");
-
 	} else if (result > 0) {
 		/* Long command line - need malloc'd buffer */
-		char* commandLineBuffer = (char*)j9mem_allocate_memory(result, OMRMEM_CATEGORY_VM);
-		if (commandLineBuffer) {
+		char *commandLineBuffer = (char*)j9mem_allocate_memory(result, OMRMEM_CATEGORY_VM);
+		if (NULL != commandLineBuffer) {
 			if (j9sysinfo_get_env("IBM_JAVA_COMMAND_LINE", commandLineBuffer, result) == 0) {
 				commandLineBuffer[result-1] = '\0';
 				_OutputStream.writeCharacters("1CICMDLINE     ");
@@ -1263,11 +1233,9 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			}
 
 			j9mem_free_memory(commandLineBuffer);
-
 		} else {
 			_OutputStream.writeCharacters("1CICMDLINE     [not enough space]\n");
 		}
-
 	} else {
 		_OutputStream.writeCharacters("1CICMDLINE     [not available]\n");
 	}
@@ -1299,13 +1267,13 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 
 	_OutputStream.writeCharacters("1CIUSERARGS    UserArgs:\n");
 
-	for (int j = 0; j < args->nOptions; j++) {
+	for (jint i = 0; i < args->nOptions; i++) {
 		_OutputStream.writeCharacters("2CIUSERARG               ");
-		_OutputStream.writeCharacters(args->options[j].optionString);
+		_OutputStream.writeCharacters(args->options[i].optionString);
 
-		if (args->options[j].extraInfo) {
+		if (NULL != args->options[i].extraInfo) {
 			_OutputStream.writeCharacters(" ");
-			_OutputStream.writePointer(args->options[j].extraInfo);
+			_OutputStream.writePointer(args->options[i].extraInfo);
 		}
 
 		_OutputStream.writeCharacters("\n");
@@ -1330,7 +1298,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			/* print the data in columns */
 			while (j9sysinfo_limit_iterator_hasNext(&limitState)) {
 				char padding[20];
-				IDATA paddingLength;
+				IDATA paddingLength = 0;
 				UDATA fieldWidth = 21;
 
 				result = j9sysinfo_limit_iterator_next(&limitState, &limitElement);
@@ -1382,8 +1350,6 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	/* Write the environment variables */
 	J9SysinfoEnvIteratorState envState;
 	J9SysinfoEnvElement envElement;
-	void *buffer = NULL;
-	UDATA bufferSizeBytes = 0;
 
 	_OutputStream.writeCharacters("NULL\n");
 
@@ -1396,15 +1362,15 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 
 	/* call init with zero length buffer to get the required buffer size */
-	result = j9sysinfo_env_iterator_init(&envState, buffer, bufferSizeBytes);
+	result = j9sysinfo_env_iterator_init(&envState, NULL, 0);
 
 	if (result < 0) {
 		/* a problem occurred */
 		_OutputStream.writeCharacters("2CIENVVARERR   Cannot access environment variables\n");
 	} else {
 		/* the init has returned the size of buffer required so now go and allocate it */
-		bufferSizeBytes = result;
-		buffer = j9mem_allocate_memory(bufferSizeBytes, OMRMEM_CATEGORY_VM);
+		UDATA bufferSizeBytes = result;
+		void *buffer = j9mem_allocate_memory(bufferSizeBytes, OMRMEM_CATEGORY_VM);
 		if (NULL == buffer) {
 			/* out of memory */
 			_OutputStream.writeCharacters("2CIENVVARERR   Cannot access environment variables\n");
@@ -1434,7 +1400,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			"NULL           ------------------------------------------------------------------------\n");
 	}
 	J9RASSystemInfo* systemInfo = J9_LINKED_LIST_START_DO(_VirtualMachine->j9ras->systemInfo);
-	while (systemInfo != NULL) {
+	while (NULL != systemInfo) {
 		switch (systemInfo->key) {
 		case J9RAS_SYSTEMINFO_SCHED_COMPAT_YIELD:
 			{
@@ -1549,7 +1515,7 @@ JavaCoreDumpWriter::writeMemorySection(void)
 
 	/* Write the jit memory segments sub-section */
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
-	if (_VirtualMachine->jitConfig) {
+	if (NULL != _VirtualMachine->jitConfig) {
 		_OutputStream.writeCharacters(
 			"NULL\n"
 			"1STSEGTYPE     JIT Code Cache\n"
@@ -1558,12 +1524,12 @@ JavaCoreDumpWriter::writeMemorySection(void)
 		writeSegments(_VirtualMachine->jitConfig->codeCacheList, true);
 
 		/* Write the limit specified for the code cache size as well. */
-		int decimalLength = sizeof(void*) == 4 ? 10 : 20;
+		int decimalLength = (sizeof(void *) == 4) ? 10 : 20;
 		_OutputStream.writeCharacters("1STSEGLIMIT    ");
 		_OutputStream.writeCharacters("Allocation limit:    ");
-		_OutputStream.writeVPrintf(FORMAT_SIZE_DECIMAL, decimalLength, _VirtualMachine->jitConfig->codeCacheTotalKB*1024); // Needs to be codeCacheTotalKB
+		_OutputStream.writeVPrintf(FORMAT_SIZE_DECIMAL, decimalLength, _VirtualMachine->jitConfig->codeCacheTotalKB * 1024); // Needs to be codeCacheTotalKB
 		_OutputStream.writeCharacters(" (");
-		_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, _VirtualMachine->jitConfig->codeCacheTotalKB*1024); // Needs to be codeCacheTotalKB
+		_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, _VirtualMachine->jitConfig->codeCacheTotalKB * 1024); // Needs to be codeCacheTotalKB
 		_OutputStream.writeCharacters(")\n");
 		_OutputStream.writeCharacters(
 			"NULL\n"
@@ -1574,9 +1540,9 @@ JavaCoreDumpWriter::writeMemorySection(void)
 		/* Write the limit specified for the data cache size as well. */
 		_OutputStream.writeCharacters("1STSEGLIMIT    ");
 		_OutputStream.writeCharacters("Allocation limit:    ");
-		_OutputStream.writeVPrintf(FORMAT_SIZE_DECIMAL, decimalLength, _VirtualMachine->jitConfig->dataCacheTotalKB*1024);
+		_OutputStream.writeVPrintf(FORMAT_SIZE_DECIMAL, decimalLength, _VirtualMachine->jitConfig->dataCacheTotalKB * 1024);
 		_OutputStream.writeCharacters(" (");
-		_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, _VirtualMachine->jitConfig->dataCacheTotalKB*1024);
+		_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, _VirtualMachine->jitConfig->dataCacheTotalKB * 1024);
 		_OutputStream.writeCharacters(")\n");
 	}
 #endif
@@ -1588,7 +1554,6 @@ JavaCoreDumpWriter::writeMemorySection(void)
 	);
 
 	writeTraceHistory(HIST_TYPE_GC);
-
 
 	/* Write the section trailer */
 	_OutputStream.writeCharacters(
@@ -1616,6 +1581,7 @@ countMemoryCategoriesCallback (U_32 categoryCode, const char * categoryName, UDA
 			max_indexes->languageMaxIndex = categoryCode;
 		}
 	}
+
 	return J9MEM_CATEGORIES_KEEP_ITERATING;
 }
 
@@ -1625,7 +1591,7 @@ countMemoryCategoriesCallback (U_32 categoryCode, const char * categoryName, UDA
  * Maintains a total count of all categories beneath total->codeToMatch
  */
 static UDATA
-innerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state)
+innerMemCategoryCallBack(U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state)
 {
 	memcategory_total * total = (memcategory_total *) state->userData1;
 	JavaCoreDumpWriter * writer = (JavaCoreDumpWriter*) state->userData2;
@@ -1657,10 +1623,10 @@ innerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA li
  * Starts the inner walk and prints the ASCII art lines to the file.
  */
 static UDATA
-outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state)
+outerMemCategoryCallBack(U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state)
 {
-	U_32 i;
-	U_32 depth;
+	U_32 i = 0;
+	U_32 depth = 0;
 	JavaCoreDumpWriter * writer = (JavaCoreDumpWriter*) state->userData1;
 	memcategory_total total;
 	U_32 oldStackTop = writer->_CategoryStackTop;
@@ -1672,25 +1638,25 @@ outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA li
 		writer->_CategoryStackTop = 1;
 	} else {
 		/* Determine our position in the tree by checking the _CategoryStack for our parent */
-		for (i=0; i < writer->_CategoryStackTop; i++) {
+		for (i = 0; i < writer->_CategoryStackTop; i++) {
 			if (writer->_CategoryStack[i].category == parentCategoryCode) {
 				break;
 			}
 		}
 
-		depth = i+1;
-		writer->_CategoryStack[i+1].category = categoryCode;
-		writer->_CategoryStackTop = i+2;
+		depth = i + 1;
+		writer->_CategoryStack[i + 1].category = categoryCode;
+		writer->_CategoryStackTop = i + 2;
 	}
 
 	/* If we popped frames from the category stack, write out the "Other" rows
 	 * for popped frames.
 	 */
 	if (oldStackTop >= writer->_CategoryStackTop) {
-		for (i=oldStackTop; i >= writer->_CategoryStackTop; i--) {
+		for (i = oldStackTop; i >= writer->_CategoryStackTop; i--) {
 			int deferredDepth = i - 1;
 			memcategory_data_frame * frame = &writer->_CategoryStack[deferredDepth];
-			if (frame->liveAllocations != 0) {
+			if (0 != frame->liveAllocations) {
 				writer->writeNativeAllocator("Other", deferredDepth + 1, 0, frame->liveBytes, frame->liveAllocations);
 			}
 		}
@@ -1726,7 +1692,7 @@ outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA li
 		writer->writeNativeAllocator(categoryName, depth, isRoot, total.liveBytes, total.liveAllocations);
 
 		/* Store liveBytes and liveAllocations away to print the "Other" row after the children have been printed (see top of function) */
-		if (total.liveAllocations != liveAllocations && liveAllocations > 0) {
+		if ((total.liveAllocations != liveAllocations) && (liveAllocations > 0)) {
 			writer->_CategoryStack[depth].liveBytes = liveBytes;
 			writer->_CategoryStack[depth].liveAllocations = liveAllocations;
 		}
@@ -1738,7 +1704,7 @@ outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA li
 void
 JavaCoreDumpWriter::writeMemoryCountersSection(void)
 {
-	I_32 i;
+	I_32 i = 0;
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 
 	/* Write the section header */
@@ -1773,7 +1739,7 @@ JavaCoreDumpWriter::writeMemoryCountersSection(void)
 	j9mem_walk_categories(&walkState);
 
 	/* Print any final "Other" categories */
-	for (i=_CategoryStackTop - 1; i >= 0; i--) {
+	for (i = _CategoryStackTop - 1; i >= 0; i--) {
 		memcategory_data_frame * frame = &_CategoryStack[i];
 		if (frame->liveAllocations != 0) {
 			writeNativeAllocator("Other", i + 1, 0, frame->liveBytes, frame->liveAllocations);
@@ -1795,12 +1761,12 @@ JavaCoreDumpWriter::writeMemoryCountersSection(void)
 void
 JavaCoreDumpWriter::writeNativeAllocator(const char * name, U_32 depth, BOOLEAN isRoot, UDATA liveBytes, UDATA liveAllocations)
 {
-	U_32 i;
+	U_32 i = 0;
 	/* Print the separating row containing down lines */
 	if (depth > 0) {
 		_OutputStream.writeInteger(depth, "%u");
 		_OutputStream.writeCharacters("MEMUSER     ");
-		for (i=0; i < depth; i++) {
+		for (i = 0; i < depth; i++) {
 			_OutputStream.writeCharacters("  |");
 		}
 
@@ -1812,8 +1778,8 @@ JavaCoreDumpWriter::writeNativeAllocator(const char * name, U_32 depth, BOOLEAN 
 	/* Print the row for this category */
 	_OutputStream.writeInteger(depth + 1, "%u");
 	_OutputStream.writeCharacters("MEMUSER       ");
-	if (! isRoot) {
-		for (i=0; i < (depth - 1); i++) {
+	if (!isRoot) {
+		for (i = 0; i < (depth - 1); i++) {
 			_OutputStream.writeCharacters("|  ");
 		}
 		_OutputStream.writeCharacters("+--");
@@ -1845,11 +1811,11 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 	/* The code calling this method must have taken the monitorTableMutex and the thread library monitor_mutex
 	 * (in that order) prior to calling and must release those locks on return from this method.
 	 */
-	J9ThreadMonitor* monitor = NULL;
+	J9ThreadMonitor *monitor = NULL;
 	omrthread_monitor_walk_state_t walkState;
-	blocked_thread_record *threadStore;
+	blocked_thread_record *threadStore = NULL;
 	UDATA blockedCount = 0;
-	bool restartedWalk = 0;
+	bool restartedWalk = false;
 	J9VMThread* vmThread = _Context->onThread;
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 
@@ -1873,7 +1839,7 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 	/* Stack-allocate a store for blocked thread information, to save having to re-walk the threads. First
 	 * check that we have enough stack space, and bail out if not (typically ~10,000 threads). See RTC 87530.
 	 */
-	UDATA freeStack = vmThread ? vmThread->currentOSStackFree : _VirtualMachine->defaultOSStackSize;
+	UDATA freeStack = (NULL != vmThread) ? vmThread->currentOSStackFree : _VirtualMachine->defaultOSStackSize;
 	if (((_AllocatedVMThreadCount + 1) * sizeof(blocked_thread_record) + STACK_SAFETY_MARGIN) > freeStack) {
 		_OutputStream.writeCharacters("1LKALLOCERR    Insufficient stack space for thread monitor walk\n");
 		/* Write the section trailer */
@@ -1887,26 +1853,26 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 
 	/* populate the thread store with information on blocked threads to stop us re-walking the threads */
 	J9VMThread* walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
-	for (UDATA i = 0; walkThread != NULL && i < _AllocatedVMThreadCount; i++) {
-		omrthread_monitor_t monitor;
-		J9VMThread *lockOwner;
-		void *args[] = {walkThread, NULL, &monitor, &lockOwner, NULL};
+	for (UDATA i = 0; (NULL != walkThread) && (i < _AllocatedVMThreadCount); i++) {
+		omrthread_monitor_t monitor = NULL;
+		J9VMThread *lockOwner = NULL;
+		void *args[] = { walkThread, NULL, &monitor, &lockOwner, NULL };
 		UDATA stateClean = 0;
 		UDATA stateFault = stateClean;
 
-		if (i == 0) {
+		if (0 == i) {
 			// The walk may have started or restarted which is why initialization is in the loop.
-			memset(threadStore, 0, (_AllocatedVMThreadCount+1) * sizeof(blocked_thread_record));
+			memset(threadStore, 0, (_AllocatedVMThreadCount + 1) * sizeof(blocked_thread_record));
 		}
 
-		if (j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
+		if (j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
 			// Nothing to do if we couldn't get the details for this thread.
 		} else {
 			// Only store interesting threads, list will be null terminated.
-			if( ((stateClean == J9VMTHREAD_STATE_BLOCKED) ||
-				(stateClean == J9VMTHREAD_STATE_WAITING) ||
-				(stateClean == J9VMTHREAD_STATE_WAITING_TIMED))
-				) {
+			if ((J9VMTHREAD_STATE_BLOCKED == stateClean)
+				|| (J9VMTHREAD_STATE_WAITING == stateClean)
+				|| (J9VMTHREAD_STATE_WAITING_TIMED == stateClean)
+			) {
 				threadStore[blockedCount].monitor = monitor;
 				threadStore[blockedCount].waitingThread = walkThread;
 				threadStore[blockedCount].waitingThreadState = stateClean;
@@ -1915,17 +1881,17 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 		}
 
 		walkThread = J9_LINKED_LIST_NEXT_DO(_VirtualMachine->mainThread, walkThread);
-		if (walkThread != NULL && walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION) {
+		if ((NULL != walkThread) && (walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION)) {
 			/* restart the walk */
 			if (!restartedWalk) {
 				walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
 				i = 0;
-				restartedWalk = 1;
+				restartedWalk = true;
 				continue;
 			} else {
 				_OutputStream.writeCharacters(
 					"1LKTHRERR            <aborting search for blocked and waiting threads due to exiting thread>\n"
-					"NULL\n" );
+					"NULL\n");
 				break;
 			}
 		}
@@ -1936,9 +1902,9 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 
 	omrthread_monitor_init_walk(&walkState);
 
-	while ( NULL != (monitor = omrthread_monitor_walk_no_locking(&walkState)) ) {
+	while (NULL != (monitor = omrthread_monitor_walk_no_locking(&walkState))) {
 		J9ThreadAbstractMonitor* lock = (J9ThreadAbstractMonitor*)monitor;
-		if ((lock->flags & J9THREAD_MONITOR_OBJECT) == J9THREAD_MONITOR_OBJECT) {
+		if (J9_ARE_ALL_BITS_SET(lock->flags, J9THREAD_MONITOR_OBJECT)) {
 			writeMonitorObject(monitor, (j9object_t)lock->userData, threadStore);
 		}
 	}
@@ -1951,9 +1917,9 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 
 	omrthread_monitor_init_walk(&walkState);
 
-	while ( NULL != (monitor = omrthread_monitor_walk_no_locking(&walkState)) ) {
+	while (NULL != (monitor = omrthread_monitor_walk_no_locking(&walkState))) {
 		J9ThreadAbstractMonitor* lock = (J9ThreadAbstractMonitor*)monitor;
-		if ((lock->flags & J9THREAD_MONITOR_OBJECT) != J9THREAD_MONITOR_OBJECT) {
+		if (!J9_ARE_ALL_BITS_SET(lock->flags, J9THREAD_MONITOR_OBJECT)) {
 			writeMonitorObject(monitor, NULL, threadStore);
 		}
 	}
@@ -2002,13 +1968,12 @@ JavaCoreDumpWriter::writeThreadSection(void)
 
 #if !defined(OSX)
 	/* if thread preempt is enabled, and we have the lock, then collect the native stacks */
-	if ((_Agent->requestMask & J9RAS_DUMP_DO_PREEMPT_THREADS) && _PreemptLocked
+	if (J9_ARE_ANY_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_PREEMPT_THREADS) && _PreemptLocked
 #if defined(WIN32)
 		/* On Windows don't attempt to collect native stacks for the thread start and end hook events because
 		 * the Windows DbgHelp functions are prone to hangs if called when threads are starting or stopping.
 		 */
-		&& !(_Context->eventFlags & J9RAS_DUMP_ON_THREAD_START)
-		&& !(_Context->eventFlags & J9RAS_DUMP_ON_THREAD_END)
+		&& J9_ARE_NO_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_THREAD_START | J9RAS_DUMP_ON_THREAD_END)
 #endif /* defined(WIN32) */
 	) {
 		struct walkClosure closure;
@@ -2017,23 +1982,23 @@ JavaCoreDumpWriter::writeThreadSection(void)
 		closure.state = NULL;
 		j9sig_protect(protectedWriteThreadsWithNativeStacks,
 				&closure, handlerWriteStacks, this,
-				J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
+				J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN,
 				&sink);
 	}
 #endif /* !defined(OSX) */
 
-	if( !_ThreadsWalkStarted ) {
+	if (!_ThreadsWalkStarted) {
 		struct walkClosure closure;
 		UDATA sink = 0;
 		closure.jcw = this;
 		closure.state = NULL;
 		j9sig_protect(protectedWriteThreadsJavaOnly,
 				&closure, handlerWriteStacks, this,
-				J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
+				J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN,
 				&sink);
 	}
 
-	if ((_Agent->requestMask & J9RAS_DUMP_DO_PREEMPT_THREADS) && (_PreemptLocked == false) ) {
+	if (J9_ARE_ANY_BITS_SET(_Agent->requestMask, J9RAS_DUMP_DO_PREEMPT_THREADS) && (_PreemptLocked == false)) {
 		/* another thread had the preempt lock */
 		_OutputStream.writeCharacters("1XMWLKTHDINF   Multiple dumps in progress, native stacks not collected\n");
 	}
@@ -2042,7 +2007,10 @@ JavaCoreDumpWriter::writeThreadSection(void)
 	 * and this isn't a thrstop event. Trace may receive the call to the J9HOOK_VM_THREAD_END hook first and clean up
 	 * the trace data for this thread first.
 	 */
-	if( _Context->onThread && (_Context->eventFlags & syncEventsMask) && !(_Context->eventFlags & J9RAS_DUMP_ON_THREAD_END)) {
+	if ((NULL != _Context->onThread)
+		&& J9_ARE_ANY_BITS_SET(_Context->eventFlags, syncEventsMask)
+		&& J9_ARE_NO_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_THREAD_END)
+	) {
 		// Write current thread trace.
 		_OutputStream.writeCharacters("1XECTHTYPE     Current thread history (J9VMThread:");
 		_OutputStream.writePointer(_Context->onThread);
@@ -2060,7 +2028,7 @@ JavaCoreDumpWriter::writeThreadSection(void)
 		closure.state = NULL;
 		j9sig_protect(protectedWriteThreadsUsageSummary,
 					  &closure, handlerGetThreadsUsageInfo, this,
-					  J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &sink);
+					  J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink);
 	}
 
 	// End the threads section here.
@@ -2226,13 +2194,12 @@ JavaCoreDumpWriter::writeHookInterface(struct J9HookInterface **hookInterface)
 void
 JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 {
-
 	J9VMThread* vmThread = _Context->onThread;
 	J9PlatformThread *nativeThread = NULL;
 	J9ThreadWalkState state;
 	J9AVLTree vmthreads;
-	vmthread_avl_node *vmthreadStore;
-	J9Heap *heap;
+	vmthread_avl_node *vmthreadStore = NULL;
+	J9Heap *heap = NULL;
 	UDATA i = 0;
 	UDATA vmstate = 0;
 	UDATA javaState = 0;
@@ -2241,7 +2208,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 	const char *errorMessage = NULL;
 	/* backs the heap we use for thread introspection. Size is a guess for context + reasonable stack */
 	char backingStore[8096];
-	bool restartedWalk = 0;
+	bool restartedWalk = false;
 
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 
@@ -2249,7 +2216,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 	 * not got to the point where we set _ThreadsWalkStarted, the calling code in writeThreadSection()
 	 * will re-try, writing the Java threads and stacks only. See PR 81717 and PR 40206.
 	 */
-	UDATA freeStack = vmThread ? vmThread->currentOSStackFree : _VirtualMachine->defaultOSStackSize;
+	UDATA freeStack = (NULL != vmThread) ? vmThread->currentOSStackFree : _VirtualMachine->defaultOSStackSize;
 	if ((_AllocatedVMThreadCount * sizeof(vmthread_avl_node) + STACK_SAFETY_MARGIN) > freeStack) {
 		_OutputStream.writeCharacters("NULL\n");
 		_OutputStream.writeCharacters("1XMWLKTHDINF   Insufficient stack space for native stack collection\n");
@@ -2266,7 +2233,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 	_ThreadsWalkStarted = true;
 
 	/* first and second phase of native thread stack collection timeout set to 10 seconds each */
-	state.deadline1 = (j9time_current_time_millis()/1000) + 10;
+	state.deadline1 = (j9time_current_time_millis() / 1000) + 10;
 	state.deadline2 = state.deadline1 + 10;
 
 	closure.state = &state;
@@ -2275,7 +2242,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 
 	/* populate the VM thread avl tree or dump the java stacks if they won't fit */
 	J9VMThread* walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
-	for (i = 0; walkThread != NULL && i < _AllocatedVMThreadCount; i++) {
+	for (i = 0; (NULL != walkThread) && (i < _AllocatedVMThreadCount); i++) {
 		j9object_t lockObject = NULL;
 		J9VMThread *lockOwner = NULL;
 		void *args[] = {walkThread, &lockObject, NULL, &lockOwner, NULL};
@@ -2285,7 +2252,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		UDATA javaThreadState = 0;
 		UDATA javaPriority = 0;
 
-		if (i == 0) {
+		if (0 == i) {
 			/* build the avl tree for lookup. Having this in the loop allows us to restart the walk easily if needed */
 			memset(&vmthreads, 0, sizeof(J9AVLTree));
 			vmthreads.insertionComparator = vmthread_comparator;
@@ -2295,19 +2262,19 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		vmthreadStore[i].vmthread = walkThread;
 
 		/* Obtain java state through getVMThreadObjectState() for outputting to javacore */
-		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 			javaThreadState = J9VMTHREAD_STATE_UNREADABLE;
 		} else {
 			javaThreadState = stateClean;
 		}
 
-		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 			vmThreadState = J9VMTHREAD_STATE_UNREADABLE;
 		} else {
 			vmThreadState = stateClean;
 		}
 
-		if (walkThread->threadObject) {
+		if (NULL != walkThread->threadObject) {
 			javaPriority = _VirtualMachine->internalVMFunctions->getJavaThreadPriority(_VirtualMachine, walkThread);
 		}
 
@@ -2319,12 +2286,12 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		avl_insert(&vmthreads, (J9AVLTreeNode*)&vmthreadStore[i]);
 
 		walkThread = J9_LINKED_LIST_NEXT_DO(_VirtualMachine->mainThread, walkThread);
-		if (walkThread != NULL && walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION) {
+		if ((NULL != walkThread) && (walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION)) {
 			/* restart the walk */
 			if (!restartedWalk) {
 				walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
 				i = 0;
-				restartedWalk = 1;
+				restartedWalk = true;
 				continue;
 			} else {
 				errorMessage = "Truncating collection of java threads due to multiple threads stopping during walk, some java thread details will be omitted";
@@ -2333,32 +2300,32 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		}
 	}
 
-	UDATA returnValue;
+	UDATA returnValue = 0;
 	nativeThread = NULL;
 
-	if (vmThread && vmThread->gpInfo) {
+	if ((NULL != vmThread) && (NULL != vmThread->gpInfo)) {
 		/* Extract the OS thread */
 		closure.gpInfo = vmThread->gpInfo;
 
-		returnValue = j9sig_protect(protectedStartDoWithSignal, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread);
+		returnValue = j9sig_protect(protectedStartDoWithSignal, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread);
 	} else {
-		returnValue = j9sig_protect(protectedStartDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread);
+		returnValue = j9sig_protect(protectedStartDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread);
 	}
 
-	if (returnValue == J9PORT_SIG_EXCEPTION_OCCURRED) {
+	if (J9PORT_SIG_EXCEPTION_OCCURRED == returnValue) {
 		errorMessage = "GPF received while walking native threads\n";
 
 		/* we need to set up the next thread so we continue the walk if possible */
-		while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) == J9PORT_SIG_EXCEPTION_OCCURRED) {
+		while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) == J9PORT_SIG_EXCEPTION_OCCURRED) {
 			errorMessage = "GPF received while walking native threads\n";
 		}
 	}
 
 	/** Write the current thread out (if appropriate) **/
-	if ((vmThread && vmThread->gpInfo) || (_Context->eventFlags & syncEventsMask)) {
+	if (((NULL != vmThread) && (NULL != vmThread->gpInfo)) || J9_ARE_ANY_BITS_SET(_Context->eventFlags, syncEventsMask)) {
 		/* if synchronous */
 		J9PlatformThread pseudoThread;
-		vmthread_avl_node *node;
+		vmthread_avl_node *node = NULL;
 		j9object_t lockObject = NULL;
 		J9VMThread *lockOwnerThread = NULL;
 		/* Write the failing thread sub section */
@@ -2367,7 +2334,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 			"1XMCURTHDINFO  Current thread\n"
 		);
 
-		if (nativeThread == NULL) {
+		if (NULL == nativeThread) {
 			nativeThread = &pseudoThread;
 			memset(nativeThread, 0, sizeof(J9PlatformThread));
 
@@ -2375,9 +2342,9 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 			 * against so we can delete it and prevent it being duplicated when we dump outstanding
 			 * java threads
 			 */
-			if (vmThread && vmThread->osThread) {
+			if ((NULL != vmThread) && (NULL != vmThread->osThread)) {
 				pseudoThread.thread_id = omrthread_get_osId(vmThread->osThread);
-				if (pseudoThread.thread_id == 0) {
+				if (0 == pseudoThread.thread_id) {
 					pseudoThread.thread_id = (UDATA) (((U_8*)vmThread->osThread) + sizeof(J9AbstractThread));
 				}
 			}
@@ -2385,7 +2352,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 
 		node = (vmthread_avl_node *)avl_search(&vmthreads, nativeThread->thread_id);
 
-		if (node) {
+		if (NULL != node) {
 			avl_delete(&vmthreads, (J9AVLTreeNode*)node);
 			walkThread = node->vmthread;
 			vmstate = node->vmThreadState;
@@ -2414,14 +2381,14 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		writeThread(walkThread, nativeThread, vmstate, javaState, javaPriority, lockObject, lockOwnerThread);
 
 		/* set up the next thread for processing */
-		while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) != 0) {
+		while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) != 0) {
 			errorMessage = "GPF received while walking native threads\n";
 		}
 	} else {
 		/* this is an externally prompted event so don't pull out any thread as special */
 	}
 
-	if (nativeThread != NULL || vmthreads.rootNode != NULL) {
+	if ((NULL != nativeThread) || (NULL != vmthreads.rootNode)) {
 		/* Write the all threads sub section */
 		_OutputStream.writeCharacters(
 			"NULL\n"
@@ -2430,13 +2397,13 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 		);
 
 		/* dump combined native/java or pure native threads */
-		while (nativeThread != NULL) {
+		while (NULL != nativeThread) {
 			J9VMThread *javaThread = NULL;
 			j9object_t lockObject = NULL;
 			J9VMThread *lockOwnerThread = NULL;
-			if (vmthreads.rootNode != NULL) {
+			if (NULL != vmthreads.rootNode) {
 				vmthread_avl_node *node = (vmthread_avl_node *)avl_search(&vmthreads, nativeThread->thread_id);
-				if (node) {
+				if (NULL != node) {
 					avl_delete(&vmthreads, (J9AVLTreeNode*)node);
 					javaThread = node->vmthread;
 					vmstate = node->vmThreadState;
@@ -2455,13 +2422,13 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 			writeThread(javaThread, nativeThread, vmstate, javaState, javaPriority, lockObject, lockOwnerThread);
 
 			/* set up the next thread safely */
-			while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) != 0) {
+			while (j9sig_protect(protectedNextDo, &closure, handlerNativeThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nativeThread) != 0) {
 				errorMessage = "GPF received while walking native threads\n";
 			}
 		}
 
 		/* dump any additional java threads */
-		while (vmthreads.rootNode != NULL) {
+		while (NULL != vmthreads.rootNode) {
 			vmthread_avl_node *node = (vmthread_avl_node*)vmthreads.rootNode;
 			avl_delete(&vmthreads, (J9AVLTreeNode*)node);
 			writeThread(node->vmthread, NULL, node->vmThreadState, node->javaThreadState, node->javaPriority, node->lockObject, node->lockOwner);
@@ -2469,7 +2436,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 	}
 
 	/* If there were any errors in the walk then detail them now */
-	if (state.error || errorMessage != NULL) {
+	if (state.error || (NULL != errorMessage)) {
 		_OutputStream.writeCharacters("1XMWLKTHDERR   The following was reported while collecting native stacks:\n");
 
 		if (state.error) {
@@ -2479,7 +2446,7 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 			_OutputStream.writeInteger(state.error_detail, ", %i)\n");
 		}
 
-		if (errorMessage != NULL) {
+		if (NULL != errorMessage) {
 			_OutputStream.writeCharacters("2XMWLKTHDERR             ");
 			_OutputStream.writeCharacters(errorMessage);
 			_OutputStream.writeCharacters("\n");
@@ -2487,14 +2454,11 @@ JavaCoreDumpWriter::writeThreadsWithNativeStacks(void)
 
 		_OutputStream.writeCharacters("NULL\n");
 	}
-
 }
-
 
 void
 JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 {
-
 	J9VMThread* vmThread = _Context->onThread;
 	J9VMThread* currentThread = NULL;
 	bool restartedWalk = 0;
@@ -2503,12 +2467,12 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 
 	_ThreadsWalkStarted = true;
 
-	if ((vmThread && vmThread->gpInfo) || (_Context->eventFlags & syncEventsMask)) {
+	if (((NULL != vmThread) && (NULL != vmThread->gpInfo)) || J9_ARE_ANY_BITS_SET(_Context->eventFlags, syncEventsMask)) {
 		currentThread = vmThread;
 	}
 
 	/** Write the current thread out (if appropriate) **/
-	if ( currentThread != NULL) {
+	if (NULL != currentThread) {
 		j9object_t lockObject = NULL;
 		J9VMThread *lockOwner = NULL;
 		void *args[] = {currentThread, &lockObject, NULL, &lockOwner, NULL};
@@ -2522,19 +2486,19 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 		/* Write the failing thread sub section */
 
 		/* Obtain java state through getVMThreadObjectState() for outputting to javacore */
-		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 			javaThreadState = J9VMTHREAD_STATE_UNREADABLE;
 		} else {
 			javaThreadState = stateClean;
 		}
 
-		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+		if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 			vmThreadState = J9VMTHREAD_STATE_UNREADABLE;
 		} else {
 			vmThreadState = stateClean;
 		}
 
-		if (currentThread->threadObject) {
+		if (NULL != currentThread->threadObject) {
 			javaPriority = _VirtualMachine->internalVMFunctions->getJavaThreadPriority(_VirtualMachine, currentThread);
 		}
 
@@ -2548,10 +2512,10 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 
 	/* dump the java stacks for all threads*/
 	J9VMThread* walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
-	for (UDATA i = 0; walkThread != NULL && i < _AllocatedVMThreadCount; i++) {
+	for (UDATA i = 0; (NULL != walkThread) && (i < _AllocatedVMThreadCount); i++) {
 		j9object_t lockObject = NULL;
 		J9VMThread *lockOwner = NULL;
-		void *args[] = {walkThread, &lockObject, NULL, &lockOwner, NULL};
+		void *args[] = { walkThread, &lockObject, NULL, &lockOwner, NULL };
 		UDATA stateClean = 0;
 		UDATA stateFault = stateClean;
 		UDATA vmThreadState = 0;
@@ -2559,24 +2523,24 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 		UDATA javaPriority = 0;
 
 		/* If we have a current thread it will already have been written. */
-		if( walkThread != currentThread ) {
+		if (walkThread != currentThread) {
 			/* Obtain java state through getVMThreadObjectState() for outputting to javacore */
-			if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+			if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadObjectState, args, handlerGetVMThreadObjectState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 				javaThreadState = J9VMTHREAD_STATE_UNREADABLE;
 			} else {
 				javaThreadState = stateClean;
 			}
 
-			if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
+			if (J9PORT_SIG_EXCEPTION_OCCURRED == j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean)) {
 				vmThreadState = J9VMTHREAD_STATE_UNREADABLE;
 			} else {
 				vmThreadState = stateClean;
 			}
 
-			if (walkThread->threadObject) {
+			if (NULL != walkThread->threadObject) {
 				javaPriority = _VirtualMachine->internalVMFunctions->getJavaThreadPriority(_VirtualMachine, walkThread);
 			}
-			if( i == 0 ) {
+			if (0 == i) {
 				_OutputStream.writeCharacters(
 						"NULL\n"
 						"1XMTHDINFO     Thread Details\n"
@@ -2587,12 +2551,12 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 		}
 
 		walkThread = J9_LINKED_LIST_NEXT_DO(_VirtualMachine->mainThread, walkThread);
-		if (walkThread != NULL && walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION) {
+		if ((NULL != walkThread) && (walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION)) {
 			/* restart the walk */
 			if (!restartedWalk) {
 				walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
 				i = 0;
-				restartedWalk = 1;
+				restartedWalk = true;
 				continue;
 			} else {
 				break;
@@ -2602,7 +2566,6 @@ JavaCoreDumpWriter::writeThreadsJavaOnly(void)
 
 	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 }
-
 
 /**************************************************************************************************/
 /*                                                                                                */
@@ -2620,7 +2583,7 @@ JavaCoreDumpWriter::writeClassSection(void)
 		"1CLTEXTCLLSS   \t\t12345678: 1=primordial,2=extension,3=shareable,4=middleware,5=system,6=trusted,7=application,8=delegating\n"
 	);
 
-	pool_do(_VirtualMachine->classLoaderBlocks,writeLoaderCallBack, this);
+	pool_do(_VirtualMachine->classLoaderBlocks, writeLoaderCallBack, this);
 
 	/* Write the sub-section header */
 	_OutputStream.writeCharacters(
@@ -2694,7 +2657,6 @@ JavaCoreDumpWriter::writeClassSection(void)
  * NULL
  * NULL           ------------------------------------------------------------------------
  */
-
 void
 JavaCoreDumpWriter::writeHookSection(void)
 {
@@ -2776,7 +2738,7 @@ JavaCoreDumpWriter::writeCudaSection(void)
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 	J9CudaConfig *config = OMRPORT_FROM_J9PORT(PORTLIB)->cuda_configData;
 
-	if (config && config->getSummaryData) {
+	if ((NULL != config) && (NULL != config->getSummaryData)) {
 		J9CudaSummaryDescriptor summary;
 
 		memset(&summary, 0, sizeof(summary));
@@ -2819,7 +2781,7 @@ JavaCoreDumpWriter::writeCudaSection(void)
 		_OutputStream.writeCharacters("1CUDACOUNT     Device count:     ");
 		_OutputStream.writeInteger(summary.deviceCount, "%zu\n");
 
-		if (config->getDeviceData) {
+		if (NULL != config->getDeviceData) {
 			for (U_32 deviceId = 0; deviceId < summary.deviceCount; ++deviceId) {
 				_OutputStream.writeCharacters("NULL\n");
 
@@ -2907,7 +2869,6 @@ JavaCoreDumpWriter::writeCudaSection(void)
 		_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 	}
 }
-
 #endif /* defined(OMR_OPT_CUDA) */
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
@@ -2949,12 +2910,12 @@ void
 JavaCoreDumpWriter::writeSharedClassLockInfo(const char* lockName, IDATA lockSemid, void* lockTID)
 {
 	_OutputStream.writeCharacters(lockName);
-	if (lockSemid == -2) {
+	if (-2 == lockSemid) {
 		_OutputStream.writeCharacters("File lock                ");
 	} else {
 		writeSharedClassIPCInfo("IPC Sem (id ", ")", lockSemid, 25);
 	}
-	if (lockTID) {
+	if (NULL != lockTID) {
 		_OutputStream.writePointer(lockTID);
 		_OutputStream.writeCharacters("\n");
 	} else {
@@ -2971,7 +2932,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsHelper(J9SharedClassJava
 			"NULL\n"
 	);
 
-	if (0 != (javacoreData->extraFlags & J9SHR_EXTRA_FLAGS_NO_LINE_NUMBERS)) {
+	if (J9_ARE_ANY_BITS_SET(javacoreData->extraFlags, J9SHR_EXTRA_FLAGS_NO_LINE_NUMBERS)) {
 		_OutputStream.writeCharacters(
 				"2SCLTEXTXNL            -Xnolinenumbers       = true\n"
 		);
@@ -2981,7 +2942,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsHelper(J9SharedClassJava
 		);
 	}
 
-	if (0 != (javacoreData->extraFlags & J9SHR_EXTRA_FLAGS_BCI_ENABLED)) {
+	if (J9_ARE_ANY_BITS_SET(javacoreData->extraFlags, J9SHR_EXTRA_FLAGS_BCI_ENABLED)) {
 		_OutputStream.writeCharacters(
 				"2SCLTEXTBCI            BCI Enabled           = true\n"
 		);
@@ -2991,7 +2952,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsHelper(J9SharedClassJava
 		);
 	}
 
-	if (0 != (javacoreData->extraFlags & J9SHR_EXTRA_FLAGS_RESTRICT_CLASSPATHS)) {
+	if (J9_ARE_ANY_BITS_SET(javacoreData->extraFlags, J9SHR_EXTRA_FLAGS_RESTRICT_CLASSPATHS)) {
 		_OutputStream.writeCharacters(
 				"2SCLTEXTBCI            Restrict Classpaths   = true\n"
 		);
@@ -3008,7 +2969,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsHelper(J9SharedClassJava
 				"NULL\n"
 	);
 
-	if (0 != (javacoreData->extraFlags & J9SHR_EXTRA_FLAGS_NO_LINE_NUMBER_CONTENT)) {
+	if (J9_ARE_ANY_BITS_SET(javacoreData->extraFlags, J9SHR_EXTRA_FLAGS_NO_LINE_NUMBER_CONTENT)) {
 		_OutputStream.writeCharacters(
 				"2SCLTEXTNLC            No line number content                    = true\n"
 		);
@@ -3018,7 +2979,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsHelper(J9SharedClassJava
 		);
 	}
 
-	if (0 != (javacoreData->extraFlags & J9SHR_EXTRA_FLAGS_LINE_NUMBER_CONTENT)) {
+	if (J9_ARE_ANY_BITS_SET(javacoreData->extraFlags, J9SHR_EXTRA_FLAGS_LINE_NUMBER_CONTENT)) {
 		_OutputStream.writeCharacters(
 				"2SCLTEXTLNC            Line number content                       = true\n"
 		);
@@ -3190,7 +3151,7 @@ JavaCoreDumpWriter::writeSharedClassSectionTopLayerStatsSummaryHelper(J9SharedCl
 	} else {
 		_OutputStream.writeCharacters("Default                  ");
 	}
-	if (javacoreData->shmid == -2) {
+	if (-2 == javacoreData->shmid) {
 		_OutputStream.writeCharacters("Memory mapped file       ");
 	} else {
 		writeSharedClassIPCInfo("IPC Memory (id ", ")", javacoreData->shmid, 25);
@@ -3366,10 +3327,10 @@ JavaCoreDumpWriter::writeSharedClassSection(void)
 {
 	J9SharedClassJavacoreDataDescriptor javacoreData;
 
-	if (!_VirtualMachine->sharedClassConfig) {
+	if (NULL == _VirtualMachine->sharedClassConfig) {
 		return;
 	}
-	if (!_VirtualMachine->sharedClassConfig->getJavacoreData) {
+	if (NULL == _VirtualMachine->sharedClassConfig->getJavacoreData) {
 		return;
 	}
 
@@ -3411,10 +3372,7 @@ JavaCoreDumpWriter::writeSharedClassSection(void)
 		);
 	}
 }
-#endif
-
-
-
+#endif /* defined(J9VM_OPT_SHARED_CLASSES) */
 
 /**************************************************************************************************/
 /*                                                                                                */
@@ -3467,7 +3425,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 
 	PORT_ACCESS_FROM_JAVAVM(_VirtualMachine);
 
-	if (exceptionRef && *exceptionRef) {
+	if ((NULL != exceptionRef) && (NULL != *exceptionRef)) {
 		j9object_t message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *exceptionRef);
 		if (NULL != message) {
 			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NULL_TERMINATE_RESULT, "", 0, stackBuffer, _MaximumExceptionNameLength, &len);
@@ -3499,9 +3457,9 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 			nestedException = J9VMJAVALANGEXCEPTIONININITIALIZERERROR_EXCEPTION(vmThread, *exceptionRef);
 #endif /* JAVA_SPEC_VERSION */
 
-			if (nestedException) {
+			if (NULL != nestedException) {
 				nestedExceptionClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(vmThread, nestedException)->romClass);
-				if (nestedExceptionClassName) {
+				if (NULL != nestedExceptionClassName) {
 					_OutputStream.writeCharacters(" Nested Exception: \"");
 					_OutputStream.writeCharacters((char*)J9UTF8_DATA(nestedExceptionClassName), (UDATA)J9UTF8_LENGTH(nestedExceptionClassName));
 					_OutputStream.writeCharacters("\"");
@@ -3535,15 +3493,13 @@ void
 JavaCoreDumpWriter::writeGPCategory(void* gpInfo, const char* prefix, U_32 category)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
-
-	const char* name;
-	void*       value;
-	U_32        kind;
-
 	U_32 items = j9sig_info_count(gpInfo, category);
 
 	for (U_32 n = 0; n < items; n++) {
-		kind = j9sig_info(gpInfo, category, n, &name, &value);
+		const char *name = NULL;
+		void *value = NULL;
+		U_32 kind = j9sig_info(gpInfo, category, n, &name, &value);
+
 		writeGPValue(prefix, name, kind, value);
 	}
 }
@@ -3576,14 +3532,14 @@ JavaCoreDumpWriter::writeGPValue(const char* prefix, const char* name, U_32 kind
 		}
 		break;
 	case J9PORT_SIG_VALUE_STRING:
-		if (value) {
+		if (NULL != value) {
 			/* CMVC 160410: copy value to a local string as kernel symbols may be inaccessible to file write() */
 			char valueString[_MaximumGPValueLength];
 			if (strlen((char *)value) < _MaximumGPValueLength) {
-				 strcpy(valueString, (char *)value);
-				 _OutputStream.writeCharacters(valueString);
+				strcpy(valueString, (char *)value);
+				_OutputStream.writeCharacters(valueString);
 			} else {
-				strncpy(valueString, (char *)value, _MaximumGPValueLength-1);
+				strncpy(valueString, (char *)value, _MaximumGPValueLength - 1);
 				valueString[_MaximumGPValueLength-1] = '\0';
 				_OutputStream.writeCharacters(valueString);
 				_OutputStream.writeCharacters(" [truncated]");
@@ -3612,9 +3568,9 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 {
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 
-	J9JITConfig* jitConfig = vmThread ? vmThread->javaVM->jitConfig : NULL;
-	if (jitConfig) {
+	J9JITConfig* jitConfig = (NULL != vmThread) ? vmThread->javaVM->jitConfig : NULL;
 
+	if (NULL != jitConfig) {
 		J9Method* ramMethod       = NULL;
 		bool      insideJitMethod = false;
 		bool      isCompiling     = false;
@@ -3622,21 +3578,19 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 		if ((vmThread->omrVMThread->vmState & J9VMSTATE_MAJOR) == J9VMSTATE_JIT) {
 			ramMethod = vmThread->jitMethodToBeCompiled;
 			isCompiling = true;
-
 		} else {
-			const char* name;
-			void*      value;
+			const char *name = NULL;
+			void *value = NULL;
 
 			PORT_ACCESS_FROM_JAVAVM(_VirtualMachine);
 
 			U_32 kind = j9sig_info(vmThread->gpInfo, J9PORT_SIG_CONTROL, J9PORT_SIG_CONTROL_PC, &name, &value);
-
-			J9JITExceptionTable* table;
+			J9JITExceptionTable *table = NULL;
 
 			switch (kind) {
 			case J9PORT_SIG_VALUE_ADDRESS:
 				table = jitConfig->jitGetExceptionTableFromPC(vmThread, *(UDATA*)value);
-				if (table) {
+				if (NULL != table) {
 					ramMethod = table->ramMethod;
 					insideJitMethod = true;
 				}
@@ -3651,7 +3605,7 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 		_OutputStream.writeCharacters("1XHEXCPMODULE  ");
 		_OutputStream.writeCharacters(isCompiling ? "Compiling method: " : "Inside compiled method: ");
 
-		if (ramMethod) {
+		if (NULL != ramMethod) {
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
 			J9ROMClass *romClass = J9_CLASS_FROM_METHOD(ramMethod)->romClass;
 
@@ -3660,7 +3614,6 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 			_OutputStream.writeCharacters(J9ROMMETHOD_NAME(romMethod));
 			_OutputStream.writeCharacters(J9ROMMETHOD_SIGNATURE(romMethod));
 			_OutputStream.writeCharacters("\n");
-
 		} else {
 			_OutputStream.writeCharacters("<unknown>\n");
 		}
@@ -3668,8 +3621,7 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 		return;
 	}
 }
-
-#endif  /* J9VM_INTERP_NATIVE_SUPPORT */
+#endif /* J9VM_INTERP_NATIVE_SUPPORT */
 }
 
 /**************************************************************************************************/
@@ -3686,11 +3638,11 @@ JavaCoreDumpWriter::writeSegments(J9MemorySegmentList* list, BOOLEAN isCodeCache
 	UDATA allocTotal = 0;
 	UDATA freeTotal = 0;
 
-	while (segment != 0) {
-		UDATA warmAlloc;
-		UDATA coldAlloc;
+	while (NULL != segment) {
+		UDATA warmAlloc = 0;
+		UDATA coldAlloc = 0;
 
-		if (segment->type == MEMORY_TYPE_SHARED_META) {
+		if (MEMORY_TYPE_SHARED_META == segment->type) {
 			/* Discard the class cache metadata segment (it overlaps the last shared ROM class segment in the cache) */
 			segment = segment->nextSegment;
 			continue;
@@ -3707,9 +3659,9 @@ JavaCoreDumpWriter::writeSegments(J9MemorySegmentList* list, BOOLEAN isCodeCache
 			 */
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 			UDATA *mccCodeCache = *((UDATA**)segment->heapBase);
-			if (mccCodeCache ) {
-				J9JITConfig* jitConfig = _VirtualMachine->jitConfig;
-				if (jitConfig) {
+			if (NULL != mccCodeCache) {
+				J9JITConfig *jitConfig = _VirtualMachine->jitConfig;
+				if (NULL != jitConfig) {
 					warmAlloc = (UDATA)jitConfig->codeCacheWarmAlloc(mccCodeCache);
 					coldAlloc = (UDATA)jitConfig->codeCacheColdAlloc(mccCodeCache);
 				}
@@ -3748,7 +3700,7 @@ JavaCoreDumpWriter::writeSegments(J9MemorySegmentList* list, BOOLEAN isCodeCache
 		segment = segment->nextSegment;
 	}
 
-	int decimalLength = sizeof(void*) == 4 ? 10 : 20;
+	int decimalLength = (sizeof(void *) == 4) ? 10 : 20;
 
 	/* print out the totals */
 	_OutputStream.writeCharacters("NULL\n");
@@ -3782,18 +3734,18 @@ JavaCoreDumpWriter::writeTraceHistory(U_32 type)
 {
 	/* Extract the history data */
 	RasGlobalStorage*     j9ras        = (RasGlobalStorage*)_VirtualMachine->j9rasGlobalStorage;
-	UtInterface*          uteInterface = (UtInterface*)(j9ras ? j9ras->utIntf : NULL);
+	UtInterface*          uteInterface = (UtInterface*)((NULL != j9ras) ? j9ras->utIntf : NULL);
 	UtTracePointIterator* iterator     = NULL;
 	const char* prefix = NULL;
 	const char* bufferName = NULL;
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 
 	/* If trace isn't running, there is nothing to do */
-	if (!(uteInterface && uteInterface->server)) {
+	if ((NULL == uteInterface) || (NULL == uteInterface->server)) {
 		return;
 	}
 
-	if( HIST_TYPE_GC == type ) {
+	if (HIST_TYPE_GC == type) {
 		prefix = "ST";
 		bufferName = "gclogger";
 	} else if (HIST_TYPE_CT == type) {
@@ -3813,9 +3765,9 @@ JavaCoreDumpWriter::writeTraceHistory(U_32 type)
 
 	/* gclogger is the trace group used to capture gc data in the low frequency buffer */
 	iterator = uteInterface->server->GetTracePointIteratorForBuffer(thr, bufferName);
-	if (iterator != NULL) {
+	if (NULL != iterator) {
 		struct walkClosure closure;
-		void *args[] = {NULL, NULL, NULL};
+		void *args[] = { NULL, NULL, NULL };
 		UDATA sink = 0;
 
 		closure.jcw = this;
@@ -3827,10 +3779,10 @@ JavaCoreDumpWriter::writeTraceHistory(U_32 type)
 		/* sig_protect iterating the tracepoints so we don't fail to free the iterator if something goes wrong. */
 		j9sig_protect(protectedWriteGCHistoryLines,
 				&closure, handlerWriteSection, this,
-				J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
+				J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN,
 				&sink);
 
-		uteInterface->server->FreeTracePointIterator( thr, iterator );
+		uteInterface->server->FreeTracePointIterator(thr, iterator);
 		iterator = NULL;
 	}
 }
@@ -3838,24 +3790,24 @@ JavaCoreDumpWriter::writeTraceHistory(U_32 type)
 void JavaCoreDumpWriter::writeGCHistoryLines(UtThreadData** thr, UtTracePointIterator* iterator, const char *type)
 {
 	RasGlobalStorage*     j9ras        = (RasGlobalStorage*)_VirtualMachine->j9rasGlobalStorage;
-	UtInterface*          uteInterface = (UtInterface*)(j9ras ? j9ras->utIntf : NULL);
+	UtInterface*          uteInterface = (UtInterface*)((NULL != j9ras) ? j9ras->utIntf : NULL);
 	char                  stackBuffer[_MaximumFormattedTracePointLength];
 	int                   lineCount = 0;
 
 	/* If trace isn't running, there is nothing to do */
-	if (!(uteInterface && uteInterface->server)) {
+	if ((NULL == uteInterface) || (NULL == uteInterface->server)) {
 		return;
 	}
 
 	/* Use the iterator to get the required tracepoints */
-	while ( NULL != uteInterface->server->FormatNextTracePoint( iterator, stackBuffer, _MaximumFormattedTracePointLength) ){
+	while (NULL != uteInterface->server->FormatNextTracePoint(iterator, stackBuffer, _MaximumFormattedTracePointLength)) {
 		_OutputStream.writeCharacters("3");
 		_OutputStream.writeCharacters(type);
 		_OutputStream.writeCharacters("HSTTYPE     ");
 		_OutputStream.writeCharacters(stackBuffer);
 		_OutputStream.writeCharacters("\n");
 
-		if( ++lineCount > _MaximumGCHistoryLines ) {
+		if (++lineCount > _MaximumGCHistoryLines) {
 			_OutputStream.writeCharacters("3");
 			_OutputStream.writeCharacters(type);
 			_OutputStream.writeCharacters("HSTERR      GC history section truncated at ");
@@ -3881,7 +3833,7 @@ JavaCoreDumpWriter::writeDeadLocks(void)
 
 	PORT_ACCESS_FROM_JAVAVM(_VirtualMachine);
 
-	J9HashTable* deadlocks = hashTableNew (
+	J9HashTable* deadlocks = hashTableNew(
 		OMRPORT_FROM_J9PORT(PORTLIB), J9_GET_CALLSITE(), 0,
 		sizeof(DeadLockGraphNode), 0, 0,
 		OMRMEM_CATEGORY_VM,
@@ -3891,15 +3843,15 @@ JavaCoreDumpWriter::writeDeadLocks(void)
 	);
 
 	/* If the memory can't be allocated, skip the section */
-	if (deadlocks == NULL) {
+	if (NULL == deadlocks) {
 		return;
 	}
 
 	J9VMThread* walkThread = J9_LINKED_LIST_START_DO(_VirtualMachine->mainThread);
-	while (walkThread != NULL) {
+	while (NULL != walkThread) {
 		findThreadCycle(walkThread, deadlocks);
 		walkThread = J9_LINKED_LIST_NEXT_DO(_VirtualMachine->mainThread, walkThread);
-		if (walkThread != NULL && walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION) {
+		if ((NULL != walkThread) && (walkThread->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION)) {
 			break;
 		}
 	}
@@ -3908,13 +3860,11 @@ JavaCoreDumpWriter::writeDeadLocks(void)
 	UDATA cycle = 0;
 
 	DeadLockGraphNode* node = (DeadLockGraphNode*)hashTableStartDo(deadlocks, &hashState);
-	while (node != NULL) {
-
+	while (NULL != node) {
 		cycle++;
 
-		while (node) {
+		while (NULL != node) {
 			if (node->cycle > 0) {
-
 				/* Found a deadlock! */
 				if (node->cycle == cycle) {
 					/* Output a header for each deadlock */
@@ -3943,7 +3893,6 @@ JavaCoreDumpWriter::writeDeadLocks(void)
 
 				/* Skip already visited nodes */
 				break;
-
 			} else {
 				node->cycle = cycle;
 			}
@@ -3975,27 +3924,27 @@ JavaCoreDumpWriter::findThreadCycle(J9VMThread* vmThread, J9HashTable* deadlocks
 
 	/* Look for deadlock cycle */
 	do {
-		void *args[] = {vmThread,  &lockObject, &lock, &owner, NULL};
+		void *args[] = { vmThread, &lockObject, &lock, &owner, NULL };
 		UDATA stateClean = 0;
 		UDATA stateFault = stateClean;
 
-		if (j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &stateClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
+		if (j9sig_protect(protectedGetVMThreadRawState, args, handlerGetVMThreadRawState, &stateFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &stateClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
 			return;
 		} else {
 			status = stateClean;
 		}
 
-		if (owner == NULL || owner == vmThread) {
+		if ((NULL == owner) || (owner == vmThread)) {
 			return;
-		} else if (status == J9VMTHREAD_STATE_BLOCKED) {
+		} else if (J9VMTHREAD_STATE_BLOCKED == status) {
 			node.lock = lock;
 			node.lockObject = lockObject;
 			node.cycle = 0;
-		} else if ((status == J9VMTHREAD_STATE_WAITING) || (status == J9VMTHREAD_STATE_WAITING_TIMED)) {
+		} else if ((J9VMTHREAD_STATE_WAITING == status) || (J9VMTHREAD_STATE_WAITING_TIMED == status)) {
 			node.lock = lock;
 			node.lockObject = lockObject;
 			node.cycle = 0;
-		} else if((status == J9VMTHREAD_STATE_PARKED) || (status == J9VMTHREAD_STATE_PARKED_TIMED)) {
+		} else if ((J9VMTHREAD_STATE_PARKED == status) || (J9VMTHREAD_STATE_PARKED_TIMED == status)) {
 			node.lock = NULL;
 			node.lockObject = lockObject;
 			node.cycle = 0;
@@ -4014,8 +3963,7 @@ JavaCoreDumpWriter::findThreadCycle(J9VMThread* vmThread, J9HashTable* deadlocks
 		/* Peek ahead to see if we're in a possible cycle */
 		node.thread = vmThread;
 		prev->next = (DeadLockGraphNode*)hashTableFind(deadlocks, &node);
-
-	} while (prev->next == NULL);
+	} while (NULL == prev->next);
 }
 
 /**************************************************************************************************/
@@ -4035,13 +3983,13 @@ JavaCoreDumpWriter::writeDeadlockNode(DeadLockGraphNode* node, int count)
 	_OutputStream.writePointer(node->thread);
 	_OutputStream.writeCharacters(")\n");
 
-	if (count == 1) {
+	if (1 == count) {
 		_OutputStream.writeCharacters("3LKDEADLOCKWTR    is waiting for:\n");
 	} else {
 		_OutputStream.writeCharacters("3LKDEADLOCKWTR    which is waiting for:\n");
 	}
 
-	if ((lock != NULL) && ((lock->flags & J9THREAD_MONITOR_OBJECT) == J9THREAD_MONITOR_OBJECT)) {
+	if ((NULL != lock) && J9_ARE_ALL_BITS_SET(lock->flags, J9THREAD_MONITOR_OBJECT)) {
 		// Java monitor object
 		_OutputStream.writeCharacters("4LKDEADLOCKMON      ");
 		writeMonitor((J9ThreadMonitor*)lock);
@@ -4049,12 +3997,12 @@ JavaCoreDumpWriter::writeDeadlockNode(DeadLockGraphNode* node, int count)
 		_OutputStream.writeCharacters("4LKDEADLOCKOBJ      ");
 		writeObject((j9object_t)(lock->userData));
 		_OutputStream.writeCharacters("\n");
-	} else if (lock != NULL) {
+	} else if (NULL != lock) {
 		// System monitor
 		_OutputStream.writeCharacters("4LKDEADLOCKREG      ");
 		writeSystemMonitor((J9ThreadMonitor*)lock);
 		_OutputStream.writeCharacters("\n");
-	} else if((lock == NULL) && (lockObject != NULL)) {
+	} else if ((NULL == lock) && (NULL != lockObject)) {
 		// j.u.c lock
 		_OutputStream.writeCharacters("4LKDEADLOCKOBJ      ");
 		writeObject(lockObject);
@@ -4079,20 +4027,20 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 	/* lock->owner is volatile and may change underneath us, cache the value since this is a snapshot of VM state. */
 	J9Thread*   lockOwner = lock->owner;
 
-	if (obj) {
+	if (NULL != obj) {
 		owner = getObjectMonitorOwner(_VirtualMachine, obj, &count);
-	} else if (lockOwner) {
+	} else if (NULL != lockOwner) {
 		owner = getVMThreadFromOMRThread(_VirtualMachine, lockOwner);
 		count = lock->count;
 	}
 
 	/* Skip monitor if not interesting */
-	if ((obj || (lock->name == 0)) && (owner == 0) && (lockOwner == 0) && (lock->waiting == 0)) {
+	if (((NULL != obj) || (NULL == lock->name)) && (NULL == owner) && (NULL == lockOwner) && (NULL == lock->waiting)) {
 		return;
 	}
 
 	/* Describe the monitor */
-	if (obj) {
+	if (NULL != obj) {
 		_OutputStream.writeCharacters("2LKMONINUSE      ");
 		writeMonitor(monitor);
 		_OutputStream.writeCharacters("\n");
@@ -4105,9 +4053,9 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 	}
 
 	/* Describe its owning thread */
-	bool inflated = (lock->flags & J9THREAD_MONITOR_INFLATED) != 0;
+	bool inflated = J9_ARE_ANY_BITS_SET(lock->flags, J9THREAD_MONITOR_INFLATED);
 
-	if (owner || lockOwner) {
+	if ((NULL != owner) || (NULL != lockOwner)) {
 		if (inflated) {
 			_OutputStream.writeCharacters("owner \"");
 		} else {
@@ -4116,7 +4064,7 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 		/* See jvmfree.c : recycleVMThread which says:
 		 * dead threads are stored in "halted for inspection mode"
 		 */
-		if( owner && owner->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION ) {
+		if ((NULL != owner) && (owner->publicFlags == J9_PUBLIC_FLAGS_HALT_THREAD_INSPECTION)) {
 			// This thread should be on the dead thread list.
 			// (Or it may have died while we were looking at it if we don't have
 			// exclusive VM access.)
@@ -4125,11 +4073,11 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 			writeThreadName(owner);
 		}
 		_OutputStream.writeCharacters("\" (");
-		if( owner ) {
-			_OutputStream.writeCharacters( "J9VMThread:");
-			_OutputStream.writePointer((void*)owner );
+		if (NULL != owner) {
+			_OutputStream.writeCharacters("J9VMThread:");
+			_OutputStream.writePointer((void*)owner);
 		} else {
-			_OutputStream.writeCharacters( "native thread ID:");
+			_OutputStream.writeCharacters("native thread ID:");
 			_OutputStream.writeInteger(omrthread_get_osId(lockOwner));
 		}
 		_OutputStream.writeCharacters("), entry count ");
@@ -4143,13 +4091,13 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 	int threadIndex = 0;
 	int blockedThreadCount = 0;
 
-	while (threadStore[threadIndex].waitingThread != NULL) {
+	while (NULL != threadStore[threadIndex].waitingThread) {
 		omrthread_monitor_t blocking_monitor = threadStore[threadIndex].monitor;
 		UDATA status = threadStore[threadIndex].waitingThreadState;
 		J9VMThread* walkThread = threadStore[threadIndex].waitingThread;
-		if ((blocking_monitor == monitor) && (status == J9VMTHREAD_STATE_BLOCKED)) {
+		if ((blocking_monitor == monitor) && (J9VMTHREAD_STATE_BLOCKED == status)) {
 			/* Output the list header */
-			if (blockedThreadCount == 0) {
+			if (0 == blockedThreadCount) {
 				_OutputStream.writeCharacters("3LKWAITERQ            Waiting to enter:\n");
 			}
 
@@ -4167,13 +4115,13 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 	threadIndex = 0;
 	int waitingThreadCount = 0;
 
-	while (threadStore[threadIndex].waitingThread != NULL) {
+	while (NULL != threadStore[threadIndex].waitingThread) {
 		omrthread_monitor_t blocking_monitor = threadStore[threadIndex].monitor;
 		UDATA status = threadStore[threadIndex].waitingThreadState;
 		J9VMThread* walkThread = threadStore[threadIndex].waitingThread;
-		if ((blocking_monitor == monitor) && ((status == J9VMTHREAD_STATE_WAITING) || (status == J9VMTHREAD_STATE_WAITING_TIMED))) {
+		if ((blocking_monitor == monitor) && ((J9VMTHREAD_STATE_WAITING == status) || (J9VMTHREAD_STATE_WAITING_TIMED == status))) {
 				/* Output the list header */
-				if (waitingThreadCount == 0) {
+				if (0 == waitingThreadCount) {
 					_OutputStream.writeCharacters("3LKNOTIFYQ            Waiting to be notified:\n");
 				}
 
@@ -4187,7 +4135,6 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 		}
 		threadIndex++;
 	}
-
 }
 
 /**************************************************************************************************/
@@ -4230,7 +4177,7 @@ JavaCoreDumpWriter::writeSystemMonitor(J9ThreadMonitor* monitor)
 void
 JavaCoreDumpWriter::writeObject(j9object_t obj)
 {
-	J9ROMClass* romClass;
+	J9ROMClass* romClass = NULL;
 	if (J9VM_IS_INITIALIZED_HEAPCLASS_VM(_VirtualMachine, obj)) {
 		romClass = J9VM_J9CLASS_FROM_HEAPCLASS_VM(_VirtualMachine, obj)->romClass;
 	} else {
@@ -4292,13 +4239,13 @@ JavaCoreDumpWriter::writeThreadState(UDATA threadState)
 /*                                                                                                */
 /**************************************************************************************************/
 void
-JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeThread, UDATA vmstate, UDATA javaState, UDATA javaPriority, j9object_t lockObject, J9VMThread *lockOwnerThread )
+JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeThread, UDATA vmstate, UDATA javaState, UDATA javaPriority, j9object_t lockObject, J9VMThread *lockOwnerThread)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 	J9AbstractThread* osThread =  NULL;
 
 	/* Extract the corresponding OS thread */
-	if (vmThread != NULL) {
+	if (NULL != vmThread) {
 		osThread = (J9AbstractThread*)vmThread->osThread;
 
 		/* Write the first thread descriptor word */
@@ -4318,32 +4265,30 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 		_OutputStream.writeCharacters(", prio=");
 		_OutputStream.writeInteger(javaPriority, "%zu");
 
-
 		_OutputStream.writeCharacters("\n");
 
-		if (vmThread->threadObject) {
+		if (NULL != vmThread->threadObject) {
 			struct walkClosure closure;
-			void *args[] = {vmThread};
+			void *args[] = { vmThread };
 			UDATA sink = 0;
 
 			closure.jcw = this;
 			closure.state = args;
-			args[0] = vmThread;
 
 			j9sig_protect(protectedWriteJavaLangThreadInfo,
 						&closure, handlerWriteJavaLangThreadInfo, this,
-						J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
+						J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN,
 						&sink);
 		}
 
 		/* Write the second thread descriptor word */
-		if (osThread) {
+		if (NULL != osThread) {
 			void *stackStart = NULL;
 			void *stackEnd = NULL;
 
 			_OutputStream.writeCharacters("3XMTHREADINFO1            (native thread ID:");
 
-			if (osThread->tid) {
+			if (0 != osThread->tid) {
 				_OutputStream.writeInteger(osThread->tid);
 			} else {
 				_OutputStream.writePointer(((U_8*)osThread) + sizeof(J9AbstractThread));
@@ -4449,10 +4394,9 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			_OutputStream.writeCharacters(")\n");
 		}
 
-
-		if( !avoidLocks() ) {
+		if (!avoidLocks()) {
 			struct walkClosure closure;
-			void *args[] = {NULL, NULL, NULL, NULL};
+			void *args[] = { NULL, NULL, NULL, NULL };
 			UDATA sink = 0;
 
 			closure.jcw = this;
@@ -4464,11 +4408,11 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			/* sig_protect as we have to access the heap and monitors */
 			j9sig_protect(protectedWriteThreadBlockers,
 						&closure, handlerWriteThreadBlockers, this,
-						J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
+						J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN,
 						&sink);
 		}
 
-		if (vmThread->threadObject) {
+		if (NULL != vmThread->threadObject) {
 			UDATA bytesAllocated = _VirtualMachine->memoryManagerFunctions->j9gc_get_bytes_allocated_by_thread(vmThread);
 			_OutputStream.writeCharacters("3XMHEAPALLOC             Heap bytes allocated since last GC cycle=");
 			_OutputStream.writeInteger(bytesAllocated, "%zu");
@@ -4478,21 +4422,21 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 		}
 
 		/* Write the java stack */
-		if (vmThread->threadObject) {
+		if (NULL != vmThread->threadObject) {
 			J9StackWalkState stackWalkState;
 			struct walkClosure closure;
 			struct walkClosure monitorClosure;
-			UDATA sink;
+			UDATA sink = 0;
 			UDATA depth = 0;
 			J9ObjectMonitorInfo monitorInfos[_MaximumMonitorInfosPerThread];
 			IDATA monitorCount = 0;
-			void *monitorArgs[] = {vmThread, monitorInfos, &monitorCount};
+			void *monitorArgs[] = { vmThread, monitorInfos, &monitorCount };
 			monitorClosure.jcw = this;
 			monitorClosure.state = monitorArgs;
 
-			memset(&monitorInfos, 0, _MaximumMonitorInfosPerThread*sizeof(J9ObjectMonitorInfo));
+			memset(&monitorInfos, 0, _MaximumMonitorInfosPerThread * sizeof(J9ObjectMonitorInfo));
 
-			j9sig_protect(protectedGetOwnedObjectMonitors, &monitorClosure, handlerGetOwnedObjectMonitors, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &sink);
+			j9sig_protect(protectedGetOwnedObjectMonitors, &monitorClosure, handlerGetOwnedObjectMonitors, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink);
 
 			stackWalkState.walkThread = vmThread;
 
@@ -4508,38 +4452,38 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			stackWalkState.userData2 = &depth; /* Use this for a depth count. */
 			stackWalkState.frameWalkFunction = writeFrameCallBack;
 			stackWalkState.userData3 = &monitorInfos;
-			stackWalkState.userData4 = (void *) monitorCount;
+			stackWalkState.userData4 = (void *)monitorCount;
 
 			closure.jcw = this;
 			closure.state = &stackWalkState;
 
-			if (j9sig_protect(protectedWalkJavaStack, &closure, handlerJavaThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &sink) == 0) {
-				if (depth == 0) {
+			if (j9sig_protect(protectedWalkJavaStack, &closure, handlerJavaThreadWalk, this, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink) == 0) {
+				if (0 == depth) {
 					/* No stack frames => look for exception */
 					if (!avoidLocks()) {
 						j9object_t* throwable = NULL;
 
 						/* Have we stashed an uncaught exception? */
-						if (vmThread == _Context->onThread && _Context->eventData) {
+						if ((vmThread == _Context->onThread) && (NULL != _Context->eventData)) {
 							throwable = (j9object_t*)_Context->eventData->exceptionRef;
 						}
 
 						/* Otherwise default to current exception slot */
-						if (throwable == NULL) {
+						if (NULL == throwable) {
 							throwable = &(vmThread->currentException);
 						}
 
-						if (throwable && *throwable) {
+						if ((NULL != throwable) && (NULL != *throwable)) {
 							struct walkClosure stackClosure;
-							void *parameters[] = {vmThread, throwable, &stackWalkState};
+							void *parameters[] = { vmThread, throwable, &stackWalkState };
 
 							stackClosure.jcw = this;
 							stackClosure.state = parameters;
 
-							if(j9sig_protect(protectedIterateStackTrace,
+							if (j9sig_protect(protectedIterateStackTrace,
 									&stackClosure, handlerIterateStackTrace, this,
-									J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, &sink) == 0 ) {
-								if( depth == 0 ) { /* depth == 0 means call succeeded but no frames were written.*/
+									J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink) == 0) {
+								if (0 == depth) { /* depth == 0 means call succeeded but no frames were written.*/
 									_OutputStream.writeCharacters("3XMTHREADINFO3           No Java callstack associated with throwable\n");
 								}
 							}
@@ -4557,7 +4501,7 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			_OutputStream.writeCharacters("3XMTHREADINFO3           No Java callstack associated with this thread\n");
 		}
 	} else {
-		if (nativeThread) {
+		if (NULL != nativeThread) {
 			_OutputStream.writeCharacters("3XMTHREADINFO      Anonymous native thread\n");
 			_OutputStream.writeCharacters("3XMTHREADINFO1            (native thread ID:");
 			_OutputStream.writeInteger(nativeThread->thread_id);
@@ -4567,15 +4511,13 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 		}
 	}
 
-	if (nativeThread && nativeThread->callstack) {
-		J9PlatformStackFrame *frame;
-
+	if ((NULL != nativeThread) && (NULL != nativeThread->callstack)) {
 		_OutputStream.writeCharacters("3XMTHREADINFO3           Native callstack:\n");
 
-		frame = nativeThread->callstack;
-		while (frame) {
+		J9PlatformStackFrame *frame = nativeThread->callstack;
+		while (NULL != frame) {
 			_OutputStream.writeCharacters("4XENATIVESTACK               ");
-			if (frame->symbol) {
+			if (NULL != frame->symbol) {
 				_OutputStream.writeCharacters(frame->symbol);
 			} else {
 				_OutputStream.writePointer((void*)frame->instruction_pointer);
@@ -4594,7 +4536,6 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 	}
 
 	_OutputStream.writeCharacters("NULL\n");
-
 }
 
 /**************************************************************************************************/
@@ -4606,8 +4547,8 @@ void
 JavaCoreDumpWriter::writeThreadName(J9VMThread* vmThread)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
-	if (vmThread) {
-		void *args[] = {_VirtualMachine, vmThread};
+	if (NULL != vmThread) {
+		void *args[] = { _VirtualMachine, vmThread };
 		const char *nameClean = "";
 		const char *nameFault = nameClean;
 
@@ -4615,9 +4556,9 @@ JavaCoreDumpWriter::writeThreadName(J9VMThread* vmThread)
 		 * name out of it (i.e. we're sharing exclusive with GC). If we fault while trying to get the
 		 * name we return "<name unavailable>" instead
 		 */
-		if (j9sig_protect(protectedGetVMThreadName, args, handlerGetVMThreadName, (UDATA*)&nameFault, J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nameClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
+		if (j9sig_protect(protectedGetVMThreadName, args, handlerGetVMThreadName, (UDATA*)&nameFault, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, (UDATA*)&nameClean) == J9PORT_SIG_EXCEPTION_OCCURRED) {
 			_OutputStream.writeCharacters(nameFault);
-		} else if( nameClean != NULL ) {
+		} else if (NULL != nameClean) {
 			_OutputStream.writeCharacters(nameClean);
 		} else {
 			_OutputStream.writeCharacters("<name locked>");
@@ -4634,31 +4575,26 @@ JavaCoreDumpWriter::writeThreadName(J9VMThread* vmThread)
 /*                                                                                                */
 /**************************************************************************************************/
 void
-JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9object_t lockObject, J9VMThread *lockOwnerThread )
+JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9object_t lockObject, J9VMThread *lockOwnerThread)
 {
-	if ( vmThread == NULL ) {
+	if (NULL == vmThread) {
 		return;
 	}
 
 	j9object_t lockOwnerObject = NULL;
-	if ( vmstate == J9VMTHREAD_STATE_BLOCKED ) {
-
-		if( lockObject != NULL ) {
-			_OutputStream.writeCharacters("3XMTHREADBLOCK     Blocked on: " );
+	if (J9VMTHREAD_STATE_BLOCKED == vmstate) {
+		if (NULL != lockObject) {
+			_OutputStream.writeCharacters("3XMTHREADBLOCK     Blocked on: ");
 		} else {
 			return; // Probably a system monitor, nothing interesting to write.
 		}
-
-	} else if ( (vmstate == J9VMTHREAD_STATE_WAITING) || (vmstate == J9VMTHREAD_STATE_WAITING_TIMED) ) {
-
-		if( lockObject != NULL ) {
-			_OutputStream.writeCharacters("3XMTHREADBLOCK     Waiting on: " );
+	} else if ((J9VMTHREAD_STATE_WAITING == vmstate) || (J9VMTHREAD_STATE_WAITING_TIMED == vmstate)) {
+		if (NULL != lockObject) {
+			_OutputStream.writeCharacters("3XMTHREADBLOCK     Waiting on: ");
 		} else {
 			return; // Probably a system monitor, nothing interesting to write.
 		}
-
-	} else if ( vmstate == J9VMTHREAD_STATE_PARKED || vmstate == J9VMTHREAD_STATE_PARKED_TIMED ) {
-
+	} else if ((J9VMTHREAD_STATE_PARKED == vmstate) || (J9VMTHREAD_STATE_PARKED_TIMED == vmstate)) {
 		/*
 		 * The lock object is a reference passed to the park() call, assuming the call
 		 * was made with the version that takes an object ref. (The standard implementation
@@ -4673,22 +4609,19 @@ JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9o
 		 * for lockOwnerThread.
 		 * (This happens when the owning thread has terminated, see below.)
 		 */
-		if ( lockObject && !lockOwnerThread ) {
-			J9Class *aosClazz;
-			aosClazz = J9VMJAVAUTILCONCURRENTLOCKSABSTRACTOWNABLESYNCHRONIZER_OR_NULL(vmThread->javaVM);
+		if ((NULL != lockObject) && (NULL == lockOwnerThread)) {
+			J9Class *aosClazz = J9VMJAVAUTILCONCURRENTLOCKSABSTRACTOWNABLESYNCHRONIZER_OR_NULL(vmThread->javaVM);
 			/* skip this step if aosClazz doesn't exist */
-			if ( aosClazz ) {
-				J9Class *clazz;
-				clazz = J9OBJECT_CLAZZ(vmThread, lockObject);
+			if (NULL != aosClazz) {
+				J9Class *clazz = J9OBJECT_CLAZZ(vmThread, lockObject);
 				/* PR 80305 : Do not write back to the castClassCache as this code may be running while the GC is unloading the class */
-				if ( instanceOfOrCheckCastNoCacheUpdate(clazz, aosClazz) ) {
+				if (instanceOfOrCheckCastNoCacheUpdate(clazz, aosClazz)) {
 					lockOwnerObject =
 							J9VMJAVAUTILCONCURRENTLOCKSABSTRACTOWNABLESYNCHRONIZER_EXCLUSIVEOWNERTHREAD(vmThread, lockObject);
 				}
 			}
 		}
-		_OutputStream.writeCharacters("3XMTHREADBLOCK     Parked on: " );
-
+		_OutputStream.writeCharacters("3XMTHREADBLOCK     Parked on: ");
 	} else {
 		// If not blocked, waiting or parked, don't write anything out.
 		return;
@@ -4696,13 +4629,13 @@ JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9o
 	// We have the lockObject and lockOwner, and have decided if we are
 	// parked or blocked. Write the rest of the output here to ensure
 	// consistency.
-	if ( lockObject ) {
+	if (NULL != lockObject) {
 		writeObject(lockObject);
 	} else {
 		_OutputStream.writeCharacters("<unknown>");
 	}
 	_OutputStream.writeCharacters(" Owned by: ");
-	if ( lockOwnerThread != NULL ) {
+	if (NULL != lockOwnerThread) {
 		_OutputStream.writeCharacters("\"");
 		writeThreadName(lockOwnerThread);
 		_OutputStream.writeCharacters("\" (J9VMThread:");
@@ -4710,16 +4643,14 @@ JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9o
 		_OutputStream.writeCharacters(", java/lang/Thread:");
 		_OutputStream.writePointer(lockOwnerThread->threadObject);
 		_OutputStream.writeCharacters(")");
-	} else if ( lockOwnerObject != NULL ) {
+	} else if (NULL != lockOwnerObject) {
 		// The owning thread has terminated. We need to report this
 		// as the parked thread is deadlocked. We can't get the thread
 		// name from the lockOwner thread, it's null, but it will be
 		// available inside the java/lang/Thread object on the heap.
-		j9object_t nameObject = NULL;
-		char *threadName = NULL;
-		nameObject = J9VMJAVALANGTHREAD_NAME(vmThread, lockOwnerObject);
-		threadName = getVMThreadNameFromString(vmThread, nameObject);
-		if( threadName != NULL ) {
+		j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(vmThread, lockOwnerObject);
+		char *threadName = getVMThreadNameFromString(vmThread, nameObject);
+		if (NULL != threadName) {
 			// Port access so we can free threadName.
 			PORT_ACCESS_FROM_JAVAVM(vmThread->javaVM);
 			_OutputStream.writeCharacters("\"");
@@ -4735,7 +4666,7 @@ JavaCoreDumpWriter::writeThreadBlockers(J9VMThread* vmThread, UDATA vmstate, j9o
 		_OutputStream.writePointer(lockOwnerObject);
 		_OutputStream.writeCharacters(")");
 	} else {
-		if( vmstate == J9VMTHREAD_STATE_PARKED || vmstate == J9VMTHREAD_STATE_PARKED_TIMED ) {
+		if ((J9VMTHREAD_STATE_PARKED == vmstate) || (J9VMTHREAD_STATE_PARKED_TIMED == vmstate)) {
 			// No owning thread recorded.
 			_OutputStream.writeCharacters("<unknown>");
 		} else {
@@ -4761,19 +4692,19 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	IDATA *monitorCount = (IDATA*)(&state->userData4);
 
 	/* Reset to show we dumped frames */
-	if ((*depth) == 0) {
+	if (0 == *depth) {
 		/* first time through */
 		_OutputStream.writeCharacters("3XMTHREADINFO3           Java callstack:\n");
 	}
 
-	if( ++(*depth) > _MaximumJavaStackDepth ) {
+	if (++(*depth) > _MaximumJavaStackDepth) {
 		_OutputStream.writeCharacters("4XESTACKERR                  Java callstack truncated at ");
 		_OutputStream.writeInteger(_MaximumJavaStackDepth, "%zu");
 		_OutputStream.writeCharacters(" methods\n");
 		return J9_STACKWALK_STOP_ITERATING;
 	}
 
-	if (method == NULL) {
+	if (NULL == method) {
 		_OutputStream.writeCharacters("4XESTACKTRACE                at (Missing Method)\n");
 		return J9_STACKWALK_STOP_ITERATING;
 	}
@@ -4788,7 +4719,7 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	_OutputStream.writeCharacters(".");
 	_OutputStream.writeCharacters(methodName);
 
-	if (romMethod->modifiers & J9AccNative) {
+	if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccNative)) {
 		_OutputStream.writeCharacters("(Native Method)\n");
 		return J9_STACKWALK_KEEP_ITERATING;
 	}
@@ -4801,9 +4732,9 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	J9JITExceptionTable* metaData  = state->jitInfo;
 	void*                stackMap  = NULL;
 
-	if (jitConfig && metaData) {
+	if ((NULL != jitConfig) && (NULL != metaData)) {
 		stackMap = jitConfig->jitGetInlinerMapFromPC(_VirtualMachine, metaData, (UDATA)state->pc);
-		if (stackMap) {
+		if (NULL != stackMap) {
 			compiledMethod = true;
 		}
 	}
@@ -4813,13 +4744,13 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	/* Write source file and line number info, if available and we can take locks. */
 	if (!avoidLocks()) {
 		J9UTF8* sourceFile = getSourceFileNameForROMClass(_VirtualMachine, methodClass->classLoader, methodClass->romClass);
-		if (sourceFile) {
+		if (NULL != sourceFile) {
 			_OutputStream.writeCharacters("(");
 			_OutputStream.writeCharacters(sourceFile);
 
 			UDATA lineNumber = getLineNumberForROMClass(_VirtualMachine, method, offsetPC);
 
-			if (lineNumber != (UDATA)-1) {
+			if ((UDATA)-1 != lineNumber) {
 				_OutputStream.writeCharacters(":");
 				_OutputStream.writeInteger(lineNumber, "%zu");
 			}
@@ -4831,7 +4762,7 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 			_OutputStream.writeCharacters(")\n");
 
 			/* Use a while loop as there may be more than one lock taken in a stack frame. */
-			while((*monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
+			while ((0 != *monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
 				_OutputStream.writeCharacters("5XESTACKTRACE                   (entered lock: ");
 				writeObject(monitorInfo->object);
 				_OutputStream.writeCharacters(", entry count: ");
@@ -4860,7 +4791,7 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	_OutputStream.writeCharacters(")\n");
 
 	/* Use a while loop as there may be more than one lock taken in a stack frame. */
-	while((*monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
+	while ((0 != *monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
 		_OutputStream.writeCharacters("5XESTACKTRACE                   (entered lock: ");
 		writeObject(monitorInfo->object);
 		_OutputStream.writeCharacters(", entry count: ");
@@ -4889,13 +4820,13 @@ JavaCoreDumpWriter::writeExceptionFrame(
 	UDATA        lineNumber
 )
 {
-	if (((J9StackWalkState*)userData)->userData2) {
+	if (NULL != ((J9StackWalkState*)userData)->userData2) {
 		/* first time through */
 		_OutputStream.writeCharacters("3XMTHREADINFO3           Java callstack:\n");
-		((J9StackWalkState*)userData)->userData2 = (void*) 0;
+		((J9StackWalkState*)userData)->userData2 = (void*)0;
 	}
 
-	if (romMethod == NULL) {
+	if (NULL == romMethod) {
 		_OutputStream.writeCharacters("4XESTACKTRACE                at (Missing Method)\n");
 		return TRUE;
 	}
@@ -4908,16 +4839,16 @@ JavaCoreDumpWriter::writeExceptionFrame(
 	_OutputStream.writeCharacters(".");
 	_OutputStream.writeCharacters(methodName);
 
-	if (romMethod->modifiers & J9AccNative) {
+	if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccNative)) {
 		_OutputStream.writeCharacters("(Native Method)\n");
 		return TRUE;
 	}
 
-	if (sourceFile) {
+	if (NULL != sourceFile) {
 		_OutputStream.writeCharacters("(");
 		_OutputStream.writeCharacters(sourceFile);
 
-		if (lineNumber != (UDATA)-1) {
+		if ((UDATA)-1 != lineNumber) {
 			_OutputStream.writeCharacters(":");
 			_OutputStream.writeInteger(lineNumber, "%zu");
 		}
@@ -4930,7 +4861,6 @@ JavaCoreDumpWriter::writeExceptionFrame(
 	return TRUE;
 }
 
-
 /**************************************************************************************************/
 /*                                                                                                */
 /* JavaCoreDumpWriter::writeThreadTime() method implementation                                    */
@@ -4942,7 +4872,7 @@ JavaCoreDumpWriter::writeThreadTime(const char * timerName, I_64 nanoTime)
 	_OutputStream.writeCharacters(timerName);
 	_OutputStream.writeCharacters(": ");
 	// Special case 0 to 0.0 for readability.
-	if( nanoTime == 0) {
+	if (0 == nanoTime) {
 		_OutputStream.writeCharacters("0.0");
 	} else {
 		_OutputStream.writeInteger64((U_64)nanoTime / 1000000000, "%llu");
@@ -4962,15 +4892,15 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 {
 	/* Determine and write the status of the given loader */
 	j9object_t object = getClassLoaderObject(classLoader);
-	j9object_t parent = object ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, object) : NULL;
+	j9object_t parent = (NULL != object) ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, object) : NULL;
 	j9object_t appLdr = getClassLoaderObject(_VirtualMachine->applicationClassLoader);
-	j9object_t extLdr = appLdr ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
+	j9object_t extLdr = (NULL != appLdr) ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
 
-	bool unload = (_Context->eventFlags & J9RAS_DUMP_ON_CLASS_UNLOAD) != 0;
+	bool unload = J9_ARE_ANY_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_CLASS_UNLOAD);
 
 	bool isSystem = (classLoader == _VirtualMachine->systemClassLoader);
-	bool isApp    = (appLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
-	bool isExt    = (extLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
+	bool isApp    = ((NULL != appLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
+	bool isExt    = ((NULL != extLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
 	bool isAnon   = (classLoader == _VirtualMachine->anonClassLoader);
 
 	char flags[9];
@@ -4998,7 +4928,7 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
 
-	} else if (object == NULL) {
+	} else if (NULL == object) {
 		_OutputStream.writeCharacters(" Loader [missing](");
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
@@ -5010,7 +4940,7 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")");
 
-		if (parent) {
+		if (NULL != parent) {
 			_OutputStream.writeCharacters(", Parent ");
 			_OutputStream.writeCharacters(J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ_VM(_VirtualMachine, parent)->romClass));
 			_OutputStream.writeCharacters("(");
@@ -5025,7 +4955,7 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 	/* Determine and write the number of loaded libraries */
 	_OutputStream.writeCharacters("3CLNMBRLOADEDLIB\t\tNumber of loaded libraries ");
 
-	if (classLoader->sharedLibraries == NULL) {
+	if (NULL == classLoader->sharedLibraries) {
 		_OutputStream.writeInteger(0, "%zu");
 	} else {
 		_OutputStream.writeInteger(pool_numElements(classLoader->sharedLibraries), "%zu");
@@ -5045,22 +4975,21 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 	J9Class*         clazz = _VirtualMachine->internalVMFunctions->allClassesStartDo(&classWalkState, _VirtualMachine, classLoader);
 #if defined(J9VM_OPT_SHARED_CLASSES)
 	UDATA            sharedCount = 0;
-	void *sharedROMBoundsStart, *sharedROMBoundsEnd;
+	void *sharedROMBoundsStart = NULL;
+	void *sharedROMBoundsEnd = NULL;
 
-	if (_VirtualMachine->sharedClassConfig && (classLoader->flags & J9CLASSLOADER_SHARED_CLASSES_ENABLED)) {
+	if ((NULL != _VirtualMachine->sharedClassConfig) && J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_SHARED_CLASSES_ENABLED)) {
 		sharedROMBoundsStart = _VirtualMachine->sharedClassConfig->cacheDescriptorList->romclassStartAddress;
 		sharedROMBoundsEnd = _VirtualMachine->sharedClassConfig->cacheDescriptorList->metadataStartAddress;
-	} else {
-		sharedROMBoundsStart = sharedROMBoundsEnd = NULL;
 	}
 #endif
 
-	while (clazz) {
+	while (NULL != clazz) {
 		if ((clazz->classLoader == classLoader) || isAnon) {
 			count++;
 		}
 #if defined(J9VM_OPT_SHARED_CLASSES)
-		if (sharedROMBoundsStart && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
+		if ((NULL != sharedROMBoundsStart) && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
 			sharedCount++;
 		}
 #endif
@@ -5075,7 +5004,7 @@ JavaCoreDumpWriter::writeLoader(J9ClassLoader* classLoader)
 	_OutputStream.writeCharacters("\n");
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	if (sharedROMBoundsStart) {
+	if (NULL != sharedROMBoundsStart) {
 		/* Determine and write the number of loaded classes */
 		_OutputStream.writeCharacters("3CLNMBRSHAREDCL\t\t\tNumber of shared classes ");
 		_OutputStream.writeInteger(sharedCount, "%zu");
@@ -5095,20 +5024,20 @@ JavaCoreDumpWriter::writeLibraries(J9ClassLoader* classLoader)
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 	char* executableName = NULL;
 	/* If there are no libraries, there is nothing to do */
-	if (classLoader->sharedLibraries == NULL) {
+	if (NULL == classLoader->sharedLibraries) {
 		return;
 	}
 
 	/* Determine the status of the given loader */
 	j9object_t object = getClassLoaderObject(classLoader);
 	j9object_t appLdr = getClassLoaderObject(_VirtualMachine->applicationClassLoader);
-	j9object_t extLdr = appLdr ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
+	j9object_t extLdr = (NULL != appLdr) ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
 
-	bool unload = (_Context->eventFlags & J9RAS_DUMP_ON_CLASS_UNLOAD) != 0;
+	bool unload = J9_ARE_ANY_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_CLASS_UNLOAD);
 
 	bool isSystem = (classLoader == _VirtualMachine->systemClassLoader);
-	bool isApp = (appLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
-	bool isExt = (extLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
+	bool isApp = ((NULL != appLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
+	bool isExt = ((NULL != extLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
 
 	/* Decode and write the status */
 	_OutputStream.writeCharacters("2CLTEXTCLLIB    \t");
@@ -5123,7 +5052,7 @@ JavaCoreDumpWriter::writeLibraries(J9ClassLoader* classLoader)
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
 
-	} else if (object == NULL) {
+	} else if (NULL == object) {
 		_OutputStream.writeCharacters("Loader [missing](");
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
@@ -5140,7 +5069,7 @@ JavaCoreDumpWriter::writeLibraries(J9ClassLoader* classLoader)
 	pool_state       sharedLibrariesWalkState;
 	J9NativeLibrary* sharedLibrary = (J9NativeLibrary*)pool_startDo(classLoader->sharedLibraries, &sharedLibrariesWalkState);
 
-	while (sharedLibrary) {
+	while (NULL != sharedLibrary) {
 		if (J9NATIVELIB_LINK_MODE_STATIC == sharedLibrary->linkMode) {
 			/* Attempt obtaining executable name when first statically linked library is encountered. */
 			if (NULL == executableName) {
@@ -5177,13 +5106,13 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 	/* Determine the status of the given loader */
 	j9object_t object = getClassLoaderObject(classLoader);
 	j9object_t appLdr = getClassLoaderObject(_VirtualMachine->applicationClassLoader);
-	j9object_t extLdr = appLdr ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
+	j9object_t extLdr = (NULL != appLdr) ? J9VMJAVALANGCLASSLOADER_PARENT_VM(_VirtualMachine, appLdr) : NULL;
 
-	bool unload = (_Context->eventFlags & J9RAS_DUMP_ON_CLASS_UNLOAD) != 0;
+	bool unload = J9_ARE_ANY_BITS_SET(_Context->eventFlags, J9RAS_DUMP_ON_CLASS_UNLOAD);
 
 	bool isSystem = (classLoader == _VirtualMachine->systemClassLoader);
-	bool isApp = (appLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
-	bool isExt = (extLdr ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
+	bool isApp = ((NULL != appLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, appLdr) : false);
+	bool isExt = ((NULL != extLdr) ? classLoader == J9VMJAVALANGCLASSLOADER_VMREF_VM(_VirtualMachine, extLdr) : false);
 	bool isAnon = (classLoader == _VirtualMachine->anonClassLoader);
 	/* Decode and write the status */
 	_OutputStream.writeCharacters("2CLTEXTCLLOAD  \t\t");
@@ -5198,7 +5127,7 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
 
-	} else if (object == NULL) {
+	} else if (NULL == object) {
 		_OutputStream.writeCharacters("Loader [missing](");
 		_OutputStream.writePointer(object);
 		_OutputStream.writeCharacters(")\n");
@@ -5219,17 +5148,16 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 	J9ClassWalkState classWalkState;
 	J9Class*         clazz = _VirtualMachine->internalVMFunctions->allClassesStartDo(&classWalkState, _VirtualMachine, classLoader);
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	void *sharedROMBoundsStart, *sharedROMBoundsEnd;
+	void *sharedROMBoundsStart = NULL;
+	void *sharedROMBoundsEnd = NULL;
 
-	if (_VirtualMachine->sharedClassConfig && (classLoader->flags & J9CLASSLOADER_SHARED_CLASSES_ENABLED)) {
+	if ((NULL != _VirtualMachine->sharedClassConfig) && J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_SHARED_CLASSES_ENABLED)) {
 		sharedROMBoundsStart = _VirtualMachine->sharedClassConfig->cacheDescriptorList->romclassStartAddress;
 		sharedROMBoundsEnd = _VirtualMachine->sharedClassConfig->cacheDescriptorList->metadataStartAddress;
-	} else {
-		sharedROMBoundsStart = sharedROMBoundsEnd = NULL;
 	}
 #endif
 
-	while (clazz) {
+	while (NULL != clazz) {
 		/* Ignore classes which do not belong to the current loader */
 		if ((clazz->classLoader == classLoader) || isAnon) {
 			/* Handle arrays and normal classes separately */
@@ -5261,7 +5189,7 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 				_OutputStream.writeCharacters("(");
 				_OutputStream.writePointer(clazz);
 #if defined(J9VM_OPT_SHARED_CLASSES)
-				if (sharedROMBoundsStart && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
+				if ((NULL != sharedROMBoundsStart) && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
 					_OutputStream.writeCharacters(" shared");
 				}
 #endif
@@ -5274,7 +5202,7 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 				_OutputStream.writeCharacters("(");
 				_OutputStream.writePointer(clazz);
 #if defined(J9VM_OPT_SHARED_CLASSES)
-				if (sharedROMBoundsStart && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
+				if ((NULL != sharedROMBoundsStart) && (clazz->romClass >= sharedROMBoundsStart) && (clazz->romClass < sharedROMBoundsEnd)) {
 					_OutputStream.writeCharacters(" shared");
 				}
 #endif
@@ -5296,7 +5224,7 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 j9object_t
 JavaCoreDumpWriter::getClassLoaderObject(J9ClassLoader* loader)
 {
-	return (j9object_t)((loader != NULL) ? TMP_J9CLASSLOADER_CLASSLOADEROBJECT(loader) : NULL);
+	return (j9object_t)((NULL != loader) ? TMP_J9CLASSLOADER_CLASSLOADEROBJECT(loader) : NULL);
 }
 
 /**
@@ -5317,12 +5245,12 @@ JavaCoreDumpWriter::getOwnedObjectMonitors(J9VMThread* vmThread, J9ObjectMonitor
 	 * trace. (The array is walked backwards so the totals start at 1 at the bottom of the stack!)
 	 * (monitorCount is set to 0 if handlerGetOwnedObjectMonitors is called.)
 	 */
-	for( IDATA i = monitorCount - 2; i >= 0; i-- ) {
-		IDATA j = i+1;
-		while(  j < monitorCount &&  monitorInfos[i].object != monitorInfos[j].object ) {
+	for (IDATA i = monitorCount - 2; i >= 0; i--) {
+		IDATA j = i + 1;
+		while (j < monitorCount && monitorInfos[i].object != monitorInfos[j].object) {
 			j++;
 		}
-		if( j < monitorCount ) {
+		if (j < monitorCount) {
 			monitorInfos[i].count += monitorInfos[j].count;
 		}
 	}
@@ -5345,7 +5273,6 @@ JavaCoreDumpWriter::writeJavaLangThreadInfo (J9VMThread* vmThread)
 	_OutputStream.writeCharacters(", isDaemon:");
 	_OutputStream.writeCharacters(J9VMJAVALANGTHREAD_ISDAEMON(vmThread, vmThread->threadObject)?"true":"false");
 	_OutputStream.writeCharacters(")\n");
-
 }
 
 void
@@ -5383,9 +5310,9 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 
 	char buff[400];
 	intptr_t rc = -1;
-	if (_VirtualMachine->jitConfig) {
+	if (NULL != _VirtualMachine->jitConfig) {
 		rc = omrsysinfo_get_processor_feature_string(&_VirtualMachine->jitConfig->targetProcessor, buff, sizeof(buff));
-		if (rc != -1) {
+		if (-1 != rc) {
 			_OutputStream.writeCharacters(
 					"2CIJITFEATURE  CPU features (JIT): ");
 			_OutputStream.writeCharacters(buff);
@@ -5393,7 +5320,7 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 		}
 
 		rc = omrsysinfo_get_processor_feature_string(&_VirtualMachine->jitConfig->relocatableTargetProcessor, buff, sizeof(buff));
-		if (rc != -1) {
+		if (-1 != rc) {
 			_OutputStream.writeCharacters(
 					"2CIAOTFEATURE  CPU features (AOT): ");
 			_OutputStream.writeCharacters(buff);
@@ -5403,7 +5330,7 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 		OMRProcessorDesc processorDescription;
 		omrsysinfo_get_processor_description(&processorDescription);
 		rc = omrsysinfo_get_processor_feature_string(&processorDescription, buff, sizeof(buff));
-		if (rc != -1) {
+		if (-1 != rc) {
 			_OutputStream.writeCharacters(
 					"2CIINTFEATURE  CPU features (INT): ");
 			_OutputStream.writeCharacters(buff);
@@ -5530,11 +5457,9 @@ spaceIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateSpaceDescriptor* spa
 	UDATA allocTotal = 0;
 	UDATA freeTotal = 0;
 #if defined (J9VM_GC_VLHGC)
-	UDATA regionEnd;
 	regioniterationblock regionTotals;
 #endif /* J9VM_GC_VLHGC */
 	JavaCoreDumpWriter* jcw = (JavaCoreDumpWriter*)userData;
-
 
 	jcw->_OutputStream.writeCharacters("NULL           ");
 #if defined(J9VM_ENV_DATA64)
@@ -5561,11 +5486,11 @@ spaceIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateSpaceDescriptor* spa
 		jcw->_OutputStream.writeCharacters("1STHEAPSPACE   ");
 		jcw->_OutputStream.writePointer((void *)spaceDescriptor->id);
 		jcw->_OutputStream.writeCharacters(" ");
-		jcw->_OutputStream.writeVPrintf("%*c--%*c",  sizeof(void *), ' ',  sizeof(void *), ' ');
+		jcw->_OutputStream.writeVPrintf("%*c--%*c", sizeof(void *), ' ', sizeof(void *), ' ');
 		jcw->_OutputStream.writeCharacters(" ");
-		jcw->_OutputStream.writeVPrintf("%*c--%*c",  sizeof(void *), ' ',  sizeof(void *), ' ');
+		jcw->_OutputStream.writeVPrintf("%*c--%*c", sizeof(void *), ' ', sizeof(void *), ' ');
 		jcw->_OutputStream.writeCharacters(" ");
-		jcw->_OutputStream.writeVPrintf("%*c--%*c",  sizeof(void *), ' ',  sizeof(void *), ' ');
+		jcw->_OutputStream.writeVPrintf("%*c--%*c", sizeof(void *), ' ', sizeof(void *), ' ');
 		jcw->_OutputStream.writeCharacters(" ");
 		jcw->_OutputStream.writeCharacters(spaceDescriptor->name);
 		jcw->_OutputStream.writeCharacters("\n");
@@ -5579,7 +5504,7 @@ spaceIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateSpaceDescriptor* spa
 		jcw->_OutputStream.writeCharacters(" ");
 		jcw->_OutputStream.writePointer((void *)regionTotals._regionStart);
 		jcw->_OutputStream.writeCharacters(" ");
-		regionEnd = (UDATA)regionTotals._regionStart + (UDATA)regionTotals._regionSize;
+		UDATA regionEnd = (UDATA)regionTotals._regionStart + (UDATA)regionTotals._regionSize;
 		jcw->_OutputStream.writePointer((const void*)regionEnd);
 		jcw->_OutputStream.writeCharacters(" ");
 		jcw->_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, regionTotals._regionSize);
@@ -5594,7 +5519,7 @@ spaceIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateSpaceDescriptor* spa
 	freeTotal = virtualMachine->memoryManagerFunctions->j9gc_heap_free_memory(virtualMachine);
 	allocTotal = sizeTotal - freeTotal;
 
-	int decimalLength = sizeof(void*) == 4 ? 10 : 20;
+	int decimalLength = (sizeof(void *) == 4) ? 10 : 20;
 
 	jcw->_OutputStream.writeCharacters("NULL\n");
 	jcw->_OutputStream.writeCharacters("1STHEAPTOTAL   ");
@@ -5603,7 +5528,7 @@ spaceIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateSpaceDescriptor* spa
 	jcw->_OutputStream.writeCharacters(" (");
 	jcw->_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, sizeTotal);
 	jcw->_OutputStream.writeCharacters(")\n");
-	if (sizeTarget != 0) {
+	if (0 != sizeTarget) {
 		jcw->_OutputStream.writeCharacters("1STHEAPTARGET  ");
 		jcw->_OutputStream.writeCharacters("Target memory:       ");
 		jcw->_OutputStream.writeVPrintf(FORMAT_SIZE_DECIMAL, decimalLength, sizeTarget);
@@ -5639,7 +5564,7 @@ regionIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateRegionDescriptor* r
 #if defined(J9VM_GC_VLHGC)
 		regioniterationblock* regionTotals = (regioniterationblock*)userData;
 
-		if (true == regionTotals->_newIteration) {
+		if (regionTotals->_newIteration) {
 			regionTotals->_newIteration = false;
 			regionTotals->_regionSize = 0;
 			regionTotals->_regionStart = regionDescriptor->regionStart;
@@ -5651,14 +5576,13 @@ regionIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateRegionDescriptor* r
 		 * For normal GC modes we can print a line per region as
 		 * we iterate over the regions.
 		 */
-		UDATA regionEnd;
 		JavaCoreDumpWriter* jcw = (JavaCoreDumpWriter*)userData;
 		jcw->_OutputStream.writeCharacters("1STHEAPREGION  ");
 		jcw->_OutputStream.writePointer((void *)regionDescriptor->id);
 		jcw->_OutputStream.writeCharacters(" ");
 		jcw->_OutputStream.writePointer((void *)regionDescriptor->regionStart);
 		jcw->_OutputStream.writeCharacters(" ");
-		regionEnd = (UDATA)regionDescriptor->regionStart + (UDATA)regionDescriptor->regionSize;
+		UDATA regionEnd = (UDATA)regionDescriptor->regionStart + (UDATA)regionDescriptor->regionSize;
 		jcw->_OutputStream.writePointer((const void*)regionEnd);
 		jcw->_OutputStream.writeCharacters(" ");
 		jcw->_OutputStream.writeVPrintf(FORMAT_SIZE_HEX, sizeof(void *) * 2, regionDescriptor->regionSize);
@@ -6010,7 +5934,7 @@ handlerWriteStacks(struct J9PortLibrary *portLibrary, U_32 gpType, void* gpInfo,
 	JavaCoreDumpWriter* jcw = (JavaCoreDumpWriter*)userData;
 
 	jcw->_OutputStream.writeCharacters("NULL\n");
-	if( jcw->_ThreadsWalkStarted ==  true ) {
+	if (jcw->_ThreadsWalkStarted) {
 		jcw->_OutputStream.writeCharacters("1INTERNAL     Unable to walk threads. Some or all threads may have been omitted.\n");
 	} else {
 		jcw->_OutputStream.writeCharacters("1INTERNAL     Unable to collect native thread information.\n");
@@ -6050,25 +5974,26 @@ runJavadump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
 static IDATA
 vmthread_comparator(struct J9AVLTree *tree, struct J9AVLTreeNode *insertNode, struct J9AVLTreeNode *walkNode)
 {
-	UDATA insert_tid = 0, walk_tid = 0;
+	UDATA insert_tid = 0;
+	UDATA walk_tid = 0;
 	vmthread_avl_node *insert_thread = (vmthread_avl_node *)insertNode;
 	vmthread_avl_node *walk_thread = (vmthread_avl_node *)walkNode;
 
-	if (insert_thread == NULL || walkNode == NULL) {
+	if ((NULL == insert_thread) || (NULL == walkNode)) {
 		/* mustn't return a match for null nodes */
 		return -1;
 	}
 
-	if (insert_thread->vmthread->osThread) {
+	if (NULL != insert_thread->vmthread->osThread) {
 		insert_tid = omrthread_get_osId(insert_thread->vmthread->osThread);
-		if (insert_tid == 0) {
+		if (0 == insert_tid) {
 			insert_tid = (UDATA) (((U_8*)insert_thread->vmthread->osThread) + sizeof(J9AbstractThread));
 		}
 	}
 
-	if (walk_thread->vmthread->osThread) {
+	if (NULL != walk_thread->vmthread->osThread) {
 		walk_tid = omrthread_get_osId(walk_thread->vmthread->osThread);
-		if (walk_tid == 0) {
+		if (0 == walk_tid) {
 			walk_tid = (UDATA) (((U_8*)walk_thread->vmthread->osThread) + sizeof(J9AbstractThread));
 		}
 	}
@@ -6082,9 +6007,9 @@ vmthread_locator(struct J9AVLTree *tree, UDATA tid , struct J9AVLTreeNode *walkN
 	UDATA walk_tid = 0;
 	vmthread_avl_node *walk_thread = (vmthread_avl_node *)walkNode;
 
-	if (walk_thread->vmthread->osThread) {
+	if (NULL != walk_thread->vmthread->osThread) {
 		walk_tid = omrthread_get_osId(walk_thread->vmthread->osThread);
-		if (walk_tid == 0) {
+		if (0 == walk_tid) {
 			walk_tid = (UDATA) (((U_8*)walk_thread->vmthread->osThread) + sizeof(J9AbstractThread));
 		}
 	}


### PR DESCRIPTION
The first commit cleans up:
* remove the implicit dependency on order of flag bits in `prepState` and `requestMask`
* add missing parentheses
* explicitly compare values with `NULL` or `0`
* initialize local variables
* use `J9_ARE_ALL_BITS_SET`, `J9_ARE_ANY_BITS_SET` and `J9_ARE_NO_BITS_SET` where appropriate

The second commit fixes #13471.