### PR TITLE
Push/pop the array object into/from special frame in slow path

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6170,11 +6170,9 @@ done:
 				if ((NULL == value) && J9_IS_J9CLASS_FLATTENED(arrayrefClass)) {
 					/* We only get here due to an allocation failure */
 					buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
-					pushObjectInSpecialFrame(REGISTER_ARGS, arrayref);
 					updateVMStruct(REGISTER_ARGS);
 					value = VM_ValueTypeHelpers::loadFlattenableArrayElement(_currentThread, _objectAccessBarrier, _objectAllocate, arrayref, index, false);
 					VMStructHasBeenUpdated(REGISTER_ARGS);
-					arrayref = popObjectInSpecialFrame(REGISTER_ARGS);
 					restoreGenericSpecialStackFrame(REGISTER_ARGS);
 					if (J9_UNEXPECTED(NULL == value)) {
 						rc = THROW_HEAP_OOM;


### PR DESCRIPTION
In the slow path, loadFlattenableArrayElement() could call into
J9AllocateObject() which might trigger GC. Push/pop the array object
into/from special frame so that we always have the correct array object.

Closes #13848

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>