### PR TITLE
Add new flag for ACC_PRIMITIVE

### DIFF
--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2021 IBM Corp. and others
+# Copyright (c) 2000, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1589,4 +1589,11 @@ J9NLS_CFR_ERR_OUTER_CLASS_BAD_ARRAY_CLASS.explanation=The outer class of an Inne
 J9NLS_CFR_ERR_OUTER_CLASS_BAD_ARRAY_CLASS.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_OUTER_CLASS_BAD_ARRAY_CLASS.user_response=Contact the provider of the classfile for a corrected version.
 
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_VALUE_FLAG_MISSING_ON_PRIMITIVE_CLASS=Access flag ACC_VALUE is missing on the primitive class.
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_VALUE_FLAG_MISSING_ON_PRIMITIVE_CLASS.explanation=Primitive class requires both ACC_PRIMITIVE and ACC_VALUE to be set.
+J9NLS_CFR_ERR_VALUE_FLAG_MISSING_ON_PRIMITIVE_CLASS.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_VALUE_FLAG_MISSING_ON_PRIMITIVE_CLASS.user_response=Contact the provider of the class file for a corrected version.
 # END NON-TRANSLATABLE

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -864,6 +864,7 @@ typedef struct J9CfrClassFile {
 #define CFR_ACC_INTERFACE  					0x00000200
 #define CFR_ACC_ABSTRACT  					0x00000400
 #define CFR_ACC_STRICT  					0x00000800
+#define CFR_ACC_PRIMITIVE_VALUE_TYPE  		0x00000800
 #define CFR_ACC_SYNTHETIC  					0x00001000
 #define CFR_ACC_ANNOTATION 					0x00002000
 #define CFR_ACC_ENUM  						0x00004000
@@ -891,8 +892,9 @@ typedef struct J9CfrClassFile {
 #define CFR_MINOR_VERSION  3
 #define CFR_PUBLIC_PRIVATE_PROTECTED_MASK	(CFR_ACC_PUBLIC | CFR_ACC_PRIVATE | CFR_ACC_PROTECTED)
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-#define CFR_CLASS_ACCESS_MASK					(CFR_ACC_PUBLIC | CFR_ACC_FINAL | CFR_ACC_SUPER | CFR_ACC_INTERFACE | CFR_ACC_ABSTRACT | CFR_ACC_SYNTHETIC | CFR_ACC_ANNOTATION | CFR_ACC_ENUM | CFR_ACC_VALUE_TYPE | CFR_ACC_ATOMIC)
+#define CFR_CLASS_ACCESS_MASK					(CFR_ACC_PUBLIC | CFR_ACC_FINAL | CFR_ACC_SUPER | CFR_ACC_INTERFACE | CFR_ACC_ABSTRACT | CFR_ACC_SYNTHETIC | CFR_ACC_ANNOTATION | CFR_ACC_ENUM | CFR_ACC_VALUE_TYPE | CFR_ACC_PRIMITIVE_VALUE_TYPE | CFR_ACC_ATOMIC)
 #define J9_IS_CLASSFILE_VALUETYPE(classfile)     J9_ARE_ALL_BITS_SET((classfile)->accessFlags, CFR_ACC_VALUE_TYPE)
+#define J9_IS_CLASSFILE_PRIMITIVE_VALUETYPE(classfile)     J9_ARE_ALL_BITS_SET((classfile)->accessFlags, CFR_ACC_PRIMITIVE_VALUE_TYPE)
 #else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #define CFR_CLASS_ACCESS_MASK					(CFR_ACC_PUBLIC | CFR_ACC_FINAL | CFR_ACC_SUPER | CFR_ACC_INTERFACE | CFR_ACC_ABSTRACT | CFR_ACC_SYNTHETIC | CFR_ACC_ANNOTATION | CFR_ACC_ENUM)
 #define J9_IS_CLASSFILE_VALUETYPE(classfile)     FALSE

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,6 +125,7 @@
 #define J9AccAtomic 0x40
 #define J9AccRecord 0x400
 #define J9AccSealed 0x200
+#define J9AccPrimitiveValueType 0x800
 #define J9StaticFieldRefBaseType 0x1
 #define J9StaticFieldRefDouble 0x2
 #define J9StaticFieldRefVolatile 0x4

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,8 +82,12 @@
 #define J9ROMCLASS_IS_CONTENDED(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassIsContended)
 
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
-/* Will need to modify this if ValObject/RefObject proposal goes through */
+/*
+ * TODO: Will need to modify this if ValObject/RefObject proposal goes through.
+ * Some exiting places using J9ROMCLASS_IS_VALUE() may need to check J9ROMCLASS_IS_PRIMITIVE_VALUE_TYPE().
+ */
 #define J9ROMCLASS_IS_VALUE(romClass)	_J9ROMCLASS_SUNMODIFIER_IS_SET((romClass), J9AccValueType)
+#define J9ROMCLASS_IS_PRIMITIVE_VALUE_TYPE(romClass)	_J9ROMCLASS_SUNMODIFIER_IS_SET((romClass), J9AccPrimitiveValueType)
 #define J9ROMCLASS_IS_ATOMIC(romClass)	_J9ROMCLASS_SUNMODIFIER_IS_SET((romClass), J9AccAtomic)
 #endif/* #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES */
 

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	public static final int DEFAULTVALUE = 203;
 	public static final int WITHFIELD = 204;
 	private static final int ACC_VALUE_TYPE = 0x100;
+	private static final int ACC_PRIMITIVE = 0x800;
 	public static final int ACC_ATOMIC = 0x40;
 	
 	static {
@@ -195,11 +196,11 @@ public class ValueTypeGenerator extends ClassLoader {
 		String[] fields = config.getFields();
 		int extraClassFlags = config.getExtraClassFlags();
 		/**
-		 * Currently value type is built on JDK17, so use java file major version 61 for now.
-		 * After moving to JDK18, this needs to be incremented to 62. The check in j9bcutil_readClassFileBytes()
-		 * against BCT_JavaMajorVersionShifted(17) needs to be updated as well.
+		 * Currently value type is built on JDK19, so use java file major version 63 for now.
+		 * If moved to JDK20, this needs to be incremented to 64. The check in j9bcutil_readClassFileBytes()
+		 * against BCT_JavaMajorVersionShifted(19) needs to be updated as well.
 		 */
-		int classFileVersion = 61;
+		int classFileVersion = 63;
 
 		String nestHost = config.getNestHost();
 
@@ -223,7 +224,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		if (isRef) {
 			cw.visit(classFileVersion, ACC_PUBLIC + ACC_FINAL + ACC_SUPER + extraClassFlags, className, null, superName, null);
 		} else {
-			cw.visit(classFileVersion, ACC_PUBLIC + ACC_FINAL + ACC_SUPER + ACC_VALUE_TYPE + extraClassFlags, className, null, superName, null);
+			cw.visit(classFileVersion, ACC_PUBLIC + ACC_FINAL + ACC_SUPER + ACC_VALUE_TYPE + ACC_PRIMITIVE + extraClassFlags, className, null, superName, null);
 		}
 
 		cw.visitSource(className + ".java", null);


### PR DESCRIPTION
1. Add CFR_ACC_PRIMITIVE_VALUE_TYPE and J9AccPrimitiveValueType
2. Valhalla is built on JDKNext which is Java 19 now. Update the code to
check against Java 19 when accepting/ignoring Valhalla specific access
flags.

Closes #14460

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>