### PR TITLE
[0.31 release] Correctly throw UOE from setSecurityManager

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1118,13 +1118,15 @@ public static void setSecurityManager(final SecurityManager s) {
 	@SuppressWarnings("removal")
 	final SecurityManager currentSecurity = security;
 
-	if ((currentSecurity == null) && (s == null)) {
-		/* Return if the input argument is null and no security manager has been established. */
-		return;
-	}
-
 	/*[IF JAVA_SPEC_VERSION > 11]*/
 	if (throwUOEFromSetSM) {
+		/* The security manager is not allowed to be set dynamically. Return if the
+		 * argument is null. UnsupportedOperationException should only be thrown for
+		 * a non-null argument.
+		 */
+		if (s == null) {
+			return;
+		}
 		/*[MSG "K0B00", "The Security Manager is deprecated and will be removed in a future release"]*/
 		throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0B00")); //$NON-NLS-1$
 	}


### PR DESCRIPTION
In some cases, warning messages are no longer being printed when the input
argument is null. Revising the fix in #14329 to correctly throw
UnsupportedOperationException (UOE) in case of a null input argument when the
security manager is disallowed.

When the security manager is not allowed to be set dynamically, return if the
input argument is null. UnsupportedOperationException should only be thrown for
a non-null input argument.

Fixes: #14445

Related: https://github.com/eclipse-openj9/openj9/pull/14447

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>