### PR TITLE
AArch64: Add .text and .align directives to an asm file

### DIFF
--- a/runtime/compiler/aarch64/runtime/Recompilation.spp
+++ b/runtime/compiler/aarch64/runtime/Recompilation.spp
@@ -52,6 +52,9 @@
 #define J9VMTHREAD x19
 #define J9SP x20
 
+	.text
+	.align	2
+
 FUNC_LABEL(_countingRecompileMethod):
 	hlt	#0	// Not implemented yet
 


### PR DESCRIPTION
This commit adds .text and .align directives to an AArch64 asm file.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>