### PR TITLE
Separate tests that rely on SecurityManager (Jsr292)

### DIFF
--- a/test/functional/Jsr292/bootstrap_src_90/com/ibm/j9/jsr292/bootstrap/CallerSensitiveClass.java
+++ b/test/functional/Jsr292/bootstrap_src_90/com/ibm/j9/jsr292/bootstrap/CallerSensitiveClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9.jsr292.bootstrap;
 
-public class CallerSensitiveClass extends SecurityManager {
+public class CallerSensitiveClass {
 	@jdk.internal.reflect.CallerSensitive
 	public void callerSensitiveMethod() {
 		Class<?> c = jdk.internal.reflect.Reflection.getCallerClass();

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,25 +189,31 @@
 				</javac>
 			</then>
 			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" /> 
-					<!-- exclude non test files for indyn test -->
-					<exclude name="**/indyn/BootstrapMethods.java" />
-					<exclude name="**/indyn/ComplexIndyGenerator.java" />
-					<exclude name="**/indyn/Helper.java" />
-					<exclude name="**/indyn/SimpleIndyGenerator.java" />
-					<exclude name="**/CrossPackageHelper.java"/>
-					<exclude name="**/attachAPI/**" />
-					<classpath>
-						<pathelement location="${bootstrapBuild}"/>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/junit4.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-						<pathelement location="${LIB_DIR}/jcommander.jar"/>
-					</classpath>
-				</javac>
+				<property name="srcpath" location="${src}:${transformerListener}:${TestUtilities}" />
+				<!-- exclude non test files for indyn test -->
+				<property name="commonExcludes" value="**/indyn/BootstrapMethods.java,**/indyn/ComplexIndyGenerator.java,**/indyn/Helper.java,**/indyn/SimpleIndyGenerator.java,**/CrossPackageHelper.java,**/attachAPI/**" />
+				<path id="build.cp">
+					<pathelement location="${bootstrapBuild}/"/>
+					<fileset dir="${LIB_DIR}/" includes="asm-all.jar"/>
+					<fileset dir="${LIB_DIR}/" includes="junit4.jar"/>
+					<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
+					<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
+				</path>
+				<if>
+					<matches string="${JDK_VERSION}" pattern="^(9|(1[0-8]))$$" />
+					<then>
+						<!-- Java 9-18 -->
+						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+						</javac>
+					</then>
+					<else>
+						<!-- Java 19+ (SecurityManager removed) -->
+						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+							<!-- exclude tests that depend on SecurityManager -->
+							<exclude name="com/ibm/j9/jsr292/MethodTypeTests_SM.java"/>
+						</javac>
+					</else>
+				</if>
 			</else>
 		</if>
 	</target>

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -80,17 +80,16 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>jsr292Test_jdk9_jdk10</testCaseName>
+		<testCaseName>jsr292Test_jdk8_sm</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
-	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-	-testnames jsr292Test,jsr292Test_optional \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_8.xml$(Q) \
+	-testnames jsr292Test_SM \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
@@ -101,9 +100,12 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>9</version>
-			<version>10</version>
+			<version>8</version>
 		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>jsr292Test</testCaseName>
@@ -130,6 +132,40 @@
 			<version>11+</version>
 		</versions>
 		<!-- 
+			TODO: Further investigation is needed for running against non-openj9 sdk
+		-->
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>jsr292Test_SM</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>Mode195</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_sm.xml$(Q) \
+	-testnames jsr292Test_SM \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11</version>
+			<version>17</version>
+			<version>18</version>
+		</versions>
+		<!--
 			TODO: Further investigation is needed for running against non-openj9 sdk
 		-->
 		<impls>
@@ -176,7 +212,7 @@
 	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_8.xml$(Q) \
-	-testnames jsr292Test \
+	-testnames jsr292Test,jsr292Test_SM \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
@@ -218,6 +254,37 @@
 		</groups>
 		<versions>
 			<version>9+</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>jsr292Test_JitCount0_SM</testCaseName>
+		<variations>
+			<variation>-Xjit:count=0</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_sm.xml$(Q) \
+	-testnames jsr292Test_SM \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11</version>
+			<version>17</version>
+			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodTypeTests.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodTypeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@ package com.ibm.j9.jsr292;
 
 import org.testng.annotations.Test;
 import org.testng.AssertJUnit;
-import java.io.*;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
@@ -568,31 +567,5 @@ public class MethodTypeTests {
 		mType = MethodType.fromMethodDescriptorString( "(II)I", null );
 		mType = mType.wrap();
 		AssertJUnit.assertFalse( mType.hasPrimitives() );
-	}
-	
-	/**
-	 * Ensure that MethodTypes serialization works. Runs with the SecurityManager enabled.
-	 */
-	@Test(groups = { "level.extended" })
-	public void test_SerializeGenericMethodType() throws IOException, ClassNotFoundException {
-		Class<?> returnType = String.class;
-		Class<?> paramType = Class.class;
-		MethodType mt = MethodType.methodType(returnType, paramType);
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		ObjectOutputStream oos = new ObjectOutputStream(baos);
-		oos.writeObject(mt);
-		oos.close();
-		ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
-		System.setSecurityManager(new SecurityManager());
-		try {
-			MethodType newMT = (MethodType) ois.readObject();
-			
-			// Validate MethodType constructed from serialized data
-			AssertJUnit.assertEquals(returnType, newMT.returnType());
-			AssertJUnit.assertEquals(paramType, newMT.parameterType(0));
-		} finally {
-			ois.close();
-			System.setSecurityManager(null);
-		}
 	}
 }

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodTypeTests_SM.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodTypeTests_SM.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+import java.io.*;
+import java.lang.invoke.MethodType;
+
+/**
+ * @author mesbah
+ * This class contains tests for the MethodType API.
+ */
+public class MethodTypeTests_SM {
+
+	/**
+	 * Ensure that MethodTypes serialization works. Runs with the SecurityManager enabled.
+	 */
+	@Test(groups = { "level.extended" })
+	public void test_SerializeGenericMethodType() throws IOException, ClassNotFoundException {
+		Class<?> returnType = String.class;
+		Class<?> paramType = Class.class;
+		MethodType mt = MethodType.methodType(returnType, paramType);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(mt);
+		oos.close();
+		ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+		System.setSecurityManager(new SecurityManager());
+		try {
+			MethodType newMT = (MethodType) ois.readObject();
+
+			// Validate MethodType constructed from serialized data
+			AssertJUnit.assertEquals(returnType, newMT.returnType());
+			AssertJUnit.assertEquals(paramType, newMT.parameterType(0));
+		} finally {
+			ois.close();
+			System.setSecurityManager(null);
+		}
+	}
+}

--- a/test/functional/Jsr292/testng_8.xml
+++ b/test/functional/Jsr292/testng_8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,12 @@
 			<class name="com.ibm.j9.jsr292.GuardTest"/>
 			<class name="com.ibm.j9.jsr292.FilterArgumentsTest"/>
 			<class name="com.ibm.j9.jsr292.RestrictReceiverTest"/>
+		</classes>
+	</test>
+
+	<test name="jsr292Test_SM">
+		<classes>
+			<class name="com.ibm.j9.jsr292.MethodTypeTests_SM"/>
 		</classes>
 	</test>
 

--- a/test/functional/Jsr292/testng_sm.xml
+++ b/test/functional/Jsr292/testng_sm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="jsr292 SecurityManager suite" parallel="none" verbose="2">
+	<test name="jsr292Test_SM">
+		<classes>
+			<class name="com.ibm.j9.jsr292.MethodTypeTests_SM"/>
+		</classes>
+	</test>
+</suite>


### PR DESCRIPTION
SecurityManager will be removed in a future jdk. Separate tests that
rely on it so that they can be easily disabled in the future.

Issue: #14412
Signed-off-by: Eric Yang <eric.yang@ibm.com>