### PR TITLE
Fix annotation of 1TIPREPSTATE in javacore dumps

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -830,7 +830,9 @@ JavaCoreDumpWriter::writeTitleSection(void)
 		}
 
 		if (J9_ARE_ALL_BITS_SET(_Agent->prepState, J9RAS_DUMP_TRACE_DISABLED)) {
+			_OutputStream.writeCharacters(prefix);
 			_OutputStream.writeCharacters("trace_disabled");
+			prefix = "+";
 		}
 
 		if (' ' != *prefix) {


### PR DESCRIPTION
If the state contains only `J9RAS_DUMP_TRACE_DISABLED` it is shown as
```
  1TIPREPSTATE   Prep State: 0x80trace_disabled
```
instead of
```
  1TIPREPSTATE   Prep State: 0x80 (trace_disabled)
```