### PR TITLE
Unblock JDK-next (JDK18) acceptance build

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -603,6 +603,12 @@ private static void ensureProperties(boolean isInitialization) {
 
 	/*[IF JAVA_SPEC_VERSION >= 18]*/
 	initializedProperties.put("os.version", sysPropOSVersion); //$NON-NLS-1$
+
+	/* Setting jdk.reflect.useDirectMethodHandle to false disables the new JEP 416
+	 * changes where core reflection is reimplemented with MethodHandles. This flag
+	 * will be reenabled once OpenJ9 completely supports JEP 416.
+	 */
+	initializedProperties.put("jdk.reflect.useDirectMethodHandle", "false"); //$NON-NLS-1$
 	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
 	if (osEncoding != null) {

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -759,7 +759,11 @@ static const char * const excludeArray[] = {
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedExceptionAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/lang/NullPointerException.fillInStackTrace()Ljava/lang/Throwable;",
+#if JAVA_SPEC_VERSION >= 18
+   "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z",
+#else /* JAVA_SPEC_VERSION >= 18 */
    "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z",
+#endif /* JAVA_SPEC_VERSION >= 18 */
 };
 
 bool
@@ -2996,7 +3000,11 @@ void TR_ResolvedJ9Method::construct()
 
    static X NativeLibrariesMethods[] =
       {
+#if JAVA_SPEC_VERSION >= 18
+      {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z")},
+#else /* JAVA_SPEC_VERSION >= 18 */
       {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z")},
+#endif /* JAVA_SPEC_VERSION >= 18 */
       {  TR::unknownMethod}
       };
 

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -195,7 +195,11 @@ standardInit( J9JavaVM *vm, char *dllName)
 				if (NULL == clz) {
 					goto _fail;
 				}
+#if JAVA_SPEC_VERSION >= 18
+				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z");
+#else /* JAVA_SPEC_VERSION >= 18 */
 				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z");
+#endif /* JAVA_SPEC_VERSION >= 18 */
 				if (NULL == mid) {
 					goto _fail;
 				}

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -411,7 +411,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<!-- Static method references needed to support OpenJDK MethodHandles. -->
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="linkCallerMethod" signature="(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 
-	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="15-"/>
+	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="15-17">
+		<methodalias name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="18-"/>
+	</staticmethodref>
 
 	<!-- Security manager check -->
 	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>


### PR DESCRIPTION
**1. Signature of NativeLibraries.load has changed in JDK18** 

Update the signature of NativeLibraries.load in native code for JDK18.
 
**2. Set the useDirectMethodHandle Java flag to false** 

Setting jdk.reflect.useDirectMethodHandle to false disables the new JEP 416
changes where the reflection API is dependent on the MethodHandle API.

This flag will be reenabled once OpenJ9 supports JEP 416.

Related: #13852
Related: #13880
 
**3. Update MHN.getMemberVMInfo to work with MemberName.vminfoIsConsistent** 

MemberName.vminfoIsConsistent is only used in an assertion to validate the
vmtarget and vmindex elements of MemberName. It relies on MHN.getMemberVMInfo
to retrieve the vmtarget and vmindex elements of MemberName.

For correct validation, MHN.getMemberVMInfo should return 0 for vmindex when
the vTableIndex is 0 and ref kind is invokevirtual or invokeinterface.
Otherwise, it should return -1 for vmindex. MHN.getMemberVMInfo has been
updated to perform this behaviour. This in return fixes the behaviour of
MemberName.vminfoIsConsistent.

Closes: #13877
 
**4. InjectedInvoker behaviour modified in JDK18** 

In JDK17, InjectedInvoker does not have the NESTMATE attribute. In JDK18,
InjectedInvoker's definition has been updated, and it is given the NESTMATE
attribute. The new changes invalidate the filter that is used to identify
InjectedInvoker classes for modifying its class name. The filter has been
updated to work with JDK18.

Closes: #13878

Co-authored-by: Jason Feng <fengj@ca.ibm.com>
Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>