### PR TITLE
Replace vlogAcquire()/vlogRelease() pairs with CriticalSection

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1143,11 +1143,10 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
       bool bufferOverflow = ((curMsg - msg) >= MSG_SZ); // check for overflow at runtime
       if (fe->isLogSamplingSet())
          {
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          TR_VerboseLog::writeLine(TR_Vlog_SAMPLING,"%s", msg);
          if (bufferOverflow)
             TR_VerboseLog::writeLine(TR_Vlog_SAMPLING,"Sampling line is too big: %d characters", curMsg-msg);
-         TR_VerboseLog::vlogRelease();
          }
       Trc_JIT_Sampling_Detail(getJ9VMThreadFromTR_VM(fe), msg);
       if (bufferOverflow)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5605,7 +5605,7 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
    bool verbose = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileRequest);
    if (verbose)
       {
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
       TR_VerboseLog::write(TR_Vlog_CR, "%p   Compile request %s", vmThread, details.name());
 
       if (newInstanceThunkDetails)
@@ -5634,7 +5634,6 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
          TR_VerboseLog::write(" OBSOLETE class=%p -- request declined", clazz);
          }
       TR_VerboseLog::writeLine("");
-      TR_VerboseLog::vlogRelease();
       }
 
    // Pin the class of the method in case GC wants to unload it
@@ -6413,7 +6412,7 @@ TR::CompilationInfoPerThreadBase::outputVerboseMMapEntries(
    struct tm date;
    if (!localtime_r(&time.tv_sec, &date)) return;
 
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    outputVerboseMMapEntry(
       compilee,
       date,
@@ -6435,7 +6434,6 @@ TR::CompilationInfoPerThreadBase::outputVerboseMMapEntries(
          profiledString,
          compileString
          );
-   TR_VerboseLog::vlogRelease();
    }
 #endif // ifdef TR_HOST_S390
 
@@ -6525,7 +6523,7 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
             reloTime = j9time_usec_clock() - reloRuntime()->reloStartTime();
             }
 
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          TR_VerboseLog::write(TR_Vlog_COMP, "(AOT load) ");
          CompilationInfo::printMethodNameToVlog(method);
          TR_VerboseLog::write(" @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT, metaData->startPC, metaData->endWarmPC);
@@ -6540,7 +6538,6 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
             TR_VerboseLog::write(" compThreadID=%d", getCompThreadId());
 
          TR_VerboseLog::writeLine("");
-         TR_VerboseLog::vlogRelease();
          }
 
 #if defined(TR_HOST_S390)
@@ -7568,11 +7565,10 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
          {
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompFailure))
             {
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::write(TR_Vlog_COMP, "Method ");
             CompilationInfo::printMethodNameToVlog(method);
             TR_VerboseLog::writeLine(" will continue as interpreted");
-            TR_VerboseLog::vlogRelease();
             }
          if (entry->_compErrCode != compilationRestrictedMethod && // do not look at methods excluded by filters
              entry->_compErrCode != compilationExcessiveSize) // do not look at failures due to code cache size
@@ -9401,9 +9397,8 @@ TR::CompilationInfoPerThreadBase::compile(
          {
          if (compiler->getMaxYieldInterval() > TR::Options::_compYieldStatsThreshold)
             {
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             compiler->printCompYieldStats();
-            TR_VerboseLog::vlogRelease();
             }
          }
 
@@ -10396,7 +10391,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
             {
             const uint32_t bytecodeSize = TR::CompilationInfo::getMethodBytecodeSize(method);
             const bool isJniNative = compilee->isJNINative();
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::write(TR_Vlog_COMP,"(%s%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
                compilationTypeString,
                hotnessString,
@@ -10517,7 +10512,6 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                }
 
             TR_VerboseLog::writeLine("");
-            TR_VerboseLog::vlogRelease();
             }
 
          char compilationAttributes[40] = { 0 };
@@ -10607,9 +10601,8 @@ TR::CompilationInfoPerThreadBase::processException(
       {
       if (compiler->getMaxYieldInterval() > TR::Options::_compYieldStatsThreshold)
          {
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          compiler->printCompYieldStats();
-         TR_VerboseLog::vlogRelease();
          }
       }
 
@@ -10897,7 +10890,7 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
 
       const char *hotnessString = compiler->getHotnessName(compiler->getMethodHotness());
 
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
       if (_methodBeingCompiled->_compErrCode != compilationFailure)
          {
          if ((_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && _methodBeingCompiled->_compErrCode == compilationInterrupted)
@@ -10949,7 +10942,6 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
             static_cast<unsigned long long>(scratchSegmentProvider.systemBytesAllocated())/1024);
          }
       TR_VerboseLog::writeLine(" compThreadID=%d", compiler->getCompThreadID());
-      TR_VerboseLog::vlogRelease();
       }
 
    if(_methodBeingCompiled->_compErrCode == compilationFailure)

--- a/runtime/compiler/net/Message.cpp
+++ b/runtime/compiler/net/Message.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,7 +118,7 @@ void
 Message::print()
    {
    const MetaData *metaData = getMetaData();
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Message: type=%d numDataPoints=%u version=%lu numDescriptors=%lu\n",
                             metaData->_type, metaData->_numDataPoints, metaData->_version, _descriptorOffsets.size());
    uint32_t numDescriptorsPrinted = 0;
@@ -127,6 +127,5 @@ Message::print()
       DataDescriptor* desc = getDescriptor(i);
       numDescriptorsPrinted = desc->print(0);
       }
-   TR_VerboseLog::vlogRelease();
    }
 };

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,12 +63,13 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
    if ((trace && (numSymsThatShareSlot > 0)) || details)
       {
       UDATA bytecodePCOffset = osrFrame->bytecodePCOffset;
-      TR_VerboseLog::writeLineLocked(TR_Vlog_OSR,
+
+      TR_VerboseLog::CriticalSection vlogLock;
+      TR_VerboseLog::writeLine(TR_Vlog_OSR,
          "%x prepareForOSR at %p (startPC %p +%d) at %d:%x numSharingSyms:%d totalSlots:%d vmThread=%p", (int)vmThreadArg,
          metaData->startPC+jitPCOffset, metaData->startPC, (int)jitPCOffset,
          currentInlinedSiteIndex, (int)bytecodePCOffset, numSymsThatShareSlot, totalNumSlots, vmThread);
 
-      TR_VerboseLog::vlogAcquire();
       TR_VerboseLog::writeLine(TR_Vlog_OSRD, "%X   Jitted body:    %.*s.%.*s%.*s", (int)vmThreadArg,
          J9UTF8_LENGTH(metaData->className),       J9UTF8_DATA(metaData->className),
          J9UTF8_LENGTH(metaData->methodName),      J9UTF8_DATA(metaData->methodName),
@@ -100,8 +101,6 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
          for (i = osrFrame->numberOfLocals-1; i >= 0; --i)
             TR_VerboseLog::writeLine(TR_Vlog_OSRD, "%X       local %2d: %p", (int)vmThreadArg, i, arg0EA[-i]);
          }
-
-      TR_VerboseLog::vlogRelease();
       }
 
 
@@ -177,7 +176,7 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
                uint8_t* dataAtScrBuffer = (uint8_t*)vmThread->osrScratchBuffer + scratchBufferOffset;
                if (details)
                   {
-                  TR_VerboseLog::vlogAcquire();
+                  TR_VerboseLog::CriticalSection vlogLock;
                   TR_VerboseLog::write(TR_Vlog_OSRD, "%X     Symbol #%d osrFrameDataOffset=%d scratchBufferOffset=%d size=%d data:", (int)vmThreadArg,
                      i, osrFrameDataOffset, scratchBufferOffset, symSize);
                   switch (symSize)
@@ -193,7 +192,6 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
                         break;
                      }
                   TR_VerboseLog::writeLine("");
-                  TR_VerboseLog::vlogRelease();
                   }
                memcpy(
                   (uint8_t*)(osrFrame) + osrFrameDataOffset,

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -447,8 +447,7 @@ void vlogReclamation(const char * prefix, J9JITExceptionTable *metaData, size_t 
    {
    if (TR::Options::getVerboseOption(TR_VerboseReclamation))
       {
-
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
       TR_VerboseLog::write(
          TR_Vlog_RECLAMATION,
          "%s %.*s.%.*s%.*s @ %s [" POINTER_PRINTF_FORMAT "-",
@@ -470,7 +469,5 @@ void vlogReclamation(const char * prefix, J9JITExceptionTable *metaData, size_t 
       TR_VerboseLog::writeLine(
          POINTER_PRINTF_FORMAT "]",
          metaData->endPC);
-
-      TR_VerboseLog::vlogRelease();
       }
    }

--- a/runtime/compiler/runtime/JITServerStatisticsThread.cpp
+++ b/runtime/compiler/runtime/JITServerStatisticsThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,7 +117,7 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
                }
             omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", crtTime, OMRSTR_FTIME_FLAG_LOCAL);
             
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::writeLine(TR_Vlog_JITServer, "CurrentTime: %s", timestamp);
             TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Compilation Queue Size: %d", compInfo->getMethodQueueSize());
             TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Number of clients : %u", compInfo->getClientSessionHT()->size());
@@ -131,7 +131,6 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
                {
                TR_VerboseLog::writeLine(TR_Vlog_JITServer, "CpuLoad %d%% (AvgUsage %d%%) JvmCpu %d%%", cpuUsage, avgCpuUsage, vmCpuUsage);
                }
-            TR_VerboseLog::vlogRelease();
             lastStatsTime = crtTime;
             }
             

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1413,7 +1413,7 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
    if (stack[0] != methodHandle && TR::Options::isAnyVerboseOptionSet())
       {
       int i;
-      TR_VerboseLog::vlogAcquire();; // we want all the following output to appear together in the log
+      TR_VerboseLog::CriticalSection vlogLock; // we want all the following output to appear together in the log
       TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "%p Pointer %p found on stack @ %p does not match MethodHandle %p", vmThread, stack[0], stack, methodHandle);
       TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "%p   Nearby stack slots:", vmThread);
       for (i = -9; i <= 9; i++)
@@ -1428,7 +1428,6 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
             tag = " <- stack address";
          TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "%p     %p @ %+d: %p%s", vmThread, stack+i, i, slotValue, tag);
          }
-      TR_VerboseLog::vlogRelease();
       }
    TR_ASSERT(stack[0] == methodHandle, "Pointer %p on stack @ %p must match MethodHandle %p", stack[0], stack, methodHandle);
 
@@ -1441,7 +1440,7 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
 
    if (vlogTag)
       {
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
 
       char *curArg;
       int numArgs = 0;
@@ -1488,8 +1487,6 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
                }
             }
          }
-
-      TR_VerboseLog::vlogRelease();
       }
 
    }
@@ -1513,7 +1510,7 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
 
    if (verbose)
       {
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
       TR_VerboseLog::write(TR_Vlog_MH, "%p Starting compileMethodHandleThunk on MethodHandle %p", vmThread, methodHandle);
       if (arg)
          TR_VerboseLog::write(" arg %p", arg);
@@ -1525,7 +1522,6 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
             TR_VerboseLog::write(" %s", flagNames[i]);
          }
       TR_VerboseLog::writeLine("");
-      TR_VerboseLog::vlogRelease();
       }
    bool disabled = false;
 #if defined(J9VM_OPT_JITSERVER)


### PR DESCRIPTION
`TR_VerboseLog::CriticalSection` should be preferred whenever it is straightforward to use.