### PR TITLE
JITServer AOT cache vlog improvements

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -121,6 +121,17 @@ J9::AheadOfTimeCompile::addSerializationRecord(const AOTCacheRecord *record, con
       uint8_t *end = start + *(uintptr_t *)start;// Total size of relocation data is stored in the first word
       TR_ASSERT_FATAL(((uint8_t *)sccOffsetAddr >= start + sizeof(uintptr_t)) && ((uint8_t *)sccOffsetAddr < end),
                       "SCC offset address %p not in range %p - %p", sccOffsetAddr, start + sizeof(uintptr_t), end);
+#if defined(DEBUG)
+      if (record && TR::Options::getVerboseOption(TR_VerboseJITServer))
+         {
+         const AOTSerializationRecord *r = record->dataAddr();
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "AOT cache %s: Adding record type %u ID %zu for SCC offset %zu at relo data offset %zu in method %s",
+            comp->getClientData()->getAOTCache()->name().c_str(), r->type(), r->id(),
+            *sccOffsetAddr, (uint8_t *)sccOffsetAddr - start, comp->signature()
+         );
+         }
+#endif /* defined(DEBUG) */
       comp->addSerializationRecord(record, (uint8_t *)sccOffsetAddr - start);
       }
    }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3636,6 +3636,8 @@ void TR::CompilationInfo::stopCompilationThreads()
          {
          JITServer::ClientStream client(getPersistentInfo());
          client.writeError(JITServer::MessageType::clientSessionTerminate, getPersistentInfo()->getClientUID());
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Sent clientSessionTerminate message");
          }
       catch (const JITServer::StreamFailure &e)
          {

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -862,6 +862,14 @@ JITServerAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, TR::Comp
       TR_ASSERT_FATAL((ptr >= start + sizeof(uintptr_t)/*skip the size word*/) && (ptr < end),
                       "Out-of-bounds relocation data offset %zu in serialized method %s",
                       serializedOffset.reloDataOffset(), comp->signature());
+#if defined(DEBUG)
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "Updating SCC offset %zu -> %zu for record type %u ID %zu at relo data offset %zu in serialized method %s",
+            *(uintptr_t *)ptr, sccOffset, serializedOffset.recordType(), serializedOffset.recordId(),
+            serializedOffset.reloDataOffset(), comp->signature()
+         );
+#endif /* defined(DEBUG) */
       *(uintptr_t *)ptr = sccOffset;
       }
 


### PR DESCRIPTION
This PR adds the following to JITServer verbose logs:
- Log AOT cache hits at the JITServer as "compilation end" similarly to successful compilations.
- Record sending the termination message in JIT client vlog, which is useful for debugging the JIT client shutdown sequence.
- Trace AOT cache method [de]serialization in vlog in debug mode.

This PR depends on #14383 which needs to be merged first.