### PR TITLE
Fix overflow in Balanced expand

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1379,8 +1379,8 @@ MM_MemorySubSpaceTarok::calculateTargetContractSize(MM_EnvironmentBase *env, uin
 
 /**
  * Determine how much space we need to expand the heap by on this GC cycle to get to a better hybrid heap score
- * @note We use the approximate heap size to account for defered work that may during execution free up more memory.
- * @param expandToSatisfy - if TRUE ensure we epxand heap by at least "byteRequired" bytes
+ * @note We use the approximate heap size to account for deferred work that may during execution free up more memory.
+ * @param expandToSatisfy - if TRUE ensure we expand heap by at least "byteRequired" bytes
  * @return Number of bytes to expand. 0 if no expansion is required
  */
 uintptr_t
@@ -1396,9 +1396,10 @@ MM_MemorySubSpaceTarok::calculateExpansionSizeInternal(MM_EnvironmentBase *env, 
 		/* Only expand if we didn't expand in last _extensions->heapExpansionStabilizationCount global collections */
 		/* Note that the gcCount includes System GCs, PGCs, AFs and GMP increments */
 		uintptr_t heapSizeWithinGoodHybridRange = getHeapSizeWithinBounds(env);
+		uintptr_t activeMemorySize = getActiveMemorySize();
 
-		expandSize = heapSizeWithinGoodHybridRange - getActiveMemorySize();
-		if (0 != expandSize) {
+		if (heapSizeWithinGoodHybridRange > activeMemorySize) {
+			expandSize = heapSizeWithinGoodHybridRange - activeMemorySize;
 			_extensions->heap->getResizeStats()->setLastExpandReason(FREE_SPACE_LOW_OR_GC_HIGH);
 		}
 	}


### PR DESCRIPTION
Total heap resizing (based on GC overhead heuristics) may suggest to
expand to a smaller value than current total heap size, leading to
contraction (what might not be problem by itself). The bigger problem is
that internally it's represented as a big (overflowed) unsigned integer
and while arithmetic (+/- operators) will silently work (we will
successfully contract), that's not the case for comparisons (<,>
operators).

If there was a large object alloc request and there is not free enough
memory we may want to expand, but since this alloc size is likely to be
less than the fake expand, it won't be able to trigger the real expand.

Eventually, this may lead to failing to allocate and OOM condition.

The fix is simply to prevent the overflow math and set the expansion
value to 0, if calculated value is negative.

Fixes: https://github.com/eclipse-openj9/openj9/issues/13584

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>