### PR TITLE
Implement SVM J2I thunk validation and guarantee resolved virtual dispatch under SVM on x86

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1283,6 +1283,15 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_ValidateJ2IThunkFromMethod:
+         {
+         auto *thunkRecord = reinterpret_cast<TR_RelocationRecordValidateJ2IThunkFromMethod *>(reloRecord);
+         auto *svmRecord = reinterpret_cast<TR::J2IThunkFromMethodRecord *>(relocation->getTargetAddress());
+         thunkRecord->setThunkID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_thunk));
+         thunkRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
+         }
+         break;
+
       default:
          TR_ASSERT(false, "Unknown relo type %d!\n", kind);
          comp->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown relo type %d!\n", kind);
@@ -2167,6 +2176,22 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
             traceMsg(self()->comp(), "\n Breakpoint Guard: Inlined site index = %d, destinationAddress = %p",
                      bpgRecord->inlinedSiteIndex(reloTarget),
                      bpgRecord->destinationAddress(reloTarget));
+            }
+         }
+         break;
+
+      case TR_ValidateJ2IThunkFromMethod:
+         {
+         auto *thunkRecord = reinterpret_cast<TR_RelocationRecordValidateJ2IThunkFromMethod *>(reloRecord);
+
+         self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(
+               self()->comp(),
+               "\n Validate J2I Thunk From Method: thunkID=%d, methodID=%d",
+               thunkRecord->thunkID(reloTarget),
+               thunkRecord->methodID(reloTarget));
             }
          }
          break;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 37;
+   static const uint16_t MINOR_NUMBER = 38;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1896,5 +1896,24 @@ class TR_RelocationRecordBreakpointGuard : public TR_RelocationRecordWithInlined
       uintptr_t destinationAddress(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordValidateJ2IThunkFromMethod : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateJ2IThunkFromMethod() {}
+      TR_RelocationRecordValidateJ2IThunkFromMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateJ2IThunkFromMethod"; }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setThunkID(TR_RelocationTarget *reloTarget, uint16_t methodClassID);
+      uint16_t thunkID(TR_RelocationTarget *reloTarget);
+
+      void setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID);
+      uint16_t methodID(TR_RelocationTarget *reloTarget);
+   };
+
 #endif   // RELOCATION_RECORD_INCL
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -676,6 +676,21 @@ struct ImproperInterfaceMethodFromCPRecord : public MethodValidationRecord
    int32_t _cpIndex;
    };
 
+struct J2IThunkFromMethodRecord : public SymbolValidationRecord
+   {
+   J2IThunkFromMethodRecord(void *thunk, TR_OpaqueMethodBlock *method)
+      : SymbolValidationRecord(TR_ValidateJ2IThunkFromMethod),
+        _thunk(thunk),
+        _method(method)
+      {}
+
+   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
+   virtual void printFields();
+
+   void *_thunk;
+   TR_OpaqueMethodBlock *_method;
+   };
+
 class SymbolValidationManager
    {
 public:
@@ -759,6 +774,7 @@ public:
 
    bool addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames);
    bool addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized);
+   void addJ2IThunkFromMethodRecord(void *thunk, TR_OpaqueMethodBlock *method);
 
 
 
@@ -804,6 +820,11 @@ public:
 
    bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames);
    bool validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized);
+
+   // For J2IThunkFromMethod records, the actual thunk is loaded if necessary
+   // in TR_RelocationRecordValidateJ2IThunkFromMethod::applyRelocation() so
+   // that the thunk loading logic can be confined to RelocationRecord.cpp.
+   bool validateJ2IThunkFromMethodRecord(uint16_t thunkID, void *thunk);
 
 
    TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t & numDims);

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -98,6 +98,9 @@ public:
 
    // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
    bool guaranteesResolvedDirectDispatchForSVM() { return true; }
+
+   // See J9::CodeGenerator::guaranteesResolvedVirtualDispatchForSVM
+   bool guaranteesResolvedVirtualDispatchForSVM() { return true; }
    };
 
 }

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -708,6 +708,8 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(
       }
    else if (resolvedSite && site.resolvedVirtualShouldUseVFTCall())
       {
+      // There are no J2I thunks on x86-32, so no J2I thunk validation is needed
+
       if (entryLabel)
          generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 


### PR DESCRIPTION
The J2I thunk from method validation ensures that the J2I thunk appropriate to the method specified by the given method ID exists and is registered with the VM, and uses the address of the J2I thunk to define the given thunk ID.

Then with this validation, it's very straightforward to guarantee resolved virtual dispatch under SVM on x86. This will allow the IL generator to generate a resolved virtual call node for `invokeinterface` when calling a non-final method of `Object`, e.g. `toString()`.

This PR requires eclipse/omr#6358 to be merged first