### PR TITLE
CRIU implement internal hooks mechanism

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,6 +86,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, j
 	J9JavaVM *vm = currentThread->javaVM;
 	jboolean res = JNI_FALSE;
 
+	UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(vm));
 	if (vm->internalVMFunctions->isCRIUSupportEnabled(currentThread)) {
 #if defined(LINUX)
 		if (0 == criu_init_opts()) {
@@ -257,6 +258,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 	IDATA systemReturnCode = 0;
 	PORT_ACCESS_FROM_VMC(currentThread);
 
+	Trc_CRIU_checkpointJVMImpl_Entry(currentThread);
 	if (vmFuncs->isCheckpointAllowed(currentThread)) {
 #if defined(LINUX)
 		j9object_t cpDir = NULL;
@@ -376,15 +378,37 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 			goto wakeJavaThreads;
 		}
 
+		vmFuncs->acquireExclusiveVMAccess(currentThread);
+
+		/* Run internal checkpoint hooks, after iterating heap objects */
+		if (FALSE == vmFuncs->runInternalJVMCheckpointHooks(vm)) {
+			currentExceptionClass = vm->criuSystemCheckpointExceptionClass;
+			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_CHECKPOINT_HOOKS, NULL);
+			goto wakeJavaThreadsWithExclusiveVMAccess;
+		}
+
+		Trc_CRIU_before_checkpoint(currentThread);
 		systemReturnCode = criu_dump();
+		Trc_CRIU_after_checkpoint(currentThread);
 		if (systemReturnCode < 0) {
 			currentExceptionClass = vm->criuSystemCheckpointExceptionClass;
 			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_JCL_CRIU_DUMP_FAILED, NULL);
-			goto wakeJavaThreads;
+			goto wakeJavaThreadsWithExclusiveVMAccess;
 		}
 
 		/* We can only end up here if the CRIU restore was successful */
 		isAfterCheckpoint = TRUE;
+
+		/* Run internal restore hooks, and cleanup */
+		if (FALSE == vmFuncs->runInternalJVMRestoreHooks(vm)) {
+			currentExceptionClass = vm->criuRestoreExceptionClass;
+			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_RESTORE_HOOKS, NULL);
+			goto wakeJavaThreadsWithExclusiveVMAccess;
+		}
+
+		vmFuncs->releaseExclusiveVMAccess(currentThread);
 
 		if (FALSE == vmFuncs->jvmRestoreHooks(currentThread)) {
 			/* throw the pending exception */
@@ -394,6 +418,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 wakeJavaThreads:
 		vmFuncs->acquireExclusiveVMAccess(currentThread);
 
+wakeJavaThreadsWithExclusiveVMAccess:
 		toggleSuspendOnJavaThreads(currentThread, FALSE);
 
 		vmFuncs->releaseExclusiveVMAccess(currentThread);
@@ -464,6 +489,8 @@ freeDir:
 			j9mem_free_memory(exceptionMsg);
 		}
 	}
+
+	Trc_CRIU_checkpointJVMImpl_Exit(currentThread);
 }
 
 } /* extern "C" */

--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2021, 2021 IBM Corp. and others
+// Copyright (c) 2021, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,3 +32,8 @@ TraceAssert=Assert_CRIU_mustNotHaveVMAccess noEnv Overhead=1 Level=1 Assert="0 =
 
 TraceException=Trc_CRIU_getNativeString_getStringSizeFail Overhead=1 Level=1 Template="Failed to get Java string size: mutf8String=%s mutf8StringSize=%zu"
 TraceException=Trc_CRIU_getNativeString_convertFail Overhead=1 Level=1 Template="Failed to convert Java string: mutf8String=%s mutf8StringSize=%zu requiredConvertedStringSize=%zd"
+
+TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump()"
+TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump()"
+TraceEntry=Trc_CRIU_checkpointJVMImpl_Entry Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
+TraceExit=Trc_CRIU_checkpointJVMImpl_Exit Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2021 IBM Corp. and others
+# Copyright (c) 2000, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -498,4 +498,20 @@ J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.sample_input_1=1
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.explanation=An error occured when the JVM attempted to close the specified directory.
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.system_action=The JVM will throw a RestoreException or SystemCheckpointException.
 J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.user_response=Ensure the specified directory is accessible.
+# END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_CHECKPOINT_HOOKS=Could not run internal checkpoint hooks, errno=%li
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.sample_input_1=1
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.explanation=An error occured when the JVM attempted to run internal checkpoint hooks.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.system_action=The JVM will throw a SystemCheckpointException.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.user_response=View CRIU documentation to determine how to resolve the error.
+# END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_RESTORE_HOOKS=Could not run internal restore hooks, errno=%li
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.sample_input_1=1
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.explanation=An error occured when the JVM attempted to run internal restore hooks.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.system_action=The JVM will throw a RestoreException.
+J9NLS_JCL_CRIU_FAILED_TO_CLOSE_WORK_DIR.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -531,6 +531,30 @@ jvmCheckpointHooks(J9VMThread *currentThread);
  */
 BOOLEAN
 jvmRestoreHooks(J9VMThread *currentThread);
+
+/**
+ * @brief This iterates heap objects first, then goes through hook records,
+ * and run the checkpoint hook function.
+ * ExclusiveVMAccess is required since J9InternalHookRecord hold live object references
+ * and GC are not allowed while running these hook functions.
+ *
+ * @param vm J9JavaVM
+ * @return BOOLEAN TRUE if no error, otherwise FALSE
+ */
+BOOLEAN
+runInternalJVMCheckpointHooks(J9JavaVM *vm);
+
+/**
+ * @brief This runs the restore hook function, and cleanup.
+ * ExclusiveVMAccess is required since J9InternalHookRecord hold live object references
+ * and GC are not allowed while running these hook functions.
+ *
+ * @param vm J9JavaVM
+ * @param isRestore If FALSE, run the hook specified for checkpoint, otherwise run the hook specified for restore
+ * @return BOOLEAN TRUE if no error, otherwise FALSE
+ */
+BOOLEAN
+runInternalJVMRestoreHooks(J9JavaVM *vm);
 
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,6 +406,8 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jvmRestoreHooks,
 	isCRIUSupportEnabled,
 	isCheckpointAllowed,
+	runInternalJVMCheckpointHooks,
+	runInternalJVMRestoreHooks,
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	getClassNameString,
 };

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2021 IBM Corp. and others
+// Copyright (c) 2006, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -884,3 +884,13 @@ TraceEvent=Trc_VM_classLoaderRegisterLibrary_newNativeLibrary Overhead=1 Level=5
 
 TraceEntry=Trc_VM_WalkStackFrames_Entry Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p flags=%p sp=%p a0=%p pc=%p literals=%p els=%p j2i=%p"
 TraceExit=Trc_VM_WalkStackFrames_Exit Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p, rc=%d"
+
+TraceEntry=Trc_VM_criu_initHooks_Entry Overhead=1 Level=5 Template="initializeCriuHooks"
+TraceExit=Trc_VM_criu_initHooks_Exit Overhead=1 Level=5 Template="initializeCriuHooks - checkpointState.hookRecords (%p)"
+TraceException=Trc_VM_criu_jur_invalid_seedOffset Overhead=1 Level=3 Template="juRandomReseed instanceType (%p) - invalid seedOffset"
+TraceException=Trc_VM_criu_jur_AtomicLong_CNF Overhead=1 Level=3 Template="juRandomReseed java.util.concurrent.atomic.AtomicLong not found"
+TraceException=Trc_VM_criu_jur_invalid_valueOffset Overhead=1 Level=3 Template="juRandomReseed jucaAtomicLongClass (%p) - invalid valueOffset"
+TraceEntry=Trc_VM_criu_runCheckpointHooks_Entry Overhead=1 Level=2 Template="runInternalJVMCheckpointHooks"
+TraceExit=Trc_VM_criu_runCheckpointHooks_Exit Overhead=1 Level=2 Template="runInternalJVMCheckpointHooks"
+TraceEntry=Trc_VM_criu_runRestoreHooks_Entry Overhead=1 Level=2 Template="runInternalJVMRestoreHooks"
+TraceExit=Trc_VM_criu_runRestoreHooks_Exit Overhead=1 Level=2 Template="runInternalJVMRestoreHooks"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -904,6 +904,14 @@ freeJavaVM(J9JavaVM * vm)
 		vm->realtimeSizeClasses = NULL;
 	}
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	J9Pool *hookRecords = vm->checkpointState.hookRecords;
+	if (NULL != hookRecords) {
+		pool_kill(hookRecords);
+		vm->checkpointState.hookRecords = NULL;
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	j9mem_free_memory(vm);
 
 	if (NULL != tmpLib->self_handle) {


### PR DESCRIPTION
Defined `J9InternalHookRecord` & `J9ObjectRecord`;
Added VM internal functions `addInternalJVMCheckpointHook`, `initializeCriuHooks`, and `iterateHookRecords`;
Invokes `j9mm_iterate_all_objects` before `criu` checkpoint to record all heap objects matching instance type(s) specified within the hook record;
At restore, `iterateCriuHookRecords` performs modification accordingly.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>