### PR TITLE
Update method description to match Javadoc

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -883,8 +883,8 @@ public abstract class VarHandle extends VarHandleInternal
 	}
 	
 	/**
-	 * Inserts a release memory fence, ensuring that no stores before this fence
-	 * are reordered with any loads/stores after the fence. 
+	 * Inserts a release memory fence, ensuring that no loads and stores before
+	 * this fence are reordered with any stores after the fence.
 	 */
 	public static void releaseFence() {
 		// TODO: storeStore + loadStore
@@ -984,7 +984,7 @@ public abstract class VarHandle extends VarHandleInternal
 		
 	/**
 	 * Sets the value of the field referenced by this {@link VarHandle} using acquire semantics.
-	 * Preceding stores will not be reordered with subsequent loads/stores.
+	 * Preceding loads and stores will not be reordered after this access.
 	 * 
 	 * @param args The arguments for this operation are determined by the field type
 	 * 				(see {@link VarHandle#accessModeType(AccessMode) accessModeType()}) 


### PR DESCRIPTION
The methods function correctly but there was a slight inaccuracy in their
description (wording), which has been corrected.

Closes: https://github.com/eclipse-openj9/openj9/issues/12429

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>