### PR TITLE
Exclude testXXArgumentTesting_j9 for ibm 8 mode 650 temporarily

### DIFF
--- a/test/functional/cmdLineTests/xxargtest/playlist.xml
+++ b/test/functional/cmdLineTests/xxargtest/playlist.xml
@@ -50,6 +50,14 @@
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>bits.64</platformRequirements>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/infrastructure/issues/6123</comment>
+				<version>8</version>
+				<impl>ibm</impl>
+				<variation>Mode650</variation>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Exclude testXXArgumentTesting_j9 for ibm 8 mode 650 temporarily
- Related Issue: github_ibm/runtimes/infrastructure/issues/6123
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>