### PR TITLE
Update JITServer minor version

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -99,7 +99,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 36;
+   static const uint16_t MINOR_NUMBER = 37;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/14421 changed the layout of the relocation data. As such, the JITServer minor version has to be updated.