### PR TITLE
AArch64: Use factory methods for creating MemoryReference

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,14 +48,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    {
    flags8_t _j9Flags;
 
-public:
-   TR_ALLOC(TR_Memory::MemoryReference)
-
-   typedef enum
-      {
-      TR_ARM64MemoryReferenceControl_ThrowsImplicitNullPointerException  = 0x01,
-      /* To be added more if necessary */
-      } TR_ARM64MemoryReferenceExtraControl;
+protected:
 
    /**
     * @brief Constructor
@@ -128,6 +121,16 @@ public:
     * @param[in] cg : CodeGenerator object
     */
    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg);
+
+public:
+   TR_ALLOC(TR_Memory::MemoryReference)
+
+   typedef enum
+      {
+      TR_ARM64MemoryReferenceControl_ThrowsImplicitNullPointerException  = 0x01,
+      /* To be added more if necessary */
+      } TR_ARM64MemoryReferenceExtraControl;
+
 
    /**
     * @brief Implicit NullPointerException can be thrown or not

--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ namespace TR
 
 class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
    {
-   public:
+   private:
 
    MemoryReference(TR::CodeGenerator *cg)
       : J9::MemoryReferenceConnector(cg) {}
@@ -67,6 +67,8 @@ class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
          TR::SymbolReference *symRef,
          TR::CodeGenerator *cg)
       : J9::MemoryReferenceConnector(node, symRef, cg) {}
+
+   public:
 
    static TR::MemoryReference *create(TR::CodeGenerator *cg);
    static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);


### PR DESCRIPTION
This is a part of a series of PRs to implement https://github.com/eclipse/omr/issues/5173.
Use factory methods of MemoryReference class to instantiate MemoryReference objects.

Depends on:
https://github.com/eclipse-openj9/openj9/pull/14195
https://github.com/eclipse/omr/pull/6279

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>