### PR TITLE
Override TR_J9VMBase::isJavaLangObject at JITServer

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -834,6 +834,14 @@ TR_J9ServerVM::isString(TR_OpaqueClassBlock * clazz)
    return std::get<0>(stream->read<bool>());
    }
 
+bool
+TR_J9ServerVM::isJavaLangObject(TR_OpaqueClassBlock *clazz)
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return clazz == vmInfo->_JavaLangObject;
+   }
+
 void *
 TR_J9ServerVM::getMethods(TR_OpaqueClassBlock * clazz)
    {
@@ -2630,7 +2638,7 @@ TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method,
    bool skipFrames = false;
    TR::Compilation *comp = _compInfoPT->getCompilation();
    // For AOT with SVM do not optimize the messages by calling TR_J9ServerVM::stackWalkerMaySkipFrames
-   // because this will call isInstanceOf() and then isSuperClass() which will fail the 
+   // because this will call isInstanceOf() and then isSuperClass() which will fail the
    // the SVM validation check and result in an AOT compilation failure
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -28,14 +28,14 @@
 
 /**
  * @class TR_J9ServerVM
- * @brief Class used by JITServer for querying client-side VM information 
+ * @brief Class used by JITServer for querying client-side VM information
  *
- * This class is an extension of the TR_J9VM class which overrides a number 
- * of TR_J9VM's APIs. TR_J9ServerVM is used by JITServer and the overridden 
- * APIs mostly send remote messages to JITClient to query information from 
- * the TR_J9VM on the client. The information is needed for JITServer to 
- * compile code that is compatible with the client-side VM. To minimize the 
- * number of remote messages as a way to optimize JITServer performance, a 
+ * This class is an extension of the TR_J9VM class which overrides a number
+ * of TR_J9VM's APIs. TR_J9ServerVM is used by JITServer and the overridden
+ * APIs mostly send remote messages to JITClient to query information from
+ * the TR_J9VM on the client. The information is needed for JITServer to
+ * compile code that is compatible with the client-side VM. To minimize the
+ * number of remote messages as a way to optimize JITServer performance, a
  * lot of client-side TR_J9VM information are cached on JITServer.
  */
 
@@ -101,6 +101,7 @@ public:
    virtual int32_t getInitialLockword(TR_OpaqueClassBlock* clazzPointer) override;
    virtual bool isEnableGlobalLockReservationSet() override;
    virtual bool isString(TR_OpaqueClassBlock * clazz) override;
+   virtual bool isJavaLangObject(TR_OpaqueClassBlock *clazz) override;
    virtual void * getMethods(TR_OpaqueClassBlock * clazz) override;
    virtual void getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, List<TR_ResolvedMethod> * resolvedMethodsInClass) override;
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *clazz) override;
@@ -257,7 +258,7 @@ protected:
  * additional handling for AOT compilation
  *
  * This class is an extension of the TR_J9ServerVM class. This class conceptually
- * does very similar things compared to TR_J9ServerVM except it's used for AOT 
+ * does very similar things compared to TR_J9ServerVM except it's used for AOT
  * compilation.
  */
 
@@ -353,7 +354,7 @@ public:
 
 protected :
    bool validateClass(TR_OpaqueMethodBlock * method, TR_OpaqueClassBlock* j9class, bool isVettedForAOT);
- 
+
    };
 
 #endif // VMJ9SERVER_H

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -92,7 +92,7 @@ class TR_J9MethodFieldAttributes
       if (_definingClass != other._definingClass) return false;
       return true;
       }
-   
+
    void setMethodFieldAttributesResult(uint32_t *fieldOffset, TR::DataType *type, bool *volatileP, bool *isFinal, bool *isPrivate, bool *unresolvedInCP, bool *result, TR_OpaqueClassBlock **definingClass = NULL)
       {
       setMethodFieldAttributesResult(type, volatileP, isFinal, isPrivate, unresolvedInCP, result, definingClass);
@@ -120,7 +120,7 @@ class TR_J9MethodFieldAttributes
       }
 
    uintptr_t _fieldOffsetOrAddress; // Stores a uint32_t representing an offset for non-static fields, or an address for static fields.
-   TR::DataType _type; 
+   TR::DataType _type;
    bool _volatileP;
    bool _isFinal;
    bool _isPrivate;
@@ -174,7 +174,7 @@ public:
       @class ClassInfo
       @brief Struct that holds cached data about a class loaded on the JITClient.
 
-      It contains the ROM class, which is copied in full to the JITServer, as well 
+      It contains the ROM class, which is copied in full to the JITServer, as well
       as other items which are just pointers to data on the JITClient. ClassInfo will
       persist on the server until corresponding Java class gets unloaded or replaced by
       HCR mechanism (which JITServer also treats as a class unload event). At that point,
@@ -315,6 +315,7 @@ public:
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
       bool _useAOTCache;
       TR_AOTHeader _aotHeader;
+      TR_OpaqueClassBlock *_JavaLangObject;
       }; // struct VMInfo
 
    /**
@@ -538,7 +539,7 @@ private:
 
    WellKnownClassesCache _wellKnownClasses;
    TR::Monitor *_wellKnownClassesMonitor;
-   
+
    bool _isInStartupPhase;
 
    std::string _aotCacheName;


### PR DESCRIPTION
`TR_J9VMBase::isJavaLangObject()` is a frontend query that looks at
a field stored in JavaVM. The value of this field should be fetched from
the client, so `isJavaLangObject()` needs to be overridden.

Fixes #13954

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>