### PR TITLE
Change signatures in JDK17

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2021 IBM Corp. and others
+# Copyright (c) 2019, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,7 +290,7 @@ jvm_add_exports(jvm
 	JVM_BeforeHalt
 )
 
-if(JAVA_SPEC_VERSION LESS 18)
+if(JAVA_SPEC_VERSION LESS 17)
 	jvm_add_exports(jvm _JVM_LoadLibrary@4)
 else()
 	jvm_add_exports(jvm _JVM_LoadLibrary@8)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2007, 2021 IBM Corp. and others
+Copyright (c) 2007, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,10 +99,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_LatestUserDefinedLoader@4" />
 		<export name="_JVM_Listen@8" />
 		<export name="_JVM_LoadLibrary@4">
-			<exclude-if condition="spec.java18"/>
+			<exclude-if condition="spec.java17"/>
 		</export>
 		<export name="_JVM_LoadLibrary@8">
-			<include-if condition="spec.java18"/>
+			<include-if condition="spec.java17"/>
 		</export>
 		<export name="_JVM_LoadSystemLibrary@4" />
 		<export name="_JVM_Lseek@16" />

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3630,10 +3630,10 @@ JVM_LoadSystemLibrary(const char *libName)
 }
 
 /**
- * Prior to jdk18:
+ * Prior to jdk17:
  *   void * JNICALL JVM_LoadLibrary(char *libName)
  *
- * Beginning in jdk18:
+ * Beginning in jdk17:
  *   void * JNICALL JVM_LoadLibrary(char *libName, jboolean throwOnFailure)
  *
  * Attempts to load the shared library specified by libName.
@@ -3652,11 +3652,11 @@ JVM_LoadSystemLibrary(const char *libName)
  * It is only invoked by jdk.internal.loader.BootLoader.loadLibrary().
  */
 void * JNICALL
-#if JAVA_SPEC_VERSION < 18
+#if JAVA_SPEC_VERSION < 17
 JVM_LoadLibrary(const char *libName)
-#else /* JAVA_SPEC_VERSION < 18 */
+#else /* JAVA_SPEC_VERSION < 17 */
 JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
-#endif /* JAVA_SPEC_VERSION < 18 */
+#endif /* JAVA_SPEC_VERSION < 17 */
 {
 	void *result = NULL;
 	J9JavaVM *javaVM = (J9JavaVM *)BFUjavaVM;
@@ -3701,7 +3701,7 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 	}
 #endif /* defined(WIN32) */
 
-#if JAVA_SPEC_VERSION >= 18
+#if JAVA_SPEC_VERSION >= 17
 	if ((NULL == result) && throwOnFailure) {
 		JNIEnv *env = NULL;
 		JavaVM *vm = (JavaVM *)javaVM;
@@ -3713,7 +3713,7 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 			throwNewUnsatisfiedLinkError(env, errMsg);
 		}
 	}
-#endif /* JAVA_SPEC_VERSION >= 18 */
+#endif /* JAVA_SPEC_VERSION >= 17 */
 
 	Trc_SC_LoadLibrary_Exit(result);
 

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2001, 2021 IBM Corp. and others
+dnl Copyright (c) 2001, 2022 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ _X(JVM_InvokeMethod,JNICALL,true,jobject,JNIEnv *env, jobject method, jobject ob
 _X(JVM_IsNaN,JNICALL,true,jboolean,jdouble dbl)
 _X(JVM_LatestUserDefinedLoader,JNICALL,true,jobject,JNIEnv *env)
 _X(JVM_Listen,JNICALL,true,jint,jint descriptor, jint count)
-_IF([JAVA_SPEC_VERSION < 18],
+_IF([JAVA_SPEC_VERSION < 17],
 	_X(JVM_LoadLibrary,JNICALL,true,void *,const char *libName),
 	_X(JVM_LoadLibrary,JNICALL,true,void *,const char *libName, jboolean throwOnFailure))
 _X(JVM_Lseek,JNICALL,true,jlong,jint descriptor, jlong bytesToSeek, jint origin)

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corp. and others
+ * Copyright (c) 2012, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -177,7 +177,7 @@ getCurrentClassLoader(J9VMThread *currentThread)
 			 * is the current native method, use the class loader of "impl.fromClass".
 			 * This nativeMethod can't be cached cause HCR might make it invalid.
 			 *
-			 * Note that in jdk18, the signature of that method changed to
+			 * Note that in jdk17, the signature of that method changed to
 			 *   NativeLibraries.load(NativeLibraryImpl impl, String name, boolean isBuiltin, boolean isJNI, boolean throwOnFailure)
 			 */
 			if (J9VMJDKINTERNALLOADERNATIVELIBRARIES_LOAD_METHOD(currentThread->javaVM) == nativeMethod) {


### PR DESCRIPTION
Changes to NativeLibraries.load() and JVM_LoadLibrary() have been back-ported from JDK18:
* 8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem

See also #13844, #13898.