### PR TITLE
Add a test case in ShareClassesCML with verbose output enabled

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -58,7 +58,22 @@
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
+
+	<test id="Test 1-b: Test that only bootstrap class sharing is enabled by default with verbose output" timeout="600" runPath=".">
+		<!-- run with -Xshareclasses:bootClassesOnly,verbose, it gives us more debugging information if the above test failed -->
+		<command>$JAVA_EXE$ -Xshareclasses:bootClassesOnly,verbose -Xtrace:print={j9shr.1297,j9shr.1514,j9shr.2272,j9shr.2273,j9shr.2264,j9jcl.104,j9jcl.97} $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<!-- Enable j9shr.2272 Trc_SHR_INIT_j9shr_init_ExitOnNonFatal and j9shr.2264 Trc_SHR_OSC_getCacheDir_j9shmem_getDir_failed1 for debugging purpose when failed -->
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1514\s+ - CM commitROMClass : Data was stored in the cache for J9ROMClass</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1297\s+ - CM findROMClass: class .* found at address</output>
+		<!--Let this test pass if someone is running in container-->
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.2273\s+ - The JVM is running in container, class sharing is not enabled by default</output>
+		<output type="required" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<!-- j9jcl.104, j9jcl.97 SharedClassURLClasspathHelperImpl.storeSharedClassImpl()/findSharedClassImpl() is not triggered, non-bootstrap class sharing is not enabled.  -->
+		<output type="failure" caseSensitive="no" regex="no">SharedClassURLClasspathHelperImpl</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
 	<exec command="$JAVA_EXE$ -Xshareclasses:destroy" quiet="false"/>
 	<!--
 	***** IMPORTANT NOTE *****


### PR DESCRIPTION
In the default class sharing mode, if the SCC cannot be started up 
JVM will silently ignore the errors and start up without SCC. 
Add a test case to enable verbose message to show the start up 
error for debugging purpose.

issue #13841

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>