### PR TITLE
Enable profile directed guarded devirtualization by default in Z

### DIFF
--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1800,7 +1800,6 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
 
          if (!performGuardedDevirtualization &&
              !comp()->getOption(TR_DisableInterpreterProfiling) &&
-             comp()->getOption(TR_enableProfiledDevirtualization) &&
              TR_ValueProfileInfoManager::get(comp()) && resolvedMethod
              )
             {
@@ -1832,7 +1831,7 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
                {
                TR_ResolvedMethod *profiledVirtualMethod = methodSymRef->getOwningMethod(comp())->getResolvedVirtualMethod(comp(),
                           (TR_OpaqueClassBlock *)topValue, methodSymRef->getOffset());
-               if (profiledVirtualMethod)
+               if (profiledVirtualMethod && !profiledVirtualMethod->isInterpreted())
                   {
                   if (comp()->getOption(TR_TraceCG))
                      {


### PR DESCRIPTION
P and X do not check the `TR_enableProfiledDevirtualization` option before
performing guarded devirtualization. This patch removes this check in Z
codegen to bring it in line with P and X.

I used this unit test for checking virtual function calls:
```java
class Parent {
    public int call_count = 0;
    public int makework = -1;
    public void bar() {
        call_count++;
        makework ^= (makework << 2) * call_count;
    }
}

class Child extends Parent {
    public void bar() {
        call_count++;
        makework += 200 - call_count % 123;
    }
}

class GrandChild extends Child {
    public void bar() {
        call_count++;
        makework -= makework ^ call_count;
    }
}

public class VirtualCallTest {

    static void test(Parent p) {
        p.bar();
    }

    public static void main(String[] args) {
        Parent p = new Parent();
        Child c = new Child();
        GrandChild g = new GrandChild();
	p.bar();
	c.bar();
	g.bar();
        Parent uut;

        for (int i = 0; i < 1000000; i++) {
            if (i % 4 == 1) {
                uut = c;
            } else if (i % 4 == 3) {
                uut = g;
            } else {
                uut = p;
            }
            test(uut);
        }

        System.out.println(p.makework);
        System.out.println(c.makework);
        System.out.println(g.makework);
    }
}
```

Here's the generated instructions for `VirtualCallTest.test` [before](https://github.com/eclipse-openj9/openj9/files/7864515/before.txt) and [after](https://github.com/eclipse-openj9/openj9/files/7864517/after.txt) this change.

And here's the instruction selection log [before](https://github.com/eclipse-openj9/openj9/files/7864693/instruction_selection_after.txt) and [after](https://github.com/eclipse-openj9/openj9/files/7864692/instruction_selection_before.txt) this change.


Fixes: #13606
Signed-off-by: Spencer Comin <spencer.comin@ibm.com>