### PR TITLE
Re-enable disabled tests in jsr292_JitCount0

### DIFF
--- a/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
+++ b/test/TestConfig/resources/excludes/feature_ojdkmh_exclude.txt
@@ -33,9 +33,3 @@ com.ibm.j9.jsr292.ConstructorHandleTest:testIfConstructorHandleIsJitted AN-https
 com.ibm.j9.jsr292.ReceiverBoundHandleTest:testIfRecieverBoundHandleTestIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
 com.ibm.j9.jsr292.InterfaceHandleTest:testIfInterfaceHandleIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
 com.ibm.j9.jsr292.DirectHandleTest:testIfDirectHandleTestIsJitted AN-https://github.com/eclipse-openj9/openj9/issues/12571 generic-all
-
-com.ibm.j9.jsr292.MethodHandleTest:test_exactInvoker_ArityLimit AN-https://github.com/eclipse-openj9/openj9/issues/13050 generic-all
-com.ibm.j9.jsr292.MethodHandleTest:test_exactInvoker_Static_ArityLimit AN-https://github.com/eclipse-openj9/openj9/issues/13050 generic-all
-com.ibm.j9.jsr292.MethodHandleTest:test_invoker_ArityLimit AN-https://github.com/eclipse-openj9/openj9/issues/13050 generic-all
-com.ibm.j9.jsr292.MethodHandleTest:test_invoker_Static_ArityLimit AN-https://github.com/eclipse-openj9/openj9/issues/13050 generic-all
-com.ibm.j9.jsr292.PermuteTest:testPermuteHandleMaximumArguments AN-https://github.com/eclipse-openj9/openj9/issues/13050 generic-all


### PR DESCRIPTION
The underlying problems that caused the tests to fail have been fixed and the failures are no longer reproducible.

Issue: #13050

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>