### PR TITLE
Make some hard-coded JITServer settings configurable

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -263,6 +263,9 @@ int32_t J9::Options::_updateFreeMemoryMinPeriod = 500;  // 500 ms
 size_t J9::Options::_scratchSpaceLimitKBWhenLowVirtualMemory = 64*1024; // 64MB; currently, only used on 32 bit Windows
 
 int32_t J9::Options::_scratchSpaceFactorWhenJSR292Workload = JSR292_SCRATCH_SPACE_FACTOR;
+#if defined(J9VM_OPT_JITSERVER)
+int32_t J9::Options::_scratchSpaceFactorWhenJITServerWorkload = 2;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 int32_t J9::Options::_lowVirtualMemoryMBThreshold = 300; // Used on 32 bit Windows, Linux, 31 bit z/OS, Linux
 int32_t J9::Options::_safeReservePhysicalMemoryValue = 32 << 20;  // 32 MB
 
@@ -962,6 +965,10 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_samplingThreadExpirationTime, 0, "F%d", NOT_IN_SUBSET},
    {"scorchingSampleThreshold=", "R<nnn>\tThe maximum number of global samples taken during a sample interval for which the method will be recompiled as scorching",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_scorchingSampleThreshold, 0, "F%d", NOT_IN_SUBSET},
+#if defined(J9VM_OPT_JITSERVER)
+   {"scratchSpaceFactorWhenJITServerWorkload=","M<nnn>\tMultiplier for scratch space limit at JITServer",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_scratchSpaceFactorWhenJITServerWorkload, 0, "F%d", NOT_IN_SUBSET},
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"scratchSpaceFactorWhenJSR292Workload=","M<nnn>\tMultiplier for scratch space limit when MethodHandles are in use",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_scratchSpaceFactorWhenJSR292Workload, 0, "F%d", NOT_IN_SUBSET},
    {"scratchSpaceLimitKBWhenLowVirtualMemory=","M<nnn>\tLimit for memory used by JIT when running on low virtual memory",

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -123,12 +123,14 @@ int32_t J9::Options::_bigAppSampleThresholdAdjust = 3; //amount to shift the hot
 int32_t J9::Options::_availableCPUPercentage = 100;
 int32_t J9::Options::_cpuCompTimeExpensiveThreshold = 4000;
 uintptr_t J9::Options::_compThreadAffinityMask = 0;
+
 #if defined(J9VM_OPT_JITSERVER)
-int64_t J9::Options::_oldAge = 1000*60*1000; // 1000 minutes
-int64_t J9::Options::_oldAgeUnderLowMemory = 1000*60*5; // 5 minute
-int64_t J9::Options::_timeBetweenPurges = 1000*60*1; // 1 minute
+int64_t J9::Options::_oldAge = 1000 * 60 * 1000; // 1000 minutes
+int64_t J9::Options::_oldAgeUnderLowMemory = 1000 * 60 * 5; // 5 minutes
+int64_t J9::Options::_timeBetweenPurges = 1000 * 60 * 1; // 1 minute
 bool J9::Options::_shareROMClasses = false;
 int32_t J9::Options::_sharedROMClassCacheNumPartitions = 16;
+int32_t J9::Options::_reconnectWaitTimeMs = 1000;
 int32_t J9::Options::_highActiveThreadThreshold = -1;
 int32_t J9::Options::_veryHighActiveThreadThreshold = -1;
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -939,6 +941,10 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_qszThresholdToDowngradeOptLevel , 0, "F%d", NOT_IN_SUBSET},
    {"queueSizeThresholdToDowngradeOptLevelDuringStartup=", "M<nnn>\tCompilation queue size threshold when opt level is downgraded during startup phase",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_qszThresholdToDowngradeOptLevelDuringStartup , 0, "F%d", NOT_IN_SUBSET },
+#if defined(J9VM_OPT_JITSERVER)
+   {"reconnectWaitTimeMs=", " \tInitial wait time in milliseconds until attempting to reconnect to JITServer",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_reconnectWaitTimeMs, 0, "F%d", NOT_IN_SUBSET},
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"regmap",             0, SET_JITCONFIG_RUNTIME_FLAG(J9JIT_CG_REGISTER_MAPS) },
    {"relaxedCompilationLimitsSampleThreshold=", "R<nnn>\tGlobal samples below this threshold means we can use higher compilation limits",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_relaxedCompilationLimitsSampleThreshold, 0, "F%d", NOT_IN_SUBSET },

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -222,8 +222,9 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t getScratchSpaceFactorWhenJSR292Workload() { return _scratchSpaceFactorWhenJSR292Workload; }
 
 #if defined(J9VM_OPT_JITSERVER)
-   static int32_t getScratchSpaceFactorWhenJITServerWorkload() { return 2; }
-#endif
+   static int32_t _scratchSpaceFactorWhenJITServerWorkload;
+   static int32_t getScratchSpaceFactorWhenJITServerWorkload() { return _scratchSpaceFactorWhenJITServerWorkload; }
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _lowVirtualMemoryMBThreshold;
    static int32_t getLowVirtualMemoryMBThreshold() { return _lowVirtualMemoryMBThreshold; }

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -266,14 +266,16 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _TLHPrefetchBoundaryLineCount;
    static int32_t _TLHPrefetchTLHEndLineCount;
    static int32_t _numFirstTimeCompilationsToExitIdleMode; // use large number to disable the feature
+
 #if defined(J9VM_OPT_JITSERVER)
    static int64_t _oldAge;
    static int64_t _oldAgeUnderLowMemory;
    static int64_t _timeBetweenPurges;
    static bool _shareROMClasses;
    static int32_t _sharedROMClassCacheNumPartitions;
-   const static uint32_t DEFAULT_JITCLIENT_TIMEOUT = 10000; // ms
-   const static uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
+   static int32_t _reconnectWaitTimeMs;
+   static const uint32_t DEFAULT_JITCLIENT_TIMEOUT = 10000; // ms
+   static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _waitTimeToEnterIdleMode;

--- a/runtime/compiler/runtime/JITServerStatisticsThread.cpp
+++ b/runtime/compiler/runtime/JITServerStatisticsThread.cpp
@@ -82,9 +82,9 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
 
    persistentInfo->setStartTime(crtTime);
    persistentInfo->setElapsedTime(0);
-   while(!statsThreadObj->getStatisticsThreadExitFlag())
+   while (!statsThreadObj->getStatisticsThreadExitFlag())
       {
-      while(!statsThreadObj->getStatisticsThreadExitFlag() && j9thread_sleep_interruptable((IDATA) samplingPeriod, 0) == 0)
+      while (!statsThreadObj->getStatisticsThreadExitFlag() && j9thread_sleep_interruptable(samplingPeriod, 0) == 0)
          {
          // Read current time but prevent situations where clock goes backwards
          // Maybe we should use a monotonic clock
@@ -93,18 +93,17 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
             crtTime = t;
          persistentInfo->setElapsedTime(crtTime - persistentInfo->getStartTime());
 
-         // Every 10000 ms look for stale sessions from clients that were inactive
-         // for a long time and purge them
-         if (crtTime - lastPurgeTime >= 10000)
+         // Look for stale sessions from clients that were inactive for a long time and purge them
+         if (crtTime - lastPurgeTime >= TR::Options::_timeBetweenPurges)
             {
             lastPurgeTime = crtTime;
             OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
             compInfo->getClientSessionHT()->purgeOldDataIfNeeded();
-            }     
+            }
 
          // Print operational statistics to vlog if enabled
          CpuUtilization *cpuUtil = compInfo->getCpuUtil(); 
-         if ((statsThreadObj->getStatisticsFrequency() != 0) && ((crtTime - lastStatsTime) > statsThreadObj->getStatisticsFrequency()))
+         if ((statsThreadObj->getStatisticsFrequency() != 0) && (crtTime - lastStatsTime > statsThreadObj->getStatisticsFrequency()))
             {
             int32_t cpuUsage = 0, avgCpuUsage = 0, vmCpuUsage = 0;
             if (cpuUtil->isFunctional())


### PR DESCRIPTION
This PR adds the following `-Xjit:` command line options for JITServer that can be useful for performance tuning:
- `scratchSpaceFactorWhenJITServerWorkload` (default 2) - determines the scratch memory limit for out-of-process compilations at JITServer;
- `reconnectWaitTimeMs` (default 1000 ms) - determines the wait time for the client before attempting to reconnect to the JITServer after a network failure.

The JITServer statistics thread now also uses the value of the existing `timeBetweenPurges` option instead of a hard-coded value.