### PR TITLE
Add root values to walkStackFrames entry tracepoint

### DIFF
--- a/runtime/verbose/j9vrb.tdf
+++ b/runtime/verbose/j9vrb.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2021 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ Submodules=j9vmutil,j9util,pool,avl
 DATFileName=J9TraceFormat.dat
 
 TraceEvent=Trc_VRB_VMInitStages_Event1 Overhead=1 Level=1 Template="Trace engine initialized for module j9vrb"
-TraceEntry=Trc_VRB_WalkStackFrames_Entry Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p flags=%p"
+TraceEntry=Trc_VRB_WalkStackFrames_Entry Obsolete Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p flags=%p"
 TraceExit=Trc_VRB_WalkStackFrames_Exit Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p, rc=%d"
 TraceEvent=Trc_VRB_WalkStackFrames_swPrintf Overhead=1 Level=1 Template="%s"
 
@@ -45,3 +45,5 @@ TraceException=Trc_VRB_WriteMessageBuffer_Failed noEnv Overhead=1 Level=1 Templa
 TraceAssert=Assert_VRB_ShouldNeverHappen NoEnv Overhead=1 Level=2 Assert="(0 /* Should never happen */)"
 TraceAssert=Assert_VRB_Equals NoEnv Overhead=1 Level=2 Assert="(P1 == P2)"
 TraceAssert=Assert_VRB_NotEquals NoEnv Overhead=1 Level=2 Assert="(P1 != P2)"
+
+TraceEntry=Trc_VRB_WalkStackFrames_Entry Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p flags=%p sp=%p a0=%p pc=%p literals=%p els=%p j2i=%p"

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -881,3 +881,6 @@ TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentPackage
 TraceEvent=Trc_VM_callin_stackFree Overhead=1 Level=5 Template="OS Stack free=%zi, current native sp=%p"
 
 TraceEvent=Trc_VM_classLoaderRegisterLibrary_newNativeLibrary Overhead=1 Level=5 Template="classLoaderRegisterLibrary -- newNativeLibrary (0x%p) handle (0x%zx) logicalName (%s) name (%s) rc (0x%zx)"
+
+TraceEntry=Trc_VM_WalkStackFrames_Entry Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p flags=%p sp=%p a0=%p pc=%p literals=%p els=%p j2i=%p"
+TraceExit=Trc_VM_WalkStackFrames_Exit Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p, rc=%d"

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -102,8 +102,16 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 	void  (*savedOSlotIterator) (struct J9VMThread * vmThread, struct J9StackWalkState * walkState, j9object_t * objectSlot, const void * stackLocation) =
 		walkState->objectSlotWalkFunction;
 
-	Trc_VRB_WalkStackFrames_Entry(currentThread, walkState->walkThread, walkState->flags);
-#endif
+	Trc_VRB_WalkStackFrames_Entry(currentThread, walkState->walkThread, walkState->flags,
+			walkState->walkThread->sp, walkState->walkThread->arg0EA,
+			walkState->walkThread->pc, walkState->walkThread->literals,
+			walkState->walkThread->entryLocalStorage, walkState->walkThread->j2iFrame);
+#else /* J9VM_INTERP_STACKWALK_TRACING */
+	Trc_VM_WalkStackFrames_Entry(currentThread, walkState->walkThread, walkState->flags,
+			walkState->walkThread->sp, walkState->walkThread->arg0EA,
+			walkState->walkThread->pc, walkState->walkThread->literals,
+			walkState->walkThread->entryLocalStorage, walkState->walkThread->j2iFrame);
+#endif /* J9VM_INTERP_STACKWALK_TRACING */
 
 	if (J9_ARE_ANY_BITS_SET(walkState->flags, J9_STACKWALK_RESUME)) {
 		if (NULL != walkState->jitInfo) {
@@ -383,7 +391,9 @@ terminationPoint:
 #if defined(J9VM_INTERP_STACKWALK_TRACING) 
 	walkState->objectSlotWalkFunction = savedOSlotIterator;
 	Trc_VRB_WalkStackFrames_Exit(currentThread, walkState->walkThread, rc);
-#endif
+#else /* J9VM_INTERP_STACKWALK_TRACING */
+	Trc_VM_WalkStackFrames_Exit(currentThread, walkState->walkThread, rc);
+#endif /* J9VM_INTERP_STACKWALK_TRACING */
 
 	if (currentThread != NULL) {
 		currentThread->activeWalkState = oldState;


### PR DESCRIPTION
Also add the tracepoints to the normal (non-verbose) walker.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>