### PR TITLE
Simplify -Xaggressive code

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -696,7 +696,7 @@ bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, const char
       return false;
 
    static char *enableJCLFolding = feGetEnv("TR_EnableJCLStaticFinalFieldFolding");
-   if ((enableJCLFolding || comp->getOption(TR_AggressiveOpts))
+   if (enableJCLFolding
        && isStatic
        && comp->fej9()->isClassLibraryClass(clazz)
        && comp->fej9()->isClassInitialized(clazz))


### PR DESCRIPTION
One of the effects of the `-Xaggressive` option is to enable static final field
folding for the JCL classes. Static final field folding is already enabled
under OSR (which is on by default) so this code is now obsolete and will be
deleted in this commit.
For the cases where OSR is disabled we can still enable static final field
folding for JCL classes with the `TR_EnableJCLStaticFinalFieldFolding`
environment variable.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>