### PR TITLE
Use <disables> to disable known AOT tests

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -557,6 +557,12 @@
 	<!-- jit.test.hw tests start here -->
 	<test>
 		<testCaseName>jit_hw</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13064</comment>
+				<testflag>aot</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xdump:java -Xgcpolicy:gencon -Xjit:count=0,optLevel=hot</variation>
 			<variation>-Xdump:java -Xgcpolicy:optavgpause -Xjit:count=0</variation>
@@ -581,9 +587,6 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<features>
-			<feature>AOT:nonapplicable</feature>
-		</features>
 	</test>
 	<test>
 		<testCaseName>jit_hwWarm</testCaseName>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/playlist.xml
@@ -24,6 +24,12 @@
 	<include>variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_SCHelperCompatTests_win</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/6053</comment>
+				<testflag>aot</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -48,9 +54,6 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<features>
-			<feature>AOT:nonapplicable</feature>
-		</features>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_SCHelperCompatTests_unix</testCaseName>

--- a/test/functional/cmdLineTests/verbosetest/playlist.xml
+++ b/test/functional/cmdLineTests/verbosetest/playlist.xml
@@ -23,6 +23,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<test>
 		<testCaseName>cmdLineTester_verbosetest</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13065</comment>
+				<testflag>aot</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode501</variation>
@@ -46,9 +52,6 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<features>
-			<feature>AOT:nonapplicable</feature>
-		</features>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_verbosetest_11</testCaseName>


### PR DESCRIPTION
The approach
```
		<features>
			<feature>AOT:nonapplicable</feature>
		</features>
```
should only be used for permanent disabling of tests. Therefore, to track the known AOT failures in [1], this PR uses the `<disables>` tag as documented in [2].

[1] https://github.com/eclipse-openj9/openj9/issues/6057
[2] https://github.com/eclipse-openj9/openj9/blob/master/test/docs/OpenJ9TestUserGuide.md#5-exclude-tests