### PR TITLE
Change recognized Math.fma method on Z to use scalar instructions

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3669,19 +3669,13 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
    if (self()->isMethodInAtomicLongGroup(method))
       return true;
 
-   if (self()->getSupportsVectorRegisters()){
-      if (method == TR::java_lang_Math_fma_D ||
-          method == TR::java_lang_StrictMath_fma_D)
-         {
-         return true;
-         }
-      if (comp->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1) &&
-            (method == TR::java_lang_Math_fma_F ||
-             method == TR::java_lang_StrictMath_fma_F))
-         {
-         return true;
-         }
-   }
+   if (method == TR::java_lang_Math_fma_D ||
+       method == TR::java_lang_StrictMath_fma_D ||
+       method == TR::java_lang_Math_fma_F ||
+       method == TR::java_lang_StrictMath_fma_F)
+      {
+      return true;
+      }
 
    if (method == TR::java_lang_Integer_highestOneBit ||
        method == TR::java_lang_Integer_numberOfLeadingZeros ||
@@ -4033,41 +4027,33 @@ J9::Z::CodeGenerator::inlineDirectCall(
          }
       }
 
-      if (!comp->getOption(TR_DisableSIMDDoubleMaxMin) && cg->getSupportsVectorRegisters())
+   if (!comp->getOption(TR_DisableSIMDDoubleMaxMin) && cg->getSupportsVectorRegisters())
+      {
+      switch (methodSymbol->getRecognizedMethod())
          {
-         switch (methodSymbol->getRecognizedMethod())
-            {
-            case TR::java_lang_Math_max_D:
-               resultReg = TR::TreeEvaluator::inlineDoubleMax(node, cg);
-               return true;
-            case TR::java_lang_Math_min_D:
-               resultReg = TR::TreeEvaluator::inlineDoubleMin(node, cg);
-               return true;
-            default:
-               break;
-            }
+         case TR::java_lang_Math_max_D:
+            resultReg = TR::TreeEvaluator::inlineDoubleMax(node, cg);
+            return true;
+         case TR::java_lang_Math_min_D:
+            resultReg = TR::TreeEvaluator::inlineDoubleMin(node, cg);
+            return true;
+         default:
+            break;
          }
-      if (cg->getSupportsVectorRegisters())
-         {
-         switch (methodSymbol->getRecognizedMethod())
-            {
-            case TR::java_lang_Math_fma_D:
-            case TR::java_lang_StrictMath_fma_D:
-               resultReg = TR::TreeEvaluator::inlineMathFma(node, cg);
-               return true;
+      }
 
-            case TR::java_lang_Math_fma_F:
-            case TR::java_lang_StrictMath_fma_F:
-               if (comp->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1))
-                  {
-                  resultReg = TR::TreeEvaluator::inlineMathFma(node, cg);
-                  return true;
-                  }
-               break;
-            default:
-               break;
-            }
-         }
+   switch (methodSymbol->getRecognizedMethod())
+      {
+      case TR::java_lang_Math_fma_D:
+      case TR::java_lang_StrictMath_fma_D:
+      case TR::java_lang_Math_fma_F:
+      case TR::java_lang_StrictMath_fma_F:
+         resultReg = TR::TreeEvaluator::inlineMathFma(node, cg);
+         return true;
+
+      default:
+         break;
+      }
 
    TR::MethodSymbol * symbol = node->getSymbol()->castToMethodSymbol();
    if ((symbol->isVMInternalNative() || symbol->isJITInternalNative()) || isKnownMethod(methodSymbol))

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2238,22 +2238,42 @@ J9::Z::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGenerator *cg)
    TR_ASSERT_FATAL(node->getNumChildren() == 3,
    "In function inlineMathFma, the node at address %p should have exactly 3 children, but got %u instead", node, node->getNumChildren());
 
-   TR::Register      * targetRegister      = cg->allocateRegister(TR_FPR);
+   TR::Register * a      = cg->evaluate(node->getFirstChild());
+   TR::Register * b      = cg->evaluate(node->getSecondChild());
+   TR::Register * target = NULL;
 
-   TR::Register      * v1      = cg->evaluate(node->getFirstChild());
-   TR::Register      * v2      = cg->evaluate(node->getSecondChild());
-   TR::Register      * v3      = cg->evaluate(node->getThirdChild());
+   if (cg->getSupportsVectorRegisters() &&
+         (!node->getOpCode().isFloat() ||
+           cg->comp()->target().cpu.getSupportsVectorFacilityEnhancement1()))
+      {
+      // target = a*b + c
+      TR::Register * c = cg->evaluate(node->getThirdChild());
+      target = cg->allocateRegister(TR_FPR);
+      uint8_t mask6 = getVectorElementSizeMask(TR::DataType::getSize(node->getDataType()));
+      generateVRReInstruction(cg, TR::InstOpCode::VFMA, node, target, a, b, c, mask6, 0);
+      }
+   else
+      {
+      // target = c
+      // target += a*b
+      target = cg->fprClobberEvaluate(node->getThirdChild());
+      if (node->getDataType() == TR::Double)
+         {
+         generateRRDInstruction(cg, TR::InstOpCode::MADBR, node, target, a, b);
+         }
+      else
+         {
+         generateRRDInstruction(cg, TR::InstOpCode::MAEBR, node, target, a, b);
+         }
+      }
 
-   uint8_t mask6 = getVectorElementSizeMask(TR::DataType::getSize(node->getDataType()));
-   generateVRReInstruction(cg, TR::InstOpCode::VFMA, node, targetRegister, v1, v2, v3, mask6, 0);
-
-   node->setRegister(targetRegister);
+   node->setRegister(target);
 
    cg->decReferenceCount(node->getFirstChild());
    cg->decReferenceCount(node->getSecondChild());
    cg->decReferenceCount(node->getThirdChild());
 
-   return targetRegister;
+   return target;
    }
 
 /*


### PR DESCRIPTION
Math.fma and StrictMath.fma [were implemented](https://github.com/eclipse-openj9/openj9/pull/8445) as recognized methods on Z with the vector `VFMA` instruction. This patch changes the implementation to use non vector `MAEBR`/`MADBR` instruction.