### PR TITLE
Remove unflattened test cases for get/putValue

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -6554,18 +6554,20 @@ public final class Unsafe {
 
 	/*[IF INLINE-TYPES]*/
 	/**
-	 * Retrieves the primitive type in the obj parameter referenced by offset.
+	 * Retrieves the value of the primitive type in the obj parameter referenced by offset.
+	 * The primitive type in obj at the given offset must be flattened.
 	 * This is a non-volatile operation.
 	 *
 	 * @param obj object from which to retrieve the primitive type
 	 * @param offset position of the primitive type in obj
 	 * @param clz the class of primitive type to return
-	 * @return primitive type stored in obj
+	 * @return the value of the primitive type stored in obj at the given offset
 	 */
 	public native <V> V getValue(Object obj, long offset, Class<?> clz);
 
 	/**
 	 * Sets the value of the primitive type in the obj parameter at memory offset.
+	 * Both the new value and the primitive type in obj at the given offset must be flattened.
 	 * This is a non-volatile operation.
 	 *
 	 * @param obj object into which to store the primitive type

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4004,7 +4004,7 @@ done:
 			J9Class *clzJ9Class = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, clz);
 
 			if (J9_IS_J9CLASS_VALUETYPE(clzJ9Class)) {
-				result = VM_ValueTypeHelpers::getFlattenableFieldAtOffset(
+				result = VM_ValueTypeHelpers::getFlattenedFieldAtOffset(
 					_currentThread,
 					_objectAccessBarrier,
 					_objectAllocate,
@@ -4014,7 +4014,9 @@ done:
 					true);
 
 				if (NULL == result) {
-					result = VM_ValueTypeHelpers::getFlattenableFieldAtOffset(
+					buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
+					updateVMStruct(REGISTER_ARGS);
+					result = VM_ValueTypeHelpers::getFlattenedFieldAtOffset(
 						_currentThread,
 						_objectAccessBarrier,
 						_objectAllocate,
@@ -4022,6 +4024,8 @@ done:
 						obj,
 						offset,
 						false);
+					VMStructHasBeenUpdated(REGISTER_ARGS);
+					restoreGenericSpecialStackFrame(REGISTER_ARGS);
 				}
 			}
 		} else {
@@ -4048,7 +4052,7 @@ done:
 			J9Class *clzJ9Class = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, clz);
 
 			if (J9_IS_J9CLASS_VALUETYPE(clzJ9Class)) {
-				VM_ValueTypeHelpers::putFlattenableFieldAtOffset(_currentThread,
+				VM_ValueTypeHelpers::putFlattenedFieldAtOffset(_currentThread,
 					_objectAccessBarrier,
 					clzJ9Class,
 					value,

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -55,7 +55,7 @@ public:
 	 * Function members
 	 */
 private:
-	/*
+	/**
 	* Determine if the two valueTypes are substitutable when rhs.class equals lhs.class
 	* and rhs and lhs are not null
 	*
@@ -237,7 +237,7 @@ public:
 		return acmpResult;
 	}
 
-	/*
+	/**
 	* Determines if a name or a signature pointed by a J9UTF8 pointer is a Qtype.
 	*
 	* @param[in] utfWrapper J9UTF8 pointer that points to the name or the signature
@@ -262,7 +262,7 @@ public:
 		return rc;
 	}
 
-	/*
+	/**
 	* Determines if the classref c=signature is a Qtype. There is no validation performed
 	* to ensure that the cpIndex points at a classref.
 	*
@@ -306,7 +306,7 @@ public:
 			J9FlattenedClassCacheEntry *cache = (J9FlattenedClassCacheEntry *) cpEntry->valueOffset;
 			J9Class *flattenedFieldClass = J9_VM_FCC_CLASS_FROM_ENTRY(cache);
 
-			returnObjectRef = getFlattenableFieldAtOffset(
+			returnObjectRef = getFlattenedFieldAtOffset(
 				currentThread,
 				objectAccessBarrier,
 				objectAllocate,
@@ -324,7 +324,23 @@ public:
 	}
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	static VMINLINE j9object_t getFlattenableFieldAtOffset(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI objectAccessBarrier, MM_ObjectAllocationAPI objectAllocate, J9Class *returnObjectClass, j9object_t srcObject, UDATA srcOffset, bool fastPath) {
+	/**
+	 * Performs a getfield operation on an object given an offset in bytes. Only Handles flattened cases.
+	 *
+	 * @param currentThread thread token
+	 * @param objectAccessBarrier access barrier
+	 * @param objectAllocate allocator
+	 * @param returnObjectClass the class of the field being retrieved
+	 * @param srcObject the object that the field is being retrieved from
+	 * @param srcOffset where in srcObject the field is located (in bytes)
+	 * @param fastPath performs fastpath allocation, no GC. If this is false
+	 * 			frame must be built before calling as GC may occur
+	 *
+	 * @return NULL if allocation fails, valuetype otherwise
+	 */
+	static VMINLINE j9object_t
+	getFlattenedFieldAtOffset(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI objectAccessBarrier, MM_ObjectAllocationAPI objectAllocate, J9Class *returnObjectClass, j9object_t srcObject, UDATA srcOffset, bool fastPath)
+	{
 		j9object_t returnObjectRef = NULL;
 
 		if (fastPath) {
@@ -355,7 +371,19 @@ public:
 		return returnObjectRef;
 	}
 
-	static VMINLINE void putFlattenableFieldAtOffset(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI objectAccessBarrier, J9Class *destObjectClass, j9object_t srcObject, j9object_t destObject, UDATA destOffset) {
+	/**
+	 * Stores a valuetype at a specified offset in a specified object. Only Handles flattened cases.
+	 *
+	 * @param currentThread thread token
+	 * @param objectAccessBarrier access barrier
+	 * @param destObjectClass the class of srcObject
+	 * @param srcObject the object being stored
+	 * @param destObject the object that srcObject is being stored in
+	 * @param destOffset where in destObject to store srcObject (in bytes)
+	 */
+	static VMINLINE void
+	putFlattenedFieldAtOffset(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI objectAccessBarrier, J9Class *destObjectClass, j9object_t srcObject, j9object_t destObject, UDATA destOffset)
+	{
 		UDATA sourceObjectOffset = 0;
 		if (J9CLASS_HAS_4BYTE_PREPADDING(destObjectClass)) {
 			sourceObjectOffset += sizeof(U_32);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeUnsafeTestClasses.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeUnsafeTestClasses.java
@@ -44,8 +44,8 @@ public class ValueTypeUnsafeTestClasses {
 	}
 
 	static class IntWrapper {
-		IntWrapper(int i) { this.i = i; }
-		final int i;
+		IntWrapper(int i) { this.vti = new ValueTypeInt(i); }
+		final ValueTypeInt vti;
 	}
 
 	static class Point2D {


### PR DESCRIPTION
The `putValue` and `getValue` unsafe APIs are not supposed to support unflattened VTs, this PR makes that more clear and removes testing for unflattened VTs

It also fixes an issue in `inlUnsafeGetValue` where a special stack frame wasn't being built.

Resolves https://github.com/eclipse-openj9/openj9/issues/14529 

Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>