### PR TITLE
SysPropTest constructs String w/ native.encoding

### DIFF
--- a/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-Copyright (c) 2020, 2021 IBM Corp. and others
+Copyright (c) 2020, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<versions>
+			<version>8</version>
+			<version>11</version>
+			<version>17</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 import java.util.*;
 import java.io.*;
+import java.nio.charset.Charset;
 
 public class SysPropTest 
 {
@@ -57,7 +58,7 @@ public class SysPropTest
 				if ((argEncoding.equals("UTF-8") || argEncoding.equals("ISO-8859-1"))) {
 					strTestProp = new String(B,argEncoding);
 				} else {
-					strTestProp = new String(B);
+					strTestProp = new String(B, System.getProperty("native.encoding", Charset.defaultCharset().name()));
 				}
 			}
 			


### PR DESCRIPTION
Use `Charset.defaultCharset().name()` when `native.encoding` is not available.
Excluded `cmdLineTester_SystemPropertiesTest_aix` for JDK18 and onward.

Related https://github.com/eclipse-openj9/openj9/issues/14227

This passes `cmdLineTester_SystemPropertiesTest_win`, `cmdLineTester_SystemPropertiesTest_aix` failure is related to AIX JCL, to be addressed along w/ https://github.com/eclipse-openj9/openj9/issues/14472, https://github.com/eclipse-openj9/openj9/issues/14473.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>