### PR TITLE
Define OPENJDK_METHODHANDLES for jdk17+

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -159,6 +159,7 @@
 	<configuration
 		  label="JAVA17"
 		  outputpath="JAVA17/src"
+		  flags="OPENJDK_METHODHANDLES"
 		  dependencies="JAVA16"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>


### PR DESCRIPTION
This will allow the eclipse plugin to produce the same code as is generated in jdk17+ builds.