### PR TITLE
Add missed rememberReferenceIfRequired call

### DIFF
--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -848,6 +848,7 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 			if (classLoader == _javaVM->systemClassLoader) {
 				Assert_MM_true(NULL != _javaVM->unamedModuleForSystemLoader->moduleObject);
 				markObject(env, _javaVM->unamedModuleForSystemLoader->moduleObject);
+				rememberReferenceIfRequired(env, classLoaderObject, _javaVM->unamedModuleForSystemLoader->moduleObject);
 			}
 		}
 	}


### PR DESCRIPTION
Code added recently to support Unnamed Module Object for System
Classloader marking object, but never remember it. This line has been
missed.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>