### PR TITLE
AArch64: Disable ReferenceArrayCopy transformation

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -67,7 +67,6 @@ J9::ARM64::CodeGenerator::initialize()
       cg->setSupportsDirectJNICalls();
 
    cg->setSupportsPrimitiveArrayCopy();
-   cg->setSupportsReferenceArrayCopy();
    }
 
 TR::Linkage *


### PR DESCRIPTION
This commit disables ReferenceArrayCopy transformation for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>