### PR TITLE
Set an appropriate -Xmx for testing RAS

### DIFF
--- a/test/functional/RasapiTest/test.xml
+++ b/test/functional/RasapiTest/test.xml
@@ -54,7 +54,7 @@
 				<pathelement location="${ant.home}/lib/ant-launcher.jar"/>
 			</classpath>
 			<jvmarg value="-showversion"/>
-			<jvmarg value="-Xmx128m"/>
+			<jvmarg value="-Xmx512M"/>
 			<arg value="-buildfile"/>
 			<arg file="${ant.file}"/>
 			<arg value="test"/>
@@ -66,7 +66,7 @@
 		<echo message="Running com.ibm.jvm.ras.tests.DumpAPIBasicTests"/>
 		<junit fork="yes" showoutput="true" haltonfailure="true">
 			<jvmarg value="-showversion"/>
-			<jvmarg value="-Xmx32m"/>
+			<jvmarg value="-Xmx512M"/>
 			<classpath>
 				<pathelement location="junit4.jar"/>
 				<pathelement location="com.ibm.jvm.ras.tests.jar"/>
@@ -77,7 +77,7 @@
 		<echo message="Running com.ibm.jvm.ras.tests.DumpAPITriggerTests"/>
 		<junit fork="yes" showoutput="true" haltonfailure="true">
 			<jvmarg value="-showversion"/>
-			<jvmarg value="-Xmx32m"/>
+			<jvmarg value="-Xmx512M"/>
 			<classpath>
 				<pathelement location="junit4.jar"/>
 				<pathelement location="com.ibm.jvm.ras.tests.jar"/>
@@ -88,7 +88,7 @@
 		<echo message="Running com.ibm.jvm.ras.tests.DumpAPIQuerySetReset"/>
 		<junit fork="yes" showoutput="true" haltonfailure="true">
 			<jvmarg value="-showversion" />
-			<jvmarg value="-Xmx32m"/>
+			<jvmarg value="-Xmx512M"/>
 			<classpath>
 				<pathelement location="junit4.jar" />
 				<pathelement location="com.ibm.jvm.ras.tests.jar" />
@@ -99,7 +99,7 @@
 		<echo message="Running com.ibm.jvm.ras.tests.DumpAPITokensTests" />
 		<junit fork="yes" showoutput="true" haltonfailure="true">
 			<jvmarg value="-showversion"/>
-			<jvmarg value="-Xmx32m"/>
+			<jvmarg value="-Xmx512M"/>
 			<classpath>
 				<pathelement location="junit4.jar"/>
 				<pathelement location="com.ibm.jvm.ras.tests.jar"/>
@@ -110,7 +110,7 @@
 		<echo message="Running com.ibm.jvm.ras.tests.DumpAPISetTestXdumpdynamic with Xdump:dynamic"/>
 		<junit fork="yes" showoutput="true" haltonfailure="true">
 				<jvmarg value="-showversion" />
-				<jvmarg value="-Xmx32m"/>
+				<jvmarg value="-Xmx512M"/>
 				<jvmarg value="-Xdump:dynamic" />
 				<classpath>
 					<pathelement location="junit4.jar" />


### PR DESCRIPTION
-Xmx32M is too small, causes OOM on some platforms such as Windows and
the older AIX machines.
Increase to 512M. With smaller values OOM was still seen on AIX.

See https://github.com/eclipse-openj9/openj9/pull/14310

Tested via grinder
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/534 - old AIX
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/533 - new AIX
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/532 - Windows