### PR TITLE
AArch64: Provide factory methods for MemoryReference objects

### DIFF
--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #ifndef TR_MEMORYREFERENCE_INCL
 #define TR_MEMORYREFERENCE_INCL
 
+#include "codegen/ARM64ShiftCode.hpp"
 #include "codegen/J9MemoryReference.hpp"
 
 namespace TR { class Snippet; }
@@ -66,6 +67,12 @@ class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
          TR::SymbolReference *symRef,
          TR::CodeGenerator *cg)
       : J9::MemoryReferenceConnector(node, symRef, cg) {}
+
+   static TR::MemoryReference *create(TR::CodeGenerator *cg);
+   static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);
+   static TR::MemoryReference *createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement);
+   static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore);
+   static TR::MemoryReference *createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef);
    };
 
 } // TR


### PR DESCRIPTION
This is a part of a series of PRs to implement https://github.com/eclipse/omr/issues/5173.
This PR introduces static factory methods for MemoryReference objects into aarch64 codegen.
As we have J9MemoryReference class in OpenJ9 project, we must add the declaration of static factory methods to MemoryRererence class before we add implementation of factory methods to OMR project.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>