### PR TITLE
Improve redirector

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -197,7 +197,7 @@ add_custom_ascii_command(OUTPUT "${J9VM_INCLUDE_DIR}/jvmti.h"
 # its own rule to create it, which leads race conditions when building in parallel.
 
 add_custom_ascii_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
-	DEPENDS oti/helpers.m4 redirector/generated.c.m4
+	DEPENDS oti/helpers.m4 redirector/forwarders.m4 redirector/generated.c.m4
 	COMMAND m4 -I "${CMAKE_CURRENT_SOURCE_DIR}/oti" -I "${CMAKE_CURRENT_SOURCE_DIR}/redirector" "${CMAKE_CURRENT_SOURCE_DIR}/redirector/generated.c.m4" > generated.c
 	VERBATIM
 	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/redirector"

--- a/runtime/j9vm/generated.h.m4
+++ b/runtime/j9vm/generated.h.m4
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corp. and others
+ * Copyright (c) 2002, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,15 +43,11 @@ extern "C" {
 #endif
 
 include([helpers.m4])
-define([_IF],
-[#if $1
-$2
-#endif])
 dnl (1-name, 2-cc, 3-decorate, 4-ret, 5-args...)
 define([_X],
 [$4 ifelse($2,,,$2 )$1(join([, ],mshift(4,$@)));])
 
-include([forwarders.m4])
+include([forwarders.m4])dnl
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -59,8 +59,7 @@ _X(JVM_GC,JNICALL,true,void,void)
 _X(JVM_GCNoCompact,JNICALL,true,void,void)
 _X(JVM_GetAllThreads,JNICALL,true,jobjectArray,JNIEnv *env, jclass aClass)
 _IF([JAVA_SPEC_VERSION < 11],
-	[_X(JVM_GetCallerClass,JNICALL,true,jobject,JNIEnv *env, jint depth)])
-_IF([JAVA_SPEC_VERSION >= 11],
+	[_X(JVM_GetCallerClass,JNICALL,true,jobject,JNIEnv *env, jint depth)],
 	[_X(JVM_GetCallerClass,JNICALL,true,jobject,JNIEnv *env)])
 _X(JVM_GetClassAccessFlags,JNICALL,true,jint,JNIEnv *env, jclass clazzRef)
 _X(JVM_GetClassAnnotations,JNICALL,true,jbyteArray,JNIEnv *env, jclass target)
@@ -68,8 +67,7 @@ _X(JVM_GetClassConstantPool,JNICALL,true,jobject,JNIEnv *env, jclass target)
 _X(JVM_GetClassContext,JNICALL,true,jobject,JNIEnv *env)
 _X(JVM_GetClassLoader,JNICALL,true,jobject,JNIEnv *env, jobject obj)
 _IF([JAVA_SPEC_VERSION < 11],
-	[_X(JVM_GetClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)])
-_IF([JAVA_SPEC_VERSION >= 11],
+	[_X(JVM_GetClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)],
 	[_X(JVM_InitClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)])
 _X(JVM_GetClassSignature,JNICALL,true,jstring,JNIEnv *env, jclass target)
 _X(JVM_GetEnclosingMethodInfo,JNICALL,true,jobjectArray,JNIEnv *env, jclass theClass)
@@ -193,8 +191,7 @@ _X(JVM_StartThread,JNICALL,true,void,JNIEnv *env, jobject newThread)
 _X(JVM_StopThread,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
 _X(JVM_SuspendThread,JNICALL,true,jobject,jint arg0, jint arg1)
 _IF([JAVA_SPEC_VERSION < 15],
-	[_X(JVM_UnloadLibrary, JNICALL, true, jobject, jint arg0)])
-_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_UnloadLibrary, JNICALL, true, jobject, jint arg0)],
 	[_X(JVM_UnloadLibrary, JNICALL, true, void, void *handle)])
 _X(JVM_Yield,JNICALL,true,jobject,jint arg0, jint arg1)
 _X(JVM_SetSockOpt,JNICALL,true,jint,jint fd, int level, int optname, const char *optval, int optlen)


### PR DESCRIPTION
Only decorate function names on 32-bit Windows
* define and use `DECORATED_NAME()` where appropriate
* eliminates need to remove decoration at runtime

Also:
* define `_IF` in `helpers.m4` and add support for `#else` blocks
* add missing comments on `#else` and `#endif`
* add missing dependency of `generated.c` on `forwarders.m4`
* remove recursion from forwarding functions
* allow for better string sharing
* use `fprintf()` throughout (instead of also using `printf()`)