### PR TITLE
Update java.security.manager behaviour

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -286,31 +286,7 @@ public abstract class ClassLoader {
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 		jdk.internal.misc.VM.initLevel(2);
-		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
-		if ((javaSecurityManager != null) 
-		/*[IF JAVA_SPEC_VERSION >= 12]*/
-			/* See the SecurityManager javadoc for details about special tokens. */
-			&& !javaSecurityManager.equals("disallow") //$NON-NLS-1$ /* special token to disallow SecurityManager */
-			&& !javaSecurityManager.equals("allow") //$NON-NLS-1$ /* special token to allow SecurityManager */
-			/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
-		) {
-			/*[IF JAVA_SPEC_VERSION >= 17]*/
-			System.initialErr.println("WARNING: A command line option has enabled the Security Manager"); //$NON-NLS-1$
-			System.initialErr.println("WARNING: The Security Manager is deprecated and will be removed in a future release"); //$NON-NLS-1$
-			/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
-			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) { //$NON-NLS-1$
-				System.setSecurityManager(new SecurityManager());
-			} else {
-				try {
-					Constructor<?> constructor = Class.forName(javaSecurityManager, true, applicationClassLoader).getConstructor();
-					constructor.setAccessible(true);
-					System.setSecurityManager((SecurityManager)constructor.newInstance());
-				} catch (Throwable e) {
-					/*[MSG "K0631", "JVM can't set custom SecurityManager due to {0}"]*/
-					throw new Error(com.ibm.oti.util.Msg.getString("K0631", e.toString()), e); //$NON-NLS-1$
-				}
-			}
-		}
+		System.initSecurityManager(applicationClassLoader);
 		jdk.internal.misc.VM.initLevel(3);
 		/*[ELSE]*/
 		applicationClassLoader = sun.misc.Launcher.getLauncher().getClassLoader();

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1118,6 +1118,11 @@ public static void setSecurityManager(final SecurityManager s) {
 	@SuppressWarnings("removal")
 	final SecurityManager currentSecurity = security;
 
+	if ((currentSecurity == null) && (s == null)) {
+		/* Return if the input argument is null and no security manager has been established. */
+		return;
+	}
+
 	/*[IF JAVA_SPEC_VERSION > 11]*/
 	if (throwUOEFromSetSM) {
 		/*[MSG "K0B00", "The Security Manager is deprecated and will be removed in a future release"]*/

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import java.util.PropertyPermission;
 import java.security.*;
 import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 
 /*[IF Sidecar19-SE]*/
 import jdk.internal.misc.Unsafe;
@@ -90,6 +91,14 @@ public final class System {
 	// Show only one setSecurityManager() warning message for each caller
 	private static Map<Class<?>, Object> setSMCallers;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+
+	/*[IF JAVA_SPEC_VERSION > 11] */
+	/**
+	 * setSecurityManager() should throw UnsupportedOperationException
+	 * if throwUOEFromSetSM is set to true.
+	 */
+	private static boolean throwUOEFromSetSM;
+	/*[ENDIF] JAVA_SPEC_VERSION > 11 */
 
 	//Get a ref to the Runtime instance for faster lookup
 	private static final Runtime RUNTIME = Runtime.getRuntime();
@@ -1051,6 +1060,39 @@ public static void setProperties(Properties p) {
 	}
 }
 
+static void initSecurityManager(ClassLoader applicationClassLoader) {
+	String javaSecurityManager = internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
+	/*[IF JAVA_SPEC_VERSION > 11]*/
+	if ("allow".equals(javaSecurityManager)) {
+		/* Do nothing. */
+	} else if ("disallow".equals(javaSecurityManager) //$NON-NLS-1$
+		/*[IF JAVA_SPEC_VERSION >= 18]*/
+		|| (null == javaSecurityManager)
+		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+	) {
+		throwUOEFromSetSM = true;
+	} else
+	/*[ENDIF] JAVA_SPEC_VERSION > 11 */
+	if (null != javaSecurityManager) {
+		/*[IF JAVA_SPEC_VERSION >= 17]*/
+		initialErr.println("WARNING: A command line option has enabled the Security Manager"); //$NON-NLS-1$
+		initialErr.println("WARNING: The Security Manager is deprecated and will be removed in a future release"); //$NON-NLS-1$
+		/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+		if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) { //$NON-NLS-1$
+			setSecurityManager(new SecurityManager());
+		} else {
+			try {
+				Constructor<?> constructor = Class.forName(javaSecurityManager, true, applicationClassLoader).getConstructor();
+				constructor.setAccessible(true);
+				setSecurityManager((SecurityManager)constructor.newInstance());
+			} catch (Throwable e) {
+				/*[MSG "K0631", "JVM can't set custom SecurityManager due to {0}"]*/
+				throw new Error(com.ibm.oti.util.Msg.getString("K0631", e.toString()), e); //$NON-NLS-1$
+			}
+		}
+	}
+}
+
 /**
  * Sets the active security manager. Note that once
  * the security manager has been set, it can not be
@@ -1076,12 +1118,12 @@ public static void setSecurityManager(final SecurityManager s) {
 	@SuppressWarnings("removal")
 	final SecurityManager currentSecurity = security;
 
-	/*[IF JAVA_SPEC_VERSION >= 12]*/
-	if ("disallow".equals(systemProperties.getProperty("java.security.manager"))) { //$NON-NLS-1$ //$NON-NLS-2$
+	/*[IF JAVA_SPEC_VERSION > 11]*/
+	if (throwUOEFromSetSM) {
 		/*[MSG "K0B00", "The Security Manager is deprecated and will be removed in a future release"]*/
 		throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0B00")); //$NON-NLS-1$
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+	/*[ENDIF] JAVA_SPEC_VERSION > 11 */
 
 	/*[IF JAVA_SPEC_VERSION >= 17] */
 	Class<?> callerClz = getCallerClass();

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>JLM_Tests_interface_SE80</testCaseName>
 		<variations>
@@ -64,7 +65,7 @@
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-exports=jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED \
 	-XX:SharedCacheHardLimit=16m -Xscmx1m -Xshareclasses:name=testJLM,reset \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
@@ -190,7 +191,7 @@
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-exports=jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED \
 	-XX:SharedCacheHardLimit=16m -Xscmx1m -Xshareclasses:name=testJLM,reset \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \

--- a/test/functional/Java8andUp/java8andUpSettings.mk
+++ b/test/functional/Java8andUp/java8andUpSettings.mk
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2018, 2021 IBM Corp. and others
+#  Copyright (c) 2018, 2022 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,6 +19,8 @@
 #
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
+
+include $(TEST_ROOT)$(D)functional$(D)variables.mk
 
 ADD_MODULE_JAVA_SE_EE=
 # java.se.ee should only used for jdk 9 and 10

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1013,7 +1013,7 @@
 			<variation>-XX:RecreateClassfileOnload</variation>
 			<variation>-XX:+CompactStrings</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1113,7 +1113,7 @@
 			<variation>-Xshareclasses:none</variation>
 			<variation>-Xshareclasses:none -XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1362,7 +1362,7 @@
 		</variations>
 		<command>$(MKDIR) -p $(REPORTDIR); \
 	cd $(REPORTDIR); \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace \
+	$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace \
 	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Xbootclasspath/a:$(TEST_RESROOT)$(D)TestResources.jar \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
@@ -1459,7 +1459,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
 	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,7 @@
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
@@ -200,7 +200,7 @@
 		<variations>
 			<variation>-Xjit:count=0</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
@@ -257,7 +257,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
 	-Xbootclasspath/a:$(Q)$(TEST_RESROOT)$(D)jsr292bootstrap.jar$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \
@@ -281,7 +281,7 @@
 		<variations>
 			<variation>Mode195</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
 	-Xbootclasspath/a:$(Q)$(TEST_RESROOT)$(D)jsr292bootstrap.jar$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \

--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_J9securityTests_SE80</testCaseName>
 		<variations>
@@ -55,7 +56,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 		-DMODULE_ADDEXPORTS_OPTION=$(Q)--add-exports$(Q) -DMODULE_ADDEXPORTS_VALUE=$(Q)java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) \
 		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
 		-explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>

--- a/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,13 +21,18 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_ProxyFieldAccess_SE80</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTPROXYFIELDACCESSJAR=$(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.jar$(Q) -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.xml$(Q) -explainExcludes -nonZeroExitWhenError -xids all,$(PLATFORM),$(VARIATION) $(CMDLINETESTER_XLIST); \
-	${TEST_STATUS}</command>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+		-DTESTPROXYFIELDACCESSJAR=$(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.jar$(Q) \
+		-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError -xids all,$(PLATFORM),$(VARIATION) $(CMDLINETESTER_XLIST); \
+		${TEST_STATUS}</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -42,13 +47,18 @@
 			<version>8</version>
 		</versions>
 	</test>
+
 	<test>
 		<testCaseName>cmdLineTester_ProxyFieldAccess</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTPROXYFIELDACCESSJAR=$(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.jar$(Q) -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) --add-opens=java.base/java.lang=ALL-UNNAMED --add-reads java.base=jdk.unsupported --add-opens=java.base/java.lang=ALL-UNNAMED -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.xml$(Q) -explainExcludes -nonZeroExitWhenError -xids all,$(PLATFORM),$(VARIATION) $(CMDLINETESTER_XLIST); \
-	${TEST_STATUS}</command>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+		-DTESTPROXYFIELDACCESSJAR=$(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.jar$(Q) \
+		-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) --add-opens=java.base/java.lang=ALL-UNNAMED --add-reads java.base=jdk.unsupported --add-opens=java.base/java.lang=ALL-UNNAMED -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)testproxyfieldaccess.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError -xids all,$(PLATFORM),$(VARIATION) $(CMDLINETESTER_XLIST); \
+		${TEST_STATUS}</command>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/variables.mk
+++ b/test/functional/variables.mk
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2018, 2022 IBM Corp. and others
+#  Copyright (c) 2022, 2022 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,9 +20,11 @@
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
 
-include $(TEST_ROOT)$(D)functional$(D)variables.mk
-
-XMLSUFFIX=
-ifeq ($(JDK_VERSION), 8)
-	XMLSUFFIX=_8
+# In JDK18+, java.security.manager == null behaves as -Djava.security.manager=disallow.
+# In JDK17-, java.security.manager == null behaves as -Djava.security.manager=allow.
+# For OpenJ9 tests to work as expected, -Djava.security.manager=allow behaviour is
+# needed in JDK18+.
+JAVA_SECURITY_MANAGER=
+ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
+	JAVA_SECURITY_MANAGER=-Djava.security.manager=allow
 endif


### PR DESCRIPTION
1. Consolidate security manager startup code invoked from
`ClassLoader.initializeClassLoaders` in `System.initSecurityManager` (new method).

2. As per the Java doc, the `java.security.manager` property should only be read
at startup. Example: If this property is initialized with `"disallow"` when the
JVM is started, then a security manager will not be set at startup and cannot
be set dynamically. Currently, this property is read in
`System.setSecurityManager`. If a user changes this property after startup, then
`System.setSecurityManager`'s behaviour will change after startup. This behaviour
does not follow the Java doc and reference implementation. To fix this issue,
the `java.security.manager` is only read once at startup in
`System.initSecurityManager`.

3. In JDK18, `System.setSecurityManager`'s run-time behaviour changes with
respect to the `java.security.manager` property. Previously, if the property
was null, the run-time behaviour was `success or throws SecurityException`.
In JDK18, the new behaviour is to `throw UnsupportedOperationException` if the
property is null. This matches the behaviour when the property is set to
`"disallow"`.

4. Set `java.security.manager` property for impacted tests.

5. Explicitly handle `null` arguments in `System.setSecurityManager`.

Fixes: https://github.com/eclipse-openj9/openj9/issues/14092
Fixes: https://github.com/eclipse-openj9/openj9/issues/14094

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>