### PR TITLE
Separate tests that rely on SecurityManager (JLM_Tests)

### DIFF
--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,18 +81,30 @@
 					</else>
 				</if>
 				<property name="TestUtilitiesExports" value="--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_90}" />
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" />
-					<compilerarg line='${addExports} ${TestUtilitiesExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/commons-exec.jar" />
-					</classpath>
-				</javac>
+				<property name="srcpath" location="${src}:${src_90}:${transformerListener}:${TestUtilities}" />
+				<path id="build.cp">
+					<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
+					<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
+					<fileset dir="${LIB_DIR}/" includes="commons-exec.jar"/>
+				</path>
+				<if>
+					<matches string="${JDK_VERSION}" pattern="^(9|(1[0-8]))$$" />
+					<then>
+						<!-- Java 9-18 -->
+						<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+							<compilerarg line='${addExports} ${TestUtilitiesExports}' />
+						</javac>
+					</then>
+					<else>
+						<!-- Java 19+ (SecurityManager removed) -->
+						<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+							<compilerarg line='${addExports} ${TestUtilitiesExports}' />
+							<!-- exclude tests that depend on SecurityManager -->
+							<exclude name="org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java" />
+							<exclude name="org/openj9/test/java/lang/management/TestRegression_SM.java" />
+						</javac>
+					</else>
+				</if>
 			</else>
 		</if>
 	</target>

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,6 @@ import javax.management.openmbean.CompositeData;
 import com.ibm.lang.management.MemoryMXBean;
 
 import org.openj9.test.util.VersionCheck;
-import org.openj9.test.util.process.Task;
 
 // These classes are not public API.
 import com.ibm.java.lang.management.internal.MemoryNotificationInfoUtil;
@@ -145,20 +144,6 @@ public class TestMemoryMXBean {
 		MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
 		if (bean.isSetMaxHeapSizeSupported()) {
 			bean.setMaxHeapSize(bean.getMaxHeapSizeLimit());
-		}
-	}
-
-	static class ClassForTestMaxHeapSize implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			Thread.sleep(2000);
-			long size = bean.getMinHeapSize();
-			bean.setMaxHeapSize(size + 1024);
-			if (size + 1024 != bean.getMaxHeapSize()) {
-				throw new RuntimeException("not equal");
-			}
 		}
 	}
 

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMisc.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMisc.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ public class TestMisc {
 
 	@Test
 	public void testVerboseSetting() {
-		if (System.getSecurityManager() == null) {
+		try {
 			String val1 = System.getProperty("com.ibm.lang.management.verbose");
 
 			if (val1 != null) {
@@ -59,6 +59,8 @@ public class TestMisc {
 			} else {
 				AssertJUnit.assertFalse(ManagementUtils.VERBOSE_MODE);
 			} // end else com.ibm.lang.management.verbose was already set
+		} catch (SecurityException e) {
+			/* Security Manager was set; ignore */
 		}
 	}
 

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRegression.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRegression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,14 +24,11 @@ package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
-import org.testng.Assert;
-import org.testng.AssertJUnit;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
-import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
 
 /**
@@ -77,21 +74,6 @@ public class TestRegression {
 				logger.debug("Lock Owner ID = " + threadData.getLockOwnerId());
 			}
 			logger.debug("\n");
-		}
-	}
-
-	@Test
-	public final void testBug93006() {
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-
-		System.setSecurityManager(new SecurityManager());
-		AssertJUnit.assertNotNull(System.getSecurityManager());
-
-		try {
-			MBeanServer mbs2 = ManagementFactory.getPlatformMBeanServer();
-			Assert.fail("Should have thrown a SecurityException");
-		} catch (Exception e) {
-			AssertJUnit.assertTrue(e instanceof SecurityException);
 		}
 	}
 }

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRegression_SM.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRegression_SM.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.java.lang.management;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+
+/**
+ * Tests to catch regressions on reported bugs.
+ */
+@Test(groups = { "level.sanity" })
+public class TestRegression_SM {
+
+	@Test
+	public final void testBug93006() {
+		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+
+		System.setSecurityManager(new SecurityManager());
+		AssertJUnit.assertNotNull(System.getSecurityManager());
+
+		try {
+			MBeanServer mbs2 = ManagementFactory.getPlatformMBeanServer();
+			Assert.fail("Should have thrown a SecurityException");
+		} catch (Exception e) {
+			AssertJUnit.assertTrue(e instanceof SecurityException);
+		}
+	}
+}

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,10 +174,12 @@ public class TestRuntimeMXBean {
 			AssertJUnit.assertNotNull(mbs.getAttribute(objName, "SystemProperties"));
 			AssertJUnit.assertTrue(mbs.getAttribute(objName, "SystemProperties") instanceof TabularData);
 			AssertJUnit.assertTrue(((TabularData)(mbs.getAttribute(objName, "SystemProperties"))).size() > 0);
-			if (System.getSecurityManager() == null) {
+			try {
 				AssertJUnit.assertTrue(((TabularData)(mbs.getAttribute(objName, "SystemProperties"))).size() ==
 						System.getProperties().size());
-			} // end if no security manager
+			} catch (SecurityException e) {
+				/* Security Manager was set; ignore */
+			}
 
 			AssertJUnit.assertNotNull(mbs.getAttribute(objName, "Uptime"));
 			AssertJUnit.assertTrue(mbs.getAttribute(objName, "Uptime") instanceof Long);
@@ -332,8 +334,10 @@ public class TestRuntimeMXBean {
 		AssertJUnit.assertTrue(props instanceof Map);
 		AssertJUnit.assertTrue(props.size() > 0);
 
-		if (System.getSecurityManager() == null) {
+		try {
 			AssertJUnit.assertTrue(props.size() == System.getProperties().size());
+		} catch (SecurityException e) {
+			/* Security Manager was set; ignore */
 		}
 	}
 
@@ -506,7 +510,7 @@ public class TestRuntimeMXBean {
 						// the SystemProperties.
 						TabularData td = (TabularData)value;
 						AssertJUnit.assertTrue(td.size() > 0);
-						if (System.getSecurityManager() == null) {
+						try {
 							Properties props = System.getProperties();
 							AssertJUnit.assertTrue(td.size() == props.size());
 							Enumeration<?> propNames = props.propertyNames();
@@ -515,7 +519,9 @@ public class TestRuntimeMXBean {
 								String propVal = props.getProperty(property);
 								AssertJUnit.assertEquals(propVal, td.get(new String[] { property }).get("value"));
 							} // end while
-						} // end if no security manager
+						} catch (SecurityException e) {
+							/* Security Manager was set; ignore */
+						}
 					} // end else a String array expected
 				} // end if a known attribute
 				else {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,13 +29,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import java.lang.management.ManagementFactory;
-import java.security.AccessControlException;
 
 import com.ibm.lang.management.MemoryMXBean;
-
-import org.openj9.test.util.process.ProcessRunner;
-import org.openj9.test.util.process.Task;
-
 
 @Test(groups = { "level.sanity" })
 public class TestSharedClassMemoryMXBean {
@@ -51,66 +46,6 @@ public class TestSharedClassMemoryMXBean {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
-	}
-
-	static class ClassForTestSharedClassSoftmx implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			long size = 10 * 1024 * 1024;
-
-			bean.setSharedClassCacheSoftmxBytes(size);
-			AssertJUnit.assertTrue(size == bean.getSharedClassCacheSoftmxBytes());
-		}
-	}
-
-	static class ClassForTestSharedClassMaxAotBytes implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			long size = 1024 * 1024;
-
-			bean.setSharedClassCacheMaxAotBytes(size);
-			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMaxAotBytes());
-		}
-	}
-
-	static class ClassForTestSharedClassMinAotBytes implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			long size = 1024 * 1024;
-
-			bean.setSharedClassCacheMinAotBytes(size);
-			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMinAotBytes());
-		}
-	}
-
-	static class ClassForTestSharedClassMaxJitDataBytes implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			long size = 1024 * 1024;
-
-			bean.setSharedClassCacheMaxJitDataBytes(size);
-			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMaxJitDataBytes());
-		}
-	}
-
-	static class ClassForTestSharedClassMinJitDataBytes implements Task {
-		@Override
-		public void run() throws Exception {
-			System.setSecurityManager(new SecurityManager());
-			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
-			long size = 1024 * 1024;
-
-			bean.setSharedClassCacheMinJitDataBytes(size);
-			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMinJitDataBytes());
-		}
 	}
 
 	@Test
@@ -157,24 +92,6 @@ public class TestSharedClassMemoryMXBean {
 	}
 
 	@Test
-	public void testSeSharedClassSoftmxSizeWithSecurityManager() throws Exception {
-		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
-				/*
-				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
-				 */
-				new ProcessRunner(new ClassForTestSharedClassSoftmx()).run();
-				Assert.fail(
-						"testSeSharedClassSoftmxSizeWithSecurityManager: should throw java.security.AccessControlException: "
-								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
-			}
-		} catch (AccessControlException e) {
-			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
-			logger.debug(e);
-		}
-	}
-
-	@Test
 	public void testSharedClassMaxAotBytes() {
 		try {
 			long val = mb.getSharedClassCacheMaxAotBytes();
@@ -199,24 +116,6 @@ public class TestSharedClassMemoryMXBean {
 
 		} catch (Throwable e) {
 			Assert.fail("Caught unexpected exception : " + e.getMessage());
-		}
-	}
-
-	@Test
-	public void testSeSharedClassMaxAotWithSecurityManager() throws Exception {
-		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
-				/*
-				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
-				 */
-				new ProcessRunner(new ClassForTestSharedClassMaxAotBytes()).run();
-				Assert.fail(
-						"testSeSharedClassMaxAotWithSecurityManager: should throw java.security.AccessControlException: "
-								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
-			}
-		} catch (AccessControlException e) {
-			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
-			logger.debug(e);
 		}
 	}
 
@@ -249,24 +148,6 @@ public class TestSharedClassMemoryMXBean {
 	}
 
 	@Test
-	public void testSeSharedClassMinAotWithSecurityManager() throws Exception {
-		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
-				/*
-				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
-				 */
-				new ProcessRunner(new ClassForTestSharedClassMinAotBytes()).run();
-				Assert.fail(
-						"testSeSharedClassMinAotWithSecurityManager: should throw java.security.AccessControlException: "
-								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
-			}
-		} catch (AccessControlException e) {
-			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
-			logger.debug(e);
-		}
-	}
-
-	@Test
 	public void testSharedClassMaxJitDataBytes() {
 		try {
 			long val = mb.getSharedClassCacheMaxJitDataBytes();
@@ -294,24 +175,6 @@ public class TestSharedClassMemoryMXBean {
 	}
 
 	@Test
-	public void testSeSharedClassMaxJitDataWithSecurityManager() throws Exception {
-		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
-				/*
-				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
-				 */
-				new ProcessRunner(new ClassForTestSharedClassMaxJitDataBytes()).run();
-				Assert.fail(
-						"testSeSharedClassMaxJitDataWithSecurityManager: should throw java.security.AccessControlException: "
-								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
-			}
-		} catch (AccessControlException e) {
-			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
-			logger.debug(e);
-		}
-	}
-
-	@Test
 	public void testSharedClassMinJitDataBytes() {
 		try {
 			long val = mb.getSharedClassCacheMinJitDataBytes();
@@ -335,24 +198,6 @@ public class TestSharedClassMemoryMXBean {
 			}
 		} catch (Throwable e) {
 			Assert.fail("Caught unexpected exception : " + e.getMessage());
-		}
-	}
-
-	@Test
-	public void testSeSharedClassMinJitDataWithSecurityManager() throws Exception {
-		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
-				/*
-				 * It on hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
-				 */
-				new ProcessRunner(new ClassForTestSharedClassMinJitDataBytes()).run();
-				Assert.fail(
-						"testSeSharedClassMinJitDataWithSecurityManager: should throw java.security.AccessControlException: "
-								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
-			}
-		} catch (AccessControlException e) {
-			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
-			logger.debug(e);
 		}
 	}
 

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.java.lang.management;
+
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+import org.testng.annotations.BeforeClass;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import java.lang.management.ManagementFactory;
+import java.security.AccessControlException;
+
+import com.ibm.lang.management.MemoryMXBean;
+
+import org.openj9.test.util.process.ProcessRunner;
+import org.openj9.test.util.process.Task;
+
+@Test(groups = { "level.sanity" })
+public class TestSharedClassMemoryMXBean_SM {
+
+	private static Logger logger = Logger.getLogger(TestSharedClassMemoryMXBean_SM.class);
+
+	@BeforeClass
+	protected void setUp() throws Exception {
+		logger.info("Starting TestSharedClassMemoryMXBean_SM tests ...");
+	}
+
+	static class ClassForTestSharedClassSoftmx implements Task {
+		@Override
+		public void run() throws Exception {
+			System.setSecurityManager(new SecurityManager());
+			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+			long size = 10 * 1024 * 1024;
+
+			bean.setSharedClassCacheSoftmxBytes(size);
+			AssertJUnit.assertTrue(size == bean.getSharedClassCacheSoftmxBytes());
+		}
+	}
+
+	static class ClassForTestSharedClassMaxAotBytes implements Task {
+		@Override
+		public void run() throws Exception {
+			System.setSecurityManager(new SecurityManager());
+			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+			long size = 1024 * 1024;
+
+			bean.setSharedClassCacheMaxAotBytes(size);
+			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMaxAotBytes());
+		}
+	}
+
+	static class ClassForTestSharedClassMinAotBytes implements Task {
+		@Override
+		public void run() throws Exception {
+			System.setSecurityManager(new SecurityManager());
+			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+			long size = 1024 * 1024;
+
+			bean.setSharedClassCacheMinAotBytes(size);
+			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMinAotBytes());
+		}
+	}
+
+	static class ClassForTestSharedClassMaxJitDataBytes implements Task {
+		@Override
+		public void run() throws Exception {
+			System.setSecurityManager(new SecurityManager());
+			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+			long size = 1024 * 1024;
+
+			bean.setSharedClassCacheMaxJitDataBytes(size);
+			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMaxJitDataBytes());
+		}
+	}
+
+	static class ClassForTestSharedClassMinJitDataBytes implements Task {
+		@Override
+		public void run() throws Exception {
+			System.setSecurityManager(new SecurityManager());
+			MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+			long size = 1024 * 1024;
+
+			bean.setSharedClassCacheMinJitDataBytes(size);
+			AssertJUnit.assertTrue(size == bean.getSharedClassCacheMinJitDataBytes());
+		}
+	}
+
+	@Test
+	public void testSeSharedClassSoftmxSizeWithSecurityManager() throws Exception {
+		try {
+			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+				/*
+				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
+				 */
+				new ProcessRunner(new ClassForTestSharedClassSoftmx()).run();
+				Assert.fail(
+						"testSeSharedClassSoftmxSizeWithSecurityManager: should throw java.security.AccessControlException: "
+								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
+			}
+		} catch (AccessControlException e) {
+			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
+			logger.debug(e);
+		}
+	}
+
+	@Test
+	public void testSeSharedClassMaxAotWithSecurityManager() throws Exception {
+		try {
+			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+				/*
+				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
+				 */
+				new ProcessRunner(new ClassForTestSharedClassMaxAotBytes()).run();
+				Assert.fail(
+						"testSeSharedClassMaxAotWithSecurityManager: should throw java.security.AccessControlException: "
+								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
+			}
+		} catch (AccessControlException e) {
+			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
+			logger.debug(e);
+		}
+	}
+
+	@Test
+	public void testSeSharedClassMinAotWithSecurityManager() throws Exception {
+		try {
+			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+				/*
+				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
+				 */
+				new ProcessRunner(new ClassForTestSharedClassMinAotBytes()).run();
+				Assert.fail(
+						"testSeSharedClassMinAotWithSecurityManager: should throw java.security.AccessControlException: "
+								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
+			}
+		} catch (AccessControlException e) {
+			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
+			logger.debug(e);
+		}
+	}
+
+	@Test
+	public void testSeSharedClassMaxJitDataWithSecurityManager() throws Exception {
+		try {
+			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+				/*
+				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
+				 */
+				new ProcessRunner(new ClassForTestSharedClassMaxJitDataBytes()).run();
+				Assert.fail(
+						"testSeSharedClassMaxJitDataWithSecurityManager: should throw java.security.AccessControlException: "
+								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
+			}
+		} catch (AccessControlException e) {
+			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
+			logger.debug(e);
+		}
+	}
+
+	@Test
+	public void testSeSharedClassMinJitDataWithSecurityManager() throws Exception {
+		try {
+			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+				/*
+				 * It on hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
+				 */
+				new ProcessRunner(new ClassForTestSharedClassMinJitDataBytes()).run();
+				Assert.fail(
+						"testSeSharedClassMinJitDataWithSecurityManager: should throw java.security.AccessControlException: "
+								+ "Access denied (\"java.lang.management.ManagementPermission\" \"control\")");
+			}
+		} catch (AccessControlException e) {
+			AssertJUnit.assertTrue(e.getMessage().contains("ManagementPermission"));
+			logger.debug(e);
+		}
+	}
+}

--- a/test/functional/JLM_Tests/testng.xml
+++ b/test/functional/JLM_Tests/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,10 +90,12 @@
 			<class name="org.openj9.test.java.lang.management.TestLoggingMXBean" />
 			<!-- //not run in rtctest <class name="org.openj9.test.java.lang.management.TestJvmCpuMonitorMXBeanEx"/> -->
 			<!-- // This test runs fine when executed standalone, but when // executed
-				in batch (with other tests), it fails. <class name="org.openj9.test.java.lang.management.TestSharedClassMemoryMXBean"/> -->
+				in batch (with other tests), it fails. <class name="org.openj9.test.java.lang.management.TestSharedClassMemoryMXBean"/>
+				SecurityManager tests: <class name="org.openj9.test.java.lang.management.TestSharedClassMemoryMXBean_SM"/> -->
 			<!-- // Fixing this test suite is out of scope - neither are these //
 				tests related to DynamicMBean V. StandardMBean nor do they // seem to have
-				simple fixes. <class name="org.openj9.test.java.lang.management.TestRegression"/> -->
+				simple fixes. <class name="org.openj9.test.java.lang.management.TestRegression"/>
+				SecurityManager tests: <class name="org.openj9.test.java.lang.management.TestRegression_SM"/> -->
 		</classes>
 	</test> <!-- JLM_Tests -->
 


### PR DESCRIPTION
SecurityManager will be removed in a future jdk. Separate tests that
rely on it so that they can be easily disabled in the future.

Issue: #14412
Signed-off-by: Eric Yang <eric.yang@ibm.com>