### PR TITLE
Fix the race condition for classPathEntries and cpEntryCount (part 2)

### DIFF
--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -274,7 +274,10 @@ searchClassInBootstrapClassPath(J9VMThread * vmThread, U_8 * className, UDATA cl
 		return rc;
 	}
 	for (i = 0; i < classLoader->classPathEntryCount; i++) {
+		/* This loop goes to the file system, so cpEntriesMutex is not held during the entire loop. */
+		omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
 		cpEntry = classLoader->classPathEntries[i];
+		omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 		/* Warm up the entry */
 		vmFuncs->initializeClassPathEntry(javaVM, cpEntry);
 		rc = searchClassInCPEntry(vmThread, cpEntry, NULL, NULL, className, classNameLength, verbose);

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -576,6 +576,7 @@ initializeBootstrapClassPath(J9JavaVM *vm)
 	if (-1 == (IDATA)loader->classPathEntryCount) {
 		return -1;
 	} else {
+		omrthread_rwmutex_init(&loader->cpEntriesMutex, 0, "classPathEntries Mutex");
 		loader->initClassPathEntryCount = loader->classPathEntryCount;
 		/* Mark the class path as having been set */
 		loader->flags |= J9CLASSLOADER_CLASSPATH_SET;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3350,6 +3350,7 @@ typedef struct J9ClassLoader {
 	struct J9HashTable* classRelationshipsHashTable;
 	struct J9Pool* hotFieldPool;
 	omrthread_monitor_t hotFieldPoolMutex;
+	omrthread_rwmutex_t cpEntriesMutex;
 	UDATA initClassPathEntryCount;
 } J9ClassLoader;
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1242,10 +1242,18 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 
 	/* Write the class path data */
 	J9ClassLoader* classLoader = _VirtualMachine->systemClassLoader;
+	bool holdCpMutex = false;
+	if (classLoader->classPathEntryCount > 0) {
+		omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
+		holdCpMutex = true;
+	}
 	_OutputStream.writeCharacters("1CISYSCP       Sys Classpath:   ");
 	for (UDATA i = 0; i < classLoader->classPathEntryCount; i++) {
 		_OutputStream.writeCharacters((char*)(classLoader->classPathEntries[i]->path));
 		_OutputStream.writeCharacters(";");
+	}
+	if (holdCpMutex) {
+		omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 	}
 	_OutputStream.writeCharacters("\n");
 

--- a/runtime/shared_common/hookhelpers.cpp
+++ b/runtime/shared_common/hookhelpers.cpp
@@ -107,7 +107,9 @@ makeClasspathItems(J9JavaVM* vm, J9ClassLoader* classloader, J9ClassPathEntry** 
 	for (I_16 i = 0; i < entryCount; i++) {
 		J9ClassPathEntry* classPathEntry = NULL;
 		if (bootstrap) {
+			omrthread_rwmutex_enter_read(classloader->cpEntriesMutex);
 			classPathEntry = classloader->classPathEntries[i];
+			omrthread_rwmutex_exit_read(classloader->cpEntriesMutex);
 		} else {
 			classPathEntry = cpePtrArray[i];
 		}
@@ -288,7 +290,9 @@ createClasspath(J9VMThread* currentThread, J9ClassLoader* classloader, J9ClassPa
 		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			vm->sharedClassConfig->lastBootstrapCPE = vm->modulesPathEntry;
 		} else {
+			omrthread_rwmutex_enter_read(classloader->cpEntriesMutex);
 			vm->sharedClassConfig->lastBootstrapCPE = classloader->classPathEntries[0];
+			omrthread_rwmutex_exit_read(classloader->cpEntriesMutex);
 		}
 		vm->sharedClassConfig->bootstrapCPI = classpath;
 	}

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4358,8 +4358,10 @@ done:
 			/* Check the flags of the translation data struct */
 			J9TranslationBufferSet *translationData = _vm->dynamicLoadBuffers;
 			if (NULL != translationData) {
+				omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
 				/* Initialize the class path entry */
 				J9ClassPathEntry *cpEntry = classLoader->classPathEntries[cpIndex];
+				omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 				type = (I_32)initializeClassPathEntry(_vm, cpEntry);
 			}
 		}

--- a/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
+++ b/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
@@ -76,8 +76,10 @@ Fast_com_ibm_oti_vm_VM_getClassPathEntryType(J9VMThread *currentThread, j9object
 		/* Check the flags of the translation data struct */
 		J9TranslationBufferSet *translationData = vm->dynamicLoadBuffers;
 		if (NULL != translationData) {
+			omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
 			/* Initialize the class path entry */
 			J9ClassPathEntry *cpEntry = classLoader->classPathEntries[cpIndex];
+			omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 			type = (jint)initializeClassPathEntry(vm, cpEntry);
 		}
 	}

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -1159,18 +1159,26 @@ internalFindClassInModule(J9VMThread* vmThread, J9Module *j9module, U_8* classNa
 
 				if (reportErrorFlags == (reportErrorFlags & vmThread->privateFlags)) {
 					UDATA i;
+					BOOLEAN holdCpMutex = FALSE;
 					/* same error message as displayed by internalFindKnownClass() on failure */
 #if defined (J9VM_SIZE_SMALL_CODE)
 					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS, classNameLength, className);
 #else
 					j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_BEGIN_MULTI_LINE, J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS, classNameLength, className);
 #endif
+					if (classLoader->classPathEntryCount > 0) {
+						omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
+						holdCpMutex = TRUE;
+					}
 					for (i = 0; i < classLoader->classPathEntryCount; i++) {
 						J9ClassPathEntry *entry = classLoader->classPathEntries[i];
 						/* J9NLS_VM_SEARCHED_IN_DIR can only printed out for bootstrap class path, because classPathEntryCount is
 						 * always 0 for non-bootstrap class loader.
 						 */
 						j9nls_printf(PORTLIB, J9NLS_INFO, J9NLS_VM_SEARCHED_IN_DIR, entry->pathLength, entry->path);
+					}
+					if (holdCpMutex) {
+						omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 					}
 					j9nls_printf(PORTLIB, J9NLS_INFO, J9NLS_VM_CHECK_JAVA_HOME);
 					vmThread->privateFlags &= ~(J9_PRIVATE_FLAGS_REPORT_ERROR_LOADING_CLASS);
@@ -1251,7 +1259,9 @@ internalFindKnownClass(J9VMThread *vmThread, UDATA index, UDATA flags)
 				&& (LOAD_LOCATION_CLASSPATH == classLocation->locationType)
 				&& (classLocation->entryIndex < (IDATA)knownClass->classLoader->classPathEntryCount)
 			) {
+				omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
 				cpEntry = (knownClass->classLoader->classPathEntries[classLocation->entryIndex]);
+				omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 				if (NULL != cpEntry) {
 					if (0 == (CPE_FLAG_BOOTSTRAP & cpEntry->flags)) {
 						j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_REQUIRED_CLASS_ON_WRONG_PATH, J9UTF8_LENGTH(utfWrapper), J9UTF8_DATA(utfWrapper), cpEntry->pathLength, cpEntry->path);
@@ -1286,15 +1296,23 @@ internalFindKnownClass(J9VMThread *vmThread, UDATA index, UDATA flags)
 _fail:
 	if ((0 == (J9_RUNTIME_INITIALIZED & vm->runtimeFlags)) || (0 == (J9_FINDKNOWNCLASS_FLAG_NON_FATAL & flags))) {
 		UDATA i;
+		BOOLEAN holdCpMutex = FALSE;
 #if defined (J9VM_SIZE_SMALL_CODE)
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS, J9UTF8_LENGTH(utfWrapper), J9UTF8_DATA(utfWrapper));
 #else
 		j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_BEGIN_MULTI_LINE, J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS, J9UTF8_LENGTH(utfWrapper), J9UTF8_DATA(utfWrapper));
 #endif
+		if (classLoader->classPathEntryCount > 0) {
+			omrthread_rwmutex_enter_read(classLoader->cpEntriesMutex);
+			holdCpMutex = TRUE;
+		}
 		for (i = 0; i < classLoader->classPathEntryCount; i++) {
 			J9ClassPathEntry *entry = classLoader->classPathEntries[i];
 			/* J9NLS_VM_SEARCHED_IN_DIR can only printed out for bootstrap class path, because classPathEntryCount is always 0 for non-bootstrap class loader */
 			j9nls_printf(PORTLIB, J9NLS_INFO, J9NLS_VM_SEARCHED_IN_DIR, entry->pathLength, entry->path);
+		}
+		if (holdCpMutex) {
+			omrthread_rwmutex_exit_read(classLoader->cpEntriesMutex);
 		}
 		j9nls_printf(PORTLIB, J9NLS_INFO, J9NLS_VM_CHECK_JAVA_HOME);
 	}

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -393,19 +393,24 @@ cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader)
 		classLoader->romClassOrphansHashTable = NULL;
 	}
 
-	if (NULL != classLoader->classPathEntries) {
-		if (classLoader == javaVM->systemClassLoader) {
+	if (classLoader == javaVM->systemClassLoader) {
+		if (NULL != classLoader->classPathEntries) {
 			PORT_ACCESS_FROM_VMC(vmThread);
 			/* Free the class path entries  in system class loader */
 			freeClassLoaderEntries(vmThread, classLoader->classPathEntries, classLoader->classPathEntryCount, classLoader->initClassPathEntryCount);
 			j9mem_free_memory(classLoader->classPathEntries);
 			classLoader->classPathEntryCount = 0;
-			issueWriteBarrier();
 			classLoader->classPathEntries = NULL;
-		} else {
-			/* Free the class path entries in non-system class loaders.
-			 * classLoader->classPathEntries is set to NULL inside freeSharedCacheCLEntries().
-			 */
+			if (NULL != classLoader->cpEntriesMutex) {
+				j9thread_rwmutex_destroy(classLoader->cpEntriesMutex);
+				classLoader->cpEntriesMutex = NULL;
+			}
+		}
+	} else {
+		/* Free the class path entries in non-system class loaders.
+		 * classLoader->classPathEntries is set to NULL inside freeSharedCacheCLEntries().
+		 */
+		if (NULL != classLoader->classPathEntries) {
 			freeSharedCacheCLEntries(vmThread, classLoader);
 		}
 	}


### PR DESCRIPTION
Add a read write mutex cpEntriesMutex for bootstrap class loader. Use
the new read write mutex for all the readers and writers. This mutex is
initialized only when there is a bootstrap class path. On Java 11 and
up, there is no bootstrap class path by default unless
-Xbootclasspath/a: is used.

Closes #13414

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>