### PR TITLE
AArch64: Implement JIT field watch support

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -55,6 +55,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *irdbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ardbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2717,7 +2717,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       self()->setOption(TR_DisableNextGenHCR);
       }
 
-#if !defined(TR_HOST_X86) && !defined(TR_HOST_S390) && !defined(TR_HOST_POWER)
+#if !defined(TR_HOST_X86) && !defined(TR_HOST_S390) && !defined(TR_HOST_POWER) && !defined(TR_HOST_ARM64)
    //The bit is set when -XX:+JITInlineWatches is specified
    if (J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_JIT_INLINE_WATCHES))
       TR_ASSERT_FATAL(false, "this platform doesn't support JIT inline field watch");

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -324,8 +324,8 @@
 	-explainExcludes \
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- Option -XX:+JitInlineWatches is currently unsupported on arm and aarch64 -->
-		<platformRequirements>^arch.arm,^arch.aarch64</platformRequirements>
+		<!-- Option -XX:+JitInlineWatches is currently unsupported on arm -->
+		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit adds support for JIT field watch on aarch64.

Depends on https://github.com/eclipse/omr/pull/6252

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>