### PR TITLE
Avoid compilation errors when J9VM_INTERP_NATIVE_SUPPORT is undefined

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1212,9 +1212,10 @@ redefineClassesCommon(jvmtiEnv* env,
 			/* Indicate that a redefine has occurred */
 			vm->hotSwapCount += 1;
 
+#ifdef J9VM_INTERP_NATIVE_SUPPORT
 			/* Notify the JIT about redefined classes */
 			jitClassRedefineEvent(currentThread, &jitEventData, FALSE);
-
+#endif
 		} else {
 
 			/* Clear/suspend all breakpoints in the classes being replaced */

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1392,7 +1392,9 @@ fixVTables_forNormalRedefine(J9VMThread *currentThread, J9HashTable *classPairs,
 		/* Under fastHCR, fix the vTable in place for the redefined class. */
 		if (fastHCR && (0 != (classPair->flags & J9JVMTI_CLASS_PAIR_FLAG_REDEFINED))) {
 			newVTableHeader = oldVTableHeader;
+#ifdef J9VM_INTERP_NATIVE_SUPPORT
 			newJitVTable = oldJitVTable;
+#endif
 		}
 
 		Trc_hshelp_fixVTables_Shape(currentThread, vTableSize, getClassName(classPair->originalRAMClass));


### PR DESCRIPTION
This commit adds some #ifdef lines to avoid compilation errors when
J9VM_INTERP_NATIVE_SUPPORT is undefined.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>