### PR TITLE
Eliminate the effect -Xaggressive has on switching to profiling

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -904,7 +904,7 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
                   nextOptLevel = hot;
                   // Decide whether to deny optimizer to switch to profiling on the fly
                   if (globalSamplesInHotWindow > TR::Options::_sampleDontSwitchToProfilingThreshold &&
-                     !TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts))
+                     !TR::Options::getCmdLineOptions()->getOption(TR_AggressiveSwitchingToProfiling))
                      dontSwitchToProfiling = true;
                   recompile = true;
                   compInfo->_stats._methodsSelectedToRecompile++;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2185,9 +2185,6 @@ J9::Options::fePreProcess(void * base)
       self()->setOption(TR_DisableTraps);
    #endif
 
-   if (self()->getOption(TR_AggressiveOpts))
-      self()->setOption(TR_DontDowngradeToCold, true);
-
    if (forceSuffixLogs)
       self()->setOption(TR_EnablePIDExtension);
 

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -393,10 +393,8 @@ J9::Recompilation::switchToProfiling(uint32_t f, uint32_t c)
       return false;
       }
 
-   if (_compilation->isOptServer() && !TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts))
+   if (_compilation->isOptServer() && !_compilation->getOption(TR_AggressiveSwitchingToProfiling))
       {
-      // can afford to switch to profiling under aggressive; needed for BigDecimal opt
-      //
       return false;
       }
 


### PR DESCRIPTION
The option `-Xaggressive` allows switching to profiling of hot compilations
in a more aggressive manner. This has been seen to have negative performance
effects on some applications.
This commit eliminates the effect `-Xaggressive` has on switching to profiling.
More aggressive switching to profiling can be enabled with the newly created
option `-Xjit:aggressiveSwitchingToProfiling`

Another change is the elimination of code that tried to disable downgrading
to cold optimization level. That code had no effect because it was conditional
on an option that was not yet set at that point.

Depends on https://github.com/eclipse/omr/pull/6350

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>