### PR TITLE
Port library startup should not return -1

### DIFF
--- a/runtime/oti/j9porterror.h
+++ b/runtime/oti/j9porterror.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,6 +55,7 @@
 #define J9PORT_ERROR_STARTUP_SHSEM (J9PORT_ERROR_STARTUP_EXTENDED -3)
 #define J9PORT_ERROR_STARTUP_SHMEM (J9PORT_ERROR_STARTUP_EXTENDED -4)
 #define J9PORT_ERROR_STARTUP_SHMEM_MOSERVICE (J9PORT_ERROR_STARTUP_EXTENDED -5)
+#define J9PORT_ERROR_STARTUP_HYPERVISOR_MONITOR_INIT (J9PORT_ERROR_STARTUP_EXTENDED -6)
 
 /** @} */
 

--- a/runtime/port/common/j9hypervisor_common.c
+++ b/runtime/port/common/j9hypervisor_common.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ j9hypervisor_startup(struct J9PortLibrary *portLibrary)
 	ret = omrthread_monitor_init(&(PHD_vendorMonitor), 0);
 	if (0 != ret) {
 		/* If monitor initialization fails, fail JVM startup */
-		return (int32_t)ret;
+		return J9PORT_ERROR_STARTUP_HYPERVISOR_MONITOR_INIT;
 	}
 
 	detect_hypervisor(portLibrary);

--- a/runtime/port/common/j9port.c
+++ b/runtime/port/common/j9port.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -351,11 +351,6 @@ j9port_startup_library(struct J9PortLibrary *portLibrary)
 		goto cleanup;
 	}
 	memset(portLibrary->portGlobals, 0, sizeof(J9PortLibraryGlobalData));
-
-	/* Check for omr port startup failure after allocating port globals. Globals must be allocated. */
-	if (0 != rc) {
-		goto cleanup;
-	}
 
 	rc = portLibrary->sysinfo_startup(portLibrary);
 	if (0 != rc) {


### PR DESCRIPTION
Returning -1 does not give any useful information about what failed.

See also https://github.com/eclipse/omr/pull/6231
Issue https://github.com/ibmruntimes/Semeru-Runtimes/issues/5#issuecomment-962040999
Issue https://github.com/eclipse-openj9/openj9/issues/12526