### PR TITLE
Create -Xtune:throughput option and set options that favor throughput plus other cleanup

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,8 +110,6 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
          FIND_AND_CONSUME_ARG( EXACT_MATCH, "-Xnoquickstart", 0); // deprecated
          FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, "-Xtune:elastic", 0);
          argIndexQuickstart = FIND_AND_CONSUME_ARG( EXACT_MATCH, "-Xquickstart", 0);
-         argIndexClient = FIND_AND_CONSUME_ARG( EXACT_MATCH, "-client", 0);
-         argIndexServer = FIND_AND_CONSUME_ARG( EXACT_MATCH, "-server", 0);
          tlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XtlhPrefetch", 0);
          notlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XnotlhPrefetch", 0);
          lockReservation = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XlockReservation", 0);
@@ -138,16 +136,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
          TR::Options::_doNotProcessEnvVars = (FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:doNotProcessJitEnvVars", 0) >= 0);
 
-         // Determine if quickstart mode or not; -client, -server, -Xquickstart can all be specified
-         // on the command line. The last appearance wins
-         if (argIndexServer < argIndexClient || argIndexServer < argIndexQuickstart)
-            {
-            isQuickstart = true;
-            }
-         else if (argIndexServer > 0)
-            {
-            TR::Options::_bigAppThreshold = 1;
-            }
+         isQuickstart = J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_TUNE_QUICKSTART);
 
 #ifdef TR_HOST_X86
          // By default, disallow reservation of objects' monitors for which a

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -795,11 +795,19 @@ gcInitializeCalculatedValues(J9JavaVM *javaVM, IDATA* memoryParameters)
 	 * This used to be for free, calculations based on Xmx, now it is a manual check
 	 * in setConfigurationSpecificMemoryParameters
 	 */
-	/* TODO aryoung: eventually segregated heaps will allow heap expansion, although metronome
-	 * itself will still require a fully expanded heap on startup */
-	const bool shouldMaximizeInitialHeap = (extensions->isSegregatedHeap() || extensions->isMetronomeGC());
-	const UDATA initialXmsValueMax = shouldMaximizeInitialHeap ? J9_MEMORY_MAX : (8 * 1024 * 1024);
-	const UDATA initialXmsValueMin = shouldMaximizeInitialHeap ? UDATA_MAX     : (8 * 1024 * 1024);
+	UDATA initialXmsValueMax = 8 * 1024 * 1024;
+	UDATA initialXmsValueMin = 8 * 1024 * 1024;
+	if (extensions->isSegregatedHeap() || extensions->isMetronomeGC()) {
+		/* TODO aryoung: eventually segregated heaps will allow heap expansion, although metronome
+		 * itself will still require a fully expanded heap on startup
+		 */
+		initialXmsValueMax = J9_MEMORY_MAX;
+		initialXmsValueMin = UDATA_MAX;
+	} else if (J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_TUNE_THROUGHPUT)) {
+		/* For -Xtune:throughput we want to set Xms=Xmx */
+		initialXmsValueMax = extensions->memoryMax;
+		initialXmsValueMin = extensions->memoryMax;
+	}
 
 	/**
 	 * GC memory parameters to be store in GCExtensions
@@ -2951,7 +2959,6 @@ gcInitializeDefaults(J9JavaVM* vm)
 
 	extensions->trackMutatorThreadCategory = J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_REDUCE_CPU_MONITOR_OVERHEAD);
 
-
 	if (!gcParseTGCCommandLine(vm)) {
 		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE, "Failed to initialize, parsing command line.");
 		goto error;
@@ -3011,7 +3018,6 @@ gcInitializeDefaults(J9JavaVM* vm)
 		MM_LargeObjectAllocateStats::initializeFreeMemoryProfileMaxSizeClasses(&env, extensions->largeObjectAllocationProfilingVeryLargeObjectThreshold,
 				(float)extensions->largeObjectAllocationProfilingSizeClassRatio / (float)100.0, extensions->heap->getMaximumMemorySize());
 	}
-
 	warnIfPageSizeNotSatisfied(vm,extensions);
 	j9mem_free_memory(memoryParameterTable);
 	return J9VMDLLMAIN_OK;

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -349,6 +349,8 @@ extern "C" {
 #define J9_EXTENDED_RUNTIME2_LOAD_HEALTHCENTER_MODULE 0x4000
 #define J9_EXTENDED_RUNTIME2_3164_INTEROPERABILITY 0x8000
 #define J9_EXTENDED_RUNTIME2_ENABLE_UTF_CACHE 0x10000
+#define J9_EXTENDED_RUNTIME2_TUNE_THROUGHPUT 0x20000
+#define J9_EXTENDED_RUNTIME2_TUNE_QUICKSTART 0x40000
 
 #define J9_OBJECT_HEADER_AGE_DEFAULT 0xA /* OBJECT_HEADER_AGE_DEFAULT */
 #define J9_OBJECT_HEADER_SHAPE_MASK 0xE /* OBJECT_HEADER_SHAPE_MASK */

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ extern "C" {
 #define AGENT_XRUN 0x20000
 #define NEVER_CLOSE_DLL 0x40000
 #define BUNDLED_COMP 0x80000
-	
+
 /* Value for RC_SILENT_EXIT should not be changed as this is
  * used by launcher to hide message "Could not create the Java virtual machine"
  */
@@ -187,13 +187,13 @@ enum INIT_STAGE {
 	JIT_INITIALIZED,
 	AGENTS_STARTED,
 	ABOUT_TO_BOOTSTRAP,
-	JCL_INITIALIZED, 
+	JCL_INITIALIZED,
 	VM_INITIALIZATION_COMPLETE,
 	INTERPRETER_SHUTDOWN,
 	LIBRARIES_ONUNLOAD,
 	HEAP_STRUCTURES_FREED,
 	GC_SHUTDOWN_COMPLETE,
-	/* this stage will only be invoked for the jcl shared library when it is being run remotely */ 
+	/* this stage will only be invoked for the jcl shared library when it is being run remotely */
 	OFFLOAD_JCL_PRECONFIGURE
 
 
@@ -425,6 +425,8 @@ enum INIT_STAGE {
 #define VMOPT_XXDISCLAIMJITSCRATCH		"-XX:+DisclaimJitScratch"
 #define VMOPT_XXNODISCLAIMJITSCRATCH	"-XX:-DisclaimJitScratch"
 
+#define VMOPT_TUNE_QUICKSTART "-Xtune:quickstart"
+#define VMOPT_TUNE_THROUGHPUT "-Xtune:throughput"
 #define VMOPT_TUNE_VIRTUALIZED "-Xtune:virtualized"
 
 #define VMOPT_XXCOMPACTSTRINGS "-XX:+CompactStrings"


### PR DESCRIPTION
This PR creates a new option, called `-Xtune:throughput`, under which the JVM will favor throughput over other performance metrics. In particular, if not explicitly provided, the initial heap size (`-Xms`) will be set to the maximum heap size value (`-Xmx`). Moreover, the JIT will internally set some options to optimize more aggressively the code.

Another new option is `-Xtune:quickstart` which is set to be an alias of `-Xquickstart`.
The 3 options `-Xtune:virtualized`, `-Xtune:throughput` and `-Xtune:quickstart` are mutually exclusive (since they pull performance metrics in different directions) and the last occurrence on the command line takes effect (this is different than the old implementation where quickstart mode had precedence over -Xtune:virtualized).

The JIT code that was parsing `-server` and `-client` options has been removed since it wasn't working anyway. 

Depends on https://github.com/eclipse/omr/pull/6294

Issue: #14246