### PR TITLE
JDK18 adds java.lang.invoke.MethodHandleNatives as requiredClasses

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -590,6 +590,9 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 			J9VMCONSTANTPOOL_JDKINTERNALLOADERNATIVELIBRARIES,
 			J9VMCONSTANTPOOL_JDKINTERNALLOADERNATIVELIBRARIESNATIVELIBRARYIMPL,
 #endif /* JAVA_SPEC_VERSION >= 15 */
+#if JAVA_SPEC_VERSION >= 18
+			J9VMCONSTANTPOOL_JAVALANGINVOKEMETHODHANDLENATIVES,
+#endif /* JAVA_SPEC_VERSION >= 18 */
 	};
 
 	/* Determine java/lang/String.value signature before any required class is initialized */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -146,6 +146,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<classref name="jdk/internal/foreign/abi/ProgrammableInvoker" flags="opt_openjdkFfi" versions="16-"/>
 
+	<classref name="java/lang/invoke/MethodHandleNatives" flags="opt_openjdkMethodhandle" versions="18-"/>
+
 <!--
 	NOTE: the resolution code in jclcinit.c only looks at the J9ROMClassRef->runtimeFlags to determine
 	whether or not to attempt the class load.  The flags sepcified on the fields are ignored.


### PR DESCRIPTION
This fixes `java.lang.InternalError: sun.misc.Unsafe::theUnsafe cannot be accessed reflectively before java.lang.invoke is initialized`

fixes https://github.com/eclipse-openj9/openj9/issues/13917

Note: can't remove `-Djdk.reflect.useDirectMethodHandle=false` yet (https://github.com/eclipse-openj9/openj9/issues/13901)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>