### PR TITLE
Fix the JVM options passing to hangTest

### DIFF
--- a/test/functional/cmdLineTests/hangTest/hang.sh
+++ b/test/functional/cmdLineTests/hangTest/hang.sh
@@ -23,7 +23,7 @@
 #
 echo "Script executed from: ${PWD}"
 
-$1 -Xmx20m -Xrs:sync -cp $2 org.openj9.test.hangTest.Hang > output.txt 2>&1  &
+$1 -Xmx20m -Xrs:sync -cp $2 $3 org.openj9.test.hangTest.Hang > output.txt 2>&1  &
 sleep 5
 x=`ps -ef | grep Hang | grep java`
 echo $x

--- a/test/functional/cmdLineTests/hangTest/playlist.xml
+++ b/test/functional/cmdLineTests/hangTest/playlist.xml
@@ -34,7 +34,7 @@
 		</variations>
 		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)hangTest.jar$(Q) \
-	-DEXE=$(SQ)bash $(TEST_RESROOT)$(D)hang.sh $(JAVA_COMMAND) $(JVM_OPTIONS) $(TEST_RESROOT)$(D)hangTest.jar $(SQ) -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)bash $(TEST_RESROOT)$(D)hang.sh $(JAVA_COMMAND) $(TEST_RESROOT)$(D)hangTest.jar $(JVM_OPTIONS) $(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)hang.xml$(Q) \
 	-xids all,$(PLATFORM) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
The hang.sh script expects the second argument to be
a classpath. If JVM options (such as -XX:+UseJITServer)
are specified, the test will not run.

This commit fixes the issue by moving $JVM_OPTIONS to
a later position in the playlist.xml and modifying hang.sh
to take the options as a third argument.