### PR TITLE
VMCPTool adds a NOT operator ! for J9 flags

### DIFF
--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/Main.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/Main.java
@@ -421,6 +421,10 @@ public class Main implements Constants {
 						System.exit(-1);
 					}
 
+					if (flagName.startsWith("!")) {
+						// skip flag w/ starting !
+						flagName = flagName.substring(1);
+					}
 					/* Find or create the flag object */
 					JCLRuntimeFlag flag = runtimeFlagDefs.get(flagName);
 					if (null == flag) {

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/PrimaryItem.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/PrimaryItem.java
@@ -180,7 +180,15 @@ public abstract class PrimaryItem {
 
 		private boolean hasFlag(Set<String> flags) {
 			for (String s : this.flags) {
-				if (flags.contains(s)) {
+				if (s.startsWith("!")) {
+					// remove starting !
+					String actualFlag = s.substring(1);
+					if (flags.contains(actualFlag)) {
+						return false;
+					} else {
+						return true;
+					}
+				} else if (flags.contains(s)) {
 					return true;
 				}
 			}

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/Util.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/Util.java
@@ -24,6 +24,10 @@ package com.ibm.oti.VMCPTool;
 public class Util {
 
 	public static String transformFlag(String oldFlag) {
+		if (oldFlag.startsWith("!")) {
+			// remove starting !
+			oldFlag = oldFlag.substring(1);
+		}
 		if (!oldFlag.startsWith("J9VM_")) {
 			return oldFlag;
 		}


### PR DESCRIPTION
This is to accommodate incompatible references when a J9 flag enabled or not such as:
```
<fieldref class="java/lang/Thread" name="eetop" signature="J" cast="struct J9VMThread *" flags="opt_ojdkThreadSupport"/>
<fieldref class="java/lang/Thread" name="threadRef" signature="J" cast="struct J9VMThread *" flags="!opt_ojdkThreadSupport"/>
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>