### PR TITLE
AArch64: Fix module.xml in vm directory

### DIFF
--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2001, 2020 IBM Corp. and others
+Copyright (c) 2001, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,7 +157,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<vpath pattern="unsafeHelper.s" path="xr32" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_arm.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
-			<vpath pattern="unsafeHelper.s" path="xr64" augmentObjects="true" type="relativepath">
+			<vpath pattern="unsafeHelper.m4" path="xr64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_aarch64.*"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="rv64" augmentObjects="true" type="relativepath">


### PR DESCRIPTION
As unsafeHelper.s was renamed to unsafeHelper.m4 in `vm/xr64` directory in https://github.com/eclipse-openj9/openj9/pull/13651,
change it in module.xml accordingly.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>