### PR TITLE
Build functional tests without failing when DDR is not supported

### DIFF
--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2018, 2021 IBM Corp. and others
+Copyright (c) 2018, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,7 +132,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 						<antcall target="clean" inheritall="true" />
 					</then>
 					<else>
-						<fail message="File 'j9ddr.dat' not found; assuming JDK '${TEST_JDK_HOME}' does not support DDR." />
+						<echo>File 'j9ddr.dat' not found; assuming JDK '${TEST_JDK_HOME}' does not support DDR.</echo>
 					</else>
 				</if>
 			</then>


### PR DESCRIPTION
This commit changes a `<fail>` tag in the build.xml for DDR_Test into an
`<echo>` tag so that you can build and run functional tests on a platform
without DDR support.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>