### PR TITLE
Avoid "unused function" error for isGCPolicyMetronome

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -334,7 +334,9 @@ UDATA bytecodeLoopCompressed(J9VMThread *currentThread);
 UDATA debugBytecodeLoopCompressed(J9VMThread *currentThread);
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 
+#if (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME))
 static BOOLEAN isGCPolicyMetronome(J9JavaVM *javaVM);
+#endif /* (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME)) */
 
 #if defined(COUNT_BYTECODE_PAIRS)
 static jint
@@ -4007,6 +4009,7 @@ static void registerIgnoredOptions(J9PortLibrary *portLibrary, J9VMInitArgs* j9v
 	}
 }
 
+#if (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME))
 /**
  * Check if -Xgcpolicy:metronome is specified on the command line
  *
@@ -4029,6 +4032,7 @@ isGCPolicyMetronome(J9JavaVM *javaVM)
 
 	return isSRT;
 }
+#endif /* (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME)) */
 
 #if defined(LINUX) && defined(J9VM_GC_REALTIME) 
 /* Linux SRT only */


### PR DESCRIPTION
This commit adds conditional compilation guards for isGCPolicyMetronome()
in jvminit.c.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>