### PR TITLE
Define JVM_IsFinalizationEnabled() for Java 18+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -394,6 +394,7 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 18)
 	jvm_add_exports(jvm
 		# Additions for Java 18 (General)
+		JVM_IsFinalizationEnabled
 		JVM_ReportFinalizationComplete
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -387,6 +387,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<exports group="jdk18">
 		<!-- Additions for Java 18 (General) -->
+		<export name="JVM_IsFinalizationEnabled"/>
 		<export name="JVM_ReportFinalizationComplete"/>
 	</exports>
 

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -176,6 +176,13 @@ JVM_DumpDynamicArchive(JNIEnv *env, jstring str)
 #endif /* JAVA_SPEC_VERSION >= 17 */
 
 #if JAVA_SPEC_VERSION >= 18
+JNIEXPORT jboolean JNICALL
+JVM_IsFinalizationEnabled(JNIEnv *env)
+{
+	assert(!"JVM_IsFinalizationEnabled unimplemented");
+	return JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL
 JVM_ReportFinalizationComplete(JNIEnv *env, jobject obj)
 {

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -355,4 +355,6 @@ _IF([JAVA_SPEC_VERSION >= 17],
 _IF([JAVA_SPEC_VERSION >= 17],
 	[_X(JVM_DumpDynamicArchive, JNICALL, false, void, JNIEnv *env, jstring str)])
 _IF([JAVA_SPEC_VERSION >= 18],
+	[_X(JVM_IsFinalizationEnabled, JNICALL, false, jboolean, JNIEnv *env)])
+_IF([JAVA_SPEC_VERSION >= 18],
 	[_X(JVM_ReportFinalizationComplete, JNICALL, false, void, JNIEnv *env, jobject obj)])


### PR DESCRIPTION
Required by
* 8276422: Add command-line option to disable finalization

This will not be needed until the openj9-staging branch promotes, but it is safe to include now.