### PR TITLE
Disable skipping HCR guard creation for java/lang/invoke callees

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2502,6 +2502,7 @@ TR_J9InlinerPolicy::skipHCRGuardForCallee(TR_ResolvedMethod *callee)
        rm <= TR::LastVectorIntrinsicMethod)
       return true;
 
+#if !defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    // Skip HCR guard for non-public methods in java/lang/invoke package. These methods
    // are related to implementation details of MethodHandle and VarHandle
    int32_t length = callee->classNameLength();
@@ -2510,6 +2511,7 @@ TR_J9InlinerPolicy::skipHCRGuardForCallee(TR_ResolvedMethod *callee)
        && !strncmp("java/lang/invoke/", className, 17)
        && !callee->isPublic())
       return true;
+#endif
 
    return false;
    }


### PR DESCRIPTION
Skipping HCR guard creation for java/lang/invoke inlined callees
could result in incorrectly setting up OSR transitions.

Issue: #13162 

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>