### PR TITLE
Include ffi.h in FFITypeHelpers.hpp since Java 16

### DIFF
--- a/runtime/vm/LayoutFFITypeHelpers.hpp
+++ b/runtime/vm/LayoutFFITypeHelpers.hpp
@@ -25,7 +25,9 @@
 
 #include "ut_j9vm.h"
 #include "vm_internal.h"
+#if JAVA_SPEC_VERSION >= 16
 #include "ffi.h"
+#endif /* JAVA_SPEC_VERSION >= 16 */
 
 #define J9VM_LAYOUT_STRING_ON_STACK_LIMIT 128
 


### PR DESCRIPTION
The change is to include the ffi specific header when the java
version is greater than Java 16 to avoid the unexpected
compilation errors in Java 8 on plinux BE.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>