### PR TITLE
Exclude functional tests on AArch64 macOS

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-	Copyright (c) 2016, 2021 IBM Corp. and others
+	Copyright (c) 2016, 2022 IBM Corp. and others
 
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -161,6 +161,12 @@
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
 		<platformRequirements>bits.64,^vm.xl</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13767</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/VM_Test/j9vm.xml
+++ b/test/functional/VM_Test/j9vm.xml
@@ -4,7 +4,7 @@
 
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,13 +75,13 @@
 		<reason>Only applies to Linux SRT</reason>
 	</include>
 
-	<exclude id="j9vm.test.xlpcodecache" platform="aix_ppc.* | osx_x86.* | zos.*">
+	<exclude id="j9vm.test.xlpcodecache" platform="aix_ppc.* | osx_aarch64.* | osx_x86.* | zos.*">
 		<reason>This test is unstable on AIXPPC, and S390 Z/OS: OpenJ9 Issue 8437, and 8798 respectively. 
 				Xlp is not supported on OSX.
 		</reason>
 	</exclude>
 
-	<exclude id="j9vm.test.xlp" platform="osx_x86.* | zos.*">
+	<exclude id="j9vm.test.xlp" platform="osx_aarch64.* | osx_x86.* | zos.*">
 		<reason>This test is unstable on S390 Z/OS: OpenJ9 Issue 8798. Xlp is not supported on OSX. </reason>
 	</exclude>
 

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-Copyright (c) 2018, 2021 IBM Corp. and others
+Copyright (c) 2018, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,6 +82,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 				<platform>.*zos.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
+				<platform>aarch64_mac.*</platform>
 			</disable>
 		</disables>
 		<variations>

--- a/test/functional/cmdLineTests/gcCheck/playlist.xml
+++ b/test/functional/cmdLineTests/gcCheck/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2018, 2021 IBM Corp. and others
+  Copyright (c) 2018, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,12 @@
 	-config $(Q)$(TEST_RESROOT)$(D)gcchecktests.xml$(Q) -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcchecktests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,12 @@
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -87,6 +93,12 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -130,6 +142,12 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -173,6 +191,12 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -215,6 +239,12 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -255,6 +285,12 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -293,6 +329,12 @@
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>arch.390</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/pltest/playlist.xml
+++ b/test/functional/cmdLineTests/pltest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-Copyright (c) 2016, 2021 IBM Corp. and others
+Copyright (c) 2016, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.osx</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13767</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/xxargtest/playlist.xml
+++ b/test/functional/cmdLineTests/xxargtest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,11 @@
 				<impl>ibm</impl>
 				<variation>Mode650</variation>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13767</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+
 		</disables>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
This commit exclude functional tests that fail on AArch64 macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>