### PR TITLE
Temporarily disable Java16andUp tests on hotspot

### DIFF
--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -133,9 +133,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<target name="build">
 		<if>
-			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15)$$" />
-			</not>
+			<and>
+				<or>
+					<!-- Exclude the tests for other impls, issue: https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623 -->
+					<equals arg1="${JDK_IMPL}" arg2="ibm" />
+					<equals arg1="${JDK_IMPL}" arg2="openj9" />
+				</or>
+				<not>
+					<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15)$$" />
+				</not>
+			</and>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -23,6 +23,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep397Tests</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -46,6 +52,12 @@
 	
 	<test>
 		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentModule</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -77,6 +89,12 @@
 	
 	<test>
 		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -100,6 +118,12 @@
 	
 	<test>
 		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -126,8 +150,15 @@
 			<version>16+</version>
 		</versions>
 	</test>
+
 	<test>
 		<testCaseName>CloseScope0Tests</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>
@@ -153,8 +184,15 @@
 			<version>16+</version>
 		</versions>
 	</test>
+
 	<test>
 		<testCaseName>Jep389Tests_testClinkerFfi</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview</variation>
 		</variations>


### PR DESCRIPTION
- related issue: https://github.com/eclipse-openj9/openj9/issues/14028

[ci skip]

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>