### PR TITLE
Eliminate VM_isString1 messages from JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -384,10 +384,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getInitialLockword(clazz));
          }
          break;
-      case MessageType::VM_isString1:
+      case MessageType::VM_JavaStringObject:
          {
-         TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         client->write(response, fe->isString(clazz));
+         client->getRecvData<JITServer::Void>();
+         client->write(response, (TR_OpaqueClassBlock *)J9VMJAVALANGSTRING(vmThread->javaVM));
          }
          break;
       case MessageType::VM_getMethods:
@@ -512,6 +512,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._staticObjectAllocateFlags = fe->getStaticObjectFlags();
          vmInfo._referenceArrayCopyHelperAddress = fe->getReferenceArrayCopyHelperAddress();
          vmInfo._JavaLangObject = (TR_OpaqueClassBlock*)J9VMJAVALANGOBJECT(vmThread->javaVM);
+         vmInfo._JavaStringObject = (TR_OpaqueClassBlock*)J9VMJAVALANGSTRING(vmThread->javaVM);
 
          vmInfo._useAOTCache = comp->getPersistentInfo()->getJITServerUseAOTCache();
          if (vmInfo._useAOTCache)

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -838,8 +838,15 @@ bool
 TR_J9ServerVM::isString(TR_OpaqueClassBlock * clazz)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isString1, clazz);
-   return std::get<0>(stream->read<bool>());
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   TR_OpaqueClassBlock *javaStringObject = vmInfo->_JavaStringObject;
+   if (NULL == javaStringObject)
+      {
+      stream->write(JITServer::MessageType::VM_JavaStringObject, JITServer::Void());
+      javaStringObject = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
+      vmInfo->_JavaStringObject = javaStringObject;
+      }
+   return clazz == javaStringObject;
    }
 
 bool

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 35;
+   static const uint16_t MINOR_NUMBER = 36;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,7 @@ const char *messageNames[] =
    "VM_isClassInitialized",
    "VM_getOSRFrameSizeInBytes",
    "VM_getInitialLockword",
-   "VM_isString1",
+   "VM_JavaStringObject",
    "VM_getMethods",
    "VM_getObjectClass",
    "VM_getObjectClassAt",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corp. and others
+ * Copyright (c) 2020, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,7 +120,7 @@ enum MessageType : uint16_t
    VM_isClassInitialized,
    VM_getOSRFrameSizeInBytes,
    VM_getInitialLockword,
-   VM_isString1,
+   VM_JavaStringObject,
    VM_getMethods,
    VM_getObjectClass,
    VM_getObjectClassAt,

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -317,6 +317,7 @@ public:
       bool _useAOTCache;
       TR_AOTHeader _aotHeader;
       TR_OpaqueClassBlock *_JavaLangObject;
+      TR_OpaqueClassBlock *_JavaStringObject;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
A new _JavaStringObject field has been added to
ClientSessionData::VMInfo to cache the value of J9VMJAVALANGSTRING
from the client. This is used by the server in
TR_J9ServerVM::isString when it is not NULL, rather than always sending
a message to the client.

Fixes: #13988
Signed-off-by: Christian Despres <despresc@ibm.com>