### PR TITLE
JDK18 deprecates getObjectPendingFinalizationCount & runFinalization

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1005,6 +1005,9 @@ public static void loadLibrary(String libName) {
  * be useful to attempt to perform any outstanding
  * object finalizations.
  */
+/*[IF JAVA_SPEC_VERSION >= 18] */
+@Deprecated(forRemoval=true, since="18")
+/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 public static void runFinalization() {
 	RUNTIME.runFinalization();
 }

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -432,6 +432,9 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	 * {@inheritDoc}
 	 */
 	@Override
+	/*[IF JAVA_SPEC_VERSION >= 18] */
+	@SuppressWarnings("deprecation")
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	public int getObjectPendingFinalizationCount() {
 		return this.getObjectPendingFinalizationCountImpl();
 	}

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,6 +73,9 @@ public interface MemoryMXBean extends PlatformManagedObject {
 	 * 
 	 * @return the number of objects awaiting finalization.
 	 */
+	/*[IF JAVA_SPEC_VERSION >= 18] */
+	@Deprecated(forRemoval=false, since="18")
+	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	public int getObjectPendingFinalizationCount();
 
 	/**


### PR DESCRIPTION
```
@Deprecated(forRemoval=true, since="18")
java.lang.System.runFinalization();
@Deprecated(forRemoval=false, since="18")
java.lang.management.MemoryMXBean.getObjectPendingFinalizationCount();
```

Fixes an internal RTC item 146926.

Related https://github.com/eclipse-openj9/openj9/issues/14049

Signed-off-by: Jason Feng <fengj@ca.ibm.com>