### PR TITLE
Run GCCheck test on Metronome with noobjectheap option

### DIFF
--- a/test/functional/cmdLineTests/gcCheck/gcchecktestsMetronome.xml
+++ b/test/functional/cmdLineTests/gcCheck/gcchecktestsMetronome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2018, 2021 IBM Corp. and others
+  Copyright (c) 2021, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,13 +54,12 @@
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
         <command command="$JDMPVIEW_EXE$">
                 <arg>-core $DUMPFILE$</arg>
-                <input>!gccheck</input>
+                <input>!gccheck all,noobjectheap</input>
                 <input>quit</input>
         </command>
-  <output regex="no" type="success">Checking HEAP...done</output>
+  <output regex="no" type="success">Done (</output>
   <output regex="no" type="failure">gc check</output>
   <output regex="no" type="failure">unable to read</output>
   <output regex="no" type="failure">Exception</output>
  </test>
 </suite>
-

--- a/test/functional/cmdLineTests/gcCheck/playlist.xml
+++ b/test/functional/cmdLineTests/gcCheck/playlist.xml
@@ -26,7 +26,6 @@
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
-			<variation>Mode301</variation>
 			<variation>Mode501</variation>
 			<variation>Mode551</variation>
 		</variations>
@@ -49,4 +48,30 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_GCCheckMetronome</testCaseName>
+		<variations>
+			<variation>Mode301</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DOPTION_ADDEXPORTS=$(SQ)-showversion$(SQ) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-DRESJAR=$(Q)$(CMDLINETESTER_RESJAR)$(P)$(TEST_RESROOT)$(D)gcCheck.jar$(Q) \
+	-Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)gcchecktestsMetronome.xml$(Q) -explainExcludes \
+	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcchecktests_excludes.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
 </playlist>


### PR DESCRIPTION
Duplicated the cmdLineTester_GCCheck test so the Metronome (Mode301) variation can run `!gccheck all,noobjectheap`. The success condition also needed to change in this case from `Checking HEAP...done` to `Done (`.

Fixes https://github.com/eclipse-openj9/openj9/issues/14118