### PR TITLE
(0.30.0) Prevent recognition of J9VMInternals.getSuperclass under FSD

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4479,6 +4479,7 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
       {
       switch (rm)
          {
+         case TR::java_lang_J9VMInternals_getSuperclass:
          case TR::com_ibm_jit_JITHelpers_getSuperclass:
          case TR::com_ibm_jit_DecimalFormatHelper_formatAsDouble:
          case TR::com_ibm_jit_DecimalFormatHelper_formatAsFloat:


### PR DESCRIPTION
Include J9VMInternals.getSuperclass in the list of methods to avoid
recognizing in FSD mode.  This is to prevent special transformation
of this method to JITHelpers.getSuperclass which causes problems if
a decompilation is triggered within.

Fixes: #14115

Port of https://github.com/eclipse-openj9/openj9/pull/14163 for the 0.30 release.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>