### PR TITLE
JDK19 fix doclint:reference

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2011, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
-/*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION > 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2008, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,5 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
-/*******************************************************************************
+/*
+ *******************************************************************************
  * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/MonitorInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MonitorInfo.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2007, 2019 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2007, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,11 +45,19 @@ import java.util.List;
  * 
  * @since 1.5
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings("doclint:reference")
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public interface PlatformLoggingMXBean extends PlatformManagedObject{
 
 	/**
-	 * Returns the string name of the specified {@link java.util.logging.Logger} instance's
-	 * current log level.
+	 * Returns the string name of the specified
+	/*[IF JAVA_SPEC_VERSION >= 17]
+	 * {@link java.logging/java.util.logging.Logger}
+	/*[ELSE] JAVA_SPEC_VERSION >= 17
+	 * {@link java.util.logging.Logger}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17
+	 * instance's current log level.
 	 * 
 	 * @param loggerName
 	 *            the name of a particular <code>Logger</code> instance
@@ -71,8 +80,13 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	public List<String> getLoggerNames();
 
 	/**
-	 * Returns the name of the parent {@link java.util.logging.Logger} of the specified registered
-	 * <code>Logger</code>,<code>loggerName</code>.
+	 * Returns the name of the parent
+	/*[IF JAVA_SPEC_VERSION >= 17]
+	 * {@link java.logging/java.util.logging.Logger}
+	/*[ELSE] JAVA_SPEC_VERSION >= 17
+	 * {@link java.util.logging.Logger}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17
+	 * of the specified registered <code>Logger</code>,<code>loggerName</code>.
 	 * 
 	 * @param loggerName
 	 *            the name of a particular <code>Logger</code> instance
@@ -88,8 +102,13 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	public String getParentLoggerName(String loggerName);
 
 	/**
-	 * Attempts to update the log level of the {@link java.util.logging.Logger} with name 
-	 * <code>loggerName</code> to <code>levelName</code>.
+	 * Attempts to update the log level of the
+	/*[IF JAVA_SPEC_VERSION >= 17]
+	 * {@link java.logging/java.util.logging.Logger}
+	/*[ELSE] JAVA_SPEC_VERSION >= 17
+	 * {@link java.util.logging.Logger}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17
+	 * with name <code>loggerName</code> to <code>levelName</code>.
 	 * <p>
 	 * If <code>levelName</code> is <code>null</code> then the <code>Logger</code>
 	 * instance's log level is set to be <code>null</code> with the result that 
@@ -104,7 +123,13 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * with the name <code>loggerName</code>. Also may be thrown if 
 	 * <code>loggerName</code> is not a known log level name.
 	 * @throws SecurityException if there is a security manager active and 
-	 * the caller does not have {@link java.util.logging.LoggingPermission} of &quot;control&quot;.
+	 * the caller does not have
+	/*[IF JAVA_SPEC_VERSION >= 17]
+	 * {@link java.logging/java.util.logging.LoggingPermission}
+	/*[ELSE] JAVA_SPEC_VERSION >= 17
+	 * {@link java.util.logging.LoggingPermission}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 17
+	 * of &quot;control&quot;.
 	 */
 	public void setLoggerLevel(String loggerName, String levelName);
 

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformManagedObject.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformManagedObject.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2012, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,7 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corp. and others
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2007, 2019 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2007, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfoAccessImpl.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfoAccessImpl.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
-/*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,6 +1,7 @@
-/*[INCLUDE-IF Sidecar17]*/
-/*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*
+ *******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Add module references;
Fix javadoc warnings.

The `Copyright` format change is required due to `warning: documentation comment not expected here` and `warnings found and -Werror specified`. Similar warning messages are in `java.base` module as well, and are ignored since `java.base` is part of `WARNING_MODULES`.

JDK19 builds w/ this PR and `-version` output:
```
openjdk version "19-internal" 2022-09-20
OpenJDK Runtime Environment (build 19-internal+0-adhoc.jasonfeng.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build doclint-3b4b997b371, JRE 19 Mac OS X amd64-64-Bit Compressed References 20220201_000000 (JIT enabled, AOT enabled)
OpenJ9   - 3b4b997b371
OMR      - e449b3f83
JCL      - b90944f187b based on jdk-19+7)
```

closes https://github.com/eclipse-openj9/openj9/issues/14404

Signed-off-by: Jason Feng <fengj@ca.ibm.com>