### PR TITLE
Add cmdlinetests for -XX:+UseCompressedOops and -XX:-UseCompressedOops

### DIFF
--- a/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
+++ b/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="XXArgumentTesting.xml" timeout="1000">
+
+	<test id="Verify single/rightmost -XX:+UseCompressedOops overrides earlier -XX:-UseCompressedOops or -Xnocompressedrefs (based on mode options)">
+		<command>$EXE$ -XX:+UseCompressedOops -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify single/rightmost -XX:-UseCompressedOops overrides earlier -XX:+UseCompressedOops or -Xcompressedrefs (based on mode options)">
+		<command>$EXE$ -XX:-UseCompressedOops -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify single/rightmost -Xcompressedrefs overrides earlier -XX:-UseCompressedOops or -Xnocompressedrefs (based on mode options)">
+		<command>$EXE$ -Xcompressedrefs -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify single/rightmost -Xnocompressedrefs overrides earlier -XX:+UseCompressedOops or -Xcompressedrefs (based on mode options)">
+		<command>$EXE$ -Xnocompressedrefs -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify rightmost -XX:+UseCompressedOops overrides earlier -XX:-UseCompressedOops and optional -Xnocompressedrefs (based on mode options)">
+		<command>$EXE$ -XX:-UseCompressedOops -XX:+UseCompressedOops -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify rightmost -XX:-UseCompressedOops overrides earlier -XX:+UseCompressedOops and optional -Xcompressedrefs (based on mode options)">
+		<command>$EXE$ -XX:+UseCompressedOops -XX:-UseCompressedOops -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify rightmost -Xcompressedrefs overrides earlier -Xnocompressedrefs and optional -XX:-UseCompressedOops (based on mode options)">
+		<command>$EXE$ -Xnocompressedrefs -Xcompressedrefs -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+
+	<test id="Verify rightmost -Xnocompressedrefs overrides earlier -Xcompressedrefs and optional -XX:+UseCompressedOops (based on mode options)">
+		<command>$EXE$ -Xcompressedrefs -Xnocompressedrefs -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="yes" regex="no">Compressed References</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/xxargtest/playlist.xml
+++ b/test/functional/cmdLineTests/xxargtest/playlist.xml
@@ -36,4 +36,29 @@
 			<group>functional</group>
 		</groups>
 	</test>
+	<test>
+		<testCaseName>testXXArgumentTesting_j9</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>Mode101</variation>
+			<variation>Mode601</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)XXArgumentTesting_j9.xml$(Q) \
+	-nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>bits.64</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>


### PR DESCRIPTION
- Add cmdlinetests for -XX:[+/-]UseCompressedOops
- Related Issue https://github.com/eclipse-openj9/openj9/issues/13660#issuecomment-942707322
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>