### PR TITLE
Change GCRQueuedThresholdForCounting value for JITServer AOT cache

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2118,6 +2118,14 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          // Enable ROMClass sharing at the server by default (unless explicitly disabled) if using AOT cache
          _shareROMClasses = true;
          }
+      if ((compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT) &&
+           compInfo->getPersistentInfo()->getJITServerUseAOTCache())
+         {
+         // With JITServer AOT cache, the client generates a lot of AOT compilations
+         // that have GCR IL trees in them. Due to the negative affect of GCR counting
+         // we want to limit the amount of time counting takes place.
+         TR::Options::_GCRQueuedThresholdForCounting = 200;
+         }
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return true;


### PR DESCRIPTION
When a client wants to take advantage of the JITServer AOT cache
feature it will generate as many AOT compilations as possible.
AOT bodies have Guarded Counting Recompilation (GCR) IL trees in
them, to ensure that frequently called bodies are recompiled.
Experiments have shown that GCR counting can have a negative effect
on performance and we would like to minimize the amount of time
GCR counting is done.
Existing code includes a provision to stop counting when too many
methods have been queued for compilation due to GCR. This feature is
controlled by an option: GCRQueuedThresholdForCounting, but its default
value disables this feature.
In this commit, we set GCRQueuedThresholdForCounting=200 when the
JVM is running in client mode and is using the JITServer AOT cache.
This value can still be overidden with -Xjit command line options.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>