### PR TITLE
(v0.29.0-release) JDK17+ reduce registerBootstrapLibrary usages

### DIFF
--- a/runtime/include/j9lib.h.ftl
+++ b/runtime/include/j9lib.h.ftl
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,6 @@ extern"C"{
 #endif
 
 #define J9_DLL_VERSION_STRING "${uma.buildinfo.version.major}${uma.buildinfo.version.minor}"
-
-#define J9_DEFAULT_JCL_DLL_NAME "${uma.spec.properties.defaultJclDll.value}"
 
 <#list uma.spec.artifacts as artifact>
 <#if artifact.data.dllDescription.present>

--- a/runtime/include/j9lib.h.in
+++ b/runtime/include/j9lib.h.in
@@ -25,8 +25,6 @@
 
 #define J9_DLL_VERSION_STRING "29"
 
-#define J9_DEFAULT_JCL_DLL_NAME "jclse29"
-
 #define J9_MANAGEMENT_EXTENSIONS_DLL_NAME "management_ext"
 #define J9_JAVACORE_GENERATOR_DLL_NAME "jcoregen29"
 #define J9_VM_DLL_NAME "j9vm29"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1275,7 +1275,7 @@ initializeDllLoadTable(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, UDAT
 /* This needs to be BEFORE the JCL library as we need to install hooks that are used
  * in the initialization of JCL library */
 
-	if (!createLoadInfo(portLibrary, returnVal, J9_DEFAULT_JCL_DLL_NAME, (LOAD_BY_DEFAULT | FATAL_NO_DLL), NULL, verboseFlags))
+	if (!createLoadInfo(portLibrary, returnVal, J9_JAVA_SE_DLL_NAME, (LOAD_BY_DEFAULT | FATAL_NO_DLL), NULL, verboseFlags))
 		goto _error;
 
 	if (NULL == createLoadInfo(portLibrary, returnVal, FUNCTION_ZERO_INIT, NOT_A_LIBRARY, (void*)&zeroInitStages, verboseFlags))
@@ -2197,7 +2197,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			/* Parse jcl options */
 			argIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, VMOPT_XJCL_COLON, NULL);
 			if (argIndex >= 0) {
-				loadInfo = FIND_DLL_TABLE_ENTRY( J9_DEFAULT_JCL_DLL_NAME );
+				loadInfo = FIND_DLL_TABLE_ENTRY(J9_JAVA_SE_DLL_NAME);
 				/* we know there is a colon */
 				GET_OPTION_VALUE(argIndex, ':', &optionValue);
 				GET_OPTION_OPTION(argIndex, ':', ':', &optionExtra);			/* Eg. -jcl:cldc:library=foo */
@@ -2210,7 +2210,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				}
 				vm->jclDLLName = (char *)(loadInfo->dllName);
 			} else {
-				vm->jclDLLName = J9_DEFAULT_JCL_DLL_NAME;
+				vm->jclDLLName = J9_JAVA_SE_DLL_NAME;
 			}
 
 			/* Warm up the VM Interface */

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -543,7 +543,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	J9VMSystemProperty *javaEndorsedDirsProperty = NULL;
 	jint i = 0;
 	JavaVMInitArgs *initArgs = NULL;
-	char *jclName = J9_DEFAULT_JCL_DLL_NAME;
+	char *jclName = J9_JAVA_SE_DLL_NAME;
 	UDATA j2seVersion = J2SE_VERSION(vm);
 	const char* propValue = NULL;
 	UDATA rc = J9SYSPROP_ERROR_NONE;


### PR DESCRIPTION
Removed redundant `J9_DEFAULT_JCL_DLL_NAME`.

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/13580

Signed-off-by: Jason Feng <fengj@ca.ibm.com>