### PR TITLE
(0.29) Use correct loop condition when searching for methods

### DIFF
--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -358,7 +358,8 @@ inlinedEntry:
 						while (NULL != ramClass) {
 							U_32 i = 0;
 							J9Method *methods = ramClass->ramMethods;
-							for (i = 0; i < romClass->romMethodCount; ++i) {
+							UDATA romMethodCount = ramClass->romClass->romMethodCount;
+							for (i = 0; i < romMethodCount; ++i) {
 								J9ROMMethod *possibleMethod = J9_ROM_METHOD_FROM_RAM_METHOD(&methods[i]);
 
 								/* Note that we cannot use `J9_BYTECODE_START_FROM_ROM_METHOD` here because native method PCs
@@ -367,6 +368,7 @@ inlinedEntry:
 								if ((methodPC >= (UDATA)possibleMethod) && (methodPC < (UDATA)J9_BYTECODE_END_FROM_ROM_METHOD(possibleMethod))) {
 									romMethod = possibleMethod;
 									methodPC -= (UDATA)J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
+									romClass = ramClass->romClass;
 									goto foundROMMethod;
 								}
 							}


### PR DESCRIPTION
As of JDK8 we permitted the addition of methods when redefining classes.
This means that between two versions of the same class, the number of
methods may not be the same. As a result we can not use the same
romMethodCount when iterating ramMethods for different versions of the
same class.

Port of https://github.com/eclipse-openj9/openj9/pull/13690 for the 0.29 release.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>