### PR TITLE
Process aladd offsets that can fit in 32 bits

### DIFF
--- a/runtime/compiler/optimizer/NewInitialization.cpp
+++ b/runtime/compiler/optimizer/NewInitialization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -876,7 +876,17 @@ bool TR_NewInitialization::visitNode(TR::Node *node)
             //
             offset = node->getSymbolReference()->getOffset() + base->getSecondChild()->getInt() - c->startOffset;
             }
-         else if (node->getOpCode().isLoadVar())
+         else if (base->getSecondChild()->getOpCodeValue() == TR::lconst)
+            {
+            int64_t longOffset = base->getSecondChild()->getLongInt();
+	    if ((longOffset <= (int64_t) INT_MAX) && (longOffset >= (int64_t) INT_MIN))
+	       {
+               // Array new reference with constant index
+               //
+               offset = node->getSymbolReference()->getOffset() + ((int32_t) longOffset) - c->startOffset;
+	       }
+            }
+	 else if (node->getOpCode().isLoadVar())
             {
             // Array new reference with unknown index
             //


### PR DESCRIPTION
New initialization is enabled on 64-bit compressed refs in addition to
32-bit. Array accesses use aladd instead of aiadd on 64-bit compressed
refs and so the code that examines array accesses should check for a
long constant offset (in addition to int constant offset as is the case
presently). This would allow the code to engage and attempt
transformations on 64-bit compressed refs for arrays. Since the rest of
the data structures are using 32-bit offsets we restrict the actual
value of the long constant to be in the 32-bit range since we do not
believe this to be a significant limiting factor in practice.

Signed-off-by: Vijay Sundaresan vijaysun@ca.ibm.com