### PR TITLE
Throw correct exception when initialization already failed

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -193,6 +193,12 @@ final class J9VMInternals {
 			if (exceptions == null)
 				exceptions = new WeakHashMap();
 			synchronized(exceptions) {
+/*[IF JAVA_SPEC_VERSION >= 18]*/
+				if (!(err instanceof Error)) {
+					err = new ExceptionInInitializerError(err);
+				}
+				exceptions.put(clazz, new SoftReference(copyThrowable(err)));
+/*[ELSE] JAVA_SPEC_VERSION >= 18*/
 				Throwable cause = err;
 				if (err instanceof ExceptionInInitializerError) {
 					cause = ((ExceptionInInitializerError)err).getException();
@@ -202,6 +208,7 @@ final class J9VMInternals {
 					}
 				}
 				exceptions.put(clazz, new SoftReference(copyThrowable(cause)));
+/*[ENDIF] JAVA_SPEC_VERSION >= 18*/
 			}
 		}
 		ensureError(err);


### PR DESCRIPTION
Throw correct exception when initialization already failed

When initialization has already failed for a class before, throw
`NoClassDefFoundError` with `ExceptionInInitializerError` as its cause
instead of the `Throwable` that caused the first initialization failure.

Supersedes #14291 (renamed branch)
Fixes: #14080
Signed-off-by: Eric Yang <eric.yang@ibm.com>