### PR TITLE
(v0.30.0-release) JDK17 adds Access.encodeASCII() & NativeLibraries.load()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2021 IBM Corp. and others
+ * Copyright (c) 2007, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -497,11 +497,11 @@ final class Access implements JavaLangAccess {
 		Shutdown.exit(status);
 	}
 
-	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,10 +117,10 @@ public final class System {
 	private static final int sysPropID_PlatformEncoding = 1;
 	private static final int sysPropID_FileEncoding = 2;
 	private static final int sysPropID_OSEncoding = 3;
-	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	private static final int sysPropID_OSVersion = 0;
 	private static final String sysPropOSVersion;
-	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	private static boolean hasSetErrEncoding;
@@ -143,9 +143,9 @@ public final class System {
 		 * at early boot stage in which System is not fully initialized
 		 * os.version, os.encoding, ibm.system.encoding/sun.jnu.encoding, file.encoding
 		 */
-		/*[IF JAVA_SPEC_VERSION >= 18]*/
+		/*[IF JAVA_SPEC_VERSION >= 17]*/
 		sysPropOSVersion = getSysPropBeforePropertiesInitialized(sysPropID_OSVersion);
-		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 		platformEncoding = getSysPropBeforePropertiesInitialized(sysPropID_PlatformEncoding);;
 		String definedFileEncoding = getSysPropBeforePropertiesInitialized(sysPropID_FileEncoding);
 		String definedOSEncoding = getSysPropBeforePropertiesInitialized(sysPropID_OSEncoding);
@@ -600,9 +600,9 @@ private static void ensureProperties(boolean isInitialization) {
 	Properties initializedProperties = new Properties();
 /*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
-	/*[IF JAVA_SPEC_VERSION >= 18]*/
+	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	initializedProperties.put("os.version", sysPropOSVersion); //$NON-NLS-1$
-	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 	if (osEncoding != null) {
 		initializedProperties.put("os.encoding", osEncoding); //$NON-NLS-1$
@@ -838,11 +838,11 @@ public static String getProperty(String prop, String defaultValue) {
 			&& !prop.equals("file.encoding.pkg") //$NON-NLS-1$
 			&& !prop.equals("sun.nio.cs.map") //$NON-NLS-1$
 	) {
-		/*[IF JAVA_SPEC_VERSION >= 18]*/
+		/*[IF JAVA_SPEC_VERSION >= 17]*/
 		if (prop.equals("os.version")) { //$NON-NLS-1$
 			return sysPropOSVersion;
 		} else
-		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 		if (prop.equals("os.encoding")) { //$NON-NLS-1$
 			return osEncoding;
 		} else if (prop.equals("ibm.system.encoding")) { //$NON-NLS-1$

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -759,11 +759,11 @@ static const char * const excludeArray[] = {
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedExceptionAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/lang/NullPointerException.fillInStackTrace()Ljava/lang/Throwable;",
-#if JAVA_SPEC_VERSION >= 18
+#if JAVA_SPEC_VERSION >= 17
    "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z",
-#else /* JAVA_SPEC_VERSION >= 18 */
+#else /* JAVA_SPEC_VERSION >= 17 */
    "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z",
-#endif /* JAVA_SPEC_VERSION >= 18 */
+#endif /* JAVA_SPEC_VERSION >= 17 */
 };
 
 bool
@@ -3000,11 +3000,11 @@ void TR_ResolvedJ9Method::construct()
 
    static X NativeLibrariesMethods[] =
       {
-#if JAVA_SPEC_VERSION >= 18
+#if JAVA_SPEC_VERSION >= 17
       {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z")},
-#else /* JAVA_SPEC_VERSION >= 18 */
+#else /* JAVA_SPEC_VERSION >= 17 */
       {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z")},
-#endif /* JAVA_SPEC_VERSION >= 18 */
+#endif /* JAVA_SPEC_VERSION >= 17 */
       {  TR::unknownMethod}
       };
 

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,11 +195,11 @@ standardInit( J9JavaVM *vm, char *dllName)
 				if (NULL == clz) {
 					goto _fail;
 				}
-#if JAVA_SPEC_VERSION >= 18
+#if JAVA_SPEC_VERSION >= 17
 				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z");
-#else /* JAVA_SPEC_VERSION >= 18 */
+#else /* JAVA_SPEC_VERSION >= 17 */
 				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z");
-#endif /* JAVA_SPEC_VERSION >= 18 */
+#endif /* JAVA_SPEC_VERSION >= 17 */
 				if (NULL == mid) {
 					goto _fail;
 				}

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2021 IBM Corp. and others
+Copyright (c) 2006, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -413,9 +413,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<!-- Static method references needed to support OpenJDK MethodHandles. -->
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="linkCallerMethod" signature="(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 
-	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="15-17">
-		<methodalias name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="18-"/>
-	</staticmethodref>
+	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="17-"/>
 
 	<!-- Security manager check -->
 	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>


### PR DESCRIPTION
Expand `JDK18` methods to `JDK17`:
```
Access.encodeASCII()
NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z
```
Get system property `os.version` before properties are initialized.

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/14327

Signed-off-by: Jason Feng <fengj@ca.ibm.com>