### PR TITLE
Print unaligned class value

### DIFF
--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -390,6 +390,11 @@ target_link_libraries(j9vm
 		j9thr
 )
 
+target_compile_definitions(j9vm
+	PRIVATE
+		-DJ9_EXTENDED_DEBUG
+)
+
 omr_add_exports(j9vm
 	J9_CreateJavaVM
 	J9_GetCreatedJavaVMs

--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -59,6 +59,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<flag name="-qsuppress=1500-010" asmflag="false" definition="false">
 				<include-if condition="spec.aix.*"/>
 			</flag>
+			<flag name="J9_EXTENDED_DEBUG"/>
 		</flags>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
When the class alignment check fails in class hash table queries, print
the bad value to the console before asserting.

Debugging help for #13123 which may be removed once the underlying issue
is discovered.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>