### PR TITLE
Unify the code of hashing function signature & arguments in downcall

### DIFF
--- a/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -316,13 +316,8 @@ public class ProgrammableInvoker {
 			 * So we have to rely on the method type (deduced from the function descriptor in OpenJDK)
 			 * to differentiate the functions' signature (Only for primitives).
 			 */
-			/*[IF JAVA_SPEC_VERSION >= 18]*/
 			int funcSigHash = funcMethodType.hashCode();
 			int argTypesHash = argTypes.hashCode();
-			/*[ELSE] JAVA_SPEC_VERSION >= 18 */
-			int funcSigHash = funcDescriptor.hashCode();
-			int argTypesHash = argLayouts.hashCode();
-			/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 			Long cifNativeThunk = cachedCifNativeThunkAddr.get(funcSigHash);
 			if (cifNativeThunk != null) {
 				cifNativeThunkAddr = cifNativeThunk.longValue();


### PR DESCRIPTION
The change is to unify the code of calculating the hashcode for
the function signature and arguments to ensure it works on both
JDK17 and JDK18.

Fixes: #14169

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>