### PR TITLE
Prevent FPE in scaleSizeBasedOnBlockFrequency() float to int32 cast

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4144,7 +4144,8 @@ int32_t TR_MultipleCallTargetInliner::scaleSizeBasedOnBlockFrequency(int32_t byt
       int adjFrequency = frequency ? frequency : 1;
 
       float factor = (float)adjFrequency / (float)maxFrequency;
-      bytecodeSize = (int32_t)((float)bytecodeSize / (factor*factor));
+      float weight = (float)bytecodeSize / (factor*factor);
+      bytecodeSize = (weight > 0x7fffffff) ? 0x7fffffff : ((int32_t)weight);
 
       heuristicTrace(tracer(),"exceedsSizeThreshold: Scaled up size for call from %d to %d", oldSize, bytecodeSize);
       }


### PR DESCRIPTION
Prevent a FPE when casting a float that is larger then 0x7fffffff
to an int32.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>