### PR TITLE
Prevent recompilation of failed compilations retried at lower opt levels

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2215,6 +2215,8 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
                   entry->_optimizationPlan->setOptLevel(newHotness);
                   entry->_optimizationPlan->setInsertInstrumentation(false); // prevent profiling
                   entry->_optimizationPlan->setUseSampling(false); // disable recompilation of this method
+                  entry->_optimizationPlan->setDisableEDO(true); // disable EDO to prevent recompilation triggered from native code
+                  entry->_optimizationPlan->setDisableGCR(true); // disable GCR to prevent recompilation triggered from native code
                   }
                break;
             case compilationCHTableCommitFailure:
@@ -8087,6 +8089,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 
             if (that->_methodBeingCompiled->_optimizationPlan->disableGCR())
                options->setOption(TR_DisableGuardedCountingRecompilations);
+
+            if (that->_methodBeingCompiled->_optimizationPlan->getDisableEDO())
+               options->setOption(TR_DisableEDO);
 
             if (options->getOption(TR_DisablePrexistenceDuringGracePeriod))
                {


### PR DESCRIPTION
Under certains conditions, a compilation that fails at a particular optimization
level can be retried at a lower optimization level, hoping that the compilation
will pass. However, in this case we must prevent future recompilation at a
higher opt level, because this could lead to a perpetual compilation process.
Example:
 warm compile
 hot recompile; fail
 warm recompile
 hot recompile; fail
 ...

This commit disables GCR (guarded counting recompilation) and EDO (exception directed
optimization) for compilation retrials to avoid the possibility of the method being
upgraded to a higher optimization level in the future. Note that sampling is already
disabled, for the same reason.

Fixes #13548

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>