### PR TITLE
Reset gcRotatingVerboseLogTests GC cycle file number

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRotatingVerboseLogTests.xml
@@ -32,36 +32,36 @@
  
  <test id="GC rotating verbose log file name contains %s">
   <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 5" />
   <!-- check a file with name foo%s%s%s%s%s%s.005 is created -->
-  <command>cat foo%s%s%s%s%s%s.005</command>
+  <command>cat foo%s%s%s%s%s%s.003</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
 
  <test id="GC rotating verbose log file name contains %s and other random symbols">
   <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 5" />
   <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
-  <command>cat foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005</command>
+  <command>cat foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.003</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
 
  <test id="GC rotating verbose log file name contains %s %c %i">
   <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 5" />
   <!-- check a file with name foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005 is created -->
-  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.005</command>
+  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i.003</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>
 
  <test id="GC rotating verbose log file name contains %s %c %i and other random symbols">
   <exec command="rm foo*.*" />
-  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 1" />
+  <exec command="$EXE$ $XINT$ -verbose:gc -Xms8m -Xmx8m -Xverbosegclog:foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.#,5,1 $CP$ com.ibm.tests.garbagecollector.SpinAllocate 5" />
   <!-- check a file with name foo%s%s%s%s%s%s1234567%s%s%s%s%s%s!@%^*%s%s%s%s%s%sabcdef.005 is created -->
-  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.005</command>
+  <command>cat foo%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%i1234567!@%^*%s%s%s%s%s%s%c%c%c%c%c%i%i%i%i%isabcdef.003</command>
   <output regex="no" type="failure">No such file or directory</output>
   <output regex="no" type="success">&lt;/verbosegc&gt;</output>
  </test>


### PR DESCRIPTION
- Reset gcRotatingVerboseLogTests GC cycles file number
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/14422
- [skip ci]

Fixes https://github.com/eclipse-openj9/openj9/issues/14422

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>