### PR TITLE
Implement new vector types

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -490,16 +490,17 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
 }
 
 
-char *nvvmTypeNames[TR::NumTypes] =
+char *nvvmTypeNames[TR::NumOMRTypes] =
    {
-   "void",    // "TR::NoType"
-   "i8",      // "TR::Int8"
-   "i16",     // "TR::Int16"
-   "i32",     // "TR::Int32"
-   "i64",     // "TR::Int64"
-   "float",   // "TR::Float"
-   "double",  // "TR::Double"
-   "i8*"      // "TR::Address"
+   "void",    // TR::NoType
+   "i8",      // TR::Int8
+   "i16",     // TR::Int16
+   "i32",     // TR::Int32
+   "i64",     // TR::Int64
+   "float",   // TR::Float
+   "double",  // TR::Double
+   "i8*",     // TR::Address
+   "aggr"     // TR::Aggregate: not used
    };
 
 static const char* getTypeName(TR::DataType type) {
@@ -514,16 +515,17 @@ static const char* getTypeName(TR::DataType type) {
        }
 }
 
-char *nvvmVarTypeNames[TR::NumTypes] =
+char *nvvmVarTypeNames[TR::NumOMRTypes] =
    {
-   "void",    // "TR::NoType"
-   "i8",      // "TR::Int8"
-   "i16",     // "TR::Int16"
-   "i32",     // "TR::Int32"
-   "i64",     // "TR::Int64"
-   "f32",     // "TR::Float"
-   "f64",     // "TR::Double"
-   "p64"      // "TR::Address"
+   "void",    // TR::NoType
+   "i8",      // TR::Int8
+   "i16",     // TR::Int16
+   "i32",     // TR::Int32
+   "i64",     // TR::Int64
+   "f32",     // TR::Float
+   "f64",     // TR::Double
+   "p64",     // TR::Address
+   "paggr"    // TR::Aggregate: not used
    };
 
 static const char* getVarTypeName(TR::DataType type) {

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2146,13 +2146,13 @@ J9::SymbolReferenceTable::findOrCreateUnsafeSymbolRef(TR::DataType type, bool ja
       if (javaStaticReference)
          {
          if (_unsafeJavaStaticVolatileSymRefs == NULL)
-            _unsafeJavaStaticVolatileSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumTypes);
+            _unsafeJavaStaticVolatileSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumAllTypes);
          unsafeSymRefs = _unsafeJavaStaticVolatileSymRefs;
          }
       else
          {
          if (_unsafeVolatileSymRefs == NULL)
-            _unsafeVolatileSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumTypes);
+            _unsafeVolatileSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumAllTypes);
          unsafeSymRefs = _unsafeVolatileSymRefs;
          }
       }
@@ -2161,13 +2161,13 @@ J9::SymbolReferenceTable::findOrCreateUnsafeSymbolRef(TR::DataType type, bool ja
       if (javaStaticReference)
          {
          if (_unsafeJavaStaticSymRefs == NULL)
-            _unsafeJavaStaticSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumTypes);
+            _unsafeJavaStaticSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumAllTypes);
          unsafeSymRefs = _unsafeJavaStaticSymRefs;
          }
       else
          {
          if (_unsafeSymRefs == NULL)
-            _unsafeSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumTypes);
+            _unsafeSymRefs = new (trHeapMemory()) TR_Array<TR::SymbolReference *>(comp()->trMemory(), TR::NumAllTypes);
          unsafeSymRefs = _unsafeSymRefs;
          }
       }

--- a/runtime/compiler/il/J9DataTypes.cpp
+++ b/runtime/compiler/il/J9DataTypes.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ namespace J9 {
 
 #define TR_Bad TR::BadILOp
 
-static TR::ILOpCodes conversionMapOMR2TR[TR::NumOMRTypes][TR::NumTypes-TR::NumOMRTypes] =
+static TR::ILOpCodes conversionMapOMR2TR[TR::NumOMRTypes][TR::NumScalarTypes-TR::NumOMRTypes] =
 //                   PackedDec ZonedDec ZDecSLE ZDecSLS ZDecSTS UniDec  UniDecSL UniDecST
    {
 /* NoType */       { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // NoType
@@ -43,28 +43,22 @@ static TR::ILOpCodes conversionMapOMR2TR[TR::NumOMRTypes][TR::NumTypes-TR::NumOM
 /* Float */        { TR::f2pd, TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // Float
 /* Double */       { TR::d2pd, TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // Double
 /* Address */      { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // Address
-/* VectorInt8 */   { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // VectorInt8
-/* VectorInt16*/   { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // VectorInt16
-/* VectorInt32*/   { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // VectorInt32
-/* VectorInt64*/   { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // VectorInt64
-/* VectorFloat*/   { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad },  // VectorFloat
-/* VectorDouble*/  { TR_Bad,   TR_Bad,  TR_Bad, TR_Bad, TR_Bad, TR_Bad, TR_Bad,  TR_Bad }   // VectorDouble
    };
 
-static TR::ILOpCodes conversionMapTR2OMR[TR::NumTypes-TR::NumOMRTypes][TR::NumOMRTypes] =
-//                                       No      Int8     Int16    Int32     Int64   Float     Double    Addr     VectorInt8 VectorInt16 VectorInt32 VectorInt64 VectorFloat VectorDouble
+static TR::ILOpCodes conversionMapTR2OMR[TR::NumScalarTypes-TR::NumOMRTypes][TR::NumOMRTypes] =
+//                                           No      Int8     Int16    Int32    Int64   Float     Double    Addr
    {
-/* PackedDecimal */                    { TR_Bad, TR_Bad,  TR_Bad,  TR::pd2i,TR::pd2l,TR::pd2f, TR::pd2d, TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // PackedDecima
-/* ZonedDecimal */                     { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // ZonedDecimal
-/* ZonedDecimalSignLeadingEmbedded */  { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // ZonedDecimal
-/* ZonedDecimalSignLeadingSeparate*/   { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // ZonedDecimal
-/* ZonedDecimalSignTrailingSeparate*/  { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // ZonedDecimal
-/* UnicodeDecimal */                   { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // UnicodeDecim
-/* UnicodeDecimalSignLeading */        { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad },  // UnicodeDecim
-/* UnicodeDecimalSignTrailing */       { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad,  TR_Bad,    TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad,     TR_Bad }   // UnicodeDecim
+   /* PackedDecimal */                    { TR_Bad, TR_Bad,  TR_Bad,  TR::pd2i,TR::pd2l,TR::pd2f, TR::pd2d, TR_Bad },  // PackedDecima
+   /* ZonedDecimal */                     { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // ZonedDecimal
+   /* ZonedDecimalSignLeadingEmbedded */  { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // ZonedDecimal
+   /* ZonedDecimalSignLeadingSeparate*/   { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // ZonedDecimal
+   /* ZonedDecimalSignTrailingSeparate*/  { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // ZonedDecimal
+   /* UnicodeDecimal */                   { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // UnicodeDecim
+   /* UnicodeDecimalSignLeading */        { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad },  // UnicodeDecim
+   /* UnicodeDecimalSignTrailing */       { TR_Bad, TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,  TR_Bad,   TR_Bad,   TR_Bad }   // UnicodeDecim
    };
 
-static TR::ILOpCodes conversionMapTR2TR[TR::NumTypes-TR::NumOMRTypes][TR::NumTypes-TR::NumOMRTypes] =
+static TR::ILOpCodes conversionMapTR2TR[TR::NumScalarTypes-TR::NumOMRTypes][TR::NumScalarTypes-TR::NumOMRTypes] =
 //                                       PackedDec    ZonedDec     ZDecSLE      ZDecSLS      ZDecSTS      UniDec      UniDecSL    UniDecST
    {
 /* PackedDecimal */                    { TR_Bad,      TR::pd2zd,   TR_Bad,      TR::pd2zdsls,TR::pd2zdsts,TR::pd2ud,  TR::pd2udsl,TR::pd2udst },
@@ -182,8 +176,12 @@ char *J9::DataType::_TR_BCDSignCodeNames[num_bcd_sign_codes] =
 TR::ILOpCodes
 J9::DataType::getDataTypeConversion(TR::DataType t1, TR::DataType t2)
    {
-   TR_ASSERT(t1 < TR::NumTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());
-   TR_ASSERT(t2 < TR::NumTypes, "conversion opcode to unexpected data type %s requested", t2.toString());
+   TR_ASSERT(t1 < TR::NumAllTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());
+   TR_ASSERT(t2 < TR::NumAllTypes, "conversion opcode to unexpected data type %s requested", t2.toString());
+
+   if (t1.isVector() && t2.isVector()) return TR::v2v;
+   if (t1.isVector() || t2.isVector()) return TR::BadILOp;
+
    if (t1 < TR::NumOMRTypes)
       {
       if (t2 < TR::NumOMRTypes)
@@ -217,8 +215,8 @@ static_assert(TR::LastJ9Type - TR::FirstJ9Type + 1 == (sizeof(J9DataTypeSizes) /
 const int32_t
 J9::DataType::getSize(TR::DataType dt)
    {
-   TR_ASSERT(dt < TR::NumTypes, "dataTypeSizeMap called on unrecognized data type");
-   if (dt < TR::FirstJ9Type)
+   TR_ASSERT(dt < TR::NumAllTypes, "dataTypeSizeMap called on unrecognized data type");
+   if (dt.isOMRDataType())
       return OMR::DataType::getSize(dt);
    else
       return J9DataTypeSizes[dt - TR::FirstJ9Type];
@@ -227,8 +225,8 @@ J9::DataType::getSize(TR::DataType dt)
 void
 J9::DataType::setSize(TR::DataType dt, int32_t newSize)
    {
-   TR_ASSERT(dt < TR::NumTypes, "setDataTypeSizeInMap called on unrecognized data type");
-   if (dt < TR::FirstJ9Type)
+   TR_ASSERT(dt < TR::NumAllTypes, "setDataTypeSizeInMap called on unrecognized data type");
+   if (dt.isOMRDataType())
       OMR::DataType::setSize(dt, newSize);
    else
       J9DataTypeSizes[dt - TR::FirstJ9Type] = newSize;
@@ -252,38 +250,12 @@ static_assert(TR::LastJ9Type - TR::FirstJ9Type + 1 == (sizeof(J9DataTypeNames) /
 const char *
 J9::DataType::getName(TR::DataType dt)
    {
-   TR_ASSERT(dt < TR::NumTypes, "Name requested for unknown datatype");
-   if (dt < TR::FirstJ9Type)
+   TR_ASSERT(dt < TR::NumAllTypes, "Name requested for unknown datatype");
+   if (dt.isOMRDataType())
       return OMR::DataType::getName(dt);
    else
       return J9DataTypeNames[dt - TR::FirstJ9Type];
    }
-
-
-static const char *J9DataTypePrefixes[] =
-   {
-   "PD",    // TR::PackedDecimal
-   "ZD",    // TR::ZonedDecimal
-   "ZDSLE", // TR::ZonedDecimalSignLeadingEmbedded
-   "ZDSLS", // TR::ZonedDecimalSignLeadingSeparate
-   "ZDSTS", // TR::ZonedDecimalSignTrailingSeparate
-   "UD",    // TR::UnicodeDecimal
-   "UDSL",  // TR::UnicodeDecimalSignLeading
-   "UDST"   // TR::UnicodeDecimalSignTrailing"
-   };
-
-static_assert(TR::LastJ9Type - TR::FirstJ9Type + 1 == (sizeof(J9DataTypePrefixes) / sizeof(J9DataTypePrefixes[0])), "J9DataTypePrefixes is not the correct size");
-
-const char *
-J9::DataType::getPrefix(TR::DataType dt)
-   {
-   TR_ASSERT(dt < TR::NumTypes, "Prefix requested for unknown datatype");
-   if (dt < TR::FirstJ9Type)
-      return OMR::DataType::getPrefix(dt);
-   else
-      return J9DataTypePrefixes[dt - TR::FirstJ9Type];
-   }
-
 
 bool
 J9::DataType::isValidZonedDigit(uint8_t data)
@@ -597,8 +569,8 @@ J9::DataType::getSignCodeSize(TR::DataType dt)
          size = UnknownSignCodeSize;
          break;
       default:
-         TR_ASSERT_FATAL(false, "Unknown sign code BCD type"); 
-         break; 
+         TR_ASSERT_FATAL(false, "Unknown sign code BCD type");
+         break;
       }
    return size;
    }
@@ -846,7 +818,7 @@ J9::DataType::encodedToPrintableSign(uint32_t encodedSign, TR::DataType dt)
          break;
       default:
          TR_ASSERT(false,"unknown bcd type %s\n",dt.toString());
-         break; 
+         break;
       }
    return printableSign;
    }

--- a/runtime/compiler/il/J9DataTypes.hpp
+++ b/runtime/compiler/il/J9DataTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,6 @@ public:
    static const char    * getName(TR::DataType dt);
    static const int32_t   getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);
-   static const char    * getPrefix(TR::DataType dt);
 
    // for the overloaded instances of getName:
    // OMR::DataType::getName(TR_RawBCDSignCode)

--- a/runtime/compiler/il/J9IL.cpp
+++ b/runtime/compiler/il/J9IL.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -306,7 +306,7 @@ J9::IL::opCodeForConst(TR::DataType dt)
       return TR::iconst;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForConst(dt);
       }
@@ -334,7 +334,7 @@ J9::IL::opCodeForDirectLoad(TR::DataType dt)
       return TR::iload;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForDirectLoad(dt);
       }
@@ -350,7 +350,7 @@ J9::IL::opCodeForDirectStore(TR::DataType dt)
       return TR::istore;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForDirectStore(dt);
       }
@@ -388,7 +388,7 @@ J9::IL::opCodeForIndirectLoad(TR::DataType dt)
       return TR::iloadi;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForIndirectLoad(dt);
       }
@@ -404,7 +404,7 @@ J9::IL::opCodeForIndirectStore(TR::DataType dt)
       return TR::istorei;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForIndirectStore(dt);
       }
@@ -427,7 +427,7 @@ J9::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
 TR::ILOpCodes
 J9::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
    {
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForIndirectArrayLoad(dt);
       }
@@ -438,7 +438,7 @@ J9::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
 TR::ILOpCodes
 J9::IL::opCodeForIndirectArrayStore(TR::DataType dt)
    {
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForIndirectArrayStore(dt);
       }
@@ -449,7 +449,7 @@ J9::IL::opCodeForIndirectArrayStore(TR::DataType dt)
 TR::ILOpCodes
 J9::IL::opCodeForRegisterLoad(TR::DataType dt)
    {
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForRegisterLoad(dt);
       }
@@ -460,7 +460,7 @@ J9::IL::opCodeForRegisterLoad(TR::DataType dt)
 TR::ILOpCodes
 J9::IL::opCodeForRegisterStore(TR::DataType dt)
    {
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForRegisterStore(dt);
       }
@@ -476,7 +476,7 @@ J9::IL::opCodeForCompareEquals(TR::DataType dt)
       return TR::icmpeq;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForCompareEquals(dt);
       }
@@ -492,7 +492,7 @@ J9::IL::opCodeForCompareNotEquals(TR::DataType dt)
       return TR::icmpne;
       }
 
-   if (dt < TR::FirstJ9Type)
+   if (dt.isOMRDataType())
       {
       return OMR::IL::opCodeForCompareNotEquals(dt);
       }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2257,18 +2257,8 @@ TR_J9ByteCodeIlGenerator::calculateArrayElementAddress(TR::DataType dataType, bo
 
    if (comp()->getOption(TR_EnableSIMDLibrary))
        {
-       if (dataType == TR::VectorInt8)
-         dataType = TR::Int8;
-       else if (dataType == TR::VectorInt16)
-         dataType = TR::Int16;
-       else if (dataType == TR::VectorInt32)
-         dataType = TR::Int32;
-       else if (dataType == TR::VectorInt64)
-         dataType = TR::Int64;
-       if (dataType == TR::VectorFloat)
-         dataType = TR::Float;
-       else if (dataType == TR::VectorDouble)
-         dataType = TR::Double;
+       if (dataType.isVector())
+          dataType = dataType.getVectorElementType();
        }
 
    int32_t width = TR::Symbol::convertTypeToSize(dataType);

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,8 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "codegen/CodeGenerator.hpp"
+
+#define VECTOR_LENGTH TR::VectorLength128
 
 bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *loop)
    {
@@ -77,13 +79,13 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
                   traceMsg(comp, "SPMD PRE-CHECK FAILURE: store op code %s does not have a vector equivalent - skipping consideration of loop %d\n", comp->getDebug()->getName(opcode.getOpCodeValue()), loop->getNumber());
                 return false;
                 }
-             if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOp, node->getDataType()))
+             if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOp, node->getDataType(), VECTOR_LENGTH))
                 {
                 if (trace)
                   traceMsg(comp, "SPMD PRE-CHECK FAILURE: vector op code %s is not supported on the current platform - skipping consideration of loop %d\n", comp->getDebug()->getName(vectorOp), loop->getNumber());
                 return false;
                 }
-           
+
              continue;
              }
 

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -992,7 +992,8 @@ void TR_VectorAPIExpansion::aloadHandler(TR_VectorAPIExpansion *opt, TR::TreeTop
       }
    else if (mode == doVectorization)
       {
-      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector();
+      TR::VectorLength lengthEnum = supportedOnPlatform(comp, vectorLength);
+      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector(lengthEnum);
       vectorizeLoadOrStore(opt, node, vectorType);
       }
 
@@ -1034,7 +1035,8 @@ void TR_VectorAPIExpansion::astoreHandler(TR_VectorAPIExpansion *opt, TR::TreeTo
       }
    else if (mode == doVectorization)
       {
-      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector();
+      TR::VectorLength lengthEnum = supportedOnPlatform(comp, vectorLength);
+      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector(lengthEnum);
       vectorizeLoadOrStore(opt, node, vectorType);
       if (rhs->getOpCodeValue() == TR::aload) vectorizeLoadOrStore(opt, rhs, vectorType);
       }
@@ -1059,7 +1061,7 @@ TR::Node *TR_VectorAPIExpansion::fromArrayHandler(TR_VectorAPIExpansion *opt, TR
 
    if (mode == checkScalarization) return node;
    if (mode == checkVectorization)
-      return supportedOnPlatform(comp, vectorLength) ? node : NULL;
+      return supportedOnPlatform(comp, vectorLength) != TR::NoVectorLength ? node : NULL;
 
    if (opt->_trace)
       traceMsg(comp, "fromArrayHandler for node %p\n", node);
@@ -1080,7 +1082,7 @@ TR::Node *TR_VectorAPIExpansion::intoArrayHandler(TR_VectorAPIExpansion *opt, TR
 
    if (mode == checkScalarization) return node;
    if (mode == checkVectorization)
-      return supportedOnPlatform(comp, vectorLength) ? node : NULL;
+      return supportedOnPlatform(comp, vectorLength) != TR::NoVectorLength ? node : NULL;
 
    if (opt->_trace)
       traceMsg(comp, "intoArrayHandler for node %p\n", node);
@@ -1104,7 +1106,7 @@ TR::Node *TR_VectorAPIExpansion::addHandler(TR_VectorAPIExpansion *opt, TR::Tree
 
    if (mode == checkScalarization) return node;
    if (mode == checkVectorization)
-      return supportedOnPlatform(comp, vectorLength) ? node : NULL;
+      return supportedOnPlatform(comp, vectorLength) != TR::NoVectorLength ? node : NULL;
 
    // TODO: The above does not check the actual opcode and type
 
@@ -1126,7 +1128,7 @@ TR::Node *TR_VectorAPIExpansion::loadIntrinsicHandler(TR_VectorAPIExpansion *opt
 
    if (mode == checkScalarization) return node;
    if (mode == checkVectorization)
-      return supportedOnPlatform(comp, vectorLength) ? node : NULL;
+      return supportedOnPlatform(comp, vectorLength) != TR::NoVectorLength ? node : NULL;
 
    if (opt->_trace)
       traceMsg(comp, "loadIntrinsicHandler for node %p\n", node);
@@ -1183,7 +1185,8 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
       }
    else if (mode == doVectorization)
       {
-      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector();
+      TR::VectorLength lengthEnum = supportedOnPlatform(comp, vectorLength);
+      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector(lengthEnum);
       TR::SymbolReference *vecShadow = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(vectorType, NULL);
       TR::Node::recreate(node, TR::vloadi);
       node->setSymbolReference(vecShadow);
@@ -1200,7 +1203,7 @@ TR::Node *TR_VectorAPIExpansion::storeIntrinsicHandler(TR_VectorAPIExpansion *op
 
    if (mode == checkScalarization) return node;
    if (mode == checkVectorization)
-      return supportedOnPlatform(comp, vectorLength) ? node : NULL;
+      return supportedOnPlatform(comp, vectorLength) != TR::NoVectorLength ? node : NULL;
 
    if (opt->_trace)
       traceMsg(comp, "storeIntrinsicHandler for node %p\n", node);
@@ -1271,7 +1274,8 @@ TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *op
    else if (mode == doVectorization)
       {
       // vectorization(will be enabled later)
-      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector();
+      TR::VectorLength lengthEnum = supportedOnPlatform(comp, vectorLength);
+      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector(lengthEnum);
       TR::SymbolReference *vecShadow = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(vectorType, NULL);
 
       if (valueToWrite->getOpCodeValue() == TR::aload) vectorizeLoadOrStore(opt, valueToWrite, vectorType);
@@ -1355,7 +1359,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
 
    if (mode == checkVectorization)
       {
-      if (!supportedOnPlatform(comp, vectorLength)) return NULL;
+      if (supportedOnPlatform(comp, vectorLength) == TR::NoVectorLength) return NULL;
 
       if (useVcall) return node;
 
@@ -1363,7 +1367,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
       if (vectorOpCode == TR::BadILOp)
           return NULL;
 
-      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType))
+      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType, OMR::DataType::bitsToVectorLength(vectorLength)))
          return NULL;
 
       return node;
@@ -1391,7 +1395,7 @@ TR::Node *TR_VectorAPIExpansion::blendIntrinsicHandler(TR_VectorAPIExpansion *op
       {
       if (!supportedOnPlatform(comp, vectorLength)) return NULL;
 
-      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType))
+      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType, OMR::DataType::bitsToVectorLength(vectorLength)))
          return NULL;
 
       return node;
@@ -1411,7 +1415,7 @@ TR::Node *TR_VectorAPIExpansion::broadcastCoercedIntrinsicHandler(TR_VectorAPIEx
 
    if (mode == checkVectorization)
       {
-      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(TR::vsplats, elementType))
+      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(TR::vsplats, elementType, OMR::DataType::bitsToVectorLength(vectorLength)))
          return NULL;
       else
          return node;
@@ -1525,7 +1529,7 @@ TR::Node *TR_VectorAPIExpansion::compareIntrinsicHandler(TR_VectorAPIExpansion *
       if (vectorOpCode == TR::BadILOp)
           return NULL;
 
-      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType))
+      if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode, elementType, OMR::DataType::bitsToVectorLength(vectorLength)))
          return NULL;
 
       return node;
@@ -1625,7 +1629,8 @@ TR::Node *TR_VectorAPIExpansion::transformNary(TR_VectorAPIExpansion *opt, TR::T
       }
    else if (mode == doVectorization)
       {
-      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector();
+      TR::VectorLength lengthEnum = supportedOnPlatform(comp, vectorLength);
+      TR::DataType vectorType = OMR::DataType(elementType).scalarToVector(lengthEnum);
 
       for (int32_t i = 0; i < numOperands; i++)
          {

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -938,9 +938,6 @@ int32_t J9::Power::JNILinkage::buildJNIArgs(TR::Node *callNode,
                }
             numFloatArgs++;
             break;
-         case TR::VectorDouble:
-            TR_ASSERT(false, "JNI dispatch: VectorDouble argument not expected");
-            break;
          case TR::Aggregate:
             {
             size_t size = child->getSymbolReference()->getSymbol()->getSize();
@@ -955,6 +952,13 @@ int32_t J9::Power::JNILinkage::buildJNIArgs(TR::Node *callNode,
             }
             break;
          default:
+            if (child->getDataType().isVector() &&
+                child->getDataType().getVectorElementType() == TR::Double)
+               {
+               TR_ASSERT(false, "JNI dispatch: VectorDouble argument not expected");
+               break;
+               }
+
             TR_ASSERT(false, "Argument type %s is not supported\n", child->getDataType().toString());
          }
       }
@@ -1315,9 +1319,13 @@ int32_t J9::Power::JNILinkage::buildJNIArgs(TR::Node *callNode,
 
             }    // end of for loop
             break;
-         case TR::VectorDouble:
-            TR_ASSERT(false, "JNI dispatch: VectorDouble argument not expected");
-            break;
+
+         default:
+            if (childType.isVector() && childType.getVectorElementType() == TR::Double)
+               {
+               TR_ASSERT(false, "JNI dispatch: VectorDouble argument not expected");
+               break;
+               }
          }
       }
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -939,17 +939,17 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
          case TR::UnicodeDecimalSignTrailing:
          case TR::Aggregate:
             break;
-         case TR::VectorInt8:
-         case TR::VectorInt16:
-         case TR::VectorInt32:
-         case TR::VectorInt64:
-         case TR::VectorDouble:
-            if (numVectorArgs < self()->getNumVectorArgumentRegisters())
+         default:
+            if (dt.isVector())
                {
-               index = numVectorArgs;
+               // TODO: special handling for Float?
+               if (numVectorArgs < self()->getNumVectorArgumentRegisters())
+                  {
+                  index = numVectorArgs;
+                  }
+               numVectorArgs++;
+               break;
                }
-            numVectorArgs++;
-            break;
          }
       paramCursor->setLinkageRegisterIndex(index);
       paramCursor = paramIterator.getNext();


### PR DESCRIPTION
- see https://github.com/eclipse/omr/pull/6353 for the background
- to enable VectorAPI support, VectorAPIExpansion::supportedOnPlatform needs to be modified
  correspondingly
- to enable specific opcode getSupportsOpCodeForAutoSIMD needs to be modified correspondingly

depends https://github.com/eclipse/omr/pull/6353