### PR TITLE
JDK18+ returns os.version before System.systemProperties is initialized

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -114,6 +114,11 @@ public final class System {
 	private static String fileEncoding;
 	private static String osEncoding;
 
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	private static final int sysPropID_OSVersion = 0;
+	private static final String sysPropOSVersion;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+
 	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	private static boolean hasSetErrEncoding;
 	private static boolean hasSetOutEncoding;
@@ -132,6 +137,9 @@ public final class System {
 	// Initialize all the slots in System on first use.
 	static {
 		initEncodings();
+		/*[IF JAVA_SPEC_VERSION >= 18]*/
+		sysPropOSVersion = getSysPropBeforePropertiesInitialized(sysPropID_OSVersion);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	}
 
 	//	get following system properties in clinit and make it available via static variables
@@ -593,6 +601,10 @@ private static void ensureProperties(boolean isInitialization) {
 	Properties initializedProperties = new Properties();
 /*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	initializedProperties.put("os.version", sysPropOSVersion); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+
 	if (osEncoding != null) {
 		initializedProperties.put("os.encoding", osEncoding); //$NON-NLS-1$
 	}
@@ -825,7 +837,13 @@ public static String getProperty(String prop, String defaultValue) {
 	if (!propertiesInitialized
 			&& !prop.equals("com.ibm.IgnoreMalformedInput") //$NON-NLS-1$
 			&& !prop.equals("file.encoding.pkg") //$NON-NLS-1$
-			&& !prop.equals("sun.nio.cs.map")) { //$NON-NLS-1$
+			&& !prop.equals("sun.nio.cs.map") //$NON-NLS-1$
+	) {
+		/*[IF JAVA_SPEC_VERSION >= 18]*/
+		if (prop.equals("os.version")) { //$NON-NLS-1$
+			return sysPropOSVersion;
+		} else
+		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 		if (prop.equals("os.encoding")) { //$NON-NLS-1$
 			return osEncoding;
 		} else if (prop.equals("ibm.system.encoding")) { //$NON-NLS-1$
@@ -880,6 +898,16 @@ private static native String [] getPropertyList();
  * 		3 - command line defined os.encoding
  */
 private static native String getEncoding(int type);
+
+/*[IF JAVA_SPEC_VERSION >= 18]*/
+/**
+ * Before propertiesInitialized is set to true,
+ * this returns the requested system property according to sysPropID:
+ * 		0 - os.version
+ * 		Reserved for future
+ */
+private static native String getSysPropBeforePropertiesInitialized(int sysPropID);
+/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
 /**
  * Answers the active security manager.

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -70,11 +70,45 @@ jstring JNICALL Java_java_lang_System_getEncoding(JNIEnv *env, jclass clazz, jin
 	return getEncoding(env, encodingType);
 }
 
+#if JAVA_SPEC_VERSION >= 18
+jstring JNICALL
+Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID)
+{
+	const char *sysPropValue = NULL;
+	jstring result = NULL;
+	PORT_ACCESS_FROM_ENV(env);
+
+	switch (sysPropID) {
+	case 0: /* os.version */
+		/* Same logic as vmprops.c:initializeSystemProperties(vm) - j9sysinfo_get_OS_version() */
+		sysPropValue = j9sysinfo_get_OS_version();
+		if (NULL != sysPropValue) {
+#if defined(WIN32)
+			char *cursor = strchr(sysPropValue, ' ');
+			if (NULL != cursor) {
+				*cursor = '\0';
+			}
+#endif /* defined(WIN32) */
+		} else {
+			sysPropValue = "unknown";
+		}
+		break;
+
+	default:
+		break;
+	}
+	if (NULL != sysPropValue) {
+		result = (*env)->NewStringUTF(env, sysPropValue);
+	}
+
+	return result;
+}
+#endif /* JAVA_SPEC_VERSION >= 18 */
+
 jobject JNICALL Java_java_lang_System_getPropertyList(JNIEnv *env, jclass clazz)
 {
 	return getPropertyList(env);
 }
-
 
 jstring JNICALL Java_java_lang_System_mapLibraryName(JNIEnv * env, jclass unusedClass, jstring inName)
 {

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -615,6 +615,13 @@ if(NOT JAVA_SPEC_VERSION LESS 16)
 	)
 endif()
 
+# java 18+
+if(NOT JAVA_SPEC_VERSION LESS 18)
+	omr_add_exports(jclse
+		Java_java_lang_System_getSysPropBeforePropertiesInitialized
+	)
+endif()
+
 # OpenJDK methodhandle support
 if(J9VM_OPT_OPENJDK_METHODHANDLE)
 	omr_add_exports(jclse

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -39,6 +39,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<xi:include href="uma/se14_exports.xml"></xi:include>
 	<xi:include href="uma/se15_exports.xml"></xi:include>
 	<xi:include href="uma/se16_exports.xml"></xi:include>
+	<xi:include href="uma/se18_exports.xml"></xi:include>
 
 	<xi:include href="uma/vendor_jcl_exports.xml">
 		<xi:fallback/>
@@ -116,6 +117,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</group>
 			<group name="se16">
 				<include-if condition="spec.java16"/>
+			</group>
+			<group name="se18">
+				<include-if condition="spec.java18"/>
 			</group>
 		</exports>
 

--- a/runtime/jcl/uma/se18_exports.xml
+++ b/runtime/jcl/uma/se18_exports.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<exports group="se18">
+	<export name="Java_java_lang_System_getSysPropBeforePropertiesInitialized" />
+</exports>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -183,6 +183,9 @@ Java_com_ibm_java_lang_management_internal_MemoryManagerMXBeanImpl_isManagedPool
 void JNICALL Java_java_lang_System_setFieldImpl (JNIEnv * env, jclass cls, jstring name, jobject stream);
 jobject createSystemPropertyList (JNIEnv *env, const char *defaultValues[], int defaultCount);
 jstring JNICALL Java_java_lang_System_getEncoding (JNIEnv *env, jclass clazz, jint encodingType);
+#if JAVA_SPEC_VERSION >= 18
+jstring JNICALL Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID);
+#endif /* JAVA_SPEC_VERSION >= 18 */
 jobject JNICALL Java_java_lang_System_getPropertyList (JNIEnv *env, jclass clazz);
 jstring JNICALL Java_java_lang_System_mapLibraryName (JNIEnv * env, jclass unusedClass, jstring inName);
 void JNICALL Java_java_lang_System_initLocale (JNIEnv *env, jclass clazz);

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -812,6 +812,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
+#if JAVA_SPEC_VERSION < 18
 	propValue = j9sysinfo_get_OS_version();
 	if (NULL != propValue) {
 #if defined(WIN32)
@@ -819,10 +820,10 @@ initializeSystemProperties(J9JavaVM * vm)
 		 * The port library includes build information which derails the Java
 		 * code.  Chop off the version after the major/minor. */
 		char *cursor = strchr(propValue, ' ');
-		if (cursor != NULL) {
+		if (NULL != cursor) {
 			*cursor = '\0';
 		}
-#endif
+#endif /* defined(WIN32) */
 	} else {
 		propValue = "unknown";
 	}
@@ -830,6 +831,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto fail;
 	}
+#endif /* JAVA_SPEC_VERSION < 18 */
 
 	/* Create the -D properties. This may override any of the writeable properties above. 
 	    Should the command line override read-only props? */


### PR DESCRIPTION
Added a native `Java_java_lang_System_getSysPropBeforePropertiesInitialized`.

Related https://github.com/eclipse-openj9/openj9/issues/13828

Signed-off-by: Jason Feng <fengj@ca.ibm.com>