### PR TITLE
Make the JIT use a single consistent vmentry for each MethodHandle

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4917,24 +4917,97 @@ TR_J9VMBase::targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObject
        knot &&
        !knot->isNull(objIndex))
       {
-      TR::VMAccessCriticalSection getTarget(this);
-      uintptr_t object = knot->getPointer(objIndex);
-      return targetMethodFromMethodHandle(object);
-      }
-   return NULL;
-   }
+      const char *mhClassName = "java/lang/invoke/MethodHandle";
+      int32_t mhClassNameLen = strlen(mhClassName);
+      TR_OpaqueClassBlock *mhClass =
+         getSystemClassFromClassName(mhClassName, mhClassNameLen);
 
-TR_OpaqueMethodBlock*
-TR_J9VMBase::targetMethodFromMethodHandle(uintptr_t methodHandle)
-   {
-   TR_ASSERT(haveAccess(), "targetFromMethodHandle requires VM access");
-   uintptr_t form = getReferenceField(
-      methodHandle,
-      "form",             "Ljava/lang/invoke/LambdaForm;");
-   uintptr_t vmentry = getReferenceField(
-      form,
-      "vmentry",             "Ljava/lang/invoke/MemberName;");
-   return targetMethodFromMemberName(vmentry);
+      if (mhClass == NULL)
+         {
+         if (comp->getOption(TR_TraceOptDetails))
+            traceMsg(comp, "targetMethodFromMethodHandle: MethodHandle is not loaded\n");
+
+         return NULL;
+         }
+
+      TR::VMAccessCriticalSection getTarget(this);
+
+      uintptr_t handle = knot->getPointer(objIndex);
+      TR_OpaqueClassBlock *objClass = getObjectClass(handle);
+      if (isInstanceOf(objClass, mhClass, true, true) != TR_yes)
+         {
+         if (comp->getOption(TR_TraceOptDetails))
+            {
+            traceMsg(
+               comp,
+               "targetMethodFromMethodHandle: Cannot load ((MethodHandle)obj%d).form "
+               "because obj%d is not a MethodHandle\n",
+               objIndex,
+               objIndex);
+            }
+
+         return NULL;
+         }
+
+      J9JavaVM *javaVM = _jitConfig->javaVM;
+      uint32_t keepAliveOffset = javaVM->jitVMEntryKeepAliveOffset;
+      uint32_t keepAliveOffsetNoHeader = keepAliveOffset - getObjectHeaderSizeInBytes();
+      uintptr_t vmentry = getVolatileReferenceFieldAt(handle, keepAliveOffsetNoHeader);
+      if (vmentry == 0)
+         {
+         uintptr_t form = getReferenceField(
+            handle, "form", "Ljava/lang/invoke/LambdaForm;");
+
+         if (form == 0)
+            {
+            if (comp->getOption(TR_TraceOptDetails))
+               {
+               traceMsg(
+                  comp,
+                  "targetMethodFromMethodHandle: null ((MethodHandle)obj%d).form\n",
+                  objIndex);
+               }
+
+            return NULL;
+            }
+
+         vmentry = getReferenceField(
+            form, "vmentry", "Ljava/lang/invoke/MemberName;");
+
+         if (vmentry == 0)
+            {
+            if (comp->getOption(TR_TraceOptDetails))
+               {
+               traceMsg(
+                  comp,
+                  "targetMethodFromMethodHandle: null ((MethodHandle)obj%d).form.vmentry\n",
+                  objIndex);
+               }
+
+            return NULL;
+            }
+
+         // This should be fj9object_t*, but j9gc_objaccess_compareAndSwapObject
+         // still expects J9Object** in its signature.
+         auto **keepAliveAddr = (J9Object**)(handle + keepAliveOffset);
+         UDATA success = javaVM->memoryManagerFunctions->j9gc_objaccess_compareAndSwapObject(
+            vmThread(), (J9Object*)handle, keepAliveAddr, NULL, (J9Object*)vmentry);
+
+         if (success == 0)
+            {
+            vmentry = getVolatileReferenceFieldAt(handle, keepAliveOffsetNoHeader);
+            TR_ASSERT_FATAL(
+               vmentry != 0,
+               "((MethodHandle)obj%d).jitVMEntryKeepAlive is still null "
+               "after failing compare and swap",
+               objIndex);
+            }
+         }
+
+      return targetMethodFromMemberName(vmentry);
+      }
+
+   return NULL;
    }
 
 J9JNIMethodID*

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -790,13 +790,6 @@ public:
     * \brief
     *    Return MethodHandle.form.vmentry.vmtarget, J9method for the underlying java method
     *    The J9Method is the target to be invoked intrinsically by MethodHandle.invokeBasic
-    *    Caller must acquire VM access
-    */
-   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(uintptr_t methodHandle);
-   /*
-    * \brief
-    *    Return MethodHandle.form.vmentry.vmtarget, J9method for the underlying java method
-    *    The J9Method is the target to be invoked intrinsically by MethodHandle.invokeBasic
     *    VM access is not required
     */
    virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2166,13 +2166,6 @@ TR_J9ServerVM::targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObje
    return NULL;
    }
 
-TR_OpaqueMethodBlock*
-TR_J9ServerVM::targetMethodFromMethodHandle(uintptr_t methodHandle)
-   {
-   TR_ASSERT_FATAL(false, "targetMethodFromMethodHandle must not be called on JITServer");
-   return NULL;
-   }
-
 TR::KnownObjectTable::Index
 TR_J9ServerVM::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -226,7 +226,6 @@ public:
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(uintptr_t memberName) override;
    virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
-   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(uintptr_t methodHandle) override;
    virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
    virtual TR_ResolvedMethod *targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray) override;
    virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray) override;

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -325,6 +325,13 @@ bool J9::TransformUtil::avoidFoldingInstanceField(
             && fej9->isInstanceOf(objectClass, mcsClass, true) != TR_no;
          }
 
+      // MethodHandle.form can change even though it's declared final, so don't
+      // create a known object for it. Refinement doesn't rely on folding loads
+      // of this field to a known object. (LambdaForm.vmentry doesn't need to
+      // be listed here because it isn't even final.)
+      case TR::Symbol::Java_lang_invoke_MethodHandle_form:
+         return true;
+
       default:
          break;
       }

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -634,6 +634,10 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/invoke/MutableCallSite", "invalidationCookie", "J", &vm->mutableCallSiteInvalidationCookieOffset)) {
 		return 1;
 	}
+
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/invoke/MethodHandle", "jitVMEntryKeepAlive", "Ljava/lang/invoke/MemberName;", &vm->jitVMEntryKeepAliveOffset)) {
+		return 1;
+	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5569,6 +5569,7 @@ typedef struct J9JavaVM {
 	UDATA vmindexOffset;
 	UDATA vmtargetOffset;
 	UDATA mutableCallSiteInvalidationCookieOffset;
+	UDATA jitVMEntryKeepAliveOffset;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY)
 	U_32 javaVM31;


### PR DESCRIPTION
...when OpenJDK MethodHandles are enabled.

When the JIT processes a call to `invokeBasic()` on a known `MethodHandle`, `mh`, it loads `mh.form.vmentry` to find the `MemberName` that specifies the `LambdaForm`-generated method that implements `mh`. It then refines the call into a direct call to the implementing method. Typically this call will be inlined after refinement, but it may be generated as a call instead, e.g. due to `disableInlining`, or `dontInline={...}`, etc. Either way, the generated code may rely on the implementing method remaining loaded. For example, inlined code may need to resolve constant pool entries, load from pseudo-TOC entries that get released on unload, or OSR to continue execution in the interpreter.

The `MemberName` holds a reference to the generated class, so the implementing method will stay loaded as long as the `MemberName` is live. The references from the `MethodHandle` to the `LambdaForm` and then from there to the `MemberName` are usually enough to hold the `MemberName` live as long as the `MethodHandle`, so that the generated code works when the `invokeBasic()` call is reached at runtime. However, it is possible for some of these references to change after (or even during) compilation. In particular:

1. A `MethodHandle` may have its `LambdaForm` replaced with another semantically equivalent one.

2. A `LambdaForm` may be redundantly compiled to bytecode multiple times with no synchronization to prevent multiple distinct `MemberName` objects from being observed. The generated classes are only nominally different, so they're generally interchangeable.

If either of these situations arises after the JIT compiler has observed the `vmentry` for a particular `MethodHandle`, the update can sometimes make the original `vmentry` unreachable, and if it does, that can allow the generated bytecode to be unloaded even though it's still needed for a caller's JIT-compiled code.

This commit adds a field to `MethodHandle` called `jitVMEntryKeepAlive`. The first time the JIT compiler observes the `vmentry` corresponding to a given `MethodHandle`, it updates the field to point directly from the `MethodHandle` to the observed `MemberName` instance. Whenever the JIT subsequently looks for the `vmentry` of that `MethodHandle`, it will simply use the reference from `jitVMEntryKeepAlive`, ignoring `form.vmentry`. In this way, the compiler ensures that the `MemberName` it observes will live at least as long as the `MethodHandle`, and therefore so will the generated bytecode. The bytecode can still be unloaded once the `MethodHandle` is collected, but at that point any `invokeBasic()` call that was transformed for the handle had better already be unreachable.

Note that it's fine to miss the updates (1) and (2). For (1), the new `LambdaForm` is required to be equivalent to the old, and threads are allowed to keep running the old one indefinitely. In the case of (2), for a given `LambdaForm`, any generated class is as good as any other.

Fixes #13588

--------

There is one additional commit to prevent folding `MethodHandle.form` to a known object, just as a precaution.