### PR TITLE
Add calculate element address with element stride

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2073,6 +2073,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, TR::Compiler->cls.isClassRefValueType(comp, clazz, cpIndex));
          }
          break;
+      case MessageType::ClassEnv_flattenedArrayElementSize:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *>();
+         auto arrayClass = std::get<0>(recv);
+         client->write(response, TR::Compiler->cls.flattenedArrayElementSize(comp, arrayClass));
+         }
+         break;
       case MessageType::ClassEnv_enumerateFields:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *>();

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -977,3 +977,20 @@ J9::ClassEnv::classNameToSignature(const char *name, int32_t &len, TR::Compilati
    sig[len] = '\0';
    return sig;
    }
+
+int32_t
+J9::ClassEnv::flattenedArrayElementSize(TR::Compilation *comp, TR_OpaqueClassBlock *arrayClass)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      stream->write(JITServer::MessageType::ClassEnv_flattenedArrayElementSize, arrayClass);
+      return std::get<0>(stream->read<int32_t>());
+      }
+   else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      J9JavaVM *vm = comp->fej9()->getJ9JITConfig()->javaVM;
+      return vm->internalVMFunctions->arrayElementSize((J9ArrayClass*)self()->convertClassOffsetToClassPtr(arrayClass));
+      }
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -94,6 +94,21 @@ public:
    bool isValueTypeClass(TR_OpaqueClassBlock *);
    bool isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz);
    bool isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *);
+
+   /** \brief
+    *    Returns the size of the flattened array element
+    *
+    *  \param comp
+    *    The compilation object
+    *
+    *  \param arrayClass
+    *    The array class that is to be checked
+    *
+    *  \return
+    *    Size of the flattened array element
+    */
+   int32_t flattenedArrayElementSize(TR::Compilation *comp, TR_OpaqueClassBlock *arrayClass);
+
    /** \brief
     *	    Checks whether a class implements `IdentityObject`/`IdentityInterface`
     *

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -210,6 +210,7 @@ const char *messageNames[] =
    "ClassEnv_getITable",
    "ClassEnv_enumerateFields",
    "ClassEnv_isClassRefValueType",
+   "ClassEnv_flattenedArrayElementSize",
    "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",
    "SharedCache_addHint",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -223,6 +223,7 @@ enum MessageType : uint16_t
    ClassEnv_getITable,
    ClassEnv_enumerateFields,
    ClassEnv_isClassRefValueType,
+   ClassEnv_flattenedArrayElementSize,
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetIdentifyingLoader,

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -92,7 +92,7 @@ public:
    static bool avoidFoldingInstanceField(
       uintptr_t object,
       TR::Symbol *field,
-      uint32_t fieldOffset,       
+      uint32_t fieldOffset,
       int cpIndex,
       TR_ResolvedMethod *owningMethod,
       TR::Compilation *comp);
@@ -105,7 +105,7 @@ public:
    static TR::Node *generateArrayElementShiftAmountTrees(
          TR::Compilation *comp,
          TR::Node *object);
-   
+
    static bool transformDirectLoad(TR::Compilation *, TR::Node *node);
 
    /**
@@ -201,8 +201,34 @@ public:
    static bool fieldShouldBeCompressed(TR::Node *node, TR::Compilation *comp);
 
    static TR::Block *insertNewFirstBlockForCompilation(TR::Compilation *comp);
+   /**
+    * \brief
+    *    Calculate offset for an array element given its index based on `type`
+    *
+    * \param index
+    *    The index into the array
+    *
+    * \param type
+    *    The data type of the array element
+    *
+    * \return The Int64 value representing the offset into an array of the specified type given the index
+    */
    static TR::Node *calculateOffsetFromIndexInContiguousArray(TR::Compilation *, TR::Node * index, TR::DataType type);
+   /**
+    * \brief
+    *    Calculate offset for an array element given its index based on `elementStride`
+    *
+    * \param index
+    *    The index into the array
+    *
+    * \param elementStride
+    *    The size of the array element
+    *
+    * \return The Int64 value representing the offset into an array of the specified element size given the index
+    */
+   static TR::Node *calculateOffsetFromIndexInContiguousArrayWithElementStride(TR::Compilation *, TR::Node * index, int32_t elementStride);
    static TR::Node *calculateElementAddress(TR::Compilation *, TR::Node *array, TR::Node * index, TR::DataType type);
+   static TR::Node *calculateElementAddressWithElementStride(TR::Compilation *, TR::Node *array, TR::Node * index, int32_t elementStride);
    static TR::Node *calculateIndexFromOffsetInContiguousArray(TR::Compilation *, TR::Node * offset, TR::DataType type);
 
    static TR::Node* saveNodeToTempSlot(TR::Compilation* comp, TR::Node* node, TR::TreeTop* insertTreeTop);


### PR DESCRIPTION
Update `TransformUtil` to calculate element address with element stride and add `flattenedArrayElementSize` to `ClassEnv`. 