### PR TITLE
Add a NULL check for the iTable

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -110,8 +110,8 @@ static VMINLINE UDATA
 convertITableOffsetToVTableOffset(J9VMThread *currentThread, J9Class *receiverClass, J9Class *interfaceClass, UDATA iTableOffset)
 {
 	UDATA vTableOffset = 0;
-	J9ITable * iTable = receiverClass->lastITable;
-	if (interfaceClass == iTable->interfaceClass) {
+	J9ITable *iTable = receiverClass->lastITable;
+	if ((NULL != iTable) && (interfaceClass == iTable->interfaceClass)) {
 		goto foundITable;
 	}
 	

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7149,7 +7149,7 @@ resolve:
 
 			/* Run search in receiverClass->lastITable */
 			J9ITable *iTable = receiverClass->lastITable;
-			if (interfaceClass == iTable->interfaceClass) {
+			if ((NULL != iTable) && (interfaceClass == iTable->interfaceClass)) {
 				goto foundITableCache;
 			}
 


### PR DESCRIPTION
NULL check protects from unexpected events where the iTable is NULL due to
corruption.

Related: https://github.com/eclipse-openj9/openj9/issues/13504

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>