### PR TITLE
Include symbolic links in archive

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -316,7 +316,7 @@ def archive_sdk() {
             def archiveCmd = SPEC.contains('zos') ? 'pax -wvz -p x' : 'tar -cvz -T -'
             // Filter out unwanted files (most of which are available in the debug-image).
             def filterCmd = "sed -e '/\\.dbg\$/d' -e '/\\.debuginfo\$/d' -e '/\\.diz\$/d' -e '/\\.dSYM\\//d' -e '/\\.map\$/d' -e '/\\.pdb\$/d'"
-            sh "( cd ${buildDir} && find ${JDK_FOLDER} -type f | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"
+            sh "( cd ${buildDir} && find ${JDK_FOLDER} '(' -type f -o -type l ')' | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"
             // test if the test natives directory is present, only in JDK11+
             if (fileExists("${buildDir}${testDir}")) {
                 if (SPEC.contains('zos')) {


### PR DESCRIPTION
Symbolic links are used on some platforms (e.g. Linux); those links should be included in the generated archive.
```
$ pwd
.../images/jdk/legal/java.desktop
$ ls -log
total 40
lrwxrwxrwx. 1   36 Oct 26 11:26 ADDITIONAL_LICENSE_INFO -> ../java.base/ADDITIONAL_LICENSE_INFO
lrwxrwxrwx. 1   31 Oct 26 11:26 ASSEMBLY_EXCEPTION -> ../java.base/ASSEMBLY_EXCEPTION
-r--r--r--. 1  167 Oct 26 11:26 colorimaging.md
-r--r--r--. 1 1288 Oct 26 11:26 giflib.md
-r--r--r--. 1 2884 Oct 26 11:26 harfbuzz.md
-r--r--r--. 1 3475 Oct 26 11:26 jpeg.md
-r--r--r--. 1 1178 Oct 26 11:26 lcms.md
-r--r--r--. 1 5398 Oct 26 11:26 libpng.md
lrwxrwxrwx. 1   20 Oct 26 11:26 LICENSE -> ../java.base/LICENSE
-r--r--r--. 1 5732 Oct 26 11:26 mesa3d.md
-r--r--r--. 1 1348 Oct 26 11:26 xwd.md
```