### PR TITLE
Simplify relo header initialization process

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -91,12 +91,14 @@ void J9::ARM64::AheadOfTimeCompile::processRelocations()
       }
    }
 
-void
+bool
 J9::ARM64::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation,
                                                                              TR_RelocationTarget *reloTarget,
                                                                              TR_RelocationRecord *reloRecord,
                                                                              uint8_t targetKind)
    {
+   bool platformSpecificReloInitialized = true;
+
    switch (targetKind)
       {
       case TR_DiscontiguousSymbolFromManager:
@@ -127,7 +129,9 @@ J9::ARM64::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          break;
 
       default:
-         self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+         platformSpecificReloInitialized = false;
       }
+
+   return platformSpecificReloInitialized;
    }
 

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
@@ -58,15 +58,9 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
 
 
    /**
-    * @brief Initialization of relocation record headers for whom data for the fields are acquired
-    *        in a manner that is specific to this platform
-    *
-    * @param relocation pointer to the iterated external relocation
-    * @param reloTarget pointer to the TR_RelocationTarget object
-    * @param reloRecord pointer to the associated
-    * @param targetKind the TR_ExternalRelocationTargetKind enum value
+    * @brief Refer to J9::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader
     */
-   void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
+   bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
 
    static bool classAddressUsesReloRecordInfo() { return false; }
 

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -101,12 +101,13 @@ void J9::ARM::AheadOfTimeCompile::processRelocations()
       }
    }
 
-void
+bool
 J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation,
                                                                            TR_RelocationTarget *reloTarget,
                                                                            TR_RelocationRecord *reloRecord,
                                                                            uint8_t targetKind)
    {
+   bool platformSpecificReloInitialized = true;
    TR::Compilation* comp = self()->comp();
    TR_J9VMBase *fej9 = comp->fej9();
    TR_SharedCache *sharedCache = fej9->sharedCache();
@@ -247,6 +248,8 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          break;
 
       default:
-         self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+         platformSpecificReloInitialized = false;
       }
+
+   return platformSpecificReloInitialized;
    }

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
@@ -57,15 +57,9 @@ public:
    virtual void     processRelocations();
 
    /**
-    * @brief Initialization of relocation record headers for whom data for the fields are acquired
-    *        in a manner that is specific to this platform
-    *
-    * @param relocation pointer to the iterated external relocation
-    * @param reloTarget pointer to the TR_RelocationTarget object
-    * @param reloRecord pointer to the associated
-    * @param targetKind the TR_ExternalRelocationTargetKind enum value
+    * @brief Refer to J9::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader
     */
-   void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
+   bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
 
    List<TR::ARMRelocation>& getRelocationList() {return _relocationList;}
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -183,7 +183,8 @@ J9::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalReloca
    reloRecord->setType(reloTarget, static_cast<TR_RelocationRecordType>(targetKind));
    reloRecord->setFlag(reloTarget, wideOffsets);
 
-   self()->initializePlatformSpecificAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+   if (!self()->initializePlatformSpecificAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind))
+      self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
 
    cursor += self()->getSizeOfAOTRelocationHeader(static_cast<TR_RelocationRecordType>(targetKind));
    return cursor;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -57,17 +57,26 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
    uint8_t* dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose);
 
    /**
-    * @brief Initializes the common fields in the raw relocation record header. It then delegates
-    *        to initializePlatformSpecificAOTRelocationHeader which must be implemented on all
-    *        platforms that support AOT.
+    * @brief Initializes the relocation record header.
     *
     * @param relocation pointer to the iterated external relocation
     * @return pointer into the buffer right after the fields of the header (ie the offsets section)
     */
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
-   void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind)
-      { TR_ASSERT_FATAL(false, "Should not be called!\n"); return; }
+   /**
+    * @brief Initialization of relocation record headers for whom data for the fields are acquired
+    *        in a manner that is specific to a particular platform. This is the default implementation.
+    *
+    * @param relocation pointer to the iterated external relocation
+    * @param reloTarget pointer to the TR_RelocationTarget object
+    * @param reloRecord pointer to the TR_RelocationRecord object
+    * @param targetKind the TR_ExternalRelocationTargetKind enum value
+    *
+    * @return true if a platform specific relocation record header was initialized; false otherwise
+    */
+   bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind)
+      { return false; }
 
    static void interceptAOTRelocation(TR::ExternalRelocation *relocation);
 

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -111,12 +111,13 @@ void J9::Power::AheadOfTimeCompile::processRelocations()
       }
    }
 
-void
+bool
 J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation,
                                                                              TR_RelocationTarget *reloTarget,
                                                                              TR_RelocationRecord *reloRecord,
                                                                              uint8_t targetKind)
    {
+   bool platformSpecificReloInitialized = true;
    TR::Compilation *comp = self()->comp();
    TR_J9VMBase *fej9 = comp->fej9();
    TR_SharedCache *sharedCache = fej9->sharedCache();
@@ -369,7 +370,9 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          break;
 
       default:
-         self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+         platformSpecificReloInitialized = false;
       }
+
+   return platformSpecificReloInitialized;
    }
 

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
@@ -55,15 +55,9 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
    virtual void     processRelocations();
 
    /**
-    * @brief Initialization of relocation record headers for whom data for the fields are acquired
-    *        in a manner that is specific to this platform
-    *
-    * @param relocation pointer to the iterated external relocation
-    * @param reloTarget pointer to the TR_RelocationTarget object
-    * @param reloRecord pointer to the associated
-    * @param targetKind the TR_ExternalRelocationTargetKind enum value
+    * @brief Refer to J9::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader
     */
-   void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
+   bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
 
    static bool classAddressUsesReloRecordInfo() { return true; }
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -118,12 +118,14 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
       }
    }
 
-void
+bool
 J9::X86::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation,
                                                                            TR_RelocationTarget *reloTarget,
                                                                            TR_RelocationRecord *reloRecord,
                                                                            uint8_t targetKind)
    {
+   bool platformSpecificReloInitialized = true;
+
    switch (targetKind)
       {
       case TR_PicTrampolines:
@@ -137,7 +139,9 @@ J9::X86::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
         break;
 
       default:
-         self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+         platformSpecificReloInitialized = false;
       }
+
+   return platformSpecificReloInitialized;
    }
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
@@ -53,15 +53,9 @@ class OMR_EXTENSIBLE AheadOfTimeCompile  : public J9::AheadOfTimeCompile
    virtual void     processRelocations();
 
    /**
-    * @brief Initialization of relocation record headers for whom data for the fields are acquired
-    *        in a manner that is specific to this platform
-    *
-    * @param relocation pointer to the iterated external relocation
-    * @param reloTarget pointer to the TR_RelocationTarget object
-    * @param reloRecord pointer to the associated
-    * @param targetKind the TR_ExternalRelocationTargetKind enum value
+    * @brief Refer to J9::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader
     */
-   void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
+   bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
 
    private:
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -123,12 +123,14 @@ void J9::Z::AheadOfTimeCompile::processRelocations()
       }
    }
 
-void
+bool
 J9::Z::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation,
                                                                          TR_RelocationTarget *reloTarget,
                                                                          TR_RelocationRecord *reloRecord,
                                                                          uint8_t targetKind)
    {
+   bool platformSpecificReloInitialized = true;
+
    switch (targetKind)
       {
       case TR_EmitClass:
@@ -145,7 +147,9 @@ J9::Z::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::Ite
          break;
 
       default:
-         self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);
+         platformSpecificReloInitialized = false;
       }
+
+   return platformSpecificReloInitialized;
    }
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
@@ -50,15 +50,9 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
     virtual void     processRelocations();
 
      /**
-      * @brief Initialization of relocation record headers for whom data for the fields are acquired
-      *        in a manner that is specific to this platform
-      *
-      * @param relocation pointer to the iterated external relocation
-      * @param reloTarget pointer to the TR_RelocationTarget object
-      * @param reloRecord pointer to the associated
-      * @param targetKind the TR_ExternalRelocationTargetKind enum value
+      * @brief Refer to J9::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader
       */
-    void initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
+    bool initializePlatformSpecificAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t targetKind);
 
     TR::list<TR::S390Relocation*>& getRelocationList() {return _relocationList;}
 


### PR DESCRIPTION
This PR simplifies the process of the relocation record header
initialization by removing the requirement that implementor of
initializePlatformSpecificAOTRelocationHeader has to be the one that
calls initializeCommonAOTRelocationHeader.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>