### PR TITLE
Disable testSoftMxNotDisclaimMemory_3

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -769,6 +769,12 @@
 	</test>
 	<test>
 		<testCaseName>testSoftMxNotDisclaimMemory</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/10732</comment>
+				<variation>Mode501</variation>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode119</variation>


### PR DESCRIPTION
Fails in every Windows 64-bit build.

Issue https://github.com/eclipse-openj9/openj9/issues/10732#issuecomment-927855842

Tested in grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/249/.
Builds, shows testSoftMxNotDisclaimMemory_3 is disabled, fails because no testing runs.