### PR TITLE
Exclude z/OS cmdLineTester_hangTest temporarily

### DIFF
--- a/test/functional/cmdLineTests/hangTest/playlist.xml
+++ b/test/functional/cmdLineTests/hangTest/playlist.xml
@@ -28,6 +28,10 @@
 				<comment>Segmentation fault after killing the process</comment>
 				<platform>.*windows.*</platform>
 			</disable>
+			<disable>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/606</comment>
+				<platform>.*zos.*</platform>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
- cmdLineTester_hangTest fails for z/os jdk11, so exclude it temporarily
Related Issue: ibm_git/runtimes/backlog/issues/606
[skip ci]

Signed-off-by Longyu Zhang <longyu.zhang@ibm.com>