### PR TITLE
Add assertions to JCL startup failures

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -280,6 +280,7 @@ jint initializeKnownClasses(J9JavaVM* vm, U_32 runtimeFlags)
 					Trc_JCL_initializeKnownClasses_ClassRefNotResolvedForInstanceFieldRef(vm->mainThread, romFieldConstantPool[i].classRefCPIndex, i);
 				}  else {
 					Trc_JCL_initializeKnownClasses_ExitError(vm->mainThread, i);
+					Trc_JCL_Assert_StartupFailure();
 					return JNI_ERR;
 				}
 			}
@@ -307,6 +308,7 @@ jint initializeKnownClasses(J9JavaVM* vm, U_32 runtimeFlags)
 						Trc_JCL_initializeKnownClasses_ClassRefNotResolvedForMethodRef(vm->mainThread, romMethodConstantPool[i].classRefCPIndex, i);
 					} else {
 						Trc_JCL_initializeKnownClasses_ExitError(vm->mainThread, i);
+						Trc_JCL_Assert_StartupFailure();
 						return JNI_ERR;
 					}
 				}
@@ -323,6 +325,7 @@ jint initializeKnownClasses(J9JavaVM* vm, U_32 runtimeFlags)
 						Trc_JCL_initializeKnownClasses_ClassRefNotResolvedForMethodRef(vm->mainThread, romMethodConstantPool[i].classRefCPIndex, i);
 					} else {
 						Trc_JCL_initializeKnownClasses_ExitError(vm->mainThread, i);
+						Trc_JCL_Assert_StartupFailure();
 						return JNI_ERR;
 					}
 				} else {
@@ -339,6 +342,7 @@ jint initializeKnownClasses(J9JavaVM* vm, U_32 runtimeFlags)
 						Trc_JCL_initializeKnownClasses_ClassRefNotResolvedForMethodRef(vm->mainThread, romMethodConstantPool[i].classRefCPIndex, i);
 					} else {
 						Trc_JCL_initializeKnownClasses_ExitError(vm->mainThread, i);
+						Trc_JCL_Assert_StartupFailure();
 						return JNI_ERR;
 					}
 				} else {
@@ -743,6 +747,8 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	for (i=0; i < sizeof(requiredClasses) / sizeof(UDATA); i++) {
 		clazz = vmFuncs->internalFindKnownClass(vmThread, requiredClasses[i], J9_FINDKNOWNCLASS_FLAG_NON_FATAL);
 		if ((NULL == clazz) || (NULL != vmThread->currentException)) {
+			Trc_JCL_initializeRequiredClasses_ExitError(vmThread, i);
+			Trc_JCL_Assert_StartupFailure();
 			return 1;
 		}
 		vmFuncs->initializeClass(vmThread, clazz);

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -683,3 +683,6 @@ TraceEvent=Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty Overhead=
 TraceEvent=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_findSharedClassImpl_SetCPE Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl findSharedClassImpl: Set CPE of class loader %p to %p"
 TraceEvent=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange2_SetCPE Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl notifyClasspathChange2: Set CPE of class loader %p to NULL"
 TraceEvent=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange3_SetCPE Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl notifyClasspathChange3: Set CPE of class loader %p to %p"
+
+TraceEvent=Trc_JCL_initializeRequiredClasses_ExitError Overhead=1 Level=1 Template="initializeRequiredClasses() requiredClasses[%zu] failed"
+TraceAssert=Trc_JCL_Assert_StartupFailure NoEnv Overhead=1 Level=1 Assert="(0 /* Fatal VM error */)"


### PR DESCRIPTION
These assertions indicate the startup failure location to avoid a silent VM exit.

Related to https://github.com/eclipse-openj9/openj9/issues/13852#issuecomment-960250434

Signed-off-by: Jason Feng <fengj@ca.ibm.com>