### PR TITLE
Support StaticMethodRef alias

### DIFF
--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/InterfaceMethodRef.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/InterfaceMethodRef.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ public class InterfaceMethodRef extends PrimaryItem implements Constants {
 	}
 
 	public InterfaceMethodRef(Element e, Map classes) {
-		super(e, INTERFACEMETHODREF, new Factory(classes));
+		super(e, METHODALIAS, new Factory(classes));
 	}
 	
 	protected String cMacroName() {

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/StaticMethodRef.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/StaticMethodRef.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ public class StaticMethodRef extends PrimaryItem implements Constants {
 	}
 
 	public StaticMethodRef(Element e, Map classes) {
-		super(e, STATICMETHODREF, new Factory(classes));
+		super(e, METHODALIAS, new Factory(classes));
 	}
 	
 	protected String cMacroName() {

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/VirtualMethodRef.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/VirtualMethodRef.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ public class VirtualMethodRef extends PrimaryItem implements Constants {
 	}
 
 	public VirtualMethodRef(Element e, Map classes) {
-		super(e, VIRTUALMETHODREF, new Factory(classes));
+		super(e, METHODALIAS, new Factory(classes));
 	}
 	
 	protected String cMacroName() {


### PR DESCRIPTION
`METHODALIAS` should be used.

This was discovered when investigating https://github.com/eclipse-openj9/openj9/issues/13852

fyi @keithc-ca 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>