### PR TITLE
[WIP] Standard SATB Barrier Implementation

### DIFF
--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,7 @@
 #include "ReferenceObjectList.hpp"
 #include "ScavengerJavaStats.hpp"
 #include "StandardAccessBarrier.hpp"
+#include "StandardSATBAccessBarrier.hpp"
 #include "VMThreadListIterator.hpp"
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
@@ -107,7 +108,7 @@ MM_GlobalCollectorDelegate::initialize(MM_EnvironmentBase *env, MM_GlobalCollect
 		} else
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 		{
-			_extensions->accessBarrier = MM_StandardAccessBarrier::newInstance(env);
+			_extensions->accessBarrier = (_extensions->usingSATBBarrier() ? MM_StandardSATBAccessBarrier::newInstance(env) : MM_StandardAccessBarrier::newInstance(env));
 		}
 
 		if (NULL == _extensions->accessBarrier) {

--- a/runtime/gc_modron_standard/CMakeLists.txt
+++ b/runtime/gc_modron_standard/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@ set(gc_modron_standard_sources
 	ReferenceObjectBufferStandard.cpp
 	RootScannerReadBarrierVerifier.cpp
 	StandardAccessBarrier.cpp
+	StandardSATBAccessBarrier.cpp
 	UnfinalizedObjectBufferStandard.cpp
 )
 

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -63,29 +63,6 @@ MM_StandardAccessBarrier::newInstance(MM_EnvironmentBase *env)
 	return barrier;
 }
 
-/**
- * Enables the double barrier on the provided thread.
- */
-void
-MM_StandardAccessBarrier::setDoubleBarrierActiveOnThread(MM_EnvironmentBase* env)
-{
-	MM_GCExtensions::getExtensions(env)->sATBBarrierRememberedSet->preserveLocalFragmentIndex(env, &(((J9VMThread *)env->getLanguageVMThread())->sATBBarrierRememberedSetFragment));
-}
-
-void
-MM_StandardAccessBarrier::initializeForNewThread(MM_EnvironmentBase* env)
-{
-#if defined(OMR_GC_REALTIME)
-	if (_extensions->configuration->isSnapshotAtTheBeginningBarrierEnabled()) {
-
-		_extensions->sATBBarrierRememberedSet->initializeFragment(env, &(((J9VMThread *)env->getLanguageVMThread())->sATBBarrierRememberedSetFragment));
-		if (isDoubleBarrierActive()) {
-			setDoubleBarrierActiveOnThread(env);
-		}
-	}
-#endif /* OMR_GC_REALTIME */
-}
-
 bool 
 MM_StandardAccessBarrier::initialize(MM_EnvironmentBase *env)
 {
@@ -115,115 +92,6 @@ MM_StandardAccessBarrier::tearDown(MM_EnvironmentBase *env)
 	MM_ObjectAccessBarrier::tearDown(env);
 }
 
-/**
- * Unmarked, heap reference, about to be deleted (or overwritten), while marking
- * is in progress is to be remembered for later marking and scanning.
- */
-void
-MM_StandardAccessBarrier::rememberObjectToRescan(MM_EnvironmentBase *env, J9Object *object)
-{
-	MM_ParallelGlobalGC *globalCollector = (MM_ParallelGlobalGC *)_extensions->getGlobalCollector();
-
-	if (globalCollector->getMarkingScheme()->markObject(env, object, true)) {
-		rememberObjectImpl(env, object);
-	}
-}
-
-/**
- * Unmarked, heap reference, about to be deleted (or overwritten), while marking
- * is in progress is to be remembered for later marking and scanning.
- * This method is called by MM_StandardAccessBarrier::rememberObject()
- */
-void
-MM_StandardAccessBarrier::rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object)
-{
-	J9VMThread *vmThread = (J9VMThread *)env->getLanguageVMThread();
-	_extensions->sATBBarrierRememberedSet->storeInFragment(env, &vmThread->sATBBarrierRememberedSetFragment, (UDATA *)object);
-}
-
-
-bool
-MM_StandardAccessBarrier::preObjectStoreImpl(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile)
-{
-	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
-
-	if (isSATBBarrierActive()) {
-		if (NULL != destObject) {
-			if (isDoubleBarrierActiveOnThread(vmThread)) {
-				rememberObjectToRescan(env, value);
-			}
-
-			J9Object *oldObject = NULL;
-			protectIfVolatileBefore(vmThread, isVolatile, true, false);
-			GC_SlotObject slotObject(vmThread->javaVM->omrVM, destAddress);
-			oldObject = slotObject.readReferenceFromSlot();
-			protectIfVolatileAfter(vmThread, isVolatile, true, false);
-			rememberObjectToRescan(env, oldObject);
-		}
-	}
-
-	return true;
-}
-
-bool
-MM_StandardAccessBarrier::preObjectStoreImpl(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile)
-{
-	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
-
-	if (isSATBBarrierActive()) {
-		if (isDoubleBarrierActiveOnThread(vmThread)) {
-			rememberObjectToRescan(env, value);
-		}
-		J9Object* oldObject = NULL;
-		protectIfVolatileBefore(vmThread, isVolatile, true, false);
-		oldObject = *destAddress;
-		protectIfVolatileAfter(vmThread, isVolatile, true, false);
-		rememberObjectToRescan(env, oldObject);
-	}
-
-	return true;
-}
-/**
- * @copydoc MM_ObjectAccessBarrier::preObjectStore()
- *
- * Metronome uses a snapshot-at-the-beginning algorithm, but with a fuzzy snapshot in the
- * sense that threads are allowed to run during the root scan.  This requires a "double
- * barrier."  The barrier is active from the start of root scanning through the end of
- * tracing.  For an unscanned thread performing a store, the new value is remembered by
- * the collector.  For any thread performing a store (whether scanned or not), the old
- * value is remembered by the collector before being overwritten (thus this barrier must be
- * positioned as a pre-store barrier).  For the latter ("Yuasa barrier") aspect of the
- * double barrier, only the first overwritten value needs to be remembered (remembering
- * others is harmless but not needed), and so we omit synchronization on the reading of the
- * old value.
- **/
-bool
-MM_StandardAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile)
-{
-	return preObjectStoreImpl(vmThread, destObject, destAddress, value, isVolatile);
-}
-
-/**
- * @copydoc MM_MetronomeAccessBarrier::preObjectStore()
- *
- * Used for stores into classes
- */
-bool
-MM_StandardAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object *destClass, J9Object **destAddress, J9Object *value, bool isVolatile)
-{
-	return preObjectStoreImpl(vmThread, destAddress, value, isVolatile);
-}
-
-/**
- * @copydoc MM_MetronomeAccessBarrier::preObjectStore()
- *
- * Used for stores into internal structures
- */
-bool
-MM_StandardAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile)
-{
-	return preObjectStoreImpl(vmThread, destAddress, value, isVolatile);
-}
 /**
  * Called after an object is stored into another object.
  */
@@ -293,8 +161,7 @@ MM_StandardAccessBarrier::postObjectStoreImpl(J9VMThread *vmThread, J9Object *ds
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 		/* Call the concurrent write barrier if required */
 		if(isIncrementalUpdateBarrierActive(vmThread) && _extensions->isOld(dstObject)) {
-			/* Once dependent OMR changes are in, this should be changed to: concurrentPostWriteBarrierStore(vmThread, destinationObject); */
-			J9ConcurrentWriteBarrierStore(vmThread->omrVMThread, dstObject, srcObject);
+			concurrentPostWriteBarrierStore(vmThread->omrVMThread, dstObject, srcObject);
 		}
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 	
@@ -329,7 +196,7 @@ MM_StandardAccessBarrier::preBatchObjectStoreImpl(J9VMThread *vmThread, J9Object
 	if(_extensions->concurrentMark && 
 		(vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE) &&
 		_extensions->isOld(dstObject)) {
-		/* Once dependent OMR changes are in, this should be changed to: concurrentPostWriteBarrierStore(vmThread->omrVMThread, dstObject); */
+		/* Once dependent OMR changes are in, this should be changed to: concurrentPreWriteBarrierBatchStore(vmThread->omrVMThread, dstObject); */
 		J9ConcurrentWriteBarrierBatchStore(vmThread->omrVMThread, dstObject);
 	}
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
@@ -678,10 +545,6 @@ I_32
 MM_StandardAccessBarrier::backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots)
 {
 	I_32 retValue = ARRAY_COPY_NOT_DONE;
-	//TODO SATB re-enable opt?
-	if (_extensions->configuration->isSnapshotAtTheBeginningBarrierEnabled()) {
-		return retValue;
-	}
 
 	if(0 == lengthInSlots) {
 		retValue = ARRAY_COPY_SUCCESSFUL;
@@ -715,12 +578,7 @@ MM_StandardAccessBarrier::backwardReferenceArrayCopyIndex(J9VMThread *vmThread, 
 I_32
 MM_StandardAccessBarrier::forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots)
 {
-	//TODO SATB re-enable opt
 	I_32 retValue = ARRAY_COPY_NOT_DONE;
-
-	if (_extensions->configuration->isSnapshotAtTheBeginningBarrierEnabled()) {
-		return retValue;
-	}
 
 	if(0 == lengthInSlots) {
 		retValue = ARRAY_COPY_SUCCESSFUL;

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -36,7 +36,6 @@
 #include "ObjectAccessBarrier.hpp"
 #include "Configuration.hpp"
 #include "GenerationalAccessBarrierComponent.hpp"
-#include "RememberedSetSATB.hpp"
 
 /**
  * Access barrier for Modron collector.
@@ -48,9 +47,6 @@ private:
 #if defined(J9VM_GC_GENERATIONAL)
 	MM_GenerationalAccessBarrierComponent _generationalAccessBarrierComponent;	/**< Generational Component of Access Barrier */
 #endif /* J9VM_GC_GENERATIONAL */
-#if defined(OMR_GC_REALTIME)
-	bool _doubleBarrierActive; /**< Global indicator that the double barrier is active. New threads will be set to double barrier mode if this falg is true. */
-#endif /* OMR_GC_REALTIME */
 	void postObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject, J9Object *srcObject);
 	void preBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject);
 
@@ -75,11 +71,6 @@ public:
 
 	virtual J9Object* asConstantPoolObject(J9VMThread *vmThread, J9Object* toConvert, UDATA allocationFlags);
 
-	virtual void rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object);
-	virtual bool preObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile=false);
-	virtual bool preObjectStore(J9VMThread *vmThread, J9Object *destClass, J9Object **destAddress, J9Object *value, bool isVolatile=false);
-	virtual bool preObjectStore(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile=false);
-
 	virtual void postObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile=false);
 	virtual void postObjectStore(J9VMThread *vmThread, J9Class *destClass, J9Object **destAddress, J9Object *value, bool isVolatile=false);
 	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
@@ -90,7 +81,6 @@ public:
 	virtual void jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, jarray array, void * elems, jint mode);
 	virtual const jchar* jniGetStringCritical(J9VMThread* vmThread, jstring str, jboolean *isCopy);
 	virtual void jniReleaseStringCritical(J9VMThread* vmThread, jstring str, const jchar* elems);
-	virtual void initializeForNewThread(MM_EnvironmentBase* env);
 
 	virtual I_32 backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
 	virtual I_32 forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
@@ -104,38 +94,11 @@ public:
 	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);	
 #endif	
 
-	bool preObjectStoreImpl(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile);
-	bool preObjectStoreImpl(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile);
-
-	void rememberObjectToRescan(MM_EnvironmentBase *env, J9Object *object);
-
-	MMINLINE bool isSATBBarrierActive()
-	{
-		return ((_extensions->configuration->isSnapshotAtTheBeginningBarrierEnabled()) &&
-				(!_extensions->sATBBarrierRememberedSet->isGlobalFragmentIndexPreserved()));
-	}
-
 	MMINLINE bool isIncrementalUpdateBarrierActive(J9VMThread *vmThread)
 	{
 		return ((vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE) &&
 				_extensions->configuration->isIncrementalUpdateBarrierEnabled());
 	}
-
-#if defined(OMR_GC_REALTIME)
-	MMINLINE void setDoubleBarrierActive() { _doubleBarrierActive = true; }
-	MMINLINE void setDoubleBarrierInactive() { _doubleBarrierActive = false; }
-	MMINLINE bool isDoubleBarrierActive() { return _doubleBarrierActive; }
-#endif /* OMR_GC_REALTIME */
-
-	MMINLINE bool isDoubleBarrierActiveOnThread(J9VMThread *vmThread)
-	{
-		/* The double barrier is enabled in by setting the threads remembered set fragment index
-		 * to the special value, this ensures the JIT will go out-of line. We can determine if the double
-		 * barrier is active simply by checking if the fragment index corresponds to the special value.
-		 */
-		return (J9GC_REMEMBERED_SET_RESERVED_INDEX == vmThread->sATBBarrierRememberedSetFragment.localFragmentIndex);
-	}
-	void setDoubleBarrierActiveOnThread(MM_EnvironmentBase* env);
 
 	virtual void referenceReprocess(J9VMThread *vmThread, J9Object *refObject)
 	{

--- a/runtime/gc_modron_standard/StandardSATBAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardSATBAccessBarrier.cpp
@@ -1,0 +1,353 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+/**
+ * @file
+ * @ingroup GC_Modron_Base
+ */
+
+#include "j9.h"
+#include "j9cfg.h"
+#include "j9consts.h"
+#include "j9protos.h"
+#include "ModronAssertions.h"
+
+#include "StandardSATBAccessBarrier.hpp"
+#include "AtomicOperations.hpp"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+#include "ConcurrentGC.hpp"
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+#include "Debug.hpp"
+#include "EnvironmentStandard.hpp"
+#include "mmhook_internal.h"
+#include "GCExtensions.hpp"
+#include "ObjectModel.hpp"
+#include "SublistFragment.hpp"
+
+MM_StandardSATBAccessBarrier *
+MM_StandardSATBAccessBarrier::newInstance(MM_EnvironmentBase *env)
+{
+	MM_StandardSATBAccessBarrier *barrier;
+
+	barrier = (MM_StandardSATBAccessBarrier *)env->getForge()->allocate(sizeof(MM_StandardSATBAccessBarrier), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	if (barrier) {
+		new(barrier) MM_StandardSATBAccessBarrier(env);
+		if (!barrier->initialize(env)) {
+			barrier->kill(env);
+			barrier = NULL;
+		}
+	}
+	return barrier;
+}
+
+void
+MM_StandardSATBAccessBarrier::kill(MM_EnvironmentBase *env)
+{
+	tearDown(env);
+	env->getForge()->free(this);
+}
+
+void
+MM_StandardSATBAccessBarrier::initializeForNewThread(MM_EnvironmentBase* env)
+{
+#if defined(OMR_GC_REALTIME)
+	_extensions->sATBBarrierRememberedSet->initializeFragment(env, &(((J9VMThread *)env->getLanguageVMThread())->sATBBarrierRememberedSetFragment));
+#endif /* OMR_GC_REALTIME */
+}
+
+/**
+ * Unmarked, heap reference, about to be deleted (or overwritten), while marking
+ * is in progress is to be remembered for later marking and scanning.
+ */
+void
+MM_StandardSATBAccessBarrier::rememberObjectToRescan(MM_EnvironmentBase *env, J9Object *object)
+{
+	MM_ParallelGlobalGC *globalCollector = (MM_ParallelGlobalGC *)_extensions->getGlobalCollector();
+
+	if (globalCollector->getMarkingScheme()->markObject(env, object, true)) {
+		rememberObjectImpl(env, object);
+	}
+}
+
+/**
+ * Unmarked, heap reference, about to be deleted (or overwritten), while marking
+ * is in progress is to be remembered for later marking and scanning.
+ * This method is called by MM_StandardSATBAccessBarrier::rememberObjectToRescan()
+ */
+void
+MM_StandardSATBAccessBarrier::rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object)
+{
+	J9VMThread *vmThread = (J9VMThread *)env->getLanguageVMThread();
+#if defined(OMR_GC_REALTIME)
+	_extensions->sATBBarrierRememberedSet->storeInFragment(env, &vmThread->sATBBarrierRememberedSetFragment, (UDATA *)object);
+#endif /* OMR_GC_REALTIME */
+}
+
+/**
+ * @copydoc MM_ObjectAccessBarrier::preObjectStore()
+ *
+ * Barrier for snapshot-at-the-beginning CM, the barrier is active through the end of
+ * tracing. For any thread performing a store, the old value is remembered by the collector
+ * before being overwritten (thus this barrier must be positioned as a pre-store barrier).
+ **/
+bool
+MM_StandardSATBAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile)
+{
+	return preObjectStoreImpl(vmThread, destObject, destAddress, value, isVolatile);
+}
+
+/**
+ * @copydoc MM_StandardSATBAccessBarrier::preObjectStore()
+ *
+ * Used for stores into classes
+ */
+bool
+MM_StandardSATBAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object *destClass, J9Object **destAddress, J9Object *value, bool isVolatile)
+{
+	return preObjectStoreImpl(vmThread, destAddress, value, isVolatile);
+}
+
+/**
+ * @copydoc MM_StandardSATBAccessBarrier::preObjectStore()
+ *
+ * Used for stores into internal structures
+ */
+bool
+MM_StandardSATBAccessBarrier::preObjectStore(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile)
+{
+	return preObjectStoreImpl(vmThread, destAddress, value, isVolatile);
+}
+
+bool
+MM_StandardSATBAccessBarrier::preObjectStoreImpl(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile)
+{
+	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+
+	if (_extensions->isSATBBarrierActive()) {
+		if (NULL != destObject) {
+			J9Object *oldObject = NULL;
+			protectIfVolatileBefore(vmThread, isVolatile, true, false);
+			GC_SlotObject slotObject(vmThread->javaVM->omrVM, destAddress);
+			oldObject = slotObject.readReferenceFromSlot();
+			protectIfVolatileAfter(vmThread, isVolatile, true, false);
+			rememberObjectToRescan(env, oldObject);
+		}
+	}
+
+	return true;
+}
+
+bool
+MM_StandardSATBAccessBarrier::preObjectStoreImpl(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile)
+{
+	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+
+	if (_extensions->isSATBBarrierActive()) {
+		J9Object* oldObject = NULL;
+		protectIfVolatileBefore(vmThread, isVolatile, true, false);
+		oldObject = *destAddress;
+		protectIfVolatileAfter(vmThread, isVolatile, true, false);
+		rememberObjectToRescan(env, oldObject);
+	}
+
+	return true;
+}
+
+/**
+ * Finds opportunities for doing the copy without or partially executing writeBarrier.
+ * @return ARRAY_COPY_SUCCESSFUL if copy was successful, ARRAY_COPY_NOT_DONE no copy is done
+ */
+I_32
+MM_StandardSATBAccessBarrier::backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots)
+{
+	/* TODO SATB re-enable opt? */
+	return ARRAY_COPY_NOT_DONE;
+}
+
+/**
+ * Finds opportunities for doing the copy without or partially executing writeBarrier.
+ * @return ARRAY_COPY_SUCCESSFUL if copy was successful, ARRAY_COPY_NOT_DONE no copy is done
+ */
+I_32
+MM_StandardSATBAccessBarrier::forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots)
+{
+	/* TODO SATB re-enable opt? */
+	return ARRAY_COPY_NOT_DONE;
+}
+
+bool
+MM_StandardSATBAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile)
+{
+	/* Assert should be removed once ReferenceArrayCopyIndex opts and JIT is enabled for SATB */
+	Assert_MM_unreachable();
+	return false;
+}
+
+bool
+MM_StandardSATBAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile)
+{
+	/* Assert should be removed once ReferenceArrayCopyIndex opts and JIT is enabled for SATB */
+	Assert_MM_unreachable();
+	return false;
+}
+
+void
+MM_StandardSATBAccessBarrier::forcedToFinalizableObject(J9VMThread* vmThread, J9Object* object)
+{
+	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+	if (_extensions->isSATBBarrierActive()) {
+		rememberObjectToRescan(env, object);
+	}
+}
+
+/**
+ * Override of referenceGet.  When the collector is tracing, it makes any gotten object "grey" to ensure
+ * that it is eventually traced.
+ *
+ * @param refObject the SoftReference or WeakReference object on which get() is being called.
+ *	This barrier must not be called for PhantomReferences.  The parameter must not be NULL.
+ */
+J9Object *
+MM_StandardSATBAccessBarrier::referenceGet(J9VMThread *vmThread, J9Object *refObject)
+{
+	MM_ParallelGlobalGC *globalCollector = (MM_ParallelGlobalGC *)_extensions->getGlobalCollector();
+	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+
+	UDATA offset = J9VMJAVALANGREFREFERENCE_REFERENT_OFFSET(vmThread);
+	J9Object *referent = mixedObjectReadObject(vmThread, refObject, offset, false);
+
+	/* Do nothing exceptional for NULL or marked referents */
+	if ((NULL == referent) || (globalCollector->getMarkingScheme()->isMarked(referent))) {
+		return referent;
+	}
+
+	/* Throughout tracing, we must turn any gotten reference into a root, because the
+	 * thread doing the getting may already have been scanned.  However, since we are
+	 * running on a mutator thread and not a gc thread we do this indirectly by putting
+	 * the object in the barrier buffer.
+	 */
+	if (_extensions->isSATBBarrierActive()) {
+		rememberObjectToRescan(env, referent);
+	}
+
+	/* We must return the external reference */
+	return referent;
+}
+
+void
+MM_StandardSATBAccessBarrier::referenceReprocess(J9VMThread *vmThread, J9Object *refObject)
+{
+	referenceGet(vmThread, refObject);
+}
+
+void
+MM_StandardSATBAccessBarrier::jniDeleteGlobalReference(J9VMThread *vmThread, J9Object *reference)
+{
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+	rememberObjectToRescan(env, reference);
+}
+
+void
+MM_StandardSATBAccessBarrier::storeObjectToInternalVMSlotImpl(J9VMThread *vmThread, j9object_t *destAddress, mm_j9object_t value, bool isVolatile)
+{
+	if (_extensions->isSATBBarrierActive()) {
+		MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+		rememberObjectToRescan(env, value);
+	}
+
+	*destAddress = value;
+}
+
+mm_j9object_t
+MM_StandardSATBAccessBarrier::readObjectFromInternalVMSlotImpl(J9VMThread *vmThread, j9object_t *srcAddress, bool isVolatile)
+{
+	mm_j9object_t object = *srcAddress;
+	if (NULL != vmThread) {
+		if (_extensions->isSATBBarrierActive()) {
+			MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+			rememberObjectToRescan(env, object);
+		}
+	}
+	return object;
+}
+
+void
+MM_StandardSATBAccessBarrier::stringConstantEscaped(J9VMThread *vmThread, J9Object *stringConst)
+{
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+
+	if (_extensions->isSATBBarrierActive()) {
+		rememberObjectToRescan(env, stringConst);
+	}
+}
+
+bool
+MM_StandardSATBAccessBarrier::checkStringConstantsLive(J9JavaVM *javaVM, j9object_t stringOne, j9object_t stringTwo)
+{
+	if (_extensions->isSATBBarrierActive()) {
+		J9VMThread* vmThread =  javaVM->internalVMFunctions->currentVMThread(javaVM);
+		stringConstantEscaped(vmThread, (J9Object *)stringOne);
+		stringConstantEscaped(vmThread, (J9Object *)stringTwo);
+	}
+	return true;
+}
+
+/**
+ *  Equivalent to checkStringConstantsLive but for a single string constant
+ */
+bool
+MM_StandardSATBAccessBarrier::checkStringConstantLive(J9JavaVM *javaVM, j9object_t string)
+{
+	if (_extensions->isSATBBarrierActive()) {
+		J9VMThread* vmThread =  javaVM->internalVMFunctions->currentVMThread(javaVM);
+		stringConstantEscaped(vmThread, (J9Object *)string);
+	}
+	return true;
+}
+
+#if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
+bool
+MM_StandardSATBAccessBarrier::checkClassLive(J9JavaVM *javaVM, J9Class *classPtr)
+{
+	J9ClassLoader *classLoader = classPtr->classLoader;
+	bool result = false;
+
+	if ((0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) && (0 == (J9CLASS_FLAGS(classPtr) & J9AccClassDying))) {
+		result = true;
+		/* this class has not been discovered dead yet so mark it if necessary to force it to be alive */
+		J9Object *classLoaderObject = classLoader->classLoaderObject;
+
+		if (NULL != classLoaderObject) {
+			/*  If mark is active but not completed yet force this class to be marked to survive this GC */
+			J9VMThread* vmThread =  javaVM->internalVMFunctions->currentVMThread(javaVM);
+			MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+			if (_extensions->isSATBBarrierActive()) {
+				rememberObjectToRescan(env, classLoaderObject);
+			}
+		}
+		/* else this class loader probably is in initialization process and class loader object has not been attached yet */
+	}
+
+	return result;
+}
+#endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */

--- a/runtime/gc_modron_standard/StandardSATBAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardSATBAccessBarrier.hpp
@@ -1,0 +1,103 @@
+
+/*******************************************************************************
+ * Copyright (c) 1991, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+/**
+ * @file
+ * @ingroup GC_Modron_Standard
+ */
+
+#if !defined(STANDARDSATBACCESSBARRIER_HPP_)
+#define STANDARDSATBACCESSBARRIER_HPP_
+
+
+#include "j9.h"
+#include "j9cfg.h"
+#include "StandardAccessBarrier.hpp"
+#include "RememberedSetSATB.hpp"
+
+/**
+ * Access barrier for Standard Concurrent SATB collector.
+ */
+
+class MM_StandardSATBAccessBarrier : public MM_StandardAccessBarrier
+{
+private:
+
+protected:
+
+public:
+	static MM_StandardSATBAccessBarrier *newInstance(MM_EnvironmentBase *env);
+	virtual void kill(MM_EnvironmentBase *env);
+
+	virtual void initializeForNewThread(MM_EnvironmentBase* env);
+	virtual void rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object);
+
+	virtual bool preObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile=false);
+	virtual bool preObjectStore(J9VMThread *vmThread, J9Object *destClass, J9Object **destAddress, J9Object *value, bool isVolatile=false);
+	virtual bool preObjectStore(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile=false);
+
+	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
+	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
+
+	virtual I_32 backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
+	virtual I_32 forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
+
+	bool preObjectStoreImpl(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile);
+	bool preObjectStoreImpl(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile);
+
+	void rememberObjectToRescan(MM_EnvironmentBase *env, J9Object *object);
+
+	virtual J9Object* referenceGet(J9VMThread *vmThread, J9Object *refObject);
+	virtual void referenceReprocess(J9VMThread *vmThread, J9Object *refObject);
+	virtual void forcedToFinalizableObject(J9VMThread* vmThread, J9Object *object);
+	virtual void jniDeleteGlobalReference(J9VMThread *vmThread, J9Object *reference);
+
+	virtual mm_j9object_t readObjectFromInternalVMSlotImpl(J9VMThread *vmThread, j9object_t *srcAddress, bool isVolatile=false);
+	virtual void storeObjectToInternalVMSlotImpl(J9VMThread *vmThread, j9object_t *destAddress, mm_j9object_t value, bool isVolatile=false);
+
+	virtual void stringConstantEscaped(J9VMThread *vmThread, J9Object *stringConst);
+	virtual bool checkStringConstantsLive(J9JavaVM *javaVM, j9object_t stringOne, j9object_t stringTwo);
+	virtual bool checkStringConstantLive(J9JavaVM *javaVM, j9object_t string);
+
+#if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
+	/**
+	 * Check is class alive
+	 * Required to prevent visibility of dead classes in SATB GC policies
+	 * Check is J9_GC_CLASS_LOADER_DEAD flag set for classloader and try to mark
+	 * class loader object if bit is not set to force class to be alive
+	 * @param javaVM pointer to J9JavaVM
+	 * @param classPtr class to check
+	 * @return true if class is alive
+	 */
+	virtual bool checkClassLive(J9JavaVM *javaVM, J9Class *classPtr);
+#endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
+
+	MM_StandardSATBAccessBarrier(MM_EnvironmentBase *env) :
+		MM_StandardAccessBarrier(env)
+	{
+		_typeId = __FUNCTION__;
+	}
+};
+
+#endif /* STANDARDSATBACCESSBARRIER_HPP_ */

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -543,7 +543,7 @@ allLiveClassesNextDo(J9ClassWalkState* state)
 	J9Class* clazzPtr = NULL;
 	J9Class* clazzPtrCandidate = NULL;
 	J9JavaVM* vm = state->vm;
-	const BOOLEAN needCheckInGC = (J9_GC_POLICY_METRONOME == vm->gcPolicy);
+	const BOOLEAN needCheckInGC = ((J9_GC_WRITE_BARRIER_TYPE_SATB == vm->gcWriteBarrierType) || (J9_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK == vm->gcWriteBarrierType));
 
 	do {
 		clazzPtrCandidate = allClassesNextDo(state);


### PR DESCRIPTION
These changes implement the the SATB access barriers, these have been adapted from the Realtime access barriers. Additionally, the existing SATB barriers has been reorganized.

- Introduced SATB Access Barrier class `StandardSATBAccessBarrier`, derived from `StandardAccessBarrier`

- Removed all SATB specifics out of Standard Access Barrier
  - `initializeForNewThread`
  - `rememberObjectToRescan` / `rememberObjectImpl`
  - `preObjectStore` / `preObjectStoreImpl`

- Removed Double Barrier Code, Standard SATB does not make use of it

- Adapted the following barrier from realtime for Standard SATB:
  - `forcedToFinalizableObject`
  - `referenceGet`
  - `referenceReprocess`
  - `jniDeleteGlobalReference`
  - `storeObjectToInternalVMSlotImpl`
  - `readObjectFromInternalVMSlotImpl`
  - `stringConstantEscaped` / `checkStringConstantsLive`
  - `checkClassLive`

Signed-off-by: Salman Rana <salman.rana@ibm.com>