### PR TITLE
Fix link warnings on Windows

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9447,7 +9447,7 @@ JIT_HELPER(initialInvokeExactThunkGlue);
 JIT_HELPER(_initialInvokeExactThunkGlue);
 #endif
 
-JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
+jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
    (JNIEnv *env, jclass clazz)
    {
 #if defined(J9ZOS390)
@@ -9465,7 +9465,7 @@ JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
  * (private interface method, methods in Object) have been adapted away by the java code, so this
  * native only ever deals with iTable interface methods.
  */
-JNIEXPORT jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex
+jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex
   (JNIEnv *env, jclass InterfaceMethodHandle, jlong interfaceArg, jint itableIndex, jlong receiverClassArg)
    {
    J9Class  *interfaceClass = (J9Class*)(intptr_t)interfaceArg;
@@ -9498,12 +9498,7 @@ JNIEXPORT jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexT
    }
 
 
-extern "C" {
-JNIEXPORT void JNICALL Java_java_lang_invoke_MutableCallSite_invalidate
-  (JNIEnv *env, jclass MutableCallSite, jlongArray cookieArrayObject);
-}
-
-JNIEXPORT void JNICALL Java_java_lang_invoke_MutableCallSite_invalidate
+void JNICALL Java_java_lang_invoke_MutableCallSite_invalidate
   (JNIEnv *env, jclass MutableCallSite, jlongArray cookieArrayObject)
    {
    J9VMThread          *vmThread  = (J9VMThread*)env;

--- a/runtime/compiler/env/exports.h
+++ b/runtime/compiler/env/exports.h
@@ -32,11 +32,14 @@ extern "C" {
 JNIEXPORT jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex
   (JNIEnv *, jclass, jlong, jint, jlong);
 
+JNIEXPORT void JNICALL Java_java_lang_invoke_MutableCallSite_invalidate
+  (JNIEnv *, jclass, jlongArray);
+
 JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
   (JNIEnv *, jclass);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* EXPORTS_H */


### PR DESCRIPTION
Windows builds include a number of link warnings:
```
VMJ9.cpp.obj : warning LNK4197: export 'Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex' specified multiple times; using first specification
VMJ9.cpp.obj : warning LNK4197: export 'Java_java_lang_invoke_MutableCallSite_invalidate' specified multiple times; using first specification
VMJ9.cpp.obj : warning LNK4197: export 'Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk' specified multiple times; using first specification
```
See https://openj9-jenkins.osuosl.org/view/Build_Nightly/job/Build_JDK8_x86-64_windows_Nightly/159/consoleFull for a recent example.

This fixes those warnings:
* move prototype for `MutableCallSite.invalidate()` to `exports.h`
* remove redundant uses of `JNIEXPORT`