### PR TITLE
Cache client array class element size

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,7 @@ public:
       CLASSINFO_METHODS_OF_CLASS,
       CLASSINFO_CONSTANT_POOL,
       CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
+      CLASSINFO_ARRAY_ELEMENT_SIZE,
       };
 
    // NOTE: when adding new elements to this tuple, add them to the end,
@@ -82,7 +83,8 @@ public:
       uintptr_t,                         // 19: _classFlags
       uintptr_t,                         // 20: _classChainOffsetIdentifyingLoader
       std::vector<J9ROMMethod *>,        // 21: _origROMMethods
-      std::string                        // 22: _classNameIdentifyingLoader
+      std::string,                       // 22: _classNameIdentifyingLoader
+      int32_t                            // 23: _arrayElementSize
       >;
 
    // Packs a ROMClass to be transferred to the server.

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -984,8 +984,9 @@ J9::ClassEnv::flattenedArrayElementSize(TR::Compilation *comp, TR_OpaqueClassBlo
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITServer::MessageType::ClassEnv_flattenedArrayElementSize, arrayClass);
-      return std::get<0>(stream->read<int32_t>());
+      int32_t arrayElementSize = 0;
+      JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, TR::compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_ARRAY_ELEMENT_SIZE, (void *)&arrayElementSize);
+      return arrayElementSize;
       }
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 34;
+   static const uint16_t MINOR_NUMBER = 35;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -414,6 +414,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _classChainOffsetIdentifyingLoader(0),
    _classNameIdentifyingLoader(),
    _aotCacheClassRecord(NULL),
+   _arrayElementSize(0),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(persistentMemory->_persistentAllocator.get())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -209,6 +209,7 @@ public:
       uintptr_t _classChainOffsetIdentifyingLoader;
       std::string _classNameIdentifyingLoader;
       const AOTCacheClassRecord *_aotCacheClassRecord;
+      int32_t _arrayElementSize;
 
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;


### PR DESCRIPTION
The new _arrayElementSize component in ClassInfo now caches the constant
(at runtime) element size of an array class. This component is now used
by J9::ClassEnv::flattenedArrayElementSize to avoid unnecessary messages
to the client.

Fixes: #14323

Signed-off-by: Christian Despres <despresc@ibm.com>