### PR TITLE
Fill dataAddr field of multidimensional array on z

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -4240,9 +4240,6 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    TR::LabelSymbol *nonZeroFirstDimLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
    TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
-#ifdef TR_TARGET_64BIT
-   TR::LabelSymbol *populateFirstDimDataAddrSlot = generateLabelSymbol(cg);
-#endif /* TR_TARGET_64BIT */
 
    // oolJumpLabel is a common point that all branches will jump to. From this label, we branch to OOL code.
    // We do this instead of jumping directly to OOL code from mainline because the RA can only handle the case where there's
@@ -4303,23 +4300,10 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
 
+   // Init class field, then jump to end of ICF
    generateRXInstruction(cg, use64BitClasses ? TR::InstOpCode::STG : TR::InstOpCode::ST, node, classReg, generateS390MemoryReference(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg));
-#ifdef TR_TARGET_64BIT
-   TR_ASSERT_FATAL_WITH_NODE(node
-      , IS_32BIT_SIGNED(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
-      , "dataAddrFieldOffset is too big for the instruction.");
-
-   // Load dataAddr slot offset difference since 0 size arrays are treated as discontiguous.
-   generateRILInstruction(cg
-      , TR::InstOpCode::LGFI
-      , node
-      , temp1Reg
-      , static_cast<int32_t>(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField()));
-   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, populateFirstDimDataAddrSlot);
-#else
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
-#endif /* TR_TARGET_64BIT */
-   iComment("Init class field and jump.");
+   iComment("Init class field and jump to end of ICF.");
 
    // We end up in this region of the ICF if the first dimension is non-zero and the second dimension is zero.
    cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, nonZeroFirstDimLabel);
@@ -4393,23 +4377,8 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    cursor = generateRXInstruction(cg, use64BitClasses ? TR::InstOpCode::STG : TR::InstOpCode::ST, node, componentClassReg, generateS390MemoryReference(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg));
    iComment("Init 2nd dim class field.");
 
-   TR::Register *temp3Reg = cg->allocateRegister();
-
-#ifdef TR_TARGET_64BIT
-   // Populate dataAddr slot for 2nd dimension zero size array.
-   generateRXInstruction(cg
-      , TR::InstOpCode::LAY
-      , node
-      , temp3Reg
-      , generateS390MemoryReference(temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), cg));
-   generateRXInstruction(cg
-      , TR::InstOpCode::STG
-      , node
-      , temp3Reg
-      , generateS390MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg));
-#endif /* TR_TARGET_64BIT */
-
    // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
+   TR::Register *temp3Reg = cg->allocateRegister();
    if (comp->target().is64Bit() && comp->useCompressedPointers())
       {
       int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
@@ -4431,14 +4400,7 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    generateRILInstruction(cg, TR::InstOpCode::SLFI, node, firstDimLenReg, 1);
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CL, node, firstDimLenReg, 0, TR::InstOpCode::COND_BNE, loopLabel, false);
-
-#ifdef TR_TARGET_64BIT
-   // No offset is needed since 1st dimension array is contiguous.
-   generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, temp1Reg, temp1Reg);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, populateFirstDimDataAddrSlot);
-#else
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
-#endif /* TR_TARGET_64BIT */
 
    TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions(0,10,cg);
    dependencies->addPostCondition(dimReg, TR::RealRegister::AssignAny);
@@ -4454,23 +4416,6 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, oolJumpLabel);
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, oolFailLabel);
-
-#ifdef TR_TARGET_64BIT
-   /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
-    * use contiguous header layout while zero size arrays use discontiguous header layout.
-    */
-   cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, populateFirstDimDataAddrSlot);
-   iComment("populateFirstDimDataAddrSlot.");
-
-   generateRXInstruction(cg, TR::InstOpCode::LAY
-      , node
-      , temp3Reg
-      , generateS390MemoryReference(targetReg, temp1Reg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg));
-   generateRXInstruction(cg, TR::InstOpCode::STG
-      , node
-      , temp3Reg
-      , generateS390MemoryReference(targetReg, temp1Reg, fej9->getOffsetOfContiguousDataAddrField(), cg));
-#endif /* TR_TARGET_64BIT */
 
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowRegionEnd, dependencies);
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -4240,6 +4240,9 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    TR::LabelSymbol *nonZeroFirstDimLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
    TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
+#ifdef TR_TARGET_64BIT
+   TR::LabelSymbol *populateFirstDimDataAddrSlot = generateLabelSymbol(cg);
+#endif /* TR_TARGET_64BIT */
 
    // oolJumpLabel is a common point that all branches will jump to. From this label, we branch to OOL code.
    // We do this instead of jumping directly to OOL code from mainline because the RA can only handle the case where there's
@@ -4300,10 +4303,23 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
 
-   // Init class field, then jump to end of ICF
    generateRXInstruction(cg, use64BitClasses ? TR::InstOpCode::STG : TR::InstOpCode::ST, node, classReg, generateS390MemoryReference(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg));
+#ifdef TR_TARGET_64BIT
+   TR_ASSERT_FATAL_WITH_NODE(node
+      , IS_32BIT_SIGNED(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField())
+      , "dataAddrFieldOffset is too big for the instruction.");
+
+   // Load dataAddr slot offset difference since 0 size arrays are treated as discontiguous.
+   generateRILInstruction(cg
+      , TR::InstOpCode::LGFI
+      , node
+      , temp1Reg
+      , static_cast<int32_t>(fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField()));
+   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, populateFirstDimDataAddrSlot);
+#else
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
-   iComment("Init class field and jump to end of ICF.");
+#endif /* TR_TARGET_64BIT */
+   iComment("Init class field and jump.");
 
    // We end up in this region of the ICF if the first dimension is non-zero and the second dimension is zero.
    cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, nonZeroFirstDimLabel);
@@ -4377,8 +4393,23 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    cursor = generateRXInstruction(cg, use64BitClasses ? TR::InstOpCode::STG : TR::InstOpCode::ST, node, componentClassReg, generateS390MemoryReference(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg));
    iComment("Init 2nd dim class field.");
 
-   // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
    TR::Register *temp3Reg = cg->allocateRegister();
+
+#ifdef TR_TARGET_64BIT
+   // Populate dataAddr slot for 2nd dimension zero size array.
+   generateRXInstruction(cg
+      , TR::InstOpCode::LAY
+      , node
+      , temp3Reg
+      , generateS390MemoryReference(temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), cg));
+   generateRXInstruction(cg
+      , TR::InstOpCode::STG
+      , node
+      , temp3Reg
+      , generateS390MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg));
+#endif /* TR_TARGET_64BIT */
+
+   // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
    if (comp->target().is64Bit() && comp->useCompressedPointers())
       {
       int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
@@ -4400,7 +4431,14 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    generateRILInstruction(cg, TR::InstOpCode::SLFI, node, firstDimLenReg, 1);
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CL, node, firstDimLenReg, 0, TR::InstOpCode::COND_BNE, loopLabel, false);
+
+#ifdef TR_TARGET_64BIT
+   // No offset is needed since 1st dimension array is contiguous.
+   generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, temp1Reg, temp1Reg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, populateFirstDimDataAddrSlot);
+#else
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
+#endif /* TR_TARGET_64BIT */
 
    TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions(0,10,cg);
    dependencies->addPostCondition(dimReg, TR::RealRegister::AssignAny);
@@ -4416,6 +4454,23 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, oolJumpLabel);
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, oolFailLabel);
+
+#ifdef TR_TARGET_64BIT
+   /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
+    * use contiguous header layout while zero size arrays use discontiguous header layout.
+    */
+   cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, populateFirstDimDataAddrSlot);
+   iComment("populateFirstDimDataAddrSlot.");
+
+   generateRXInstruction(cg, TR::InstOpCode::LAY
+      , node
+      , temp3Reg
+      , generateS390MemoryReference(targetReg, temp1Reg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg));
+   generateRXInstruction(cg, TR::InstOpCode::STG
+      , node
+      , temp3Reg
+      , generateS390MemoryReference(targetReg, temp1Reg, fej9->getOffsetOfContiguousDataAddrField(), cg));
+#endif /* TR_TARGET_64BIT */
 
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowRegionEnd, dependencies);
 


### PR DESCRIPTION
Adapt `multianewArrayEvaluator` to populate `dataAddr` field of
multidimensional arrays. Two cases we address are:
- Both 1st and 2nd dimensional arrays are zero size
- 1st dimensional array is of size non-zero and 2nd dimensional array is
  of size zero.

Part of phase 2 of #11438.

Signed-off-by: Shubham Verma shubhamv.sv@gmail.com