### PR TITLE
Avoid locking the CHTable at end of compilation if possible

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9439,11 +9439,12 @@ TR::CompilationInfoPerThreadBase::compile(
          _compInfo.getHWProfiler()->registerRecords(metaData, compiler);
          }
 
+      TR_CHTable *chTable = compiler->getCHTable();
+      if (chTable && !chTable->canSkipCommit(compiler))
          {
          TR::ClassTableCriticalSection chTableCommit(&vm);
          TR_ASSERT(!chTableCommit.acquiredVMAccess(), "We should have already acquired VM access at this point.");
-         TR_CHTable *chTable = compiler->getCHTable();
-         if (chTable && chTable->commit(compiler) == false)
+         if (chTable->commit(compiler) == false)
             {
             // If we created a TR_PersistentMethodInfo, fix the next compilation level
             // because if we retry the compilation we will fail an assume later on

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -215,11 +215,11 @@ class TR_PatchNOPedGuardSiteOnMethodBreakPoint : public TR::PatchNOPedGuardSite
                        uint8_t *location, uint8_t *destination)
       : TR::PatchNOPedGuardSite(pm, (uintptr_t)j9method, RuntimeAssumptionOnMethodBreakPoint, location, destination) {}
 
-   public: 
+   public:
    static TR_PatchNOPedGuardSiteOnMethodBreakPoint *make(
       TR_FrontEnd *fe, TR_PersistentMemory * pm, TR_OpaqueMethodBlock *j9method, uint8_t *location, uint8_t *destination,
       OMR::RuntimeAssumption **sentinel);
- 
+
    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnMethodBreakPoint; }
    };
 
@@ -406,6 +406,8 @@ class TR_CHTable
    bool recompileOnMethodOverride(TR::Compilation *c, TR_ResolvedMethod *method);
 
    void cleanupNewlyExtendedInfo(TR::Compilation *comp);
+
+   bool canSkipCommit(TR::Compilation *comp);
 
    // Commit the CHTable into the persistent table.  This method must be called
    // with the class table mutex in hand.


### PR DESCRIPTION
At the end of compilation the JIT acquires the VM class mutex
just before performing chtable.commit(). We can skip this lock acquire
operation if we test beforehand that a chtable.commit does not need
to be performed. This can speed up AOT loads and some JIT compilations,
because they don't have to wait for the VM class mutex.
Contention on the VM class mutex has been shown to be very heavy
in very large applications that load very many classes.

Partially addresses issue #13807

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>