### PR TITLE
Handle TLHRemainders inside CopyForward final step

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -193,6 +193,11 @@ public:
 	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
 	UDATA minimumFreeSizeForSurvivor; /**< minimum free size can be reused by collector as survivor, for balanced GC only */
 	UDATA freeSizeThresholdForSurvivor; /**< if average freeSize(freeSize/freeCount) of the region is smaller than the Threshold, the region would not be reused by collector as survivor, for balanced GC only */
+	bool  preserveRemainders;	/**< true if need to preserve TLHRemainders at the end of PGC for the following PGCs, for balanced GC only */
+	bool  recycleRemainders;
+
+	UDATA samplingCount;
+
 protected:
 private:
 protected:
@@ -325,6 +330,10 @@ public:
 		, initialRAMPercent(0.0) /* this would get overwritten by user specified value */
 		, minimumFreeSizeForSurvivor(DEFAULT_SURVIVOR_MINIMUM_FREESIZE)
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
+		, preserveRemainders(false)
+		, recycleRemainders(true)
+		, samplingCount(0)
+
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1484,6 +1484,26 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "noPreserveRemainders")) {
+
+			extensions->preserveRemainders = false;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "preserveRemainders")) {
+
+			extensions->preserveRemainders = true;
+			extensions->recycleRemainders = false;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "recycleRemainders")) {
+
+			extensions->recycleRemainders = true;
+			extensions->preserveRemainders = false;
+			continue;
+		}
+
 		if (try_scan(&scan_start, "stringDedupPolicy=")) {
 			if (try_scan(&scan_start, "disabled")) {
 				extensions->stringDedupPolicy = MM_GCExtensions::J9_JIT_STRING_DEDUP_POLICY_DISABLED;

--- a/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
+++ b/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
@@ -32,6 +32,13 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "modronopt.h"
+#include "Math.hpp"
+
+#include "GCExtensions.hpp"
+#include "CompactGroupManager.hpp"
+#include "MemoryPool.hpp"
+#include "EnvironmentVLHGC.hpp"
+#include "HeapRegionDescriptorVLHGC.hpp"
 
 class MM_CopyScanCacheVLHGC;
 class MM_LightweightNonReentrantLock;
@@ -50,6 +57,8 @@ public:
 	MM_LightweightNonReentrantLock *_copyCacheLock; /**< The lock associated with the list this copy cache belongs to */
 	void *_TLHRemainderBase;  /**< base pointers of the last unused TLH copy cache, that might be reused  on next copy refresh */
 	void *_TLHRemainderTop;	  /**< top pointers of the last unused TLH copy cache, that might be reused  on next copy refresh */
+	uintptr_t _gcIDForTLHRemainder;  /**< the gc cycle when preserving the TLHRemainder. */
+	bool _preservedTLHRemainder;
 	void *_DFCopyBase;	/**< The base address of the inlined "copy cache" used by CopyForwardSchemeDepthFirst */
 	void *_DFCopyAlloc;	/**< The alloc pointer of the inlined "copy cache" used by CopyForwardSchemeDepthFirst */
 	void *_DFCopyTop;	/**< The top address of the inlined "copy cache" used by CopyForwardSchemeDepthFirst */
@@ -73,6 +82,8 @@ public:
 	UDATA _freeMemoryMeasured;	/**< The number of bytes which were wasted while this thread was working with the given _copyCache (due to alignment, etc) which is needs to save back into the pool when giving up the cache */
 	UDATA _discardedBytes; /**< The number of bytes discarded in survivor regions for this compact group by the owning thread due to incompletely filled copy caches and other inefficiencies */
 	UDATA _TLHRemainderCount; /**< number of TLHRemainders has been created for the compact group during the copyforward */
+	uintptr_t _preparedRemainderBytes;
+	uintptr_t _preservedRemainderBytes;
 	U_64 _allocationAge; /**< Average allocation age for this compact group */
 	
 	/* Mark map rebuilding cache values for the active MM_CopyScanCacheVLHGC associated with this group */
@@ -86,8 +97,6 @@ public:
 	void initialize(MM_EnvironmentVLHGC *env) {
 		_copyCache = NULL;
 		_copyCacheLock = NULL;
-		_TLHRemainderBase = NULL;
-		_TLHRemainderTop = NULL;
 		_DFCopyBase = NULL;
 		_DFCopyAlloc = NULL;
 		_DFCopyTop = NULL;
@@ -109,6 +118,8 @@ public:
 		_freeMemoryMeasured = 0;
 		_discardedBytes = 0;
 		_TLHRemainderCount = 0;
+		_preparedRemainderBytes = 0;
+		_preservedRemainderBytes = 0;
 		_allocationAge = 0;
 		_markMapAtomicHeadSlotIndex = 0;
 		_markMapAtomicTailSlotIndex = 0;
@@ -122,16 +133,208 @@ public:
 private:
 protected:
 public:
+	MMINLINE void setPreservedTLHRemainder()
+	{
+		_preservedTLHRemainder = true;
+	}
+
+	MMINLINE void resetPreservedTLHRemainder()
+	{
+		_preservedTLHRemainder = false;
+	}
+
+	MMINLINE bool isPreservedTLHRemainder()
+	{
+		return _preservedTLHRemainder;
+	}
+
 	MMINLINE void resetTLHRemainder()
 	{
 		_TLHRemainderBase = NULL;
 		_TLHRemainderTop = NULL;
+		_gcIDForTLHRemainder = 0;
+		resetPreservedTLHRemainder();
 	}
 
 	MMINLINE void setTLHRemainder(void *base, void *top)
 	{
 		_TLHRemainderBase = base;
 		_TLHRemainderTop = top;
+		_TLHRemainderCount += 1;
+		resetPreservedTLHRemainder();
+	}
+
+	MMINLINE void moveTLHRemainder(MM_CopyForwardCompactGroup *dest)
+	{
+		dest->_TLHRemainderBase = _TLHRemainderBase;
+		dest->_TLHRemainderTop = _TLHRemainderTop;
+		dest->_gcIDForTLHRemainder = _gcIDForTLHRemainder;
+		resetTLHRemainder();
+	}
+
+	MMINLINE uintptr_t getTLHRemainderSize()
+	{
+		return ((uintptr_t)_TLHRemainderTop - (uintptr_t)_TLHRemainderBase);
+	}
+
+	/**
+	 * @return true if TLHRemainder has been aligned.
+	 * @return false if TLHRemainder is too small to use after alignment
+	 */
+	MMINLINE bool alignTLHRemainder(uintptr_t tlhSurvivorDiscardThreshold)
+	{
+		bool aligned = false;
+		if (_TLHRemainderBase) {
+			void *newAlignedTLHRemainderBase = (void*) MM_Math::roundToCeilingCard((uintptr_t) _TLHRemainderBase);
+			void *newAlignedTLHRemainderTop =  (void*) MM_Math::roundToFloorCard((uintptr_t) _TLHRemainderTop);
+			if (((uintptr_t)newAlignedTLHRemainderTop - (uintptr_t)newAlignedTLHRemainderBase) >= tlhSurvivorDiscardThreshold) {
+				/* TLHRemainder need to be card aligned for being reuse cross PGCs */
+				_TLHRemainderBase = newAlignedTLHRemainderBase;
+				_TLHRemainderTop = newAlignedTLHRemainderTop;
+				aligned = true;
+			}
+			/* else aligned TLHRemainder is smaller than tlhSurvivorDiscardThreshold, need to be reset */
+		}
+		return aligned;
+	}
+
+	/**
+	 * abandonTLHRemainder
+	 * make TLHRemainder walkable hole and preserve it for next PGCs
+	 * count remainderBytes as darkMatterBytes in related memoryPool for avoiding to affect scheduling, estimating, projecting process before the next PGC
+	 */
+	MMINLINE void abandonTLHRemainder(MM_EnvironmentVLHGC* env)
+	{
+		if (NULL != _TLHRemainderBase) {
+			Assert_MM_true(NULL != _TLHRemainderTop);
+			/* make it a walkable hole */
+			env->_cycleState->_activeSubSpace->abandonHeapChunk(_TLHRemainderBase, _TLHRemainderTop);
+			MM_GCExtensions *extensions =MM_GCExtensions::getExtensions(env);
+			/* can discard the remainder in Nursery region here, but it is also be part of collection set in next PGC, so discard it at beginning of next PGC */
+			/* MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC*)extensions->heapRegionManager->tableDescriptorForAddress(_TLHRemainderBase);
+		    if (age < extensions->tarokNurseryMaxAge._valueSpecified) {
+				discardHeapChunk();
+				resetTLHRemainder();
+			} else {} */
+
+			_gcIDForTLHRemainder = extensions->globalVLHGCStats.gcCount;
+			_preservedRemainderBytes += getTLHRemainderSize();
+			MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC*)extensions->heapRegionManager->tableDescriptorForAddress(_TLHRemainderBase);
+			incrementDarkMatterBytesForRemainder(region);
+		} else {
+			Assert_MM_true(NULL == _TLHRemainderTop);
+		}
+	}
+
+	MMINLINE void discardTLHRemainder(MM_EnvironmentVLHGC* env)
+	{
+		if (NULL != _TLHRemainderBase) {
+			/* make it a walkable hole */
+			env->_cycleState->_activeSubSpace->abandonHeapChunk(_TLHRemainderBase, _TLHRemainderTop);
+			MM_GCExtensions *extensions =MM_GCExtensions::getExtensions(env);
+			MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC*)extensions->heapRegionManager->tableDescriptorForAddress(_TLHRemainderBase);
+			discardHeapChunk(_TLHRemainderBase, _TLHRemainderTop, region);
+			resetTLHRemainder();
+		} else {
+			Assert_MM_true(NULL == _TLHRemainderTop);
+		}
+	}
+
+	MMINLINE void recycleTLHRemainder(MM_EnvironmentVLHGC* env)
+	{
+		if (NULL != _TLHRemainderBase) {
+			/* make it a walkable hole */
+			env->_cycleState->_activeSubSpace->abandonHeapChunk(_TLHRemainderBase, _TLHRemainderTop);
+			MM_GCExtensions *extensions =MM_GCExtensions::getExtensions(env);
+			MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC*)extensions->heapRegionManager->tableDescriptorForAddress(_TLHRemainderBase);
+			MM_MemoryPoolAddressOrderedList *pool = (MM_MemoryPoolAddressOrderedList *)region->getMemoryPool();
+
+//			PORT_ACCESS_FROM_ENVIRONMENT(env);
+//			U_64 startTime = 0;
+//
+//			UDATA samplingCount = MM_AtomicOperations::add(&extensions->samplingCount, 1);
+//			if (0 == (samplingCount % 100)) {
+//				startTime = j9time_hires_clock();
+//			}
+
+			pool->recycleHeapChunk(env, _TLHRemainderBase, _TLHRemainderTop);
+//
+//			if (0 != startTime) {
+//				j9tty_printf(PORTLIB, "Sampling recycleTLHRemainder size=%zu, time=%zu us\n",
+//						getTLHRemainderSize(), j9time_hires_delta(startTime, j9time_hires_clock(), J9PORT_TIME_DELTA_IN_MICROSECONDS));
+//			}
+			resetTLHRemainder();
+		} else {
+			Assert_MM_true(NULL == _TLHRemainderTop);
+		}
+	}
+
+	MMINLINE void decrementDarkMatterBytesForRemainder(MM_HeapRegionDescriptorVLHGC *region)
+	{
+		region->getMemoryPool()->decrementDarkMatterBytes(getTLHRemainderSize(), true);
+	}
+
+	MMINLINE void incrementDarkMatterBytesForRemainder(MM_HeapRegionDescriptorVLHGC *region)
+	{
+		region->getMemoryPool()->incrementDarkMatterBytes(getTLHRemainderSize(), true);
+	}
+
+
+	MMINLINE void discardHeapChunk()
+	{
+		_discardedBytes = getTLHRemainderSize();
+	}
+
+	MMINLINE void discardHeapChunk(void *base, void *top, MM_HeapRegionDescriptorVLHGC *region)
+	{
+		uintptr_t discardSize = ((uintptr_t)top - (uintptr_t)base);
+		_discardedBytes += discardSize;
+		region->getMemoryPool()->incrementDarkMatterBytes(discardSize, true);
+	}
+
+	/**
+	 * check and prepare TLHRemainder ready for using by collector
+	 *  1, reset TLHRemainder if it is invalid.
+	 *  2, reset TLHRemainder if it is in collection set
+	 *  3, align TLHRemainder with Card
+	 *  4, move TLHRemainder from compactGroup to regionCompactGroup (region age is incremented at every end of PGC or jump to tenure if the region is overflow)
+	 *  if there are more than one TLHRemainder in the same regionCompactGroup, keep the largest TLHRemainder, reset others.
+	 */
+	MMINLINE void prepareTLHRemainder(MM_EnvironmentVLHGC* env, uintptr_t compactGroup)
+	{
+		if (NULL != _TLHRemainderBase) {
+			MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+			bool needResetTLHRemainder = !extensions->preserveRemainders;
+			MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC*)extensions->heapRegionManager->tableDescriptorForAddress(_TLHRemainderBase);
+			if (needResetTLHRemainder || region->_markData._shouldMark || !region->containsObjects() || (_gcIDForTLHRemainder <= region->_copyForwardData._lastGcIDForReclaim)) {
+				/* the region is part of collection set or has been reclaimed(swept/compacted/freed), reset TLHRemainder related with the region */
+				needResetTLHRemainder = true;
+			} else {
+				/* align TLHRemainder with card */
+				needResetTLHRemainder = !alignTLHRemainder(extensions->tlhSurvivorDiscardThreshold);
+				if (!needResetTLHRemainder) {
+					uintptr_t regionCompactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
+					if (regionCompactGroup != compactGroup) {
+						/* matching to region compact group, if there is already one remainder for the region compact group, pick bigger remainder */
+						MM_CopyForwardCompactGroup *dest = &(env->_copyForwardCompactGroups[regionCompactGroup]);
+						if (getTLHRemainderSize() > dest->getTLHRemainderSize()) {
+							if (0 != dest->getTLHRemainderSize()) {
+
+								dest->discardHeapChunk();
+							}
+							moveTLHRemainder(dest);
+						} else {
+							needResetTLHRemainder = true;
+						}
+					}
+				}
+			}
+
+			if (needResetTLHRemainder) {
+				discardHeapChunk();
+				resetTLHRemainder();
+			}
+		}
 	}
 };
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -1123,11 +1123,8 @@ public:
 		return false;
 	}
 
-	void abandonTLHRemainder(MM_EnvironmentVLHGC *env, bool preserveRemainders = false);
+	void abandonTLHRemainders(MM_EnvironmentVLHGC *env);
 
-	/* after Global GC or before first PGC after GMP, we need to reset all of TLHRemainders */
-	void resetAllTLHRemainders(MM_EnvironmentVLHGC *env);
-	MMINLINE void discardHeapChunk(MM_CopyForwardCompactGroup *compactGroupForMarkData, void *base, void *top);
 	friend class MM_CopyForwardGMPCardCleaner;
 	friend class MM_CopyForwardNoGMPCardCleaner;
 	friend class MM_CopyForwardSchemeTask;

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
@@ -82,6 +82,7 @@ MM_HeapRegionDescriptorVLHGC::initialize(MM_EnvironmentBase *env, MM_HeapRegionM
 	_copyForwardData._requiresPhantomReferenceProcessing = false;
 	_copyForwardData._survivor = false;
 	_copyForwardData._freshSurvivor = false;
+	_copyForwardData._lastGcIDForReclaim = MM_GCExtensions::getExtensions(env)->globalVLHGCStats.gcCount;
 	_copyForwardData._nextRegion = NULL;
 	_copyForwardData._previousRegion = NULL;
 

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
@@ -69,6 +69,7 @@ public:
 		bool _requiresPhantomReferenceProcessing; /**< Set to true by main thread if this region must be processed during parallel phantom reference processing */
 		bool _survivor;
 		bool _freshSurvivor;
+		uintptr_t _lastGcIDForReclaim;  /**< last gc cycle, which reclaim(sweep/compact/free) the region. */
 		MM_HeapRegionDescriptorVLHGC *_nextRegion;  /**< Region list link for compact group resource management during a copyforward operation */
 		MM_HeapRegionDescriptorVLHGC *_previousRegion;  /**< Region list link for compact group resource management during a copyforward operation */
 	} _copyForwardData;

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -416,6 +416,8 @@ public:
 		return _schedulingDelegate.getCurrentEdenSizeInBytes(env);
 	}
 
+	MMINLINE MM_SchedulingDelegate* getSchedulingDelegate() { return &_schedulingDelegate; };
+
 	MM_IncrementalGenerationalGC(MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager);
 
 	friend class MM_MainGCThread;

--- a/runtime/gc_vlhgc/ReclaimDelegate.hpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,7 +205,7 @@ public:
 	/**
 	 * Untag all regions after sweep/compact is completed, .
 	 */	
-	void untagRegionsAfterSweep();
+	void untagRegionsAfterSweep(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Build the internal representation of the set of regions that are to be collected for this cycle.

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1877,7 +1877,7 @@ MM_WriteOnceCompactor::recycleFreeRegionsAndFixFreeLists(MM_EnvironmentVLHGC *en
 
 				regionPool->reset(MM_MemoryPool::forCompact);
 				if (currentFreeSize > regionPool->getMinimumFreeEntrySize()) {
-					regionPool->recycleHeapChunk(currentFreeBase, byteAfterFreeEntry);
+					regionPool->recycleHeapChunk(env, currentFreeBase, byteAfterFreeEntry);
 					regionPool->updateMemoryPoolStatistics(env, currentFreeSize, 1, currentFreeSize);
 				} else {
 					regionPool->abandonHeapChunk(currentFreeBase, byteAfterFreeEntry);


### PR DESCRIPTION

        - new XXgc options preserveRemainders(default), noPreserveRemainders and
	 recycleRemainders.

	- if option recycleRemainders is set, discard remainders in nursery
	 regions and recycle remainders in non nuresery regions at the end of
	 PGC.

	- otherwise preserve all remainders
	if  option preserveRemainders is set, prepare/align the remainders,
	which are not in collection set and haven't been reclaimed,
	at the beginning of next PGC.

	- reset and discard the rest of remainders

depends on https://github.com/eclipse/omr/pull/6260

Signed-off-by: Lin Hu <linhu@ca.ibm.com>