### PR TITLE
Exclude hangTest for AOT temporarily

### DIFF
--- a/test/functional/cmdLineTests/hangTest/playlist.xml
+++ b/test/functional/cmdLineTests/hangTest/playlist.xml
@@ -48,5 +48,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<!-- Temporarily disable due to issue https://github.com/eclipse-openj9/openj9/issues/13657 -->
+		<aot>nonapplicable</aot>
 	</test>
 </playlist>


### PR DESCRIPTION
- Exclude hangTest for AOT temporarily
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/13657
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>