### PR TITLE
Impose a limit on the compilation queue size

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -178,6 +178,7 @@ int32_t J9::Options::_qszThresholdToDowngradeOptLevel = -1; // not yet set
 int32_t J9::Options::_qsziThresholdToDowngradeDuringCLP = 0; // -1 or 0 disables the feature and reverts to old behavior
 int32_t J9::Options::_qszThresholdToDowngradeOptLevelDuringStartup = 100000; // a large number disables the feature
 int32_t J9::Options::_cpuUtilThresholdForStarvation = 25; // 25%
+int32_t J9::Options::_qszLimit = 5000; // when limit is reached the JIT will postpone new compilation requests
 
 // If too many GCR are queued we stop counting.
 // Use a large value to disable the feature. 400 is a good default
@@ -725,6 +726,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"compilationPriorityQSZThreshold=", "M<nnn>\tCompilation queue size threshold when priority of post-profiling"
                                "compilation requests is increased",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_compPriorityQSZThreshold , 0, "F%d", NOT_IN_SUBSET},
+   {"compilationQueueSizeLimit=", "R<nnn>\tWhen limit is reached, first-time compilations are postponed by replenishing the invocation count",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_qszLimit, 0, "F%d", NOT_IN_SUBSET},
    {"compilationThreadAffinityMask=", "M<nnn>\taffinity mask for compilation threads. Use hexa without 0x",
         TR::Options::setStaticHexadecimal, (intptr_t)&TR::Options::_compThreadAffinityMask, 0, "F%d", NOT_IN_SUBSET},
    {"compilationYieldStatsHeartbeatPeriod=", "M<nnn>\tperiodically print stats about compilation yield points "

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -100,7 +100,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static int32_t _veryHighActiveThreadThreshold;
    static int32_t getVeryHighActiveThreadThreshold() {return _veryHighActiveThreadThreshold;}
-   
+
    static int32_t _maxCheckcastProfiledClassTests;
    static int32_t getCheckcastMaxProfiledClassTests() {return _maxCheckcastProfiledClassTests;}
 
@@ -252,6 +252,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _qsziThresholdToDowngradeDuringCLP;
    static int32_t _qszThresholdToDowngradeOptLevelDuringStartup;
    static int32_t _cpuUtilThresholdForStarvation;
+   static int32_t _qszLimit; // maximum size of the compilation queue
    static int32_t _compPriorityQSZThreshold;
    static int32_t _GCRQueuedThresholdForCounting; // if too many GCR are queued we stop counting
    static int32_t _minimumSuperclassArraySize; //size of the minimum superclass array


### PR DESCRIPTION
In corner cases the compilation queue size can grow to tens of
thousand of entries. A large compilation queue adds overhead in
terms of memory and CPU (inserting an entry requires queue scanning
to find the proper place). To avoid these overheads, this commit
imposes a limit for the compilation queue size. When the limit is
reached, future asynchronous compilation requests for interpreted
methods are rejected, and the invocation count for the methods in
question is replenished. The rejected methods will continue to
run interpreted until their invocation count reaches 0 again.
Postponing such compilation requests is not expected to be detrimental
to performance because those methods would have waited a very
long time in the queue anyway.
This compilation queue size limit does not apply to recompilation
requests, to JNI methods (which don't use an invocation count) or
to synchronous requests which need to be processed as soon as possible.
The default value for the compilation queue size limit is set to 5000.
This value can be changed with -Xjit:compilationQueueSizeLimit=<NNN>
This feature can be disabled by setting a very large value for the
compilation queue size limit.

Partially addresses issue #13807

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>