### PR TITLE
Separate console encoding tests that aren't supported on jdk18

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_consoleUpTo17.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_consoleUpTo17.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2021, 2022 IBM Corp. and others
+  Copyright (c) 2022, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,24 +35,23 @@
   <!-- Use an encoding supported by Java 8 and in the jdk.charsets module -->
   <variable name="ENCODING2" value="Cp948" />
 
-  <test id="sun.stdout.encoding $ENCODING1$">
-    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ -Dsun.stdout.encoding=$ENCODING1$ $TARGET$ out $ENCODING1$</command>
+  <test id="$DEFAULT_ENCODING_PROP$ System.out $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING1$ $TARGET$ out $ENCODING1$</command>
     <return type="success" value="0" />
   </test>
 
-  <test id="sun.stderr.encoding $ENCODING1$">
-    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ -Dsun.stderr.encoding=$ENCODING1$ $TARGET$ err $ENCODING1$</command>
+  <test id="$DEFAULT_ENCODING_PROP$ System.err $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING1$ $TARGET$ err $ENCODING1$</command>
     <return type="success" value="0" />
   </test>
 
-  <test id="sun.stdout.encoding $ENCODING2$">
-    <command>$EXE$ $OPENS$ $CP$ -Dsun.stdout.encoding=$ENCODING2$ $TARGET$ out $ENCODING2$</command>
+  <test id="$DEFAULT_ENCODING_PROP$ System.out $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ $TARGET$ out $ENCODING2$</command>
     <return type="success" value="0" />
   </test>
 
-  <test id="sun.stderr.encoding $ENCODING2$">
-    <command>$EXE$ $OPENS$ $CP$ -Dsun.stderr.encoding=$ENCODING2$ $TARGET$ err $ENCODING2$</command>
+  <test id="$DEFAULT_ENCODING_PROP$ System.err $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ $TARGET$ err $ENCODING2$</command>
     <return type="success" value="0" />
   </test>
-
 </suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -164,6 +164,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>cmdLineTest_J9test_consoleUpTo17</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_consoleUpTo17.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>8</version>
+			<version>11</version>
+			<version>17</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>cmdLineTest_J9test_console_zos</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
@@ -183,6 +209,33 @@
 		</groups>
 		<versions>
 			<version>11+</version>
+		</versions>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTest_J9test_consoleUpTo17_zos</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_consoleUpTo17.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.zos</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11</version>
+			<version>17</version>
 		</versions>
 		<impls>
 			<impl>ibm</impl>


### PR DESCRIPTION
Move the console encoding tests that are only supported up to jdk17 to a
different file and test case name so they don't run and fail on jdk18.

From jdk18 the console does not use the file.encoding but the
native.encoding. native.encoding cannot be overridden on the command
line.

See JEP 400 UTF-8 by Default https://openjdk.java.net/jeps/400

Fixes https://github.com/eclipse-openj9/openj9/issues/14321

Tested via grinders:
jdk17 - https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/537- ran J9test_console, J9test_consoleUpTo17 
jdk18 - https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/539 - ran just J9test_console