### PR TITLE
Update VT implementation to unblock valhalla builds

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -6634,36 +6634,140 @@ public final class Unsafe {
 		throw OpenJDKCompileStubThrowError();
 	}
 
-	public final <V> boolean compareAndSetReference(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Atomically sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of get.
+	 * The set operation has the memory semantics of setRelease.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param setValue value that will be set in obj at offset if compare is successful
+	 * @return boolean value indicating whether the field was updated
+	 */
+	public final <V> boolean compareAndSetReference(Object obj, long offset, Class<?> clz, V compareValue, V setValue) {
+		return compareAndSetReference(obj, offset, compareValue, setValue);
 	}
 
-	public final <V> boolean weakCompareAndSetReferenceAcquire(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Atomically sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of getAcquire.
+	 * The set operation has the memory semantics of set.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param setValue value that will be set in obj at offset if compare is successful
+	 * @return boolean value indicating whether the field was updated
+	 */
+	public final <V> boolean weakCompareAndSetReferenceAcquire(Object obj, long offset, Class<?> clz, V compareValue, V setValue) {
+		return weakCompareAndSetReferenceAcquire(obj, offset, compareValue, setValue);
 	}
 
-	public final <V> boolean weakCompareAndSetReferenceRelease(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of get.
+	 * The set operation has the memory semantics of setRelease.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param setValue value that will be set in obj at offset if compare is successful
+	 * @return boolean value indicating whether the field was updated
+	 */
+	public final <V> boolean weakCompareAndSetReferenceRelease(Object obj, long offset, Class<?> clz, V compareValue, V setValue) {
+		return weakCompareAndSetReferenceRelease(obj, offset, compareValue, setValue);
 	}
 
-	public final <V> Object compareAndExchangeReference(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Atomically sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of getVolatile.
+	 * The set operation has the memory semantics of setVolatile.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param exchangeValue value that will be set in obj at offset if compare is successful
+	 * @return value in obj at offset before this operation. This will be compareValue if the exchange was successful
+	 */
+	public final <V> Object compareAndExchangeReference(Object obj, long offset, Class<?> clz, V compareValue, V exchangeValue) {
+		return compareAndExchangeReference(obj, offset, compareValue, exchangeValue);
 	}
 
-	public final <V> Object compareAndExchangeReferenceAcquire(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Atomically sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of getAcquire.
+	 * The set operation has the memory semantics of set.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param exchangeValue value that will be set in obj at offset if compare is successful
+	 * @return value in obj at offset before this operation. This will be compareValue if the exchange was successful
+	 */
+	public final <V> Object compareAndExchangeReferenceAcquire(Object obj, long offset, Class<?> clz, V compareValue, V exchangeValue) {
+		return compareAndExchangeReferenceAcquire(obj, offset, compareValue, exchangeValue);
 	}
 
-	public final <V> Object compareAndExchangeReferenceRelease(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Atomically sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of get.
+	 * The set operation has the memory semantics of setRelease.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param exchangeValue value that will be set in obj at offset if compare is successful
+	 * @return value in obj at offset before this operation. This will be compareValue if the exchange was successful
+	 */
+	public final <V> Object compareAndExchangeReferenceRelease(Object obj, long offset, Class<?> clz, V compareValue, V exchangeValue) {
+		return compareAndExchangeReferenceRelease(obj, offset, compareValue, exchangeValue);
 	}
 
-	public final <V> boolean weakCompareAndSetReferencePlain(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of get.
+	 * The set operation has the memory semantics of set.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param setValue value that will be set in obj at offset if compare is successful
+	 * @return boolean value indicating whether the field was updated
+	 */
+	public final <V> boolean weakCompareAndSetReferencePlain(Object obj, long offset, Class<?> clz, V compareValue, V setValue) {
+		return weakCompareAndSetReferencePlain(obj, offset, compareValue, setValue);
 	}
 
-	public final <V> boolean weakCompareAndSetReference(Object obj, long offset, Class<?> clz, V v1, V v2) {
-		throw OpenJDKCompileStubThrowError();
+	/**
+	 * Sets the reference at offset in obj if the compare value
+	 * matches the existing value in the object.
+	 * The get operation has memory semantics of get.
+	 * The set operation has the memory semantics of set.
+	 *
+	 * @param obj object into which to store the value
+	 * @param offset location to compare and store value in obj
+	 * @param clz Class of the obj
+	 * @param compareValue value that is expected to be in obj at offset
+	 * @param setValue value that will be set in obj at offset if compare is successful
+	 * @return boolean value indicating whether the field was updated
+	 */
+	public final <V> boolean weakCompareAndSetReference(Object obj, long offset, Class<?> clz, V compareValue, V setValue) {
+		return weakCompareAndSetReference(obj, offset, compareValue, setValue);
 	}
 
 	public Object getReferenceVolatile(Object obj, long offset, Class<?> clz) {

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -377,7 +377,16 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda, 
 	if (newCPEntry) {
 		anonClassName->slot2 = 0;
 		anonClassName->tag = CFR_CONSTANT_Utf8;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		/**
+		 * The following line should be put inside if (classfile->majorVersion > 61) according to the SPEC. However, the current
+		 * OpenJDK Valhalla implementation is not updated on this yet. There are cases that the new VT form is used in old classes
+		 * from OpenJDK Valhalla JCL.
+		 */
+		anonClassName->flags1 |= CFR_CLASS_FILE_VERSION_SUPPORT_VALUE_TYPE;
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		anonClassName->flags1 = 0;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		anonClassName->nextCPIndex = 0;
 		anonClassName->romAddress = 0;
 	}

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1249,6 +1249,14 @@ readPool(J9CfrClassFile* classfile, U_8* data, U_8* dataEnd, U_8* segment, U_8* 
 				previousUTF8 = info;
 			}
 			classfile->lastUTF8CPIndex = i;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			/**
+			 * The following line should be put inside if (classfile->majorVersion > 61) according to the SPEC. However, the current
+			 * OpenJDK Valhalla implementation is not updated on this yet. There are cases that the new VT form is used in old classes
+			 * from OpenJDK Valhalla JCL.
+			 */
+			info->flags1 |= CFR_CLASS_FILE_VERSION_SUPPORT_VALUE_TYPE;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			i++;
 			break;
 

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -959,6 +959,9 @@ typedef struct J9CfrClassFile {
 
 #define CFR_FOUND_CHARS_IN_EXTENDED_MUE_FORM 0x1
 #define CFR_FOUND_SEPARATOR_IN_MUE_FORM 0x2
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define CFR_CLASS_FILE_VERSION_SUPPORT_VALUE_TYPE 0x4
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 #define IDENTITY_OBJECT_NAME "java/lang/IdentityObject"
 

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -335,6 +335,8 @@ static const struct { \
 #define IS_QTYPE(firstChar) FALSE
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
+#define J9_IS_STRING_DESCRIPTOR(str, strLen) (((strLen) > 2) && (IS_REF_OR_VAL_SIGNATURE(*(str))) && (';' == *((str) + (strLen) - 1)))
+
 #if defined(OPENJ9_BUILD)
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE
 #else /* defined(OPENJ9_BUILD) */

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -974,6 +974,13 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 	BOOLEAN fastMode = J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_FAST_CLASS_HASH_TABLE);
 	BOOLEAN loaderMonitorLocked = FALSE;
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (J9_IS_STRING_DESCRIPTOR(className, classNameLength)) {
+		className += 1; /* 1 for 'L' or 'Q' */
+		classNameLength -= 2; /* 2 for 'L'/'Q' and ';' */
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	vmThread->privateFlags &= ~J9_PRIVATE_FLAGS_CLOAD_NO_MEM;
 
 	if (J9CLASSLOADER_PARALLEL_CAPABLE == (J9CLASSLOADER_PARALLEL_CAPABLE & classLoader->flags)) {


### PR DESCRIPTION
Update VT implementation to unblock valhalla builds on repo
ibmruntimes/openj9-openjdk-jdk.valuetypes

Update checkNameImpl() to allow Constant_class descriptors.
Add implememtation of new unsafe methods.

Closes #13694

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>