### PR TITLE
JDK18 isReflectionMethod checks Method.invoke(Object,Object[],Class<?>)

### DIFF
--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -98,6 +98,9 @@ isPrivilegedFrameIterator(J9VMThread * currentThread, J9StackWalkState * walkSta
 	if (NULL == walkState->userData2) {
 		J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 		if ((walkState->method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+			|| (walkState->method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 			|| (walkState->method == vm->jliMethodHandleInvokeWithArgs)
 			|| (walkState->method == vm->jliMethodHandleInvokeWithArgsList)
 			|| (vm->srMethodAccessor && VM_VMHelpers::isSameOrSuperclass(J9VM_J9CLASS_FROM_JCLASS(currentThread, vm->srMethodAccessor), currentClass))
@@ -1268,6 +1271,9 @@ isPrivilegedFrameIteratorGetAccSnapshot(J9VMThread * currentThread, J9StackWalkS
 		/* find the callers of each doPrivileged method */
 		J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 		if ((walkState->method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+			|| (walkState->method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 			|| (walkState->method == vm->jliMethodHandleInvokeWithArgs)
 			|| (walkState->method == vm->jliMethodHandleInvokeWithArgsList)
 			|| (vm->srMethodAccessor && VM_VMHelpers::isSameOrSuperclass(J9VM_J9CLASS_FROM_JCLASS(currentThread, vm->srMethodAccessor), currentClass))
@@ -1689,6 +1695,9 @@ isPrivilegedFrameIteratorGetCallerPD(J9VMThread * currentThread, J9StackWalkStat
 	J9JavaVM *vm = currentThread->javaVM;
 	J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 	if ((walkState->method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+		|| (walkState->method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 		|| (walkState->method == vm->jliMethodHandleInvokeWithArgs)
 		|| (walkState->method == vm->jliMethodHandleInvokeWithArgsList)
 		|| (vm->srMethodAccessor && VM_VMHelpers::isSameOrSuperclass(J9VM_J9CLASS_FROM_JCLASS(currentThread, vm->srMethodAccessor), currentClass))

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1478,6 +1478,9 @@ exit:
 		J9Class* currentClass = J9_CLASS_FROM_METHOD(method);
 		J9JavaVM* vm = currentThread->javaVM;
 		return ((method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+				|| (method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 				|| (method == vm->jliMethodHandleInvokeWithArgs)
 				|| (method == vm->jliMethodHandleInvokeWithArgsList)
 				|| (vm->srMethodAccessor

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5391,6 +5391,9 @@ typedef struct J9JavaVM {
 	jclass srMethodAccessor;
 	jclass srConstructorAccessor;
 	struct J9Method* jlrMethodInvoke;
+#if JAVA_SPEC_VERSION >= 18
+	struct J9Method* jlrMethodInvokeMH;
+#endif /* JAVA_SPEC_VERSION >= 18 */
 	struct J9Method* jliMethodHandleInvokeWithArgs;
 	struct J9Method* jliMethodHandleInvokeWithArgsList;
 	jclass jliArgumentHelper;

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -177,7 +177,13 @@ getCallerClassIterator(J9VMThread * currentThread, J9StackWalkState * walkState)
 		return J9_STACKWALK_KEEP_ITERATING;
 	}
 
-	if ((walkState->method != vm->jlrMethodInvoke) && (walkState->method != vm->jliMethodHandleInvokeWithArgs) && (walkState->method != vm->jliMethodHandleInvokeWithArgsList)) {
+	if ((walkState->method != vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+		&& (walkState->method != vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
+		&& (walkState->method != vm->jliMethodHandleInvokeWithArgs)
+		&& (walkState->method != vm->jliMethodHandleInvokeWithArgsList)
+	) {
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 		J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 
@@ -231,6 +237,9 @@ getCallerClassJEP176Iterator(J9VMThread * currentThread, J9StackWalkState * walk
 		if ((walkState->method == vm->jliMethodHandleInvokeWithArgs)
 				|| (walkState->method == vm->jliMethodHandleInvokeWithArgsList)
 				|| (walkState->method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+				|| (walkState->method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 				|| (vm->srMethodAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srMethodAccessor))))
 				|| (vm->srConstructorAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srConstructorAccessor))))
 		) {
@@ -565,7 +574,13 @@ getClassContextIterator(J9VMThread * currentThread, J9StackWalkState * walkState
 		return J9_STACKWALK_KEEP_ITERATING;
 	}
 
-	if ((walkState->method != vm->jlrMethodInvoke) && (walkState->method != vm->jliMethodHandleInvokeWithArgs) && (walkState->method != vm->jliMethodHandleInvokeWithArgsList)) {
+	if ((walkState->method != vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+		&& (walkState->method != vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
+		&& (walkState->method != vm->jliMethodHandleInvokeWithArgs)
+		&& (walkState->method != vm->jliMethodHandleInvokeWithArgsList)
+	) {
 		J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 

--- a/runtime/vm/NativeHelpers.cpp
+++ b/runtime/vm/NativeHelpers.cpp
@@ -109,6 +109,9 @@ cInterpGetStackClassJEP176Iterator(J9VMThread * currentThread, J9StackWalkState 
 		if ((walkState->method == vm->jliMethodHandleInvokeWithArgs)
 				|| (walkState->method == vm->jliMethodHandleInvokeWithArgsList)
 				|| (walkState->method == vm->jlrMethodInvoke)
+#if JAVA_SPEC_VERSION >= 18
+				|| (walkState->method == vm->jlrMethodInvokeMH)
+#endif /* JAVA_SPEC_VERSION >= 18 */
 				|| (vm->srMethodAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srMethodAccessor))))
 				|| (vm->srConstructorAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srConstructorAccessor))))
 		) {


### PR DESCRIPTION
Added `J9JavaVM.jlrMethodInvokeMH` and assigned `java.lang.reflect.Method.invoke(Object,Object[],Class<?>)`;
`VMHelpers.hpp:isReflectionMethod()` recognizes `jlrMethodInvokeMH`;
Updated other frame iterator functions accordingly.

[JEP 416](https://github.com/eclipse-openj9/openj9/issues/13852) uses `java.lang.reflect.Method.invoke(Object obj, Object[] args, Class<?> caller)` [1] instead of `java.lang.reflect.Method.invoke(Object obj, Object... args)` which is invoked by earlier Java levels or Java 18 w/ JEP 416 disabled.

Verified this fixes the issue https://github.com/eclipse-openj9/openj9/issues/14136 in default mode and `-Xjit:count=0` as well.

Note: there are a few references to `javaVM->jlrMethodInvoke` (`java.lang.reflect.Method.invoke(Object,Object[],Class<?>)`) within JIT such as https://github.com/eclipse-openj9/openj9/blob/2736f740ef0eb5b85aabdc7759f8845956b638f2/runtime/compiler/control/JITClientCompilationThread.cpp#L461
Maybe a JIT PR is needed as well.
fyi @0xdaryl 

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/742164f41ccbae087b64a8f282ff98d610ab3f14/src/java.base/share/classes/java/lang/reflect/Method.java#L580-L591

Signed-off-by: Jason Feng <fengj@ca.ibm.com>