### PR TITLE
Mark first/last vector methods consistently

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -446,18 +446,18 @@
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,
 
-   First_vector_api_method,
-   jdk_internal_vm_vector_VectorSupport_load,
+   FirstVectorMethod,
+   jdk_internal_vm_vector_VectorSupport_load = FirstVectorMethod,
    jdk_internal_vm_vector_VectorSupport_store,
    jdk_internal_vm_vector_VectorSupport_binaryOp,
-   Last_vector_api_intrinsic_method = jdk_internal_vm_vector_VectorSupport_binaryOp,
+   LastVectorIntrinsicMethod = jdk_internal_vm_vector_VectorSupport_binaryOp,
    jdk_incubator_vector_FloatVector_fromArray,
    jdk_incubator_vector_FloatVector_intoArray,
    jdk_incubator_vector_FloatVector_fromArray_mask,
    jdk_incubator_vector_FloatVector_intoArray_mask,
    jdk_incubator_vector_FloatVector_add,
    jdk_incubator_vector_VectorSpecies_indexInRange,
-   Last_vector_api_method,
+   LastVectorMethod = jdk_incubator_vector_VectorSpecies_indexInRange,
 
    java_lang_reflect_Array_getLength,
    java_lang_reflect_Method_invoke,
@@ -1218,6 +1218,6 @@
    com_ibm_crypto_provider_AEScryptInHardware_cbcDecrypt,
    com_ibm_crypto_provider_AEScryptInHardware_cbcEncrypt,
 
-   LastIBMMethod = com_ibm_crypto_provider_P384PrimeField_mod,
+   LastJ9Method = com_ibm_crypto_provider_P384PrimeField_mod,
 
-#endif
+#endif /* J9_RECOGNIZEDMETHODS_ENUM_INCL */

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -210,12 +210,12 @@ bool
 TR_J9InlinerPolicy::inlineRecognizedMethod(TR::RecognizedMethod method)
    {
 
-   if (method > TR::First_vector_api_method &&
-       method < TR::Last_vector_api_method)
+   if (method >= TR::FirstVectorMethod &&
+       method <= TR::LastVectorMethod)
       {
       comp()->getMethodSymbol()->setHasVectorAPI(true);
 
-      if (method <= TR::Last_vector_api_intrinsic_method &&
+      if (method <= TR::LastVectorIntrinsicMethod &&
           !comp()->getOption(TR_DisableVectorAPIExpansion))
          return false;
       }
@@ -2513,8 +2513,8 @@ TR_J9InlinerPolicy::skipHCRGuardForCallee(TR_ResolvedMethod *callee)
       }
 
    // VectorSupport intrinsic candidates should not be redefined by the user
-   if (rm > TR::First_vector_api_method &&
-       rm <= TR::Last_vector_api_intrinsic_method)
+   if (rm >= TR::FirstVectorMethod &&
+       rm <= TR::LastVectorIntrinsicMethod)
       return true;
 
    // Skip HCR guard for non-public methods in java/lang/invoke package. These methods

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1462,8 +1462,7 @@ TR_VectorAPIExpansion::TR_VectorAPIExpansion(TR::OptimizationManager *manager)
       : TR::Optimization(manager), _trace(false), _aliasTable(trMemory()), _nodeTable(trMemory())
    {
    static_assert(sizeof(methodTable) / sizeof(methodTable[0]) == _numMethods,
-                 "methodTable should contain recognized methods between TR::First_vector_api_method and TR::Last_vector_api_method");
-
+                 "methodTable should contain recognized methods between TR::FirstVectorMethod and TR::LastVectorMethod");
    }
 
 

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -77,8 +77,8 @@ class TR_VectorAPIExpansion : public TR::Optimization
 
    typedef int vec_sz_t;
 
-   static int const _firstMethod = TR::First_vector_api_method + 1;
-   static int const _lastMethod = TR::Last_vector_api_method - 1;
+   static int const _firstMethod = TR::FirstVectorMethod;
+   static int const _lastMethod = TR::LastVectorMethod;
 
    static int const _numMethods = _lastMethod - _firstMethod + 1;
    static int const _numArguments = 15;
@@ -842,4 +842,4 @@ class TR_VectorAPIExpansion : public TR::Optimization
    static TR::Node *transformBinary(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, vec_sz_t vectorLength, handlerMode mode, TR::Node *firstChild, TR::Node *secondChild, TR::ILOpCodes opcode);
 
    };
-#endif
+#endif /* VECTORAPIEXPANSION_INCL */


### PR DESCRIPTION
Rename `LastIBMMethod` to `LastJ9Method` for consistency with `FirstJ9Method`.

Make first/last vector method literals consistent with the pattern established by `FirstOMRMethod`, `LastOMRMethod`, `FirstJ9Method`, `LastJ9Method` and `LastVectorIntrinsicMethod` (so they all refer to meaningful values).

Use a consistent naming pattern: `(First/Last)Vector*Method`.