### PR TITLE
Remove whitespace in RootScanner

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -104,8 +104,6 @@ MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 			doSlot(&javaVM->unamedModuleForSystemLoader->moduleObject);
 		}
 	}
-
-
 }
 
 /**


### PR DESCRIPTION
Remove whitespace in RootScanner

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>