### PR TITLE
Thread.stop() is deprecated for removal in jdk18

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -1206,7 +1206,9 @@ private native void startImpl();
  *
  * @deprecated
  */
-/*[IF Sidecar19-SE]*/
+/*[IF JAVA_SPEC_VERSION >= 18]*/
+@Deprecated(forRemoval=true, since="1.2")
+/*[ELSEIF JAVA_SPEC_VERSION >= 9]*/
 @Deprecated(forRemoval=false, since="1.2")
 /*[ELSE]*/
 @Deprecated


### PR DESCRIPTION
See

https://bugs.openjdk.java.net/browse/JDK-8277861

http://cr.openjdk.java.net/~iris/se/18/build/latest/api/java.base/java/lang/Thread.html#stop()

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>