### PR TITLE
Fix incorrect casts

### DIFF
--- a/runtime/jcl/common/com_ibm_oti_vm_VM.c
+++ b/runtime/jcl/common/com_ibm_oti_vm_VM.c
@@ -165,6 +165,6 @@ Java_com_ibm_oti_vm_VM_markCurrentThreadAsSystemImpl(JNIEnv *env)
 jlong JNICALL
 Java_com_ibm_oti_vm_VM_getJ9ConstantPoolFromJ9Class(JNIEnv *env, jclass unused, jlong j9clazz)
 {
-	J9Class *clazz = (J9Class *)(UDATA)j9clazz;
-	return (jlong)(UDATA)clazz->ramConstantPool;
+	J9Class *clazz = (J9Class *)(IDATA)j9clazz;
+	return (jlong)(IDATA)clazz->ramConstantPool;
 }


### PR DESCRIPTION
Change UDATA casts to use IDATA when casting to and from jlong.

PR: #13424
Signed-off-by: Eric Yang <eric.yang@ibm.com>