### PR TITLE
AArch64: Preserve vector registers across helper calls

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2019, 2021 IBM Corp. and others
+dnl Copyright (c) 2019, 2022 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -244,6 +244,35 @@ START_PROC($1)
 END_PROC($1)
 })
 
+dnl Helpers that are at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in arm64helpers.m4
+dnl for details.
+
+define({METHOD_INVOCATION})
+
+PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
+SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
+
+dnl jitStackOverflow is special case in that the frame size argument
+dnl is implicit (in the register file) rather than being passed as
+dnl an argument in the usual way.
+
+SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitStackOverflow,0)
+
+dnl Helpers that are not at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in arm64helpers.m4
+dnl for details.
+
+undefine({METHOD_INVOCATION})
+
 dnl Runtime helpers
 
 NEW_DUAL_MODE_HELPER(jitNewValue,1)
@@ -255,12 +284,6 @@ DUAL_MODE_HELPER(jitANewArrayNoZeroInit,2)
 DUAL_MODE_HELPER(jitNewArray,2)
 DUAL_MODE_HELPER(jitNewArrayNoZeroInit,2)
 SLOW_PATH_ONLY_HELPER(jitAMultiNewArray,3)
-
-dnl jitStackOverflow is special case in that the frame size argument
-dnl is implicit (in the register file) rather than being passed as
-dnl an argument in the usual way.
-
-SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitStackOverflow,0)
 
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitCheckAsyncMessages,0)
 DUAL_MODE_HELPER_NO_RETURN_VALUE(jitCheckCast,2)
@@ -309,7 +332,6 @@ dnl Only called from PicBuilder
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsNative,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsSync,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitResolvedFieldIsVolatile,3)
-PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveString,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClass,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClassFromStaticField,3)
@@ -317,10 +339,6 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveFieldSetter,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetter,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodType,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodHandle,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
@@ -338,7 +356,6 @@ dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)
 SLOW_PATH_ONLY_HELPER(jitRetranslateCallerWithPreparation,3)
-SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
 
 dnl Exception throw helpers
 
@@ -372,8 +389,6 @@ FAST_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitWriteBarrierStoreMetronome,3)
 
 dnl Misc
 
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
 SLOW_PATH_ONLY_HELPER(jitNewInstanceImplAccessCheck,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallCFunction,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallJitAddPicToPatchOnClassUnload,2)

--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2019, 2021 IBM Corp. and others
+dnl Copyright (c) 2019, 2022 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,35 +107,41 @@ define({SAVE_C_VOLATILE_REGS},{
 	stp x14,x15,JIT_GPR_SAVE_SLOT(14)
 	stp x16,x17,JIT_GPR_SAVE_SLOT(16)
 	str x18,JIT_GPR_SAVE_SLOT(18)
+ifdef({METHOD_INVOCATION},{
 	stp d0,d1,JIT_FPR_SAVE_SLOT(0)
 	stp d2,d3,JIT_FPR_SAVE_SLOT(2)
 	stp d4,d5,JIT_FPR_SAVE_SLOT(4)
 	stp d6,d7,JIT_FPR_SAVE_SLOT(6)
-	add x15, sp, JIT_FPR_SAVE_OFFSET(16)
-	stp d16,d17,[x15,#0]
-	stp d18,d19,[x15,#16]
-	stp d20,d21,[x15,#32]
-	stp d22,d23,[x15,#48]
-	stp d24,d25,[x15,#64]
-	stp d26,d27,[x15,#80]
-	stp d28,d29,[x15,#96]
-	stp d30,d31,[x15,#112]
+},{ dnl METHOD_INVOCATION
+	add x15, sp, JIT_FPR_SAVE_OFFSET(0)
+	st1 {{v0.4s, v1.4s, v2.4s, v3.4s}}, [x15], #64
+	st1 {{v4.4s, v5.4s, v6.4s, v7.4s}}, [x15], #64
+	st1 {{v8.4s, v9.4s, v10.4s, v11.4s}}, [x15], #64
+	st1 {{v12.4s, v13.4s, v14.4s, v15.4s}}, [x15], #64
+	st1 {{v16.4s, v17.4s, v18.4s, v19.4s}}, [x15], #64
+	st1 {{v20.4s, v21.4s, v22.4s, v23.4s}}, [x15], #64
+	st1 {{v24.4s, v25.4s, v26.4s, v27.4s}}, [x15], #64
+	st1 {{v28.4s, v29.4s, v30.4s, v31.4s}}, [x15]
+}) dnl METHOD_INVOCATION
 })
 
 define({RESTORE_C_VOLATILE_REGS},{
+ifdef({METHOD_INVOCATION},{
 	ldp d0,d1,JIT_FPR_SAVE_SLOT(0)
 	ldp d2,d3,JIT_FPR_SAVE_SLOT(2)
 	ldp d4,d5,JIT_FPR_SAVE_SLOT(4)
 	ldp d6,d7,JIT_FPR_SAVE_SLOT(6)
-	add x15, sp, JIT_FPR_SAVE_OFFSET(16)
-	ldp d16,d17,[x15,#0]
-	ldp d18,d19,[x15,#16]
-	ldp d20,d21,[x15,#32]
-	ldp d22,d23,[x15,#48]
-	ldp d24,d25,[x15,#64]
-	ldp d26,d27,[x15,#80]
-	ldp d28,d29,[x15,#96]
-	ldp d30,d31,[x15,#112]
+},{ dnl METHOD_INVOCATION
+	add x15, sp, JIT_FPR_SAVE_OFFSET(0)
+	ld1 {{v0.4s, v1.4s, v2.4s, v3.4s}}, [x15], #64
+	ld1 {{v4.4s, v5.4s, v6.4s, v7.4s}}, [x15], #64
+	ld1 {{v8.4s, v9.4s, v10.4s, v11.4s}}, [x15], #64
+	ld1 {{v12.4s, v13.4s, v14.4s, v15.4s}}, [x15], #64
+	ld1 {{v16.4s, v17.4s, v18.4s, v19.4s}}, [x15], #64
+	ld1 {{v20.4s, v21.4s, v22.4s, v23.4s}}, [x15], #64
+	ld1 {{v24.4s, v25.4s, v26.4s, v27.4s}}, [x15], #64
+	ld1 {{v28.4s, v29.4s, v30.4s, v31.4s}}, [x15]
+}) dnl METHOD_INVOCATION
 	ldp x0,x1,JIT_GPR_SAVE_SLOT(0)
 	ldp x2,x3,JIT_GPR_SAVE_SLOT(2)
 	ldp x4,x5,JIT_GPR_SAVE_SLOT(4)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5815,7 +5815,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA preservedGPRs[12]; /* x19-x30 */
 	U_8 preservedFPRs[8 * 8]; /* v8-15 */
 	UDATA jitGPRs[32]; /* x0-x31 */
-	U_8 jitFPRs[32 * 8]; /* v0-v31 */
+	U_8 jitFPRs[32 * 16]; /* v0-v31 */
 #elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_ARM */
 	UDATA preservedGPRs[13];   /* x8, x9 and x18-x27 and ra */
 	U_8 preservedFPRs[12 * 8]; /* f8, f9 and f18-f27 */


### PR DESCRIPTION
Preserve vector registers across helper calls.
Split helper functions into two categories as other platform do.
For method invocation helpers, we save parameter FPRs only.
For other helpers, we save all 128-bit vector registers.

This implementation is based on x.

Resolves https://github.com/eclipse-openj9/openj9/issues/12179.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>