### PR TITLE
Update the FFI downcall code for primitives against JEP419 in Java18

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1560,15 +1560,49 @@ exit:
 			*returnStorage = (UDATA)*(U_32*)returnStorage;
 			break;
 		case J9NtcVoid:
-			*returnStorage = (UDATA)0;
+			/* Fall through is intentional */
+		case J9NtcLong:
+			/* Fall through is intentional */
+		case J9NtcDouble:
+			/* Fall through is intentional */
+		case J9NtcClass:
+			break;
+		}
+	}
+
+	/**
+	 * @brief Converts the type of the return value to the return type intended for JEP389/419 FFI downcall/upcall
+	 * @param currentThread[in] The pointer to the current J9VMThread
+	 * @param returnType[in] The type of the return value
+	 * @param returnStorage[in] The pointer to the return value
+	 */
+	static VMINLINE void
+	convertFFIReturnValue(J9VMThread* currentThread, U_8 returnType, UDATA* returnStorage)
+	{
+		switch (returnType) {
+		case J9NtcVoid:
+			currentThread->returnValue = (UDATA)0;
+			break;
+		case J9NtcBoolean:
+			currentThread->returnValue = (UDATA)(U_8)*returnStorage;
+			break;
+		case J9NtcByte:
+			currentThread->returnValue = (UDATA)(IDATA)(I_8)*returnStorage;
+			break;
+		case J9NtcShort:
+			currentThread->returnValue = (UDATA)(IDATA)(I_16)*returnStorage;
+			break;
+		case J9NtcInt:
+			currentThread->returnValue = (UDATA)(IDATA)(I_32)*returnStorage;
+			break;
+		case J9NtcFloat:
+			currentThread->returnValue = (UDATA)*(U_32*)returnStorage;
 			break;
 		case J9NtcLong:
 			/* Fall through is intentional */
 		case J9NtcDouble:
 			/* Fall through is intentional */
 		case J9NtcPointer:
-			/* Fall through is intentional */
-		case J9NtcClass:
 			break;
 		}
 	}

--- a/runtime/tests/clinkerffi/downcall.c
+++ b/runtime/tests/clinkerffi/downcall.c
@@ -21,8 +21,8 @@
  *******************************************************************************/
 
 /**
- * This file contains the native code used by org.openj9.test.jep389.downcall.PrimitiveTypeTests
- * via a Clinker FFI DownCall.
+ * This file contains the native code used by the test suites in org.openj9.test.jep389.downcall
+ * and org.openj9.test.jep419.downcall via a Clinker FFI DownCall.
  *
  * Created by jincheng@ca.ibm.com
  */
@@ -126,10 +126,10 @@ add2IntsReturnVoid(int intArg1, int intArg2)
  * @param boolArg2 the 2nd boolean
  * @return the result of the OR operation
  */
-int
-add2BoolsWithOr(int boolArg1, int boolArg2)
+bool
+add2BoolsWithOr(bool boolArg1, bool boolArg2)
 {
-	int result = (boolArg1 || boolArg2);
+	bool result = (boolArg1 || boolArg2);
 	return result;
 }
 
@@ -140,10 +140,10 @@ add2BoolsWithOr(int boolArg1, int boolArg2)
  * @param boolArg2 a pointer to boolean
  * @return the result of the OR operation
  */
-int
-addBoolAndBoolFromPointerWithOr(int boolArg1, int *boolArg2)
+bool
+addBoolAndBoolFromPointerWithOr(bool boolArg1, bool *boolArg2)
 {
-	int result = (boolArg1 || *boolArg2);
+	bool result = (boolArg1 || *boolArg2);
 	return result;
 }
 

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -262,6 +262,8 @@ doneGetArrayFFIType:
 		case 'V':	/* VOID */
 			typeFFI = &ffi_type_void;
 			break;
+		case 'B':	/* C_BOOL */
+			typeFFI = &ffi_type_uint8;
 		case 'C':	/* C_CHAR */
 			typeFFI = &ffi_type_sint8;
 			break;

--- a/runtime/vm/OutOfLineINL_jdk_internal_foreign_abi_ProgrammableInvoker.cpp
+++ b/runtime/vm/OutOfLineINL_jdk_internal_foreign_abi_ProgrammableInvoker.cpp
@@ -44,6 +44,7 @@ OutOfLineINL_jdk_internal_foreign_abi_ProgrammableInvoker_resolveRequiredFields(
 				J9VMCONSTANTPOOL_JDKINTERNALFOREIGNABIPROGRAMMABLEINVOKER_ARGTYPESADDR
 			};
 
+	VM_OutOfLineINL_Helpers::buildInternalNativeStackFrame(currentThread, method);
 	for (int i = 0; i < cpEntryNum; i++) {
 		J9RAMFieldRef *cpFieldRef = ((J9RAMFieldRef*)jclConstantPool) + cpIndex[i];
 		UDATA const flags = cpFieldRef->flags;
@@ -57,6 +58,7 @@ OutOfLineINL_jdk_internal_foreign_abi_ProgrammableInvoker_resolveRequiredFields(
 			}
 		}
 	}
+	VM_OutOfLineINL_Helpers::restoreInternalNativeStackFrame(currentThread);
 
 done:
 	VM_OutOfLineINL_Helpers::returnVoid(currentThread, 0);

--- a/test/functional/Java17andUp/src/org/openj9/test/java/lang/DummyClass.java
+++ b/test/functional/Java17andUp/src/org/openj9/test/java/lang/DummyClass.java
@@ -1,0 +1,35 @@
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+/**
+ * A placeholder class in Java 17 which can be replaced if any test case
+ * is added here.
+ */
+@Test(enabled=false)
+ public class DummyClass {
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/InvalidDownCallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/InvalidDownCallTests.java
@@ -27,16 +27,17 @@ import org.testng.AssertJUnit;
 import static org.testng.Assert.fail;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.ValueLayout;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.ValueLayout;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
@@ -58,7 +59,7 @@ public class InvalidDownCallTests {
 	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The return type must be .*")
 	public void test_invalidBooleanTypeOnReturn() throws Throwable {
 		MethodType mt = MethodType.methodType(Boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		fail("Failed to throw out IllegalArgumentException in the case of the Boolean return type");
@@ -67,7 +68,7 @@ public class InvalidDownCallTests {
 	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The passed-in argument type at index .*")
 	public void test_invalidBooleanTypeArgument() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, Boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		fail("Failed to throw out IllegalArgumentException in the case of the Boolean argument");
@@ -247,7 +248,7 @@ public class InvalidDownCallTests {
 	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Mismatched size .*")
 	public void test_mismatchedBoolArgWithShortLayout() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_SHORT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_SHORT, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		fail("Failed to throw out IllegalArgumentException in the case of the mismatched layout");

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiCallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiCallTests.java
@@ -26,12 +26,13 @@ import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
@@ -145,13 +146,5 @@ public class MultiCallTests {
 		Addressable functionSymbol2 = nativeLibLookup.lookup("add2IntsReturnVoid").get();
 		mh = clinker.downcallHandle(functionSymbol2, mt2, fd2);
 		mh.invokeExact(454, 398);
-
-		MethodType mt3 = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		Addressable functionSymbol3 = nativeLibLookup.lookup("add2BoolsWithOr").get();
-		mh = clinker.downcallHandle(functionSymbol3, mt3, fd);
-		boolean boolResult = (boolean)mh.invokeExact(true, false);
-		Assert.assertEquals(boolResult, true);
-		boolResult = (boolean)mh.invokeExact(false, false);
-		Assert.assertEquals(boolResult, false);
 	}
 }

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests1.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests1.java
@@ -26,19 +26,20 @@ import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
- * which verifies the downcalls with the diffrent return types in multithreading.
+ * which verifies the downcalls with the same layout & argument and return types in multithreading.
  */
 @Test(groups = { "level.sanity" })
-public class MultiThreadingTests3 implements Thread.UncaughtExceptionHandler {
+public class MultiThreadingTests1 implements Thread.UncaughtExceptionHandler {
 	private volatile Throwable initException;
 	private static CLinker clinker = CLinker.getInstance();
 
@@ -54,7 +55,7 @@ public class MultiThreadingTests3 implements Thread.UncaughtExceptionHandler {
 	}
 
 	@Test
-	public void test_twoThreadsWithDiffReturnType() throws Throwable {
+	public void test_twoThreadsWithSameFuncDescriptor() throws Throwable {
 		Thread thr1 = new Thread(){
 			public void run() {
 				try {
@@ -69,25 +70,24 @@ public class MultiThreadingTests3 implements Thread.UncaughtExceptionHandler {
 				}
 			}
 		};
+		thr1.setUncaughtExceptionHandler(this);
+		thr1.start();
 
 		Thread thr2 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(void.class, int.class, int.class);
-					FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+					MethodType mt = MethodType.methodType(int.class, int.class, int.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
 					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
-					mh.invokeExact(454, 398);
+					int result = (int)mh.invokeExact(235, 439);
+					Assert.assertEquals(result, 674);
 				} catch (Throwable t) {
 					throw new RuntimeException(t);
 				}
 			}
 		};
-
-		thr1.setUncaughtExceptionHandler(this);
 		thr2.setUncaughtExceptionHandler(this);
-
-		thr1.start();
 		thr2.start();
 
 		thr1.join();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests2.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests2.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep389.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.CLinker;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
+
+/**
+ * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
+ * which verifies the downcalls with the diffrent layouts and arguments/return types in multithreading.
+ */
+@Test(groups = { "level.sanity" })
+public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
+	private volatile Throwable initException;
+	private static CLinker clinker = CLinker.getInstance();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(enabled=false)
+	@Override
+	public void uncaughtException(Thread thr, Throwable t) {
+		initException =  t;
+	}
+
+	@Test
+	public void test_twoThreadsWithDiffFuncDescriptor() throws Throwable {
+		Thread thr1 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(int.class, int.class, int.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					int result = (int)mh.invokeExact(112, 123);
+					Assert.assertEquals(result, 235);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr2 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(int.class, int.class, int.class, int.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT, C_INT);
+					Addressable functionSymbol = nativeLibLookup.lookup("add3Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					int result = (int)mh.invokeExact(112, 123, 235);
+					Assert.assertEquals(result, 470);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		thr1.setUncaughtExceptionHandler(this);
+		thr2.setUncaughtExceptionHandler(this);
+
+		thr1.start();
+		thr2.start();
+
+		thr1.join();
+		thr2.join();
+
+		if (initException != null){
+			throw new RuntimeException(initException);
+		}
+	}
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests4.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/MultiThreadingTests4.java
@@ -26,19 +26,20 @@ import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
- * which verifies the downcalls with the diffrent layouts and arguments/return types in multithreading.
+ * which verifies multiple downcalls combined with the diffrent layouts/arguments/return types in multithreading.
  */
 @Test(groups = { "level.sanity" })
-public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
+public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 	private volatile Throwable initException;
 	private static CLinker clinker = CLinker.getInstance();
 
@@ -54,7 +55,7 @@ public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 	}
 
 	@Test
-	public void test_twoThreadsWithDiffFuncDescriptor() throws Throwable {
+	public void test_multiThreadsWithMixedFuncDescriptors() throws Throwable {
 		Thread thr1 = new Thread(){
 			public void run() {
 				try {
@@ -62,8 +63,8 @@ public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
 					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
 					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
-					int result = (int)mh.invokeExact(112, 123);
-					Assert.assertEquals(result, 235);
+					int result = (int)mh.invokeExact(128, 246);
+					Assert.assertEquals(result, 374);
 				} catch (Throwable t) {
 					throw new RuntimeException(t);
 				}
@@ -77,8 +78,68 @@ public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT, C_INT);
 					Addressable functionSymbol = nativeLibLookup.lookup("add3Ints").get();
 					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
-					int result = (int)mh.invokeExact(112, 123, 235);
-					Assert.assertEquals(result, 470);
+					int result = (int)mh.invokeExact(112, 642, 971);
+					Assert.assertEquals(result, 1725);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr3 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
+					Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					boolean result = (boolean)mh.invokeExact(true, false);
+					Assert.assertEquals(result, true);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr4 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(int.class, int.class, int.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					int result = (int)mh.invokeExact(416, 728);
+					Assert.assertEquals(result, 1144);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr5 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(int.class, int.class, int.class, int.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT, C_INT);
+					Addressable functionSymbol = nativeLibLookup.lookup("add3Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					int result = (int)mh.invokeExact(1012, 1023, 2035);
+					Assert.assertEquals(result, 4070);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr6 = new Thread(){
+			public void run() {
+				try {
+					MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
+					FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
+					Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					boolean result = (boolean)mh.invokeExact(false, false);
+					Assert.assertEquals(result, false);
 				} catch (Throwable t) {
 					throw new RuntimeException(t);
 				}
@@ -87,12 +148,24 @@ public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 
 		thr1.setUncaughtExceptionHandler(this);
 		thr2.setUncaughtExceptionHandler(this);
+		thr3.setUncaughtExceptionHandler(this);
+		thr4.setUncaughtExceptionHandler(this);
+		thr5.setUncaughtExceptionHandler(this);
+		thr6.setUncaughtExceptionHandler(this);
 
 		thr1.start();
 		thr2.start();
+		thr3.start();
+		thr4.start();
+		thr5.start();
+		thr6.start();
 
-		thr1.join();
+		thr6.join();
+		thr5.join();
+		thr4.join();
+		thr3.join();
 		thr2.join();
+		thr1.join();
 
 		if (initException != null){
 			throw new RuntimeException(initException);

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests1.java
@@ -26,34 +26,34 @@ import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import static jdk.incubator.foreign.CLinker.VaList.Builder;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.ValueLayout;
-import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
-import jdk.incubator.foreign.SegmentAllocator;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.ValueLayout;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
  * which covers generic tests, tests with the void type, the MemoryAddress type, and the vararg list.
  *
  * Note: the test suite is intended for the following Clinker API:
- * MethodHandle downcallHandle(Addressable symbol, SegmentAllocator allocator, MethodType type, FunctionDescriptor function)
+ * MethodHandle downcallHandle(Addressable symbol, MethodType type, FunctionDescriptor function)
  */
 @Test(groups = { "level.sanity" })
-public class PrimitiveTypeTests2 {
+public class PrimitiveTypeTests1 {
 	private static boolean isWinOS = System.getProperty("os.name").toLowerCase().contains("win");
 	private static ValueLayout longLayout = isWinOS ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();
 	private static ResourceScope resourceScope = ResourceScope.newImplicitScope();
-	private static SegmentAllocator allocator = SegmentAllocator.ofScope(resourceScope);
 
 	static {
 		System.loadLibrary("clinkerffitests");
@@ -62,55 +62,55 @@ public class PrimitiveTypeTests2 {
 	private static final SymbolLookup defaultLibLookup = CLinker.systemLookup();
 
 	@Test
-	public void test_addTwoBoolsWithOr_2() throws Throwable {
+	public void test_addTwoBoolsWithOr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		boolean result = (boolean)mh.invokeExact(true, false);
 		Assert.assertEquals(result, true);
 	}
 
 	@Test
-	public void test_addBoolAndBoolFromPointerWithOr_2() throws Throwable {
+	public void test_addBoolAndBoolFromPointerWithOr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, MemoryAddress.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_POINTER);
 		Addressable functionSymbol = nativeLibLookup.lookup("addBoolAndBoolFromPointerWithOr").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
-		MemorySegment intSegmt = MemorySegment.allocateNative(C_INT, resourceScope);
-		MemoryAccess.setInt(intSegmt, 1);
-		boolean result = (boolean)mh.invokeExact(false, intSegmt.address());
+		MemorySegment boolSegmt = MemorySegment.allocateNative(C_CHAR, resourceScope);
+		MemoryAccess.setByte(boolSegmt, (byte)1);
+		boolean result = (boolean)mh.invokeExact(false, boolSegmt.address());
 		Assert.assertEquals(result, true);
 	}
 
 	@Test
-	public void test_addTwoBoolsWithOr_fromMemAddr_2() throws Throwable {
+	public void test_addTwoBoolsWithOr_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		boolean result = (boolean)mh.invokeExact(true, false);
 		Assert.assertEquals(result, true);
 	}
 
 	@Test
-	public void test_generateNewChar_2() throws Throwable {
+	public void test_generateNewChar_1() throws Throwable {
 		MethodType mt = MethodType.methodType(char.class, char.class, char.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("createNewCharFrom2Chars").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		char result = (char)mh.invokeExact('B', 'D');
 		Assert.assertEquals(result, 'C');
 	}
 
 	@Test
-	public void test_generateNewCharFromPointer_2() throws Throwable {
+	public void test_generateNewCharFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(char.class, MemoryAddress.class, char.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_POINTER, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("createNewCharFromCharAndCharFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment shortSegmt = MemorySegment.allocateNative(C_SHORT, resourceScope);
 		MemoryAccess.setChar(shortSegmt, 'B');
@@ -119,42 +119,42 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_generateNewChar_fromMemAddr_2() throws Throwable {
+	public void test_generateNewChar_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(char.class, char.class, char.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("createNewCharFrom2Chars").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		char result = (char)mh.invokeExact('B', 'D');
 		Assert.assertEquals(result, 'C');
 	}
 
 	@Test
-	public void test_addTwoBytes_2() throws Throwable {
+	public void test_addTwoBytes_1() throws Throwable {
 		MethodType mt = MethodType.methodType(byte.class, byte.class, byte.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		byte result = (byte)mh.invokeExact((byte)6, (byte)3);
 		Assert.assertEquals(result, (byte)9);
 	}
 
 	@Test
-	public void test_addTwoNegtiveBytes_2() throws Throwable {
+	public void test_addTwoNegtiveBytes_1() throws Throwable {
 		MethodType mt = MethodType.methodType(byte.class, byte.class, byte.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		byte result = (byte)mh.invokeExact((byte)-6, (byte)-3);
 		Assert.assertEquals(result, (byte)-9);
 	}
 
 	@Test
-	public void test_addByteAndByteFromPointer_2() throws Throwable {
+	public void test_addByteAndByteFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(byte.class, byte.class, MemoryAddress.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_POINTER);
 		Addressable functionSymbol = nativeLibLookup.lookup("addByteAndByteFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment charSegmt = MemorySegment.allocateNative(C_CHAR, resourceScope);
 		MemoryAccess.setByte(charSegmt, (byte)3);
@@ -163,42 +163,42 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoBytes_fromMemAddr_2() throws Throwable {
+	public void test_addTwoBytes_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(byte.class, byte.class, byte.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		byte result = (byte)mh.invokeExact((byte)6, (byte)3);
 		Assert.assertEquals(result, (byte)9);
 	}
 
 	@Test
-	public void test_addTwoShorts_2() throws Throwable {
+	public void test_addTwoShorts_1() throws Throwable {
 		MethodType mt = MethodType.methodType(short.class, short.class, short.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		short result = (short)mh.invokeExact((short)24, (short)32);
 		Assert.assertEquals(result, (short)56);
 	}
 
 	@Test
-	public void test_addTwoNegtiveShorts_2() throws Throwable {
+	public void test_addTwoNegtiveShorts_1() throws Throwable {
 		MethodType mt = MethodType.methodType(short.class, short.class, short.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		short result = (short)mh.invokeExact((short)-24, (short)-32);
 		Assert.assertEquals(result, (short)-56);
 	}
 
 	@Test
-	public void test_addShortAndShortFromPointer_2() throws Throwable {
+	public void test_addShortAndShortFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(short.class, MemoryAddress.class, short.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_POINTER, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("addShortAndShortFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment shortSegmt = MemorySegment.allocateNative(C_SHORT, resourceScope);
 		MemoryAccess.setShort(shortSegmt, (short)24);
@@ -207,42 +207,42 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoShorts_fromMemAddr_2() throws Throwable {
+	public void test_addTwoShorts_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(short.class, short.class, short.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		short result = (short)mh.invokeExact((short)24, (short)32);
 		Assert.assertEquals(result, (short)56);
 	}
 
 	@Test
-	public void test_addTwoInts_2() throws Throwable {
+	public void test_addTwoInts_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		int result = (int)mh.invokeExact(112, 123);
 		Assert.assertEquals(result, 235);
 	}
 
 	@Test
-	public void test_addTwoNegtiveInts_2() throws Throwable {
+	public void test_addTwoNegtiveInts_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		int result = (int)mh.invokeExact(-112, -123);
 		Assert.assertEquals(result, -235);
 	}
 
 	@Test
-	public void test_addIntAndIntFromPointer_2() throws Throwable {
+	public void test_addIntAndIntFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, MemoryAddress.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
 		Addressable functionSymbol = nativeLibLookup.lookup("addIntAndIntFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment intSegmt = MemorySegment.allocateNative(C_INT, resourceScope);
 		MemoryAccess.setInt(intSegmt, 215);
@@ -251,18 +251,18 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoInts_fromMemAddr_2() throws Throwable {
+	public void test_addTwoInts_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		int result = (int)mh.invokeExact(112, 123);
 		Assert.assertEquals(result, 235);
 	}
 
 	@Test
-	public void test_addIntsWithVaList_2() throws Throwable {
+	public void test_addIntsWithVaList_1() throws Throwable {
 		Addressable functionSymbol = nativeLibLookup.lookup("addIntsFromVaList").get();
 		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_VA_LIST);
@@ -270,67 +270,67 @@ public class PrimitiveTypeTests2 {
 				.vargFromInt(C_INT, 800)
 				.vargFromInt(C_INT, 900)
 				.vargFromInt(C_INT, 1000), resourceScope);
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		int result = (int)mh.invoke(4, vaList);
 		Assert.assertEquals(result, 3400);
 	}
 
 	@Test
-	public void test_addTwoIntsReturnVoid_2() throws Throwable {
+	public void test_addTwoIntsReturnVoid_1() throws Throwable {
 		MethodType mt = MethodType.methodType(void.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_INT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		mh.invokeExact(454, 398);
 	}
 
 	@Test
-	public void test_addTwoIntsReturnVoid_fromMemAddr_2() throws Throwable {
+	public void test_addTwoIntsReturnVoid_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(void.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_INT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		mh.invokeExact(454, 398);
 	}
 
 	@Test
-	public void test_addIntAndChar_2() throws Throwable {
+	public void test_addIntAndChar_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, char.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("addIntAndChar").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		int result = (int)mh.invokeExact(58, 'A');
 		Assert.assertEquals(result, 123);
 	}
 
 	@Test
-	public void test_addIntAndChar_fromMemAddr_2() throws Throwable {
+	public void test_addIntAndChar_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(int.class, int.class, char.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_SHORT);
 		Addressable functionSymbol = nativeLibLookup.lookup("addIntAndChar").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		int result = (int)mh.invokeExact(58, 'A');
 		Assert.assertEquals(result, 123);
 	}
 
 	@Test
-	public void test_addTwoLongs_2() throws Throwable {
+	public void test_addTwoLongs_1() throws Throwable {
 		MethodType mt = MethodType.methodType(long.class, long.class, long.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, longLayout, longLayout);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Longs").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		long result = (long)mh.invokeExact(57424L, 698235L);
 		Assert.assertEquals(result, 755659L);
 	}
 
 	@Test
-	public void test_addLongAndLongFromPointer_2() throws Throwable {
+	public void test_addLongAndLongFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(long.class, MemoryAddress.class, long.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_POINTER, longLayout);
 		Addressable functionSymbol = nativeLibLookup.lookup("addLongAndLongFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment longSegmt = MemorySegment.allocateNative(longLayout, resourceScope);
 		MemoryAccess.setLong(longSegmt, 57424L);
@@ -339,18 +339,18 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoLongs_fromMemAddr_2() throws Throwable {
+	public void test_addTwoLongs_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(long.class, long.class, long.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, longLayout, longLayout);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Longs").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		long result = (long)mh.invokeExact(57424L, 698235L);
 		Assert.assertEquals(result, 755659L);
 	}
 
 	@Test
-	public void test_addLongsWithVaList_2() throws Throwable {
+	public void test_addLongsWithVaList_1() throws Throwable {
 		Addressable functionSymbol = nativeLibLookup.lookup("addLongsFromVaList").get();
 		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_VA_LIST);
@@ -358,27 +358,27 @@ public class PrimitiveTypeTests2 {
 				.vargFromLong(longLayout, 800000L)
 				.vargFromLong(longLayout, 900000L)
 				.vargFromLong(longLayout, 1000000L), resourceScope);
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		long result = (long)mh.invoke(4, vaList);
 		Assert.assertEquals(result, 3400000L);
 	}
 
 	@Test
-	public void test_addTwoFloats_2() throws Throwable {
+	public void test_addTwoFloats_1() throws Throwable {
 		MethodType mt = MethodType.methodType(float.class, float.class, float.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_FLOAT, C_FLOAT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Floats").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		float result = (float)mh.invokeExact(5.74f, 6.79f);
 		Assert.assertEquals(result, 12.53f, 0.01f);
 	}
 
 	@Test
-	public void test_addFloatAndFloatFromPointer_2() throws Throwable {
+	public void test_addFloatAndFloatFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(float.class, float.class, MemoryAddress.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_FLOAT, C_POINTER);
 		Addressable functionSymbol = nativeLibLookup.lookup("addFloatAndFloatFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment floatSegmt = MemorySegment.allocateNative(C_FLOAT, resourceScope);
 		MemoryAccess.setFloat(floatSegmt, 6.79f);
@@ -387,32 +387,32 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoFloats_fromMemAddr_2() throws Throwable {
+	public void test_addTwoFloats_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(float.class, float.class, float.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_FLOAT, C_FLOAT);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Floats").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		float result = (float)mh.invokeExact(5.74f, 6.79f);
 		Assert.assertEquals(result, 12.53f, 0.01f);
 	}
 
 	@Test
-	public void test_addTwoDoubles_2() throws Throwable {
+	public void test_addTwoDoubles_1() throws Throwable {
 		MethodType mt = MethodType.methodType(double.class, double.class, double.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_DOUBLE, C_DOUBLE);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Doubles").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		double result = (double)mh.invokeExact(159.748d, 262.795d);
 		Assert.assertEquals(result, 422.543d, 0.001d);
 	}
 
 	@Test
-	public void test_addDoubleAndDoubleFromPointer_2() throws Throwable {
+	public void test_addDoubleAndDoubleFromPointer_1() throws Throwable {
 		MethodType mt = MethodType.methodType(double.class, MemoryAddress.class, double.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_DOUBLE);
 		Addressable functionSymbol = nativeLibLookup.lookup("addDoubleAndDoubleFromPointer").get();
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 
 		MemorySegment doubleSegmt = MemorySegment.allocateNative(C_DOUBLE, resourceScope);
 		MemoryAccess.setDouble(doubleSegmt, 159.748d);
@@ -421,18 +421,18 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_addTwoDoubles_fromMemAddr_2() throws Throwable {
+	public void test_addTwoDoubles_fromMemAddr_1() throws Throwable {
 		MethodType mt = MethodType.methodType(double.class, double.class, double.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_DOUBLE, C_DOUBLE);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2Doubles").get();
 		MemoryAddress memAddr = functionSymbol.address();
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		double result = (double)mh.invokeExact(159.748d, 262.795d);
 		Assert.assertEquals(result, 422.543d, 0.001d);
 	}
 
 	@Test
-	public void test_addDoublesWithVaList_2() throws Throwable {
+	public void test_addDoublesWithVaList_1() throws Throwable {
 		Addressable functionSymbol = nativeLibLookup.lookup("addDoublesFromVaList").get();
 		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_VA_LIST);
@@ -440,40 +440,40 @@ public class PrimitiveTypeTests2 {
 				.vargFromDouble(C_DOUBLE, 160.2002D)
 				.vargFromDouble(C_DOUBLE, 170.1001D)
 				.vargFromDouble(C_DOUBLE, 180.2002D), resourceScope);
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		double result = (double)mh.invoke(4, vaList);
 		Assert.assertEquals(result, 660.6006D);
 	}
 
 	@Test
-	public void test_strlenFromDefaultLibWithMemAddr_2() throws Throwable {
+	public void test_strlenFromDefaultLibWithMemAddr_1() throws Throwable {
 		Addressable strlenSymbol = defaultLibLookup.lookup("strlen").get();
 		MethodType mt = MethodType.methodType(long.class, MemoryAddress.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_POINTER);
-		MethodHandle mh = clinker.downcallHandle(strlenSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(strlenSymbol, mt, fd);
 		MemorySegment funcMemSegment = CLinker.toCString("JEP389 DOWNCALL TEST SUITES", resourceScope);
 		long strLength = (long)mh.invokeExact(funcMemSegment.address());
 		Assert.assertEquals(strLength, 27);
 	}
 
 	@Test
-	public void test_strlenFromDefaultLibWithMemAddr_fromMemAddr_2() throws Throwable {
+	public void test_strlenFromDefaultLibWithMemAddr_fromMemAddr_1() throws Throwable {
 		Addressable strlenSymbol = defaultLibLookup.lookup("strlen").get();
 		MemoryAddress memAddr = strlenSymbol.address();
 		MethodType mt = MethodType.methodType(long.class, MemoryAddress.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_POINTER);
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		MemorySegment funcMemSegment = CLinker.toCString("JEP389 DOWNCALL TEST SUITES", resourceScope);
 		long strLength = (long)mh.invokeExact(funcMemSegment.address());
 		Assert.assertEquals(strLength, 27);
 	}
 
 	@Test
-	public void test_memoryAllocFreeFromDefaultLib_2() throws Throwable {
+	public void test_memoryAllocFreeFromDefaultLib_1() throws Throwable {
 		Addressable allocSymbol = defaultLibLookup.lookup("malloc").get();
 		MethodType allocMethodType = MethodType.methodType(MemoryAddress.class, long.class);
 		FunctionDescriptor allocFuncDesc = FunctionDescriptor.of(C_POINTER, longLayout);
-		MethodHandle allocHandle = clinker.downcallHandle(allocSymbol, allocator, allocMethodType, allocFuncDesc);
+		MethodHandle allocHandle = clinker.downcallHandle(allocSymbol, allocMethodType, allocFuncDesc);
 		MemoryAddress allocMemAddr = (MemoryAddress)allocHandle.invokeExact(10L);
 		MemorySegment memSeg = allocMemAddr.asSegment(10L, resourceScope);
 		MemoryAccess.setIntAtOffset(memSeg, 0, 15);
@@ -482,17 +482,17 @@ public class PrimitiveTypeTests2 {
 		Addressable freeSymbol = defaultLibLookup.lookup("free").get();
 		MethodType freeMethodType = MethodType.methodType(void.class, MemoryAddress.class);
 		FunctionDescriptor freeFuncDesc = FunctionDescriptor.ofVoid(C_POINTER);
-		MethodHandle freeHandle = clinker.downcallHandle(freeSymbol, allocator, freeMethodType, freeFuncDesc);
+		MethodHandle freeHandle = clinker.downcallHandle(freeSymbol, freeMethodType, freeFuncDesc);
 		freeHandle.invokeExact(allocMemAddr);
 	}
 
 	@Test
-	public void test_memoryAllocFreeFromDefaultLib_fromMemAddr_2() throws Throwable {
+	public void test_memoryAllocFreeFromDefaultLib_fromMemAddr_1() throws Throwable {
 		Addressable allocSymbol = defaultLibLookup.lookup("malloc").get();
 		MemoryAddress allocMemAddrFromSymbol = allocSymbol.address();
 		MethodType allocMethodType = MethodType.methodType(MemoryAddress.class, long.class);
 		FunctionDescriptor allocFuncDesc = FunctionDescriptor.of(C_POINTER, longLayout);
-		MethodHandle allocHandle = clinker.downcallHandle(allocMemAddrFromSymbol, allocator, allocMethodType, allocFuncDesc);
+		MethodHandle allocHandle = clinker.downcallHandle(allocMemAddrFromSymbol, allocMethodType, allocFuncDesc);
 		MemoryAddress allocMemAddr = (MemoryAddress)allocHandle.invokeExact(10L);
 		MemorySegment memSeg = allocMemAddr.asSegment(10L, resourceScope);
 		MemoryAccess.setIntAtOffset(memSeg, 0, 15);
@@ -502,12 +502,12 @@ public class PrimitiveTypeTests2 {
 		MemoryAddress freeMemAddr = freeSymbol.address();
 		MethodType freeMethodType = MethodType.methodType(void.class, MemoryAddress.class);
 		FunctionDescriptor freeFuncDesc = FunctionDescriptor.ofVoid(C_POINTER);
-		MethodHandle freeHandle = clinker.downcallHandle(freeMemAddr, allocator, freeMethodType, freeFuncDesc);
+		MethodHandle freeHandle = clinker.downcallHandle(freeMemAddr, freeMethodType, freeFuncDesc);
 		freeHandle.invokeExact(allocMemAddr);
 	}
 
 	@Test
-	public void test_memoryAllocFreeFromCLinkerMethod_2() throws Throwable {
+	public void test_memoryAllocFreeFromCLinkerMethod_1() throws Throwable {
 		MemoryAddress allocMemAddr = CLinker.allocateMemory(10L);
 		MemorySegment memSeg = allocMemAddr.asSegment(10L, resourceScope);
 		MemoryAccess.setIntAtOffset(memSeg, 0, 49);
@@ -516,28 +516,28 @@ public class PrimitiveTypeTests2 {
 	}
 
 	@Test
-	public void test_printfFromDefaultLibWithMemAddr_2() throws Throwable {
+	public void test_printfFromDefaultLibWithMemAddr_1() throws Throwable {
 		Addressable functionSymbol = defaultLibLookup.lookup("printf").get();
 		MethodType mt = MethodType.methodType(int.class, MemoryAddress.class, int.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_POINTER, C_INT, C_INT, C_INT);
-		MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 		MemorySegment formatMemSegment = CLinker.toCString("\n%d + %d = %d\n", resourceScope);
 		mh.invoke(formatMemSegment.address(), 15, 27, 42);
 	}
 
 	@Test
-	public void test_printfFromDefaultLibWithMemAddr_fromMemAddr_2() throws Throwable {
+	public void test_printfFromDefaultLibWithMemAddr_fromMemAddr_1() throws Throwable {
 		Addressable functionSymbol = defaultLibLookup.lookup("printf").get();
 		MemoryAddress memAddr = functionSymbol.address();
 		MethodType mt = MethodType.methodType(int.class, MemoryAddress.class, int.class, int.class, int.class);
 		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_POINTER, C_INT, C_INT, C_INT);
-		MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+		MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 		MemorySegment formatMemSegment = CLinker.toCString("\n%d + %d = %d\n", resourceScope);
 		mh.invoke(formatMemSegment.address(), 15, 27, 42);
 	}
 
 	@Test
-	public void test_vprintfFromDefaultLibWithVaList_2() throws Throwable {
+	public void test_vprintfFromDefaultLibWithVaList_1() throws Throwable {
 		/* Disable the test on Windows given a misaligned access exception coming from
 		 * java.base/java.lang.invoke.MemoryAccessVarHandleBase triggered by CLinker.toCString()
 		 * is also captured on OpenJDK/Hotspot.
@@ -550,13 +550,13 @@ public class PrimitiveTypeTests2 {
 			VaList vaList = CLinker.VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 7)
 					.vargFromInt(C_INT, 8)
 					.vargFromInt(C_INT, 56), resourceScope);
-			MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
 			mh.invoke(formatMemSegment.address(), vaList);
 		}
 	}
 
 	@Test
-	public void test_vprintfFromDefaultLibWithVaList_fromMemAddr_2() throws Throwable {
+	public void test_vprintfFromDefaultLibWithVaList_fromMemAddr_1() throws Throwable {
 		/* Disable the test on Windows given a misaligned access exception coming from
 		 * java.base/java.lang.invoke.MemoryAccessVarHandleBase triggered by CLinker.toCString()
 		 * is also captured on OpenJDK/Hotspot.
@@ -570,7 +570,7 @@ public class PrimitiveTypeTests2 {
 			VaList vaList = CLinker.VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 7)
 					.vargFromInt(C_INT, 8)
 					.vargFromInt(C_INT, 56), resourceScope);
-			MethodHandle mh = clinker.downcallHandle(memAddr, allocator, mt, fd);
+			MethodHandle mh = clinker.downcallHandle(memAddr, mt, fd);
 			mh.invoke(formatMemSegment.address(), vaList);
 		}
 	}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests3.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests3.java
@@ -26,19 +26,20 @@ import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
 import static jdk.incubator.foreign.CLinker.VaList.Builder;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.ValueLayout;
-import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.Addressable;
-import jdk.incubator.foreign.SymbolLookup;
-import jdk.incubator.foreign.SegmentAllocator;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.ValueLayout;
 
 /**
  * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
@@ -64,7 +65,7 @@ public class PrimitiveTypeTests3 {
 	@Test
 	public void test_addTwoBoolsWithOr_3() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MethodHandle mh = clinker.downcallHandle(mt, fd);
 		boolean result = (boolean)mh.invokeExact(functionSymbol, true, false);
@@ -74,20 +75,20 @@ public class PrimitiveTypeTests3 {
 	@Test
 	public void test_addBoolAndBoolFromPointerWithOr_3() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, MemoryAddress.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_POINTER);
 		Addressable functionSymbol = nativeLibLookup.lookup("addBoolAndBoolFromPointerWithOr").get();
 		MethodHandle mh = clinker.downcallHandle(mt, fd);
 
-		MemorySegment intSegmt = MemorySegment.allocateNative(C_INT, resourceScope);
-		MemoryAccess.setInt(intSegmt, 1);
-		boolean result = (boolean)mh.invokeExact(functionSymbol, false, intSegmt.address());
+		MemorySegment boolSegmt = MemorySegment.allocateNative(C_CHAR, resourceScope);
+		MemoryAccess.setByte(boolSegmt, (byte)1);
+		boolean result = (boolean)mh.invokeExact(functionSymbol, false, boolSegmt.address());
 		Assert.assertEquals(result, true);
 	}
 
 	@Test
 	public void test_addTwoBoolsWithOr_fromMemAddr_3() throws Throwable {
 		MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, C_CHAR);
 		Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
 		MemoryAddress memAddr = functionSymbol.address();
 		MethodHandle mh = clinker.downcallHandle(mt, fd);

--- a/test/functional/Java18andUp/build.xml
+++ b/test/functional/Java18andUp/build.xml
@@ -20,31 +20,20 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-<project name="Java17AndUp" default="build" basedir=".">
+<project name="Java18AndUp" default="build" basedir=".">
 	<taskdef resource='net/sf/antcontrib/antlib.xml' />
 	<description>
-		Tests for Java 17 and up
+		Tests for Java 18 and up
 	</description>
 
 	<!-- set global properties for this build -->
-	<property name="DEST" value="${BUILD_ROOT}/functional/Java17andUp" />
+	<property name="DEST" value="${BUILD_ROOT}/functional/Java18andUp" />
 
 	<!--Properties for this particular build-->
 	<property name="src" location="src" />
 	<property name="build" location="bin" />
 	<property name="LIB" value="asm,testng,jcommander" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
-
-	<if>
-		<equals arg1="${JDK_VERSION}" arg2="17" />
-		<then>
-			<!-- Java APIs of JEP389 and related features in Java 16 is incompatible with the APIs in Java17 and beyond -->
-			<property name="src_170" value="src_170" />
-		</then>
-		<else>
-			<property name="src_170" value="" />
-		</else>
-	</if>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -61,7 +50,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
-			<src path="${src_170}" />
 			<compilerarg line='--add-modules jdk.incubator.foreign' />
 			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
 			<classpath>
@@ -88,7 +76,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<target name="build">
 		<if>
 			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15|16)$$" />
+				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15|16|17)$$" />
 			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />

--- a/test/functional/Java18andUp/playlist.xml
+++ b/test/functional/Java18andUp/playlist.xml
@@ -22,7 +22,7 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>Jep389Tests_testClinkerFfi</testCaseName>
+		<testCaseName>Jep419Tests_testClinkerFfi</testCaseName>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -31,7 +31,7 @@
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep389Tests_testClinkerFfi \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep419Tests_testClinkerFfi \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
@@ -47,7 +47,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>17</version>
+			<version>18+</version>
 		</versions>
 	</test>
 </playlist>

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/InvalidDownCallTests.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/InvalidDownCallTests.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import static org.testng.Assert.fail;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
+ * which verifies the illegal cases including unsupported layouts, etc.
+ * Note: the majority of illegal cases are removed given the corresponding method type
+ * is deduced from the function descriptor which is verified in OpenJDK.
+ */
+@Test(groups = { "level.sanity" })
+public class InvalidDownCallTests {
+	private static CLinker clinker = CLinker.systemCLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Unsupported layout: .*")
+	public void test_invalidLayoutForIntType() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.ofVoid(JAVA_INT, MemoryLayout.paddingLayout(32));
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		fail("Failed to throw out IllegalArgumentException in the case of the invalid MemoryLayout");
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Unsupported layout: .*")
+	public void test_invalidLayoutForMemoryAddress() throws Throwable {
+		NativeSymbol functionSymbol = clinker.lookup("strlen").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, MemoryLayout.paddingLayout(64));
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		fail("Failed to throw out IllegalArgumentException in the case of the invalid MemoryLayout");
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Unsupported layout: .*")
+	public void test_invalidLayoutForReturnType() throws Throwable {
+		NativeSymbol functionSymbol = clinker.lookup("strlen").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(MemoryLayout.paddingLayout(64), JAVA_LONG);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		fail("Failed to throw out IllegalArgumentException in the case of the invalid MemoryLayout");
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiCallTests.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiCallTests.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
+ * which verifies multiple downcalls with the same or different layouts or argument/return types.
+ */
+@Test(groups = { "level.sanity" })
+public class MultiCallTests {
+	private static CLinker clinker = CLinker.systemCLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_twoCallsWithSameFuncDescriptor() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		int result = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(result, 235);
+
+		mh = clinker.downcallHandle(functionSymbol, fd);
+		result = (int)mh.invokeExact(235, 439);
+		Assert.assertEquals(result, 674);
+	}
+
+	@Test
+	public void test_twoCallsWithDiffFuncDescriptor() throws Throwable {
+		FunctionDescriptor fd1 = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol1 = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol1, fd1);
+		int result = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(result, 235);
+
+		FunctionDescriptor fd2 = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol2 = nativeLibLookup.lookup("add3Ints").get();
+		mh = clinker.downcallHandle(functionSymbol2, fd2);
+		result = (int)mh.invokeExact(112, 123, 235);
+		Assert.assertEquals(result, 470);
+	}
+
+	@Test
+	public void test_multiCallsWithMixedFuncDescriptors() throws Throwable {
+		FunctionDescriptor fd1 = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol1 = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol1, fd1);
+		int result = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(result, 235);
+
+		FunctionDescriptor fd2 = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol2 = nativeLibLookup.lookup("add3Ints").get();
+		mh = clinker.downcallHandle(functionSymbol2, fd2);
+		result = (int)mh.invokeExact(112, 123, 235);
+		Assert.assertEquals(result, 470);
+
+		FunctionDescriptor fd3 = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol3 = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		mh = clinker.downcallHandle(functionSymbol3, fd3);
+		mh.invokeExact(454, 398);
+
+		mh = clinker.downcallHandle(functionSymbol1, fd1);
+		result = (int)mh.invokeExact(234, 567);
+		Assert.assertEquals(result, 801);
+
+		mh = clinker.downcallHandle(functionSymbol2, fd2);
+		result = (int)mh.invokeExact(312, 323, 334);
+		Assert.assertEquals(result, 969);
+
+		mh = clinker.downcallHandle(functionSymbol3, fd3);
+		mh.invokeExact(539, 672);
+	}
+
+	@Test
+	public void test_twoCallsWithDiffReturnType() throws Throwable {
+		FunctionDescriptor fd1 = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol1 = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol1, fd1);
+		int result = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(result, 235);
+
+		FunctionDescriptor fd2 = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol2 = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		mh = clinker.downcallHandle(functionSymbol2, fd2);
+		mh.invokeExact(454, 398);
+	}
+
+	@Test
+	public void test_multiCallsWithSameArgLayouts() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol1 = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol1, fd);
+		int intResult = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(intResult, 235);
+
+		mh = clinker.downcallHandle(functionSymbol1, fd);
+		intResult = (int)mh.invokeExact(234, 567);
+		Assert.assertEquals(intResult, 801);
+
+		FunctionDescriptor fd2 = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol2 = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		mh = clinker.downcallHandle(functionSymbol2, fd2);
+		mh.invokeExact(454, 398);
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests1.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests1.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
+ * which verifies the downcalls with the same layout & argument and return types in multithreading.
+ */
+@Test(groups = { "level.sanity" })
+public class MultiThreadingTests1 implements Thread.UncaughtExceptionHandler {
+	private volatile Throwable initException;
+	private static CLinker clinker = CLinker.systemCLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(enabled=false)
+	@Override
+	public void uncaughtException(Thread thr, Throwable t) {
+		initException =  t;
+	}
+
+	@Test
+	public void test_twoThreadsWithSameFuncDescriptor() throws Throwable {
+		Thread thr1 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					int result = (int)mh.invokeExact(112, 123);
+					Assert.assertEquals(result, 235);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+		thr1.setUncaughtExceptionHandler(this);
+		thr1.start();
+
+		Thread thr2 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					int result = (int)mh.invokeExact(235, 439);
+					Assert.assertEquals(result, 674);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+		thr2.setUncaughtExceptionHandler(this);
+		thr2.start();
+
+		thr1.join();
+		thr2.join();
+
+		if (initException != null){
+			throw new RuntimeException(initException);
+		}
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests2.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests2.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
+ * which verifies the downcalls with the diffrent layouts and arguments/return types in multithreading.
+ */
+@Test(groups = { "level.sanity" })
+public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
+	private volatile Throwable initException;
+	private static CLinker clinker = CLinker.systemCLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(enabled=false)
+	@Override
+	public void uncaughtException(Thread thr, Throwable t) {
+		initException =  t;
+	}
+
+	@Test
+	public void test_twoThreadsWithDiffFuncDescriptor() throws Throwable {
+		Thread thr1 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					int result = (int)mh.invokeExact(112, 123);
+					Assert.assertEquals(result, 235);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr2 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add3Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					int result = (int)mh.invokeExact(112, 123, 235);
+					Assert.assertEquals(result, 470);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		thr1.setUncaughtExceptionHandler(this);
+		thr2.setUncaughtExceptionHandler(this);
+
+		thr1.start();
+		thr2.start();
+
+		thr1.join();
+		thr2.join();
+
+		if (initException != null){
+			throw new RuntimeException(initException);
+		}
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests3.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests3.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
+ * which verifies the downcalls with the diffrent return types in multithreading.
+ */
+@Test(groups = { "level.sanity" })
+public class MultiThreadingTests3 implements Thread.UncaughtExceptionHandler {
+	private volatile Throwable initException;
+	private static CLinker clinker = CLinker.systemCLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(enabled=false)
+	@Override
+	public void uncaughtException(Thread thr, Throwable t) {
+		initException =  t;
+	}
+
+	@Test
+	public void test_twoThreadsWithDiffReturnType() throws Throwable {
+		Thread thr1 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					int result = (int)mh.invokeExact(112, 123);
+					Assert.assertEquals(result, 235);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		Thread thr2 = new Thread(){
+			public void run() {
+				try {
+					FunctionDescriptor fd = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+					mh.invokeExact(454, 398);
+				} catch (Throwable t) {
+					throw new RuntimeException(t);
+				}
+			}
+		};
+
+		thr1.setUncaughtExceptionHandler(this);
+		thr2.setUncaughtExceptionHandler(this);
+
+		thr1.start();
+		thr2.start();
+
+		thr1.join();
+		thr2.join();
+
+		if (initException != null){
+			throw new RuntimeException(initException);
+		}
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests4.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/MultiThreadingTests4.java
@@ -19,28 +19,27 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package org.openj9.test.jep389.downcall;
+package org.openj9.test.jep419.downcall;
 
 import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
 import jdk.incubator.foreign.CLinker;
-import static jdk.incubator.foreign.CLinker.*;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.NativeSymbol;
 import jdk.incubator.foreign.SymbolLookup;
-import jdk.incubator.foreign.ResourceScope;
+import static jdk.incubator.foreign.ValueLayout.*;
 
 /**
- * Test cases for JEP 389: Foreign Linker API (Incubator) DownCall for primitive types,
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types,
  * which verifies multiple downcalls combined with the diffrent layouts/arguments/return types in multithreading.
  */
 @Test(groups = { "level.sanity" })
 public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 	private volatile Throwable initException;
-	private static CLinker clinker = CLinker.getInstance();
+	private static CLinker clinker = CLinker.systemCLinker();
 
 	static {
 		System.loadLibrary("clinkerffitests");
@@ -58,10 +57,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr1 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(int.class, int.class, int.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					int result = (int)mh.invokeExact(128, 246);
 					Assert.assertEquals(result, 374);
 				} catch (Throwable t) {
@@ -73,10 +71,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr2 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(int.class, int.class, int.class, int.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add3Ints").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add3Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					int result = (int)mh.invokeExact(112, 642, 971);
 					Assert.assertEquals(result, 1725);
 				} catch (Throwable t) {
@@ -88,10 +85,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr3 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, JAVA_BOOLEAN);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					boolean result = (boolean)mh.invokeExact(true, false);
 					Assert.assertEquals(result, true);
 				} catch (Throwable t) {
@@ -103,10 +99,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr4 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(int.class, int.class, int.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add2Ints").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					int result = (int)mh.invokeExact(416, 728);
 					Assert.assertEquals(result, 1144);
 				} catch (Throwable t) {
@@ -118,10 +113,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr5 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(int.class, int.class, int.class, int.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add3Ints").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add3Ints").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					int result = (int)mh.invokeExact(1012, 1023, 2035);
 					Assert.assertEquals(result, 4070);
 				} catch (Throwable t) {
@@ -133,10 +127,9 @@ public class MultiThreadingTests4 implements Thread.UncaughtExceptionHandler {
 		Thread thr6 = new Thread(){
 			public void run() {
 				try {
-					MethodType mt = MethodType.methodType(boolean.class, boolean.class, boolean.class);
-					FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
-					Addressable functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
-					MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+					FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, JAVA_BOOLEAN);
+					NativeSymbol functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+					MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
 					boolean result = (boolean)mh.invokeExact(false, false);
 					Assert.assertEquals(result, false);
 				} catch (Throwable t) {

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/PrimitiveTypeTests1.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.VaList;
+import static jdk.incubator.foreign.ValueLayout.*;
+import static jdk.incubator.foreign.VaList.Builder;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types, which
+ * covers generic tests, tests with the void return type and tests with the vararg list.
+ *
+ * Note: the test suite is intended for the following Clinker API:
+ * MethodHandle downcallHandle(NativeSymbol symbol, FunctionDescriptor function)
+ */
+@Test(groups = { "level.sanity" })
+public class PrimitiveTypeTests1 {
+	private static boolean isWinOS = System.getProperty("os.name").toLowerCase().contains("win");
+	private static CLinker clinker = CLinker.systemCLinker();
+	private static ResourceScope resourceScope = ResourceScope.newImplicitScope();
+	private static SegmentAllocator nativeAllocator = SegmentAllocator.nativeAllocator(resourceScope);
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_addTwoBoolsWithOr_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, JAVA_BOOLEAN);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		boolean result = (boolean)mh.invokeExact(true, false);
+		Assert.assertEquals(result, true);
+	}
+
+	@Test
+	public void test_addBoolAndBoolFromPointerWithOr_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addBoolAndBoolFromPointerWithOr").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment boolSegmt = MemorySegment.allocateNative(JAVA_BOOLEAN, resourceScope);
+		boolSegmt.set(JAVA_BOOLEAN, 0, true);
+		boolean result = (boolean)mh.invoke(false, boolSegmt);
+		Assert.assertEquals(result, true);
+	}
+
+	@Test
+	public void test_generateNewChar_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_CHAR, JAVA_CHAR, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("createNewCharFrom2Chars").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		char result = (char)mh.invokeExact('B', 'D');
+		Assert.assertEquals(result, 'C');
+	}
+
+	@Test
+	public void test_generateNewCharFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_CHAR, ADDRESS, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("createNewCharFromCharAndCharFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment charSegmt = nativeAllocator.allocate(JAVA_CHAR, 'B');
+		char result = (char)mh.invoke(charSegmt, 'D');
+		Assert.assertEquals(result, 'C');
+	}
+
+	@Test
+	public void test_addTwoBytes_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, JAVA_BYTE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		byte result = (byte)mh.invokeExact((byte)6, (byte)3);
+		Assert.assertEquals(result, (byte)9);
+	}
+
+	@Test
+	public void test_addTwoNegtiveBytes_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, JAVA_BYTE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		byte result = (byte)mh.invokeExact((byte)-6, (byte)-3);
+		Assert.assertEquals(result, (byte)-9);
+	}
+
+	@Test
+	public void test_addByteAndByteFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addByteAndByteFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment byteSegmt = nativeAllocator.allocate(JAVA_BYTE, (byte)3);
+		byte result = (byte)mh.invoke((byte)6, byteSegmt);
+		Assert.assertEquals(result, (byte)9);
+	}
+
+	@Test
+	public void test_addTwoShorts_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		short result = (short)mh.invokeExact((short)24, (short)32);
+		Assert.assertEquals(result, (short)56);
+	}
+
+	@Test
+	public void test_addTwoNegtiveShorts_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		short result = (short)mh.invokeExact((short)-24, (short)-32);
+		Assert.assertEquals(result, (short)-56);
+	}
+
+	@Test
+	public void test_addShortAndShortFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, ADDRESS, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addShortAndShortFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment shortSegmt = nativeAllocator.allocate(JAVA_SHORT, (short)24);
+		short result = (short)mh.invoke(shortSegmt, (short)32);
+		Assert.assertEquals(result, (short)56);
+	}
+
+	@Test
+	public void test_addTwoInts_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		int result = (int)mh.invokeExact(112, 123);
+		Assert.assertEquals(result, 235);
+	}
+
+	@Test
+	public void test_addTwoNegtiveInts_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		int result = (int)mh.invokeExact(-112, -123);
+		Assert.assertEquals(result, -235);
+	}
+
+	@Test
+	public void test_addIntAndIntFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntAndIntFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment intSegmt = nativeAllocator.allocate(JAVA_INT, 215);
+		int result = (int)mh.invoke(321, intSegmt);
+		Assert.assertEquals(result, 536);
+	}
+
+	@Test
+	public void test_addIntsWithVaList_1() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntsFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_INT, 700)
+				.addVarg(JAVA_INT, 800)
+				.addVarg(JAVA_INT, 900)
+				.addVarg(JAVA_INT, 1000), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		int result = (int)mh.invoke(4, vaList);
+		Assert.assertEquals(result, 3400);
+	}
+
+	@Test
+	public void test_addTwoIntsReturnVoid_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		mh.invokeExact(454, 398);
+	}
+
+	@Test
+	public void test_addIntAndChar_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntAndChar").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		int result = (int)mh.invokeExact(58, 'A');
+		Assert.assertEquals(result, 123);
+	}
+
+	@Test
+	public void test_addTwoLongs_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, JAVA_LONG);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Longs").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		long result = (long)mh.invokeExact(57424L, 698235L);
+		Assert.assertEquals(result, 755659L);
+	}
+
+	@Test
+	public void test_addLongAndLongFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_LONG);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addLongAndLongFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment longSegmt = nativeAllocator.allocate(JAVA_LONG, 57424L);
+		long result = (long)mh.invoke(longSegmt, 698235L);
+		Assert.assertEquals(result, 755659L);
+	}
+
+	@Test
+	public void test_addLongsWithVaList_1() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addLongsFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_LONG, 700000L)
+				.addVarg(JAVA_LONG, 800000L)
+				.addVarg(JAVA_LONG, 900000L)
+				.addVarg(JAVA_LONG, 1000000L), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		long result = (long)mh.invoke(4, vaList);
+		Assert.assertEquals(result, 3400000L);
+	}
+
+	@Test
+	public void test_addTwoFloats_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_FLOAT, JAVA_FLOAT, JAVA_FLOAT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Floats").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		float result = (float)mh.invokeExact(5.74f, 6.79f);
+		Assert.assertEquals(result, 12.53f, 0.01f);
+	}
+
+	@Test
+	public void test_addFloatAndFloatFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_FLOAT, JAVA_FLOAT, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addFloatAndFloatFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment floatSegmt = nativeAllocator.allocate(JAVA_FLOAT, 6.79f);
+		float result = (float)mh.invoke(5.74f, floatSegmt);
+		Assert.assertEquals(result, 12.53f, 0.01f);
+	}
+
+	@Test
+	public void test_addTwoDoubles_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, JAVA_DOUBLE, JAVA_DOUBLE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Doubles").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		double result = (double)mh.invokeExact(159.748d, 262.795d);
+		Assert.assertEquals(result, 422.543d, 0.001d);
+	}
+
+	@Test
+	public void test_addDoubleAndDoubleFromPointer_1() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, ADDRESS, JAVA_DOUBLE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addDoubleAndDoubleFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+
+		MemorySegment doubleSegmt = nativeAllocator.allocate(JAVA_DOUBLE, 159.748d);
+		double result = (double)mh.invoke(doubleSegmt, 262.795d);
+		Assert.assertEquals(result, 422.543d, 0.001d);
+	}
+
+	@Test
+	public void test_addDoublesWithVaList_1() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addDoublesFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_DOUBLE, 150.1001D)
+				.addVarg(JAVA_DOUBLE, 160.2002D)
+				.addVarg(JAVA_DOUBLE, 170.1001D)
+				.addVarg(JAVA_DOUBLE, 180.2002D), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		double result = (double)mh.invoke(4, vaList);
+		Assert.assertEquals(result, 660.6006D);
+	}
+
+	@Test
+	public void test_strlenFromDefaultLibWithMemAddr_1() throws Throwable {
+		NativeSymbol strlenSymbol = clinker.lookup("strlen").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS);
+		MethodHandle mh = clinker.downcallHandle(strlenSymbol, fd);
+		MemorySegment funcSegmt = nativeAllocator.allocateUtf8String("JEP419 DOWNCALL TEST SUITES");
+		long strLength = (long)mh.invoke(funcSegmt);
+		Assert.assertEquals(strLength, 27);
+	}
+
+	@Test
+	public void test_memoryAllocFreeFromDefaultLib_1() throws Throwable {
+		NativeSymbol allocSymbol = clinker.lookup("malloc").get();
+		FunctionDescriptor allocFuncDesc = FunctionDescriptor.of(ADDRESS, JAVA_LONG);
+		MethodHandle allocHandle = clinker.downcallHandle(allocSymbol, allocFuncDesc);
+		MemoryAddress allocMemAddr = (MemoryAddress)allocHandle.invokeExact(10L);
+		allocMemAddr.set(JAVA_INT, 0, 15);
+		Assert.assertEquals(allocMemAddr.get(JAVA_INT, 0), 15);
+
+		NativeSymbol freeSymbol = clinker.lookup("free").get();
+		FunctionDescriptor freeFuncDesc = FunctionDescriptor.ofVoid(ADDRESS);
+		MethodHandle freeHandle = clinker.downcallHandle(freeSymbol, freeFuncDesc);
+		freeHandle.invoke(allocMemAddr);
+	}
+
+	@Test
+	public void test_printfFromDefaultLibWithMemAddr_1() throws Throwable {
+		NativeSymbol functionSymbol = clinker.lookup("printf").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+		MemorySegment formatSegmt = nativeAllocator.allocateUtf8String("\n%d + %d = %d\n");
+		mh.invoke(formatSegmt, 15, 27, 42);
+	}
+
+	@Test
+	public void test_vprintfFromDefaultLibWithVaList_1() throws Throwable {
+		/* Disable the test on Windows given a misaligned access exception coming from
+		 * java.base/java.lang.invoke.MemoryAccessVarHandleBase triggered by CLinker.toCString()
+		 * is also captured on OpenJDK/Hotspot.
+		 */
+		if (!isWinOS) {
+			NativeSymbol functionSymbol = clinker.lookup("vprintf").get();
+			FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS);
+			MemorySegment formatSegmt = nativeAllocator.allocateUtf8String("%d * %d = %d\n");
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_INT, 7)
+					.addVarg(JAVA_INT, 8)
+					.addVarg(JAVA_INT, 56), resourceScope);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, fd);
+			mh.invoke(formatSegmt, vaList);
+		}
+	}
+}

--- a/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/PrimitiveTypeTests2.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/jep419/downcall/PrimitiveTypeTests2.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep419.downcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeSymbol;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.VaList;
+import static jdk.incubator.foreign.ValueLayout.*;
+import static jdk.incubator.foreign.VaList.Builder;
+
+/**
+ * Test cases for JEP 419: Foreign Linker API (Second Incubator) DownCall for primitive types, which
+ * covers generic tests, tests with the void return type and tests with the vararg list.
+ *
+ * Note: the test suite is intended for the following Clinker API:
+ * MethodHandle downcallHandle(FunctionDescriptor function)
+ */
+@Test(groups = { "level.sanity" })
+public class PrimitiveTypeTests2 {
+	private static boolean isWinOS = System.getProperty("os.name").toLowerCase().contains("win");
+	private static CLinker clinker = CLinker.systemCLinker();
+	private static ResourceScope resourceScope = ResourceScope.newImplicitScope();
+	private static SegmentAllocator nativeAllocator = SegmentAllocator.nativeAllocator(resourceScope);
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_addTwoBoolsWithOr_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, JAVA_BOOLEAN);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2BoolsWithOr").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		boolean result = (boolean)mh.invokeExact(functionSymbol, true, false);
+		Assert.assertEquals(result, true);
+	}
+
+	@Test
+	public void test_addBoolAndBoolFromPointerWithOr_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_BOOLEAN, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addBoolAndBoolFromPointerWithOr").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment boolSegmt = MemorySegment.allocateNative(JAVA_BOOLEAN, resourceScope);
+		boolSegmt.set(JAVA_BOOLEAN, 0, true);
+		boolean result = (boolean)mh.invoke(functionSymbol, false, boolSegmt);
+		Assert.assertEquals(result, true);
+	}
+
+	@Test
+	public void test_generateNewChar_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_CHAR, JAVA_CHAR, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("createNewCharFrom2Chars").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		char result = (char)mh.invokeExact(functionSymbol, 'B', 'D');
+		Assert.assertEquals(result, 'C');
+	}
+
+	@Test
+	public void test_generateNewCharFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_CHAR, ADDRESS, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("createNewCharFromCharAndCharFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment charSegmt = nativeAllocator.allocate(JAVA_CHAR, 'B');
+		char result = (char)mh.invoke(functionSymbol, charSegmt, 'D');
+		Assert.assertEquals(result, 'C');
+	}
+
+	@Test
+	public void test_addTwoBytes_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, JAVA_BYTE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		byte result = (byte)mh.invokeExact(functionSymbol, (byte)6, (byte)3);
+		Assert.assertEquals(result, (byte)9);
+	}
+
+	@Test
+	public void test_addTwoNegtiveBytes_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, JAVA_BYTE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Bytes").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		byte result = (byte)mh.invokeExact(functionSymbol, (byte)-6, (byte)-3);
+		Assert.assertEquals(result, (byte)-9);
+	}
+
+	@Test
+	public void test_addByteAndByteFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addByteAndByteFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment byteSegmt = nativeAllocator.allocate(JAVA_BYTE, (byte)3);
+		byte result = (byte)mh.invoke(functionSymbol, (byte)6, byteSegmt);
+		Assert.assertEquals(result, (byte)9);
+	}
+
+	@Test
+	public void test_addTwoShorts_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		short result = (short)mh.invokeExact(functionSymbol, (short)24, (short)32);
+		Assert.assertEquals(result, (short)56);
+	}
+
+	@Test
+	public void test_addTwoNegtiveShorts_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Shorts").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		short result = (short)mh.invokeExact(functionSymbol, (short)-24, (short)-32);
+		Assert.assertEquals(result, (short)-56);
+	}
+
+	@Test
+	public void test_addShortAndShortFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, ADDRESS, JAVA_SHORT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addShortAndShortFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment shortSegmt = nativeAllocator.allocate(JAVA_SHORT, (short)24);
+		short result = (short)mh.invoke(functionSymbol, shortSegmt, (short)32);
+		Assert.assertEquals(result, (short)56);
+	}
+
+	@Test
+	public void test_addTwoInts_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		int result = (int)mh.invokeExact(functionSymbol, 112, 123);
+		Assert.assertEquals(result, 235);
+	}
+
+	@Test
+	public void test_addTwoNegtiveInts_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Ints").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		int result = (int)mh.invokeExact(functionSymbol, -112, -123);
+		Assert.assertEquals(result, -235);
+	}
+
+	@Test
+	public void test_addIntAndIntFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntAndIntFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment intSegmt = nativeAllocator.allocate(JAVA_INT, 215);
+		int result = (int)mh.invoke(functionSymbol, 321, intSegmt);
+		Assert.assertEquals(result, 536);
+	}
+
+	@Test
+	public void test_addIntsWithVaList_2() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntsFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_INT, 700)
+				.addVarg(JAVA_INT, 800)
+				.addVarg(JAVA_INT, 900)
+				.addVarg(JAVA_INT, 1000), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(fd);
+		int result = (int)mh.invoke(functionSymbol, 4, vaList);
+		Assert.assertEquals(result, 3400);
+	}
+
+	@Test
+	public void test_addTwoIntsReturnVoid_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2IntsReturnVoid").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		mh.invokeExact(functionSymbol, 454, 398);
+	}
+
+	@Test
+	public void test_addIntAndChar_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_CHAR);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addIntAndChar").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		int result = (int)mh.invokeExact(functionSymbol, 58, 'A');
+		Assert.assertEquals(result, 123);
+	}
+
+	@Test
+	public void test_addTwoLongs_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, JAVA_LONG, JAVA_LONG);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Longs").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		long result = (long)mh.invokeExact(functionSymbol, 57424L, 698235L);
+		Assert.assertEquals(result, 755659L);
+	}
+
+	@Test
+	public void test_addLongAndLongFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_LONG);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addLongAndLongFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment longSegmt = nativeAllocator.allocate(JAVA_LONG, 57424L);
+		long result = (long)mh.invoke(functionSymbol, longSegmt, 698235L);
+		Assert.assertEquals(result, 755659L);
+	}
+
+	@Test
+	public void test_addLongsWithVaList_2() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addLongsFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_LONG, 700000L)
+				.addVarg(JAVA_LONG, 800000L)
+				.addVarg(JAVA_LONG, 900000L)
+				.addVarg(JAVA_LONG, 1000000L), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(fd);
+		long result = (long)mh.invoke(functionSymbol, 4, vaList);
+		Assert.assertEquals(result, 3400000L);
+	}
+
+	@Test
+	public void test_addTwoFloats_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_FLOAT, JAVA_FLOAT, JAVA_FLOAT);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Floats").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		float result = (float)mh.invokeExact(functionSymbol, 5.74f, 6.79f);
+		Assert.assertEquals(result, 12.53f, 0.01f);
+	}
+
+	@Test
+	public void test_addFloatAndFloatFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_FLOAT, JAVA_FLOAT, ADDRESS);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addFloatAndFloatFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment floatSegmt = nativeAllocator.allocate(JAVA_FLOAT, 6.79f);
+		float result = (float)mh.invoke(functionSymbol, 5.74f, floatSegmt);
+		Assert.assertEquals(result, 12.53f, 0.01f);
+	}
+
+	@Test
+	public void test_addTwoDoubles_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, JAVA_DOUBLE, JAVA_DOUBLE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("add2Doubles").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+		double result = (double)mh.invokeExact(functionSymbol, 159.748d, 262.795d);
+		Assert.assertEquals(result, 422.543d, 0.001d);
+	}
+
+	@Test
+	public void test_addDoubleAndDoubleFromPointer_2() throws Throwable {
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, ADDRESS, JAVA_DOUBLE);
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addDoubleAndDoubleFromPointer").get();
+		MethodHandle mh = clinker.downcallHandle(fd);
+
+		MemorySegment doubleSegmt = nativeAllocator.allocate(JAVA_DOUBLE, 159.748d);
+		double result = (double)mh.invoke(functionSymbol, doubleSegmt, 262.795d);
+		Assert.assertEquals(result, 422.543d, 0.001d);
+	}
+
+	@Test
+	public void test_addDoublesWithVaList_2() throws Throwable {
+		NativeSymbol functionSymbol = nativeLibLookup.lookup("addDoublesFromVaList").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT, ADDRESS);
+		VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_DOUBLE, 150.1001D)
+				.addVarg(JAVA_DOUBLE, 160.2002D)
+				.addVarg(JAVA_DOUBLE, 170.1001D)
+				.addVarg(JAVA_DOUBLE, 180.2002D), resourceScope);
+		MethodHandle mh = clinker.downcallHandle(fd);
+		double result = (double)mh.invoke(functionSymbol, 4, vaList);
+		Assert.assertEquals(result, 660.6006D);
+	}
+
+	@Test
+	public void test_strlenFromDefaultLibWithMemAddr_2() throws Throwable {
+		NativeSymbol strlenSymbol = clinker.lookup("strlen").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS);
+		MethodHandle mh = clinker.downcallHandle(fd);
+		MemorySegment funcSegmt = nativeAllocator.allocateUtf8String("JEP419 DOWNCALL TEST SUITES");
+		long strLength = (long)mh.invoke(strlenSymbol, funcSegmt);
+		Assert.assertEquals(strLength, 27);
+	}
+
+	@Test
+	public void test_memoryAllocFreeFromDefaultLib_2() throws Throwable {
+		NativeSymbol allocSymbol = clinker.lookup("malloc").get();
+		FunctionDescriptor allocFuncDesc = FunctionDescriptor.of(ADDRESS, JAVA_LONG);
+		MethodHandle allocHandle = clinker.downcallHandle(allocFuncDesc);
+		MemoryAddress allocMemAddr = (MemoryAddress)allocHandle.invokeExact(allocSymbol, 10L);
+		allocMemAddr.set(JAVA_INT, 0, 15);
+		Assert.assertEquals(allocMemAddr.get(JAVA_INT, 0), 15);
+
+		NativeSymbol freeSymbol = clinker.lookup("free").get();
+		FunctionDescriptor freeFuncDesc = FunctionDescriptor.ofVoid(ADDRESS);
+		MethodHandle freeHandle = clinker.downcallHandle(freeFuncDesc);
+		freeHandle.invoke(freeSymbol, allocMemAddr);
+	}
+
+	@Test
+	public void test_printfFromDefaultLibWithMemAddr_2() throws Throwable {
+		NativeSymbol functionSymbol = clinker.lookup("printf").get();
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
+		MethodHandle mh = clinker.downcallHandle(fd);
+		MemorySegment formatSegmt = nativeAllocator.allocateUtf8String("\n%d + %d = %d\n");
+		mh.invoke(functionSymbol, formatSegmt, 15, 27, 42);
+	}
+
+	@Test
+	public void test_vprintfFromDefaultLibWithVaList_2() throws Throwable {
+		/* Disable the test on Windows given a misaligned access exception coming from
+		 * java.base/java.lang.invoke.MemoryAccessVarHandleBase triggered by CLinker.toCString()
+		 * is also captured on OpenJDK/Hotspot.
+		 */
+		if (!isWinOS) {
+			NativeSymbol functionSymbol = clinker.lookup("vprintf").get();
+			FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS);
+			MemorySegment formatSegmt = nativeAllocator.allocateUtf8String("%d * %d = %d\n");
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.addVarg(JAVA_INT, 7)
+					.addVarg(JAVA_INT, 8)
+					.addVarg(JAVA_INT, 56), resourceScope);
+			MethodHandle mh = clinker.downcallHandle(fd);
+			mh.invoke(functionSymbol, formatSegmt, vaList);
+		}
+	}
+}

--- a/test/functional/Java18andUp/testClinkerFfi.xml
+++ b/test/functional/Java18andUp/testClinkerFfi.xml
@@ -23,18 +23,17 @@
 -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Java17andUp test suite" parallel="none" verbose="2">
-	<test name="Jep389Tests_testClinkerFfi">
+<suite name="Java18andUp test suite" parallel="none" verbose="2">
+	<test name="Jep419Tests_testClinkerFfi">
 		<classes>
-			<class name="org.openj9.test.jep389.downcall.InvalidDownCallTests"/>
-			<class name="org.openj9.test.jep389.downcall.MultiCallTests"/>
-			<class name="org.openj9.test.jep389.downcall.MultiThreadingTests1"/>
-			<class name="org.openj9.test.jep389.downcall.MultiThreadingTests2"/>
-			<class name="org.openj9.test.jep389.downcall.MultiThreadingTests3"/>
-			<class name="org.openj9.test.jep389.downcall.MultiThreadingTests4"/>
-			<class name="org.openj9.test.jep389.downcall.PrimitiveTypeTests1"/>
-			<class name="org.openj9.test.jep389.downcall.PrimitiveTypeTests2"/>
-			<class name="org.openj9.test.jep389.downcall.PrimitiveTypeTests3"/>
+			<class name="org.openj9.test.jep419.downcall.InvalidDownCallTests"/>
+			<class name="org.openj9.test.jep419.downcall.MultiCallTests"/>
+			<class name="org.openj9.test.jep419.downcall.MultiThreadingTests1"/>
+			<class name="org.openj9.test.jep419.downcall.MultiThreadingTests2"/>
+			<class name="org.openj9.test.jep419.downcall.MultiThreadingTests3"/>
+			<class name="org.openj9.test.jep419.downcall.MultiThreadingTests4"/>
+			<class name="org.openj9.test.jep419.downcall.PrimitiveTypeTests1"/>
+			<class name="org.openj9.test.jep419.downcall.PrimitiveTypeTests2"/>
 		</classes>
 	</test>
 </suite>


### PR DESCRIPTION
The change is to update the code specific to the FFI downcall for
primitives to accommodate the latest APIs of JEP419 in Java18.

Fixes: #14013

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>