### PR TITLE
Add deserialized method flag to method MetaData

### DIFF
--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1527,6 +1527,11 @@ createMethodMetaData(
 #if defined(J9VM_OPT_JITSERVER)
    if (comp->isOutOfProcessCompilation())
       data->flags |= JIT_METADATA_IS_REMOTE_COMP;
+
+   if (comp->isDeserializedAOTMethod())
+      {
+      data->flags |= JIT_METADATA_IS_DESERIALIZED_COMP;
+      }
 #endif
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -555,6 +555,7 @@ typedef struct J9JITExceptionTable {
 #define JIT_METADATA_IS_STUB 0x4
 #define JIT_METADATA_NOT_INITIALIZED 0x8
 #define JIT_METADATA_IS_REMOTE_COMP 0x10
+#define JIT_METADATA_IS_DESERIALIZED_COMP 0x20
 
 typedef struct J9JIT16BitExceptionTableEntry {
 	U_16 startPC;


### PR DESCRIPTION
The new flag JIT_METADATA_IS_DESERIALIZED_COMP in the
J9JITExceptionTable flags tracks whether or not the relevant method was
deserialized and relocated from the JITServer AOT cache.

Fixes: #14297
Signed-off-by: Christian Despres <despresc@ibm.com>