### PR TITLE
(0.30.0) Update OpenSSL except Windows to 1.1.1m

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -152,7 +152,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1l'
+  extra_getsource_options: '--openssl-version=1.1.1m'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Cherry pick of https://github.com/eclipse-openj9/openj9/pull/14155 for the 0.30.0 release.