### PR TITLE
Do not wait for message under lock in TR_J9ServerVM::classHasBeenExtended

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -588,9 +588,10 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
    if (bClassHasBeenExtended)
       return true;
 
+   bool cachedAndNotInCHTable = false;
       {
       OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
-      auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+      auto it = clientSessionData->getROMClassMap().find((J9Class *)clazz);
       if (it != clientSessionData->getROMClassMap().end())
          {
          if ((it->second._classDepthAndFlags & J9AccClassHasBeenOverridden) != 0)
@@ -601,32 +602,39 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
             // The flag is neither set in the CHTable nor the class data cache.
             return false;
             }
-         else
-            {
-            // The class info does not exist in the CHTable but it's cached in
-            // the class data cache and the flag is not set.
-            stream->write(JITServer::MessageType::VM_classHasBeenExtended, clazz);
-            bool result = std::get<0>(stream->read<bool>());
-            if (result)
-               {
-               it->second._classDepthAndFlags |= J9AccClassHasBeenOverridden;
-               }
-            return result;
-            }
+
+         cachedAndNotInCHTable = true;
          }
+      }
+
+   if (cachedAndNotInCHTable)
+      {
+      // The class info does not exist in the CHTable but it's cached in
+      // the class data cache and the flag is not set.
+      stream->write(JITServer::MessageType::VM_classHasBeenExtended, clazz);
+      bool result = std::get<0>(stream->read<bool>());
+      if (result)
+         {
+         OMR::CriticalSection cs(clientSessionData->getROMMapMonitor());
+         auto it = clientSessionData->getROMClassMap().find((J9Class *)clazz);
+         TR_ASSERT(it != clientSessionData->getROMClassMap().end(), "Class %p must be cached", clazz);
+         it->second._classDepthAndFlags |= J9AccClassHasBeenOverridden;
+         }
+      return result;
       }
 
    if (bIsClassInfoInCHTable)
       {
       // The class data exists in the CHTable but it's not cached in the ROMClass cache.
+      TR_ASSERT(!bClassHasBeenExtended, "Must not be extended");
       return false;
       }
-   else
-      {
-      // The class data does not exist in the CHTable and is not cached. Retrieve ClassInfo from the client.
-      uintptr_t classDepthAndFlags = JITServerHelpers::getRemoteClassDepthAndFlagsWhenROMClassNotCached((J9Class *)clazz, clientSessionData, stream);
-      return ((classDepthAndFlags & J9AccClassHasBeenOverridden) != 0);
-      }
+
+   // The class data does not exist in the CHTable and is not cached. Retrieve ClassInfo from the client.
+   uintptr_t classDepthAndFlags = JITServerHelpers::getRemoteClassDepthAndFlagsWhenROMClassNotCached(
+      (J9Class *)clazz, clientSessionData, stream
+   );
+   return (classDepthAndFlags & J9AccClassHasBeenOverridden) != 0;
    }
 
 bool


### PR DESCRIPTION
In an edge case, `TR_J9ServerVM::classHasBeenExtended()` currently waits for a client response while holding a client session ROM map lock. This PR changes the implementation of this method to release the lock while waiting for the response.