### PR TITLE
Improve JITServer message statistics

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -180,9 +180,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
    // Acquire VM access and check for possible class unloading
    acquireVMAccessNoSuspend(vmThread);
 
-   // Update statistics for server message type
-   JITServerHelpers::serverMsgTypeCount[response] += 1;
-
    // If JVM has unloaded classes inform the server to abort this compilation
    uint8_t interruptReason = compInfoPT->compilationShouldBeInterrupted();
    if (interruptReason && response != MessageType::jitDumpPrintIL)

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -127,8 +127,6 @@ public:
    static void printJITServerCHTableStats(J9JITConfig *, TR::CompilationInfo *);
    static void printJITServerCacheStats(J9JITConfig *, TR::CompilationInfo *);
 
-   static uint32_t serverMsgTypeCount[JITServer::MessageType_MAXTYPE];
-
    static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
 
    static uintptr_t walkReferenceChainWithOffsets(TR_J9VM *fe, const std::vector<uintptr_t> &listOfOffsets, uintptr_t receiver);

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,33 +58,7 @@ void CommunicationStream::initSSL()
    (*OSSL_load_error_strings)();
    (*OSSL_library_init)();
    // OpenSSL_add_ssl_algorithms() is a synonym for SSL_library_init() and is implemented as a macro
-   // It's redundant, should be able to remove it later
-   // OpenSSL_add_ssl_algorithms();
-   }
-
-void
-CommunicationStream::readMessage2(Message &msg)
-   {
-   msg.clearForRead();
-
-   // read message size
-   uint32_t serializedSize;
-   readBlocking(serializedSize);
-
-   msg.expandBufferIfNeeded(serializedSize);
-   msg.setSerializedSize(serializedSize);
-
-   // read the rest of the message
-   uint32_t messageSize = serializedSize - sizeof(uint32_t);
-   readBlocking(msg.getBufferStartForRead() + sizeof(uint32_t), messageSize);
-
-   // rebuild the message
-   msg.deserialize();
-
-   // collect message size
-#if defined(MESSAGE_SIZE_STATS)
-   msgSizeStats[int(msg.type())].update(serializedSize);
-#endif /* defined(MESSAGE_SIZE_STATS) */
+   // It's redundant and doesn't need to be called
    }
 
 void
@@ -103,7 +77,7 @@ CommunicationStream::readMessage(Message &msg)
    // an exception already if (bytesRead <= 0).
    if (bytesRead < sizeof(uint32_t))
       {
-      throw JITServer::StreamFailure("JITServer I/O error: fail to read the size of the message");
+      throw JITServer::StreamFailure("JITServer I/O error: failed to read the size of the message");
       }
 
    // bytesRead >= sizeof(uint32_t)

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -31,8 +31,10 @@ namespace JITServer
 
 uint32_t CommunicationStream::CONFIGURATION_FLAGS = 0;
 
+uint32_t CommunicationStream::_msgTypeCount[] = {0};
+uint64_t CommunicationStream::_totalMsgSize = 0;
 #if defined(MESSAGE_SIZE_STATS)
-TR_Stats JITServer::CommunicationStream::msgSizeStats[];
+TR_Stats CommunicationStream::_msgSizeStats[];
 #endif /* defined(MESSAGE_SIZE_STATS) */
 
 void
@@ -109,8 +111,11 @@ CommunicationStream::readMessage(Message &msg)
    // rebuild the message
    msg.deserialize();
 
+   // Update message count and size statistics
+   _msgTypeCount[msg.type()] += 1;
+   _totalMsgSize += serializedSize;
 #if defined(MESSAGE_SIZE_STATS)
-   msgSizeStats[int(msg.type())].update(serializedSize);
+   _msgSizeStats[msg.type()].update(serializedSize);
 #endif /* defined(MESSAGE_SIZE_STATS) */
    }
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -43,8 +43,10 @@ public:
    static bool useSSL();
    static void initSSL();
 
+   static uint32_t _msgTypeCount[MessageType::MessageType_MAXTYPE];
+   static uint64_t _totalMsgSize;
 #if defined(MESSAGE_SIZE_STATS)
-   static TR_Stats msgSizeStats[JITServer::MessageType_MAXTYPE];
+   static TR_Stats _msgSizeStats[MessageType::MessageType_MAXTYPE];
 #endif /* defined(MESSAGE_SIZE_STATS) */
 
    static void initConfigurationFlags();

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -86,9 +86,6 @@ protected:
    // Build a message sent by a remote party by reading from the socket
    // as much as possible (up to internal buffer capacity)
    void readMessage(Message &msg);
-   // Build a message sent by a remote party by first reading the message
-   // size and then reading the rest of the message
-   void readMessage2(Message &msg);
    void writeMessage(Message &msg);
 
    int getConnFD() const { return _connfd; }
@@ -104,16 +101,6 @@ protected:
    static uint32_t CONFIGURATION_FLAGS;
 
 private:
-   // readBlocking and writeBlocking are functions that directly read/write
-   // passed object from/to the socket. For the object to be correctly written,
-   // it needs to be contiguous.
-   template <typename T>
-   void readBlocking(T &val)
-      {
-      static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-      readBlocking((char*)&val, sizeof(T));
-      }
-
    void readBlocking(char *data, size_t size)
       {
       size_t totalBytesRead = 0;
@@ -167,13 +154,6 @@ private:
             }
          }
       return bytesRead;
-      }
-
-   template <typename T>
-   void writeBlocking(const T &val)
-      {
-      static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-      writeBlocking(&val, sizeof(T));
       }
 
    void writeBlocking(const char *data, size_t size)


### PR DESCRIPTION
- Measure the number of messages and the amount of received data, even when detailed message size statistics (`MESSAGE_SIZE_STATS`) are not enabled at build time.
- Move all the counter definitions and updates to a single place (`CommunicationStream.cpp`).
- Factor out duplicated code for printing statistics at the client and at the server.
- Correctly compute the number of messages per compilation at the server.
- Remove dead code in `JITServer::CommunicationStream`