### PR TITLE
Replace forceUnresolvedDispatch() with isResolved*DispatchGuaranteed()

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1247,7 +1247,7 @@ void J9::ARM64::PrivateLinkage::buildDirectCall(TR::Node *callNode,
    if (callSymRef->getReferenceNumber() >= TR_ARM64numRuntimeHelpers)
       fej9->reserveTrampolineIfNecessary(comp(), callSymRef, false);
 
-   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
+   bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp());
 
    if (callSymbol->isJITInternalNative() ||
        (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() &&

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -633,6 +633,24 @@ public:
    */
    void setSupportsIntegerToChars() {_j9Flags.set(SupportsIntegerToChars); }
 
+   /**
+    * \brief Determine whether this code generator guarantees resolved direct
+    * dispatch under AOT with SVM.
+    *
+    * \return true if resolved direct dispatch is guaranteed, false otherwise
+    * \see TR_J9VMBase::isResolvedDirectDispatchGuaranteed
+    */
+   bool guaranteesResolvedDirectDispatchForSVM() { return false; } // safe default
+
+   /**
+    * \brief Determine whether this code generator guarantees resolved virtual
+    * dispatch under AOT with SVM.
+    *
+    * \return true if resolved virtual dispatch is guaranteed, false otherwise
+    * \see TR_J9VMBase::isResolvedVirtualDispatchGuaranteed
+    */
+   bool guaranteesResolvedVirtualDispatchForSVM() { return false; } // safe default
+
 private:
 
    enum // Flags

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -528,6 +528,32 @@ TR_J9SharedCacheVM::shouldDelayAotLoad()
    return isAOT_DEPRECATED_DO_NOT_USE();
    }
 
+bool
+TR_J9SharedCacheVM::isResolvedDirectDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return isAotResolvedDirectDispatchGuaranteed(comp);
+   }
+
+bool
+TR_J9VMBase::isAotResolvedDirectDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return comp->getOption(TR_UseSymbolValidationManager)
+      && comp->cg()->guaranteesResolvedDirectDispatchForSVM();
+   }
+
+bool
+TR_J9SharedCacheVM::isResolvedVirtualDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return isAotResolvedVirtualDispatchGuaranteed(comp);
+   }
+
+bool
+TR_J9VMBase::isAotResolvedVirtualDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return comp->getOption(TR_UseSymbolValidationManager)
+      && comp->cg()->guaranteesResolvedVirtualDispatchForSVM();
+   }
+
 J9Class *
 TR_J9VMBase::matchRAMclassFromROMclass(J9ROMClass * clazz, TR::Compilation * comp)
    {

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -3153,3 +3153,15 @@ TR_J9SharedCacheServerVM::getResolvedInterfaceMethod(TR_OpaqueMethodBlock *inter
       }
    return ramMethod;
    }
+
+bool
+TR_J9SharedCacheServerVM::isResolvedDirectDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return isAotResolvedDirectDispatchGuaranteed(comp);
+   }
+
+bool
+TR_J9SharedCacheServerVM::isResolvedVirtualDispatchGuaranteed(TR::Compilation *comp)
+   {
+   return isAotResolvedVirtualDispatchGuaranteed(comp);
+   }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -285,7 +285,6 @@ public:
    virtual bool       needRelocationsForLookupEvaluationData() override        { return true; }
    virtual bool       needRelocationsForBodyInfoData() override                { return true; }
    virtual bool       needRelocationsForPersistentInfoData() override          { return true; }
-   virtual bool       forceUnresolvedDispatch() override                       { return true; }
    virtual bool       nopsAlsoProcessedByRelocations() override                { return true; }
    virtual bool       supportsGuardMerging() override                          { return false; }
    virtual bool       canDevirtualizeDispatch() override                       { return false; }
@@ -296,6 +295,9 @@ public:
    virtual bool       supportsJitMethodEntryAlignment() override               { return false; }
    virtual bool       isBenefitInliningCheckIfFinalizeObject() override        { return true; }
    virtual bool       needsContiguousCodeAndDataCacheAllocation() override     { return true; }
+
+   virtual bool       isResolvedDirectDispatchGuaranteed(TR::Compilation *comp) override;
+   virtual bool       isResolvedVirtualDispatchGuaranteed(TR::Compilation *comp) override;
 
    virtual bool shouldDelayAotLoad() override                                  { return true; }
    virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) override { return false; }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1312,6 +1312,13 @@ TR_ResolvedRelocatableJ9Method::getResolvedPossiblyPrivateVirtualMethod(
          ignoreRtResolve,
          unresolvedInCP);
 
+   return aotMaskResolvedPossiblyPrivateVirtualMethod(comp, method);
+   }
+
+TR_ResolvedMethod *
+TR_ResolvedJ9Method::aotMaskResolvedPossiblyPrivateVirtualMethod(
+   TR::Compilation *comp, TR_ResolvedMethod *method)
+   {
    if (comp->getOption(TR_UseSymbolValidationManager))
       return method;
 
@@ -1793,8 +1800,16 @@ TR_ResolvedRelocatableJ9Method::getResolvedImproperInterfaceMethod(
    TR::Compilation * comp,
    I_32 cpIndex)
    {
+   return aotMaskResolvedImproperInterfaceMethod(
+      comp, TR_ResolvedJ9Method::getResolvedImproperInterfaceMethod(comp, cpIndex));
+   }
+
+TR_ResolvedMethod *
+TR_ResolvedJ9Method::aotMaskResolvedImproperInterfaceMethod(
+   TR::Compilation *comp, TR_ResolvedMethod *method)
+   {
    if (comp->getOption(TR_UseSymbolValidationManager))
-      return TR_ResolvedJ9Method::getResolvedImproperInterfaceMethod(comp, cpIndex);
+      return method;
 
    // For now leave private and Object invokeinterface unresolved in AOT. If we
    // resolve it, we may forceUnresolvedDispatch in codegen, in which case the

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -466,6 +466,11 @@ public:
    virtual TR_ResolvedMethod *     getResolvedInterfaceMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
    virtual TR_ResolvedMethod *     getResolvedVirtualMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t virtualCallOffset, bool ignoreRtResolve = true);
 
+protected:
+   TR_ResolvedMethod *             aotMaskResolvedPossiblyPrivateVirtualMethod(TR::Compilation *comp, TR_ResolvedMethod *method);
+   TR_ResolvedMethod *             aotMaskResolvedImproperInterfaceMethod(TR::Compilation *comp, TR_ResolvedMethod *method);
+
+public:
    virtual bool                    virtualMethodIsOverridden();
    virtual void                    setVirtualMethodIsOverridden();
    virtual void *                  addressContainingIsOverriddenBit();

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2217,14 +2217,9 @@ TR_ResolvedRelocatableJ9JITServerMethod::getResolvedImproperInterfaceMethod(
    TR::Compilation * comp,
    I_32 cpIndex)
    {
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      return TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(comp, cpIndex);
-
-   // For now leave private and Object invokeinterface unresolved in AOT. If we
-   // resolve it, we may forceUnresolvedDispatch in codegen, in which case the
-   // generated code would attempt to resolve the wrong kind of constant pool
-   // entry.
-   return NULL;
+   return aotMaskResolvedImproperInterfaceMethod(
+      comp,
+      TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(comp, cpIndex));
    }
 
 void *
@@ -2390,13 +2385,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod
          ignoreRtResolve,
          unresolvedInCP);
 
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      return method;
-
-   // For now leave private invokevirtual unresolved in AOT. If we resolve it,
-   // we may forceUnresolvedDispatch in codegen, in which case the generated
-   // code would attempt to resolve the wrong kind of constant pool entry.
-   return (method == NULL || method->isPrivate()) ? NULL : method;
+   return aotMaskResolvedPossiblyPrivateVirtualMethod(comp, method);
    }
 
 bool

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -282,10 +282,7 @@ TR_RuntimeHelper TR::PPCCallSnippet::getInterpretedDispatchHelper(
       isJitInduceOSRCall = true;
       }
 
-   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      forceUnresolvedDispatch = false;
-
+   bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp);
    if (methodSymRef->isUnresolved() || forceUnresolvedDispatch)
       {
       TR_ASSERT(!isJitInduceOSRCall || !forceUnresolvedDispatch, "calling jitInduceOSR is not supported yet under AOT\n");
@@ -398,9 +395,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
    //continue execution in interpreted mode. Therefore, it doesn't need the method pointer.
    if (!glueRef->isOSRInductionHelper())
       {
-      bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
-      if (comp->getOption(TR_UseSymbolValidationManager))
-         forceUnresolvedDispatch = false;
+      bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp);
 
       // Store the method pointer: it is NULL for unresolved
       if (methodSymRef->isUnresolved() || forceUnresolvedDispatch)
@@ -1243,10 +1238,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCCallSnippet * snippet)
    const char          *labelString = NULL;
    bool                 isNativeStatic = false;
 
-   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      forceUnresolvedDispatch = false;
-
+   bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp);
    if (methodSymbol->isHelper() &&
        methodSymRef->isOSRInductionHelper())
       {

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,6 +111,9 @@ public:
     * \brief Determines whether the code generator supports stack allocations
     */
    bool supportsStackAllocations() { return true; }
+
+   // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
+   bool guaranteesResolvedDirectDispatchForSVM() { return true; }
    };
 
 }

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2686,10 +2686,7 @@ void J9::Power::PrivateLinkage::buildDirectCall(TR::Node *callNode,
    if (callSymRef->getReferenceNumber() >= TR_PPCnumRuntimeHelpers)
       fej9->reserveTrampolineIfNecessary(comp(), callSymRef, false);
 
-   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
-   if (comp()->getOption(TR_UseSymbolValidationManager))
-      forceUnresolvedDispatch = false;
-
+   bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp());
    if ((callSymbol->isJITInternalNative() ||
         (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() && ((forceUnresolvedDispatch && callSymbol->isHelper()) || !forceUnresolvedDispatch))))
       {

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1343,7 +1343,9 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
       {
       traceMsg(comp(), "buildVirtualOrComputedCall(%p), isComputed=%d\n", site.getCallNode(), methodSymRef->getSymbol()->castToMethodSymbol()->isComputed());
       }
-   bool evaluateVftEarly = methodSymRef->isUnresolved() || fej9->forceUnresolvedDispatch();
+
+   bool evaluateVftEarly = methodSymRef->isUnresolved()
+      || !fej9->isResolvedVirtualDispatchGuaranteed(comp());
 
    if (methodSymRef->getSymbol()->castToMethodSymbol()->isComputed())
       {

--- a/runtime/compiler/x/codegen/CallSnippet.hpp
+++ b/runtime/compiler/x/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,10 @@ class X86PicDataSnippet : public TR::Snippet
 
    bool forceUnresolvedDispatch()
       {
-      return ((TR_J9VMBase*)(cg()->fe()))->forceUnresolvedDispatch();
+      // No need to force unresolved dispatch for interface calls, since those
+      // are unresolved anyway.
+      return !isInterface()
+         && !((TR_J9VMBase*)(cg()->fe()))->isResolvedVirtualDispatchGuaranteed(cg()->comp());
       }
 
    bool unresolvedDispatch()

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,6 +95,9 @@ public:
     *     Determines whether to insert instructions to check DF flag and break on DF set
     */
    bool canEmitBreakOnDFSet();
+
+   // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
+   bool guaranteesResolvedDirectDispatchForSVM() { return true; }
    };
 
 }

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1538,8 +1538,13 @@ bool TR::X86CallSite::resolvedVirtualShouldUseVFTCall()
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    TR_ASSERT(getMethodSymbol()->isVirtual() && !getSymbolReference()->isUnresolved(), "assertion failure");
 
+   // WARNING: VPIC doesn't work for resolved calls at the moment, so setting
+   // TR_EnableVPICForResolvedVirtualCalls won't work. The most straightforward
+   // way to get VPIC to support (most) resolved calls is to simply treat them
+   // the same way as unresolved ones, but that isn't allowed when we are
+   // promising isResolvedVirtualDispatchGuaranteed().
    return
-      !fej9->forceUnresolvedDispatch() &&
+      fej9->isResolvedVirtualDispatchGuaranteed(comp()) &&
       (!comp()->getOption(TR_EnableVPICForResolvedVirtualCalls)    ||
        getProfiledTargets()                                        ||
        getCallNode()->isTheVirtualCallNodeForAGuardedInlinedCall() ||

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -695,7 +695,9 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(
       uint8_t *thunk)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   bool resolvedSite = !(site.getSymbolReference()->isUnresolved() || fej9->forceUnresolvedDispatch());
+   bool resolvedSite = !site.getSymbolReference()->isUnresolved()
+      && fej9->isResolvedVirtualDispatchGuaranteed(comp());
+
    if (site.getSymbolReference()->getSymbol()->castToMethodSymbol()->isComputed())
       {
       // TODO:JSR292: Try to avoid the explicit VFT load

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -331,6 +331,9 @@ public:
     * \brief Determines whether the code generator supports stack allocations
     */
    bool supportsStackAllocations() { return true; }
+
+   // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
+   bool guaranteesResolvedDirectDispatchForSVM() { return true; }
 
    private:
 


### PR DESCRIPTION
Certain transformations in the compiler rely on a guarantee that a given resolved call node will simply call the target method without attempting to resolve a constant pool entry, since the constant pool entry may not correspond to the call in the usually expected way.

We always have this guarantee in non-AOT compilations.

In AOT compilations, we currently have this guarantee for direct calls when using the symbol validation manager (SVM) on x86, Power, and z.

In the SVM case, each code generator must now opt in to this class of transformations by explicitly declaring that it provides the needed guarantee for direct calls, virtual calls, or both.

Special-case virtual and interface resolution in AOT now respects `isResolved*DispatchGuaranteed()`. In particular, private `invokevirtual`, private `invokeinterface`, and final `Object` `invokeinterface` will all become direct, so heed `isResolvedDirectDispatchGuaranteed()`, and non-final `Object` `invokeinterface` will become virtual, so now heeds `isResolvedVirtualDispatchGuaranteed()`.

Additionally, refinement of `invokeBasic()` and `linkTo*()` now also respects these queries, though it shouldn't (currently) be attempted in AOT regardless. Refinement requires a known object index for either the `MethodHandle` or the `MemberName`, and AOT does not support the known object table.

It probably also makes sense to gate value propagation's type refinement of indirect calls on `isResolvedDirectDispatchGuaranteed()` for fixed type and `isResolvedVirtualDispatchGuaranteed()` for type bounds, but this is not done in this commit. That change would require modifications to OMR, and there is currently no problem with call refinement in VP because it respects `canDevirtualizeDispatch()`, which is false in AOT compilations.

As a result of the above, this commit effectively stops AOT compilations using the SVM from generating resolved virtual calls for `invokeinterface` calling non-final methods of `Object`. Instead, such calls are left to be treated as (unresolved) interface calls as in non-SVM AOT. This ilgen transformation can be re-enabled for a particular code generator by overriding `guaranteesResolvedVirtualDispatchForSVM()` to return true, but first it will be necessary to ensure that the code generator really provides that guarantee. If the sequence generated for a resolved virtual call is simply a call through the vtable, then providing the guarantee should only involve:
- sending execution to the resolved path when the SVM is enabled, and
- generating an appropriate J2I thunk validation.

However, the required J2I thunk validation does not yet exist. It will be implemented separately.

----

There is one preparatory refactoring commit.

----

Fixes #14124
Fixes #14230