### PR TITLE
Disable stackMap cache during ASGCT

### DIFF
--- a/runtime/codert_vm/CodertVMHelpers.cpp
+++ b/runtime/codert_vm/CodertVMHelpers.cpp
@@ -323,7 +323,7 @@ jitGetExceptionCatcher(J9VMThread *currentThread, void *handlerPC, J9JITExceptio
 	 * because jitGetMapsFromPC is expecting a return address, so it subtracts 1.  The value passed in is
 	 * the start address of the compiled exception handler.
 	 */
-	jitGetMapsFromPC(currentThread->javaVM, metaData, (UDATA)handlerPC + 1, &stackMap, &inlineMap);
+	jitGetMapsFromPC(currentThread, metaData, (UDATA)handlerPC + 1, &stackMap, &inlineMap);
 	Assert_CodertVM_false(NULL == inlineMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
 		inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1714,7 +1714,7 @@ slow_jitMonitorEnterImpl(J9VMThread *currentThread, bool forMethod)
 			J9JavaVM *vm = currentThread->javaVM;
 			J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, (UDATA)oldPC);
 			Assert_CodertVM_false(NULL == metaData);
-			jitGetMapsFromPC(vm, metaData, (UDATA)oldPC, &stackMap, &inlineMap);
+			jitGetMapsFromPC(currentThread, metaData, (UDATA)oldPC, &stackMap, &inlineMap);
 			Assert_CodertVM_false(NULL == inlineMap);
 			if ((NULL == getJitInlinedCallInfo(metaData)) || (NULL == getFirstInlinedCallSite(metaData, inlineMap))) {
 				J9SFJITResolveFrame *resolveFrame = (J9SFJITResolveFrame*)currentThread->sp;

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1236,7 +1236,7 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 	 * because jitGetMapsFromPC is expecting a return address, so it subtracts 1.  The value stored in the
 	 * decomp record is the start address of the compiled exception handler.
 	 */
-	jitGetMapsFromPC(vm, metaData, (UDATA)jitPC + 1, &stackMap, &inlineMap);
+	jitGetMapsFromPC(currentThread, metaData, (UDATA)jitPC + 1, &stackMap, &inlineMap);
 	Assert_CodertVM_false(NULL == inlineMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
 		inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
@@ -1826,13 +1826,12 @@ osrFrameSizeRomMethod(J9ROMMethod *romMethod)
 static UDATA
 osrAllFramesSize(J9VMThread *currentThread, J9JITExceptionTable *metaData, void *jitPC, UDATA resolveFrameFlags)
 {
-	J9JavaVM *vm = currentThread->javaVM;
 	UDATA totalSize = 0;
 	void * stackMap = NULL;
 	void * inlineMap = NULL;
 
 	/* Count the inlined methods */
-	jitGetMapsFromPC(vm, metaData, (UDATA)jitPC, &stackMap, &inlineMap);
+	jitGetMapsFromPC(currentThread, metaData, (UDATA)jitPC, &stackMap, &inlineMap);
 	Assert_CodertVM_false(NULL == inlineMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
 		void *inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
@@ -2157,7 +2156,6 @@ static UDATA
 initializeOSRBuffer(J9VMThread *currentThread, J9OSRBuffer *osrBuffer, J9OSRData *osrData)
 {
 	UDATA result = OSR_OK;
-	J9JavaVM *vm = currentThread->javaVM;
 	J9JITExceptionTable *metaData = osrData->metaData;
 	void *jitPC = osrData->jitPC;
 	UDATA resolveFrameFlags = osrData->resolveFrameFlags;
@@ -2170,7 +2168,7 @@ initializeOSRBuffer(J9VMThread *currentThread, J9OSRBuffer *osrBuffer, J9OSRData
 	U_16 numberOfMapBits = 0;
 
 	/* Get the stack map, inline map and live monitor metadata */
-	jitGetMapsFromPC(vm, metaData, (UDATA)jitPC, &stackMap, &inlineMap);
+	jitGetMapsFromPC(currentThread, metaData, (UDATA)jitPC, &stackMap, &inlineMap);
 	liveMonitorMap = getJitLiveMonitors(metaData, stackMap);
 	gcStackAtlas = (J9JITStackAtlas *)getJitGCStackAtlas(metaData);
 	numberOfMapBits = getJitNumberOfMapBytes(gcStackAtlas) << 3;

--- a/runtime/codert_vm/jswalk.c
+++ b/runtime/codert_vm/jswalk.c
@@ -186,7 +186,7 @@ UDATA  jitWalkStackFrames(J9StackWalkState *walkState)
 		walkState->outgoingArgCount = walkState->argCount;
 
 		if ((!(walkState->flags & J9_STACKWALK_SKIP_INLINES)) && getJitInlinedCallInfo(walkState->jitInfo)) {
-			jitGetMapsFromPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA) walkState->pc, &(walkState->stackMap), &(walkState->inlineMap));
+			jitGetMapsFromPC(walkState->currentThread, walkState->jitInfo, (UDATA) walkState->pc, &(walkState->stackMap), &(walkState->inlineMap));
 			if (NULL != walkState->inlineMap) {
 				walkState->inlinedCallSite = getFirstInlinedCallSite(walkState->jitInfo, walkState->inlineMap);
 
@@ -217,7 +217,7 @@ resumeWalkInline:
 				}
 			}
 		} else if (walkState->flags & J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET) {
-			jitGetMapsFromPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA) walkState->pc, &(walkState->stackMap), &(walkState->inlineMap));
+			jitGetMapsFromPC(walkState->currentThread, walkState->jitInfo, (UDATA) walkState->pc, &(walkState->stackMap), &(walkState->inlineMap));
 		}
 
 		SET_A0_CP_METHOD(walkState);
@@ -517,7 +517,7 @@ static void jitWalkFrame(J9StackWalkState *walkState, UDATA walkLocals, void *st
 	WALK_METHOD_CLASS(walkState);
 
 	if (stackMap == NULL) {
-		stackMap = getStackMapFromJitPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA) walkState->pc);
+		stackMap = getStackMapFromJitPC(walkState->currentThread, walkState->jitInfo, (UDATA) walkState->pc);
 		if (stackMap == NULL) {
 			if (J9_ARE_ANY_BITS_SET(walkState->flags, J9_STACKWALK_NO_ERROR_REPORT)) {
 				return;
@@ -554,7 +554,7 @@ static void jitWalkFrame(J9StackWalkState *walkState, UDATA walkLocals, void *st
 	variableInternalPtrSize = 0;
 	registerMap = getJitRegisterMap(walkState->jitInfo, stackMap);
 	jitDescriptionCursor = getJitStackSlots(walkState->jitInfo, stackMap);
-	stackAllocMapCursor = getStackAllocMapFromJitPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA) walkState->pc, stackMap);
+	stackAllocMapCursor = getStackAllocMapFromJitPC(walkState->currentThread, walkState->jitInfo, (UDATA) walkState->pc, stackMap);
 
 	walkState->slotType = J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL;
 	walkState->slotIndex = 0;
@@ -1061,7 +1061,7 @@ static void jitWalkResolveMethodFrame(J9StackWalkState *walkState)
 			}
 			return;
 		}
-		jitGetMapsFromPC(walkState->walkThread->javaVM, metaData, (UDATA)walkState->pc, &stackMap, &inlineMap);
+		jitGetMapsFromPC(walkState->currentThread, metaData, (UDATA)walkState->pc, &stackMap, &inlineMap);
 
 		/* If there are no inlines, use the outer method.  Otherwise, use the innermost inline at the current PC */
 
@@ -1680,7 +1680,7 @@ jitGetOwnedObjectMonitors(J9StackWalkState *walkState)
 	}
 
 	/* get the stackmap and inline map for the given pc (this is a single walk of jit metadata) */
-	jitGetMapsFromPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA)walkState->pc, &stackMap, &inlineMap);
+	jitGetMapsFromPC(walkState->currentThread, walkState->jitInfo, (UDATA)walkState->pc, &stackMap, &inlineMap);
 
 	/* get a slot map of all live monitors on the JIT frame.  May include slots from inlined methods */
 	liveMonitorMap = getJitLiveMonitors(walkState->jitInfo, stackMap);
@@ -1732,7 +1732,7 @@ countOwnedObjectMonitors(J9StackWalkState *walkState)
 	U_16 numberOfMapBits;
 
 	/* get the stackmap and inline map for the given pc (this is a single walk of jit metadata) */
-	jitGetMapsFromPC(walkState->walkThread->javaVM, walkState->jitInfo, (UDATA)walkState->pc, &stackMap, &inlineMap);
+	jitGetMapsFromPC(walkState->currentThread, walkState->jitInfo, (UDATA)walkState->pc, &stackMap, &inlineMap);
 
 	/* get a slot map of all live monitors on the JIT frame.  May include slots from inlined methods */
 	liveMonitorMap = getJitLiveMonitors(walkState->jitInfo, stackMap);

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -224,21 +224,27 @@ static VMINLINE TR_StackMapTable * initializeMapTable(J9JavaVM * javaVM, J9TR_Me
    return mapTable;
    }
 
-static VMINLINE TR_StackMapTable * findOrCreateMapTable(J9JavaVM * javaVM, J9TR_MethodMetaData * metaData, UDATA fourByteOffsets)
+static VMINLINE TR_StackMapTable * findOrCreateMapTable(J9VMThread * currentThread, J9TR_MethodMetaData * metaData, UDATA fourByteOffsets)
    {
    TR_StackMapTable * mapTablePtr = 0;
    assert(metaData);
 
-   if (metaData->bodyInfo &&
-       (javaVM->phase == J9VM_PHASE_NOT_STARTUP || 0 == (javaVM->jitConfig->runtimeFlags & J9JIT_QUICKSTART))) // save footprint during startup in Xquickstart mode
+   // In a signal handler, do not use or create the map tables. The tables may be in an inconsistent
+   // state when interrupted by the signal, and malloc must not be called from a signal handler.
+   if (J9_ARE_NO_BITS_SET(currentThread->privateFlags2, J9_PRIVATE_FLAGS2_ASYNC_GET_CALL_TRACE))
       {
-      mapTablePtr = ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->_mapTable; /* cache it */
-      if (mapTablePtr == (TR_StackMapTable *)-1) /* if nobody wrote to it yet */
-        { mapTablePtr = initializeMapTable(javaVM, metaData, fourByteOffsets); }
+      J9JavaVM * javaVM = currentThread->javaVM;
+      if (metaData->bodyInfo &&
+          (javaVM->phase == J9VM_PHASE_NOT_STARTUP || 0 == (javaVM->jitConfig->runtimeFlags & J9JIT_QUICKSTART))) // save footprint during startup in Xquickstart mode
+         {
+         mapTablePtr = ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->_mapTable; /* cache it */
+         if (mapTablePtr == (TR_StackMapTable *)-1) /* if nobody wrote to it yet */
+           { mapTablePtr = initializeMapTable(javaVM, metaData, fourByteOffsets); }
 #if defined(TR_HOST_64BIT)
-      if (((U_32)((UDATA)mapTablePtr) == (U_32)-1) || ((U_32)((UDATA)mapTablePtr >> 32) == (U_32)-1)) /* check upper and lower word */
-         { mapTablePtr = 0; } /* give up the optimization */
+         if (((U_32)((UDATA)mapTablePtr) == (U_32)-1) || ((U_32)((UDATA)mapTablePtr >> 32) == (U_32)-1)) /* check upper and lower word */
+            { mapTablePtr = 0; } /* give up the optimization */
 #endif
+         }
       }
 
    return mapTablePtr;
@@ -398,7 +404,7 @@ static void fastwalkDebug(J9TR_MethodMetaData * methodMetaData, UDATA offsetPC, 
    }
 #endif /* defined(DEBUG) */
 
-void jitGetMapsFromPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, UDATA jitPC, void * * stackMap, void * * inlineMap)
+void jitGetMapsFromPC(J9VMThread * currentThread, J9TR_MethodMetaData * methodMetaData, UDATA jitPC, void * * stackMap, void * * inlineMap)
    {
    TR_MapIterator i;
    TR_StackMapTable * stackMapTable = 0;
@@ -429,7 +435,7 @@ void jitGetMapsFromPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, U
 
 #ifdef FASTWALK
 
-   stackMapTable = findOrCreateMapTable(javaVM, methodMetaData, fourByteOffsets);
+   stackMapTable = findOrCreateMapTable(currentThread, methodMetaData, fourByteOffsets);
 
    if (stackMapTable)
       {
@@ -519,23 +525,23 @@ void jitGetMapsFromPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, U
       }
    }
 
-void * jitGetInlinerMapFromPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, UDATA jitPC)
+void * jitGetInlinerMapFromPC(J9VMThread * currentThread, J9TR_MethodMetaData * methodMetaData, UDATA jitPC)
    {
    void * stackMap, * inlineMap;
-   jitGetMapsFromPC(javaVM, methodMetaData, jitPC, &stackMap, &inlineMap);
+   jitGetMapsFromPC(currentThread, methodMetaData, jitPC, &stackMap, &inlineMap);
    return inlineMap;
    }
 
-void * getStackMapFromJitPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, UDATA jitPC)
+void * getStackMapFromJitPC(J9VMThread * currentThread, J9TR_MethodMetaData * methodMetaData, UDATA jitPC)
    {
    void * stackMap, * inlineMap;
-   jitGetMapsFromPC(javaVM, methodMetaData, jitPC, &stackMap, &inlineMap);
+   jitGetMapsFromPC(currentThread, methodMetaData, jitPC, &stackMap, &inlineMap);
    return stackMap;
    }
 
 
 
-void * getStackAllocMapFromJitPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, UDATA jitPC, void *curStackMap)
+void * getStackAllocMapFromJitPC(J9VMThread * currentThread, J9TR_MethodMetaData * methodMetaData, UDATA jitPC, void *curStackMap)
    {
    void * stackMap, ** stackAllocMap;
 
@@ -545,7 +551,7 @@ void * getStackAllocMapFromJitPC(J9JavaVM * javaVM, J9TR_MethodMetaData * method
    if (curStackMap)
       stackMap = curStackMap;
    else
-      stackMap = getStackMapFromJitPC(javaVM, methodMetaData, jitPC);
+      stackMap = getStackMapFromJitPC(currentThread, methodMetaData, jitPC);
 
    stackAllocMap = (void **)((J9JITStackAtlas *) methodMetaData->gcStackAtlas)->stackAllocMap;
    if (stackAllocMap)
@@ -2441,7 +2447,7 @@ void* preOSR(J9VMThread* currentThread, J9JITExceptionTable *metaData, void *pc)
    assert(metaData);
    assert(metaData->osrInfo);
 
-   jitGetMapsFromPC(currentThread->javaVM, metaData, (UDATA) pc, &stackMap, &inlineMap);
+   jitGetMapsFromPC(currentThread, metaData, (UDATA) pc, &stackMap, &inlineMap);
    bcInfo = (TR_ByteCodeInfo*) getByteCodeInfoFromStackMap(metaData, inlineMap);
 /*
    printf("offset=%08X bytecode.caller=%d bytecode.index=%x\n",

--- a/runtime/compiler/runtime/MethodMetaData.h
+++ b/runtime/compiler/runtime/MethodMetaData.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,11 +240,11 @@ typedef struct TR_MapIterator
       } \
    }
 
-void * getStackMapFromJitPC(J9JavaVM * javaVM, J9TR_MethodMetaData * exceptionTable, UDATA jitPC);
-void * getStackAllocMapFromJitPC(J9JavaVM * javaVM, J9TR_MethodMetaData * exceptionTable, UDATA jitPC, void *curStackMap);
+void * getStackMapFromJitPC(J9VMThread * currentThread, J9TR_MethodMetaData * exceptionTable, UDATA jitPC);
+void * getStackAllocMapFromJitPC(J9VMThread * currentThread, J9TR_MethodMetaData * exceptionTable, UDATA jitPC, void *curStackMap);
 UDATA jitExceptionHandlerSearch(J9VMThread * currentThread, J9StackWalkState * walkState);
-void * jitGetInlinerMapFromPC(J9JavaVM * javaVM, J9JITExceptionTable * exceptionTable, UDATA jitPC);
-void jitGetMapsFromPC(J9JavaVM * javaVM, J9JITExceptionTable * exceptionTable, UDATA jitPC, void * * inlineMap, void * * stackMap);
+void * jitGetInlinerMapFromPC(J9VMThread * currentThread, J9JITExceptionTable * exceptionTable, UDATA jitPC);
+void jitGetMapsFromPC(J9VMThread * currentThread, J9JITExceptionTable * exceptionTable, UDATA jitPC, void * * inlineMap, void * * stackMap);
 void * getFirstInlineRange(TR_MapIterator * i, void * methodMetaData, UDATA * startOffset, UDATA * endOffset);
 void * getNextInlineRange(TR_MapIterator * i, UDATA * startOffset, UDATA * endOffset);
 void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** jitDescriptionCursor, UDATA * scanCursor, void *stackMap, J9JITStackAtlas *gcStackAtlas);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3910,11 +3910,11 @@ typedef struct J9JITConfig {
 	UDATA codeCacheTotalKB;
 	UDATA dataCacheTotalKB;
 	struct J9JITExceptionTable*  ( *jitGetExceptionTableFromPC)(struct J9VMThread * vmThread, UDATA jitPC) ;
-	void*  ( *jitGetStackMapFromPC)(struct J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
-	void*  ( *jitGetInlinerMapFromPC)(struct J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
+	void*  ( *jitGetStackMapFromPC)(struct J9VMThread * currentThread, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
+	void*  ( *jitGetInlinerMapFromPC)(struct J9VMThread * currentThread, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
 	UDATA  ( *getJitInlineDepthFromCallSite)(struct J9JITExceptionTable *metaData, void *inlinedCallSite) ;
 	void*  ( *getJitInlinedCallInfo)(struct J9JITExceptionTable * md) ;
-	void*  ( *getStackMapFromJitPC)(struct J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
+	void*  ( *getStackMapFromJitPC)(struct J9VMThread * currentThread, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
 	void*  ( *getFirstInlinedCallSite)(struct J9JITExceptionTable * metaData, void * stackMap) ;
 	void*  ( *getNextInlinedCallSite)(struct J9JITExceptionTable * metaData, void * inlinedCallSite) ;
 	UDATA  ( *hasMoreInlinedMethods)(void * inlinedCallSite) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1375,13 +1375,13 @@ extern J9_CFUNC UDATA  hasMoreInlinedMethods (void * inlinedCallSite);
 extern J9_CFUNC UDATA  getByteCodeIndex (void * inlinedCallSite);
 extern J9_CFUNC void  jitReportDynamicCodeLoadEvents (J9VMThread * currentThread);
 extern J9_CFUNC UDATA  getJitInlineDepthFromCallSite (J9JITExceptionTable *metaData, void *inlinedCallSite);
-extern J9_CFUNC void*  jitGetInlinerMapFromPC (J9JavaVM * javaVM, J9JITExceptionTable * exceptionTable, UDATA jitPC);
-extern J9_CFUNC void*  getStackMapFromJitPC (J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC);
+extern J9_CFUNC void*  jitGetInlinerMapFromPC (J9VMThread * currentThread, J9JITExceptionTable * exceptionTable, UDATA jitPC);
+extern J9_CFUNC void*  getStackMapFromJitPC (J9VMThread * currentThread, struct J9JITExceptionTable * exceptionTable, UDATA jitPC);
 extern J9_CFUNC UDATA  getCurrentByteCodeIndexAndIsSameReceiver (J9JITExceptionTable *metaData, void *stackMap, void *currentInlinedCallSite, UDATA * isSameReceiver);
 extern J9_CFUNC void  clearFPStack (void);
 extern J9_CFUNC void  jitExclusiveVMShutdownPending (J9VMThread *vmThread);
 extern J9_CFUNC void*  getNextInlinedCallSite (J9JITExceptionTable * metaData, void * inlinedCallSite);
-extern J9_CFUNC void*  jitGetStackMapFromPC (J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC);
+extern J9_CFUNC void*  jitGetStackMapFromPC (J9VMThread * currentThread, struct J9JITExceptionTable * exceptionTable, UDATA jitPC);
 extern J9_CFUNC void  jitAddPicToPatchOnClassUnload (void *classPointer, void *addressToBePatched);
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 #endif /* _J9VMNATIVEHELPERSLARGE_ */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -4720,20 +4720,7 @@ JavaCoreDumpWriter::writeFrame(J9StackWalkState* state)
 	}
 
 	UDATA offsetPC = state->bytecodePCOffset;
-	bool compiledMethod = false;
-
-#ifdef J9VM_INTERP_NATIVE_SUPPORT
-	J9JITConfig*         jitConfig = _VirtualMachine->jitConfig;
-	J9JITExceptionTable* metaData  = state->jitInfo;
-	void*                stackMap  = NULL;
-
-	if ((NULL != jitConfig) && (NULL != metaData)) {
-		stackMap = jitConfig->jitGetInlinerMapFromPC(_VirtualMachine, metaData, (UDATA)state->pc);
-		if (NULL != stackMap) {
-			compiledMethod = true;
-		}
-	}
-#endif
+	bool compiledMethod = (NULL != state->jitInfo);
 
 #ifdef J9VM_OPT_DEBUG_INFO_SERVER
 	/* Write source file and line number info, if available and we can take locks. */

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -279,7 +279,7 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 			if (jitConfig) {
 				metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, methodPC);
 				if (metaData) {
-					inlineMap = jitConfig->jitGetInlinerMapFromPC(vm, metaData, methodPC);
+					inlineMap = jitConfig->jitGetInlinerMapFromPC(vmThread, metaData, methodPC);
 					if (inlineMap) {
 						inlinedCallSite = jitConfig->getFirstInlinedCallSite(metaData, inlineMap);
 						if (inlinedCallSite) {


### PR DESCRIPTION
Do not use the cache as it may be in an inconsistent state. Also, do not
allocate a new cache to avoid malloc during signal handler.

Remove unnecessary stack map query in dump creation.

Related: #13838

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>