### PR TITLE
Disable VarHandleMethodType lookup table code for OJDK MH

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -292,11 +292,13 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 		if (!constantPoolMap->isOK()) {
 			_buildResult = _constantPoolMap->getBuildResult();
 		} else {
+#if defined(J9VM_OPT_METHOD_HANDLE)
 			/* computeConstantPoolMapAndSizes must complete successfully before calling findVarHandleMethodRefs */
 			_constantPoolMap->findVarHandleMethodRefs();
 			if (!constantPoolMap->isOK()) {
 				_buildResult = _constantPoolMap->getBuildResult();
 			}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 		}
 	}
 

--- a/runtime/bcutil/ConstantPoolMap.cpp
+++ b/runtime/bcutil/ConstantPoolMap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,9 +52,9 @@ ConstantPoolMap::ConstantPoolMap(BufferManager *bufferManager, ROMClassCreationC
 	_invokeCacheCount(0),
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	_methodTypeCount(0),
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	_varHandleMethodTypeCount(0),
 	_varHandleMethodTypeLookupTable(NULL),
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	_callSiteCount(0),
 	_ramConstantPoolCount(0),
 	_romConstantPoolCount(0),
@@ -70,7 +70,9 @@ ConstantPoolMap::~ConstantPoolMap()
 	_bufferManager->free(_constantPoolEntries);
 	_bufferManager->free(_romConstantPoolEntries);
 	_bufferManager->free(_romConstantPoolTypes);
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	j9mem_free_memory(_varHandleMethodTypeLookupTable);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 }
 
 void
@@ -323,6 +325,7 @@ ConstantPoolMap::computeConstantPoolMapAndSizes()
 	}
 }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 void
 ConstantPoolMap::findVarHandleMethodRefs()
 {
@@ -374,7 +377,7 @@ ConstantPoolMap::findVarHandleMethodRefs()
 		j9mem_free_memory(varHandleMethodTable);
 	}
 }
-
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void
 ConstantPoolMap::constantPoolDo(ConstantPoolVisitor *visitor)

--- a/runtime/bcutil/ConstantPoolMap.hpp
+++ b/runtime/bcutil/ConstantPoolMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,7 +125,9 @@ public:
 
 	void computeConstantPoolMapAndSizes();
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	void findVarHandleMethodRefs();
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	bool isOK() const { return OK == _buildResult; }
 	BuildResult getBuildResult() const { return _buildResult; }
@@ -167,10 +169,10 @@ public:
 	U_32 getInvokeCacheCount() const { return _invokeCacheCount; }
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 getMethodTypeCount() const { return _methodTypeCount; }
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 getVarHandleMethodTypeCount() const { return _varHandleMethodTypeCount; }
 	U_32 getVarHandleMethodTypePaddedCount() const { return _varHandleMethodTypeCount + (_varHandleMethodTypeCount & 0x1); /* Rounding up to an even number */ }
 	U_16 *getVarHandleMethodTypeLookupTable() const { return _varHandleMethodTypeLookupTable; }
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 getCallSiteCount() const { return _callSiteCount; }
 	U_16 getRAMConstantPoolCount() const { return _ramConstantPoolCount; }
 	U_16 getROMConstantPoolCount() const { return _romConstantPoolCount; }
@@ -260,7 +262,9 @@ public:
 	bool hasSpecialSplitTable() const { return _specialSplitEntryCount != 0; }
 
 	bool hasCallSites() const { return 0 != _callSiteCount; }
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	bool hasVarHandleMethodRefs() const { return 0 != _varHandleMethodTypeCount; }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	void markConstantAsReferencedDoubleSlot(U_16 cfrCPIndex) { mark(cfrCPIndex); }
 	void markConstantAsUsedByLDC(U_8 cfrCPIndex) { _constantPoolEntries[cfrCPIndex].isUsedByLDC = true; }
@@ -364,9 +368,9 @@ private:
 	U_32 _invokeCacheCount;
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 _methodTypeCount;
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_16 _varHandleMethodTypeCount;
 	U_16 *_varHandleMethodTypeLookupTable;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 _callSiteCount;
 	U_16 _ramConstantPoolCount;
 	U_16 _romConstantPoolCount;

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -479,7 +479,10 @@ ROMClassBuilder::getSizeInfo(ROMClassCreationContext *context, ROMClassWriter *r
 				ROMClassWriter::MARK_AND_COUNT_ONLY);
 	}
 	/* NOTE: the size of the VarHandle MethodType lookup table is already included in
-	 * rcWithOutUTF8sSize; see ROMClassWriter::writeVarHandleMethodTypeLookupTable() */
+	 * rcWithOutUTF8sSize; see ROMClassWriter::writeVarHandleMethodTypeLookupTable().
+	 * VarHandleMethodTypeLookupTable is disabled for OpenJDK MethodHandles because
+	 * it is not used.
+	 */
 	sizeInformation->rcWithOutUTF8sSize = mainAreaCursor.getCount();
 	sizeInformation->lineNumberSize = lineNumberCursor.getCount();
 	sizeInformation->variableInfoSize = variableInfoCursor.getCount();
@@ -1104,7 +1107,10 @@ ROMClassBuilder::finishPrepareAndLaydown(
 									ROMClassWriter::MARK_AND_COUNT_ONLY);
 
 		/* NOTE: the size of the VarHandle MethodType lookup table is already included in
-		 * rcWithOutUTF8sSize; see ROMClassWriter::writeVarHandleMethodTypeLookupTable() */
+		 * rcWithOutUTF8sSize; see ROMClassWriter::writeVarHandleMethodTypeLookupTable().
+		 * VarHandleMethodTypeLookupTable is disabled for OpenJDK MethodHandles because
+		 * it is not used.
+		 */
 		sizeInformation->rcWithOutUTF8sSize = mainAreaCursor.getCount();
 		sizeInformation->lineNumberSize = 0;
 		sizeInformation->variableInfoSize = 0;

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -315,7 +315,9 @@ ROMClassWriter::ROMClassWriter(BufferManager *bufferManager, ClassFileOracle *cl
 	_callSiteDataSRPKey(srpKeyProducer->generateKey()),
 	_staticSplitTableSRPKey(srpKeyProducer->generateKey()),
 	_specialSplitTableSRPKey(srpKeyProducer->generateKey()),
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	_varHandleMethodTypeLookupTableSRPKey(srpKeyProducer->generateKey()),
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	_injectedInterfaceInfoSRPKey(srpKeyProducer->generateKey()),
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
@@ -412,8 +414,8 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 		cursor->writeU32(_constantPoolMap->getInvokeCacheCount(), Cursor::GENERIC);
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		cursor->writeU32(_constantPoolMap->getMethodTypeCount(), Cursor::GENERIC);
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		cursor->writeU32(_constantPoolMap->getVarHandleMethodTypeCount(), Cursor::GENERIC);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		cursor->writeU32(_classFileOracle->getBootstrapMethodCount(), Cursor::GENERIC);
 		cursor->writeU32(_constantPoolMap->getCallSiteCount(), Cursor::GENERIC);
 		cursor->writeSRP(_callSiteDataSRPKey, Cursor::SRP_TO_GENERIC);
@@ -423,7 +425,9 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 		cursor->writeU16(_constantPoolMap->getSpecialSplitEntryCount(), Cursor::GENERIC);
 		cursor->writeSRP(_staticSplitTableSRPKey, Cursor::SRP_TO_GENERIC);
 		cursor->writeSRP(_specialSplitTableSRPKey, Cursor::SRP_TO_GENERIC);
+#if defined(J9VM_OPT_METHOD_HANDLE)
 		cursor->writeSRP(_varHandleMethodTypeLookupTableSRPKey, Cursor::SRP_TO_GENERIC);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 		cursor->padToAlignment(sizeof(U_64), Cursor::GENERIC);
 	}
 
@@ -451,7 +455,9 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	writeOptionalInfo(cursor);
 	writeCallSiteData(cursor, markAndCountOnly);
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	writeVarHandleMethodTypeLookupTable(cursor, markAndCountOnly);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	writeStaticSplitTable(cursor, markAndCountOnly);
 	writeSpecialSplitTable(cursor, markAndCountOnly);
 	/* aligned to U_64 required by the shared classes */
@@ -854,6 +860,7 @@ public:
 		}
 	}
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	void writeVarHandleMethodTypeLookupTable()
 	{
 		if (!_markAndCountOnly) {
@@ -876,6 +883,7 @@ public:
 			}
 		}
 	}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	void writeBootstrapMethods()
 	{
@@ -1968,6 +1976,7 @@ ROMClassWriter::writeCallSiteData(Cursor *cursor, bool markAndCountOnly)
 	}
 }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 void
 ROMClassWriter::writeVarHandleMethodTypeLookupTable(Cursor *cursor, bool markAndCountOnly)
 {
@@ -1982,6 +1991,7 @@ ROMClassWriter::writeVarHandleMethodTypeLookupTable(Cursor *cursor, bool markAnd
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	}
 }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void
 ROMClassWriter::writeStaticSplitTable(Cursor *cursor, bool markAndCountOnly)

--- a/runtime/bcutil/ROMClassWriter.hpp
+++ b/runtime/bcutil/ROMClassWriter.hpp
@@ -142,7 +142,9 @@ private:
 	void writeStackMaps(Cursor *cursor);
 	void writeOptionalInfo(Cursor *cursor);
 	void writeCallSiteData(Cursor *cursor, bool markAndCountOnly);
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	void writeVarHandleMethodTypeLookupTable(Cursor *cursor, bool markAndCountOnly);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	void writeStaticSplitTable(Cursor *cursor, bool markAndCountOnly);
 	void writeSpecialSplitTable(Cursor *cursor, bool markAndCountOnly);
 	void writeByteCodes(Cursor *cursor, ClassFileOracle::MethodIterator *methodIterator);
@@ -180,7 +182,9 @@ private:
 	UDATA _annotationInfoClassSRPKey;
 	UDATA _typeAnnotationInfoSRPKey;
 	UDATA _callSiteDataSRPKey;	
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	UDATA _varHandleMethodTypeLookupTableSRPKey;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	UDATA _staticSplitTableSRPKey;
 	UDATA _specialSplitTableSRPKey;
 	UDATA _recordInfoSRPKey;

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -573,6 +573,7 @@ J9::SymbolReferenceTable::findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMet
    return symRef;
    }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
@@ -604,6 +605,7 @@ J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::Re
    aliasBuilder.methodTypeTableEntrySymRefs().set(symRef->getReferenceNumber());
    return symRef;
    }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 
 TR::SymbolReference *

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -130,7 +130,9 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char *signature);
    TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);
    TR::SymbolReference * findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
+#if defined(J9VM_OPT_METHOD_HANDLE)
    TR::SymbolReference * findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
    TR::SymbolReference * methodSymRefWithSignature(TR::SymbolReference *original, char *effectiveSignature, int32_t effectiveSignatureLength);
    TR::SymbolReference * findOrCreateTypeCheckArrayStoreSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateArrayClassRomPtrSymbolRef();

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1595,6 +1595,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, mirror->callSiteTableEntryAddress(callSiteIndex));
          }
          break;
+#if defined(J9VM_OPT_METHOD_HANDLE)
       case MessageType::ResolvedMethod_varHandleMethodTypeTableEntryAddress:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method*, int32_t>();
@@ -1611,6 +1612,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, mirror->isUnresolvedVarHandleMethodTypeTableEntry(cpIndex));
          }
          break;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
       case MessageType::ResolvedMethod_getResolvedDynamicMethod:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t>();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5917,6 +5917,7 @@ TR_ResolvedJ9Method::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
    return *(j9object_t*)callSiteTableEntryAddress(callSiteIndex) == NULL;
    }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 void *
 TR_ResolvedJ9Method::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
    {
@@ -5953,6 +5954,7 @@ TR_ResolvedJ9Method::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
    {
    return *(j9object_t*)varHandleMethodTypeTableEntryAddress(cpIndex) == NULL;
    }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void *
 TR_ResolvedJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -412,8 +412,10 @@ public:
    virtual void *                  callSiteTableEntryAddress(int32_t callSiteIndex);
    virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  methodTypeTableEntryAddress(int32_t cpIndex);
+#if defined(J9VM_OPT_METHOD_HANDLE)
    virtual bool                    isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  varHandleMethodTypeTableEntryAddress(int32_t cpIndex);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
    virtual bool                    fieldsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame);
    virtual bool                    staticsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1145,6 +1145,7 @@ TR_ResolvedJ9JITServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex)
    return std::get<0>(_stream->read<void*>());
    }
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 bool
 TR_ResolvedJ9JITServerMethod::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
    {
@@ -1158,6 +1159,7 @@ TR_ResolvedJ9JITServerMethod::varHandleMethodTypeTableEntryAddress(int32_t cpInd
    _stream->write(JITServer::MessageType::ResolvedMethod_varHandleMethodTypeTableEntryAddress, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<void*>());
    }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 TR_ResolvedMethod *
 TR_ResolvedJ9JITServerMethod::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callSiteIndex, bool * unresolvedInCP)

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -197,8 +197,10 @@ public:
    virtual void * methodTypeTableEntryAddress(int32_t cpIndex) override;
    virtual bool isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) override;
    virtual void * callSiteTableEntryAddress(int32_t callSiteIndex) override;
+#if defined(J9VM_OPT_METHOD_HANDLE)
    virtual bool isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex) override;
    virtual void * varHandleMethodTypeTableEntryAddress(int32_t cpIndex) override;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
    virtual TR_ResolvedMethod * getResolvedDynamicMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP) override;
    virtual bool isSameMethod(TR_ResolvedMethod *) override;
    virtual bool isInlineable(TR::Compilation *) override;

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -81,8 +81,10 @@ enum MessageType : uint16_t
    ResolvedMethod_stringConstant,
    ResolvedMethod_getResolvedVirtualMethod,
    ResolvedMethod_getMultipleResolvedMethods,
+#if defined(J9VM_OPT_METHOD_HANDLE)
    ResolvedMethod_varHandleMethodTypeTableEntryAddress,
    ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry,
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
    ResolvedMethod_getConstantDynamicTypeFromCP,
    ResolvedMethod_isUnresolvedConstantDynamic,
    ResolvedMethod_dynamicConstant,
@@ -332,8 +334,10 @@ static const char *messageNames[] =
    "ResolvedMethod_stringConstant",
    "ResolvedMethod_getResolvedVirtualMethod",
    "ResolvedMethod_getMultipleResolvedMethods",
+#if defined(J9VM_OPT_METHOD_HANDLE)
    "ResolvedMethod_varHandleMethodTypeTableEntryAddress",
    "ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry",
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
    "ResolvedMethod_getConstantDynamicTypeFromCP",
    "ResolvedMethod_isUnresolvedConstantDynamic",
    "ResolvedMethod_dynamicConstant",

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -171,6 +171,7 @@ TR::RecognizedMethod TR_VarHandleTransformer::getVarHandleAccessMethod(TR::Node 
  */
 int32_t TR_VarHandleTransformer::perform()
 {
+#if defined(J9VM_OPT_METHOD_HANDLE)
    TR::ResolvedMethodSymbol *methodSymbol = comp()->getMethodSymbol();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
    for (TR::TreeTop * tt = methodSymbol->getFirstTreeTop(); tt != NULL; tt = tt->getNextTreeTop())
@@ -358,6 +359,7 @@ int32_t TR_VarHandleTransformer::perform()
             }
          }
       }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 return 0;
 }
 

--- a/runtime/gc_structs/ClassIterator.cpp
+++ b/runtime/gc_structs/ClassIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,12 +94,14 @@ GC_ClassIterator::nextSlot()
 		}
 		_state += 1;
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	case classiterator_state_varhandlemethodtypes:
 		slotPtr = _varHandlesMethodTypesIterator.nextSlot();
 		if (NULL != slotPtr) {
 			return slotPtr;
 		}
 		_state += 1;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	case classiterator_state_valuetypes:
 		slotPtr = _valueTypesIterator.nextSlot();

--- a/runtime/gc_structs/ClassIterator.hpp
+++ b/runtime/gc_structs/ClassIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,9 @@ enum {
 	classiterator_state_slots,
 	classiterator_state_callsites,
 	classiterator_state_methodtypes,
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	classiterator_state_varhandlemethodtypes,
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	classiterator_state_valuetypes,
 	classiterator_state_end
 };
@@ -73,7 +75,9 @@ protected:
 	GC_ConstantPoolObjectSlotIterator _constantPoolObjectSlotIterator;
 	GC_CallSitesIterator _callSitesIterator;
 	GC_MethodTypesIterator _methodTypesIterator;
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	GC_MethodTypesIterator _varHandlesMethodTypesIterator;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	GC_ValueTypesIterator _valueTypesIterator;
 	const bool _shouldScanClassObject; /**< Boolean needed for balanced GC to prevent ClassObject from being scanned twice  */
 
@@ -89,8 +93,8 @@ public:
 		, _methodTypesIterator(clazz->romClass->invokeCacheCount, clazz->invokeCache)
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _methodTypesIterator(clazz->romClass->methodTypeCount, clazz->methodTypes)
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _varHandlesMethodTypesIterator(clazz->romClass->varHandleMethodTypeCount, clazz->varHandleMethodTypes)
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _valueTypesIterator(clazz)
 		, _shouldScanClassObject(shouldScanClassObject)
 	{}
@@ -106,8 +110,8 @@ public:
 		, _methodTypesIterator(clazz->romClass->invokeCacheCount, clazz->invokeCache)
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _methodTypesIterator(clazz->romClass->methodTypeCount, clazz->methodTypes)
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _varHandlesMethodTypesIterator(clazz->romClass->varHandleMethodTypeCount, clazz->varHandleMethodTypes)
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		, _valueTypesIterator(clazz)
 		, _shouldScanClassObject(true)
 	{}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -4702,6 +4702,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			/*
 			 * scan VarHandle MethodTypes
 			 */
+#if defined(J9VM_OPT_METHOD_HANDLE)
 			GC_MethodTypesIterator varHandleMethodTypesIterator(classPtr->romClass->varHandleMethodTypeCount, classPtr->varHandleMethodTypes);
 			while(NULL != (slotPtr = varHandleMethodTypesIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
@@ -4718,6 +4719,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 					Assert_MM_unreachable();
 				}
 			}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 			/*
 			 * scan constant pool objects

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1402,6 +1402,7 @@ done:
 		return (jobject)ref;
 	}
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	static VMINLINE U_32
 	lookupVarHandleMethodTypeCacheIndex(J9ROMClass *romClass, UDATA cpIndex)
 	{
@@ -1421,6 +1422,7 @@ done:
 
 		return index;
 	}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	/**
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3420,8 +3420,8 @@ typedef struct J9ROMClass {
 	U_32 invokeCacheCount;
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 methodTypeCount;
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 varHandleMethodTypeCount;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 bsmCount;
 	U_32 callSiteCount;
 	J9SRP callSiteData;
@@ -3431,7 +3431,9 @@ typedef struct J9ROMClass {
 	U_16 specialSplitMethodRefCount;
 	J9SRP staticSplitMethodRefIndexes;
 	J9SRP specialSplitMethodRefIndexes;
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	J9SRP varHandleMethodTypeLookupTable;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 #if defined(J9VM_ENV_DATA64)
 #if JAVA_SPEC_VERSION >= 11
 	U_32 padding;
@@ -3573,8 +3575,8 @@ typedef struct J9ROMReflectClass {
 	U_32 invokeCacheCount;
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 methodTypeCount;
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 varHandleMethodTypeCount;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	U_32 bsmCount;
 	U_32 callSiteCount;
 	J9SRP callSiteData;
@@ -3584,7 +3586,9 @@ typedef struct J9ROMReflectClass {
 	U_16 specialSplitMethodRefCount;
 	J9SRP staticSplitMethodRefIndexes;
 	J9SRP specialSplitMethodRefIndexes;
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	J9SRP varHandleMethodTypeLookupTable;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 #if defined(J9VM_ENV_DATA64)
 #if JAVA_SPEC_VERSION >= 11
 	U_32 padding;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2528,10 +2528,10 @@ fail:
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		/* add in the method types */
 		classSize += romClass->methodTypeCount;
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 		/* add in the varhandle method types */
 		classSize += romClass->varHandleMethodTypeCount;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 		/* add in the static and special split tables */
 		classSize += (romClass->staticSplitMethodRefCount + romClass->specialSplitMethodRefCount);
@@ -2790,7 +2790,11 @@ fail:
 			/* varhandle method types fragment */
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].alignment = sizeof(UDATA);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].alignedSize = 0;
+#else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].alignedSize = romClass->varHandleMethodTypeCount * sizeof(UDATA);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].address = NULL;
 
 			/* static split table fragment */


### PR DESCRIPTION
J9RomClass.varHandleMethodTypeLookupTable is not used in the OJDK method
handle implementation as varhandles are treated as method handles and
use the invoke cache instead.

Closes: #11580
Signed-off-by: Eric Yang <eric.yang@ibm.com>