### PR TITLE
Remove nonexistent data from relo log format string

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1813,7 +1813,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
          self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
          if (isVerbose)
             {
-            traceMsg(self()->comp(), "\n Validate Stack Walker May Skip Frames: methodID=%d, methodClassID=%d, beholderID=%d, skipFrames=%s ",
+            traceMsg(self()->comp(), "\n Validate Stack Walker May Skip Frames: methodID=%d, methodClassID=%d, skipFrames=%s ",
                      (uint32_t)swmsfRecord->methodID(reloTarget),
                      (uint32_t)swmsfRecord->methodClassID(reloTarget),
                      swmsfRecord->skipFrames(reloTarget) ? "true" : "false");


### PR DESCRIPTION
The relocation debug dump code for
TR_ValidateStackWalkerMaySkipFramesRecord incorrectly tried to also
print out a beholderMethod even though there isn't one.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>