### PR TITLE
(v0.29.1-release) JVMTI trigger VMStart event according to can_generate_early_vmstart

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -884,7 +884,6 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 							}
 
 							vm->runtimeFlags |= J9_RUNTIME_JAVA_BASE_MODULE_CREATED;
-							TRIGGER_J9HOOK_JAVA_BASE_LOADED(vm->hookInterface, currentThread);
 							Trc_MODULE_defineModule(currentThread, "java.base", j9mod);
 						}
 

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -209,6 +209,10 @@ standardInit( J9JavaVM *vm, char *dllName)
 			vmFuncs->internalReleaseVMAccess(vmThread);
 	#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			vmFuncs->initializeAttachedThread(vmThread, threadName, (j9object_t *)threadGroup, FALSE, vmThread);
+#if JAVA_SPEC_VERSION >= 11
+			/* Trigger the VMStart event via jvmtiHookVMStarted handler if the can_generate_early_vmstart capability is set */
+			TRIGGER_J9HOOK_JAVA_BASE_LOADED(vm->hookInterface, vmThread);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 			vmFuncs->internalAcquireVMAccess(vmThread);
 


### PR DESCRIPTION
Moved `TRIGGER_J9HOOK_JAVA_BASE_LOADED` to `standardInit()` after `initializeAttachedThread()` for `mainThread`, which is the earliest point to run an agent such as `YourKit Java profiler` agent;
Fixed `processEvent()` for `J9HOOK_JAVA_BASE_LOADED`;
When `can_generate_early_vmstart` capability is specified, `VMStart` event is triggered in the `jvmtiHookModuleSystemStarted` handler, otherwise in `jvmtiHookVMStarted` after JavaVM initialization;
Refactoring the functions affected, replaced `JAVA_SPEC_VERSION` `9` with `11`.

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/13737

Proposing this to `v0.29.1-release` based on 
* this is not a high risk change
* it fixes a JDK17 user issue https://github.com/eclipse-openj9/openj9/issues/13708

Signed-off-by: Jason Feng <fengj@ca.ibm.com>