### PR TITLE
Standard SATB Barrier Implementation

### DIFF
--- a/runtime/gc_base/GenerationalAccessBarrierComponent.cpp
+++ b/runtime/gc_base/GenerationalAccessBarrierComponent.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,7 @@ MM_GenerationalAccessBarrierComponent::postObjectStore(J9VMThread *vmThread, J9O
  * to optimistically add an object to the remembered set without checking too hard.
  */
 void 
-MM_GenerationalAccessBarrierComponent::preBatchObjectStore(J9VMThread *vmThread, J9Object *dstObject)
+MM_GenerationalAccessBarrierComponent::postBatchObjectStore(J9VMThread *vmThread, J9Object *dstObject)
 {
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);

--- a/runtime/gc_base/GenerationalAccessBarrierComponent.hpp
+++ b/runtime/gc_base/GenerationalAccessBarrierComponent.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ public:
 	void tearDown(MM_EnvironmentBase *env);
 
 	void postObjectStore(J9VMThread *vmThread, J9Object *dstObject, J9Object *srcObject);
-	void preBatchObjectStore(J9VMThread *vmThread, J9Object *dstObject);
+	void postBatchObjectStore(J9VMThread *vmThread, J9Object *dstObject);
 	
 	MM_GenerationalAccessBarrierComponent()
 	{

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -2047,7 +2047,7 @@ MM_ObjectAccessBarrier::postObjectStore(J9VMThread *vmThread, J9Object **destAdd
  * TODO: This should probably be postBatchObjectStore, not pre-.
  */
 bool
-MM_ObjectAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile)
+MM_ObjectAccessBarrier::postBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile)
 {
 #if defined(J9VM_GC_COMBINATION_SPEC)
 	/* (assert here to verify that we aren't defaulting to this implementation through some unknown path - delete once combination is stable) */
@@ -2057,7 +2057,7 @@ MM_ObjectAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Object *dest
 }
 
 bool
-MM_ObjectAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile)
+MM_ObjectAccessBarrier::postBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile)
 {
 #if defined(J9VM_GC_COMBINATION_SPEC)
 	/* (assert here to verify that we aren't defaulting to this implementation through some unknown path - delete once combination is stable) */

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -256,8 +256,8 @@ public:
 	virtual void postObjectStore(J9VMThread *vmThread, J9Class *destClass, J9Object **destAddress, J9Object *value, bool isVolatile=false);
 	virtual void postObjectStore(J9VMThread *vmThread, J9Object **destAddress, J9Object *value, bool isVolatile=false);
 	
-	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
-	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
+	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
+	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
 
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Object *srcObject, fj9object_t *srcAddress);
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Class *srcClass, j9object_t *srcAddress);

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -698,7 +698,7 @@ J9WriteBarrierBatch(J9VMThread *vmThread, J9Object *dstObject)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread->javaVM)->accessBarrier;
 	/* In Metronome, write barriers are always pre-store */
-	barrier->preBatchObjectStore(vmThread, dstObject);	
+	barrier->postBatchObjectStore(vmThread, dstObject);
 }
 
 void
@@ -706,7 +706,7 @@ J9WriteBarrierClassBatch(J9VMThread *vmThread, J9Class *dstClazz)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread->javaVM)->accessBarrier;
 	/* In Metronome, write barriers are always pre-store */
-	barrier->preBatchObjectStore(vmThread, dstClazz);	
+	barrier->postBatchObjectStore(vmThread, dstClazz);
 }
 
 void

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,11 +103,11 @@ MM_GlobalCollectorDelegate::initialize(MM_EnvironmentBase *env, MM_GlobalCollect
 
 #if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 		if (1 == _extensions->fvtest_enableReadBarrierVerification) {
-			_extensions->accessBarrier = MM_ReadBarrierVerifier::newInstance(env);
+			_extensions->accessBarrier = MM_ReadBarrierVerifier::newInstance(env, _markingScheme);
 		} else
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 		{
-			_extensions->accessBarrier = MM_StandardAccessBarrier::newInstance(env);
+			_extensions->accessBarrier = MM_StandardAccessBarrier::newInstance(env, _markingScheme);
 		}
 
 		if (NULL == _extensions->accessBarrier) {

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,13 +44,13 @@
 #if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 
 MM_ReadBarrierVerifier *
-MM_ReadBarrierVerifier::newInstance(MM_EnvironmentBase *env)
+MM_ReadBarrierVerifier::newInstance(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme)
 {
 	MM_ReadBarrierVerifier *barrier;
 
 	barrier = (MM_ReadBarrierVerifier *)env->getForge()->allocate(sizeof(MM_ReadBarrierVerifier), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (barrier) {
-		new(barrier) MM_ReadBarrierVerifier(env);
+		new(barrier) MM_ReadBarrierVerifier(env, markingScheme);
 		if (!barrier->initialize(env)) {
 			barrier->kill(env);
 			barrier = NULL;

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,11 +48,11 @@ protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
 public:
-	static MM_ReadBarrierVerifier *newInstance(MM_EnvironmentBase *env);
+	static MM_ReadBarrierVerifier *newInstance(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme);
 	virtual void kill(MM_EnvironmentBase *env);
 
-	MM_ReadBarrierVerifier(MM_EnvironmentBase *env) :
-		MM_StandardAccessBarrier(env)
+	MM_ReadBarrierVerifier(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme) :
+		MM_StandardAccessBarrier(env, markingScheme)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -106,19 +106,19 @@ MM_VLHGCAccessBarrier::postObjectStore(J9VMThread *vmThread, J9Class *destClass,
 }
 
 bool 
-MM_VLHGCAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile)
+MM_VLHGCAccessBarrier::postBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile)
 {
-	preBatchObjectStoreImpl(vmThread, destObject);
+	postBatchObjectStoreImpl(vmThread, destObject);
 	
 	return true;
 }
 
 bool 
-MM_VLHGCAccessBarrier::preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile)
+MM_VLHGCAccessBarrier::postBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile)
 {
 	j9object_t destObject = J9VM_J9CLASS_TO_HEAPCLASS(destClass);
 	
-	preBatchObjectStoreImpl(vmThread, destObject);
+	postBatchObjectStoreImpl(vmThread, destObject);
 	
 	return true;
 }
@@ -167,7 +167,7 @@ MM_VLHGCAccessBarrier::postObjectStoreImpl(J9VMThread *vmThread, J9Object *dstOb
  * to optimistically add an object to the remembered set without checking too hard.
  */
 void 
-MM_VLHGCAccessBarrier::preBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject)
+MM_VLHGCAccessBarrier::postBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject)
 {
 	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(vmThread);
 	_extensions->cardTable->dirtyCard(env, dstObject);

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
@@ -45,7 +45,7 @@ class MM_VLHGCAccessBarrier : public MM_ObjectAccessBarrier
 {
 private:
 	void postObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject, J9Object *srcObject);
-	void preBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject);
+	void postBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject);
 	void copyArrayCritical(J9VMThread *vmThread, GC_ArrayObjectModel *indexableObjectModel,
 				J9InternalVMFunctions *functions, void **data,
 				J9IndexableObject *arrayObject, jboolean *isCopy);
@@ -74,8 +74,8 @@ public:
 
 	virtual void postObjectStore(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile=false);
 	virtual void postObjectStore(J9VMThread *vmThread, J9Class *destClass, J9Object **destAddress, J9Object *value, bool isVolatile=false);
-	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
-	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
+	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
+	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
 	virtual void recentlyAllocatedObject(J9VMThread *vmThread, J9Object *object); 
 	virtual void postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);
 	
@@ -93,7 +93,7 @@ public:
 	virtual void referenceReprocess(J9VMThread *vmThread, J9Object *refObject)
 	{
 		/* Equivalent to J9WriteBarrierBatchStore */
-		preBatchObjectStore(vmThread, refObject);
+		postBatchObjectStore(vmThread, refObject);
 	}
 };
 

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -543,7 +543,7 @@ allLiveClassesNextDo(J9ClassWalkState* state)
 	J9Class* clazzPtr = NULL;
 	J9Class* clazzPtrCandidate = NULL;
 	J9JavaVM* vm = state->vm;
-	const BOOLEAN needCheckInGC = (J9_GC_POLICY_METRONOME == vm->gcPolicy);
+	const BOOLEAN needCheckInGC = ((J9_GC_WRITE_BARRIER_TYPE_SATB == vm->gcWriteBarrierType) || (J9_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK == vm->gcWriteBarrierType));
 
 	do {
 		clazzPtrCandidate = allClassesNextDo(state);


### PR DESCRIPTION
These changes implement the the SATB access barriers, these have been adapted from the Realtime access barriers.

- Removed Double Barrier Code, Standard SATB does not make use of it

Adapted the following barrier from realtime for Standard SATB:

- forcedToFinalizableObject
- referenceGet
- referenceReprocess
- jniDeleteGlobalReference
- ~storeObjectToInternalVMSlotImpl~
- ~readObjectFromInternalVMSlotImpl~
- stringConstantEscaped / checkStringConstantsLive
checkClassLive

Signed-off-by: Salman Rana <salman.rana@ibm.com>