### PR TITLE
Fix GCArrayletObjectModelBase.externalArrayletsSize()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCArrayletObjectModelBase.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCArrayletObjectModelBase.java
@@ -438,7 +438,11 @@ public abstract class GCArrayletObjectModelBase extends GCArrayObjectModel
 	{
 		UDATA numberArraylets = numExternalArraylets(array);
 
-		return numberArraylets.mult(arrayletLeafSize);
+		if (numberArraylets.isZero()) {
+			return numberArraylets;
+		} else {
+			return numberArraylets.mult(arrayletLeafSize);
+		}
 	}
 
 }


### PR DESCRIPTION
Only multiply by `arrayletLeafSize` when arraylets are in use: fixes #13467.

Also, clean up:
* formatting and whitespace
* remove extraneous parentheses
* use consistent parameter names and make consistent with javadoc