### PR TITLE
[JEP416] Add caller sensitive adapter method in java.lang.ClassLoader

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,10 @@ import sun.reflect.CallerSensitive;
 import jdk.internal.loader.NativeLibraries;
 import jdk.internal.loader.NativeLibrary;
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+
+/*[IF JAVA_SPEC_VERSION >= 18]*/
+import jdk.internal.reflect.CallerSensitiveAdapter;
+/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
 /**
  * ClassLoaders are used to dynamically load, link and install
@@ -1400,6 +1404,13 @@ Class<?> loadClassHelper(final String className, boolean resolveClass, boolean d
 protected static boolean registerAsParallelCapable() {
 	final Class<?> callerCls = System.getCallerClass();
 	
+/*[IF JAVA_SPEC_VERSION >= 18]*/
+	return registerAsParallelCapable(callerCls);
+}
+
+@CallerSensitiveAdapter
+private static boolean registerAsParallelCapable(Class<?> callerCls) {
+/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	if (parallelCapableCollection.containsKey(callerCls)) {
 		return true;
 	}

--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,11 @@ ClassFileOracle::KnownAnnotation ClassFileOracle::_knownAnnotations[] = {
 #define JDK_INTERNAL_REFLECT_CALLERSENSITIVE_SIGNATURE "Ljdk/internal/reflect/CallerSensitive;"
 		{JDK_INTERNAL_REFLECT_CALLERSENSITIVE_SIGNATURE, sizeof(JDK_INTERNAL_REFLECT_CALLERSENSITIVE_SIGNATURE)},
 #undef JDK_INTERNAL_REFLECT_CALLERSENSITIVE_SIGNATURE
+#if JAVA_SPEC_VERSION >= 18
+#define JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_SIGNATURE "Ljdk/internal/reflect/CallerSensitiveAdapter;"
+		{JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_SIGNATURE, sizeof(JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_SIGNATURE)},
+#undef JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_SIGNATURE
+#endif /* JAVA_SPEC_VERSION >= 18 */
 #define JAVA8_CONTENDED_SIGNATURE "Lsun/misc/Contended;" /* TODO remove this if VM does not support Java 8 */
 		{JAVA8_CONTENDED_SIGNATURE, sizeof(JAVA8_CONTENDED_SIGNATURE)},
 #undef JAVA8_CONTENDED_SIGNATURE
@@ -923,6 +928,9 @@ ClassFileOracle::walkMethodAttributes(U_16 methodIndex)
 			knownAnnotations = addAnnotationBit(knownAnnotations, FRAMEITERATORSKIP_ANNOTATION);
 			knownAnnotations = addAnnotationBit(knownAnnotations, SUN_REFLECT_CALLERSENSITIVE_ANNOTATION);
 			knownAnnotations = addAnnotationBit(knownAnnotations, JDK_INTERNAL_REFLECT_CALLERSENSITIVE_ANNOTATION);
+#if JAVA_SPEC_VERSION >= 18
+			knownAnnotations = addAnnotationBit(knownAnnotations, JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_ANNOTATION);
+#endif /* JAVA_SPEC_VERSION >= 18*/
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 			knownAnnotations = addAnnotationBit(knownAnnotations, HIDDEN_ANNOTATION);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
@@ -935,6 +943,9 @@ ClassFileOracle::walkMethodAttributes(U_16 methodIndex)
 				UDATA foundAnnotations = walkAnnotations(attribAnnotations->numberOfAnnotations, attribAnnotations->annotations, knownAnnotations);
 				if (containsKnownAnnotation(foundAnnotations, SUN_REFLECT_CALLERSENSITIVE_ANNOTATION)
 					|| containsKnownAnnotation(foundAnnotations, JDK_INTERNAL_REFLECT_CALLERSENSITIVE_ANNOTATION)
+#if JAVA_SPEC_VERSION >= 18
+					|| containsKnownAnnotation(foundAnnotations, JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_ANNOTATION)
+#endif /* JAVA_SPEC_VERSION >= 18*/
 				) {
 					_methodsInfo[methodIndex].modifiers |= J9AccMethodCallerSensitive;
 				}

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1053,6 +1053,9 @@ private:
 		FRAMEITERATORSKIP_ANNOTATION,
 		SUN_REFLECT_CALLERSENSITIVE_ANNOTATION,
 		JDK_INTERNAL_REFLECT_CALLERSENSITIVE_ANNOTATION,
+#if JAVA_SPEC_VERSION >= 18
+		JDK_INTERNAL_REFLECT_CALLERSENSITIVEADAPTER_ANNOTATION,
+#endif /* JAVA_SPEC_VERSION >= 18*/
 		JAVA8_CONTENDED_ANNOTATION,
 		CONTENDED_ANNOTATION,
 		UNMODIFIABLE_ANNOTATION,


### PR DESCRIPTION
For JEP416, a private adapter method, which accepts an additional `Class<?>`
parameter, is needed for `ClassLoader.registerAsParallelCapable(Class<?>)`.

`@CallerSensitiveAdapter` is a variant of `@CallerSensitive`. So, treat
`@CallerSensitiveAdapter` similar to `@CallerSensitive` in
- `inlInternalsNewInstanceImpl`
- `inlVMGetStackClassLoader`
- `inlVMGetStackClass`

Closes: https://github.com/eclipse-openj9/openj9/issues/14133
Related: https://github.com/eclipse-openj9/openj9/issues/13852

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>