### PR TITLE
Fix AArch64 cache line size in ContendedFieldsTests

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,13 @@ public class ContendedFieldsTests {
 			CACHE_LINE_SIZE = 256;			
 		} else if (osArch.startsWith("amd64") || osArch.startsWith("x86")) {
 			CACHE_LINE_SIZE = 64;			
+		} else if (osArch.startsWith("aarch64")) {
+			String osName = System.getProperty("os.name");
+			if (osName.startsWith("Mac OS X")) {
+				CACHE_LINE_SIZE = 128;
+			} else {
+				CACHE_LINE_SIZE = 64;
+			}
 		}
 		jep142Restricted = true;
 		for (String vmarg: ManagementFactory.getRuntimeMXBean().getInputArguments()) {


### PR DESCRIPTION
This commit adds some lines in ContendedFieldsTests for AArch64 cache
line size.

Fixes: #14501

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>