### PR TITLE
(0.30.0) Don't create non-relocatable table during AOT in IdiomRecognition

### DIFF
--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -1592,6 +1592,12 @@ CISCTransform2FindBytes(TR_CISCTransformer *trans)
       }
    else
       {
+      // the static table currently cannot be relocated
+      if (comp->compileRelocatableCode())
+         {
+         if (disptrace) traceMsg(comp, "Abandoning reduction since we can't relocate the static table\n");
+         return false;
+         }
       tableNode = createTableLoad(comp, baseRepNode, 8, 8, tmpTable, disptrace);    // function table for TRT
       }
 


### PR DESCRIPTION
- Fixes https://github.com/eclipse-openj9/openj9/issues/14072

Port of https://github.com/eclipse-openj9/openj9/pull/14144 for the 0.30 release.