### PR TITLE
Enable GCRotatingVerboseLogTests for ibm 8

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
@@ -53,13 +53,6 @@
 			<variation>Mode551</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/13891</comment>
-				<impl>ibm</impl>
-				<version>8</version>
-			</disable>
-		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRotatingVerboseLogTests.xml$(Q) \
 		-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRotatingVerboseLogTests_excludes.xml$(Q) -nonZeroExitWhenError; \


### PR DESCRIPTION
- Enable GCRotatingVerboseLogTests for ibm 8
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/13891
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>