### PR TITLE
JDK19 adds JVM_LoadZipLibrary stub method

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -399,6 +399,13 @@ if(NOT JAVA_SPEC_VERSION LESS 18)
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 19)
+	jvm_add_exports(jvm
+		# Additions for Java 19 (General)
+		JVM_LoadZipLibrary
+	)
+endif()
+
 if(J9VM_OPT_JITSERVER)
 	jvm_add_exports(jvm
 		JITServer_CreateServer

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -391,4 +391,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_ReportFinalizationComplete"/>
 	</exports>
 
+	<exports group="jdk19">
+		<!-- Additions for Java 19 (General) -->
+		<export name="JVM_LoadZipLibrary"/>
+	</exports>
+
 </exportlists>

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -191,5 +191,13 @@ JNIEXPORT void JNICALL
 JVM_ReportFinalizationComplete(JNIEnv *env, jobject obj)
 {
 	assert(!"JVM_ReportFinalizationComplete unimplemented");
+}
+#endif /* JAVA_SPEC_VERSION >= 18 */
+
+#if JAVA_SPEC_VERSION >= 19
+JNIEXPORT void JNICALL
+JVM_LoadZipLibrary(void)
+{
+	assert(!"JVM_LoadZipLibrary unimplemented");
 }
 #endif /* JAVA_SPEC_VERSION >= 18 */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2021 IBM Corp. and others
+Copyright (c) 2006, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</group>
 			<group name="jdk18">
 				<include-if condition="spec.java18"/>
+			</group>
+			<group name="jdk19">
+				<include-if condition="spec.java19"/>
 			</group>
 		</exports>
 		<includes>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -358,3 +358,5 @@ _IF([JAVA_SPEC_VERSION >= 18],
 	[_X(JVM_IsFinalizationEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 18],
 	[_X(JVM_ReportFinalizationComplete, JNICALL, false, void, JNIEnv *env, jobject obj)])
+_IF([JAVA_SPEC_VERSION >= 19],
+	[_X(JVM_LoadZipLibrary, JNICALL, false, void, void)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2007, 2021 IBM Corp. and others
+Copyright (c) 2007, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,6 +73,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</group>
 			<group name="jdk18">
 				<include-if condition="spec.java18"/>
+			</group>
+			<group name="jdk19">
+				<include-if condition="spec.java19"/>
 			</group>
 		</exports>
 		<includes>


### PR DESCRIPTION
Added `JNIEXPORT void JNICALL JVM_LoadZipLibrary(void)` stub method.

JDK19 builds w/ this PR, and `-version` output:
```
openjdk version "19-internal" 2022-09-20
OpenJDK Runtime Environment (build 19-internal+0-adhoc.jasonfeng.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-9398b11019e, JRE 19 Mac OS X amd64-64-Bit Compressed References 20220204_000000 (JIT enabled, AOT enabled)
OpenJ9   - 9398b11019e
OMR      - 96a484d1b
JCL      - 2f47958cb14 based on jdk-19+8)
```
This fixes JDKNext abuild failure - https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/201/console

Signed-off-by: Jason Feng <fengj@ca.ibm.com>