### PR TITLE
(0.29) Add fast JNI implementation for java.lang.ref.Reference.refersTo()

### DIFF
--- a/runtime/vm/FastJNI_java_lang_ref_Reference.cpp
+++ b/runtime/vm/FastJNI_java_lang_ref_Reference.cpp
@@ -46,6 +46,28 @@ Fast_java_lang_ref_Reference_reprocess(J9VMThread *currentThread, j9object_t rec
 	mmFuncs->j9gc_objaccess_referenceReprocess(currentThread, receiverObject);
 }
 
+#if JAVA_SPEC_VERSION >= 16
+/* java.lang.ref.Reference: public native boolean refersTo(T target) */
+jboolean JNICALL
+Fast_java_lang_ref_Reference_refersTo(J9VMThread *currentThread, j9object_t reference, j9object_t target)
+{
+	J9JavaVM * const vm = currentThread->javaVM;
+	jboolean result = JNI_FALSE;
+
+	if (NULL == reference) {
+		vm->internalVMFunctions->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
+	} else {
+		j9object_t referent = vm->memoryManagerFunctions->j9gc_objaccess_referenceGet(currentThread, reference);
+
+		if (referent == target) {
+			result = JNI_TRUE;
+		}
+	}
+
+	return result;
+}
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
 J9_FAST_JNI_METHOD_TABLE(java_lang_ref_Reference)
 	J9_FAST_JNI_METHOD("getImpl", "()Ljava/lang/Object;", Fast_java_lang_ref_Reference_getImpl,
 		J9_FAST_JNI_RETAIN_VM_ACCESS | J9_FAST_JNI_NOT_GC_POINT | J9_FAST_JNI_NO_NATIVE_METHOD_FRAME | J9_FAST_JNI_NO_EXCEPTION_THROW |
@@ -53,5 +75,9 @@ J9_FAST_JNI_METHOD_TABLE(java_lang_ref_Reference)
 	J9_FAST_JNI_METHOD("reprocess", "()V", Fast_java_lang_ref_Reference_reprocess,
 		J9_FAST_JNI_RETAIN_VM_ACCESS | J9_FAST_JNI_NOT_GC_POINT | J9_FAST_JNI_NO_NATIVE_METHOD_FRAME | J9_FAST_JNI_NO_EXCEPTION_THROW |
 		J9_FAST_JNI_NO_SPECIAL_TEAR_DOWN | J9_FAST_JNI_DO_NOT_WRAP_OBJECTS)
+#if JAVA_SPEC_VERSION >= 16
+	J9_FAST_JNI_METHOD("refersTo", "(Ljava/lang/Object;)Z", Fast_java_lang_ref_Reference_refersTo,
+		J9_FAST_JNI_RETAIN_VM_ACCESS | J9_FAST_JNI_DO_NOT_WRAP_OBJECTS)
+#endif /* JAVA_SPEC_VERSION >= 16 */
 J9_FAST_JNI_METHOD_TABLE_END
 }


### PR DESCRIPTION
Add fast JNI implementation for java.lang.ref.Reference.refersTo()

back port of https://github.com/eclipse-openj9/openj9/pull/13597

Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>