### PR TITLE
Handle Compilation Threads at checkpoint/restore

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -691,6 +691,17 @@ public:
    void waitOnCompMonitor(J9VMThread *vmThread);
    intptr_t waitOnCompMonitorTimed(J9VMThread *vmThread, int64_t millis, int32_t nanos);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   /* The CR Monitor (Checkpoint/Restore Monitor) must always be acquired with the Comp Monitor
+    * in hand. If waiting on the CR Monitor, the Comp Monitor should be released. After being
+    * notified, the CR Monitor should be released before re-acquiring the Comp Monitor.
+    */
+   TR::Monitor *getCRMonitor() { return _crMonitor; }
+   void acquireCRMonitor();
+   void releaseCRMonitor();
+   void waitOnCRMonitor();
+#endif
+
    TR_PersistentMemory *     persistentMemory() { return _persistentMemory; }
 
    TR::PersistentInfo    * getPersistentInfo() { return persistentMemory()->getPersistentInfo(); }
@@ -1155,6 +1166,10 @@ private:
    struct DLT_record     *_dltHash[DLT_HASHSIZE];
 #endif
    DLTTracking           *_dltHT;
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   TR::Monitor *_crMonitor;
+#endif
 
    TR::Monitor *_vlogMonitor;
    TR::Monitor *_rtlogMonitor;

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -765,18 +765,158 @@ public:
    void stopCompilationThreads();
 
    /**
-    * \brief
+    * @brief
     *    Stops a compilation thread by issuing an interruption request at the threads next yield point and by changing
     *    its state to signal termination. Note that there can be a delay between making this request and the thread
     *    state changing to `COMPTHREAD_STOPPED`.
     *
-    * \param compInfoPT
+    * @param compInfoPT
     *    The thread to be stopped.
     */
    void stopCompilationThread(CompilationInfoPerThread* compInfoPT);
 
-   void suspendCompilationThread();
+   /**
+    * @brief Suspends all compilation threads. By default it also purges the comp queue.
+    *
+    * @param purgeCompQueue bool to determine whether or not to purge the comp queue.
+    */
+   void suspendCompilationThread(bool purgeCompQueue = true);
+
+   /**
+    * @brief Resumes suspended compilation threads; the number of threads that are
+    *        resumed depends on several factors, such as the queue size and available
+    *        CPU resources.
+    */
    void resumeCompilationThread();
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   /**
+    * @brief Work that is necessary prior to taking a snapshot. This includes:
+    *        - Setting the _checkpointStatus state.
+    *        - Suspending all compilation threads.
+    *        - Waiting until all compilation threads are suspended.
+    *
+    * Normal Execution (steps 5&6 can be interchanged)
+    * ================================================
+    * 1. Hook Thread acquires Comp Monitor
+    * 2. Hook Thread signals Comp Threads to suspend
+    * 3. Hook Thread acquires CR Monitor, releases Comp Monitor, and waits on
+    *    CR Monitor
+    * 4. Comp Threads acquire Comp Monitor and CompThread Monitor, and change
+    *    state to COMPTHREAD_SUSPENDED
+    * 5. Comp Threads acquire CR Monitor, call notifyAll, and release CR
+    *    Monitor
+    * 6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor, and
+    *    blocks on Comp Monitor
+    * 7. Comp Threads release Comp Monitor and wait on CompThread Monitor
+    * 8. Hook Thread acquires Comp Monitor, ensures state has changed to
+    *    COMPTHREAD_SUSPENDED for the current compInfoPT
+    * 9. Hook Thread checks the next compInfoPT, waiting on the CR Monitor if
+    *    needed (it will release the Comp Monitor prior to waiting)
+    * 10. Hook Thread releases Comp Monitor, returns from the hook
+    *
+    *
+    * JIT Dump
+    * ========
+    * - Crash on application thread:
+    *    - Hook Thread running prepareForCheckpoint will run as normal
+    *       - Comp Threads will suspend themselves
+    *       - Hook Thread will wait till all Comp Threads are suspended
+    *       - Hook Thread will return from the jit hook
+    *       - VM will need to ensure it doesn't invoke criu API
+    *
+    * - Crash on compilation thread:
+    *    - Crashing Comp Thread will return to the VM and terminate process
+    *      (https://github.com/eclipse-openj9/openj9/blob/500e0a26e2c5be6ead0f838495ae8d8cc34821e1/runtime/compiler/control/CompilationThread.cpp#L3442-L3447)
+    *    - Possible scenarios for Hook Thread:
+    *       1. Hook Thread will try to acquire the Comp Monitor to signal Comp
+    *          Threads to suspend but will end up blocking until the JVM
+    *          terminates
+    *       2. Hook Thread will manage to signal Comp Threads to suspend, but
+    *          will remain waiting on the CR Monitor for the crashed Comp
+    *          Thread to suspend until the JVM terminates
+    *    - VM will need to ensure it doesn't invoke criu API
+    *
+    *
+    * Normal Shutdown
+    * ===============
+    * - Scenario 1
+    *    1. Hook Thread waits on CR Monitor
+    *    2. Comp Thread goes to suspend, already has Comp Monitor in hand
+    *    3. Shutdown Thread blocks on the Comp Monitor
+    *    4. Comp Thread updates state to COMPTHREAD_SUSPENDED, acquires CR
+    *       Monitor, and calls notifyAll
+    *    5. Comp Thread releases CR Monitor, releases Comp Monitor, and waits
+    *       on CompThread Monitor
+    *    6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor,
+    *       acquires Comp Monitor and continues on to next thread
+    *    7. Hook Thread checks state and moves onto the next threads possibly
+    *       finding them all suspended.
+    *    8. Hook Thread release Comp Monitor and returns from hook
+    *    9. Shutdown Thread goes through the sequence of stopping all threads
+    *
+    * - Scenario 2
+    *    Repeat steps 1-5 from Scenario 1
+    *    6. Shutdown Thread acquires Comp Monitor
+    *    7. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor
+    *       and blocks on the Comp Monitor
+    *    8. Shutdown Thread sets checkpoint to be interrupted flag.
+    *       Additionally (though irrelevant in this scenario) it also
+    *       acquires the CR Monitor, calls notify, and releases CR Monitor.
+    *    9. Shutdown Thread finishes stopping all threads, releases Comp
+    *       Monitor
+    *    10. Hook Thread acquires Comp Monitor, sees that the checkpoint should
+    *        be interrupted
+    *    11. Hook Thread breaks out of the loops, releases Comp Monitor, and
+    *        returns from hook
+    *
+    * - Scenario 3
+    *    1. Hook Thread waits on CR Monitor
+    *    2. Shutdown Thread acquires Comp Monitor
+    *    3. Comp Thread blocks on the Comp Monitor in order to (eventually)
+    *       suspend itself
+    *    4. Shutdown Thread sets checkpoint to be interrupted flag, acquires CR
+    *       Monitor, calls notify, and releases CR Monitor
+    *    5. Shutdown Thread goes about the task of stopping Comp Threads
+    *    6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor
+    *       and blocks on the Comp Monitor
+    *    7. Shutdown Thread finishes stopping all threads, releases Comp
+    *       Monitor (steps 5 & 6 can be interchanged with the same following
+    *       steps)
+    *    8. Hook Thread acquires Comp Monitor, sees that the checkpoint should
+    *       be interrupted
+    *    9. Hook Thread breaks out of the loops, releases Comp Monitor, and
+    *       returns from hook
+    *
+    * It should be noted that when the Hook Thread runs prepareForCheckpoint,
+    * either it will succeed in signalling the Comp Threads to suspend, or it
+    * will wait indefinitely on the Comp Monitor (in the case of a JIT Dump) or
+    * it will abort after acquring the Comp Monitor if the Shutdown Thread
+    * already finished its task. Once the Hook Thread reaches the point where
+    * it waits on the CR Monitor, the scenarioes above can occur.
+    *
+    *
+    * Shutdown during JIT Dump
+    * ========================
+    * - Crash on application thread
+    *    - same as Normal Shutdown
+    *
+    * - Crash on compilation thread
+    *    - In all of the above scenarios:
+    *       - Hook Thread remains waiting on CR Monitor
+    *       - Shutdown Thread blocks on the Comp Monitor
+    *       - Comp Thread returns to VM and terminates the process
+    */
+   void prepareForCheckpoint();
+
+   /**
+    * @brief Work that is necessary after the JVM has been restored. This includes:
+    *        - Resetting the _checkpointStatus state.
+    *        - Resuming all suspended compilation threads.
+    */
+   void prepareForRestore();
+#endif
+
    void purgeMethodQueue(TR_CompilationErrorCode errorCode);
    void *compileMethod(J9VMThread * context, TR::IlGeneratorMethodDetails &details, void *oldStartPC,
       TR_YesNoMaybe async, TR_CompilationErrorCode *, bool *queued, TR_OptimizationPlan *optPlan);

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -389,6 +389,15 @@ public:
       UNDEFINED_ACTION
       };
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   enum TR_CheckpointStatus
+      {
+      NO_CHECKPOINT_IN_PROGRESS,
+      CHECKPOINT_IN_PROGRESS,
+      INTERRUPT_CHECKPOINT
+      };
+#endif
+
    struct DLT_record
       {
       DLT_record         *_next;
@@ -700,6 +709,13 @@ public:
    void acquireCRMonitor();
    void releaseCRMonitor();
    void waitOnCRMonitor();
+
+   /* The following APIs should only be invoked with the Comp Monitor in hand. */
+   bool isCheckpointInProgress()        { return _checkpointStatus != TR_CheckpointStatus::NO_CHECKPOINT_IN_PROGRESS; }
+   void setCheckpointInProgress()       {        _checkpointStatus  = TR_CheckpointStatus::CHECKPOINT_IN_PROGRESS;    }
+   void resetCheckpointInProgress()     {        _checkpointStatus  = TR_CheckpointStatus::NO_CHECKPOINT_IN_PROGRESS; }
+   bool shouldCheckpointBeInterrupted() { return _checkpointStatus == TR_CheckpointStatus::INTERRUPT_CHECKPOINT;      }
+   void interruptCheckpoint()           {        _checkpointStatus  = TR_CheckpointStatus::INTERRUPT_CHECKPOINT;      }
 #endif
 
    TR_PersistentMemory *     persistentMemory() { return _persistentMemory; }
@@ -1169,6 +1185,7 @@ private:
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
    TR::Monitor *_crMonitor;
+   TR_CheckpointStatus _checkpointStatus;
 #endif
 
    TR::Monitor *_vlogMonitor;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1126,6 +1126,9 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
    _dltMonitor = TR::Monitor::create("JIT-DLTmonitor");
 #endif
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   _crMonitor = TR::Monitor::create("JIT-CheckpointRestoreMonitor");
+#endif
    _iprofilerBufferArrivalMonitor = TR::Monitor::create("JIT-IProfilerBufferArrivalMonitor");
    _classUnloadMonitor = TR::MonitorTable::get()->getClassUnloadMonitor(); // by this time this variable is initialized
                                              // TODO: hang these monitors to something persistent
@@ -1428,6 +1431,23 @@ void TR::CompilationInfo::releaseCompilationLock()
       releaseCompMonitor(0);
       }
    }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void TR::CompilationInfo::acquireCRMonitor()
+   {
+   getCRMonitor()->enter();
+   }
+
+void TR::CompilationInfo::releaseCRMonitor()
+   {
+   getCRMonitor()->exit();
+   }
+
+void TR::CompilationInfo::waitOnCRMonitor()
+   {
+   getCRMonitor()->wait();
+   }
+#endif
 
 TR::Monitor * TR::CompilationInfo::createLogMonitor()
    {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1128,6 +1128,7 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
 #endif
 #if defined(J9VM_OPT_CRIU_SUPPORT)
    _crMonitor = TR::Monitor::create("JIT-CheckpointRestoreMonitor");
+   _checkpointStatus = TR_CheckpointStatus::NO_CHECKPOINT_IN_PROGRESS;
 #endif
    _iprofilerBufferArrivalMonitor = TR::Monitor::create("JIT-IProfilerBufferArrivalMonitor");
    _classUnloadMonitor = TR::MonitorTable::get()->getClassUnloadMonitor(); // by this time this variable is initialized

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2449,13 +2449,8 @@ void TR::CompilationInfoPerThread::suspendCompilationThread()
 // This method may be called when we want all JIT activity to stop temporarily
 // It is called normally by a java thread
 //----------------------------------------------------------------------------
-void TR::CompilationInfo::suspendCompilationThread()
+void TR::CompilationInfo::suspendCompilationThread(bool purgeCompQueue)
    {
-   // if we compile on application thread, there is no compilation
-   // request queue and there is no compilation thread
-   // There can only be one request that is in progress. All the others
-   // will see the SUSPENDED state when they get the application monitor
-
    TR_ASSERT(_compilationMonitor, "Must have a compilation queue monitor\n");
    J9JavaVM   *vm       = _jitConfig->javaVM;
    J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
@@ -2484,7 +2479,7 @@ void TR::CompilationInfo::suspendCompilationThread()
             }
          }
       }
-   if (stoppedOneCompilationThread)
+   if (stoppedOneCompilationThread && purgeCompQueue)
       purgeMethodQueue(compilationSuspended);
    TR_ASSERT(_numCompThreadsActive == 0, "We must have all compilation threads suspended at this point\n");
    releaseCompMonitor(vmThread);
@@ -2617,6 +2612,93 @@ void TR::CompilationInfo::resumeCompilationThread()
    releaseCompMonitor(vmThread);
    }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void TR::CompilationInfo::prepareForCheckpoint()
+   {
+   J9JavaVM   *vm       = _jitConfig->javaVM;
+   J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
+
+   {
+   OMR::CriticalSection suspendCompThreadsForCheckpoint(getCompilationMonitor());
+
+   if (shouldCheckpointBeInterrupted())
+      return;
+
+   TR_ASSERT_FATAL(!isCheckpointInProgress(), "Checkpoint already in progress!\n");
+
+   /* Set the checkpoint in progress status. */
+   setCheckpointInProgress();
+
+   /* Inform compilation threads to suspend themselves. The compilation
+    * threads will complete any in-progress compilations first.
+    */
+   bool purgeMethodQueue = false;
+   suspendCompilationThread(purgeMethodQueue);
+
+   /* Wait until all compilation threads are suspended. */
+   for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
+      {
+      TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
+      if (!curCompThreadInfoPT->isDiagnosticThread())
+         {
+         do
+            {
+            /* Determine whether to wait on the CR Monitor.
+             *
+             * IMPORTANT: There should be no return, or C++ exception thrown, after
+             *            releasing the Comp Monitor below until it is re-acquired.
+             *            The Comp Monitor was acquired in an OMR::CriticalSection
+             *            object; a return, or thrown exception, will destruct this
+             *            object as part leaving the scope, or stack unwinding, which
+             *            will attempt to release the monitor in its destructor.
+             */
+            if (!shouldCheckpointBeInterrupted()
+                && curCompThreadInfoPT->getCompilationThreadState() != COMPTHREAD_SUSPENDED)
+               {
+               /* Acquire the CR monitor */
+               acquireCRMonitor();
+
+               /* Release the Comp Monitor before waiting */
+               releaseCompMonitor(vmThread);
+
+               /* Wait until notified */
+               waitOnCRMonitor();
+
+               /* Release CR Monitor and re-acquire the Comp Monitor */
+               releaseCRMonitor();
+               acquireCompMonitor(vmThread);
+               }
+            else
+               {
+               break;
+               }
+            }
+         while(true);
+         }
+
+      /* Stop cycling through the threads if checkpointing should be interrupted. */
+      if (shouldCheckpointBeInterrupted())
+         break;
+      }
+   }
+
+   }
+
+void TR::CompilationInfo::prepareForRestore()
+   {
+
+   {
+   OMR::CriticalSection resumeCompThreadsForRestore(getCompilationMonitor());
+
+   /* Reset the checkpoint in progress flag. */
+   resetCheckpointInProgress();
+
+   /* Resume suspended compilation threads. */
+   resumeCompilationThread();
+   }
+
+   }
+#endif // #if defined(J9VM_OPT_CRIU_SUPPORT)
 
 int TR::CompilationInfo::computeCompilationThreadPriority(J9JavaVM *vm)
    {
@@ -3428,6 +3510,18 @@ void TR::CompilationInfo::stopCompilationThreads()
 #endif
    acquireCompMonitor(vmThread);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   // Interrupt any checkpoint in progress and notify
+   // the thread waiting in the checkpoint hook.
+   if (isCheckpointInProgress())
+      {
+      interruptCheckpoint();
+      acquireCRMonitor();
+      getCRMonitor()->notifyAll();
+      releaseCRMonitor();
+      }
+#endif
+
    // Cycle through all non-diagnostic threads and stop them
    for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
@@ -3893,13 +3987,34 @@ TR::CompilationInfoPerThread::doSuspend()
    {
    _compInfo.setSuspendThreadDueToLowPhysicalMemory(false);
    getCompThreadMonitor()->enter();
+
+   // Set the new state
    setCompilationThreadState(COMPTHREAD_SUSPENDED);
-   _compInfo.releaseCompMonitor(getCompilationThread());   // release the queue monitor before waiting
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   // Notify the thread waiting in the checkpoint hook.
+   if (_compInfo.isCheckpointInProgress())
+      {
+      _compInfo.acquireCRMonitor();
+      _compInfo.getCRMonitor()->notifyAll();
+      _compInfo.releaseCRMonitor();
+      }
+#endif
+
+   // release the queue monitor before waiting
+   _compInfo.releaseCompMonitor(getCompilationThread());
+
    setLastTimeThreadWasSuspended(_compInfo.getPersistentInfo()->getElapsedTime());
    setVMThreadNameWithFlag(getCompilationThread(), getCompilationThread(), getSuspendedThreadName(), 1);
-   getCompThreadMonitor()->wait(); // wait here until someone notifies us
+
+   // wait here until someone notifies us
+   getCompThreadMonitor()->wait();
+
    setVMThreadNameWithFlag(getCompilationThread(), getCompilationThread(), getActiveThreadName(), 1);
+
    getCompThreadMonitor()->exit();
+
+   // reacquire the queue monitor
    _compInfo.acquireCompMonitor(getCompilationThread());
    }
 

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1812,6 +1812,13 @@ static void jitHookThreadDestroy(J9HookInterface * * hookInterface, UDATA eventN
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 static void jitHookPrepareCheckpoint(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
    {
+   J9VMClassesUnloadEvent * restoreEvent = (J9VMClassesUnloadEvent *)eventData;
+   J9VMThread * vmThread = restoreEvent->currentThread;
+   J9JavaVM * javaVM = vmThread->javaVM;
+   J9JITConfig * jitConfig = javaVM->jitConfig;
+
+   TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
+   compInfo->prepareForCheckpoint();
    }
 
 static void jitHookPrepareRestore(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
@@ -1819,6 +1826,7 @@ static void jitHookPrepareRestore(J9HookInterface * * hookInterface, UDATA event
    J9VMClassesUnloadEvent * restoreEvent = (J9VMClassesUnloadEvent *)eventData;
    J9VMThread * vmThread = restoreEvent->currentThread;
    J9JavaVM * javaVM = vmThread->javaVM;
+   J9JITConfig * jitConfig = javaVM->jitConfig;
 
    /* If the restored run does not allow further checkpoints, then
     * remove the portability restrictions on the target CPU (used
@@ -1829,6 +1837,9 @@ static void jitHookPrepareRestore(J9HookInterface * * hookInterface, UDATA event
       TR::Compiler->target.cpu = TR::CPU::detect(TR::Compiler->omrPortLib);
       jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
       }
+
+   TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
+   compInfo->prepareForRestore();
    }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1336,8 +1336,17 @@ static void jitMethodSampleInterrupt(J9VMThread* vmThread, IDATA handlerKey, voi
          }
 
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_MimicInterpreterFrameShape) &&
-          !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_MimicInterpreterFrameShape)
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+          /* It's ok to not acquire the comp monitor here. Even if at this
+           * point a checkpoint isn't in progress but later it does, a
+           * compilation won't be started because of other places where the
+           * flag is checked with the monitor in hand. This is more of an
+           * optimization that statistically should be useful.
+           */
+          && !compInfo->isCheckpointInProgress()
+#endif
+          && !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
          {
          static char *enableDebugDLT = feGetEnv("TR_DebugDLT");
          static J9Method *skipDLTMethod = NULL;
@@ -1382,8 +1391,17 @@ static void jitMethodSampleInterrupt(J9VMThread* vmThread, IDATA handlerKey, voi
             TR::Recompilation::sampleMethod(vmThread, vm, startPC, codeSize, walkState.pc, walkState.method, jitConfig->samplingTickCount);
          }
 #else // !J9VM_JIT_DYNAMIC_LOOP_TRANSFER
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_MimicInterpreterFrameShape) &&
-          !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_MimicInterpreterFrameShape)
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+          /* It's ok to not acquire the comp monitor here. Even if at this
+           * point a checkpoint isn't in progress but later it does, a
+           * compilation won't be started because of other places where the
+           * flag is checked with the monitor in hand. This is more of an
+           * optimization that statistically should be useful.
+           */
+          && !compInfo->isCheckpointInProgress()
+#endif
+          && !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
          {
          TR::Recompilation::sampleMethod(vmThread, vm, startPC, codeSize, walkState.pc, walkState.method, jitConfig->samplingTickCount);
          }


### PR DESCRIPTION
In order to ensure that a checkpoing/restore does not happen in the
middle of a compilation, when the J9HOOK_VM_PREPARING_FOR_CHECKPOINT
hook is called, all compilation threads are slated to be suspended.
Any existing compilations are allowed to complete. At restore time,
the compilation threads are resumed.

One difference between suspension at checkpoint time vs at any other
point is that the compilation queue is not purged. The reason for
this is that we want execution to continue as normal on restore.

### Normal Execution (steps 5&6 can be interchanged)
1. Hook Thread acquires Comp Monitor
2. Hook Thread signals Comp Threads to suspend
3. Hook Thread acquires CR Monitor, releases Comp Monitor, and waits on
   CR Monitor
4. Comp Threads acquire Comp Monitor and CompThread Monitor, and change
   state to COMPTHREAD_SUSPENDED
5. Comp Threads acquire CR Monitor, call notifyAll, and release CR
   Monitor
6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor, and
   blocks on Comp Monitor
7. Comp Threads release Comp Monitor and wait on CompThread Monitor
8. Hook Thread acquires Comp Monitor, ensures state has changed to
   COMPTHREAD_SUSPENDED for the current compInfoPT
9. Hook Thread checks the next compInfoPT, waiting on the CR Monitor if
   needed (it will release the Comp Monitor prior to waiting)
10. Hook Thread releases Comp Monitor, returns from the hook

### JIT Dump
- Crash on application thread:
   - Hook Thread running prepareForCheckpoint will run as normal
      - Comp Threads will suspend themselves
      - Hook Thread will wait till all Comp Threads are suspended
      - Hook Thread will return from the jit hook
      - VM will need to ensure it doesn't invoke criu API

- Crash on compilation thread:
   - Crashing Comp Thread will return to the VM and terminate process
     (https://github.com/eclipse-openj9/openj9/blob/500e0a26e2c5be6ead0f838495ae8d8cc34821e1/runtime/compiler/control/CompilationThread.cpp#L3442-L3447)
   - Possible scenarios for Hook Thread:
      1. Hook Thread will try to acquire the Comp Monitor to signal Comp
         Threads to suspend but will end up blocking until the JVM
         terminates
      2. Hook Thread will manage to signal Comp Threads to suspend, but
         will remain waiting on the CR Monitor for the crashed Comp
         Thread to suspend until the JVM terminates
   - VM will need to ensure it doesn't invoke criu API

### Normal Shutdown
- Scenario 1
   1. Hook Thread waits on CR Monitor
   2. Comp Thread goes to suspend, already has Comp Monitor in hand
   3. Shutdown Thread blocks on the Comp Monitor
   4. Comp Thread updates state to COMPTHREAD_SUSPENDED, acquires CR
      Monitor, and calls notifyAll
   5. Comp Thread releases CR Monitor, releases Comp Monitor, and waits
      on CompThread Monitor
   6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor,
      acquires Comp Monitor and continues on to next thread
   7. Hook Thread checks state and moves onto the next threads possibly
      finding them all suspended.
   8. Hook Thread release Comp Monitor and returns from hook
   9. Shutdown Thread goes through the sequence of stopping all threads

- Scenario 2
   Repeat steps 1-5 from Scenario 1
   6. Shutdown Thread acquires Comp Monitor
   7. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor
      and blocks on the Comp Monitor
   8. Shutdown Thread sets checkpoint to be interrupted flag.
      Additionally (though irrelevant in this scenario) it also
      acquires the CR Monitor, calls notify, and releases CR Monitor.
   9. Shutdown Thread finishes stopping all threads, releases Comp
      Monitor
   10. Hook Thread acquires Comp Monitor, sees that the checkpoint should
       be interrupted
   11. Hook Thread breaks out of the loops, releases Comp Monitor, and
       returns from hook

- Scenario 3
   1. Hook Thread waits on CR Monitor
   2. Shutdown Thread acquires Comp Monitor
   3. Comp Thread blocks on the Comp Monitor in order to (eventually)
      suspend itself
   4. Shutdown Thread sets checkpoint to be interrupted flag, acquires CR
      Monitor, calls notify, and releases CR Monitor
   5. Shutdown Thread goes about the task of stopping Comp Threads
   6. Hook Thread wakes up with CR Monitor in hand, releases CR Monitor
      and blocks on the Comp Monitor
   7. Shutdown Thread finishes stopping all threads, releases Comp
      Monitor (steps 5 & 6 can be interchanged with the same following
      steps)
   8. Hook Thread acquires Comp Monitor, sees that the checkpoint should
      be interrupted
   9. Hook Thread breaks out of the loops, releases Comp Monitor, and
      returns from hook

It should be noted that when the Hook Thread runs prepareForCheckpoint,
either it will succeed in signalling the Comp Threads to suspend, or it
will wait indefinitely on the Comp Monitor (in the case of a JIT Dump) or
it will abort after acquring the Comp Monitor if the Shutdown Thread
already finished its task. Once the Hook Thread reaches the point where
it waits on the CR Monitor, the scenarioes above can occur.

### Shutdown during JIT Dump
- Crash on application thread
   - same as Normal Shutdown

- Crash on compilation thread
   - In all of the above scenarios:
      - Hook Thread remains waiting on CR Monitor
      - Shutdown Thread blocks on the Comp Monitor
      - Comp Thread returns to VM and terminates the process

Fixes https://github.com/eclipse-openj9/openj9/issues/14281