### PR TITLE
(0.29.1) AArch64: Load heap size from vmstruct on AOT compilation

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -383,7 +383,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
          }
       generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, temp1Reg, dstReg, temp1Reg);
 
-      if (comp->getOptions()->isVariableHeapSizeForBarrierRange0())
+      if (comp->getOptions()->isVariableHeapSizeForBarrierRange0() || comp->compileRelocatableCode())
          {
          generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, temp2Reg, new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapSizeForBarrierRange0), cg));
          }
@@ -463,7 +463,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
       // If doCrdMrk is false, then temp2Reg still contains heapSize
       if (doCrdMrk)
          {
-         if (comp->getOptions()->isVariableHeapSizeForBarrierRange0())
+         if (comp->getOptions()->isVariableHeapSizeForBarrierRange0() || comp->compileRelocatableCode())
             {
             generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, temp2Reg, new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapSizeForBarrierRange0), cg));
             }
@@ -577,7 +577,7 @@ VMCardCheckEvaluator(
    // If we know the object is definitely in heap, then we skip the check.
    if (!node->isHeapObjectWrtBar())
       {
-      if (comp->getOptions()->isVariableHeapSizeForBarrierRange0())
+      if (comp->getOptions()->isVariableHeapSizeForBarrierRange0() || comp->compileRelocatableCode())
          {
          generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, temp2Reg, new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, heapSizeForBarrierRange0), cg));
          }


### PR DESCRIPTION
The write barrier instruction sequence uses the heap size for checking
if the object is in the heap.
The heap size must be loaded from vmstruct on AOT compilation
even if the size is constant.

Original PR in the master branch: #13927

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>