### PR TITLE
(0.29.1) Update 0.29 release notes with missing content

### DIFF
--- a/doc/release-notes/0.29/0.29.md
+++ b/doc/release-notes/0.29/0.29.md
@@ -48,10 +48,28 @@ The following table covers notable changes in v0.29.0. Further information about
 </thead>
 <tbody>
 
+<tr><td valign="top">N/A</td>
+<td valign="top">AArch64 Linux is now a fully supported, production-ready target</td>
+<td valign="top">AArch64 Linux, all JDK versions</td>
+<td valign="top">The remaining features, performance items, and bug fixes are implemented, making AArch64 Linux a production-ready target.</td>
+</tr>
+
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/13481">#13481</a></td>
+<td valign="top"><tt>-Xsoftmx</tt> updates for gencon</td>
+<td valign="top">All versions</td>
+<td valign="top">When using gencon, the <tt>-Xsoftmx</tt> limit is proportional to the maximum amount of nursery space specified relative to the <tt>-Xmx</tt> value.</td>
+</tr>
+
 <tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/13492">#13492</a></td>
 <td valign="top">JITServer technology is now a supported feature for Linux on x86-64 and Power</td>
 <td valign="top">OpenJDK 8 and 11 (Linux on x86-64, Linux on Power)</td>
 <td valign="top">JITServer decouples the JIT compiler from the OpenJ9 VM, freeing up CPU and memory for an application. JITServer then runs in its own process, either locally or on a remote machine, where resources can be separately managed.</td>
+</tr>
+
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/13568">#13568</a></td>
+<td valign="top"><tt>-XX:[+|-]UTFCache</tt> option added</td>
+<td valign="top">All versions</td>
+<td valign="top">A UTF to String cache is added to enhance reflection performance. The cache is enabled by default but can be disabled using the <tt>-XX:[+|-]UTFCache</tt> option.</td>
 </tr>
 
 </tbody>


### PR DESCRIPTION
Cherry pick #13702 and #13731 for the 0.29.1 branch