### PR TITLE
Add z/OS dispatch for fast_jitInstanceOf

### DIFF
--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -4,7 +4,7 @@ define(`ZZ',`**')
 define(`ZZ',`##')
 ')dnl
 
-ZZ Copyright (c) 2000, 2020 IBM Corp. and others
+ZZ Copyright (c) 2000, 2022 IBM Corp. and others
 ZZ
 ZZ This program and the accompanying materials are made
 ZZ available under the terms of the Eclipse Public License 2.0
@@ -1949,24 +1949,33 @@ ZZ  R1-3 have been saved. just need to save r0, r4-15 here.
 
 ZZ  Now start to call fast_jitInstanceOf as a C function
     ST_GPR  J9SP,J9TR_VMThread_sp(r13)
+
 ifdef({J9ZOS390},{dnl
-    L_GPR   rSSP,eq_vmThrSSP(r13)
-    XC      eq_vmThrSSP(PTR_SIZE,r13),eq_vmThrSSP(r13)
+
+RestoreSSP
+
+LOAD_ADDR_FROM_TOC(r6,TR_instanceOf)
+
 ifdef({TR_HOST_64BIT},{dnl
-ZZ 64 bit zOS. Do nothing.
+
+ZZ 64 bit zOS
+   BASR r7,r6              # call instanceOf
+   LR   r0,r0
+
 },{dnl
+
 ZZ 31 bit zOS. See definition of J9TR_CAA_SAVE_OFFSET
-    L_GPR  r12,2080(rSSP)
-})dnl
+   L_GPR  r12,J9TR_CAA_save_offset(rSSP)
+   BASR r7,r6              # call instanceOf
+   DC   X'4700',Y((LCALLDESCPICREG-(*-8))/8)   * nop desc
 
 })dnl
+SaveSSP
+},{dnl
 
+ZZ zLinux case
 LOAD_ADDR_FROM_TOC(r14,TR_instanceOf)
-
     BASR    r14,r14        # call instanceOf
-
-ifdef({J9ZOS390},{dnl
-    ST_GPR   rSSP,eq_vmThrSSP(r13)
 })dnl
 
     L_GPR   J9SP,J9TR_VMThread_sp(r13)

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2018, 2021 IBM Corp. and others
+  Copyright (c) 2018, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,12 +73,6 @@
 		 -->
 	<test>
 		<testCaseName>Nestmate_virtual_private</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/9167</comment>
-				<platform>.*zos.*</platform>
-			</disable>
-		</disables>
 		<variations>
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*},{org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*}(count=0)$(SQ)</variation>
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedJitted*,org/openj9/test/nestmates/NestmatesTest$InnerClass.innerPrivateMethod*},{org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*}(count=0),{org/openj9/test/nestmates/NestmatesTest$InnerClass.innerPrivateMethod*}(count=100)$(SQ)</variation>


### PR DESCRIPTION
Adds cases for the BASR call to the C helper instanceOf for both 31 and 64 bit z/OS for unresolved net mates interface call.
Previously only the zLinux case was present, causing a bad branch on z/OS due to differing C linkages.

Fixes: #9167
Signed-off-by: Spencer Comin <Spencer.Comin@ibm.com>