### PR TITLE
Cannot have two aot instructions in test playlists

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
@@ -44,7 +44,6 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<aot>explicit</aot>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Update SCHelperCompatTests to remove `<aot>explicit</aot>`

Functional testing is failing to compile related to stricter validation on playlists: https://github.com/adoptium/TKG/pull/235