### PR TITLE
(0.30.0) Auto-download OpenSSL on Windows

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1556,6 +1556,35 @@ def set_build_variables_per_node() {
     if (!check_path(OPENJDK_REFERENCE_REPO)) {
         println("The git cache OPENJDK_REFERENCE_REPO: ${buildspec.getScalarField('openjdk_reference_repo', SDK_VERSION)} does not exist on ${NODE_NAME}!")
     }
+
+    if(SPEC.contains('win')) {
+        echo "Check for OpenSSL install..."
+        def configureOptions = buildspec.getScalarField('extra_configure_options', SDK_VERSION)
+        def match = (configureOptions =~ /.*--with-openssl=(\S+)\b/)
+        def opensslLocation = ''
+        if (match.find()) {
+            opensslLocation = match.group(1)
+        } else {
+            error("Unable to parse variables for OpenSSL location")
+        }
+        if (!check_path("${opensslLocation}")) {
+            echo "Downloading OpenSSL..."
+            def opensslVersion = opensslLocation.substring(opensslLocation.lastIndexOf('/') + 1)
+            def opensslParentFolder = opensslLocation.substring(0, opensslLocation.lastIndexOf('/'))
+            dir('openssl') {
+                sh """
+                    curl -Ok ${JENKINS_URL}userContent/${opensslVersion}.zip
+                    unzip ${opensslVersion}.zip
+                    rm ${opensslVersion}.zip
+                    mkdir -p ${opensslParentFolder}
+                    mv ${opensslVersion} ${opensslParentFolder}/
+                """
+            }
+            cleanWs()
+        } else {
+            echo "OpenSSL found at ${opensslLocation}"
+        }
+    }
 }
 
 def check_path(inPath) {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2021 IBM Corp. and others
+# Copyright (c) 2018, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -545,11 +545,11 @@ x86-64_windows:
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
   extra_configure_options:
     all: '--disable-ccache --with-cuda="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.0"'
-    8: '--with-toolchain-version=2013 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_64-VS2013'
-    11: '--with-toolchain-version=2017 --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_64-VS2017'
-    16: '--with-toolchain-version=2019 --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_64-VS2019'
-    17: '--with-toolchain-version=2019 --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_64-VS2019'
-    next: '--with-toolchain-version=2019 --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_64-VS2019'
+    8: '--with-toolchain-version=2013 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_64-VS2013'
+    11: '--with-toolchain-version=2017 --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_64-VS2017'
+    16: '--with-toolchain-version=2019 --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_64-VS2019'
+    17: '--with-toolchain-version=2019 --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_64-VS2019'
+    next: '--with-toolchain-version=2019 --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_64-VS2019'
   node_labels:
     build: 'ci.role.build && hw.arch.x86 && sw.os.windows'
   build_env:
@@ -602,7 +602,7 @@ x86-32_windows:
   release:
     8: 'windows-x86-normal-server-release'
   extra_configure_options:
-    8: '--with-toolchain-version=2013 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-target-bits=32 --disable-ccache --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1l-x86_32-VS2013'
+    8: '--with-toolchain-version=2013 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-target-bits=32 --disable-ccache --with-openssl=/cygdrive/f/Users/jenkins/openssl/OpenSSL-1.1.1m-x86_32-VS2013'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
   node_labels:
     build:


### PR DESCRIPTION
Cherry pick auto-download from https://github.com/eclipse-openj9/openj9/pull/14309
and port the openssl 1.1.1m changes for Windows.