### PR TITLE
Only enable verbose gc log for -Xlog levels trace, debug, info

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6308,9 +6308,24 @@ xlogerr:
 							if ('\0' == *upToComma) {
 								goto xlogerr;
 							}
-							gclog = 0 != j9_cmdla_stricmp("off", upToComma);
-							if (gclog) {
+							/* only levels trace, debug, info, and not off, warning, error, enable the gc verbose log */
+							if (0 == j9_cmdla_stricmp("off", upToComma)) {
+								gclog = FALSE;
+							} else if ((0 == j9_cmdla_stricmp("warning", upToComma))
+								|| (0 == j9_cmdla_stricmp("error", upToComma))
+							) {
+								gclog = FALSE;
 								/* OpenJ9 doesn't understand log levels */
+								unrecognizedOption = TRUE;
+							} else if ((0 == j9_cmdla_stricmp("trace", upToComma))
+								|| (0 == j9_cmdla_stricmp("debug", upToComma))
+								|| (0 == j9_cmdla_stricmp("info", upToComma))
+							) {
+								gclog = TRUE;
+								/* OpenJ9 doesn't understand log levels */
+								unrecognizedOption = TRUE;
+							} else {
+								/* unrecognized log level */
 								unrecognizedOption = TRUE;
 							}
 						}

--- a/test/functional/cmdLineTests/xlogTests/xlog.xml
+++ b/test/functional/cmdLineTests/xlogTests/xlog.xml
@@ -91,6 +91,30 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<output regex="no" type="failure">JVMJ9VM007</output>
 	</test>
 
+	<test id="-Xlog:gc=trace">
+		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=trace -version</command>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
+		<output regex="no" type="required">verbosegc</output>
+		<output regex="no" type="required">JVMJ9VM007</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Xlog:gc=debug">
+		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=debug -version</command>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
+		<output regex="no" type="required">verbosegc</output>
+		<output regex="no" type="required">JVMJ9VM007</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Xlog:gc=info">
+		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=info -version</command>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
+		<output regex="no" type="required">verbosegc</output>
+		<output regex="no" type="required">JVMJ9VM007</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
 	<test id="-Xlog:gc:">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc: -version</command>
 		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
@@ -178,6 +202,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<test id="-Xlog:gc=off">
 		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=off -version</command>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
+		<output regex="no" type="required">JVMJ9VM007W</output>
+		<output regex="no" type="failure">verbosegc</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Xlog:gc=warning">
+		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=warning -version</command>
+		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
+		<output regex="no" type="required">JVMJ9VM007W</output>
+		<output regex="no" type="failure">verbosegc</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Xlog:gc=error">
+		<command>$EXE$ $ENABLEXLOG$ -Xlog:gc=error -version</command>
 		<output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="success">(openjdk|java|semeru) version</output>
 		<output regex="no" type="required">JVMJ9VM007W</output>
 		<output regex="no" type="failure">verbosegc</output>


### PR DESCRIPTION
Levels off, warning, error do not enable the verbose gc log

Issue https://github.com/eclipse-openj9/openj9/issues/13865