### PR TITLE
AArch64: Implement the inline monitor cache

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -28,6 +28,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "compile/Compilation.hpp"
 #include "runtime/CodeCacheManager.hpp"
 
 extern void TEMPORARY_initJ9ARM64TreeEvaluatorTable(TR::CodeGenerator *cg);
@@ -47,6 +48,7 @@ J9::ARM64::CodeGenerator::initialize()
    self()->J9::CodeGenerator::initialize();
 
    TR::CodeGenerator *cg = self();
+   TR::Compilation *comp = cg->comp();
 
    cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
 
@@ -63,11 +65,17 @@ J9::ARM64::CodeGenerator::initialize()
 
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsDivCheck();
-   if (!comp()->getOption(TR_FullSpeedDebug))
+   if (!comp->getOption(TR_FullSpeedDebug))
       cg->setSupportsDirectJNICalls();
 
    cg->setSupportsPrimitiveArrayCopy();
    cg->setSupportsReferenceArrayCopy();
+
+   static char *disableMonitorCacheLookup = feGetEnv("TR_disableMonitorCacheLookup");
+   if (!disableMonitorCacheLookup)
+      {
+      comp->setOption(TR_EnableMonitorCacheLookup);
+      }
    }
 
 TR::Linkage *

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -165,14 +165,15 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    /**
     * @brief Generates the sequence to handle cases where the monitor object is value type
     * @param[in] node : the monitor enter/exit node
-    * @param[in] helperCallLabel : the label for OOL code calling VM monitor enter/exit helpers
+    * @param[in] mergeLabel : the label to return from OOL code
+    * @param[in] helperCallLabel : the label for OOL code calling VM monitor enter/exit helpers. If null, an OOL code section is created.
     * @param[in] objReg : register for the monitor object
     * @param[in] temp1Reg : temporary register 1
     * @param[in] temp2Reg : temporary register 2
     * @param[in] cg : CodeGenerator
     * @param[in] classFlag : class flag
     */
-   static void generateCheckForValueMonitorEnterOrExit(TR::Node *node, TR::LabelSymbol *helperCallLabel, TR::Register *objReg, TR::Register *temp1Reg, TR::Register *temp2Reg, TR::CodeGenerator *cg, int32_t classFlag);
+   static void generateCheckForValueMonitorEnterOrExit(TR::Node *node, TR::LabelSymbol *mergeLabel, TR::LabelSymbol *helperCallLabel, TR::Register *objReg, TR::Register *temp1Reg, TR::Register *temp2Reg, TR::CodeGenerator *cg, int32_t classFlag);
 
    /**
     * @brief Generates array copy code with array store check


### PR DESCRIPTION
This commit changes `monentEvaluator` and `monExitEvaluator` to
- support the inline monitor cache.
- use OOL code section for slowpath instead of monitorenter/monitorexit snippet

Depends on https://github.com/eclipse/omr/pull/6212

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>