### PR TITLE
Infrastructure for creating JITServer AOT cache records during compilation

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -237,7 +237,7 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          // flags stored in data3 are currently unused
          uintptr_t inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(symRef->getOwningMethod(comp)->constantPool(), recordInfo->data2);
 
-         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(j9class);
          uintptr_t classChainOffsetInSharedCache = self()->getClassChainOffset(j9class);
 
          acaRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -499,7 +499,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
          traceMsg(comp, "class is %p, romclass is %p, offset is %llu\n", inlinedCodeClass, romClass, romClassOffsetInSharedCache);
 
-         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(inlinedCodeClass);
+         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(inlinedCodeClass);
 
          uintptr_t classChainOffsetInSharedCache = self()->getClassChainOffset(inlinedCodeClass);
 
@@ -540,7 +540,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR_OpaqueClassBlock *j9class = fej9->getClassFromMethodBlock(j9method);
 
-         uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(j9class);
          uintptr_t classChainForInlinedMethodOffsetInSharedCache = self()->getClassChainOffset(j9class);
 
          uintptr_t vTableOffset = static_cast<uintptr_t>(fej9->getInterpreterVTableSlot(j9method, j9class));
@@ -580,7 +580,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
                j9class = reinterpret_cast<TR_OpaqueClassBlock *>(aconstNode->getAddress());
             }
 
-         uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(j9class);
          uintptr_t classChainForInlinedMethodOffsetInSharedCache = self()->getClassChainOffset(j9class);
 
          cpRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
@@ -596,7 +596,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::AOTClassInfo *aotCI = reinterpret_cast<TR::AOTClassInfo*>(relocation->getTargetAddress2());
          TR_OpaqueClassBlock *classToValidate = aotCI->_clazz;
 
-         uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(classToValidate);
+         uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetIdentifyingLoader(classToValidate);
 
          void *classChainForClassToValidate = aotCI->_classChain;
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
@@ -642,7 +642,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          void *classChainForClassToValidate = svmRecord->_classChain;
 
          //store the classchain's offset for the classloader for the class
-         uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(classToValidate);
+         uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetIdentifyingLoader(classToValidate);
 
          //store the classchain's offset for the class that needs to be validated in the second run
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
@@ -1074,7 +1074,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);
 
-         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(j9class);
          uintptr_t classChainOffsetInSharedCache = self()->getClassChainOffset(j9class);
 
          acaRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -195,6 +195,7 @@ J9::Compilation::Compilation(int32_t id,
    _globalMemory(*::trPersistentMemory, heapMemoryRegion),
    _perClientMemory(_trMemory),
    _methodsRequiringTrampolines(getTypedAllocator<TR_OpaqueMethodBlock *>(self()->allocator())),
+   _aotCacheStore(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -342,6 +342,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
       }
 
    TR::list<TR_OpaqueMethodBlock *>& getMethodsRequiringTrampolines() { return _methodsRequiringTrampolines; }
+
+   bool isAOTCacheStore() const { return _aotCacheStore; }
+   void setAOTCacheStore(bool store) { _aotCacheStore = store; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -454,6 +457,10 @@ private:
    // It needs to be sent to the client at the end of compilation
    // so that trampolines can be reserved there.
    TR::list<TR_OpaqueMethodBlock *> _methodsRequiringTrampolines;
+
+   // True if the result of this out-of-process compilation will be
+   // stored in JITServer AOT cache; always false at the client
+   bool _aotCacheStore;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -845,15 +845,14 @@ TR::CompilationInfoPerThread::getRemoteROMClassIfCached(J9Class *clazz)
    }
 
 J9ROMClass *
-TR::CompilationInfoPerThread::getAndCacheRemoteROMClass(J9Class *clazz, TR_Memory *trMemory)
+TR::CompilationInfoPerThread::getAndCacheRemoteROMClass(J9Class *clazz)
    {
    auto romClass = getRemoteROMClassIfCached(clazz);
    if (romClass == NULL)
       {
       JITServerHelpers::ClassInfoTuple classInfoTuple;
-      TR_Memory *currentMemory = trMemory ? trMemory : TR::comp()->trMemory();
-      romClass = JITServerHelpers::getRemoteROMClass(clazz, getStream(), currentMemory, &classInfoTuple);
-      romClass = JITServerHelpers::cacheRemoteROMClassOrFreeIt(getClientData(), clazz, romClass, &classInfoTuple, currentMemory->trPersistentMemory());
+      romClass = JITServerHelpers::getRemoteROMClass(clazz, getStream(), getClientData()->persistentMemory(), classInfoTuple);
+      romClass = JITServerHelpers::cacheRemoteROMClassOrFreeIt(getClientData(), clazz, romClass, classInfoTuple);
       TR_ASSERT_FATAL(romClass, "ROM class of J9Class=%p must be cached at this point", clazz);
       }
    return romClass;

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -489,8 +489,8 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    TR_J9SharedCacheServerVM *getSharedCacheServerVM() const { return _sharedCacheServerVM; }
    void                      setSharedCacheServerVM(TR_J9SharedCacheServerVM *vm) { _sharedCacheServerVM = vm; }
    JITServer::ServerStream  *getStream();
-   J9ROMClass               *getAndCacheRemoteROMClass(J9Class *, TR_Memory *trMemory=NULL);
-   J9ROMClass               *getRemoteROMClassIfCached(J9Class *);
+   J9ROMClass               *getAndCacheRemoteROMClass(J9Class *clazz);
+   J9ROMClass               *getRemoteROMClassIfCached(J9Class *clazz);
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() const { return _classesThatShouldNotBeNewlyExtended; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1197,6 +1197,8 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
 
    if (xxJITServerUseAOTCacheArgIndex > xxDisableJITServerUseAOTCacheArgIndex)
       compInfo->getPersistentInfo()->setJITServerUseAOTCache(true);
+   else
+      compInfo->getPersistentInfo()->setJITServerUseAOTCache(false);
 
    if (xxJITServerLogConnectionsArgIndex > xxDisableJITServerLogConnectionsArgIndex)
       {
@@ -2050,6 +2052,16 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             if (xxJITServerLocalSyncCompilesArgIndex > xxDisableJITServerLocalSyncCompilesArgIndex)
                {
                compInfo->getPersistentInfo()->setLocalSyncCompiles(true);
+               }
+
+            const char *xxJITServerAOTCacheNameOption = "-XX:JITServerAOTCacheName=";
+            int32_t xxJITServerAOTCacheNameArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTCacheNameOption, 0);
+
+            if (xxJITServerAOTCacheNameArgIndex >= 0)
+               {
+               char *name = NULL;
+               GET_OPTION_VALUE(xxJITServerAOTCacheNameArgIndex, '=', &name);
+               compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
                }
             }
          }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2085,10 +2085,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, entries, fieldNames, typeSignatures); 
          }
          break;
-      case MessageType::SharedCache_getClassChainOffsetInSharedCache:
+      case MessageType::SharedCache_getClassChainOffsetIdentifyingLoader:
          {
          auto j9class = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         uintptr_t classChainOffsetInSharedCache = fe->sharedCache()->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainOffsetInSharedCache = fe->sharedCache()->getClassChainOffsetIdentifyingLoader(j9class);
          client->write(response, classChainOffsetInSharedCache);
          }
          break;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -504,8 +504,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._isAllocateZeroedTLHPagesEnabled = fe->tlhHasBeenCleared();
          vmInfo._staticObjectAllocateFlags = fe->getStaticObjectFlags();
          vmInfo._referenceArrayCopyHelperAddress = fe->getReferenceArrayCopyHelperAddress();
+         vmInfo._useAOTCache = comp->getPersistentInfo()->getJITServerUseAOTCache();
 
-         client->write(response, vmInfo, listOfCacheDescriptors);
+         client->write(response, vmInfo, listOfCacheDescriptors, comp->getPersistentInfo()->getJITServerAOTCacheName());
          }
          break;
       case MessageType::VM_getObjectClass:

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -504,7 +504,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._isAllocateZeroedTLHPagesEnabled = fe->tlhHasBeenCleared();
          vmInfo._staticObjectAllocateFlags = fe->getStaticObjectFlags();
          vmInfo._referenceArrayCopyHelperAddress = fe->getReferenceArrayCopyHelperAddress();
+
          vmInfo._useAOTCache = comp->getPersistentInfo()->getJITServerUseAOTCache();
+         if (vmInfo._useAOTCache)
+            {
+            auto header = compInfoPT->reloRuntime()->getStoredAOTHeader(vmThread);
+            TR_ASSERT_FATAL(header, "Must have valid AOT header stored in SCC by now");
+            vmInfo._aotHeader = *header;
+            }
 
          client->write(response, vmInfo, listOfCacheDescriptors, comp->getPersistentInfo()->getJITServerAOTCacheName());
          }

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -694,9 +694,9 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             // a previous request, info which the server is expected to cache. However, this
             // could be a new JITServer instance.
             // Send a message to the client to retrieve desired info.
-            romClass = JITServerHelpers::getRemoteROMClass(clazz, stream, clientSession->persistentMemory(), &classInfoTuple);
+            romClass = JITServerHelpers::getRemoteROMClass(clazz, stream, clientSession->persistentMemory(), classInfoTuple);
             }
-         romClass = JITServerHelpers::cacheRemoteROMClassOrFreeIt(getClientData(), clazz, romClass, &classInfoTuple, clientSession->persistentMemory());
+         romClass = JITServerHelpers::cacheRemoteROMClassOrFreeIt(clientSession, clazz, romClass, classInfoTuple);
          TR_ASSERT_FATAL(romClass, "ROM class of J9Class=%p must be cached at this point", clazz);
          }
 

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -579,9 +579,9 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
    for (uint32_t i = 0; i < numMethods; i++)
       {
-      methodMap.insert({ &methods[i],
-         { romMethod, origROMMethods[i], NULL, static_cast<bool>(methodTracingInfo[i]), (TR_OpaqueClassBlock *)clazz, false }
-      });
+      ClientSessionData::J9MethodInfo m(romMethod, origROMMethods[i], (TR_OpaqueClassBlock *)clazz,
+                                        i, static_cast<bool>(methodTracingInfo[i]));
+      methodMap.insert({ &methods[i], m });
       romMethod = nextROMMethod(romMethod);
       }
 

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -80,20 +80,25 @@ class JITServerHelpers
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory, bool serializeClass);
    static void freeRemoteROMClass(J9ROMClass *romClass, TR_PersistentMemory *persistentMemory);
-   static J9ROMClass *cacheRemoteROMClassOrFreeIt(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, TR_PersistentMemory *persistentMemory);
-   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
+   static J9ROMClass *cacheRemoteROMClassOrFreeIt(ClientSessionData *clientSessionData, J9Class *clazz,
+                                                  J9ROMClass *romClass, const ClassInfoTuple &classInfoTuple);
+   static ClientSessionData::ClassInfo &cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz,
+                                                            J9ROMClass *romClass, const ClassInfoTuple &classInfoTuple);
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
-   static J9ROMClass *getRemoteROMClass(J9Class *, JITServer::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
-   static J9ROMClass *getRemoteROMClass(J9Class *, JITServer::ServerStream *stream, TR_PersistentMemory *trMemory, ClassInfoTuple *classInfoTuple);
-   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1,
+   static J9ROMClass *getRemoteROMClass(J9Class *clazz, JITServer::ServerStream *stream,
+                                        TR_PersistentMemory *persistentMemory, ClassInfoTuple &classInfoTuple);
+   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *persistentMemory);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData,
+                                       JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData,
+                                       JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1,
                                        ClassInfoDataType dataType2, void *data2);
    static J9ROMMethod *romMethodOfRamMethod(J9Method* method);
 
    static void insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry);
 
-   static uintptr_t getRemoteClassDepthAndFlagsWhenROMClassNotCached(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream);
+   static uintptr_t getRemoteClassDepthAndFlagsWhenROMClassNotCached(J9Class *clazz, ClientSessionData *clientSessionData,
+                                                                     JITServer::ServerStream *stream);
 
    // Functions used for allowing the client to compile locally when server is unavailable.
    // Should be used only on the client side.

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -52,8 +52,9 @@ class JITServerHelpers
       CLASSINFO_CLASS_FLAGS,
       CLASSINFO_METHODS_OF_CLASS,
       CLASSINFO_CONSTANT_POOL,
-      CLASSINFO_CLASS_CHAIN_OFFSET,
+      CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
       };
+
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
    using ClassInfoTuple = std::tuple
@@ -68,7 +69,7 @@ class JITServerHelpers
       TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
       uintptr_t, J9ROMClass *,                                       // 16: _totalInstanceSize      17: _remoteRomClass
       uintptr_t, uintptr_t,                                          // 18: _constantPool           19: _classFlags
-      uintptr_t, std::vector<J9ROMMethod *>                          // 20: _classChainOffsetOfIdentifyingLoaderForClazz 21. _origROMMethods
+      uintptr_t, std::vector<J9ROMMethod *>                          // 20: _classChainOffsetIdentifyingLoader 21. _origROMMethods
       >;
 
    // Packs a ROMClass to be transferred to the server.

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -131,6 +131,16 @@ public:
 
    static uintptr_t walkReferenceChainWithOffsets(TR_J9VM *fe, const std::vector<uintptr_t> &listOfOffsets, uintptr_t receiver);
 
+   // Called by the client as part of handling the SharedCache_rememberClass message when AOT cache is enabled.
+   // Returns the list of RAMClasses in the class chain for clazz and populates uncachedRAMClasses and
+   // uncachedClassInfos with the classes (and their data) that the client has not yet sent to the server.
+   static std::vector<J9Class *>
+   getRAMClassChain(J9Class *clazz, size_t length, J9VMThread *vmThread, TR_Memory *trMemory, TR::CompilationInfo *compInfo,
+                    std::vector<J9Class *> &uncachedRAMClasses, std::vector<ClassInfoTuple> &uncachedClassInfos);
+
+   static void cacheRemoteROMClassBatch(ClientSessionData *clientData, const std::vector<J9Class *> &ramClasses,
+                                        const std::vector<ClassInfoTuple> &classInfoTuples);
+
 private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
 

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -26,9 +26,10 @@
 #include "net/MessageTypes.hpp"
 #include "runtime/JITClientSession.hpp"
 
+
 class JITServerHelpers
    {
-   public:
+public:
    enum ClassInfoDataType
       {
       CLASSINFO_ROMCLASS_MODIFIERS,
@@ -59,17 +60,29 @@ class JITServerHelpers
    // to not mess with the established order.
    using ClassInfoTuple = std::tuple
       <
-      std::string, J9Method *,                                       // 0:  string                  1:  _methodsOfClass
-      TR_OpaqueClassBlock *, int32_t,                                // 2:  _baseComponentClass     3:  _numDimensions
-      TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>,     // 4:  _parentClass            5:  _tmpInterfaces
-      std::vector<uint8_t>, bool,                                    // 6:  _methodTracingInfo      7:  _classHasFinalFields
-      uintptr_t, bool,                                               // 8:  _classDepthAndFlags     9:  _classInitialized
-      uint32_t, TR_OpaqueClassBlock *,                               // 10: _byteOffsetToLockword   11: _leafComponentClass
-      void *, TR_OpaqueClassBlock *,                                 // 12: _classLoader            13: _hostClass
-      TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
-      uintptr_t, J9ROMClass *,                                       // 16: _totalInstanceSize      17: _remoteRomClass
-      uintptr_t, uintptr_t,                                          // 18: _constantPool           19: _classFlags
-      uintptr_t, std::vector<J9ROMMethod *>                          // 20: _classChainOffsetIdentifyingLoader 21. _origROMMethods
+      std::string,                       // 0:  _packedROMClass
+      J9Method *,                        // 1:  _methodsOfClass
+      TR_OpaqueClassBlock *,             // 2:  _baseComponentClass
+      int32_t,                           // 3:  _numDimensions
+      TR_OpaqueClassBlock *,             // 4:  _parentClass
+      std::vector<TR_OpaqueClassBlock *>,// 5:  _tmpInterfaces
+      std::vector<uint8_t>,              // 6:  _methodTracingInfo
+      bool,                              // 7:  _classHasFinalFields
+      uintptr_t,                         // 8:  _classDepthAndFlags
+      bool,                              // 9:  _classInitialized
+      uint32_t,                          // 10: _byteOffsetToLockword
+      TR_OpaqueClassBlock *,             // 11: _leafComponentClass
+      void *,                            // 12: _classLoader
+      TR_OpaqueClassBlock *,             // 13: _hostClass
+      TR_OpaqueClassBlock *,             // 14: _componentClass
+      TR_OpaqueClassBlock *,             // 15: _arrayClass
+      uintptr_t,                         // 16: _totalInstanceSize
+      J9ROMClass *,                      // 17: _remoteRomClass
+      uintptr_t,                         // 18: _constantPool
+      uintptr_t,                         // 19: _classFlags
+      uintptr_t,                         // 20: _classChainOffsetIdentifyingLoader
+      std::vector<J9ROMMethod *>,        // 21: _origROMMethods
+      std::string                        // 22: _classNameIdentifyingLoader
       >;
 
    // Packs a ROMClass to be transferred to the server.
@@ -116,10 +129,11 @@ class JITServerHelpers
 
    static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
 
-   static uintptr_t walkReferenceChainWithOffsets(TR_J9VM * fe, const std::vector<uintptr_t>& listOfOffsets, uintptr_t receiver);
+   static uintptr_t walkReferenceChainWithOffsets(TR_J9VM *fe, const std::vector<uintptr_t> &listOfOffsets, uintptr_t receiver);
 
-   private:
+private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
+
    static TR::Monitor *getClientStreamMonitor()
       {
       if (!_clientStreamMonitor)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1994,7 +1994,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
          else
             {
-            TR::Compiler->relocatableTarget.cpu = TR::CPU::customize(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(fe, curThread));
+            TR::Compiler->relocatableTarget.cpu = TR::CPU::customize(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(curThread));
             jitConfig->relocatableTargetProcessor = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
             }
          }

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -166,6 +166,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerUseAOTCache(false),
          _requireJITServer(false),
          _localSyncCompiles(false),
+         _JITServerAOTCacheName(),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -332,7 +333,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 
    static JITServer::RemoteCompilationModes getRemoteCompilationMode() { return _remoteCompilationMode; }
    const std::string &getJITServerAddress() const { return _JITServerAddress; }
-   void setJITServerAddress(char *addr) { _JITServerAddress = addr; }
+   void setJITServerAddress(const char *addr) { _JITServerAddress = addr; }
    uint32_t getSocketTimeout() const { return _socketTimeoutMs; }
    void setSocketTimeout(uint32_t t) { _socketTimeoutMs = t; }
    uint32_t getJITServerPort() const { return _JITServerPort; }
@@ -341,12 +342,14 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setClientUID(uint64_t val) { _clientUID = val; }
    uint64_t getServerUID() const { return _serverUID; }
    void setServerUID(uint64_t val) { _serverUID = val; }
-   bool getJITServerUseAOTCache() const { return _JITServerUseAOTCache; }
-   void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
    bool getRequireJITServer() const { return _requireJITServer; }
    void setRequireJITServer(bool requireJITServer) { _requireJITServer = requireJITServer; }
    bool isLocalSyncCompiles() const { return _localSyncCompiles; }
    void setLocalSyncCompiles(bool localSyncCompiles) { _localSyncCompiles = localSyncCompiles; }
+   bool getJITServerUseAOTCache() const { return _JITServerUseAOTCache; }
+   void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
+   const std::string &getJITServerAOTCacheName() const { return _JITServerAOTCacheName; }
+   void setJITServerAOTCacheName(const char *name) { _JITServerAOTCacheName = name; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -416,7 +419,6 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 
    TR_J2IThunkTable *_invokeExactJ2IThunkTable;
 
-
    TR::Monitor *_gpuInitMonitor;
 
    bool _runtimeInstrumentationEnabled;
@@ -425,21 +427,21 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    bool _classLoadingPhase;            ///< true, if we detect a large number of classes loaded per second
    bool _inlinerTemporarilyRestricted; ///< do not inline when true; used to restrict cold inliner during startup
 
-
    volatile uint64_t _elapsedTime; ///< elapsed time as computed by the sampling thread (ms)
                                    ///< May need adjustment if sampling thread goes to sleep
 
-
    int32_t _numLoadedClasses; ///< always increasing
+
 #if defined(J9VM_OPT_JITSERVER)
    std::string _JITServerAddress;
    uint32_t    _JITServerPort;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    uint64_t    _clientUID;
    uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
-   bool        _JITServerUseAOTCache;
    bool        _requireJITServer;
    bool        _localSyncCompiles;
+   bool        _JITServerUseAOTCache;
+   std::string _JITServerAOTCacheName; // Name of the server AOT cache that this client is using
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -860,15 +860,15 @@ TR_J9SharedCache::createClassKey(UDATA classOffsetInCache, char *key, uint32_t &
    convertUnsignedOffsetToASCII(classOffsetInCache, key);
    }
 
-UDATA *
-TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
+uintptr_t *
+TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord, bool create)
    {
-   UDATA *chainData = NULL;
+   uintptr_t *chainData = NULL;
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
    J9ROMClass *romClass = TR::Compiler->cls.romClassOf(fej9->convertClassPtrToClassOffset(clazz));
 
-   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+   J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
    LOG(1, "rememberClass class %p romClass %p %.*s\n", clazz, romClass, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
    uintptr_t classOffsetInCache;
@@ -895,10 +895,10 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    int32_t numInterfaces = numInterfacesImplemented(clazz);
 
    LOG(3, "\tcreating chain now: 1 + 1 + %d superclasses + %d interfaces\n", numSuperclasses, numInterfaces);
-   UDATA chainLength = (2 + numSuperclasses + numInterfaces) * sizeof(UDATA);
-   UDATA chainDataBuffer[maxClassChainLength];
+   uintptr_t chainLength = (2 + numSuperclasses + numInterfaces) * sizeof(uintptr_t);
+   uintptr_t chainDataBuffer[maxClassChainLength];
    chainData = chainDataBuffer;
-   if (chainLength > maxClassChainLength * sizeof(UDATA))
+   if (chainLength > maxClassChainLength * sizeof(uintptr_t))
       {
       LOG(1, "\t\t > %u so bailing\n", maxClassChainLength);
       return NULL;
@@ -913,13 +913,13 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    if (!create)
       {
       LOG(1, "\tnot asked to create but could create, returning non-null\n");
-      return (UDATA *) 0x1;
+      return (uintptr_t *)0x1;
       }
 
-   UDATA chainDataLength = chainData[0];
+   uintptr_t chainDataLength = chainData[0];
 
    J9SharedDataDescriptor dataDescriptor;
-   dataDescriptor.address = (U_8*)chainData;
+   dataDescriptor.address = (uint8_t *)chainData;
    dataDescriptor.length  = chainDataLength;
    dataDescriptor.type    = J9SHR_DATA_TYPE_AOTCLASSCHAIN;
    dataDescriptor.flags   = J9SHRDATA_SINGLE_STORE_FOR_KEY_TYPE;
@@ -928,10 +928,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
       aotStats()->numNewCHEntriesInSharedClass++;
 
    J9VMThread *vmThread = fej9->getCurrentVMThread();
-   chainData = (UDATA *) sharedCacheConfig()->storeSharedData(vmThread,
-                                                             (const char*)key,
-                                                             keyLength,
-                                                             &dataDescriptor);
+   chainData = (uintptr_t *)sharedCacheConfig()->storeSharedData(vmThread, key, keyLength, &dataDescriptor);
    if (chainData)
       {
       LOG(1, "\tstored data, chain at %p\n", chainData);
@@ -1360,34 +1357,68 @@ TR_J9JITServerSharedCache::TR_J9JITServerSharedCache(TR_J9VMBase *fe)
    _stream = NULL;
    }
 
-UDATA *
-TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
+uintptr_t *
+TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord, bool create)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   auto clientData = TR::compInfoPT->getClientData();
-   PersistentUnorderedMap<J9Class *, UDATA *> & cache = clientData->getClassChainDataCache();
+
+   uintptr_t *classChain = NULL;
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool needClassChainRecord = create && comp->isAOTCacheStore();
+   const AOTCacheClassChainRecord *record = NULL;
+
+   // Check if the class chain is already cached
+   auto &cache = clientData->getClassChainDataMap();
       {
       OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
       auto it = cache.find(clazz);
       if (it != cache.end())
-         return it->second;
-      }
-   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create);
-   UDATA * chainData = std::get<0>(_stream->read<UDATA *>());
-   if (chainData)
-      {
-      if (!create)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "not asked to create but could create, returning non-null \n");
+         classChain = it->second._classChain;
+         record = it->second._aotCacheClassChainRecord;
+         }
+      }
+
+   // If the class chain is cached and the AOT cache record is either cached or not needed, return the cached values
+   if (classChain && (record || !needClassChainRecord))
+      {
+      if (classChainRecord)
+         *classChainRecord = record;
+      return classChain;
+      }
+
+   // Request missing class chain information from the client
+   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create, needClassChainRecord);
+   auto recv = _stream->read<uintptr_t *, std::vector<J9Class *>, std::vector<J9Class *>,
+                             std::vector<JITServerHelpers::ClassInfoTuple>>();
+   if (classChain)
+      TR_ASSERT_FATAL(std::get<0>(recv) == classChain, "Received mismatching class chain: %p != %p",
+                      std::get<0>(recv), classChain);
+   classChain = std::get<0>(recv);
+   auto &ramClassChain = std::get<1>(recv);
+   auto &uncachedRAMClasses = std::get<2>(recv);
+   auto &uncachedClassInfos = std::get<3>(recv);
+
+   // Cache the result if the class chain was succesfully created at the client
+   if (classChain && create)
+      {
+      if (needClassChainRecord)
+         {
+         JITServerHelpers::cacheRemoteROMClassBatch(clientData, uncachedRAMClasses, uncachedClassInfos);
+         // This call will cache both the class chain and the AOT cache record in the client session
+         record = clientData->getClassChainRecord(clazz, classChain, ramClassChain, _stream);
+         if (classChainRecord)
+            *classChainRecord = record;
          }
       else
          {
          OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
-         cache.insert(std::make_pair(clazz, chainData));
+         cache.insert({ clazz, { classChain, NULL } });
          }
       }
-   return chainData;
+
+   return classChain;
    }
 
 J9SharedClassCacheDescriptor *

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -296,17 +296,17 @@ public:
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
 
-   virtual uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz);
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) override;
 
-   #if defined(J9VM_OPT_JITSERVER)
+#if defined(J9VM_OPT_JITSERVER)
    /**
      * \brief Finds the offset in SCC of the class chain identifying the class loader of the given class.
-     *        This is very similar to getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache
+     *        This is very similar to getClassChainOffsetIdentifyingLoader
      *        except that it will not fail the compilation if the offset is not valid.
      * \return Returns the offset of the class chain that identifies given class or 0 is such offset is not valid.
     */
-   uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCacheNoFail(TR_OpaqueClassBlock *clazz);
-   #endif
+   uintptr_t getClassChainOffsetIdentifyingLoaderNoFail(TR_OpaqueClassBlock *clazz);
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
 
@@ -583,7 +583,7 @@ public:
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT_FATAL(false, "called"); return TR_no;}
    static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT_FATAL(false, "called"); }
 
-   virtual uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) override;
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -173,17 +173,19 @@ public:
 
    static const uint32_t maxClassChainLength = 32;
 
-   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
+   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) override
       {
-      return (rememberClass((J9Class *) classPtr, false) != NULL);
+      return rememberClass((J9Class *)classPtr, NULL, false) != NULL;
       }
 
-   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *classPtr)
+   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *classPtr,
+                                    const AOTCacheClassChainRecord **classChainRecord = NULL) override
       {
-      return (uintptr_t *) rememberClass((J9Class *) classPtr, true);
+      return (uintptr_t *)rememberClass((J9Class *)classPtr, classChainRecord, true);
       }
 
-   virtual UDATA *rememberClass(J9Class *clazz, bool create=true);
+   virtual uintptr_t *rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
+                                    bool create = true);
 
    virtual UDATA rememberDebugCounterName(const char *name);
    virtual const char *getDebugCounterName(UDATA offset);
@@ -569,7 +571,8 @@ public:
    virtual void addHint(J9Method *, TR_SharedCacheHint) override;
    virtual bool isMostlyFull() override { TR_ASSERT_FATAL(false, "called"); return false;}
 
-   virtual UDATA *rememberClass(J9Class *clazz, bool create=true) override;
+   virtual uintptr_t *rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
+                                    bool create = true) override;
 
    virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT_FATAL(false, "called"); return 0;}
    virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL;}

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -296,7 +296,7 @@ public:
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
 
-   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) override;
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override;
 
 #if defined(J9VM_OPT_JITSERVER)
    /**
@@ -305,7 +305,7 @@ public:
      *        except that it will not fail the compilation if the offset is not valid.
      * \return Returns the offset of the class chain that identifies given class or 0 is such offset is not valid.
     */
-   uintptr_t getClassChainOffsetIdentifyingLoaderNoFail(TR_OpaqueClassBlock *clazz);
+   uintptr_t getClassChainOffsetIdentifyingLoaderNoFail(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
@@ -583,7 +583,7 @@ public:
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT_FATAL(false, "called"); return TR_no;}
    static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT_FATAL(false, "called"); }
 
-   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) override;
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override;
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
 

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -30,6 +30,7 @@ class TR_PersistentClassLoaderTable;
 class TR_ResolvedMethod;
 namespace TR { class ResolvedMethodSymbol; }
 
+
 class TR_SharedCache
    {
 public:
@@ -64,7 +65,7 @@ public:
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *loader) { return NULL; }
 
-   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) { return 0; }
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) { return 0; }
 
    void setPersistentClassLoaderTable(TR_PersistentClassLoaderTable *table) { _persistentClassLoaderTable = table; }
    TR_PersistentClassLoaderTable *persistentClassLoaderTable() { return _persistentClassLoaderTable; }

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -29,19 +29,20 @@
 class TR_PersistentClassLoaderTable;
 class TR_ResolvedMethod;
 namespace TR { class ResolvedMethodSymbol; }
+class AOTCacheClassChainRecord;
 
 
 class TR_SharedCache
    {
 public:
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *) { return; }
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *) { return; }
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *) { }
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *) { }
 
    virtual bool isMostlyFull() { return false; }
 
-   virtual bool canRememberClass(TR_OpaqueClassBlock *clazz) { return 0; }
-   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *clazz) { return 0; }
-   virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *clazz, uintptr_t *chainData=NULL) { return false; }
+   virtual bool canRememberClass(TR_OpaqueClassBlock *clazz) { return false; }
+   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL) { return NULL; }
+   virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *clazz, uintptr_t *chainData = NULL) { return false; }
 
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
    virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr) { return 0; }

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,12 +62,11 @@ public:
    virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) { return false; }
    virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) { return false; }
 
-   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *cinaData, void *loader) { return NULL; }
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *loader) { return NULL; }
 
-   virtual uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) { return 0; }
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz) { return 0; }
 
    void setPersistentClassLoaderTable(TR_PersistentClassLoaderTable *table) { _persistentClassLoaderTable = table; }
-
    TR_PersistentClassLoaderTable *persistentClassLoaderTable() { return _persistentClassLoaderTable; }
 
 private:

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9367,7 +9367,7 @@ bool
 TR_J9SharedCacheVM::canRememberClass(TR_OpaqueClassBlock *classPtr)
    {
    if (_sharedCache)
-      return (_sharedCache->rememberClass((J9Class *) classPtr, false) != NULL);
+      return (_sharedCache->rememberClass((J9Class *)classPtr, NULL, false) != NULL);
    return false;
    }
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1523,7 +1523,7 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    _literals = methodInfoStruct.literals;
    _ramClass = methodInfoStruct.ramClass;
 
-   _romClass = threadCompInfo->getAndCacheRemoteROMClass(_ramClass, trMemory);
+   _romClass = threadCompInfo->getAndCacheRemoteROMClass(_ramClass);
    _romMethod = romMethodAtClassIndex(_romClass, methodInfoStruct.methodIndex);
    _romLiterals = (J9ROMConstantPoolItem *) ((UDATA) _romClass + sizeof(J9ROMClass));
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2066,7 +2066,8 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
       }
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
-   void *classChain = fej9->sharedCache()->rememberClass(definingClass);
+   const AOTCacheClassChainRecord *classChainRecord = NULL;
+   void *classChain = fej9->sharedCache()->rememberClass(definingClass, &classChainRecord);
    if (!classChain)
       return false;
 
@@ -2111,7 +2112,10 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
       return true;
       }
 
-   TR::AOTClassInfo *classInfo = new (comp->trHeapMemory()) TR::AOTClassInfo(fej9, (TR_OpaqueClassBlock *)definingClass, (void *) classChain, (TR_OpaqueMethodBlock *)ramMethod, cpIndex, reloKind);
+   TR::AOTClassInfo *classInfo = new (comp->trHeapMemory()) TR::AOTClassInfo(
+      fej9, (TR_OpaqueClassBlock *)definingClass, (void *)classChain,
+      (TR_OpaqueMethodBlock *)ramMethod, cpIndex, reloKind, classChainRecord
+   );
    if (classInfo)
       {
       traceMsg(comp, "\tCreated new AOT class info %p\n", classInfo);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 31;
+   static const uint16_t MINOR_NUMBER = 32;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -218,6 +218,7 @@ enum MessageType : uint16_t
    ClassEnv_iTableRomClass,
    ClassEnv_getITable,
    ClassEnv_enumerateFields,
+   ClassEnv_isClassRefValueType,
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetIdentifyingLoader,
@@ -275,7 +276,7 @@ enum MessageType : uint16_t
    KnownObjectTable_getReferenceField,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType,
+   AOTCache_getROMClassBatch,
 
    MessageType_MAXTYPE
    };
@@ -462,6 +463,7 @@ static const char *messageNames[] =
    "ClassEnv_iTableRomClass",
    "ClassEnv_getITable",
    "ClassEnv_enumerateFields",
+   "ClassEnv_isClassRefValueType",
    "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",
    "SharedCache_addHint",
@@ -506,7 +508,7 @@ static const char *messageNames[] =
    "KnownObjectTable_createSymRefWithKnownObject",
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType",
+   "AOTCache_getROMClassBatch",
    };
 
    static_assert(sizeof(messageNames) / sizeof(messageNames[0]) == MessageType_MAXTYPE,

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -220,7 +220,7 @@ enum MessageType : uint16_t
    ClassEnv_enumerateFields,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache,
+   SharedCache_getClassChainOffsetIdentifyingLoader,
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
@@ -462,7 +462,7 @@ static const char *messageNames[] =
    "ClassEnv_iTableRomClass",
    "ClassEnv_getITable",
    "ClassEnv_enumerateFields",
-   "SharedCache_getClassChainOffsetInSharedCache",
+   "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -299,7 +299,7 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          uint8_t flags = (uint8_t)recordInfo->data3;
          uintptr_t inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(symRef->getOwningMethod(comp)->constantPool(), recordInfo->data2);
 
-         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(j9class);
          uintptr_t classChainOffsetInSharedCache = self()->getClassChainOffset(j9class);
 
          TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -55,7 +55,7 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo, TR_Pers
    _registeredInvokeExactJ2IThunksSet(decltype(_registeredInvokeExactJ2IThunksSet)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _wellKnownClasses(),
    _isInStartupPhase(false),
-   _aotCacheName(), _aotCache(NULL)
+   _aotCacheName(), _aotCache(NULL), _aotHeaderRecord(NULL)
    {
    updateTimeOfLastAccess();
    _javaLangClassPtr = NULL;
@@ -758,6 +758,7 @@ ClientSessionData::getOrCreateAOTCache(JITServer::ServerStream *stream)
       if (auto aotCacheMap = TR::CompilationInfo::get()->getJITServerAOTCacheMap())
          {
          _aotCache = aotCacheMap->get(_aotCacheName, _clientUID);
+         _aotHeaderRecord = _aotCache->getAOTHeaderRecord(&_vmInfo->_aotHeader, _clientUID);
          }
       else
          {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -396,10 +396,10 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _numDimensions(0),
    _parentClass(NULL),
    _interfaces(NULL),
-   _classHasFinalFields(false),
-   _classDepthAndFlags(0),
-   _classInitialized(false),
    _byteOffsetToLockword(0),
+   _classHasFinalFields(false),
+   _classInitialized(false),
+   _classDepthAndFlags(0),
    _leafComponentClass(NULL),
    _classLoader(NULL),
    _hostClass(NULL),
@@ -409,6 +409,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _constantPool(NULL),
    _classFlags(0),
    _classChainOffsetIdentifyingLoader(0),
+   _classNameIdentifyingLoader(),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
@@ -597,6 +598,7 @@ ClientSessionData::destroy(ClientSessionData *clientSession)
          {
          if (sharedROMClassCache)
             sharedROMClassCache->release(it.second._romClass);
+         it.second._classNameIdentifyingLoader.~basic_string();
          for (auto &kv : it.second._J9MethodNameCache)
             kv.second.~J9MethodNameAndSignature();
          }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -408,7 +408,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _totalInstanceSize(0),
    _constantPool(NULL),
    _classFlags(0),
-   _classChainOffsetOfIdentifyingLoaderForClazz(0),
+   _classChainOffsetIdentifyingLoader(0),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(persistentMemory->_persistentAllocator.get())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -209,7 +209,7 @@ public:
       uintptr_t _totalInstanceSize;
       J9ConstantPool *_constantPool;
       uintptr_t _classFlags;
-      uintptr_t _classChainOffsetOfIdentifyingLoaderForClazz;
+      uintptr_t _classChainOffsetIdentifyingLoader;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;
       TR_FieldAttributesCache _fieldAttributesCache;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -54,7 +54,6 @@ using TR_JitFieldsCache = PersistentUnorderedMap<int32_t, TR_JitFieldsCacheEntry
    @class TR_J9MethodFieldAttributes
    @brief Class used for caching various field attributes of a j9method
  */
-
 class TR_J9MethodFieldAttributes
    {
    public:
@@ -163,7 +162,6 @@ struct J9MethodNameAndSignature
    (several compilation threads from the client can issue compilation requests)
    access to most fields need to be protected by monitors.
  */
-
 class ClientSessionData
    {
 public:
@@ -182,7 +180,6 @@ public:
       HCR mechanism (which JITServer also treats as a class unload event). At that point,
       JITServer will be notified and the cache will be purged.
    */
-
    struct ClassInfo
       {
       ClassInfo(TR_PersistentMemory *persistentMemory);
@@ -197,19 +194,21 @@ public:
       int32_t _numDimensions;
       TR_OpaqueClassBlock *_parentClass;
       PersistentVector<TR_OpaqueClassBlock *> *_interfaces;
-      bool _classHasFinalFields;
-      uintptr_t _classDepthAndFlags;
-      bool _classInitialized;
       uint32_t _byteOffsetToLockword;
-      TR_OpaqueClassBlock * _leafComponentClass;
+      bool _classHasFinalFields;
+      bool _classInitialized;
+      uintptr_t _classDepthAndFlags;
+      TR_OpaqueClassBlock *_leafComponentClass;
       void *_classLoader;
-      TR_OpaqueClassBlock * _hostClass;
-      TR_OpaqueClassBlock * _componentClass; // caching the componentType of the J9ArrayClass
-      TR_OpaqueClassBlock * _arrayClass;
+      TR_OpaqueClassBlock *_hostClass;
+      TR_OpaqueClassBlock *_componentClass; // caching the componentType of the J9ArrayClass
+      TR_OpaqueClassBlock *_arrayClass;
       uintptr_t _totalInstanceSize;
       J9ConstantPool *_constantPool;
       uintptr_t _classFlags;
       uintptr_t _classChainOffsetIdentifyingLoader;
+      std::string _classNameIdentifyingLoader;
+
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;
       TR_FieldAttributesCache _fieldAttributesCache;
@@ -532,7 +531,6 @@ private:
    compilation. The StatistcisThread can also perform purging duties.
    Entried with inUse > 0 must not be purged.
  */
-
 class ClientSessionHT
    {
    public:

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -329,6 +329,12 @@ public:
       uintptr_t metadataStartAddress;
       };
 
+   struct ClassChainData
+      {
+      uintptr_t *_classChain;
+      const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
+      };
+
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)
    ClientSessionData(uint64_t clientUID, uint32_t seqNo, TR_PersistentMemory *persistentMemory, bool usesPerClientMemory);
    ~ClientSessionData();
@@ -337,13 +343,13 @@ public:
    TR_PersistentMemory *persistentMemory() { return _persistentMemory; }
    bool usesPerClientMemory() { return _usesPerClientMemory; }
    void setJavaLangClassPtr(TR_OpaqueClassBlock* j9clazz) { _javaLangClassPtr = j9clazz; }
-   TR_OpaqueClassBlock * getJavaLangClassPtr() const { return _javaLangClassPtr; }
+   TR_OpaqueClassBlock *getJavaLangClassPtr() const { return _javaLangClassPtr; }
    TR_PersistentCHTable *getCHTable();
-   PersistentUnorderedMap<J9Class*, ClassInfo> & getROMClassMap() { return _romClassMap; }
-   PersistentUnorderedMap<J9Method*, J9MethodInfo> & getJ9MethodMap() { return _J9MethodMap; }
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassBySignatureMap() { return _classBySignatureMap; }
-   PersistentUnorderedMap<J9Class *, UDATA *> & getClassChainDataCache() { return _classChainDataMap; }
-   PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock*> & getConstantPoolToClassMap() { return _constantPoolToClassMap; }
+   PersistentUnorderedMap<J9Class *, ClassInfo> &getROMClassMap() { return _romClassMap; }
+   PersistentUnorderedMap<J9Method *, J9MethodInfo> &getJ9MethodMap() { return _J9MethodMap; }
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock *> &getClassBySignatureMap() { return _classBySignatureMap; }
+   PersistentUnorderedMap<J9Class *, ClassChainData> &getClassChainDataMap() { return _classChainDataMap; }
+   PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock *> &getConstantPoolToClassMap() { return _constantPoolToClassMap; }
    void initializeUnloadedClassAddrRanges(const std::vector<TR_AddressRange> &unloadedClassRanges, int32_t maxRanges);
    void processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*> &classes, bool updateUnloadedClasses);
    void processIllegalFinalFieldModificationList(const std::vector<TR_OpaqueClassBlock*> &classes);
@@ -449,6 +455,8 @@ public:
 
    const AOTCacheClassRecord *getClassRecord(J9Class *clazz, JITServer::ServerStream *stream);
    const AOTCacheMethodRecord *getMethodRecord(J9Method *method, J9Class *definingClass, JITServer::ServerStream *stream);
+   const AOTCacheClassChainRecord *getClassChainRecord(J9Class *clazz, uintptr_t *classChain,
+                                                       const std::vector<J9Class *> &ramClassChain, JITServer::ServerStream *stream);
 
 private:
    void destroyMonitors();
@@ -471,7 +479,7 @@ private:
    // All classes in here are loaded by the systemClassLoader so we know they cannot be unloaded
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> _classBySignatureMap;
 
-   PersistentUnorderedMap<J9Class *, UDATA *> _classChainDataMap;
+   PersistentUnorderedMap<J9Class *, ClassChainData> _classChainDataMap;
    //Constant pool to class map
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock *> _constantPoolToClassMap;
    TR::Monitor *_romMapMonitor;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -416,8 +416,8 @@ public:
    J9SharedClassCacheDescriptor * reconstructJ9SharedClassCacheDescriptorList(const std::vector<CacheDescriptor> &listOfCacheDescriptors);
    void destroyJ9SharedClassCacheDescriptorList();
 
-   volatile bool isClassUnloadingAttempted() const { return _bClassUnloadingAttempt; }
-   volatile bool isReadingClassUnload() { return !omrthread_rwmutex_is_writelocked(_classUnloadRWMutex); }
+   bool isClassUnloadingAttempted() const { return _bClassUnloadingAttempt; }
+   bool isReadingClassUnload() { return !omrthread_rwmutex_is_writelocked(_classUnloadRWMutex); }
 
    void readAcquireClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT);
    void readReleaseClassUnloadRWMutex(TR::CompilationInfoPerThreadBase *compInfoPT);

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -208,6 +208,7 @@ public:
       uintptr_t _classFlags;
       uintptr_t _classChainOffsetIdentifyingLoader;
       std::string _classNameIdentifyingLoader;
+      const AOTCacheClassRecord *_aotCacheClassRecord;
 
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;
@@ -438,8 +439,13 @@ public:
       return _aotHeaderRecord;
       }
 
+   const AOTCacheClassRecord *getClassRecord(J9Class *clazz, JITServer::ServerStream *stream);
+
 private:
    void destroyMonitors();
+
+   const AOTCacheClassRecord *getClassRecord(ClientSessionData::ClassInfo &classInfo);
+   const AOTCacheClassRecord *getClassRecord(J9Class *clazz, bool &missingLoaderRecord);
 
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -231,15 +231,23 @@ public:
    */
    struct J9MethodInfo
       {
+      J9MethodInfo(J9ROMMethod *romMethod, J9ROMMethod *origROMMethod,
+                   TR_OpaqueClassBlock *owningClass, uint32_t index, bool isMethodTracingEnabled) :
+         _romMethod(romMethod), _origROMMethod(origROMMethod), _IPData(NULL),
+         _owningClass(owningClass), _index(index), _isMethodTracingEnabled(isMethodTracingEnabled),
+         _isCompiledWhenProfiling(false), _isLambdaFormGeneratedMethod(false), _aotCacheMethodRecord(NULL) { }
+
       J9ROMMethod *_romMethod; // pointer to local/server cache
       J9ROMMethod *_origROMMethod; // pointer to the client-side method
       // The following is a hashtable that maps a bcIndex to IProfiler data
       // The hashtable is created on demand (NULL means it is missing)
       IPTable_t *_IPData;
-      bool _isMethodTracingEnabled;
       TR_OpaqueClassBlock * _owningClass;
+      uint32_t _index;// Index in the array of methods of the defining class
+      bool _isMethodTracingEnabled;
       bool _isCompiledWhenProfiling; // To record if the method is compiled when doing Profiling
       bool _isLambdaFormGeneratedMethod;
+      const AOTCacheMethodRecord * _aotCacheMethodRecord;
       }; // struct J9MethodInfo
 
    /**
@@ -440,6 +448,7 @@ public:
       }
 
    const AOTCacheClassRecord *getClassRecord(J9Class *clazz, JITServer::ServerStream *stream);
+   const AOTCacheMethodRecord *getMethodRecord(J9Method *method, J9Class *definingClass, JITServer::ServerStream *stream);
 
 private:
    void destroyMonitors();

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -429,10 +429,13 @@ public:
    // Returns the cached client-side pointer to well-known class chain offsets
    // if included classes and their SCC offsets match, otherwise returns NULL
    const void *getCachedWellKnownClassChainOffsets(unsigned int includedClasses, size_t numClasses,
-                                                   const uintptr_t *classChainOffsets);
+                                                   const uintptr_t *classChainOffsets,
+                                                   const AOTCacheWellKnownClassesRecord *&wellKnownClassesRecord);
    // Cache the client-side pointer to well-known class chain offsets
    void cacheWellKnownClassChainOffsets(unsigned int includedClasses, size_t numClasses,
-                                        const uintptr_t *classChainOffsets, const void *wellKnownClassChainOffsets);
+                                        const uintptr_t *classChainOffsets, const void *wellKnownClassChainOffsets,
+                                        const AOTCacheClassChainRecord *const *classChainRecords,
+                                        const AOTCacheWellKnownClassesRecord *&wellKnownClassesRecord);
 
    bool isInStartupPhase() const { return _isInStartupPhase; }
    void setIsInStartupPhase(bool isInStartupPhase) { _isInStartupPhase = isInStartupPhase; }
@@ -530,6 +533,7 @@ private:
       unsigned int _includedClasses;// bitset of indices in the list of well-known classes
       uintptr_t _classChainOffsets[WELL_KNOWN_CLASS_COUNT];// ROMClass SCC offsets
       const void *_wellKnownClassChainOffsets;// client-side pointer to "well-known class chain offsets" in SCC
+      const AOTCacheWellKnownClassesRecord *_aotCacheWellKnownClassesRecord;
       };
 
    WellKnownClassesCache _wellKnownClasses;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -307,6 +307,7 @@ public:
       UDATA _vmindexOffset;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
       bool _useAOTCache;
+      TR_AOTHeader _aotHeader;
       }; // struct VMInfo
 
    /**
@@ -433,6 +434,12 @@ public:
       return _aotCache;
       }
 
+   const AOTCacheAOTHeaderRecord *getAOTHeaderRecord() const
+      {
+      TR_ASSERT(_aotHeaderRecord, "Must have valid AOT header record");
+      return _aotHeaderRecord;
+      }
+
 private:
    void destroyMonitors();
 
@@ -511,6 +518,7 @@ private:
 
    std::string _aotCacheName;
    JITServerAOTCache *_aotCache;
+   const AOTCacheAOTHeaderRecord *_aotHeaderRecord;
    }; // class ClientSessionData
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -185,7 +185,7 @@ public:
 
    struct ClassInfo
       {
-      ClassInfo();
+      ClassInfo(TR_PersistentMemory *persistentMemory);
       void freeClassInfo(TR_PersistentMemory *persistentMemory); // this method is in place of a destructor. We can't have destructor
       // because it would be called after inserting ClassInfo into the ROM map, freeing romClass
 
@@ -224,7 +224,6 @@ public:
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
       PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
       }; // struct ClassInfo
-
 
    /**
       @class J9MethodInfo

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -755,22 +755,36 @@ TR_RelocationRuntime::aotMethodHeaderVersionsMatch()
 bool
 TR_RelocationRuntime::storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    {
-   TR_ASSERT(0, "Error: storeAOTHeader not supported in this relocation runtime");
+   TR_ASSERT_FATAL(false, "Error: storeAOTHeader not supported in this relocation runtime");
    return false;
+   }
+
+const TR_AOTHeader *
+TR_RelocationRuntime::getStoredAOTHeader(J9VMThread *curThread)
+   {
+   TR_ASSERT_FATAL(false, "Error: getStoredAOTHeader not supported in this relocation runtime");
+   return NULL;
    }
 
 TR_AOTHeader *
 TR_RelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
    {
-   TR_ASSERT(0, "Error: createAOTHeader not supported in this relocation runtime");
+   TR_ASSERT_FATAL(false, "Error: createAOTHeader not supported in this relocation runtime");
    return NULL;
    }
 
 bool
 TR_RelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    {
-   TR_ASSERT(0, "Error: validateAOTHeader not supported in this relocation runtime");
+   TR_ASSERT_FATAL(false, "Error: validateAOTHeader not supported in this relocation runtime");
    return false;
+   }
+
+OMRProcessorDesc
+TR_RelocationRuntime::getProcessorDescriptionFromSCC(J9VMThread *curThread)
+   {
+   TR_ASSERT_FATAL(false, "Error: getProcessorDescriptionFromSCC not supported in this relocation runtime");
+   return OMRProcessorDesc();
    }
 
 #if defined(J9VM_OPT_JITSERVER)
@@ -923,7 +937,7 @@ TR_SharedCacheRelocationRuntime::generateError(U_32 module_name, U_32 reason, ch
    }
 
 void
-TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(TR_AOTHeader *hdrInCache, intptr_t featureFlags)
+TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hdrInCache, intptr_t featureFlags)
    {
    bool defaultMessage = true;
 
@@ -985,26 +999,15 @@ TR_SharedCacheRelocationRuntime::getCurrentLockwordOptionHashValue(J9JavaVM *vm)
    }
 
 OMRProcessorDesc
-TR_SharedCacheRelocationRuntime::getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread)
+TR_SharedCacheRelocationRuntime::getProcessorDescriptionFromSCC(J9VMThread *curThread)
    {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
-   J9SharedDataDescriptor firstDescriptor;
-   firstDescriptor.address = NULL;
-   javaVM()->sharedClassConfig->findSharedData(curThread,
-                                             aotHeaderKey,
-                                             aotHeaderKeyLength,
-                                             J9SHR_DATA_TYPE_AOTHEADER,
-                                             FALSE,
-                                             &firstDescriptor,
-                                             NULL);
-
-   const void* result = firstDescriptor.address;
-   TR_ASSERT_FATAL(result, "No Shared Class Cache available for Processor Description\n");
-   TR_AOTHeader * hdrInCache = (TR_AOTHeader *)result;
+   const TR_AOTHeader *hdrInCache = getStoredAOTHeader(curThread);
+   TR_ASSERT_FATAL(hdrInCache, "No Shared Class Cache available for Processor Description\n");
    return hdrInCache->processorDescription;
    }
 
-static void setAOTHeaderInvalid(TR_JitPrivateConfig *privateConfig)
+static void
+setAOTHeaderInvalid(TR_JitPrivateConfig *privateConfig)
    {
    TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
    TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
@@ -1045,23 +1048,10 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
       }
 
    /* Look for an AOT header in the cache and see if this JVM is compatible */
-
-   J9SharedDataDescriptor firstDescriptor;
-   firstDescriptor.address = NULL;
-   javaVM()->sharedClassConfig->findSharedData(curThread,
-                                             aotHeaderKey,
-                                             aotHeaderKeyLength,
-                                             J9SHR_DATA_TYPE_AOTHEADER,
-                                             FALSE,
-                                             &firstDescriptor,
-                                             NULL);
-
-   const void* result = firstDescriptor.address;
-   if (result)
+   const TR_AOTHeader *hdrInCache = getStoredAOTHeader(curThread);
+   if (hdrInCache)
       {
       /* check compatibility */
-      TR_AOTHeader * hdrInCache = (TR_AOTHeader * )result;
-
       intptr_t featureFlags = generateFeatureFlags(fe);
 
       TR_Version currentVersion;
@@ -1127,6 +1117,16 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
       // static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig)->aotValidHeader = TR_maybe;
       return false;
       }
+   }
+
+const TR_AOTHeader *
+TR_SharedCacheRelocationRuntime::getStoredAOTHeader(J9VMThread *curThread)
+   {
+   J9SharedDataDescriptor firstDescriptor;
+   firstDescriptor.address = NULL;
+   javaVM()->sharedClassConfig->findSharedData(curThread, aotHeaderKey, aotHeaderKeyLength,
+                                               J9SHR_DATA_TYPE_AOTHEADER, FALSE, &firstDescriptor, NULL);
+   return (const TR_AOTHeader *)firstDescriptor.address;
    }
 
 TR_AOTHeader *

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -136,7 +136,7 @@ class TR_RelocationRuntime {
       TR_J9VMBase *fej9()                                         { return (TR_J9VMBase *)_fe; }
       J9JavaVM *javaVM()                                          { return _javaVM; }
       TR_Memory *trMemory()                                       { return _trMemory; }
-      TR::CompilationInfo *compInfo()                              { return _compInfo; }
+      TR::CompilationInfo *compInfo()                             { return _compInfo; }
       J9VMThread *currentThread()                                 { return _currentThread; }
       J9Method *method()                                          { return _method; }
       TR::CodeCache *codeCache()                                  { return _codeCache; }
@@ -164,11 +164,11 @@ class TR_RelocationRuntime {
       int32_t returnCode()                                        { return _returnCode; }
       void setReturnCode(int32_t rc)                              { _returnCode = rc; }
 
-      TR::Options *options()                                       { return _options; }
-      TR::Compilation *comp()                                    { return _comp; }
+      TR::Options *options()                                      { return _options; }
+      TR::Compilation *comp()                                     { return _comp; }
       TR_ResolvedMethod *currentResolvedMethod()                  { return _currentResolvedMethod; }
 
-      TR::PersistentInfo *getPersistentInfo()                      { return comp()->getPersistentInfo(); }
+      TR::PersistentInfo *getPersistentInfo()                     { return comp()->getPersistentInfo(); }
 
       // current main entry point
       J9JITExceptionTable *prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
@@ -183,9 +183,10 @@ class TR_RelocationRuntime {
                                                          uint8_t *existingCode = NULL);
 
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
+      virtual const TR_AOTHeader *getStoredAOTHeader(J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread) { TR_ASSERT_FATAL(0, "Error: getProcessorDescriptionFromSCC not supported in this relocation runtime"); return OMRProcessorDesc();}
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(J9VMThread *curThread);
 
       static uintptr_t    getGlobalValue(uint32_t g)
          {
@@ -350,10 +351,11 @@ public:
       TR_SharedCacheRelocationRuntime(J9JITConfig *jitCfg) :
          _sharedCacheIsFull(false), TR_RelocationRuntime(jitCfg) {}
 
-      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
-      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread);
+      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread) override;
+      virtual const TR_AOTHeader *getStoredAOTHeader(J9VMThread *curThread) override;
+      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe) override;
+      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread) override;
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(J9VMThread *curThread) override;
 
 private:
       uint32_t getCurrentLockwordOptionHashValue(J9JavaVM *vm) const;
@@ -364,7 +366,7 @@ private:
 
       virtual void incompatibleCache(U_32 module, U_32 reason, char *assumeMessage);
 
-      void checkAOTHeaderFlags(TR_AOTHeader * hdrInCache, intptr_t featureFlags);
+      void checkAOTHeaderFlags(const TR_AOTHeader *hdrInCache, intptr_t featureFlags);
       bool generateError(U_32 module_name, U_32 reason, char *assumeMessage);
 
       bool _sharedCacheIsFull;
@@ -382,10 +384,16 @@ public:
       void * operator new(size_t, J9JITConfig *);
       TR_JITServerRelocationRuntime(J9JITConfig *jitCfg) : TR_RelocationRuntime(jitCfg) {}
       // The following public APIs should not be used with this class
-      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread) override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
+      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread) override
+         { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return false; }
+      virtual const TR_AOTHeader *getStoredAOTHeader(J9VMThread *curThread) override
+         { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return NULL; }
+      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe) override
+         { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return NULL; }
+      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread) override
+         { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return false; }
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(J9VMThread *curThread) override
+         { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
 
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -42,6 +42,7 @@
 class ClientSessionData;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 class AOTCacheClassChainRecord;
+class AOTCacheWellKnownClassesRecord;
 
 
 #define SVM_ASSERT_LOCATION_INNER(line) __FILE__ ":" #line
@@ -696,7 +697,10 @@ public:
    bool validateWellKnownClasses(const uintptr_t *wellKnownClassChainOffsets);
    bool isWellKnownClass(TR_OpaqueClassBlock *clazz);
    bool classCanSeeWellKnownClasses(TR_OpaqueClassBlock *clazz);
-   const void *wellKnownClassChainOffsets() { return _wellKnownClassChainOffsets; }
+   const void *wellKnownClassChainOffsets() const { return _wellKnownClassChainOffsets; }
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheWellKnownClassesRecord *aotCacheWellKnownClassesRecord() const { return _aotCacheWellKnownClassesRecord; }
+#endif /* defined(J9VM_OPT_JITSERVER */
 
    enum Presence
       {
@@ -903,6 +907,9 @@ private:
 
    TR_OpaqueClassBlock *_rootClass;
    const void *_wellKnownClassChainOffsets;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheWellKnownClassesRecord *_aotCacheWellKnownClassesRecord;
+#endif /* defined(J9VM_OPT_JITSERVER */
 
    /* List of validation records to be written to the AOT buffer */
    SymbolValidationRecordList _symbolValidationRecords;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -40,7 +40,9 @@
 
 #if defined(J9VM_OPT_JITSERVER)
 class ClientSessionData;
-#endif
+#endif /* defined(J9VM_OPT_JITSERVER) */
+class AOTCacheClassChainRecord;
+
 
 #define SVM_ASSERT_LOCATION_INNER(line) __FILE__ ":" #line
 #define SVM_ASSERT_LOCATION(line) SVM_ASSERT_LOCATION_INNER(line)
@@ -156,12 +158,25 @@ struct ClassValidationRecordWithChain : public ClassValidationRecord
    {
    ClassValidationRecordWithChain(TR_ExternalRelocationTargetKind kind, TR_OpaqueClassBlock *clazz)
       : ClassValidationRecord(kind), _class(clazz), _classChain(NULL)
-      {}
+      {
+#if defined(J9VM_OPT_JITSERVER)
+      _aotCacheClassChainRecord = NULL;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      }
 
    virtual void printFields();
 
-   TR_OpaqueClassBlock * _class;
-   void * _classChain;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return _aotCacheClassChainRecord; }
+#else /* defined(J9VM_OPT_JITSERVER) */
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return NULL; }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   TR_OpaqueClassBlock *_class;
+   void *_classChain;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
    };
 
 struct ClassByNameRecord : public ClassValidationRecordWithChain
@@ -180,16 +195,30 @@ struct ClassByNameRecord : public ClassValidationRecordWithChain
 
 struct ProfiledClassRecord : public ClassValidationRecord
    {
-   ProfiledClassRecord(TR_OpaqueClassBlock *clazz, void *classChain)
+   ProfiledClassRecord(TR_OpaqueClassBlock *clazz, void *classChain,
+                       const AOTCacheClassChainRecord *aotCacheClassChainRecord = NULL)
       : ClassValidationRecord(TR_ValidateProfiledClass),
         _class(clazz), _classChain(classChain)
-      {}
+      {
+#if defined(J9VM_OPT_JITSERVER)
+      _aotCacheClassChainRecord = aotCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      }
 
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueClassBlock * _class;
-   void * _classChain;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return _aotCacheClassChainRecord; }
+#else /* defined(J9VM_OPT_JITSERVER) */
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return NULL; }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   TR_OpaqueClassBlock *_class;
+   void *_classChain;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
    };
 
 struct ClassFromCPRecord : public ClassValidationRecord
@@ -358,17 +387,31 @@ struct ConcreteSubClassFromClassRecord : public ClassValidationRecord
 
 struct ClassChainRecord : public SymbolValidationRecord
    {
-   ClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain)
+   ClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain,
+                    const AOTCacheClassChainRecord *aotCacheClassChainRecord = NULL)
       : SymbolValidationRecord(TR_ValidateClassChain),
         _class(clazz),
         _classChain(classChain)
-      {}
+      {
+#if defined(J9VM_OPT_JITSERVER)
+      _aotCacheClassChainRecord = aotCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      }
 
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return _aotCacheClassChainRecord; }
+#else /* defined(J9VM_OPT_JITSERVER) */
+   const AOTCacheClassChainRecord *getAOTCacheClassChainRecord() { return NULL; }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    TR_OpaqueClassBlock *_class;
    void *_classChain;
+#if defined(J9VM_OPT_JITSERVER)
+   const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
    };
 
 struct MethodValidationRecord : public SymbolValidationRecord
@@ -801,11 +844,19 @@ private:
    struct ClassChainInfo
       {
       ClassChainInfo()
-         : _baseComponent(NULL), _baseComponentClassChain(NULL), _arrayDims(0) {}
+         : _baseComponent(NULL), _baseComponentClassChain(NULL), _arrayDims(0)
+         {
+#if defined(J9VM_OPT_JITSERVER)
+         _baseComponentAOTCacheClassChainRecord = NULL;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         }
 
       TR_OpaqueClassBlock *_baseComponent;
       void *_baseComponentClassChain;
       int32_t _arrayDims;
+#if defined(J9VM_OPT_JITSERVER)
+      const AOTCacheClassChainRecord *_baseComponentAOTCacheClassChainRecord;
+#endif /* defined(J9VM_OPT_JITSERVER) */
       };
 
    bool getClassChainInfo(TR_OpaqueClassBlock *clazz, TR::SymbolValidationRecord *record, ClassChainInfo &info);


### PR DESCRIPTION
This PR adds infrastructure for requesting necessary information from the client JVM for creating JITServer AOT cache records, and caching pointers to these records in client session data. The APIs modified or added in this PR will be used by the AOT compiler to create and remember AOT cache records corresponding to relocation and validation records.