### PR TITLE
Fix GPUAssist enablement

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssistHolder.java
+++ b/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssistHolder.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,9 @@ package com.ibm.gpu.spi;
 public final class GPUAssistHolder {
 
 	/**
-	 * The value of this field is updated as necessary by System.completeInitialization().
+	 * The instance to be used to sort primitive arrays.
 	 */
+	/* Note: The value of this field is updated as necessary by System.initGPUAssist(). */
 	public static GPUAssist instance = GPUAssist.NONE;
 
 }

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -93,9 +93,10 @@ final class J9VMInternals {
 		Thread.currentThread().completeInitialization();
 
 		/*[IF Sidecar19-SE]*/
-		if (Boolean.getBoolean("ibm.java9.forceCommonCleanerShutdown")) {//$NON-NLS-1$
-			Runnable runnable = () -> {
+		System.initGPUAssist();
 
+		if (Boolean.getBoolean("ibm.java9.forceCommonCleanerShutdown")) { //$NON-NLS-1$
+			Runnable runnable = () -> {
 				CleanerShutdown.shutdownCleaner();
 				ThreadGroup threadGroup = Thread.currentThread().group; // the system ThreadGroup
 				/*[IF OJDKTHREAD_SUPPORT]*/
@@ -115,22 +116,22 @@ final class J9VMInternals {
 						for (Thread t : threads) {
 							if (t.getName().equals("Common-Cleaner")) { //$NON-NLS-1$
 								t.interrupt();
-			 					try {
-			 						/* Need to wait for the Common-Cleaner thread to die before
-			 						 * continuing. If not this will result in a race condition where
-			 						 * the VM might attempt to shutdown before Common-Cleaner has a
-			 						 * chance to stop properly. This will result in an unsuccessful
-			 						 * shutdown and we will not release vm resources.
-			 						 */
-				 					 t.join(3000);
-				 					 /* giving this a 3sec timeout. If it works it should work fairly
-				 					  * quickly, 3 seconds should be more than enough time. If it doesn't
-				 					  * work it may block indefinitely. Turning on -verbose:shutdown will
-				 					  * let us know if it worked or not
-				 					  */
-			 					} catch (Throwable e) {
-			 						/* empty block */
-			 					}
+								try {
+									/* Need to wait for the Common-Cleaner thread to die before
+									 * continuing. If not this will result in a race condition where
+									 * the VM might attempt to shutdown before Common-Cleaner has a
+									 * chance to stop properly. This will result in an unsuccessful
+									 * shutdown and we will not release vm resources.
+									 */
+									t.join(3000);
+									/* giving this a 3sec timeout. If it works it should work fairly
+									 * quickly, 3 seconds should be more than enough time. If it doesn't
+									 * work it may block indefinitely. Turning on -verbose:shutdown will
+									 * let us know if it worked or not
+									 */
+								} catch (Throwable e) {
+									/* empty block */
+								}
 							}
 						}
 					}
@@ -138,7 +139,7 @@ final class J9VMInternals {
 			};
 			Runtime.getRuntime().addShutdownHook(new Thread(runnable, "CommonCleanerShutdown", true, false, false, null)); //$NON-NLS-1$
 		}
-		/*[ENDIF]*/
+		/*[ENDIF] Sidecar19-SE */
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -426,10 +426,6 @@ static void completeInitialization() {
 	/*[PR 102344] call Terminator.setup() after Thread init */
 	Terminator.setup();
 
-	/*[IF Sidecar19-SE]*/
-	initGPUAssist();
-	/*[ENDIF] Sidecar19-SE */
-
 	/*[IF !Sidecar19-SE_RAWPLUSJ9&!Sidecar18-SE-OpenJ9]*/
 	try {
 		if (null != systemInitialization) {
@@ -443,7 +439,7 @@ static void completeInitialization() {
 }
 
 /*[IF Sidecar19-SE]*/
-private static void initGPUAssist() {
+static void initGPUAssist() {
 	Properties props = internalGetProperties();
 
 	if ((props.getProperty("com.ibm.gpu.enable") == null) //$NON-NLS-1$

--- a/test/functional/cmdLineTests/gputests/build.xml
+++ b/test/functional/cmdLineTests/gputests/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2022, 2022 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<project name="Command-line GPU Tests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests/gputests
+	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml" />
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/gputests" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.mk" />
+			<fileset dir="${src}" includes="*.xml" />
+		</copy>
+	</target>
+
+	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/gputests/gputests.xml
+++ b/test/functional/cmdLineTests/gputests/gputests.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+Copyright (c) 2022, 2022 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="GPU test" timeout="300">
+	<!--
+	Verify that System.initGPUAssist() has access to the relevent system properties.
+	With com.ibm.gpu.verbose set, an illegal value for com.ibm.gpu.enable should elicit
+	a warning. The absence of that warning signals a failure.
+	-->
+	<test id="initGPUAssist">
+		<command>$EXE$ -Dcom.ibm.gpu.verbose -Dcom.ibm.gpu.enable=test -version</command>
+		<output type="success" regex="no">Invalid value "test" given on system property com.ibm.gpu.enable</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/gputests/gputests_exclude.xml
+++ b/test/functional/cmdLineTests/gputests/gputests_exclude.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+Copyright (c) 2022, 2022 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl"?>
+<suite id="CmdLine GPU Tests">
+</suite>

--- a/test/functional/cmdLineTests/gputests/playlist.xml
+++ b/test/functional/cmdLineTests/gputests/playlist.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright (c) 2022, 2022 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTests_gputests</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+			<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+				$(JAVA_COMMAND) \
+				$(JVM_OPTIONS) \
+				-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+				-jar $(CMDLINETESTER_JAR) \
+				-config $(Q)$(TEST_RESROOT)$(D)gputests.xml$(Q) \
+				-explainExcludes \
+				-plats all,$(PLATFORM),$(VARIATION) \
+				-xids all,$(PLATFORM),$(VARIATION) \
+				-xlist $(Q)$(TEST_RESROOT)$(D)gputests_exclude.xml$(Q) \
+				-nonZeroExitWhenError; \
+				${TEST_STATUS}
+			</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+</playlist>


### PR DESCRIPTION
Checking of properties `com.ibm.gpu.enable` or `com.ibm.gpu.enforce` was occurring before they were available and so the CUDA GPU sort assist could not be enabled (with either of those properties).

This delays the call to `System.initGPUAssist()` to a point where the relevant properties are available and adds a test to verify that.