### PR TITLE
Fix GCCheck class not found error

### DIFF
--- a/test/functional/cmdLineTests/gcCheck/build.xml
+++ b/test/functional/cmdLineTests/gcCheck/build.xml
@@ -32,7 +32,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gcCheck" />
 	<property name="src" location="./src"/>
-	<property name="allocator" location="${TEST_ROOT}/functional/Java8andUp/src/org/openj9/test/nogc"/>
 	<property name="build" location="./bin"/>
 
 	<target name="init">
@@ -49,7 +48,9 @@
 		<echo>===destdir:                      ${DEST}</echo>
 		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
-			<include name="${TEST_ROOT}/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java"/>
+			<src path="${TEST_ROOT}/functional/Java8andUp/src" />
+			<include name="org/openj9/test/nogc/Allocator.java" />
+			<include name="org/openj9/test/nogc/Main.java" />
 		</javac>
 	</target>
 

--- a/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
+++ b/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
@@ -40,6 +40,7 @@
   <exec command="rm -f $DUMPFILE$" />
   <command>$EXE$ -Xmx256m $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">System dump written</output>
+  <output regex="no" type="required">GCCheck Main class executed successfully</output>
  </test>
 
  <test id="Run gccheck">

--- a/test/functional/cmdLineTests/gcCheck/src/org/openj9/test/nogc/Main.java
+++ b/test/functional/cmdLineTests/gcCheck/src/org/openj9/test/nogc/Main.java
@@ -41,5 +41,7 @@ class Main {
 				e.printStackTrace();
 			}
 		}
+
+		System.out.println("GCCheck Main class executed successfully");
 	}
 }


### PR DESCRIPTION
- Fix GCCheck class not found error
- Add print info in Main class to be used as a required condition
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/12463
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>