### PR TITLE
Fill dataAddr slot of multidimensional array on x

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1516,7 +1516,11 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *nonZeroFirstDimLabel = generateLabelSymbol(cg);
 #ifdef TR_TARGET_64BIT
-   TR::LabelSymbol *populateFirstDimDataAddrSlot = generateLabelSymbol(cg);
+   J9JavaVM *vm = fej9->vmThread()->javaVM;
+   bool isOffHeapAllocationEnabled = vm->memoryManagerFunctions->j9gc_off_heap_allocation_enabled(vm);
+   TR::LabelSymbol *populateFirstDimDataAddrSlot = NULL;
+   if (isOffHeapAllocationEnabled)
+      populateFirstDimDataAddrSlot = generateLabelSymbol(cg);
 #endif /* TR_TARGET_64BIT */
 
    startLabel->setStartInternalControlFlow();
@@ -1572,21 +1576,23 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, generateX86MemoryReference(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
-#ifdef TR_TARGET_64BIT
-   // Load dataAddr slot offset difference since 0 size arrays are treated as discontiguous.
-   TR_ASSERT_FATAL_WITH_NODE(node
-      , IS_32BIT_SIGNED(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
-      , "dataAddrFieldOffset is too big for the instruction.");
+#if defined(TR_TARGET_64BIT)
+   if (isOffHeapAllocationEnabled)
+      {
+      // Load dataAddr slot offset difference since 0 size arrays are treated as discontiguous.
+      TR_ASSERT_FATAL_WITH_NODE(node
+         , IS_32BIT_SIGNED(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
+         , "dataAddrFieldOffset is too big for the instruction.");
 
-   generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm4
-      , node
-      , temp3Reg
-      , static_cast<int32_t>(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
-      , cg);
+      generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64
+         , node, temp3Reg
+         , static_cast<int32_t>(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
+         , cg);
 
-   generateLabelInstruction(TR::InstOpCode::JMP4, node, populateFirstDimDataAddrSlot, cg);
-#else
-   generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThru, cg);
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, populateFirstDimDataAddrSlot, cg);
+      }
+   else
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThru, cg);
 #endif /* TR_TARGET_64BIT */
 
    //First dim length not 0
@@ -1651,18 +1657,21 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, generateX86MemoryReference(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, generateX86MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
-#ifdef TR_TARGET_64BIT
-   // Populate dataAddr slot for 2nd dimension zero size array.
-   generateRegMemInstruction(TR::InstOpCode::LEARegMem()
-      , node
-      , temp3Reg
-      , generateX86MemoryReference(temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), cg)
-      , cg);
-   generateMemRegInstruction(TR::InstOpCode::SMemReg()
-      , node
-      , generateX86MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg)
-      , temp3Reg
-      , cg);
+#if defined(TR_TARGET_64BIT)
+   if (isOffHeapAllocationEnabled)
+      {
+      // Populate dataAddr slot for 2nd dimension zero size array.
+      generateRegMemInstruction(TR::InstOpCode::LEARegMem()
+         , node
+         , temp3Reg
+         , generateX86MemoryReference(temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), cg)
+         , cg);
+      generateMemRegInstruction(TR::InstOpCode::SMemReg()
+         , node
+         , generateX86MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg)
+         , temp3Reg
+         , cg);
+      }
 #endif /* TR_TARGET_64BIT */
 
    // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
@@ -1688,12 +1697,15 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    generateRegInstruction(TR::InstOpCode::DEC4Reg, node, firstDimLenReg, cg);
    generateLabelInstruction(TR::InstOpCode::JA4, node, loopLabel, cg);
 
-#ifdef TR_TARGET_64BIT
-   // No offset is needed since 1st dimension array is contiguous.
-   generateRegRegInstruction(TR::InstOpCode::XORRegReg(), node, temp3Reg, temp3Reg, cg);
-   generateLabelInstruction(TR::InstOpCode::JMP4, node, populateFirstDimDataAddrSlot, cg);
-#else
-   generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThru, cg);
+#if defined(TR_TARGET_64BIT)
+   if (isOffHeapAllocationEnabled)
+      {
+      // No offset is needed since 1st dimension array is contiguous.
+      generateRegRegInstruction(TR::InstOpCode::XORRegReg(), node, temp3Reg, temp3Reg, cg);
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, populateFirstDimDataAddrSlot, cg);
+      }
+   else
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThru, cg);
 #endif /* TR_TARGET_64BIT */
 
    TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 13, cg);
@@ -1741,21 +1753,24 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    generateLabelInstruction(TR::InstOpCode::label, node, oolJumpPoint, cg);
    generateLabelInstruction(TR::InstOpCode::JMP4, node, oolFailLabel, cg);
 
-#ifdef TR_TARGET_64BIT
-   /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
-    * use contiguous header layout while zero size arrays use discontiguous header layout.
-    */
-   generateLabelInstruction(TR::InstOpCode::label, node, populateFirstDimDataAddrSlot, cg);
-   generateRegMemInstruction(TR::InstOpCode::LEARegMem()
-      , node
-      , temp2Reg
-      , generateX86MemoryReference(targetReg, temp3Reg, 0, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg)
-      , cg);
-   generateMemRegInstruction(TR::InstOpCode::SMemReg()
-      , node
-      , generateX86MemoryReference(targetReg, temp3Reg, 0, fej9->getOffsetOfContiguousDataAddrField(), cg)
-      , temp2Reg
-      , cg);
+#if defined(TR_TARGET_64BIT)
+   if (isOffHeapAllocationEnabled)
+      {
+      /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
+       * use contiguous header layout while zero size arrays use discontiguous header layout.
+       */
+      generateLabelInstruction(TR::InstOpCode::label, node, populateFirstDimDataAddrSlot, cg);
+      generateRegMemInstruction(TR::InstOpCode::LEARegMem()
+         , node
+         , temp2Reg
+         , generateX86MemoryReference(targetReg, temp3Reg, 0, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg)
+         , cg);
+      generateMemRegInstruction(TR::InstOpCode::SMemReg()
+         , node
+         , generateX86MemoryReference(targetReg, temp3Reg, 0, fej9->getOffsetOfContiguousDataAddrField(), cg)
+         , temp2Reg
+         , cg);
+      }
 #endif /* TR_TARGET_64BIT */
 
    generateLabelInstruction(TR::InstOpCode::label, node, fallThru, deps, cg);


### PR DESCRIPTION
Adapt `multianewArrayEvaluator` to populate `dataAddr` field in the
array header for multidimensional array. Two cases addressed here are:
- Both 1st and 2nd dimension arrays are zero size.
- 1st dimension array is of size non-zero and 2nd dimension array is
  of size zero.

Part of phase 2 of #11438.

Signed-off-by: Shubham Verma shubhamv.sv@gmail.com