### PR TITLE
Don't override counts if specified by user in subset

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -402,18 +402,26 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
 
    method->methodRunAddress = jitGetCountingSendTarget(vmThread, method);
 
+   bool countInOptionSet = false;
+
    if (TR::Options::getJITCmdLineOptions()->anOptionSetContainsACountValue())
       {
       TR::OptionSet * optionSet = findOptionSet(method, false);
       if (optionSet)
+         {
          optionsJIT = optionSet->getOptions();
+         countInOptionSet = true;
+         }
       }
 
    if (TR::Options::getAOTCmdLineOptions()->anOptionSetContainsACountValue())
       {
       TR::OptionSet * optionSet = findOptionSet(method, true);
       if (optionSet)
+         {
          optionsAOT = optionSet->getOptions();
+         countInOptionSet = true;
+         }
       }
 
    int32_t count = -1; // means we didn't set the value yet
@@ -470,7 +478,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
                compInfo->incrementNumMethodsFoundInSharedCache();
                }
             // AOT Body not in SCC, so scount was not set
-            else if (!TR::Options::getCountsAreProvidedByUser())
+            else if (!TR::Options::getCountsAreProvidedByUser() && !countInOptionSet)
                {
                bool useLowerCountsForAOTCold = false;
                if (TR::Options::getCmdLineOptions()->getOption(TR_LowerCountsForAotCold) && compInfo->isWarmSCC() == TR_no)


### PR DESCRIPTION
There's a corner case where specifying counts in an option set while the
SCC is enabled results in the option set getting ignored. The reason
this happens is because in `jitHookInitializeSendTarget`, the update is
guarded by `TR::Options::getCountsAreProvidedByUser`, which only returns
true when counts are set by the user outside an option set. This PR
fixes this issue.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>