### PR TITLE
Fix inconsistent heap size reporting in verbose gc

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2261,7 +2261,9 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		}
 		if (!isLessThanEqualOrUnspecifiedAgainstFixed(&extensions->userSpecifiedParameters._Xmns, ms)) {
 			if (!opt_XmsSet) {
-				extensions->initialMemorySize = extensions->userSpecifiedParameters._Xmns._valueSpecified;
+				ms = extensions->userSpecifiedParameters._Xmns._valueSpecified;
+				extensions->initialMemorySize = ms;
+				extensions->oldSpaceSize = extensions->initialMemorySize;
 			} else {
 				memoryOption = "-Xmn";
 				subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);


### PR DESCRIPTION
	In balanced GC, the default initial tenure size(Xmos) should be
	equal to initial Heap Size(Xms).
	In case when the default initial Heap Size(Xms) match to initial
	Eden Size(Xmns), we also need to update initial tenure size(Xmos).

	this update also fix mxbean gcNotification issue due to the case
	Xms < Xmns.

fix: https://github.com/eclipse-openj9/openj9/issues/13558
Signed-off-by: Lin Hu <linhu@ca.ibm.com>