### PR TITLE
Remove unused exports in java.base/module-info.java.extra

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,16 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[IF PLATFORM-mz31 | PLATFORM-mz64 | PLATFORM-xz64]*/
-exports com.ibm.jit.crypto to ibm.crypto.hdwrcca;
-exports jdk.internal.misc to ibm.security.pkcs;
-exports sun.net.util to ibm.security.pkcs;
-exports sun.net.www to ibm.security.pkcs;
-exports sun.security.action to ibm.security.pkcs;
-exports sun.security.provider to ibm.security.pkcs;
-exports sun.security.provider.certpath to ibm.security.pkcs;
-exports sun.security.util to ibm.security.pkcs;
-/*[ENDIF]*/
 exports com.ibm.sharedclasses.spi to openj9.sharedclasses, java.management, java.rmi;
 exports com.ibm.oti.vm to java.management, jdk.attach, jdk.management, openj9.cuda, openj9.gpu, openj9.jvm, openj9.sharedclasses;
 exports com.ibm.oti.util to java.management, jdk.attach, jdk.jcmd, jdk.management, openj9.sharedclasses;


### PR DESCRIPTION
These exports to non-existent ibm modules were never used, except
perhaps temporarily for an obsolete project, and don't belong in OpenJ9
anyway. The first line was added before contribution to open source, the
others were added by https://github.com/eclipse-openj9/openj9/pull/10075