### PR TITLE
Include error details in JITServer network exception messages

### DIFF
--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,7 +128,8 @@ int ClientStream::static_init(TR::PersistentInfo *info)
 
 SSL_CTX *ClientStream::_sslCtx = NULL;
 
-int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs)
+static int
+openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs)
    {
    // TODO consider support for IPv6
    struct addrinfo hints;
@@ -146,10 +147,8 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
    struct addrinfo *addrList = NULL;
    int res = getaddrinfo(address.c_str(), portName, &hints, &addrList);
    if (res != 0)
-      {
-      // Can use gai_strerror(res) to show error code
-      throw StreamFailure("Cannot resolve server name");
-      }
+      throw StreamFailure("Cannot resolve server name: " + std::string(gai_strerror(res)));
+
    struct addrinfo *pAddr;
    int sockfd = -1;
    for (pAddr = addrList; pAddr; pAddr = pAddr->ai_next) 
@@ -161,53 +160,61 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
       }
    if (sockfd < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
-      throw StreamFailure("Cannot create socket for JITServer");
+      throw StreamFailure("Cannot create socket: " + std::string(strerror(err)));
       }
-   
+
    int flag = 1;
-   if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void*)&flag, sizeof(flag)) < 0)
+   if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Cannot set option SO_KEEPALIVE on socket");
+      throw StreamFailure("Cannot set option SO_KEEPALIVE on socket: " + std::string(strerror(err)));
       }
 
-   struct linger lingerVal = {1, 2}; // linger 2 seconds
-   if (setsockopt(sockfd, SOL_SOCKET, SO_LINGER, (void *)&lingerVal, sizeof(lingerVal)) < 0)
+   struct linger lingerVal = { 1, 2 }; // linger 2 seconds
+   if (setsockopt(sockfd, SOL_SOCKET, SO_LINGER, &lingerVal, sizeof(lingerVal)) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Cannot set option SO_LINGER on socket");
+      throw StreamFailure("Cannot set option SO_LINGER on socket: " + std::string(strerror(err)));
       }
 
-   struct timeval timeout = {(timeoutMs / 1000), ((timeoutMs % 1000) * 1000)};
-   if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (void *)&timeout, sizeof(timeout)) < 0)
+   struct timeval timeout = { timeoutMs / 1000 , (timeoutMs % 1000) * 1000 };
+   if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Cannot set option SO_RCVTIMEO on socket");
+      throw StreamFailure("Cannot set option SO_RCVTIMEO on socket: " + std::string(strerror(err)));
       }
-
-   if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (void *)&timeout, sizeof(timeout)) < 0)
+   if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Cannot set option SO_SNDTIMEO on socket");
+      throw StreamFailure("Cannot set option SO_SNDTIMEO on socket: " + std::string(strerror(err)));
       }
 
    if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Cannot set option TCP_NODELAY on socket");
+      throw StreamFailure("Cannot set option TCP_NODELAY on socket: " + std::string(strerror(err)));
       }
+
    if (connect(sockfd, pAddr->ai_addr, pAddr->ai_addrlen) < 0)
       {
+      int err = errno;
       freeaddrinfo(addrList);
       close(sockfd);
-      throw StreamFailure("Connect failed");
+      throw StreamFailure("Connect failed: " + std::string(strerror(err)));
       }
+
    freeaddrinfo(addrList);
    return sockfd;
    }

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -203,19 +203,19 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
 
    // see `man 7 socket` for option explanations
    int flag = true;
-   if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (void *)&flag, sizeof(flag)) < 0)
+   if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) < 0)
       {
       perror("Can't set SO_REUSEADDR");
       exit(1);
       }
-   if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void *)&flag, sizeof(flag)) < 0)
+   if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) < 0)
       {
       perror("Can't set SO_KEEPALIVE");
       exit(1);
       }
 
    struct sockaddr_in serv_addr;
-   memset((char *)&serv_addr, 0, sizeof(serv_addr));
+   memset(&serv_addr, 0, sizeof(serv_addr));
    serv_addr.sin_family = AF_INET;
    serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
    serv_addr.sin_port = htons(port);
@@ -277,19 +277,20 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
                {
                if (TR::Options::getVerboseOption(TR_VerboseJITServer))
                   {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d", errno);
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d: %s",
+                                                 errno, strerror(errno));
                   }
                }
             }
          else
             {
-            struct timeval timeoutMsForConnection = {(timeoutMs / 1000), ((timeoutMs % 1000) * 1000)};
-            if (setsockopt(connfd, SOL_SOCKET, SO_RCVTIMEO, (void *)&timeoutMsForConnection, sizeof(timeoutMsForConnection)) < 0)
+            struct timeval timeout = { timeoutMs / 1000, (timeoutMs % 1000) * 1000 };
+            if (setsockopt(connfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0)
                {
                perror("Can't set option SO_RCVTIMEO on connfd socket");
                exit(1);
                }
-            if (setsockopt(connfd, SOL_SOCKET, SO_SNDTIMEO, (void *)&timeoutMsForConnection, sizeof(timeoutMsForConnection)) < 0)
+            if (setsockopt(connfd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0)
                {
                perror("Can't set option SO_SNDTIMEO on connfd socket");
                exit(1);


### PR DESCRIPTION
Include the error description (obtained with `strerror(errno)`) in JITServer network exception messages to improve diagnostics of network connectivity issues.