### PR TITLE
(0.29.0) Fix memcpy byte-to-char loop reduction for little endian architectures

### DIFF
--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -855,7 +855,7 @@ indexContainsArray(TR::Compilation *comp, TR::Node *index, vcount_t visitCount)
 
    if (comp->trace(OMR::idiomRecognition))
       traceMsg(comp, "analyzing node %p\n", index);
-   
+
    if (index->getOpCode().hasSymbolReference() &&
          index->getSymbolReference()->getSymbol()->isArrayShadowSymbol())
       {
@@ -877,7 +877,7 @@ indexContainsArrayAccess(TR::Compilation *comp, TR::Node *aXaddNode)
    {
    if (comp->trace(OMR::idiomRecognition))
       traceMsg(comp, "axaddnode %p\n", aXaddNode);
-   
+
    TR::Node *loadNode1, *loadNode2, *topLevelIndex;
    findIndexLoad(aXaddNode, loadNode1, loadNode2, topLevelIndex);
    // topLevelIndex now contains the actual expression q in a[q]
@@ -5734,7 +5734,7 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
 
 
    int32_t postIncrement = checkForPostIncrement(comp, block, cmpIfAllCISCNode->getHeadOfTrNodeInfo()->_node, exitVarSymRef->getSymbol());
-   
+
    if (disptrace)
       traceMsg(comp, "detected postIncrement %d modLength %d modStartIdx %d\n", postIncrement, modLength, modStartIdx);
 
@@ -6163,7 +6163,7 @@ CISCTransform2ArrayCopyB2CorC2B(TR_CISCTransformer *trans)
 
    // check whether the transformation is valid
    //
-   if (outputMemNode->getOpCode().isShort() && outputMemNode->getOpCode().isUnsigned())
+   if (outputMemNode->getOpCode().isShort())
       {
       TR::Node * iorNode = trans->getP2TRepInLoop(P->getImportantNode(2))->getHeadOfTrNodeInfo()->_node;
       if (!checkByteToChar(comp, iorNode, inputNode, bigEndian))

--- a/test/functional/JIT_Test/src/jit/test/loopReduction/bigEndianByte2CharMemCpy.java
+++ b/test/functional/JIT_Test/src/jit/test/loopReduction/bigEndianByte2CharMemCpy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,11 @@
  *******************************************************************************/
 package jit.test.loopReduction;
 
-public class byte2CharMemCpy extends base {
+/**
+ * The inner loop will only be detected and transformed on big endian architectures.
+ * Little endian architectures will run the loop untransformed.
+ */
+public class bigEndianByte2CharMemCpy extends base {
    static byte array1[] = new byte [10000];
    static char array2[] = new char [10000];
 

--- a/test/functional/JIT_Test/src/jit/test/loopReduction/idiomTests.java
+++ b/test/functional/JIT_Test/src/jit/test/loopReduction/idiomTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,8 @@ public class idiomTests
    public void testTRTOArray(Context c) { new TRTOArray().runTest(c); }
    public void testLongMemCpy(Context c) { new longMemCpy().runTest(c); }
    public void testByteMemCpy(Context c) { new byteMemCpy().runTest(c); }
-   public void testByte2CharMemCpy(Context c) { new byte2CharMemCpy().runTest(c); }
+   public void testBigEndianByte2CharMemCpy(Context c) { new bigEndianByte2CharMemCpy().runTest(c); }
+   public void testLittleEndianByte2CharMemCpy(Context c) { new littleEndianByte2CharMemCpy().runTest(c); }
    public void testChar2ByteMemCpy(Context c) { new char2ByteMemCpy().runTest(c); }
    public void testMEMCPYChar2Byte2(Context c) { new MEMCPYChar2Byte2().runTest(c); }
    public void testByteMemSet(Context c) { new byteMemSet().runTest(c); }

--- a/test/functional/JIT_Test/src/jit/test/loopReduction/littleEndianByte2CharMemCpy.java
+++ b/test/functional/JIT_Test/src/jit/test/loopReduction/littleEndianByte2CharMemCpy.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.loopReduction;
+
+/**
+ * The inner loop will only be detected and transformed on little endian architectures.
+ * Big endian architectures will run the loop untransformed.
+ */
+public class littleEndianByte2CharMemCpy extends base {
+   static byte array1[] = new byte [10000];
+   static char array2[] = new char [10000];
+
+   public int test(Context c, int len) {
+      int j = -1;
+      long start, end, elapsed;
+      start = System.currentTimeMillis();
+      for (int iters = 0; iters < c.iterations()*50; iters++){
+         int i = 0;
+         for (j = 0; j < len; ){
+	    array2[j] = (char)(((array1[i+1] & 0xFF) << 8) | (array1[i] & 0xFF));
+	    i+=2;
+	    j++;
+         }
+      }
+      if (c.verify())
+         if (j != len) c.printerr("j != len!");
+      end = System.currentTimeMillis();
+      elapsed = end - start;
+      c.println(this.getClass().getName() + ": len="+ len + ", test took " + elapsed + " millis");
+      return j;
+   }
+}


### PR DESCRIPTION
Cherry-picked from the `master` branch.

Idiom recognition is incorrectly transforming byte-to-char loops for little endian.  For example,
```
    for (int i = 0, j = 0; j < numChars; i += 2, j++) {
        dst[j + offsetDst] = (char) (((src[i + 1 + offsetSrc] & 0xFF) << 8) | (src[i + offsetSrc] & 0xFF))
    }
```
A loop such as this can be recognized and reduced to an arraycopy on little endian architectures.  Similarly, if the char was composed with the shift on the lower address byte then it would be recognized as an arraycopy on big endian architectures.

However, for little endian, the wrong address tree is chosen to start the arraycopy (i.e., `src[i + 1 + offsetSrc]` is chosen instead of  `src[i + offsetSrc]`).  Big endian selects the correct address.

Select the starting address based on the endianess of the target platform.

The loop reduction unit tests for this idiom only provide big endian patterns.  A second test is provided to have the arraycopy pattern recognized on little endian platforms.
