### PR TITLE
Shared cache - fix comparison > 0 after nattach declaration change

### DIFF
--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -392,7 +392,7 @@ deleteExpiredSharedCache(void *element, void *param)
 
 	Trc_SHR_CLM_deleteExpiredSharedCache_Entry();
 
-	if (cacheInfo->nattach > 0) {
+	if ((0 != cacheInfo->nattach) && (J9SH_OSCACHE_UNKNOWN != cacheInfo->nattach)) {
 		/* Somebody still attached to the cache */
 		Trc_SHR_CLM_deleteExpiredSharedCache_StillAttached();
 		return;


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/13925 modified the
declaration of nattach from IDATA to UDATA. Fix the `nattach > 0`
comparison.

Fixes https://github.com/eclipse-openj9/openj9/issues/14218