### PR TITLE
PGC consumption rate

### DIFF
--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1866,6 +1866,8 @@ MM_WriteOnceCompactor::recycleFreeRegionsAndFixFreeLists(MM_EnvironmentVLHGC *en
 				region->getSubSpace()->recycleRegion(env, region);
 				/* mark bits will be cleared during the rebuilding phase */
 			} else {
+				static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._compactStats._survivorRegionCount += 1;
+
 				if (NULL != region->_compactData._previousContext) {
 					/* we migrated this region into a new context so ask its previous owner to migrate the contexts' views of the region's ownership to make the meta-structures consistent */
 					region->_compactData._previousContext->migrateRegionToAllocationContext(region, region->_allocateData._owningContext);


### PR DESCRIPTION
Current rate is not quite correct since
1) it was not accounting for heap resizing changes, while it should
2) and accounting for sweep reclamation, while it should not

As a result of (1), during heap expansion (that is initially justified,
like ramp-up phase) we would underestimate heap consumption, what would
delay GMP kickoff, and in some cases we would be forced to expand even
more to be able to continue PGC. That could create positive feedback
where we would continue expanding till fully expanded.

The rate formula is completely changed to rely simply on current PGC
metrics:
consumed (survived) regions - freed (evacuated) regions

...as opposed to measuring the difference in heap occupancy between
previous and current GC.

In a stable state, those 2 approaches are very similar, but during heap
resizing, the new one is far more correct.

As a side effect of this change, GMP cycles during heap expansion will
be more frequent, but in a way it is good as it will help with more
precise heuristics (like live set estimate).

defragmentRegionConsumptionRate suffers from the same problem, but it
will be scrutinized separately, since it affects a different huristic.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>