### PR TITLE
JDK19 uses NativeLibraries.newInstance() API

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -206,7 +206,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava18.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava19.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=19"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>


### PR DESCRIPTION
Also updated reference to `rt-compressed.sunJava19.jar` for pConfig compilation.

JDK19 `openj9-staging` branch builds w/ this PR and `-version` output:
```
openjdk version "19-internal" 2022-09-20
OpenJDK Runtime Environment (build 19-internal-adhoc.jasonfeng.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-ed430d715a4, JRE 19 Mac OS X amd64-64-Bit Compressed References 20220217_000000 (JIT enabled, AOT enabled)
OpenJ9   - ed430d715a4
OMR      - 2f87d0fa1
JCL      - 289d0fccf8d based on jdk-19+10)
```

closes https://github.com/eclipse-openj9/openj9/issues/14539

Signed-off-by: Jason Feng <fengj@ca.ibm.com>