### PR TITLE
GetExtendedNPEMessage skips hidden frames and recognizes MH newInstance

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -603,12 +603,6 @@ private static void ensureProperties(boolean isInitialization) {
 
 	/*[IF JAVA_SPEC_VERSION >= 18]*/
 	initializedProperties.put("os.version", sysPropOSVersion); //$NON-NLS-1$
-
-	/* Setting jdk.reflect.useDirectMethodHandle to false disables the new JEP 416
-	 * changes where core reflection is reimplemented with MethodHandles. This flag
-	 * will be reenabled once OpenJ9 completely supports JEP 416.
-	 */
-	initializedProperties.put("jdk.reflect.useDirectMethodHandle", "false"); //$NON-NLS-1$
 	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
 	if (osEncoding != null) {

--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -531,6 +531,17 @@ getCompleteNPEMessage(J9VMThread *vmThread, U_8 *bcCurrentPtr, J9ROMClass *romCl
 			J9UTF8* methodSig = J9ROMNAMEANDSIGNATURE_SIGNATURE(methodNameAndSig);
 			bool npeMsgRequired = true;
 
+#if JAVA_SPEC_VERSION >= 18
+			if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(definingClassFullQualifiedName), J9UTF8_LENGTH(definingClassFullQualifiedName), "jdk/internal/reflect/DirectConstructorHandleAccessor")) {
+				if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodName), "invokeImpl")) {
+					/* JEP416 - jdk.internal.reflect.DirectConstructorHandleAccessor.invokeImpl() is invoked by DirectConstructorHandleAccessor.newInstance().
+					 * No message generated for new NullPointerException().getMessage() or new NullPointerException(null).getMessage()
+					 */
+					npeMsgRequired = false;
+					Trc_VM_GetCompleteNPEMessage_Not_Required(vmThread);
+				}
+			} else
+#endif /* JAVA_SPEC_VERSION >= 18 */
 			if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(definingClassFullQualifiedName), J9UTF8_LENGTH(definingClassFullQualifiedName), "java/lang/NullPointerException")) {
 				if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodName), "<init>")) {
 					/* No message generated for new NullPointerException().getMessage() or new NullPointerException(null).getMessage() */

--- a/test/functional/cmdline_options_testresources/build.xml
+++ b/test/functional/cmdline_options_testresources/build.xml
@@ -37,6 +37,7 @@
 	<property name="src_80" location="./src_80"/>
 	<property name="src_90" location="./src_90"/>
 	<property name="build" location="./bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -73,7 +74,11 @@
 				<javac srcdir="${src}" destdir="${build}" source="1.9" target="1.9" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${src_90}" />
+					<src path="${TestUtilities}" />
 					<compilerarg line='${addExports}' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar"/>
+					</classpath>
 				</javac>
 			</else>
 		</if>


### PR DESCRIPTION
The `getStackTraceElementIterator()` invoked by `GetExtendedNPEMessage()` skips hidden frames;
`JDK18` `NPE` extended message generation recognizes `JEP416` `MH` methods for `java.lang.reflect.Constructor.newInstance()`;
Updated `test_getCallerClass_Helper_Reflection_fromBootExtWithAnnotation()` to adopt `MH` frames;
Removed `-Djdk.reflect.useDirectMethodHandle=false` to re-enable `JEP416`.

Note: currently OpenJ9 stack frame iterator functions check `J9AccMethodFrameIteratorSkip` individually, ideally a unified solution can be developed to hide/show those hidden frames. Created https://github.com/eclipse-openj9/openj9/issues/13951.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>