### PR TITLE
Avoid leading tabs in makefiles outside of recipes

### DIFF
--- a/test/functional/Jsr292/variables.mk
+++ b/test/functional/Jsr292/variables.mk
@@ -22,7 +22,8 @@
 
 include $(TEST_ROOT)$(D)functional$(D)variables.mk
 
-XMLSUFFIX=
 ifeq ($(JDK_VERSION), 8)
-	XMLSUFFIX=_8
+  XMLSUFFIX = _8
+else
+  XMLSUFFIX =
 endif

--- a/test/functional/variables.mk
+++ b/test/functional/variables.mk
@@ -24,7 +24,8 @@
 # In JDK17-, java.security.manager == null behaves as -Djava.security.manager=allow.
 # For OpenJ9 tests to work as expected, -Djava.security.manager=allow behaviour is
 # needed in JDK18+.
-JAVA_SECURITY_MANAGER=
 ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
-	JAVA_SECURITY_MANAGER=-Djava.security.manager=allow
+  JAVA_SECURITY_MANAGER = -Djava.security.manager=allow
+else
+  JAVA_SECURITY_MANAGER =
 endif


### PR DESCRIPTION
Leading tabs have the potential to cause elements of makefiles to be considered part of a recipe instead of part of the global structure: use spaces instead.