### PR TITLE
Add VMStart event & can_generate_early_vmstart tests

### DIFF
--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,6 +140,7 @@ static jvmtiTest jvmtiTestList[] =
 #endif /* JAVA_SPEC_VERSION >= 11 */
 	{ "gsp001", gsp001, "com.ibm.jvmti.tests.getSystemProperty.gsp001", "Ensure JVMTI GetSystemProperty can retrieve certain system properties at early phrase" },
 	{ "ee001", ee001, "com.ibm.jvmti.tests.eventException.ee001", "Ensure only single JVMTI Exception event gets generated with JNI frame before handler" },
+	{ "vmstart001", vmstart001, "com.ibm.jvmti.tests.eventVMStart.vmstart001", "EventVMStart - check for VMStart event with can_generate_early_vmstart (Java 11+)" },
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/runtime/tests/jvmtitests/exports.cmake
+++ b/runtime/tests/jvmtitests/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -206,6 +206,7 @@ omr_add_exports(jvmtitest
 	Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_cleanup
 	Java_com_ibm_jvmti_tests_eventException_ee001_invoke
 	Java_com_ibm_jvmti_tests_eventException_ee001_check
+	Java_com_ibm_jvmti_tests_eventVMStart_vmstart001_check
 )
 
 if(NOT JAVA_SPEC_VERSION LESS 9)

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -255,5 +255,6 @@ jint JNICALL snmp001(agentEnv * agent_env, char * args);
 jint JNICALL soae001(agentEnv * agent_env, char * args);
 jint JNICALL gsp001(agentEnv *agent_env, char *args);
 jint JNICALL ee001(agentEnv *agent_env, char *args);
+jint JNICALL vmstart001(agentEnv* agent_env, char* args);
 
 #endif /*JVMTI_TEST_H_*/

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2020 IBM Corp. and others
+  Copyright (c) 2001, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -210,6 +210,7 @@
 		<export name="Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_cleanup" />
 		<export name="Java_com_ibm_jvmti_tests_eventException_ee001_invoke" />
 		<export name="Java_com_ibm_jvmti_tests_eventException_ee001_check" />
+		<export name="Java_com_ibm_jvmti_tests_eventVMStart_vmstart001_check" />
 	</exports>
 		
 	<exports group="jdk9">

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -185,6 +185,8 @@ j9vm_add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/eventException/ee001.c
 
 	com/ibm/jvmti/tests/fieldwatch/fw001.c
+
+	com/ibm/jvmti/tests/eventVMStart/vmstart001.c
 )
 
 target_link_libraries(jvmti_test_src

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventVMStart/vmstart001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventVMStart/vmstart001.c
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+
+#include "ibmjvmti.h"
+#include "jvmti_test.h"
+
+/* The VMStart event callback method */
+static void JNICALL vmStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env);
+/* The number of times that the VMStart event callback has been invoked */
+static jint numberVMStartCallbackInvoked = 0;
+
+jint JNICALL
+vmstart001(agentEnv *agent_env, char *args)
+{
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+	jvmtiError err = JVMTI_ERROR_NONE;
+	jint result = JNI_OK;
+	jvmtiCapabilities initialCapabilities;
+
+	memset(&initialCapabilities, 0, sizeof(jvmtiCapabilities));
+	err = (*jvmti_env)->GetPotentialCapabilities(jvmti_env, &initialCapabilities);
+	if (JVMTI_ERROR_NONE != err) {
+		error(agent_env, err, "Failed to GetPotentialCapabilities");
+		result = JNI_ERR;
+#if JAVA_SPEC_VERSION >= 11
+	} else if (0 == initialCapabilities.can_generate_early_vmstart) {
+		error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "can_generate_early_vmstart should be available in onload phase");
+		result = JNI_ERR;
+#endif /* JAVA_SPEC_VERSION >= 11 */
+	} else {
+		jvmtiEventCallbacks callbacks;
+
+		/* Set the VMStart event callback */
+		memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+		callbacks.VMStart = vmStart;
+		err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+		if (JVMTI_ERROR_NONE != err) {
+			error(agent_env, err, "Failed to set callback for VMStart event");
+			result = JNI_ERR;
+#if JAVA_SPEC_VERSION >= 11
+		} else {
+			const char* enableEarlyVMStart = agent_env->testArgs;
+
+			if (NULL != enableEarlyVMStart) {
+				if (0 == strcmp(enableEarlyVMStart, "can_generate_early_vmstart")) {
+					jvmtiCapabilities capabilities;
+					/* Require the can_generate_early_vmstart capability to enable early vmstart callback */
+					memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+					capabilities.can_generate_early_vmstart = 1;
+					err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+					if (JVMTI_ERROR_NONE != err) {
+						error(agent_env, err, "Failed to add capability can_generate_early_vmstart");
+						result = JNI_ERR;
+					}
+				} else {
+					error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Unsupported arguments");
+					result = JNI_ERR;
+				}
+			} else {
+				/* This is vmstart001 test run w/o enabling can_generate_early_vmstart */
+			}
+#endif /* JAVA_SPEC_VERSION >= 11 */
+		}
+
+		if (JVMTI_ERROR_NONE == err) {
+			/* Enable the JVMTI_EVENT_VM_START callback */
+			err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL);
+			if (JVMTI_ERROR_NONE != err) {
+				error(agent_env, err, "Failed to enable JVMTI_EVENT_VM_START event");
+				result = JNI_ERR;
+			}
+		}
+	}
+
+	return result;
+}
+
+static void JNICALL
+vmStart(jvmtiEnv *jvmti_env, JNIEnv *jni_env)
+{
+	numberVMStartCallbackInvoked += 1;
+}
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_eventVMStart_vmstart001_check(JNIEnv *jni_env, jclass cls)
+{
+	jboolean result = JNI_FALSE;
+	if (1 == numberVMStartCallbackInvoked) {
+		/* The VMStart callback should be invoked just once. */
+		result = JNI_TRUE;
+	}
+
+	return result;
+}

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2019 IBM Corp. and others
+  Copyright (c) 2004, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -419,6 +419,10 @@
 	</test>
 	<test id="ee001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:ee001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+	<test id="vmstart001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:vmstart001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_Java11andUp.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_Java11andUp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,11 @@
 
 	<test id="soae001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:soae001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="vmstart001-can_generate_early_vmstart">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:vmstart001,args:can_generate_early_vmstart -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -622,7 +622,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jvmtitests_soae</testCaseName>
+		<testCaseName>cmdLineTester_jvmtitests_Java11andUp</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode148</variation>
@@ -636,7 +636,7 @@
 	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump $(SQ) \
 	-DMODE_HINTS=$(Q)$(MODE_HINTS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_soae.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_Java11andUp.xml$(Q) \
 	-explainExcludes \
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventVMStart/vmstart001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventVMStart/vmstart001.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.eventVMStart;
+
+public class vmstart001 {
+	private native static boolean check();	/* Check if the VMStart event callback was invoked just once */
+
+	public boolean testEventVMStart() {
+		return check();
+	}
+
+	public String helpEventVMStart() {
+		return "Test that the VMStart event callback has been invoked just once.";
+	}
+}


### PR DESCRIPTION
Verify that `VMStart` event can be fired w/ or w/o `can_generate_early_vmstart` capability specified, and just fired once.

Related https://github.com/eclipse-openj9/openj9/issues/13708

fyi @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>