### PR TITLE
Avoid r11 in iTable offset tag bits check on Power

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -2645,7 +2645,7 @@ _interfaceSlotsUnavailable:
         bne     .L.callHelper
         ! lastITable is a match
         laddr   r12, 4*ALen(r11)                                ! Load the itable offset from the snippet
-        andi.   r11,r12,J9TR_J9_ITABLE_OFFSET_TAG_BITS          ! Call the helper if the itable offset is tagged
+        andi.   r0, r12, J9TR_J9_ITABLE_OFFSET_TAG_BITS         ! Call the helper if the itable offset is tagged
         bne     .L.callHelper
         laddrx  r12, r9, r12                                    ! Load the interpreter vft offset
         neg     r12, r12


### PR DESCRIPTION
We need to maintain the contents of `r11` for the case where we have
to call the helper. The GPR result of the `andi.` therefore needs to go
into another register. The GPR result isn't actually needed, only the
result of the test against 0 (stored in `cr0`) is, so we can use any
register that's free at that moment. `r0` is a good candidate.

Fixes https://github.com/eclipse-openj9/openj9/issues/14465

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>