### PR TITLE
JDK18 adds Access.encodeASCII()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -205,7 +205,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava17.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava18.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=18"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -483,9 +483,6 @@ final class Access implements JavaLangAccess {
 		return VMAccess.findClassOrNull(name, ClassLoader.bootstrapClassLoader);
 	}
 
-	/*[IF OPENJDK_METHODHANDLES]*/
-	// This JPP flag is used to workaround the issue that latest 
-	// String update hasn't been promoted into openj9 branch. 
 	public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
 		return String.join(prefix, suffix, delimiter, elements, size);
 	}
@@ -511,7 +508,12 @@ final class Access implements JavaLangAccess {
 		Shutdown.exit(status);
 	}
 
-	/*[ENDIF] OPENJDK_METHODHANDLES*/
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
+		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 /*[ENDIF] Sidecar19-SE */


### PR DESCRIPTION
Removed `OPENJDK_METHODHANDLES` since `ojdk_mh` has been promoted;
Add `rt-compressed.sunJava18.jar` for `JAVA18 pConfig`.

Related to https://github.com/eclipse-openj9/openj9/issues/13600

Signed-off-by: Jason Feng <fengj@ca.ibm.com>