### PR TITLE
AArch64: Add .text and .align directives to asm files

### DIFF
--- a/runtime/compiler/aarch64/runtime/FlushICache.spp
+++ b/runtime/compiler/aarch64/runtime/FlushICache.spp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,9 @@
  *******************************************************************************/
 
 	.globl	flushICache
+
+	.text
+	.align	2
 
 // in:  x0 = start address to flush
 //      x1 = # of bytes to flush

--- a/runtime/compiler/aarch64/runtime/Recompilation.spp
+++ b/runtime/compiler/aarch64/runtime/Recompilation.spp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,9 @@
 
 #define J9VMTHREAD x19
 #define J9SP x20
+
+	.text
+	.align	2
 
 _countingRecompileMethod:
 	hlt	#0	// Not implemented yet


### PR DESCRIPTION
This commit adds .text and .align directives to AArch64 asm files.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>