### PR TITLE
Fix hangTest failure with dynamic compile

### DIFF
--- a/test/functional/cmdLineTests/hangTest/build.xml
+++ b/test/functional/cmdLineTests/hangTest/build.xml
@@ -28,6 +28,8 @@
 		Build cmdLineTests hangTest
 	</description>
 
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/hangTest" />
 	<property name="src" location="./src"/>
@@ -66,7 +68,7 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
 		<if>
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />


### PR DESCRIPTION
- Add dependency for hangTest dynamic compile
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>