### PR TITLE
Reduce ClientStream::INCOMPATIBILITY_COUNT_LIMIT to 1

### DIFF
--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -47,7 +47,7 @@ int ClientStream::_numConnectionsClosed = 0;
 int ClientStream::_incompatibilityCount = 0;
 uint64_t ClientStream::_incompatibleStartTime = 0;
 const uint64_t ClientStream::RETRY_COMPATIBILITY_INTERVAL_MS = 10000; //ms
-const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
+const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 1; // This needs to be smaller than the recompilation retry count (3)
 
 // Create SSL context, load certs and keys. Only needs to be done once.
 // This is called during startup from rossa.cpp


### PR DESCRIPTION
When the client discovers that the JITServer it wants to connect to is
incompatible, it will increment an incompatiblityCounter, and when this
counter exceeds `ClientStream::INCOMPATIBILITY_COUNT_LIMIT`, the client
will compile locally. After 10 seconds, the client can try again to compile
remotely, because the incompatible server could have been replaced by a
compatible one.
Currently `ClientStream::INCOMPATIBILITY_COUNT_LIMIT` is set to 5. This
is wasteful because it's very unlikely that a new compatible server will
appear in a very short amount of time. However, the bigger problem is that
a compilation will be retried 3 times (remotely) after which the method is
deemed uncompilable and it will remain interpreted.
In this commit we set `ClientStream::INCOMPATIBILITY_COUNT_LIMIT` to 1,
which solves both problems mentioned above.

Fixes: #13746

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>