### PR TITLE
Modify getObjectAlignmentInBytes for jitserver

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -728,3 +728,16 @@ J9::ObjectModel::compressObjectReferences()
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return _compressObjectReferences;
    }
+
+int32_t
+J9::ObjectModel::getObjectAlignmentInBytes()
+{
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_objectAlignmentInBytes;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   return _objectAlignmentInBytes;
+}

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,7 +139,7 @@ public:
    */
    bool compressObjectReferences();
 
-   int32_t getObjectAlignmentInBytes() { return _objectAlignmentInBytes; }
+   int32_t getObjectAlignmentInBytes();
 
 private:
 


### PR DESCRIPTION
The definition of J9::ObjectModel::getObjectAlignmentInBytes needs to be overridden for the JIT server so that it uses the object alignment from the vmInfo if necessary.

Fixes: #14286