### PR TITLE
Validate the count field when deserializing StringBuffer/StringBuilder

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF]*/
 #
-# Copyright (c) 1998, 2021 IBM Corp. and others
+# Copyright (c) 1998, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ K0084=can\ only\ instantiate\ one\ BootstrapClassLoader
 
 K00b7=File\ is\ closed
 
-K0199=Count\ out\ of\ range
+K0199=count value invalid
 
 K01c3=Unable\ to\ open\:\ {0}
 K01c4=Invalid\ zip\ file\:\ {0}

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar16 & !Sidecar19-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 package java.lang;
 
 import java.io.IOException;
-import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.StreamCorruptedException;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -1819,42 +1819,30 @@ private synchronized void writeObject(ObjectOutputStream stream) throws IOExcept
 
 private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 	ObjectInputStream.GetField gf = stream.readFields();
-	
 	int streamCount = gf.get("count", 0); //$NON-NLS-1$
-
 	char[] streamValue = (char[]) gf.get("value", null); //$NON-NLS-1$
-	
-	if (streamCount > streamValue.length) {
-		throw new InvalidObjectException(com.ibm.oti.util.Msg.getString("K0199")); //$NON-NLS-1$
-	} 
-	
+
+	if ((streamCount < 0) || (streamCount > streamValue.length)) {
+		/*[MSG "K0199", "count value invalid"]*/
+		throw new StreamCorruptedException(com.ibm.oti.util.Msg.getString("K0199")); //$NON-NLS-1$
+	}
 	if (String.COMPACT_STRINGS) {
 		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
 			value = new char[(streamValue.length + 1) >>> 1];
-			
 			String.compress(streamValue, 0, value, 0, streamValue.length);
-			
 			count = streamCount;
-			
 			capacity = streamValue.length;
 		} else {
 			value = new char[streamValue.length];
-			
 			System.arraycopy(streamValue, 0, value, 0, streamValue.length);
-			
 			count = streamCount | uncompressedBit;
-
 			capacity = streamValue.length;
-			
 			String.initCompressionFlag();
 		}
 	} else {
 		value = new char[streamValue.length];
-		
 		System.arraycopy(streamValue, 0, value, 0, streamValue.length);
-		
 		count = streamCount;
-		
 		capacity = streamValue.length;
 	}
 }


### PR DESCRIPTION
Added a precautionary condition check `count >= 0`;
Changed `InvalidObjectException` to `StreamCorruptedException` to match RI behaviours.

related internal RTC 146534

Signed-off-by: Jason Feng <fengj@ca.ibm.com>