### PR TITLE
Handle TLHRemainders inside CopyForward - recycle

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -193,6 +193,8 @@ public:
 	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
 	UDATA minimumFreeSizeForSurvivor; /**< minimum free size can be reused by collector as survivor, for balanced GC only */
 	UDATA freeSizeThresholdForSurvivor; /**< if average freeSize(freeSize/freeCount) of the region is smaller than the Threshold, the region would not be reused by collector as survivor, for balanced GC only */
+	bool  recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
+
 protected:
 private:
 protected:
@@ -325,6 +327,7 @@ public:
 		, initialRAMPercent(0.0) /* this would get overwritten by user specified value */
 		, minimumFreeSizeForSurvivor(DEFAULT_SURVIVOR_MINIMUM_FREESIZE)
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
+		, recycleRemainders(true)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1481,6 +1481,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				break;
 			}
 			extensions->freeSizeThresholdForSurvivor = size;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "noRecycleRemainders")) {
+			extensions->recycleRemainders = false;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "recycleRemainders")) {
+			extensions->recycleRemainders = true;
 			continue;
 		}
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1123,11 +1123,8 @@ public:
 		return false;
 	}
 
-	void abandonTLHRemainder(MM_EnvironmentVLHGC *env, bool preserveRemainders = false);
+	void abandonTLHRemainders(MM_EnvironmentVLHGC *env);
 
-	/* after Global GC or before first PGC after GMP, we need to reset all of TLHRemainders */
-	void resetAllTLHRemainders(MM_EnvironmentVLHGC *env);
-	MMINLINE void discardHeapChunk(MM_CopyForwardCompactGroup *compactGroupForMarkData, void *base, void *top);
 	friend class MM_CopyForwardGMPCardCleaner;
 	friend class MM_CopyForwardNoGMPCardCleaner;
 	friend class MM_CopyForwardSchemeTask;

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1877,7 +1877,7 @@ MM_WriteOnceCompactor::recycleFreeRegionsAndFixFreeLists(MM_EnvironmentVLHGC *en
 
 				regionPool->reset(MM_MemoryPool::forCompact);
 				if (currentFreeSize > regionPool->getMinimumFreeEntrySize()) {
-					regionPool->recycleHeapChunk(currentFreeBase, byteAfterFreeEntry);
+					regionPool->recycleHeapChunk(env, currentFreeBase, byteAfterFreeEntry);
 					regionPool->updateMemoryPoolStatistics(env, currentFreeSize, 1, currentFreeSize);
 				} else {
 					regionPool->abandonHeapChunk(currentFreeBase, byteAfterFreeEntry);


### PR DESCRIPTION
	- new XXgc options noRecycleRemainders, recycleRemainders(default).

	- if option recycleRemainders is set, discard remainders in nursery
	 regions and recycle remainders in non nuresery regions at the end of
	 PGC.

	- otherwise discard all remainders at the end of PGC.

depends on https://github.com/eclipse/omr/pull/6314

Signed-off-by: Lin Hu <linhu@ca.ibm.com>