### PR TITLE
(0.29.0) Fix GCArrayletObjectModelBase.externalArrayletsSize()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCArrayletObjectModelBase.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCArrayletObjectModelBase.java
@@ -438,7 +438,11 @@ public abstract class GCArrayletObjectModelBase extends GCArrayObjectModel
 	{
 		UDATA numberArraylets = numExternalArraylets(array);
 
-		return numberArraylets.mult(arrayletLeafSize);
+		if (numberArraylets.isZero()) {
+			return numberArraylets;
+		} else {
+			return numberArraylets.mult(arrayletLeafSize);
+		}
 	}
 
 }


### PR DESCRIPTION
This is a cherry-pick of #13689 for the 0.29.0 release branch.