### PR TITLE
JDK18 specifies file.encoding UTF-8 when w/o command line defines

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -106,7 +106,10 @@ jstring JNICALL
 Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID)
 {
 	const char *sysPropValue = NULL;
+#if !defined(OSX) || (JAVA_SPEC_VERSION < 18)
+	/* The sysPropValue points to following property which has to be declared at top level. */
 	char property[128] = {0};
+#endif /* !defined(OSX) || (JAVA_SPEC_VERSION < 18) */
 	jstring result = NULL;
 	PORT_ACCESS_FROM_ENV(env);
 
@@ -137,7 +140,11 @@ Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass 
 	case 2: /* file.encoding */
 		sysPropValue = getDefinedEncoding(env, "-Dfile.encoding=");
 		if (NULL == sysPropValue) {
+#if JAVA_SPEC_VERSION >= 18
+			sysPropValue = "UTF-8";
+#else /* JAVA_SPEC_VERSION >= 18 */
 			sysPropValue = getPlatformFileEncoding(env, property, sizeof(property), sysPropID);
+#endif /* JAVA_SPEC_VERSION >= 18 */
 		}
 #if defined(J9ZOS390)
 		if (__CSNameType(sysPropValue) == _CSTYPE_ASCII) {


### PR DESCRIPTION
Required by JEP 400: UTF-8 by Default.

Related to https://github.com/eclipse-openj9/openj9/issues/13470
fixes an internal workitem RTC 146694.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>