### PR TITLE
Handle checkcast and NULLCHK during VectorAPI expansion

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,7 +145,7 @@ TR_VectorAPIExpansion::buildVectorAliases()
       TR::Node *node = tt->getNode();
       TR::ILOpCodes opCodeValue = node->getOpCodeValue();
 
-      if (opCodeValue == TR::treetop || opCodeValue == TR::NULLCHK)
+      if (opCodeValue == TR::treetop)
           {
           node = node->getFirstChild();
           }
@@ -349,6 +349,11 @@ TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node)
                              child->getSymbolReference()->getReferenceNumber(), node);
          invalidateSymRef(child->getSymbolReference());
          }
+      }
+   else if (node->getOpCodeValue() == TR::checkcast ||
+            node->getOpCodeValue() == TR::NULLCHK)
+      {
+      // ignore for now and check the children
       }
    else
       {
@@ -703,6 +708,28 @@ TR_VectorAPIExpansion::expandVectorAPI()
       TR::ILOpCodes opCodeValue = node->getOpCodeValue();
       TR::Node *parent = NULL;
       TR::MethodSymbol *methodSymbol = NULL;
+
+
+      // remove unnecessary checkcast and NULLCHK as soon as possible
+      if (node->getOpCodeValue() == TR::checkcast ||
+         node->getOpCodeValue() == TR::NULLCHK)
+         {
+         TR::Node *firstChild = node->getFirstChild();
+         if (firstChild->getOpCodeValue() == TR::PassThrough)
+            firstChild = firstChild->getFirstChild();
+
+         if (firstChild->getOpCode().hasSymbolReference())
+            {
+            int32_t childClassId = _aliasTable[firstChild->getSymbolReference()->getReferenceNumber()]._classId;
+            if (childClassId > 0)
+               {
+               // can be removed since the child will be scalarized or vectorized
+               TR::Node::recreate(node, TR::treetop);
+               }
+            }
+         continue;
+         }
+
 
       if (opCodeValue == TR::treetop || opCodeValue == TR::NULLCHK)
           {


### PR DESCRIPTION
- do not skip NULLCHK in buildVectorAliases
- ignore checkcast and NULLCHK during analysis
- remove checkcast and NULLCHK during transformation if they check an object
  that is part of a class