### PR TITLE
Adopt RI java.lang.Thread/ThreadGroup w/ opt_ojdkThreadSupport

### DIFF
--- a/buildspecs/core.feature
+++ b/buildspecs/core.feature
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2021 IBM Corp. and others
+Copyright (c) 2006, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,6 +107,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="module_verutil" value="true"/>
 		<flag id="module_vm" value="true"/>
 		<flag id="opt_criuSupport" value="false"/>
+		<flag id="opt_ojdkThreadSupport" value="false"/>
 		<flag id="opt_fragmentRamClasses" value="true"/>
 		<flag id="opt_inlineJsrs" value="true"/>
 		<flag id="opt_jitserver" value="false"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2021 IBM Corp. and others
+Copyright (c) 2006, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1831,6 +1831,10 @@ Only available on zOS</description>
 	<flag id="opt_openjdkFfi">
 		<description>Enables support for Foreign Linker API (part of Project Panama) such as native invocations to ffi_call</description>
 		<ifRemoved>No support for Foreign Linker API</ifRemoved>
+	</flag>
+	<flag id="opt_ojdkThreadSupport">
+		<description>Enables OpenJDK Thread support for Project Loom</description>
+		<ifRemoved>No OpenDJK Thread support for Project Loom</ifRemoved>
 	</flag>
 	<flag id="opt_valhallaValueTypes">
 		<description>Enables support for Project Valhalla L-World Value Types</description>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE configurationreg SYSTEM "http://home.ottawa.ibm.com/teams/bluebird/web/eclipse_site/jpp.dtd">
 <!--
 /*******************************************************************************
- * Copyright (c) 2002, 2021 IBM Corp. and others
+ * Copyright (c) 2002, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@
 	<!-- START SET DEFINITIONS -->
 	<set
 		label="newflags"
-		flags="INLINE-TYPES,OPENJDK_METHODHANDLES,CRIU_SUPPORT"/>
+		flags="INLINE-TYPES,OPENJDK_METHODHANDLES,CRIU_SUPPORT,OJDKTHREAD_SUPPORT"/>
 
 	<set
 		label="oldflags"

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,11 +98,19 @@ final class J9VMInternals {
 
 				CleanerShutdown.shutdownCleaner();
 				ThreadGroup threadGroup = Thread.currentThread().group; // the system ThreadGroup
+				/*[IF OJDKTHREAD_SUPPORT]*/
+				ThreadGroup threadGroups[] = new ThreadGroup[threadGroup.ngroups];
+				/*[ELSE] OJDKTHREAD_SUPPORT
 				ThreadGroup threadGroups[] = new ThreadGroup[threadGroup.numGroups];
+				/*[ENDIF] OJDKTHREAD_SUPPORT */
 				threadGroup.enumerate(threadGroups, false); /* non-recursive enumeration */
 				for (ThreadGroup tg : threadGroups) {
 					if ("InnocuousThreadGroup".equals(tg.getName())) { //$NON-NLS-1$
+						/*[IF OJDKTHREAD_SUPPORT]*/
+						Thread threads[] = new Thread[tg.nthreads];
+						/*[ELSE] OJDKTHREAD_SUPPORT
 						Thread threads[] = new Thread[tg.numThreads];
+						/*[ENDIF] OJDKTHREAD_SUPPORT */
 						tg.enumerate(threads, false);
 						for (Thread t : threads) {
 							if (t.getName().equals("Common-Cleaner")) { //$NON-NLS-1$
@@ -310,7 +318,11 @@ final class J9VMInternals {
 		/*[PR 106323] -- remove might throw an exception, so make sure we finish the cleanup*/
 		try {
 			// Leave the ThreadGroup. This is why remove can't be private
+			/*[IF OJDKTHREAD_SUPPORT]*/
+			thread.group.threadTerminated(thread);
+			/*[ELSE] OJDKTHREAD_SUPPORT*/
 			thread.group.remove(thread);
+			/*[ENDIF] OJDKTHREAD_SUPPORT */
 		}
 		finally {
 			thread.cleanup();

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF Sidecar18-SE & !OJDKTHREAD_SUPPORT]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF Sidecar18-SE & !OJDKTHREAD_SUPPORT]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,6 +138,7 @@ option(J9VM_OPT_METHOD_HANDLE "Enables support for OpenJ9 MethodHandles. J9VM_OP
 option(J9VM_OPT_METHOD_HANDLE_COMMON "Enables common dependencies between OpenJ9 and OpenJDK MethodHandles.")
 option(J9VM_OPT_MODULE "Turns on module support")
 option(J9VM_OPT_MULTI_VM "Decides if multiple VMs can be created in the same address space")
+option(J9VM_OPT_OJDK_THREAD_SUPPORT "Enables OpenJDK Thread support for Project Loom.")
 option(J9VM_OPT_OPENJDK_METHODHANDLE "Enables support for OpenJDK MethodHandles. J9VM_OPT_METHOD_HANDLE should be disabled.")
 
 option(J9VM_OPT_PANAMA "Enables support for Project Panama features such as native method handles")

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -233,6 +233,7 @@ extern "C" {
 #cmakedefine J9VM_OPT_NEW_ROM_CLASS_BUILDER
 #cmakedefine J9VM_OPT_NO_CLASSLOADERS
 #cmakedefine J9VM_OPT_NRR
+#cmakedefine J9VM_OPT_OJDK_THREAD_SUPPORT
 #cmakedefine J9VM_OPT_OPENJDK_METHODHANDLE
 #cmakedefine J9VM_OPT_PACKED
 #cmakedefine J9VM_OPT_PANAMA

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2021 IBM Corp. and others
+Copyright (c) 2006, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,7 +190,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/StackTraceElement" name="fileName" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="lineNumber" signature="I"/>
 	<fieldref class="java/lang/StackTraceElement" name="source" signature="Ljava/lang/Object;"/>
-	<fieldref class="java/lang/Thread" name="threadRef" signature="J" cast="struct J9VMThread *"/>
+	<fieldref class="java/lang/Thread" name="threadRef" signature="J" cast="struct J9VMThread *" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="eetop" signature="J" cast="struct J9VMThread *" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
 	<fieldref class="java/lang/Thread" name="stackSize" signature="J"/>
 	<fieldref class="java/lang/Thread" name="tid" signature="J"/>
 	<fieldref class="java/lang/Thread" name="deadInterrupt" signature="Z" versions="14-"/>
@@ -209,13 +211,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="frameModule" signature="Ljava/lang/Module;" versions="9-"/>
 
 	<fieldref class="java/lang/Thread" name="priority" signature="I"/>
-	<fieldref class="java/lang/Thread" name="isDaemon" signature="Z"/>
-	<fieldref class="java/lang/Thread" name="runnable" signature="Ljava/lang/Runnable;"/>
+	<fieldref class="java/lang/Thread" name="isDaemon" signature="Z" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="daemon" signature="Z" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
 	<fieldref class="java/lang/Thread" name="group" signature="Ljava/lang/ThreadGroup;"/>
 	<fieldref class="java/lang/Thread" name="stopCalled" signature="Z"/>
 	<fieldref class="java/lang/Thread" name="contextClassLoader" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/Thread" name="inheritedAccessControlContext" signature="Ljava/security/AccessControlContext;"/>
-	<fieldref class="java/lang/Thread" name="lock" signature="Ljava/lang/Object;"/>
+	<fieldref class="java/lang/Thread" name="lock" signature="Ljava/lang/Object;" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="blockerLock" signature="Ljava/lang/Object;" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
 	<fieldref class="java/lang/Thread" name="parkBlocker" signature="Ljava/lang/Object;"/>
 	<fieldref class="java/lang/Throwable" name="cause" signature="Ljava/lang/Throwable;"/>
 	<fieldref class="java/lang/Throwable" name="detailMessage" signature="Ljava/lang/String;"/>
@@ -268,13 +273,23 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/ThreadGroup" name="name" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/ThreadGroup" name="maxPriority" signature="I"/>
 	<fieldref class="java/lang/ThreadGroup" name="parent" signature="Ljava/lang/ThreadGroup;"/>
-	<fieldref class="java/lang/ThreadGroup" name="numThreads" signature="I"/>
-	<fieldref class="java/lang/ThreadGroup" name="numGroups" signature="I"/>
-	<fieldref class="java/lang/ThreadGroup" name="childrenThreads" signature="[Ljava/lang/Thread;"/>
-	<fieldref class="java/lang/ThreadGroup" name="childrenGroups" signature="[Ljava/lang/ThreadGroup;"/>
-	<fieldref class="java/lang/ThreadGroup" name="isDaemon" signature="Z"/>
-	<fieldref class="java/lang/ThreadGroup" name="childrenGroupsLock" signature="Ljava/lang/Object;"/>
-	<fieldref class="java/lang/ThreadGroup" name="childrenThreadsLock" signature="Ljava/lang/Object;"/>
+	<fieldref class="java/lang/ThreadGroup" name="numThreads" signature="I" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="nthreads" signature="I" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="numGroups" signature="I" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="ngroups" signature="I" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="childrenThreads" signature="[Ljava/lang/Thread;" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="threads" signature="[Ljava/lang/Thread;" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="childrenGroups" signature="[Ljava/lang/ThreadGroup;" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="groups" signature="[Ljava/lang/ThreadGroup;" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="isDaemon" signature="Z" flags="!opt_ojdkThreadSupport">
+		<fieldalias name="daemon" signature="Z" flags="opt_ojdkThreadSupport"/>
+	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="childrenGroupsLock" signature="Ljava/lang/Object;" flags="!opt_ojdkThreadSupport"/>
+	<fieldref class="java/lang/ThreadGroup" name="childrenThreadsLock" signature="Ljava/lang/Object;" flags="!opt_ojdkThreadSupport"/>
 	<fieldref class="java/lang/ref/Reference" name="referent" signature="Ljava/lang/Object;"/>
 	<fieldref class="java/lang/ref/Reference" name="queue" signature="Ljava/lang/ref/ReferenceQueue;"/>
 	<fieldref class="java/lang/ref/Reference" name="state" signature="I"/>


### PR DESCRIPTION
Added `opt_ojdkThreadSupport` flag and decorate the behaviour change w/ `J9VM_OPT_OJDK_THREAD_SUPPORT`;
Replaced `j.l.Thread.threadRef` with `eetop`;
Replaced `j.l.Thread.isDaemon` with `daemon`;
Replaced `j.l.Thread.runnable` with `target`;
Replaced `j.l.Thread.lock` with `blockerLock`;
Replaced `j.l.ThreadGroup.numThreads` with `nthreads`;
Replaced `j.l.ThreadGroup.numGroups` with `ngroups`;
Replaced `j.l.ThreadGroup.childrenThreads` with `threads`;
Replaced `j.l.ThreadGroup.childrenGroups` with `groups`;
Replaced `j.l.ThreadGroup.isDaemon` with `daemon`;
Updated references accordingly;
Minor refactoring at methods affected.

fyi @pshipton @0xdaryl 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>