### PR TITLE
Disable automatic execution of linter job

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -22,16 +22,18 @@
 
 name: Linter
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '.gitignore'
-      - '*.md'
-      - 'doc/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yml'
-      - 'buildenv/**'
+on: workflow_dispatch
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened, ready_for_review]
+#     branches: [master]
+#     paths-ignore:
+#       - '.gitignore'
+#       - '*.md'
+#       - 'buildenv/**'
+#       - 'doc/**'
+#       - '.github/ISSUE_TEMPLATE/**'
+#       - '.github/*.yml'
 jobs:
   Linter:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
* only run on master branch after it is updated for
  a supported build environment

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/13565 for the 0.29 branch.