### PR TITLE
Fix missing condition for scrubbing reference of unamedModuleObject

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2598,7 +2598,7 @@ MM_CopyForwardScheme::scanClassLoaderObjectSlots(MM_EnvironmentVLHGC *env, MM_Al
 					modulePtr = (J9Module**)hashTableNextDo(&walkState);
 				}
 
-				if (classLoader == _javaVM->systemClassLoader) {
+				if (success && (classLoader == _javaVM->systemClassLoader)) {
 					success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(_javaVM->unamedModuleForSystemLoader->moduleObject));
 				}
 			}
@@ -4281,7 +4281,7 @@ MM_CopyForwardScheme::scanRoots(MM_EnvironmentVLHGC* env)
 										modulePtr = (J9Module**)hashTableNextDo(&walkState);
 									}
 
-									if (classLoader == _javaVM->systemClassLoader) {
+									if (success && (classLoader == _javaVM->systemClassLoader)) {
 										success = copyAndForward(env, getContextForHeapAddress(_javaVM->unamedModuleForSystemLoader->moduleObject), (J9Object **)&(_javaVM->unamedModuleForSystemLoader->moduleObject));
 									}
 								}

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -255,7 +255,9 @@ MM_GlobalMarkCardScrubber::scrubClassLoaderObject(MM_EnvironmentVLHGC *env, J9Ob
 
 			if (classLoader == javaVM->systemClassLoader) {
 				Assert_MM_true(NULL != javaVM->unamedModuleForSystemLoader->moduleObject);
-				doScrub = mayScrubReference(env, classLoaderObject, javaVM->unamedModuleForSystemLoader->moduleObject);
+				if (doScrub) {
+					doScrub = mayScrubReference(env, classLoaderObject, javaVM->unamedModuleForSystemLoader->moduleObject);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
A card can be scrubbed only if no inter-region reference coming out of
it exists.

fix: https://github.com/eclipse-openj9/openj9/issues/14396
Signed-off-by: Lin Hu <linhu@ca.ibm.com>