### PR TITLE
Remove --enable-preview for JEP 358/360/384/389/397 tests

### DIFF
--- a/test/functional/Java14andUp/build.xml
+++ b/test/functional/Java14andUp/build.xml
@@ -56,7 +56,7 @@
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${TestUtilities}" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
+			<compilerarg line='--source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>
@@ -77,7 +77,7 @@
 		<javac srcdir="${src}" destdir="${build-noDebugInfo}" debug="false" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${TestUtilities}" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
+			<compilerarg line='--source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -23,9 +23,6 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep359Tests</testCaseName>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
             -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -50,10 +47,6 @@
 	</test>
 	<test>
 		<testCaseName>ThreadInterruptImplTest</testCaseName>
-		<variations>
-			<!-- enable-preview is needed here because JEP 359 test class files will be included on the classpath. -->
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
             -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
             org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ThreadInterruptImplTest \
@@ -78,7 +71,7 @@
 	<test>
 		<testCaseName>JEP358NPEMessageTests</testCaseName>
 		<variations>
-			<variation>--enable-preview -XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
+			<variation>-XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DhasDebugInfo=true \
             -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -104,7 +97,7 @@
 	<test>
 		<testCaseName>JEP358NPEMessageTests-noDebugInfo</testCaseName>
 		<variations>
-			<variation>--enable-preview -XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
+			<variation>-XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DhasDebugInfo=false \
             -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest-noDebugInfo.jar$(Q) \

--- a/test/functional/Java14andUp/src/org/openj9/test/utilities/RecordClassGenerator.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/utilities/RecordClassGenerator.java
@@ -1,7 +1,7 @@
 package org.openj9.test.utilities;
 
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ import org.openj9.test.util.VersionCheck;
     /* Generata a valid record with optional attributes */
     public static byte[] generateRecordAttributes(String className, String rcName, String rcType, String rcSignature) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         /* add record component */
         RecordComponentVisitor rcv = cw.visitRecordComponent(
@@ -62,14 +62,14 @@ import org.openj9.test.util.VersionCheck;
 
     private static byte[] generateRecordWithCustomOpcodes(String className, int access) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(classVersion | V_PREVIEW, access, className, null, "java/lang/Record", null);
+        cw.visit(classVersion, access, className, null, "java/lang/Record", null);
         cw.visitEnd();
         return cw.toByteArray();
     }
 
     public static byte[] generateRecordAttributesWithNoAccessor(String className, String rcName, String rcType) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         RecordComponentVisitor rcv = cw.visitRecordComponent(
                 rcName,
@@ -85,7 +85,7 @@ import org.openj9.test.util.VersionCheck;
 
     public static byte[] generateRecordAttributesWithInvalidAccessor(String className, String rcName, String rcType, String invalidType) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         RecordComponentVisitor rcv = cw.visitRecordComponent(
                 rcName,

--- a/test/functional/Java15andUp/build.xml
+++ b/test/functional/Java15andUp/build.xml
@@ -34,6 +34,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="LIB" value="asm,testng,jcommander"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
@@ -52,8 +53,9 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<src path="${TestUtilities}" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+			<compilerarg line='--source ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Java15andUp/playlist.xml
+++ b/test/functional/Java15andUp/playlist.xml
@@ -23,9 +23,6 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep360Tests</testCaseName>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
             -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
             -javaagent:$(Q)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -46,9 +43,6 @@
 	</test>
 	<test>
 		<testCaseName>Jep384Tests</testCaseName>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
             --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
             -cp $(Q)$(LIB_DIR)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
@@ -23,39 +23,18 @@ package org.openj9.test.utilities;
  *******************************************************************************/
 
  import org.objectweb.asm.*;
+ import org.openj9.test.util.VersionCheck;
 
  public class SealedClassGenerator implements Opcodes {
 	private static String dummySubclassName = "TestSubclassGen";
-	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
-	 * major version match the latest supported version when --enable-preview flag is active
-	 */
-	private static int latestPreviewVersion;
-	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 15:
-				latestPreviewVersion = V15;
-				break;
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			case 18:
-				latestPreviewVersion = 62; // does ASM support jdk18 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
-		}
-	}
+	/* sealed classes are NOT a preview feature since LTS jdk 17 */
+	private static int latestVersion = VersionCheck.classFile();
 
 	public static byte[] generateFinalSealedClass(String className) {
 		int accessFlags = ACC_FINAL | ACC_SUPER;
 
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, accessFlags, className, null, "java/lang/Object", null);
+		cw.visit(latestVersion, accessFlags, className, null, "java/lang/Object", null);
 
 		/* Sealed class must have a PermittedSubclasses attribute */
 		cw.visitPermittedSubclass(dummySubclassName);
@@ -67,7 +46,7 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubclassIllegallyExtendingSealedSuperclass(String className, Class<?> superClass) {
 		String superName = superClass.getName().replace('.', '/');
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, superName, null);
+		cw.visit(latestVersion, ACC_SUPER, className, null, superName, null);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
@@ -75,14 +54,14 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubinterfaceIllegallyExtendingSealedSuperinterface(String className, Class<?> superInterface) {
 		String[] interfaces = { superInterface.getName().replace('.', '/') };
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", interfaces);
+		cw.visit(latestVersion, ACC_SUPER, className, null, "java/lang/Object", interfaces);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
 
 	public static byte[] generateSealedClass(String className, String[] permittedSubclassNames) {
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", null);
+		cw.visit(latestVersion, ACC_SUPER, className, null, "java/lang/Object", null);
 
 		for (String psName : permittedSubclassNames) {
 			cw.visitPermittedSubclass(psName);

--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -69,10 +69,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
 				<mkdir dir="${module_bin_dir}" />
 				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir}" />
-				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${module_src_dir}" />
+				<javac srcdir="${module_src_dir}"
+					destdir="${module_bin_dir}"
+					includes="org/openj9/test/modularity/**,org/openj9/test/util/VersionCheck.java"
+					debug="true" fork="true"
+					executable="${compiler.javac}"
+					includeAntRuntime="false"
+					encoding="ISO-8859-1">
+					<compilerarg line='--add-reads org.openj9test.modularity.@{mod}=ALL-UNNAMED' />
 					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
-					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line='--source ${JDK_VERSION}' />
 					<compilerarg line="${modpath}" />
 					<classpath>
 						<pathelement location="${LIB_DIR}/testng.jar" />
@@ -98,7 +104,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<src path="${src_160}" />
 			<src path="${TestUtilities}" />
 			<exclude name="**/modules/**" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+			<compilerarg line='--source ${JDK_VERSION}' />
 			<compilerarg line='--add-modules jdk.incubator.foreign' />
 			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
@@ -125,6 +131,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<fileset dir="${dest_module_bin}" />
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
 		</jar>
+		<copy file="${DEST}/GeneralTest.jar" todir="${dest_module_bin}" />
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.xml" />
 			<fileset dir="${src}/../" includes="*.mk" />

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
@@ -26,9 +26,6 @@ import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.objectweb.asm.*;
-import static org.objectweb.asm.Opcodes.V_PREVIEW;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
-import static org.objectweb.asm.Opcodes.V16;
 
 /**
  * Test cases for JEP 397: Sealed Classes (Second Preview)
@@ -39,36 +36,14 @@ import static org.objectweb.asm.Opcodes.V16;
 @Test(groups = { "level.sanity" })
 public class Test_SubClass {
 	static String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted1";
-	
-	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
-	 * major version match the latest supported version when --enable-preview flag is active
-	 */
-	private static int latestPreviewVersion;
-	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			case 18:
-				latestPreviewVersion = 62; // does ASM support jdk18 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
-		}
-	}
-	
+
 	@Test
 	public void test_subClassInTheDifferentPackageFromSealedSuperClass() throws ClassNotFoundException {
 		String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted1";
 		ClassLoader classloader = Test_SubClass.class.getClassLoader();
 		Class<?> subClass = classloader.loadClass(subClassName);
 	}
-	
+
 	@Test
 	public void test_subClassInTheDifferentPackageFromSealedSuperInterface() throws ClassNotFoundException {
 		String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted2";

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -29,9 +29,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
             -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
             org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Jep397Tests \
@@ -58,9 +55,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleX$(Q) \
@@ -95,9 +89,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule.xml$(Q) -testnames Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule \
@@ -124,9 +115,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleX$(Q) \
@@ -159,9 +147,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
@@ -193,9 +178,6 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<variations>
-			<variation>--enable-preview</variation>
-		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--add-modules jdk.incubator.foreign \
 			-Dforeign.restricted=permit \

--- a/test/functional/Java16andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
+++ b/test/functional/Java16andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
@@ -23,36 +23,18 @@ package org.openj9.test.utilities;
  *******************************************************************************/
 
  import org.objectweb.asm.*;
+ import org.openj9.test.util.VersionCheck;
 
  public class SealedClassGenerator implements Opcodes {
 	private static String dummySubclassName = "TestSubclassGen";
-	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
-	 * major version match the latest supported version when --enable-preview flag is active
-	 */
-	private static int latestPreviewVersion;
-	static {
-		String runtimeVersion = System.getProperty("java.version");
-		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
-		switch (versionNum) {
-			case 16:
-				latestPreviewVersion = V16;
-				break;
-			case 17:
-				latestPreviewVersion = 61; // does ASM support jdk17 yet?
-				break;
-			case 18:
-				latestPreviewVersion = 62; // does ASM support jdk18 yet?
-				break;
-			default:
-				latestPreviewVersion = V16; // next release
-		}
-	}
+	/* sealed classes are NOT a preview feature since LTS jdk 17 */
+	private static int latestVersion = VersionCheck.classFile();
 
 	public static byte[] generateFinalSealedClass(String className) {
 		int accessFlags = ACC_FINAL | ACC_SUPER;
 
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, accessFlags, className, null, "java/lang/Object", null);
+		cw.visit(latestVersion, accessFlags, className, null, "java/lang/Object", null);
 
 		/* Sealed class must have a PermittedSubclasses attribute */
 		cw.visitPermittedSubclass(dummySubclassName);
@@ -64,7 +46,7 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubclassIllegallyExtendingSealedSuperclass(String className, Class<?> superClass) {
 		String superName = superClass.getName().replace('.', '/');
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, superName, null);
+		cw.visit(latestVersion, ACC_SUPER, className, null, superName, null);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
@@ -72,14 +54,14 @@ package org.openj9.test.utilities;
 	public static byte[] generateSubinterfaceIllegallyExtendingSealedSuperinterface(String className, Class<?> superInterface) {
 		String[] interfaces = { superInterface.getName().replace('.', '/') };
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", interfaces);
+		cw.visit(latestVersion, ACC_SUPER, className, null, "java/lang/Object", interfaces);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
 
 	public static byte[] generateSealedClass(String className, String[] permittedSubclassNames) {
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", null);
+		cw.visit(latestVersion, ACC_SUPER, className, null, "java/lang/Object", null);
 
 		for (String psName : permittedSubclassNames) {
 			cw.visitPermittedSubclass(psName);
@@ -88,7 +70,7 @@ package org.openj9.test.utilities;
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
-	
+
 	public static byte[] generateSubclassInDifferentPackageFromSealedSuper(String className, Class<?> superClass, Class<?> superInterface) {
 		String superClassName = superClass.getName().replace('.', '/');
 		String[] superInterfaceNames = null;
@@ -98,7 +80,7 @@ package org.openj9.test.utilities;
 		}
 		
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		cw.visit(latestPreviewVersion | V_PREVIEW, ACC_PRIVATE, className, null, superClassName, superInterfaceNames);
+		cw.visit(latestVersion, ACC_PRIVATE, className, null, superClassName, superInterfaceNames);
 		cw.visitEnd();
 		return cw.toByteArray();
 	}


### PR DESCRIPTION
Remove `--enable-preview` for `JEP 358/360/384/389/397` tests

Note: this fixes `Jep360Tests_0_FAILED`, `Jep397Tests_testSubClassOfSealedSuperFromDifferentModule_0_FAILED` & `Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule_0_FAILED ` at https://openj9-jenkins.osuosl.org/job/Test_openjdknext_j9_sanity.functional_s390x_linux_OpenJDK/22/tapResults/.

fyi @llxia 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>