### PR TITLE
Enable GC rotating verbose log tests for jdk 11 and up

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2001, 2021 IBM Corp. and others
+  Copyright (c) 2001, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -330,43 +330,6 @@
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
 
-<!--
- <test id="GC rotating verbose log file name contains %s">
-  <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s.005 is created
-  <command>cat foo%s%s%s%s%s%s.005</command>
-  <output regex="no" type="failure">No such file or directory</output>
-  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
- </test>
-
- <test id="GC rotating verbose log file name contains %s and other random symbols">
-  <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created
-  <command>cat foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005</command>
-  <output regex="no" type="failure">No such file or directory</output>
-  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
- </test>
-
- <test id="GC rotating verbose log file name contains %s %c %i">
-  <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005 is created
-  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005</command>
-  <output regex="no" type="failure">No such file or directory</output>
-  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
- </test>
-
- <test id="GC rotating verbose log file name contains %s %c %i and other random symbols">
-  <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
-  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created
-  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.005</command>
-  <output regex="no" type="failure">No such file or directory</output>
-  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
- </test>
- -->
  <!-- CMVC 178000 - disable until a new version of the test can be added after the GC promotes
  <test id="-verbose:gc -Xverbosegclog:<invalid> - use a file name in a directory that doesn't exist">
   <exec command="rm foo.*.log" />

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2001, 2021 IBM Corp. and others
+  Copyright (c) 2001, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,20 +42,6 @@
 <!-- Metronome and Staccato do not use excessive GC -->
 <exclude id="Excessive GC throws OOM" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not use excessive GC</reason></exclude>
 <exclude id="Excessive GC appears in verbose log" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not use excessive GC</reason></exclude>
-
-<!-- Metronome does not cause multiple verboseGC logging files -->
-<!--
-<exclude id="GC rotating verbose log file name contains %s" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
-<exclude id="GC rotating verbose log file name contains %s and other random symbols" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
-<exclude id="GC rotating verbose log file name contains %s %c %i" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
-<exclude id="GC rotating verbose log file name contains %s %c %i and other random symbols" platform="Mode301" shouldFix="false"><reason>Metronome does not cause multiple verboseGC logging files</reason></exclude>
--->
-
-<!-- The Windows system also does not support the * character in file or directory names.  -->
-<!--
-<exclude id="GC rotating verbose log file name contains %s and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
-<exclude id="GC rotating verbose log file name contains %s %c %i and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
--->
 
 <!-- only Gencon GC is supported on RISC-V -->
 <exclude id="Excessive GC throws OOM" platform="linux_riscv.*" shouldFix="false"><reason>The initial memory setting does not work on RISC-V</reason></exclude>

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2001, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 GC Rotating Verbose Log Tests" timeout="900">
+
+ <!-- Arguments used in all tests -->
+ <variable name="CP" value="-cp $TESTSJARPATH$" />
+ <variable name="XINT" value="-Xint" />
+ 
+ <test id="GC rotating verbose log file name contains %s">
+  <exec command="rm foo*.*" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <!-- check a file with name foo%s%s%s%s%s%s.005 is created -->
+  <command>cat foo%s%s%s%s%s%s.005</command>
+  <output regex="no" type="failure">No such file or directory</output>
+  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
+ </test>
+
+ <test id="GC rotating verbose log file name contains %s and other random symbols">
+  <exec command="rm foo*.*" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
+  <command>cat foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005</command>
+  <output regex="no" type="failure">No such file or directory</output>
+  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
+ </test>
+
+ <test id="GC rotating verbose log file name contains %s %c %i">
+  <exec command="rm foo*.*" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <!-- check a file with name foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005 is created -->
+  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005</command>
+  <output regex="no" type="failure">No such file or directory</output>
+  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
+ </test>
+
+ <test id="GC rotating verbose log file name contains %s %c %i and other random symbols">
+  <exec command="rm foo*.*" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
+  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.005</command>
+  <output regex="no" type="failure">No such file or directory</output>
+  <output regex="no" type="success">&lt;/verbosegc&gt;</output>
+ </test>
+</suite>

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests_excludes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2001, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+
+<suite id="J9 GC Rotating Verbose Log Tests">
+
+<!-- The Windows system also does not support the * character in file or directory names.  -->
+<exclude id="GC rotating verbose log file name contains %s and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
+<exclude id="GC rotating verbose log file name contains %s %c %i and other random symbols" platform="win_x86.*" shouldFix="false"><reason>Windows does not support * symbol</reason></include>
+
+</suite>
+

--- a/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,37 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
 		-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRegressionTests_excludes.xml$(Q) -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_GCRotatingVerboseLogTests</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13891</comment>
+				<impl>ibm</impl>
+				<version>8</version>
+			</disable>
+		</disables>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRotatingVerboseLogTests.xml$(Q) \
+		-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRotatingVerboseLogTests_excludes.xml$(Q) -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
- Enable GC rotating verbose log tests for jdk 11 and up
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/13891
- [skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>