### PR TITLE
Clarify J9Class.ramConstantPool

### DIFF
--- a/runtime/ddr/overrides-vm
+++ b/runtime/ddr/overrides-vm
@@ -82,6 +82,9 @@ typeoverride.J9AnnotationInfoEntry.annotationType=J9SRP(J9UTF8)
 typeoverride.J9AnnotationInfoEntry.memberName=J9SRP(J9UTF8)
 typeoverride.J9AnnotationInfoEntry.memberSignature=J9SRP(J9UTF8)
 
+# Retain the old type for compatibility with dumps from older VMs.
+typeoverride.J9Class.ramConstantPool=UDATA*
+
 typeoverride.J9MethodParameter.name=J9SRP(J9UTF8)
 
 typeoverride.J9EnclosingObject.nameAndSignature=J9SRP(J9ROMNameAndSignature)

--- a/runtime/ddr/vmddrstructs.properties
+++ b/runtime/ddr/vmddrstructs.properties
@@ -28,11 +28,10 @@
 #ddrblob.<header>.prop=value
 #
 #Properties for each header:
-# * constantbehaviour - How to handle any #defined constants. Options are "builder" - attach any constants to the 
+# * constantbehaviour - How to handle any #defined constants. Options are "builder" - attach any constants to the
 #                       structure directly above the constant, "pseudostructure" - creates a pseudo-structure
 #                       called <Header>Constants containing all the constants. Defaults to builder.
 #
-
 
 ddrblob.name=VM
 ddrblob.headers=bcverify.h,\
@@ -110,7 +109,6 @@ omrgcconsts.h, \
 omrmodroncore.h, \
 shchelp.h
 
-
 ddrblob.j9generated.h.constantbehaviour=builder
 ddrblob.j9nonbuilder.h.constantbehaviour=builder
 ddrblob.j9nongenerated.h.constantbehaviour=builder
@@ -143,7 +141,6 @@ ddrblob.dbgsharedcache.h.constantbehaviour.pseudostructure=SharedCacheConsts
 #Override default pseudostructure name for omravldefines.h
 ddrblob.omravldefines.h.constantbehaviour.pseudostructure=J9AVLConsts
 
-
 #j9cfg.h contains the build flags
 ddrblob.j9cfg.h.constantbehaviour=J9BuildFlags
 
@@ -161,6 +158,9 @@ ddrblob.typeoverride.J9AnnotationInfoEntry.memberName=J9SRP(struct J9UTF8)
 ddrblob.typeoverride.J9AnnotationInfoEntry.memberSignature=J9SRP(struct J9UTF8)
 
 ddrblob.typeoverride.J9MethodParameter.name=J9SRP(struct J9UTF8)
+
+# Retain the old type for compatibility with dumps from older VMs.
+ddrblob.typeoverride.J9Class.ramConstantPool=UDATA*
 
 ddrblob.typeoverride.J9EnclosingObject.nameAndSignature=J9SRP(struct J9ROMNameAndSignature)
 
@@ -264,7 +264,6 @@ ddrblob.typeoverride.J9ObjectMemorySegment.rightChild=IDATA
 ddrblob.typeoverride.CacheletWrapper.dataStart=I_32
 
 ddrblob.typeoverride.J9MethodDebugInfo.srpToVarInfo=J9SRP(struct J9VariableInfo)
-
 
 #Type override for SRPs in shared string intern table
 ddrblob.typeoverride.J9SRPHashTableInternal.nodes=J9SRP(J9SRP(void))

--- a/runtime/oti/j9cp.h
+++ b/runtime/oti/j9cp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,9 +30,7 @@
 #define J9_AFTER_CLASS(clazz) ((UDATA *) (((J9Class *) (clazz)) + 1))
 
 #define J9_CP_FROM_METHOD(method) ((J9ConstantPool *) ((UDATA) ((method)->constantPool) & ~J9_STARTPC_STATUS))
-#ifndef J9_CP_FROM_CLASS
-#define J9_CP_FROM_CLASS(clazz) ((J9ConstantPool *) (clazz)->ramConstantPool)
-#endif
+#define J9_CP_FROM_CLASS(clazz) ((clazz)->ramConstantPool)
 #define J9_CLASS_FROM_CP(cp) (((J9ConstantPool *) (cp))->ramClass)
 #define J9_CLASS_FROM_METHOD(method) J9_CLASS_FROM_CP(J9_CP_FROM_METHOD(method))
 #define J9_ROM_CP_FROM_CP(cp) (((J9ConstantPool *) (cp))->romConstantPool)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3122,7 +3122,6 @@ typedef struct J9ROMImageHeader {
 
 /* @ddr_namespace: map_to_type=J9ClassLocation */
 
-struct J9Class;
 typedef struct J9ClassLocation {
 	struct J9Class *clazz;
 	IDATA entryIndex;
@@ -3179,7 +3178,7 @@ typedef struct J9Class {
 	struct J9Class* replacedClass;
 	UDATA finalizeLinkOffset;
 	struct J9Class* nextClassInSegment;
-	UDATA* ramConstantPool;
+	struct J9ConstantPool *ramConstantPool;
 	j9object_t* callSites;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	j9object_t* invokeCache;

--- a/runtime/util/annhelp.c
+++ b/runtime/util/annhelp.c
@@ -170,7 +170,7 @@ fieldContainsRuntimeAnnotation(J9VMThread *currentThread, J9Class *clazz, UDATA 
 	J9UTF8 *name = NULL;
 	J9UTF8 *signature = NULL;
 	J9Class *definingClass = NULL;
-	J9ConstantPool *ramCP = (J9ConstantPool *)clazz->ramConstantPool;
+	J9ConstantPool *ramCP = clazz->ramConstantPool;
 
 	Assert_VMUtil_true(NULL != clazz);
 	Assert_VMUtil_true(NULL != annotationName);
@@ -206,7 +206,7 @@ fieldContainsRuntimeAnnotation(J9VMThread *currentThread, J9Class *clazz, UDATA 
 				U_32 len = *fieldAnnotationData;
 				U_8 *data = (U_8 *)(fieldAnnotationData + 1);
 
-				annotationFound = findRuntimeVisibleAnnotation(currentThread, data, len, annotationName, ((J9ConstantPool *)definingClass->ramConstantPool)->romConstantPool);
+				annotationFound = findRuntimeVisibleAnnotation(currentThread, data, len, annotationName, definingClass->ramConstantPool->romConstantPool);
 			}
 		}
 	} else {

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2460,8 +2460,8 @@ swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
 	SWAP_MEMBER(romClass, J9ROMClass *, originalClass, obsoleteClass);
 	SWAP_MEMBER(ramMethods, J9Method *, originalClass, obsoleteClass);
 	SWAP_MEMBER(ramConstantPool, J9ConstantPool *, originalClass, obsoleteClass);
-	((J9ConstantPool *) originalClass->ramConstantPool)->ramClass = originalClass;
-	((J9ConstantPool *) obsoleteClass->ramConstantPool)->ramClass = obsoleteClass;
+	originalClass->ramConstantPool->ramClass = originalClass;
+	obsoleteClass->ramConstantPool->ramClass = obsoleteClass;
 	SWAP_MEMBER(replacedClass, J9Class *, originalClass, obsoleteClass);
 	SWAP_MEMBER(staticSplitMethodTable, J9Method **, originalClass, obsoleteClass);
 	SWAP_MEMBER(specialSplitMethodTable, J9Method **, originalClass, obsoleteClass);

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -118,7 +118,7 @@ isNameOrSignatureQtype(J9UTF8 *utfWrapper)
 BOOLEAN
 isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex)
 {
-	return VM_ValueTypeHelpers::isClassRefQtype((J9ConstantPool *) cpContextClass->ramConstantPool, cpIndex);
+	return VM_ValueTypeHelpers::isClassRefQtype(cpContextClass->ramConstantPool, cpIndex);
 }
 
 UDATA
@@ -245,6 +245,5 @@ areValueTypesEnabled(J9JavaVM *vm)
 {
 	return J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VALHALLA);
 }
-
 
 } /* extern "C" */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1046,7 +1046,7 @@ found:
 			/* Default Method conflict */
 			J9Method *defaultMethod = (J9Method*)(temp & ~DEFAULT_CONFLICT_METHOD_ID_TAG);
 			conflictMethodPtr->bytecodes = (U_8*)(J9_ROM_METHOD_FROM_RAM_METHOD(defaultMethod) + 1);
-			conflictMethodPtr->constantPool = (J9ConstantPool *)ramClass->ramConstantPool;
+			conflictMethodPtr->constantPool = ramClass->ramConstantPool;
 			conflictMethodPtr->methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_DEFAULT_CONFLICT);
 			conflictMethodPtr->extra = (void *)((UDATA)defaultMethod | J9_STARTPC_NOT_TRANSLATED);
 			vTableMethod = conflictMethodPtr;
@@ -2873,7 +2873,7 @@ fail:
 				}
 				ramClass->superclasses = (J9Class **) allocationRequests[RAM_SUPERCLASSES_FRAGMENT].address;
 				ramClass->ramStatics = allocationRequests[RAM_STATICS_FRAGMENT].address;
-				ramClass->ramConstantPool = allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].address;
+				ramClass->ramConstantPool = (J9ConstantPool *) allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].address;
 				ramClass->callSites = (j9object_t *) allocationRequests[RAM_CALL_SITES_FRAGMENT].address;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 				ramClass->invokeCache = (j9object_t *) allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].address;
@@ -2923,7 +2923,7 @@ fail:
 
 		/* initialize RAM Class */
 		{
-			J9ConstantPool *ramConstantPool = (J9ConstantPool *) (ramClass->ramConstantPool);
+			J9ConstantPool *ramConstantPool = ramClass->ramConstantPool;
 			UDATA ramConstantPoolCount = romClass->ramConstantPoolCount * 2; /* 2 slots per CP entry */
 			U_32 tempClassDepthAndFlags = 0;
 			UDATA iTableMethodCount = 0;

--- a/runtime/vmchk/checkclasses.c
+++ b/runtime/vmchk/checkclasses.c
@@ -195,7 +195,7 @@ verifyJ9ClassHeader(J9JavaVM *vm, J9Class *clazz, J9Class *javaLangObjectClass)
 	}
 
 	if ((NULL != romClass) && (0 != romClass->ramConstantPoolCount)) {
-		J9ConstantPool *constantPool = (J9ConstantPool*)clazz->ramConstantPool;
+		J9ConstantPool *constantPool = clazz->ramConstantPool;
 		J9Class *cpClass = constantPool->ramClass;
 
 		if (clazz != cpClass) {

--- a/runtime/vmchk/checkmethods.c
+++ b/runtime/vmchk/checkmethods.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,7 +79,7 @@ verifyClassMethods(J9JavaVM *vm, J9Class *clazz)
 	J9ROMClass *romClass = clazz->romClass;
 	UDATA romClassModifiers = romClass->modifiers;
 	BOOLEAN isInterfaceClass = (J9AccInterface == (romClassModifiers & J9AccInterface));
-	J9ConstantPool *ramConstantPool = (J9ConstantPool*)clazz->ramConstantPool;
+	J9ConstantPool *ramConstantPool = clazz->ramConstantPool;
 	U_32 methodCount = romClass->romMethodCount;
 	J9Method *methods = clazz->ramMethods;
 	U_32 i;


### PR DESCRIPTION
This is in response to https://github.com/eclipse-openj9/openj9/pull/13836#discussion_r761245514.

It is a pointer to `J9ConstantPool` (not `UDATA`): declare it as such and remove the (now redundant) casts where it is used.

Add a DDR type override to avoid compatibility problems with system dumps from older VMs.