### PR TITLE
Throw an exception in arrayIndexScale when index scale is not a power of 2

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1573,10 +1573,15 @@ public final class Unsafe {
 	 * 
 	 * @throws NullPointerException if class is null
 	 * @throws IllegalArgumentException if class is not an array
+	 * @throws RuntimeException if index scale is not a power of 2
 	 */
 	public int arrayIndexScale(Class<?> c) {
 		Objects.requireNonNull(c);
-		return arrayIndexScale0(c);
+		int indexScale = arrayIndexScale0(c);
+		if (indexScale == 0 || (indexScale & (indexScale - 1)) != 0) {
+			throw new RuntimeException("The class array index scale is not a power of two");
+		}
+		return indexScale;
 	}
 
 	/**

--- a/runtime/oti/UnsafeAPI.hpp
+++ b/runtime/oti/UnsafeAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -378,7 +378,7 @@ public:
 
 	static VMINLINE I_32 arrayIndexScale(J9ArrayClass *arrayClass)
 	{
-		return (UDATA)1 << ((J9ROMArrayClass*)arrayClass->romClass)->arrayShape;
+		return (I_32)J9ARRAYCLASS_GET_STRIDE((J9Class*)arrayClass);
 	}
 
 	static VMINLINE I_32 addressSize()

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3337,6 +3337,7 @@ fail:
 					}
 					J9ARRAYCLASS_SET_STRIDE(ramClass, (((UDATA) 1) << (((J9ROMArrayClass*)romClass)->arrayShape & 0x0000FFFF)));
 				}
+				Assert_VM_true(J9ARRAYCLASS_GET_STRIDE(ramClass) <= I_32_MAX);
 			} else if (J9ROMCLASS_IS_PRIMITIVE_TYPE(ramClass->romClass)) {
 				ramClass->module = module;
 			} else {


### PR DESCRIPTION
`Unsafe.arrayIndexScale` is supposed to always return a power of 2, but the index scale of flattened arrays are not guaranteed to be a power of 2.
Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>