### PR TITLE
Remove duplicate definition of DEFERRED_RS_REMOVE_FLAG

### DIFF
--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -161,17 +161,6 @@ typedef jvmtiIterationControl J9MODRON_REFERENCE_CHAIN_WALKER_CALLBACK(J9Object 
  */
 
 /**
- * #defines representing tags used in the Remembered Set
- * @ingroup GC_Include
- * @{
- */
-#define DEFERRED_RS_REMOVE_FLAG 			0x1	
-/**
- * @}
- */
-
-
-/**
  * @ingroup GC_Include
  * @name Class loader flags
  * Borrowed from builder - should be made collector specific 


### PR DESCRIPTION
This flag is defined in omrgcconts.h in OMR project

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>