### PR TITLE
Thread MXBean (Build ThreadInfo) Fix for CS

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -256,5 +256,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_notifyGCOfClassReplacement,
 	j9gc_get_jit_string_dedup_policy,
 	j9gc_stringHashFn,
-	j9gc_stringHashEqualFn
+	j9gc_stringHashEqualFn,
+	j9gc_ensureLockedSynchronizersIntegrity
 };

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -274,10 +274,7 @@ MM_GCExtensions::computeDefaultMaxHeapForJava(bool enableOriginalJDK8HeapSizeCom
 MM_OwnableSynchronizerObjectList *
 MM_GCExtensions::getOwnableSynchronizerObjectListsExternal(J9VMThread *vmThread)
 {
-	if (isConcurrentScavengerInProgress()) {
-		MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
-		((MM_MemorySpace *)vmThread->omrVMThread->memorySpace)->localGarbageCollect(env, J9MMCONSTANT_IMPLICIT_GC_COMPLETE_CONCURRENT);
-	}
+	Assert_MM_true(!isConcurrentScavengerInProgress());
 
 	return ownableSynchronizerObjectLists;
 }

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -255,6 +255,7 @@ extern J9_CFUNC void j9gc_objaccess_jniReleaseStringCritical(J9VMThread* vmThrea
 extern J9_CFUNC UDATA j9gc_arraylet_getLeafSize(J9JavaVM* javaVM);
 extern J9_CFUNC UDATA j9gc_arraylet_getLeafLogSize(J9JavaVM* javaVM);
 extern J9_CFUNC void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64* mainCpuMillis, U_64* workerCpuMillis, U_32* maxThreads, U_32* currentThreads);
+extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThread);
 
 
 /* J9VMFinalizeSupport*/

--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -679,6 +679,12 @@ Java_openj9_internal_tools_attach_target_DiagnosticUtils_dumpAllThreadsImpl(JNIE
 	vmfns->internalEnterVMFromJNI(currentThread);
 	vmfns->acquireExclusiveVMAccess(currentThread);
 
+	/* j9gc_ensureLockedSynchronizersIntegrity can't be delayed, it must be called before fetching any references as
+	 * it may complete any GC in progress and move references */
+	if (getLockedSynchronizers) {
+		vm->memoryManagerFunctions->j9gc_ensureLockedSynchronizersIntegrity(currentThread);
+	}
+
 	allinfolen = vm->totalThreadCount;
 
 	/* build array of ThreadInfo */
@@ -818,6 +824,12 @@ getArrayOfThreadInfo(JNIEnv *env,
 
 	vmfns->internalEnterVMFromJNI(currentThread);
 	vmfns->acquireExclusiveVMAccess(currentThread);
+
+	/* j9gc_ensureLockedSynchronizersIntegrity can't be delayed, it must be called before fetching any references as
+	 * it may complete any GC in progress and move references */
+	if (getLockedSynchronizers) {
+		vm->memoryManagerFunctions->j9gc_ensureLockedSynchronizersIntegrity(currentThread);
+	}
 
 	/** 
 	 * @todo Slightly evil.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4417,6 +4417,7 @@ typedef struct J9MemoryManagerFunctions {
 	I_32  ( *j9gc_get_jit_string_dedup_policy)(struct J9JavaVM *javaVM) ;
 	UDATA ( *j9gc_stringHashFn)(void *key, void *userData);
 	BOOLEAN ( *j9gc_stringHashEqualFn)(void *leftKey, void *rightKey, void *userData);
+	void  ( *j9gc_ensureLockedSynchronizersIntegrity)(struct J9VMThread *vmThread) ;
 } J9MemoryManagerFunctions;
 
 typedef struct J9InternalVMFunctions {


### PR DESCRIPTION
Currently, CS completion _(for externally consuming ownable sync list)_ is delayed until iterating the ownable sync objs. Delaying this can be problematic when CS completion results in global (percolate), resulting in stale references (gathered prior to fetching the ownable list). As a workaround, CS completion should be done at the start of building threadinfo. This is implemented with new `j9gc_ensureLockedSynchronizersIntegrity ` API.

Signed-off-by: Salman Rana <salman.rana@ibm.com>