### PR TITLE
(0.31.0) Exclude cmdLineTester_fieldwatchtests on AArch64 macOS

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -368,6 +368,12 @@
 	${TEST_STATUS}</command>
 		<!-- Option -XX:+JitInlineWatches is currently unsupported on arm -->
 		<platformRequirements>^arch.arm</platformRequirements>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14502</comment>
+				<platform>aarch64.*mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit excludes cmdLineTester_fieldwatchtests in
extended.functional on AArch64 macOS.

Original PR in master: #14523

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>