### PR TITLE
Add classNameToSignature to ClassEnv

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -951,3 +951,29 @@ J9::ClassEnv::isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cp
       return vm->internalVMFunctions->isClassRefQtype(j9class, cpIndex);
       }
    }
+
+char *
+J9::ClassEnv::classNameToSignature(const char *name, int32_t &len, TR::Compilation *comp, TR_AllocationKind allocKind, TR_OpaqueClassBlock *clazz)
+   {
+   char *sig;
+
+   if (name[0] == '[')
+      {
+      sig = (char *)comp->trMemory()->allocateMemory(len+1, allocKind);
+      memcpy(sig,name,len);
+      }
+   else
+      {
+      len += 2;
+      sig = (char *)comp->trMemory()->allocateMemory(len+1, allocKind);
+      if (clazz && TR::Compiler->om.areValueTypesEnabled() && self()->isValueTypeClass(clazz))
+         sig[0] = 'Q';
+      else
+         sig[0] = 'L';
+      memcpy(sig+1,name,len-2);
+      sig[len-1]=';';
+      }
+
+   sig[len] = '\0';
+   return sig;
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -185,6 +185,30 @@ public:
    char *classSignature_DEPRECATED(TR::Compilation *comp, TR_OpaqueClassBlock * clazz, int32_t & length, TR_Memory *);
    char *classSignature(TR::Compilation *comp, TR_OpaqueClassBlock * clazz, TR_Memory *);
 
+   /**
+    * \brief
+    *    Constructs a class signature char string based on the class name
+    *
+    * \param[in] name
+    *    The class name
+    *
+    * \param[in,out] len
+    *    The input is the length of the class name. Returns the length of the signature
+    *
+    * \param[in] comp
+    *    The compilation object
+    *
+    * \param[in] allocKind
+    *    The type of the memory allocation
+    *
+    * \param[in] clazz
+    *    The class that the class name belongs to
+    *
+    * \return
+    *    A class signature char string
+    */
+   char *classNameToSignature(const char *name, int32_t &len, TR::Compilation *comp, TR_AllocationKind allocKind = stackAlloc, TR_OpaqueClassBlock *clazz = NULL);
+
    int32_t vTableSlot(TR::Compilation *comp, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
    int32_t flagValueForPrimitiveTypeCheck(TR::Compilation *comp);
    int32_t flagValueForArrayCheck(TR::Compilation *comp);


### PR DESCRIPTION
This will replace the implementation in Aliases.cpp.
This API adds a new default argument `TR_OpaqueClassBlock *` to be used to check if the class is a value type or not.

Depends on 
- [x] eclipse/omr#6219

Related to eclipse/omr#6217

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>