### PR TITLE
Run findVectorAPIMethods() at the end of Inliner

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -48,7 +48,7 @@ TR_VectorAPIExpansion::perform()
    if (J2SE_VERSION(TR::Compiler->javaVM) >= J2SE_V17 &&
        !disableVectorAPIExpansion &&
        !TR::Compiler->om.canGenerateArraylets() &&
-       findVectorMethods())
+       findVectorMethods(comp()))
       expandVectorAPI();
 
    return 0;
@@ -506,12 +506,14 @@ TR_VectorAPIExpansion::getDataTypeFromClassNode(TR::Node *classNode)
 
 
 bool
-TR_VectorAPIExpansion::findVectorMethods()
+TR_VectorAPIExpansion::findVectorMethods(TR::Compilation *comp)
    {
-   if (_trace)
-      traceMsg(comp(), "%s in findVectorMethods\n", OPT_DETAILS_VECTOR);
+   bool trace = comp->getOption(TR_TraceVectorAPIExpansion);
 
-   for (TR::TreeTop *tt = comp()->getMethodSymbol()->getFirstTreeTop(); tt ; tt = tt->getNextTreeTop())
+   if (trace)
+      traceMsg(comp, "%s in findVectorMethods\n", OPT_DETAILS_VECTOR);
+
+   for (TR::TreeTop *tt = comp->getMethodSymbol()->getFirstTreeTop(); tt ; tt = tt->getNextTreeTop())
       {
       TR::Node *node = tt->getNode();
       TR::ILOpCodes opCodeValue = node->getOpCodeValue();
@@ -529,6 +531,8 @@ TR_VectorAPIExpansion::findVectorMethods()
 
          if (isVectorAPIMethod(methodSymbol))
             {
+            if (trace)
+               traceMsg(comp, "%s found Vector API method\n", OPT_DETAILS_VECTOR);
             return true;
             }
          }

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -248,15 +248,17 @@ class TR_VectorAPIExpansion : public TR::Optimization
    /** \brief
     *     Checks if the method being compiled contains any recognized Vector API methods
     *
+    *  \param comp
+    *     Compilation
+    *
     *  \return
     *     \c true if it finds any methods,
     *     \c false otherwise
     */
-   bool findVectorMethods();
+   static bool findVectorMethods(TR::Compilation *comp);
 
   /** \brief
    *     The method that does the final transformation
-   *
    */
    int32_t expandVectorAPI();
 
@@ -270,7 +272,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *     \c true if \c methodSymbol is a recognized Vector API method(high level or intrinsic),
    *     \c false otherwise
    */
-   bool isVectorAPIMethod(TR::MethodSymbol * methodSymbol);
+   static bool isVectorAPIMethod(TR::MethodSymbol * methodSymbol);
 
   /** \brief
    *     Checks if methodSymbol returns Vector object


### PR DESCRIPTION
Checking for vector methods in inlineRecognizedMethod() is not enough,
so we need to run a pass through IL after inlining to make detection
more reliable.