### PR TITLE
Fix scalarization of broadcast for byte and short

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1407,10 +1407,10 @@ TR::Node *TR_VectorAPIExpansion::broadcastCoercedIntrinsicHandler(TR_VectorAPIEx
           newNode = TR::Node::create(node, TR::lbits2d, 1, valueToBroadcast);
           break;
       case TR::Int8:
-          newNode = TR::Node::create(node, TR::l2b, 1, valueToBroadcast);
+         newNode = TR::Node::create(node, doScalarization ? TR::l2i : TR::l2b, 1, valueToBroadcast);
           break;
       case TR::Int16:
-          newNode = TR::Node::create(node, TR::l2s, 1, valueToBroadcast);
+         newNode = TR::Node::create(node, doScalarization ? TR::l2i : TR::l2s, 1, valueToBroadcast);
           break;
       case TR::Int32:
           newNode = TR::Node::create(node, TR::l2i, 1, valueToBroadcast);


### PR DESCRIPTION
- broadcast long argument should be converted to int instead of byte or short
since we promote byte and short into int during scalarization