### PR TITLE
CMake: add guards on compiler arch includes

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -146,8 +146,11 @@ if(J9VM_OPT_JITSERVER)
 	add_subdirectory(net)
 endif()
 
-add_subdirectory(${TR_HOST_ARCH})
-if(NOT TR_TARGET_ARCH STREQUAL TR_HOST_ARCH)
+if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${TR_HOST_ARCH}")
+	add_subdirectory(${TR_HOST_ARCH})
+endif()
+
+if(NOT TR_TARGET_ARCH STREQUAL TR_HOST_ARCH AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${TR_TARGET_ARCH}")
 	add_subdirectory(${TR_TARGET_ARCH})
 endif()
 


### PR DESCRIPTION
Only include arch specific subdirectories, if the they actually exist.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>