### PR TITLE
Fix getOriginalROMMethod() crash indexing off the end of the J9Class VFT

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1388,10 +1388,10 @@ static bool getProfiledCallSiteInfo(TR::CodeGenerator *cg, TR::Node *callNode, u
    info->getSortedList(comp, &allValues);
 
    TR_ResolvedMethod   *owningMethod = methodSymRef->getOwningMethod(comp);
-   TR_OpaqueClassBlock *callSiteMethod;
+   TR_OpaqueClassBlock *callSiteMethodClass;
 
    if (methodSymbol->isVirtual())
-       callSiteMethod = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
+       callSiteMethodClass = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
 
    ListIterator<TR_ExtraAddressInfo> valuesIt(&allValues);
 
@@ -1411,8 +1411,8 @@ static bool getProfiledCallSiteInfo(TR::CodeGenerator *cg, TR::Node *callNode, u
 
       if (methodSymbol->isVirtual())
          {
-         TR_ASSERT_FATAL(callSiteMethod, "Expecting valid callSiteMethod for virtual call");
-         if (fej9->isInstanceOf(clazz, callSiteMethod, true, true) != TR_yes)
+         TR_ASSERT_FATAL(callSiteMethodClass, "Expecting valid callSiteMethodClass for virtual call");
+         if (!cg->isProfiledClassAndCallSiteCompatible(clazz, callSiteMethodClass))
             continue;
 
          method = owningMethod->getResolvedVirtualMethod(comp, clazz, methodSymRef->getOffset());

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -595,6 +595,16 @@ public:
     */
    uint32_t initializeLinkageInfo(void *linkageInfoPtr);
 
+   /**
+    * \brief Check if a profiled class is compatible with the call site
+    *
+    * \param[in] profiledClass : The J9Class obtained from profiling data
+    * \param[in] callSiteMethodClass : The J9Class from the J9Method of the call site target
+    *
+    * \return True if it can be determined that the profiled class is compatible, otherwise False
+    */
+   bool isProfiledClassAndCallSiteCompatible(TR_OpaqueClassBlock *profiledClass, TR_OpaqueClassBlock *callSiteMethodClass);
+
 private:
 
    enum // Flags

--- a/runtime/compiler/optimizer/J9CallGraph.hpp
+++ b/runtime/compiler/optimizer/J9CallGraph.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "optimizer/CallInfo.hpp"
+#include "il/J9DataTypes.hpp"
 
 class TR_ResolvedMethod;
 
@@ -35,6 +36,7 @@ class TR_ProfileableCallSite : public  TR_IndirectCallSite
       //capabilities
       void findSingleProfiledReceiver(ListIterator<TR_ExtraAddressInfo>&, TR_AddressInfo * valueInfo, TR_InlinerBase* inliner);
       virtual void findSingleProfiledMethod(ListIterator<TR_ExtraAddressInfo>&, TR_AddressInfo * valueInfo, TR_InlinerBase* inliner);
+      virtual TR_YesNoMaybe isCallingObjectMethod() { return TR_maybe; };
    };
 
 
@@ -61,7 +63,7 @@ class TR_J9MutableCallSite : public  TR_FunctionPointerCallSite
 class TR_J9VirtualCallSite : public TR_ProfileableCallSite
    {
    public:
-      TR_CALLSITE_TR_ALLOC_AND_INHERIT_EMPTY_CONSTRUCTOR(TR_J9VirtualCallSite, TR_ProfileableCallSite)
+      TR_CALLSITE_TR_ALLOC_AND_INHERIT_CONSTRUCTOR(TR_J9VirtualCallSite, TR_ProfileableCallSite) { _isCallingObjectMethod = TR_maybe; }
       virtual bool findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner);
       virtual TR_ResolvedMethod* findSingleJittedImplementer (TR_InlinerBase *inliner);
       virtual const char*  name () { return "TR_J9VirtualCallSite"; }
@@ -70,7 +72,12 @@ class TR_J9VirtualCallSite : public TR_ProfileableCallSite
 		//capabilities
 		bool findCallSiteForAbstractClass(TR_InlinerBase* inliner);
 		//queries
+		bool isBasicInvokeVirtual();
       virtual TR_OpaqueClassBlock* getClassFromMethod ();
+      // Is the call site calling a method of java/lang/Object
+      virtual TR_YesNoMaybe isCallingObjectMethod() { return _isCallingObjectMethod; };
+   private:
+      TR_YesNoMaybe _isCallingObjectMethod;
 
    };
 

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2020,10 +2020,10 @@ static bool getProfiledCallSiteInfo(TR::CodeGenerator *cg, TR::Node *callNode, u
    info->getSortedList(comp, &allValues);
 
    TR_ResolvedMethod   *owningMethod = methodSymRef->getOwningMethod(comp);
-   TR_OpaqueClassBlock *callSiteMethod;
+   TR_OpaqueClassBlock *callSiteMethodClass;
 
    if (methodSymbol->isVirtual())
-       callSiteMethod = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
+       callSiteMethodClass = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
 
    ListIterator<TR_ExtraAddressInfo> valuesIt(&allValues);
 
@@ -2043,8 +2043,8 @@ static bool getProfiledCallSiteInfo(TR::CodeGenerator *cg, TR::Node *callNode, u
 
       if (methodSymbol->isVirtual())
          {
-         TR_ASSERT(callSiteMethod, "Expecting valid callSiteMethod for virtual call");
-         if (fej9->isInstanceOf(clazz, callSiteMethod, true, true) != TR_yes)
+         TR_ASSERT(callSiteMethodClass, "Expecting valid callSiteMethodClass for virtual call");
+         if (!cg->isProfiledClassAndCallSiteCompatible(clazz, callSiteMethodClass))
             continue;
 
          method = owningMethod->getResolvedVirtualMethod(comp, clazz, methodSymRef->getOffset());

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1344,12 +1344,11 @@ void TR::X86CallSite::computeProfiledTargets()
                {
                topValue = 0;
                }
-            // We can't do this guarded devirtualization if the profile data is not correct for this context. See defect 98813
             else
                {
                //printf("Checking is instanceof for top %p for %s\n", topValue, methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->signature(comp()->trMemory())); fflush(stdout);
-               TR_OpaqueClassBlock *callSiteMethod = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
-               if (fej9->isInstanceOf((TR_OpaqueClassBlock *)topValue, callSiteMethod, true, true) != TR_yes)
+               TR_OpaqueClassBlock *callSiteMethodClass = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
+               if (!cg()->isProfiledClassAndCallSiteCompatible((TR_OpaqueClassBlock *)topValue, callSiteMethodClass))
                   {
                   topValue = 0;
                   }

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1833,11 +1833,10 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
                   {
                   topValue = 0;
                   }
-               // We can't do this guarded devirtualization if the profile data is not correct for this context. See defect 98813
                else
                   {
-                  TR_OpaqueClassBlock *callSiteMethod = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
-                  if( fej9->isInstanceOf( (TR_OpaqueClassBlock *)topValue, callSiteMethod, true, true ) != TR_yes )
+                  TR_OpaqueClassBlock *callSiteMethodClass = methodSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->classOfMethod();
+                  if (!cg()->isProfiledClassAndCallSiteCompatible((TR_OpaqueClassBlock *)topValue, callSiteMethodClass))
                      {
                      topValue = 0;
                      }


### PR DESCRIPTION
When using Interpreter Profiling data to inline or devirtualize a call
it's possible for the isInstanceOf() check to pass despite the profiled
class not being compatible with the caller's context. This can happen
when compiling for AOT where the caller is sharing a J9ROMMethod with
a 2nd classloader and the callee in the bytecodes is an Abstract class
where some method is not defined in the Abstract class but is required
by an interface. This results in the the Abstract classes VFT containing
a reference to the Interface's J9Method. Because the VFT index for any
interface methods can differ between different implementors, if we use
the VFT index to retrieve a method from a profiled class that is from
an incorrect context several different bad things can happen. The
isInstanceOf() check can fail to protect us here because isInstanceOf()
will return true when checking the profiled class against an Interface
class retrieved from the Abstract classes VFT entry for an unimplemented
method of an Interface.

The fix is in two parts. 1) Inlining, 2) Codegen

1) There is an existing attempt to refine the _receiverClass for a
virtual CallSite that refers to an Interface class. This attempt
fails when compiling for AOT because the "optimizeForAOT" parameter
of the isInstanceOf() call and the "returnClassForAOT" parameter
of the getClassFromConstantPool() call was set to false. This fix adds
the required checks to make sure that setting the parameters to true is
safe for AOT compiles thereby allowing the refinement of the
_receiverClass from an interface into an Abstract class.

The fix also insures that any attempt use profile directed inlining when
the CallSite _receiverClass is an Interface will be aborted.

2) When code generator is attempting to perform a profile directed
devirtualization, this fix will check if the class of the call site
method is an Interface. In such cases the devirtualization attempt
will be aborted.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>