### PR TITLE
(0.31.0) AArch64 macOS: Add OpenSSL options

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -414,7 +414,7 @@ x86-64_mac:
 # Mac M1 Aarch64
 #========================================#
 aarch64_mac:
-  extends: ['boot_jdk_default']
+  extends: ['boot_jdk_default', 'openssl', 'openssl_bundle']
   boot_jdk:
     arch: 'aarch64'
     os: 'mac'


### PR DESCRIPTION
This commit adds options for OpenSSL to AArch64 macOS build.

Original PR in master: #14444

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>