### PR TITLE
Add user hooks capabilities

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
@@ -26,15 +26,26 @@ package org.eclipse.openj9.criu;
  * A CRIU exception representing a failure in the JVM before checkpoint.
  */
 public final class JVMCheckpointException extends JVMCRIUException {
-    private static final long serialVersionUID = 3729891178366898261L;
+	private static final long serialVersionUID = 4486137934620495516L;
 
-    /**
-     * Creates a JVMCheckpointException with the specified message and error code.
-     *
-     * @param message the message
-     * @param errorCode the error code
-     */
-    public JVMCheckpointException(String message, int errorCode) {
-        super(message, errorCode);
-    }
+	/**
+	 * Creates a JVMCheckpointException with the specified message and error code.
+	 *
+	 * @param message   the message
+	 * @param errorCode the error code
+	 */
+	public JVMCheckpointException(String message, int errorCode) {
+		super(message, errorCode);
+	}
+
+	/**
+	 * Creates a CheckpointException with the specified message and error code.
+	 *
+	 * @param message   the message
+	 * @param errorCode the error code
+	 * @param causedBy  throwable that cuased the exception
+	 */
+	public JVMCheckpointException(String message, int errorCode, Throwable causedBy) {
+		super(message, errorCode, causedBy);
+	}
 }


### PR DESCRIPTION
Add user hooks capabilities

This is a first pass of adding user hooks. A subsequent PR will be
created to prevent deadlocks.

Also, re-enable security checks for JDK17+, it is likely users will
continue to use them until they are finally removed.

Additional, add helpfull messages indicating what the problem might be
if `isCRIUSupportEnabled()` returns false.

Also, delay criu library load until `isCRIUSupportEnabled()` is called
to avoid throwing exceptions in the class initializer.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>