### PR TITLE
Update verification for initial memory paramters in Balanced GC

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2259,6 +2259,15 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 			subSpaceTooLargeOption = "-Xmns";
 			goto _subSpaceTooLarge;
 		}
+		if (!isLessThanEqualOrUnspecifiedAgainstFixed(&extensions->userSpecifiedParameters._Xmns, ms)) {
+			if (!opt_XmsSet) {
+				extensions->initialMemorySize = extensions->userSpecifiedParameters._Xmns._valueSpecified;
+			} else {
+				memoryOption = "-Xmn";
+				subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
+				goto _subSpaceTooLarge;
+			}
+		}
 		/* now interpret the values */
 		UDATA idealEdenMin = 0;
 		UDATA idealEdenMax = 0;


### PR DESCRIPTION
In case Xmns is specified and Xmns > Xms, match the same behavior in
 Gencon.
if Xms is specified, need to report error JVMJ9GC019E " -Xmns is too
 large for -Xms".
if Xms is not specified, need to reset extensions->initialMemorySize
 = Xmns.

fix:https://github.com/eclipse-openj9/openj9/issues/13558

Signed-off-by: Lin Hu <linhu@ca.ibm.com>