### PR TITLE
(0.30.0) Add release documentation for java option `-XX:[+|-]EnsureHashed`

### DIFF
--- a/doc/release-notes/0.30/0.30.md
+++ b/doc/release-notes/0.30/0.30.md
@@ -55,6 +55,13 @@ The following table covers notable changes in v0.30.0. Further information about
 <td valign="top">If any arguments are ignored, the group is introduced with <tt>1CIIGNOREDARGS</tt>, followed by a line beginning with <tt>2CIIGNOREDARG</tt> for each ignored argument.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/14042">#14042</a></td>
+<td valign="top">New <tt>-XX:[+|-]EnsureHashed</tt> option added</td>
+<td valign="top">All versions</td>
+<td valign="top">This option specifies/unspecifies classes of objects that will be hashed and extended with a hash slot upon object creation or first move. This option may improve performance for applications that frequently hash objects of a certain type.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/14042

Cherry pick https://github.com/eclipse-openj9/openj9/pull/14060 for the 0.30 release.