### PR TITLE
(0.29.1) Use the dot naming convention in exception stack traces

### DIFF
--- a/runtime/jcl/common/jclexception.cpp
+++ b/runtime/jcl/common/jclexception.cpp
@@ -203,8 +203,13 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 					goto done;
 				}
 			} else {
-				/* Can't peek anon or hidden ramClasses */
-				string = mmfns->j9gc_createJavaLangStringWithUTFCache(vmThread, (J9UTF8 *)utfClassName);
+				/* Can't peek all classes. Ie. anon/hidden classes or cases where classloader is NULL */
+				UDATA flags = J9_STR_XLAT | J9_STR_INTERN;
+
+				if (J9ROMCLASS_IS_ANON_OR_HIDDEN(romClass)) {
+					flags |= J9_STR_ANON_CLASS_NAME;
+				}
+				string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), flags);
 			}
 			element = PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);
 			J9VMJAVALANGSTACKTRACEELEMENT_SET_DECLARINGCLASS(vmThread, element, string);

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -54,6 +54,7 @@
 #define J9ROMCLASS_IS_INTERMEDIATE_DATA_A_CLASSFILE(romClass)		_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassIntermediateDataIsClassfile)
 #define J9ROMCLASS_IS_UNSAFE(romClass)			_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassUnsafe)
 #define J9ROMCLASS_IS_HIDDEN(romClass)			_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassHidden)
+#define J9ROMCLASS_IS_ANON_OR_HIDDEN(romClass)			_J9ROMCLASS_J9MODIFIER_IS_ANY_SET((romClass), J9AccClassAnonClass | J9AccClassHidden)
 #define J9ROMCLASS_IS_OPTIONNESTMATE_SET(romClass)		_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassHiddenOptionNestmate)
 #define J9ROMCLASS_IS_OPTIONSTRONG_SET(romClass)		_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassHiddenOptionStrong)
 #define J9ROMCLASS_HAS_VERIFY_DATA(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassHasVerifyData)


### PR DESCRIPTION
Use the dot naming convention in exception stack traces

Fixes https://github.com/eclipse-openj9/openj9/issues/13846

Port of https://github.com/eclipse-openj9/openj9/pull/13883 for the 0.29.1 release.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>