### PR TITLE
Fix javadoc accessibility issues in published docs

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/OperatingSystemMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 package com.ibm.lang.management;
 
 /**
- * OpenJ9 platform management extension interface for the Operating System on which the Java Virtual Machine is running. 
+ * OpenJ9 platform management extension interface for the Operating System on which the Java Virtual Machine is running.
  * <br>
  * <table border="1">
  * <caption><b>Usage example for the {@link com.ibm.lang.management.OperatingSystemMXBean}</b></caption>
@@ -43,7 +43,7 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 
 	/**
 	 * Returns the total available physical memory on the system in bytes.
-	 * 
+	 *
 	 * @since 1.8
 	 * @return the total available physical memory on the system in bytes.
 	 */
@@ -51,7 +51,7 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 
 	/**
 	 * Deprecated: use getTotalPhysicalMemorySize()
-	 * 
+	 *
 	 * @return the total available physical memory on the system in bytes.
 	 */
 	/*[IF Sidecar19-SE]
@@ -68,7 +68,7 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	 * 100 is equal to 1 physical processor. In environments without
 	 * such partitioning support, this call will return
 	 * getAvailableProcessors() * 100.
-	 * 
+	 *
 	 * @return the collective capacity of the virtual processors available
 	 * to the VM.
 	 */
@@ -78,11 +78,11 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	 * Returns total amount of time the process has been scheduled or
 	 * executed so far in both kernel and user modes. Returns -1 if the
 	 * value is unavailable on this platform or in the case of an error.
-	 * 
-	 * Note that as of Java 8 SR5 the returned value is in 1 ns units, unless the system property 
+	 *
+	 * Note that as of Java 8 SR5 the returned value is in 1 ns units, unless the system property
 	 * com.ibm.lang.management.OperatingSystemMXBean.isCpuTime100ns is set to "true".
 	 *
-	 * @return process cpu time.
+	 * @return process CPU time.
 	 */
 	public long getProcessCpuTime();
 
@@ -97,18 +97,18 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	public long getProcessCpuTimeByNS();
 
 	/**
-	 * Returns the "recent cpu usage" for the whole system. This value is a double in
+	 * Returns the recent CPU usage for the whole system. This value is a double in
 	 * the [0.0,1.0] interval. A value of 0.0 means all CPUs were idle in the recent
 	 * period of time observed, while a value of 1.0 means that all CPUs were actively
 	 * running 100% of the time during the recent period of time observed. All values
-	 * between 0.0 and 1.0 are possible. The first call to the method always 
+	 * between 0.0 and 1.0 are possible. The first call to the method always
 	 * returns {@link com.ibm.lang.management.CpuLoadCalculationConstants}.ERROR_VALUE
 	 * (-1.0), which marks the starting point. If the Java Virtual Machine's recent CPU
 	 * usage is not available, the method returns a negative error code from
 	 * {@link com.ibm.lang.management.CpuLoadCalculationConstants}.
 	 * <p>getSystemCpuLoad might not return the same value that is reported by operating system
-	 * utilities such as Unix "top" or Windows task manager.</p>
-	 *  
+	 * utilities such as Unix {@code top} or Windows task manager.</p>
+	 *
 	 * @return A value between 0 and 1.0, or a negative error code from
 	 *         {@link com.ibm.lang.management.CpuLoadCalculationConstants} in case
 	 *         of an error. On the first call to the API,
@@ -124,7 +124,7 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	public double getSystemCpuLoad();
 
 	/**
-	 * Returns the amount of physical memory that is available on the system in bytes. 
+	 * Returns the amount of physical memory that is available on the system in bytes.
 	 * Returns -1 if the value is unavailable on this platform or in the case of an error.
 	 * <ul>
 	 * <li>This information is not available on the z/OS platform.
@@ -198,14 +198,14 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	public long getFreeSwapSpaceSize();
 
 	/**
-	 * Returns the "recent cpu usage" for the Java Virtual Machine process.
+	 * Returns the recent CPU usage for the Java Virtual Machine process.
 	 * This value is a double in the [0.0,1.0] interval. A value of 0.0 means
 	 * that none of the CPUs were running threads from the JVM process during
 	 * the recent period of time observed, while a value of 1.0 means that all
 	 * CPUs were actively running threads from the JVM 100% of the time
 	 * during the recent period of time observed. Threads from the JVM include
 	 * application threads as well as JVM internal threads. All values
-	 * between 0.0 and 1.0 are possible. The first call to the method always 
+	 * between 0.0 and 1.0 are possible. The first call to the method always
 	 * returns {@link com.ibm.lang.management.CpuLoadCalculationConstants}.ERROR_VALUE
 	 * (-1.0), which marks the starting point. If the Java Virtual Machine's recent CPU
 	 * usage is not available, the method returns a negative error code from
@@ -265,7 +265,7 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	 *
 	 * @throws NullPointerException if a null reference is passed as parameter.
 	 * @throws ProcessorUsageRetrievalException if it failed obtaining Processor usage statistics.
-	 * @throws IllegalArgumentException if array provided has insufficient entries and there are more 
+	 * @throws IllegalArgumentException if array provided has insufficient entries and there are more
 	 *                   Processors to report on.
 	 *
 	 * <p>In case of an exception, the handler code might use toString() on the exception code
@@ -326,8 +326,8 @@ public interface OperatingSystemMXBean extends com.sun.management.OperatingSyste
 	 * hardware model information
 	 *
 	 * @return The new {@link java.lang.String} object or NULL in case of an error.
-	 * @throws UnsupportedOperationException if the operation is not implemented on this platform. 
-	 * UnsupportedOperationException will also be thrown if the operation is implemented but it 
+	 * @throws UnsupportedOperationException if the operation is not implemented on this platform.
+	 * UnsupportedOperationException will also be thrown if the operation is implemented but it
 	 * cannot be performed because the system does not satisfy all the requirements, for example,
 	 * an OS service is not installed.
 	 * @since   1.7

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaError.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaError.java
@@ -309,8 +309,8 @@ public interface CudaError {
 	 * either because the Driver context was created using an older version
 	 * of the API, because the Runtime API call expects a primary driver
 	 * context and the Driver context is not primary, or because the Driver
-	 * context has been destroyed. Please see \ref CUDART_DRIVER "Interactions
-	 * with the CUDA Driver API" for more information.
+	 * context has been destroyed. Please see CUDART_DRIVER <q>Interactions
+	 * with the CUDA Driver API</q> for more information.
 	 */
 	int IncompatibleDriverContext = 49;
 

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaPermission.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/CudaPermission.java
@@ -30,7 +30,7 @@ import com.ibm.cuda.CudaDevice.Limit;
 import com.ibm.cuda.CudaDevice.SharedMemConfig;
 
 /**
- * This class defines CUDA permissions as described in the table below.
+ * This class defines CUDA permissions as described in the following table.
  *
  * <table border=1 style="padding:5px">
  * <caption>CUDA Permissions</caption>

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corp. and others
+ * Copyright (c) 2004, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,21 +27,21 @@ import java.util.Iterator;
 import java.util.Properties;
 
 /**
- * <p>Represents an entire operating system image (for example, a core file).</p> 
- * 
- * <p>There are methods for accessing information about the architecture 
- * of the machine on which the image was running - hardware and 
- * operating system. The major feature, however, is the ability to 
- * iterate over the Address Spaces contained within the image.</p> 
+ * <p>Represents an entire operating system image (for example, a core file).</p>
+ *
+ * <p>There are methods for accessing information about the architecture
+ * of the machine on which the image was running - hardware and
+ * operating system. The major feature, however, is the ability to
+ * iterate over the Address Spaces contained within the image.</p>
  */
 public interface Image {
-	
+
 	/**
-	 * Get the set of address spaces within the image - typically one but may be more on some 
-	 * systems such as Z/OS. 
+	 * Get the set of address spaces within the image - typically one but may be more on some
+	 * systems such as Z/OS.
 	 * @return an Iterator which iterates over all of the address spaces
 	 * described by this Image
-	 * 
+	 *
 	 * @see ImageAddressSpace
      * @see CorruptData
 	 */
@@ -53,135 +53,135 @@ public interface Image {
 	 * @return the family name for the processor on which the image was
 	 * running. This corresponds to the value you would find in the
 	 * "os.arch" System property.
-	 * 
+	 *
 	 * @throws DataUnavailable if this data cannot be inferred from this core type
 	 * @throws CorruptDataException if expected data cannot be read from the core
 	 */
 	public String getProcessorType() throws DataUnavailable, CorruptDataException;
-	
+
 	/**
 	 * Get the precise model of the CPU.
 	 * @return the precise model of the CPU (note that this can be an empty string but not null).
 	 * <br>
-	 * e.g. getProcessorType() will return "x86" where getProcessorSubType() may return "Pentium IV step 4"
+	 * e.g. getProcessorType() will return <q>x86</q> where getProcessorSubType() may return <q>Pentium IV step 4</q>
 	 * <p>
 	 * Note that this value is platform and implementation dependent.
-	 * @throws DataUnavailable 
-	 * @throws CorruptDataException 
+	 * @throws DataUnavailable
+	 * @throws CorruptDataException
 	 */
 	public String getProcessorSubType() throws DataUnavailable, CorruptDataException;
-	
+
 	/**
 	 * Get the number of CPUs running in the system on which the image was running.
 	 * @return the number of CPUs running in the system on which the
 	 * image was running
-	 * 
+	 *
 	 * @exception DataUnavailable if the information cannot be provided
 	 */
 	public int getProcessorCount() throws DataUnavailable;
-	
+
 	/**
 	 * Get the family name for the operating system.
 	 * @return the family name for the operating system.  This should be the same value
 	 * that would be returned for the "os.name" system property
-	 * 
+	 *
 	 * @throws DataUnavailable if this data cannot be inferred from this core type
 	 * @throws CorruptDataException if expected data cannot be read from the core
 	 */
 	public String getSystemType() throws DataUnavailable, CorruptDataException;
-	
+
 	/**
 	 * Get the detailed name of the operating system.
 	 * @return the detailed name of the operating system, or an empty string
 	 * if this information is not available (null will never be returned).  This should be
 	 * the same value that would be returned for the "os.version" system property
-	 * @throws DataUnavailable 
-	 * @throws CorruptDataException 
+	 * @throws DataUnavailable
+	 * @throws CorruptDataException
 	 */
 	public String getSystemSubType() throws DataUnavailable, CorruptDataException;
-	
+
 	/**
 	 * Get the amount of physical memory (in bytes) installed in the system on which
 	 * the image was running.
 	 * @return the amount of physical memory installed in the system on which
 	 * the image was running.  The return value is specified in bytes.
-	 * 
+	 *
 	 * @exception DataUnavailable if the information cannot be provided
 	 */
 	public long getInstalledMemory() throws DataUnavailable;
-	
+
 	/**
 	 * Get the time when the image was created
-	 * 
+	 *
 	 * @return the image creation time in milliseconds since 1970
-	 * @throws DataUnavailable 
+	 * @throws DataUnavailable
 	 */
 	public long getCreationTime() throws DataUnavailable;
-	
+
 	/**
-	 * Get the host name of the system where the image was running. 
+	 * Get the host name of the system where the image was running.
 	 * @return The host name of the system where the image was running.  This string will
 	 * be non-null and non-empty
-	 * 
+	 *
 	 * @throws DataUnavailable If the image did not provide this information (would happen
 	 * if the system did not know its host name or if the image predated this feature).
-	 * @throws CorruptDataException 
-	 * 
+	 * @throws CorruptDataException
+	 *
 	 * @since 1.0
 	 */
 	public String getHostName() throws DataUnavailable, CorruptDataException;
-	
+
 	/**
-	 * The set of IP addresses (as InetAddresses) which the system running the image possessed. 
-	 * @return An Iterator over the IP addresses (as InetAddresses) which the system running 
-	 * the image possessed.  The iterator will be non-null (but can be empty if the host is 
+	 * The set of IP addresses (as InetAddresses) which the system running the image possessed.
+	 * @return An Iterator over the IP addresses (as InetAddresses) which the system running
+	 * the image possessed.  The iterator will be non-null (but can be empty if the host is
 	 * known to have no IP addresses).
-	 * 
+	 *
 	 * @throws DataUnavailable If the image did not provide this information (would happen
 	 * if the system failed to look them up or if the image pre-dated this feature).
-	 * 
+	 *
 	 * @since 1.0
-	 * 
+	 *
 	 * @see java.net.InetAddress
 	 * @see CorruptData
 	 */
 	public Iterator getIPAddresses() throws DataUnavailable;
-	
+
 	 /**
 	  * <p>Close this image and any associated resources.</p>
-	  * 
-	  * <p>Some kinds of Image require the generation of temporary resources, for example temporary files created 
+	  *
+	  * <p>Some kinds of Image require the generation of temporary resources, for example temporary files created
 	  * when reading core files and libraries from .zip archives. Ordinarily, these resources are deleted at JVM shutdown,
 	  * but DTFJ applications may want to free them earlier. This method should only be called when the Image is no
 	  * longer needed. After this method has been called, any objects associated with the image will be in an invalid state.</p>
-	  * 
+	  *
 	  * @since 1.4
 	  */
 	 public void close();
-	 
+
 	 /**
       * Gets the OS specific properties for this image.
-      *  
+      *
       * @return a set of OS specific properties
       * @since 1.7
       */
     public Properties getProperties();
-    
+
     /**
      * A unique identifier for the source of this image
-     * @return URI for this image or null if this was not used when the image was created. 
+     * @return URI for this image or null if this was not used when the image was created.
      * @since 1.10
      */
     public URI getSource();
-    
+
 	/**
 	 * Get the value of the JVM's high-resolution timer when the image was created.
-	 *  
+	 *
 	 * @return the value of the high-resolution timer, in nanoseconds
-	 * 
+	 *
 	 * @throws DataUnavailable if the image creation time is not available
 	 * @throws CorruptDataException if the image creation time is corrupted
-	 * 
+	 *
 	 * @since 1.12
 	 */
 	public long getCreationTimeNanos() throws DataUnavailable, CorruptDataException;

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/JavaReference.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/JavaReference.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corp. and others
+ * Copyright (c) 2008, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,11 +27,11 @@ import com.ibm.dtfj.image.DataUnavailable;
 
 /**
  * Represents a Java reference.
- * 
+ *
  */
 public interface JavaReference
 {
-    
+
 	/** Unknown heap root type */
     int HEAP_ROOT_UNKNOWN      = 0;
     /** JNI global reference heap root */
@@ -56,14 +56,14 @@ public interface JavaReference
     int HEAP_ROOT_CLASSLOADER = 10;
     /** Stringtable heap root */
     int HEAP_ROOT_STRINGTABLE = 11;
-    
+
 
      /** Unknown reference type */
     int REFERENCE_UNKNOWN           = 0;
-    /** Reference from an object to its class */ 
-    int REFERENCE_CLASS             = 1;  // 
+    /** Reference from an object to its class */
+    int REFERENCE_CLASS             = 1;  //
     /** Reference from an object to the value of one of its instance fields */
-    int REFERENCE_FIELD             = 2;  
+    int REFERENCE_FIELD             = 2;
     /** Reference from an array to one of its elements */
     int REFERENCE_ARRAY_ELEMENT     = 3;
     /** Reference from a class to its class loader */
@@ -75,7 +75,7 @@ public interface JavaReference
     /** Reference from a class to one of its interfaces */
     int REFERENCE_INTERFACE         = 7;
     /** Reference from a class to the value of one of its static fields */
-    int REFERENCE_STATIC_FIELD      = 8; 
+    int REFERENCE_STATIC_FIELD      = 8;
     /** Reference from a class to a resolved entry in the constant pool */
     int REFERENCE_CONSTANT_POOL     = 9;
     /** Reference from a class to its superclass */
@@ -103,26 +103,26 @@ public interface JavaReference
     /**
      * Get the root type, as defined in the JVMTI specification.
      *
-     * @return an integer representing the root type, see HEAP_ROOT_ statics above.
+     * @return an integer representing the root type, see the HEAP_ROOT_ static fields.
      */
     public int getRootType() throws CorruptDataException;
 
     /**
      * Get the reference type, as defined in the JVMTI specification.
-     * @return an integer representing the reference type, see REFERENCE_ statics above.
+     * @return an integer representing the reference type, see the REFERENCE_ static fields.
      */
     public int getReferenceType() throws CorruptDataException;
 
     /**
      * Get the reachability of the target object via this specific reference.
-     * @return an integer representing the reachability, see REACHABILITY_ statics above.
+     * @return an integer representing the reachability, see the REACHABILITY_ static fields.
      */
     public int getReachability() throws CorruptDataException;
 
     /**
      * Get a string describing the reference type.
      * Implementers should not depend on the contents or identity of this string.
-     * e.g. "JNI Weak global reference", "Instance field 'MyClass.value'", "Constant pool string constant"
+     * e.g. <q>JNI Weak global reference</q>, <q>Instance field 'MyClass.value'</q>, <q>Constant pool string constant</q>
      * @return a String describing the reference type
      */
     public String getDescription();

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/GPUPermission.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/GPUPermission.java
@@ -26,7 +26,7 @@ import java.security.BasicPermission;
 import java.security.Permission;
 
 /**
- * This class defines GPU permissions as described in the table below.
+ * This class defines GPU permissions as described in the following table.
  *
  * <table border=1 style="padding:5px">
  * <caption>GPU Permissions</caption>

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassesNamedPermission.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassesNamedPermission.java
@@ -26,7 +26,7 @@ package com.ibm.oti.shared;
 import java.security.BasicPermission;
 
 /**
- * This class defines shared cache permissions as described in the table below.
+ * This class defines shared cache permissions as described in the following table.
  *
  * <table border=1 style="padding=5px">
  * <caption>Shared Cache Permissions</caption>

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/trace/format/api/package-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/trace/format/api/package-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,52 +26,52 @@
  * the UtTraceBuffer native type which wrap the UtTraceRecord type. However, in messages from the API they are
  * called buffers to keep the naming consistent across the information output of the formatter and the -Xtrace
  * options.
- * 
+ *
  * A single buffer contains trace data for a single thread with one exception:
- * 	"0x0 Exception trace pseudo-thread"
+ * 	<q>0x0 Exception trace pseudo-thread</q>
  * This "thread" contains data from any threads that have written into the exception buffer interleaved in
  * chronological order. There is no mapping from a trace point to its source thread for trace points in the
  * exception buffer.
- * 
+ *
  * An instance of a JVM corresponds to an instance of a TraceContext object within the API. It is
  * possible to have multiple TraceContext instances, each the accessor for trace data from a single JVM.
- * 
+ *
  * The primary inputs for the API are metadata from a JVM and trace buffers.
- * 
+ *
  * A TraceContext is constructed using metadata from the JVM that's generating the trace records needing
  * formatting. This metadata is either present as a file header at the start of a trace file or can
  * be acquired via a call to the JVMTI extension com.ibm.GetTraceMetadata.
  * Also required is a data file describing the format of trace points for that level of the JVM. At
  * least one data file is required to construct a trace context but additional files can be added later
  * and they will be searched for a trace point specification in the order they are added.
- * 
+ *
  * Trace buffers must be passed to the context corresponding to the JVM that produced them; they are not
  * valid in another context and must be added in-order within a single thread.  Detecting that a buffer
  * has been added to the wrong context is not always possible so don't depend on an error being produced
  * to deduce the correct context. Trace buffers from the same thread must be added in chronological order.
- * 
+ *
  * Trace points are organised by thread, and iterators are provided that allow access:
  * 	a. chronologically across all threads (global)
  * 	b. chronologically within a single thread (thread)
- *  
+ *
  * The global iterator uses the thread iterators meaning that once a trace point has
  * been returned via either type of iterator it will not be returned again via the other type.
  * The iterators may return null (without becoming invalid) when there are no more trace points available
  * but return data after a new trace buffer has been added. iterator.hasNext() indicates whether a call to
  * iterator.next() will return null and says nothing about whether more trace points can be expected for a given
- * context or thread. 
- * 
+ * context or thread.
+ *
  * Trace points are kept sorted across threads when using the global iterator, however this optimisation invariant
  * is broken by use of a thread iterator. Consequently there is a performance hit when the global iterator is
  * next used, as the threads must be resorted. This can be significant with large numbers of threads.
- * 
+ *
  * Example fragment parsing a single buffer via the API:
  * 		// metadata - byte[] either from the header in a trace file or via jvmti
  * 		// formatData - File containing the trace point specifications
  *
  * 		TraceContext context = TraceContext.getContext(metadata, formatData, System.out, System.err, System.err, null);
  * 		TraceThread thread = context.addData(buffer);
- * 
+ *
  * 		Iterator global = context.getTracepoints();
  * 		while (global.hasNext()) {
  * 			try {


### PR DESCRIPTION
Directional words like `below` should not be used to describe page
content. A quoted phrase must use HTML tags `<q></q>` instead of quotation
marks.