### PR TITLE
Fix handling of interface methods in JIT linkToVirtual()

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -294,6 +294,8 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/armnathelp.m4
+++ b/runtime/codert_vm/armnathelp.m4
@@ -299,6 +299,8 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1606,6 +1606,52 @@ old_fast_jitLookupInterfaceMethod(J9VMThread *currentThread)
 }
 
 void J9FASTCALL
+old_fast_jitLookupDynamicInterfaceMethod(J9VMThread *currentThread)
+{
+	OLD_JIT_HELPER_PROLOGUE(3);
+	DECLARE_JIT_CLASS_PARM(receiverClass, 1);
+	DECLARE_JIT_CLASS_PARM(interfaceClass, 2);
+	DECLARE_JIT_PARM(UDATA, iTableIndex, 3);
+	UDATA iTableOffset = sizeof(struct J9ITable) + (iTableIndex * sizeof(UDATA));
+	UDATA vTableOffset = convertITableOffsetToVTableOffset(currentThread, receiverClass, interfaceClass, iTableOffset);
+	Assert_CodertVM_false(0 == vTableOffset);
+	JIT_RETURN_UDATA(vTableOffset);
+}
+
+void* J9FASTCALL
+old_slow_jitLookupDynamicPublicInterfaceMethod(J9VMThread *currentThread)
+{
+	SLOW_JIT_HELPER_PROLOGUE();
+	J9Method *method = (J9Method*)currentThread->floatTemp1;
+	buildJITResolveFrameForRuntimeHelper(currentThread, parmCount);
+	TIDY_BEFORE_THROW();
+	currentThread->javaVM->internalVMFunctions->setIllegalAccessErrorNonPublicInvokeInterface(currentThread, method);
+	return J9_JITHELPER_ACTION_THROW;
+}
+
+void* J9FASTCALL
+old_fast_jitLookupDynamicPublicInterfaceMethod(J9VMThread *currentThread)
+{
+	void *slowPath = (void*)old_slow_jitLookupDynamicPublicInterfaceMethod;
+	OLD_JIT_HELPER_PROLOGUE(3);
+	DECLARE_JIT_CLASS_PARM(receiverClass, 1);
+	DECLARE_JIT_CLASS_PARM(interfaceClass, 2);
+	DECLARE_JIT_PARM(UDATA, iTableIndex, 3);
+	UDATA iTableOffset = sizeof(struct J9ITable) + (iTableIndex * sizeof(UDATA));
+	UDATA vTableOffset = convertITableOffsetToVTableOffset(currentThread, receiverClass, interfaceClass, iTableOffset);
+	Assert_CodertVM_false(0 == vTableOffset);
+	/* The receiver's implementation is required to be public */
+	J9Method *method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
+	if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
+		slowPath = NULL;
+		JIT_RETURN_UDATA(vTableOffset);
+	} else {
+		currentThread->floatTemp1 = (void*)method;
+	}
+	return slowPath;
+}
+
+void J9FASTCALL
 old_fast_jitMethodIsNative(J9VMThread *currentThread)
 {
 	OLD_JIT_HELPER_PROLOGUE(1);
@@ -3881,6 +3927,9 @@ initPureCFunctionTable(J9JavaVM *vm)
 	jitConfig->old_fast_jitInstanceOf = (void*)old_fast_jitInstanceOf;
 	jitConfig->old_fast_jitLookupInterfaceMethod = (void*)old_fast_jitLookupInterfaceMethod;
 	jitConfig->old_slow_jitLookupInterfaceMethod = (void*)old_slow_jitLookupInterfaceMethod;
+	jitConfig->old_fast_jitLookupDynamicInterfaceMethod = (void*)old_fast_jitLookupDynamicInterfaceMethod;
+	jitConfig->old_fast_jitLookupDynamicPublicInterfaceMethod = (void*)old_fast_jitLookupDynamicPublicInterfaceMethod;
+	jitConfig->old_slow_jitLookupDynamicPublicInterfaceMethod = (void*)old_slow_jitLookupDynamicPublicInterfaceMethod;
 	jitConfig->old_fast_jitMethodIsNative = (void*)old_fast_jitMethodIsNative;
 	jitConfig->old_fast_jitMethodIsSync = (void*)old_fast_jitMethodIsSync;
 	jitConfig->old_fast_jitMethodMonitorEntry = (void*)old_fast_jitMethodMonitorEntry;

--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -369,6 +369,8 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/riscvnathelp.m4
+++ b/runtime/codert_vm/riscvnathelp.m4
@@ -292,6 +292,8 @@ OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -419,6 +419,8 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -344,6 +344,8 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
+FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
 
 dnl Trap handlers
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -303,6 +303,20 @@ J9::SymbolReferenceTable::findOrCreateStoreFlattenableArrayElementSymbolRef(TR::
 
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateLookupDynamicInterfaceMethodSymbolRef()
+   {
+   return findOrCreateRuntimeHelper(TR_jitLookupDynamicInterfaceMethod, false, false, true);
+   }
+
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef()
+   {
+   return findOrCreateRuntimeHelper(TR_jitLookupDynamicPublicInterfaceMethod, false, true, true);
+   }
+
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateFloatSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
    void * dataAddress = owningMethodSymbol->getResolvedMethod()->floatConstant(cpIndex);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -155,6 +155,20 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateLoadFlattenableArrayElementSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = NULL);
    TR::SymbolReference * findOrCreateStoreFlattenableArrayElementSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = NULL);
 
+   // This helper walks the iTables to find the VFT offset for an interface
+   // method that is not known until runtime (and therefore does not have an
+   // IPIC data snippet). The parameters are the receiver class, interface
+   // class, and iTable index (though in the trees they must appear as
+   // children in the opposite order), and the return value is the VFT offset.
+   //
+   // The given receiver class must implement the given interface class.
+   //
+   TR::SymbolReference * findOrCreateLookupDynamicInterfaceMethodSymbolRef();
+
+   // This helper is a variant of jitLookupDynamicInterfaceMethod that requires
+   // the dispatched callee to be public, otherwise throwing IllegalAccessError.
+   TR::SymbolReference * findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef();
+
    TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);
    TR::SymbolReference * findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, char* name = NULL);
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4959,15 +4959,15 @@ TR_J9VMBase::jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTab
    return NULL;
    }
 
-int32_t
+uintptr_t
 TR_J9VMBase::vTableOrITableIndexFromMemberName(uintptr_t memberName)
    {
    TR_ASSERT(haveAccess(), "vTableOrITableIndexFromMemberName requires VM access");
    auto methodID = jniMethodIdFromMemberName(memberName);
-   return (int32_t)methodID->vTableIndex;
+   return methodID->vTableIndex;
    }
 
-int32_t
+uintptr_t
 TR_J9VMBase::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
    {
    auto knot = comp->getKnownObjectTable();
@@ -4979,7 +4979,7 @@ TR_J9VMBase::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownO
       uintptr_t object = knot->getPointer(objIndex);
       return vTableOrITableIndexFromMemberName(object);
       }
-   return -1;
+   return (uintptr_t)-1;
    }
 
 TR::KnownObjectTable::Index

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -819,13 +819,13 @@ public:
     *    Return vtable or itable index of a method represented by MemberName
     *    Caller must acquire VM access
     */
-   virtual int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
+   virtual uintptr_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
    /*
     * \brief
     *    Return vtable or itable index of a method represented by MemberName
     *    VM access is not required
     */
-   virtual int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual uintptr_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
    /*
     * \brief
     *    Create and return a resolved method from member name index of an invoke cache array.

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2233,14 +2233,14 @@ TR_J9ServerVM::jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectT
    return NULL;
    }
 
-int32_t
+uintptr_t
 TR_J9ServerVM::vTableOrITableIndexFromMemberName(uintptr_t memberName)
    {
    TR_ASSERT_FATAL(false, "vTableOrITableIndexFromMemberName must not be called on JITServer");
    return 0;
    }
 
-int32_t
+uintptr_t
 TR_J9ServerVM::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
    {
    auto knot = comp->getKnownObjectTable();
@@ -2250,9 +2250,9 @@ TR_J9ServerVM::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::Know
       {
       JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
       stream->write(JITServer::MessageType::VM_vTableOrITableIndexFromMemberName, objIndex);
-      return std::get<0>(stream->read<int32_t>());
+      return std::get<0>(stream->read<uintptr_t>());
       }
-   return -1;
+   return (uintptr_t)-1;
    }
 
 TR::KnownObjectTable::Index

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -233,8 +233,8 @@ public:
 
    virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName) override;
    virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
-   virtual int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName) override;
-   virtual int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual uintptr_t vTableOrITableIndexFromMemberName(uintptr_t memberName) override;
+   virtual uintptr_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
    virtual TR::KnownObjectTable::Index delegatingMethodHandleTargetHelper( TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass) override;
    virtual UDATA getVMTargetOffset() override;
    virtual UDATA getVMIndexOffset() override;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1104,10 +1104,37 @@ InterpreterEmulator::refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&cal
 
          uint32_t vTableSlot = 0;
          if (rm == TR::java_lang_invoke_MethodHandle_linkToVirtual)
-            vTableSlot = fej9->vTableOrITableIndexFromMemberName(comp(), memberNameIndex);
+            {
+            uintptr_t slot = fej9->vTableOrITableIndexFromMemberName(comp(), memberNameIndex);
+            if ((slot & J9_JNI_MID_INTERFACE) == 0)
+               {
+               vTableSlot = (uint32_t)slot;
+               }
+            else
+               {
+               // TODO: Refine to the method identified by the itable slot
+               // together with the defining (interface) class of the method
+               // from the MemberName. For such a refinement to matter,
+               // TR_J9InterfaceCallSite will need to be able to find call
+               // targets without a CP index.
+               //
+               // For the moment, just leave the call unrefined.
+               //
+               return;
+               }
+            }
 
+         // Direct or virtual dispatch. A vTableSlot of 0 indicates a direct
+         // call, in which case vTableSlot won't really be used as such.
          callee = fej9->createResolvedMethodWithVTableSlot(comp()->trMemory(), vTableSlot, targetMethod, _calltarget->_calleeMethod);
-         isIndirectCall = rm == TR::java_lang_invoke_MethodHandle_linkToVirtual || rm == TR::java_lang_invoke_MethodHandle_linkToInterface;
+
+         isIndirectCall = vTableSlot != 0;
+         TR_ASSERT_FATAL(
+            !isIndirectCall
+            || rm == TR::java_lang_invoke_MethodHandle_linkToVirtual
+            || rm == TR::java_lang_invoke_MethodHandle_linkToInterface,
+            "indirect linkTo call should only be linkToVirtual or linkToInterface");
+
          heuristicTrace(tracer(), "Refine linkTo to %s\n", callee->signature(trMemory(), stackAlloc));
          // The refined method doesn't take MemberName as an argument, pop MemberName out of the operand stack
          pop();

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -619,7 +619,7 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
       currentChild->recursivelyDecReferenceCount(); // ref count has to be decremented twice as there were two duplicates of the parent made
       }
 
-   TR::SymbolReference *mhSymRef = argsList->front();
+   TR::SymbolReference *receiverSymRef = argsList->front();
    TR::SymbolReference *mnSymRef = argsList->back();
 
    // -------- construct trees to obtain and check if vTableIndex > 0 --------
@@ -642,10 +642,10 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
    TR::SymbolReference* vtableOffsetTempSlotSymRef = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(),vtableIndexNode->getSymbol()->getDataType());
    vtableOffsetTempSlotSymRef->getSymbol()->setNotCollected();
    treetop->insertBefore(TR::TreeTop::create(comp(), TR::Node::createStore(node, vtableOffsetTempSlotSymRef, vtableIndexNode)));
-   TR::ILOpCodes xcmpne = comp()->target().is64Bit()? TR::iflcmpne : TR::ificmpne;
+   TR::ILOpCodes ifxcmpne = comp()->target().is64Bit()? TR::iflcmpne : TR::ificmpne;
    TR::Node *zero = comp()->target().is64Bit()? TR::Node::lconst(node, 0) : TR::Node::iconst(node, 0);
 
-   TR::Node* vTableOffsetIsNotZero = TR::Node::createif(xcmpne,
+   TR::Node* vTableOffsetIsNotZero = TR::Node::createif(ifxcmpne,
                                                          TR::Node::createLoad(node, vtableOffsetTempSlotSymRef),
                                                          zero,
                                                          NULL);
@@ -666,30 +666,32 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
    TR_ResolvedMethod * dummyMethod = fej9->createResolvedMethodWithSignature(comp()->trMemory(),dummyInvoke, NULL, signature, signatureLength, owningMethodSymbol->getResolvedMethod());
    TR::SymbolReference * methodSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(owningMethodSymbol->getResolvedMethodIndex(), -1, dummyMethod, TR::MethodSymbol::ComputedStatic);
 
-   // construct trees to load target method address (which will either be a thunk or compiled method address) from VFT, but for simplicity let's call it a jitted method address
-   TR::Node* vtableOffset  =  TR::Node::create(TR::lsub, 2, TR::Node::createLoad(node, vtableOffsetTempSlotSymRef), TR::Node::lconst(node, sizeof(J9Class)));
-   TR::SymbolReference * vftSymRef = comp()->getSymRefTab()->findOrCreateVftSymbolRef();
-   TR::Node * vftNode = TR::Node::createWithSymRef(node, TR::aloadi, 1, TR::Node::createLoad(node, mhSymRef), vftSymRef);
+   // construct trees to load target method address (which will either be a thunk or compiled method address) from VFT, but for simplicity let's call it a jitted method entry point
+   TR::Node * xconstSizeofJ9Class = comp()->target().is64Bit()
+      ? TR::Node::lconst(node, sizeof(J9Class))
+      : TR::Node::iconst(node, sizeof(J9Class));
+
    TR::ILOpCodes subOp = comp()->target().is64Bit() ? TR::lsub : TR::isub;
-   TR::ILOpCodes x2a = comp()->target().is64Bit() ? TR::l2a : TR::i2a;
-   TR::Node * jittedMethodAddressNode = TR::Node::create(x2a, 1, TR::Node::create(subOp, 2, vftNode, vtableOffset));
+   TR::ILOpCodes axadd = comp()->target().is64Bit() ? TR::aladd : TR::aiadd;
+   TR::Node* jitVFTOffset = TR::Node::create(subOp, 2, xconstSizeofJ9Class, TR::Node::createLoad(node, vtableOffsetTempSlotSymRef));
+   TR::SymbolReference * vftSymRef = comp()->getSymRefTab()->findOrCreateVftSymbolRef();
+   TR::Node * vftNode = TR::Node::createWithSymRef(node, TR::aloadi, 1, TR::Node::createLoad(node, receiverSymRef), vftSymRef);
+   TR::Node * jitVFTSlotPtr = TR::Node::create(axadd, 2, vftNode, jitVFTOffset);
    TR::SymbolReference *tSymRef = comp()->getSymRefTab()->findOrCreateGenericIntShadowSymbolReference(0);
    tSymRef->getSymbol()->setNotCollected();
    TR::ILOpCodes loadOp = comp()->target().is64Bit() ? TR::lloadi : TR::iloadi;
    // arg0 ---> jitted method address (in JIT vtable)
-   TR::Node * jittedMethodAddressLoadNode = TR::Node::createWithSymRef(loadOp, 1, 1, jittedMethodAddressNode,tSymRef);
+   TR::Node * jittedMethodEntryPoint = TR::Node::createWithSymRef(loadOp, 1, 1, jitVFTSlotPtr, tSymRef);
 
-   // arg1 ---> vtable slot index
-   TR::ILOpCodes mulOp = comp()->target().is64Bit() ? TR::lmul : TR::imul;
-   TR::Node* vtableSlot = TR::Node::create(node, mulOp, 2, vtableOffset, TR::Node::lconst(node, -1));
+   // arg1 ---> vtable slot index (jitVFTOffset)
 
    // 2 additional args prepended (address in vtable entry and vtable slot index), and last arg (MemberName object) removed, so net 1 extra child
    uint32_t numChildren = node->getNumChildren() + 1;
    TR::Node * dispatchVirtualCallNode = TR::Node::createWithSymRef(node, node->getSymbol()->castToMethodSymbol()->getMethod()->indirectCallOpCode(), numChildren, methodSymRef);
 
    // set children for the dispatchVirtual call node
-   dispatchVirtualCallNode->setAndIncChild(0, jittedMethodAddressLoadNode);
-   dispatchVirtualCallNode->setAndIncChild(1, vtableSlot);
+   dispatchVirtualCallNode->setAndIncChild(0, jittedMethodEntryPoint);
+   dispatchVirtualCallNode->setAndIncChild(1, jitVFTOffset);
    argsList->pop_back(); //remove MemberName object
    int32_t child_i = 2;
    for (auto symRefIt = argsList->begin(); symRefIt != argsList->end(); ++symRefIt)
@@ -709,24 +711,145 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
 
    node->removeAllChildren();
    TR::TransformUtil::createDiamondForCall(this, treetop, vtableOffsetIsNotZeroTreeTop, dispatchVirtualTreeTop, placeholderINLCallTreeTop, false, false);
-   dispatchVirtualTreeTop->insertBefore(TR::TreeTop::create(comp(), nullChkNode));
+   TR::TreeTop *virtualNullCheckTreeTop = TR::TreeTop::create(comp(), nullChkNode);
+   dispatchVirtualTreeTop->insertBefore(virtualNullCheckTreeTop);
+
+   // Insert a conditional at the beginning of the virtual call path to
+   // determine the VFT offset for interface methods.
+   TR::Block *virtualNullCheckBlock = virtualNullCheckTreeTop->getEnclosingBlock();
+   TR::CFG *cfg = comp()->getFlowGraph();
+   TR::Block *itableLookupBlock = virtualNullCheckBlock->split(dispatchVirtualTreeTop, cfg, true);
+   TR::Block *virtualDispatchBlock = itableLookupBlock->split(dispatchVirtualTreeTop, cfg, true);
+
+   TR::ILOpCodes andOp = comp()->target().is64Bit() ? TR::land : TR::iand;
+   TR::Node * xconstITableFlagBit = comp()->target().is64Bit()
+      ? TR::Node::lconst(node, J9_JNI_MID_INTERFACE)
+      : TR::Node::iconst(node, (int32_t)J9_JNI_MID_INTERFACE);
+
+   TR::ILOpCodes ifxcmpeq = TR::ILOpCode(ifxcmpne).getOpCodeForReverseBranch();
+   // The offset is a VFT offset iff it is not an itable index
+   TR::Node * ifIsVFTOffset = TR::Node::createif(
+      ifxcmpeq,
+      TR::Node::create(
+         node,
+         andOp,
+         2,
+         TR::Node::createLoad(node, vtableOffsetTempSlotSymRef),
+         xconstITableFlagBit),
+      zero->duplicateTree(), // safe because zero is a constant
+      virtualDispatchBlock->getEntry());
+
+   virtualNullCheckBlock->append(TR::TreeTop::create(comp(), ifIsVFTOffset));
+   cfg->addEdge(virtualNullCheckBlock, virtualDispatchBlock);
+
+   // TODO: For linkToInterface() we should instead use
+   // findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef(), which will
+   // throw IllegalAccessError when the dispatched method is non-public.
+   TR::Node *vftOffsetFromITable = TR::Node::createWithSymRef(
+      node,
+      comp()->target().is64Bit() ? TR::lcall : TR::icall,
+      3,
+      comp()->getSymRefTab()->findOrCreateLookupDynamicInterfaceMethodSymbolRef());
+
+   // The first argument to the itable lookup helper is the receiver class.
+   // It's safe to duplicate vftNode here because it is just a load of
+   // <vft-symbol> from a load of a temp, and the temp has been created
+   // specifically to hold the receiver reference - there are no other defs.
+   //
+   // NOTE: This child is actually last because helper arguments are passed in
+   // reverse order.
+   //
+   vftOffsetFromITable->setAndIncChild(2, vftNode->duplicateTree());
+
+   // The next argument to the itable lookup helper is the interface class.
+   const bool vmtargetIsVolatile = false;
+   const bool vmtargetIsPrivate = false; // could be true? It's a hidden field
+   const bool vmtargetIsFinal = true;
+   TR::SymbolReference * vmtargetSymRef =
+      comp()->getSymRefTab()->findOrFabricateShadowSymbol(
+         comp()->getMethodSymbol(),
+         TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
+         TR::Address,
+         fej9->getVMTargetOffset(),
+         vmtargetIsVolatile,
+         vmtargetIsPrivate,
+         vmtargetIsFinal,
+         "java/lang/invoke/MemberName.vmtarget J");
+
+   vmtargetSymRef->getSymbol()->setNotCollected();
+
+   TR::Node * vmTargetNode = TR::Node::createWithSymRef(
+      node, TR::aloadi, 1, TR::Node::createLoad(node, mnSymRef), vmtargetSymRef);
+
+   TR::SymbolReference *cpField =
+      comp()->getSymRefTab()->findOrCreateJ9MethodConstantPoolFieldSymbolRef(
+         offsetof(struct J9Method, constantPool));
+
+   TR::Node *cpAddrIntWithFlags = TR::Node::createWithSymRef(
+      node, loadOp, 1, vmTargetNode, cpField);
+
+   TR::Node *cpAddrMask = comp()->target().is64Bit()
+      ? TR::Node::lconst(~(int64_t)J9_STARTPC_STATUS)
+      : TR::Node::iconst(~(int32_t)J9_STARTPC_STATUS);
+
+   TR::Node *cpAddrInt = TR::Node::create(
+      node, andOp, 2, cpAddrIntWithFlags, cpAddrMask);
+
+   TR::ILOpCodes x2a = comp()->target().is64Bit() ? TR::l2a : TR::i2a;
+   TR::Node *cpAddr = TR::Node::create(node, x2a, 1, cpAddrInt);
+
+   TR::Node *ramClassFieldOffset = comp()->target().is64Bit()
+      ? TR::Node::lconst(offsetof (struct J9ConstantPool, ramClass))
+      : TR::Node::iconst(offsetof (struct J9ConstantPool, ramClass));
+
+   TR::Node *ramClassFieldAddr = TR::Node::create(
+      node, axadd, 2, cpAddr, ramClassFieldOffset);
+
+   TR::Node *interfaceClassInt = TR::Node::createWithSymRef(
+      node, loadOp, 1, ramClassFieldAddr, tSymRef);
+
+   TR::Node *interfaceClass = TR::Node::create(node, x2a, 1, interfaceClassInt);
+   vftOffsetFromITable->setAndIncChild(1, interfaceClass);
+
+   // The final argument to the itable lookup helper is the itable index.
+   // NOTE: This child is actually first because helper arguments are passed in
+   // reverse order.
+   TR::Node *xconstClearITableFlagMask = comp()->target().is64Bit()
+      ? TR::Node::lconst(node, ~(int64_t)J9_JNI_MID_INTERFACE)
+      : TR::Node::iconst(node, ~(int32_t)J9_JNI_MID_INTERFACE);
+
+   // Duplicate xconstITableFlagBit to prevent commoning between blocks. The
+   // duplication is safe because it's a constant.
+   xconstITableFlagBit = xconstITableFlagBit->duplicateTree();
+   TR::Node *itableIndex = TR::Node::create(
+      andOp,
+      2,
+      TR::Node::createLoad(node, vtableOffsetTempSlotSymRef),
+      xconstClearITableFlagMask);
+
+   vftOffsetFromITable->setAndIncChild(0, itableIndex);
+
+   itableLookupBlock->append(
+      TR::TreeTop::create(
+         comp(),
+         TR::Node::create(node, TR::treetop, 1, vftOffsetFromITable)));
+
+   itableLookupBlock->append(
+      TR::TreeTop::create(
+         comp(),
+         TR::Node::createStore(
+            node, vtableOffsetTempSlotSymRef, vftOffsetFromITable)));
 
    // -------- path if vmIndex == 0 --------
    // now let's work with just the placeholder INL call as the main node, as if this is a linkToStatic/Special call. the original treetop was removed.
    treetop = placeholderINLCallTreeTop;
    node = treetop->getNode()->getFirstChild();
 
-   TR::SymbolReference * vmtargetSymRef = comp()->getSymRefTab()->findOrFabricateShadowSymbol(comp()->getMethodSymbol(),
-                                                                                                TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
-                                                                                                TR::Address,
-                                                                                                fej9->getVMTargetOffset(),
-                                                                                                false,
-                                                                                                false,
-                                                                                                true,
-                                                                                                "java/lang/invoke/MemberName.vmtarget J");
-   vmtargetSymRef->getSymbol()->setNotCollected();
+   // It's safe to duplicate vmTargetNode because it's just a load of vmtarget
+   // from a load of a temp, and the temp has been created specifically to hold
+   // the MemberName reference - there are no other defs
+   vmTargetNode = vmTargetNode->duplicateTree();
 
-   TR::Node * vmTargetNode = TR::Node::createWithSymRef(node, TR::aloadi, 1, /* memberName */ TR::Node::createLoad(node, mnSymRef), vmtargetSymRef);
    processVMInternalNativeFunction(treetop, node, vmTargetNode, argsList, duplicatedINLCallNode);
    }
 #endif // J9VM_OPT_OPENJDK_METHODHANDLE

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2173,9 +2173,6 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
 
    TR_ASSERT(targetMethod, "Can't get target method from MethodName obj%d\n", mnIndex);
 
-   if (!performTransformation(comp, "O^O Refine linkToXXX n%dn [%p] with known MemberName object\n", node->getGlobalIndex(), node))
-      return false;
-
    TR::MethodSymbol::Kinds callKind = getTargetMethodCallKind(rm);
    TR::ILOpCodes callOpCode = getTargetMethodCallOpCode(rm, node->getDataType());
 
@@ -2184,7 +2181,23 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
    int32_t jitVTableOffset = 0;
    if (rm == TR::java_lang_invoke_MethodHandle_linkToVirtual)
       {
-      vTableSlot = fej9->vTableOrITableIndexFromMemberName(comp, mnIndex);
+      uintptr_t slot = fej9->vTableOrITableIndexFromMemberName(comp, mnIndex);
+      if ((slot & J9_JNI_MID_INTERFACE) != 0)
+         {
+         // TODO: Refine this to an interface call to the method identified by
+         // the itable slot and the method's defining (interface) class from
+         // the MemberName.
+         //
+         // Unfortunately, such a call will not be representable until
+         // interface calls are allowed to be resolved. As it stands, code
+         // generation requires a CP index for the dispatch.
+         //
+         // For the moment, just leave the call unrefined.
+         //
+         return false;
+         }
+
+      vTableSlot = (uint32_t)slot;
       jitVTableOffset = fej9->vTableSlotToVirtualCallOffset(vTableSlot);
       // For private virtual methods and java/lang/Object; type virtual methods, there is no corresponding
       // entry in the vtable, and for such methods the interpreter vtable index is 0.
@@ -2195,6 +2208,10 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
       if (jitVTableOffset > 0)
          callKind = TR::MethodSymbol::Static;
       }
+
+   if (!performTransformation(comp, "O^O Refine linkToXXX n%dn [%p] with known MemberName object\n", node->getGlobalIndex(), node))
+      return false;
+
    auto resolvedMethod = fej9->createResolvedMethodWithVTableSlot(comp->trMemory(), vTableSlot, targetMethod, symRef->getOwningMethod(comp));
    newSymRef = comp->getSymRefTab()->findOrCreateMethodSymbol(symRef->getOwningMethodIndex(), -1, resolvedMethod, callKind);
    if (callKind == TR::MethodSymbol::Virtual)

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -653,6 +653,8 @@ JIT_HELPER(_jitResolveConstantDynamic);
 JIT_HELPER(_nativeStaticHelper);
 JIT_HELPER(_interpreterStaticSpecialCallGlue);
 JIT_HELPER(jitLookupInterfaceMethod);
+JIT_HELPER(jitLookupDynamicInterfaceMethod);
+JIT_HELPER(jitLookupDynamicPublicInterfaceMethod);
 JIT_HELPER(jitMethodIsNative);
 JIT_HELPER(jitMethodIsSync);
 JIT_HELPER(jitPreJNICallOffloadCheck);
@@ -1072,6 +1074,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_acmpneHelper,               (void *)jitAcmpneHelper, TR_Helper);
    SET(TR_multiANewArray,             (void *)jitAMultiNewArray, TR_Helper);
    SET(TR_aThrow,                     (void *)jitThrowException, TR_Helper);
+
+   SET(TR_jitLookupDynamicInterfaceMethod, (void *)jitLookupDynamicInterfaceMethod, TR_Helper);
+   SET(TR_jitLookupDynamicPublicInterfaceMethod, (void *)jitLookupDynamicPublicInterfaceMethod, TR_Helper);
 
    SET(TR_nullCheck,                  (void *)jitThrowNullPointerException,          TR_Helper);
    SET(TR_methodTypeCheck,            (void *)jitThrowWrongMethodTypeException,      TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -77,6 +77,8 @@ JIT_HELPER(jitInduceOSRAtCurrentPCAndRecompile);  // asm calling-convention help
 JIT_HELPER(jitInstanceOf);  // asm calling-convention helper
 JIT_HELPER(jitInterpretNewInstanceMethod);  // asm calling-convention helper
 JIT_HELPER(jitLookupInterfaceMethod);  // asm calling-convention helper
+JIT_HELPER(jitLookupDynamicInterfaceMethod);  // asm calling-convention helper
+JIT_HELPER(jitLookupDynamicPublicInterfaceMethod);  // asm calling-convention helper
 JIT_HELPER(jitMethodIsNative);  // asm calling-convention helper
 JIT_HELPER(jitMethodIsSync);  // asm calling-convention helper
 JIT_HELPER(jitMethodMonitorEntry);  // asm calling-convention helper

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -566,6 +566,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitInstanceOf", offsetof(J9JITConfig, old_fast_jitInstanceOf)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupInterfaceMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitLookupInterfaceMethod", offsetof(J9JITConfig, old_slow_jitLookupInterfaceMethod)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupDynamicInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupDynamicInterfaceMethod)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupDynamicPublicInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupDynamicPublicInterfaceMethod)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitLookupDynamicPublicInterfaceMethod", offsetof(J9JITConfig, old_slow_jitLookupDynamicPublicInterfaceMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodIsNative", offsetof(J9JITConfig, old_fast_jitMethodIsNative)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodIsSync", offsetof(J9JITConfig, old_fast_jitMethodIsSync)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodMonitorEntry", offsetof(J9JITConfig, old_fast_jitMethodMonitorEntry)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3734,6 +3734,9 @@ typedef struct J9JITConfig {
 	void *old_fast_jitInstanceOf;
 	void *old_fast_jitLookupInterfaceMethod;
 	void *old_slow_jitLookupInterfaceMethod;
+	void *old_fast_jitLookupDynamicInterfaceMethod;
+	void *old_fast_jitLookupDynamicPublicInterfaceMethod;
+	void *old_slow_jitLookupDynamicPublicInterfaceMethod;
 	void *old_fast_jitMethodIsNative;
 	void *old_fast_jitMethodIsSync;
 	void *old_fast_jitMethodMonitorEntry;


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#13711

Restore https://github.com/eclipse-openj9/openj9/pull/13578 now that https://github.com/eclipse/omr/pull/6186 has promoted.