### PR TITLE
Remove runAqaConfig.json

### DIFF
--- a/.github/workflows/runAqaConfig.json
+++ b/.github/workflows/runAqaConfig.json
@@ -1,5 +1,0 @@
-{
-    "custom_openjdk_testrepo": true,
-    "custom_openj9_repo": false,
-    "custom_tkg_repo": true
-}


### PR DESCRIPTION
Allow custom repos to be set by the users as command arguments rather than in runAqaConfig.json.

Fixes: adoptium/aqa-tests#3163

Signed-off-by: Nadeen Mohamed <nadeen@ualberta.ca>