### PR TITLE
Improve conceptual integrity of SVM nomenclature 

### DIFF
--- a/doc/compiler/aot/SymbolValidationManager.md
+++ b/doc/compiler/aot/SymbolValidationManager.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2021 IBM Corp. and others
+Copyright (c) 2018, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 In order for the OpenJ9 Compiler to compile Ahead Of Time (AOT),
 or more accurately, Relocatable, code, it needs to be able to store
-information for the AOT load infrastructure to validate all the 
-assumptions made during the compile run, since the AOT load is 
+information for the AOT load infrastructure to validate all the
+assumptions made during the compile run, since the AOT load is
 performed in a different JVM environment than the one the compilation
 was performed in. For these reasons, the Compiler and the Shared Class
 Cache (SCC) has infrastructure to facilate these validations.
@@ -33,7 +33,7 @@ Cache (SCC) has infrastructure to facilate these validations.
 Without the Symbol Validation Manager, the validations involves either
 creating a relocation record to validate an Arbitrary Class, a Class
 from a Constant Pool, an Instance Field, or a Static Field. However,
-when getting a Class By Name, the validation stored would be an 
+when getting a Class By Name, the validation stored would be an
 Arbitrary Class Validation, which is technically incorrect when the
 Name is retrieved from the signature of a method (since the answer
 depends on what the Class of that method "sees"). In order to deal
@@ -46,7 +46,7 @@ and unambigious.
 
 The Symbol Validation Manager (SVM) is very much similar to a symbol table
 that a linker might use. The idea is to store information about where
-a particular symbol (eg `J9Class`, `J9Method`, etc.) came from. For example,
+a particular value (eg `J9Class`, `J9Method`, etc.) came from. For example,
 if the compiler got the `J9Class` of `java/lang/String` by name from the
 parameter list of method `C.foo(Ljava/lang/String)V`, then the SVM will
 store a record stating that the compiler got `J9Class` `java/lang/String`
@@ -58,18 +58,18 @@ guaranteed to be compatible in the current environment.
 
 However, since `J9Class`es are artifacts of the current environment, how
 does the SVM enable a new environment to validate it? The core idea is to
-associate unique IDs to each new symbol the compiler gets a hold of. Thus,
-when a symbol is acquired by asking a query using a different symbol, the
-validation record that gets generated refers to these two symbols by their
-IDs, which are environment agnostic. In the load run, the AOT load
-infrastructure uses these IDs to build up its table of symbols that are
+associate unique IDs to each new value the compiler gets a hold of. Thus,
+when a value is acquired by asking a query using a different value, the
+validation record that gets generated refers to these two values by their
+IDs (symbols), which are environment agnostic. In the load run, the AOT load
+infrastructure uses these IDs to build up its table of values that are
 valid in _its_ environment.
 
 To give a concrete example:
 
 The compiler decides to compile `A.foo()`. As part of the compilation, it
-gets class `B` from `A`'s constant pool, gets class `C` from `A`'s 
-constant pool, and finally gets `B` by name as seen by `C`. Thus, the 
+gets class `B` from `A`'s constant pool, gets class `C` from `A`'s
+constant pool, and finally gets `B` by name as seen by `C`. Thus, the
 validation records that get generated would be:
 
 1. Root Class Record for `A`; `A` gets ID 1
@@ -89,7 +89,7 @@ following manner:
 
 Thus the information written in the validation records are entirely
 environment agnostic. In the load run, the AOT infrastructure will
-go through these validations and build up the symbols that are valid
+go through these validations and build up the values that are valid
 in _its_ environment:
 
 1. Map ID=1 to the class of the method being compiled
@@ -102,13 +102,13 @@ and map it to ID=4
 5. Get the class by name as seen by the class associated with ID=4
 and verify that it is the same class associated with ID=3
 
-If any of the validations fail, the load is aborted. Thus the general 
+If any of the validations fail, the load is aborted. Thus the general
 approach in the load run is:
 
-1. Find the symbol as specified by the validation record
-2. Map the ID from the validation record to the symbol
-3. If the map already contains a symbol for that ID, validate that
-the symbol in the map is the same as the symbol currently being
+1. Find the value as specified by the validation record
+2. Map the ID (symbol) from the validation record to the value
+3. If the map already contains a value for that ID, validate that
+the value in the map is the same as the value currently being
 validated; fail otherwise
 
 
@@ -118,7 +118,7 @@ validated; fail otherwise
 
 Class Chains are a core component of AOT validation; they ensure that
 the shape of a class is the same as that during the compile run. For
-technical details about Class Chains, see 
+technical details about Class Chains, see
 [AOT Class Chains](https://github.com/eclipse-openj9/openj9/blob/master/doc/compiler/aot/AOTClassChains.md).
 Thus, for every validation record involving classes, a Class Chain
 Validation Record is also created (unless a record for that class
@@ -161,9 +161,9 @@ unambiguous.
 Because Primitive Classes (and their associated array classes) are always
 guaranteed to exist, and because the Root Class and method from root class
 have already been validated prior to even attempting to perfom the AOT
-load, these symbols don't need to be validation records stored in 
+load, these values don't need to be validation records stored in
 the SCC. Therefore, the SVM, in its constructor, initializes the maps
-with these IDs and the associated symbols.
+with these IDs and the associated values.
 
 ### Well-known Classes
 
@@ -207,7 +207,7 @@ in the same way, to match the IDs assigned during compilation.
 
 ## Benefits
 
-1. Makes explicit the provenance of every symbol acquired by the compiler
+1. Makes explicit the provenance of every value acquired by the compiler
 2. Enables code paths previously disabled under AOT
 3. Allows relocations of classes/methods associated with cpIndex=-1
 4. Facilitates the enablement of Known Object Table under AOT
@@ -215,30 +215,30 @@ in the same way, to match the IDs assigned during compilation.
 
 ## When to create a new Validation Record
 
-Any time a new front end query is created, or an existing query is 
-modified, the appropriate validation record should be created, or 
-modified, respectively<sup>1</sup>. "Front end query" means, a query that the 
+Any time a new front end query is created, or an existing query is
+modified, the appropriate validation record should be created, or
+modified, respectively<sup>1</sup>. "Front end query" means, a query that the
 compiler (the "back end") makes of the runtime (the "front end") in order
 to get information about the environment such that execution of the
-compiled method will be functionally correct. The SVM uses the 
-validation record to redo the query in order to perform the validation. 
+compiled method will be functionally correct. The SVM uses the
+validation record to redo the query in order to perform the validation.
 Therefore, the validation record needs to contain all the information
 necessary to redo the query in a different JVM instance. Each unique
 front end query will have its own associated validation record; this is
 a fundamental aspect of the SVM.
 
-Note the validation is required where the query result is used in a way 
-that could affect **functional correctness** - queries used only for 
-heuristic purposes do not necessarily _need_ to be validated since, 
-by nature, they do not affect the correctness of the program. 
-All omissions on the basis of heuristic usage should be documented as 
-such in the code to make the omission clearly intentional and the basis 
+Note the validation is required where the query result is used in a way
+that could affect **functional correctness** - queries used only for
+heuristic purposes do not necessarily _need_ to be validated since,
+by nature, they do not affect the correctness of the program.
+All omissions on the basis of heuristic usage should be documented as
+such in the code to make the omission clearly intentional and the basis
 for that omission clear. The `enterHeuristicRegion`/`exitHeuristicRegion`
 APIs are used to facilitate making frontend queries without generating
 validation records.
 
 <hr/>
 
-1. We can have "compound" queries that simply combine other 
-existing queries for convenience (e.g. `getMethodFromName`). These 
+1. We can have "compound" queries that simply combine other
+existing queries for convenience (e.g. `getMethodFromName`). These
 queries don't necessarily need their own validation records.

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,7 +109,7 @@ J9::ARM64::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          TR_RelocationRecordDiscontiguousSymbolFromManager *dsfmRecord = reinterpret_cast<TR_RelocationRecordDiscontiguousSymbolFromManager *>(reloRecord);
 
          uint8_t *symbol = (uint8_t *)relocation->getTargetAddress();
-         uint16_t symbolID = self()->comp()->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+         uint16_t symbolID = self()->comp()->getSymbolValidationManager()->getSymbolIDFromValue(static_cast<void *>(symbol));
 
          uint16_t symbolType = (uint16_t)(uintptr_t)relocation->getTargetAddress2();
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -414,7 +414,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
             TR_OpaqueClassBlock *classOfMethod = reinterpret_cast<TR_OpaqueClassBlock *>(recordInfo->data5);
-            uint16_t classID = symValManager->getIDFromSymbol(static_cast<void *>(classOfMethod));
+            uint16_t classID = symValManager->getSymbolIDFromValue(static_cast<void *>(classOfMethod));
             allocRecord->setCpIndex(reloTarget, static_cast<uintptr_t>(classID));
             }
          else
@@ -443,7 +443,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
             TR_OpaqueClassBlock *classOfMethod = reinterpret_cast<TR_OpaqueClassBlock *>(recordInfo->data5);
-            uint16_t classID = symValManager->getIDFromSymbol(static_cast<void *>(classOfMethod));
+            uint16_t classID = symValManager->getSymbolIDFromValue(static_cast<void *>(classOfMethod));
             allocRecord->setCpIndex(reloTarget, static_cast<uintptr_t>(classID));
             }
          else
@@ -516,8 +516,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
             TR_OpaqueMethodBlock *method = resolvedMethod->getPersistentIdentifier();
-            uint16_t methodID = symValManager->getIDFromSymbol(static_cast<void *>(method));
-            uint16_t receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
+            uint16_t methodID = symValManager->getSymbolIDFromValue(static_cast<void *>(method));
+            uint16_t receiverClassID = symValManager->getSymbolIDFromValue(static_cast<void *>(thisClass));
 
             cpIndexOrData = (((uintptr_t)receiverClassID << 16) | (uintptr_t)methodID);
             }
@@ -613,7 +613,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t cpIndexOrData = 0;
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
-            uint16_t inlinedCodeClassID = symValManager->getIDFromSymbol(static_cast<void *>(inlinedCodeClass));
+            uint16_t inlinedCodeClassID = symValManager->getSymbolIDFromValue(static_cast<void *>(inlinedCodeClass));
             cpIndexOrData = static_cast<uintptr_t>(inlinedCodeClassID);
             }
          else
@@ -739,8 +739,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, svmRecord->_classChain);
 
-         cbnRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         cbnRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         cbnRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         cbnRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          cbnRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
                                         self(), svmRecord->getAOTCacheClassChainRecord());
          }
@@ -761,7 +761,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          //store the classchain's offset for the class that needs to be validated in the second run
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
 
-         pcRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(classToValidate));
+         pcRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
          pcRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
                                        self(), svmRecord->getAOTCacheClassChainRecord());
          pcRecord->setClassChainOffsetForClassLoader(reloTarget, classChainOffsetInSharedCacheForCL,
@@ -775,8 +775,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ClassFromCPRecord *svmRecord = reinterpret_cast<TR::ClassFromCPRecord *>(relocation->getTargetAddress());
 
-         cpRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         cpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         cpRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         cpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          cpRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
          }
          break;
@@ -788,8 +788,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::DefiningClassFromCPRecord *svmRecord = reinterpret_cast<TR::DefiningClassFromCPRecord *>(relocation->getTargetAddress());
 
          dcpRecord->setIsStatic(reloTarget, svmRecord->_isStatic);
-         dcpRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         dcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         dcpRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         dcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          dcpRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
          }
          break;
@@ -800,8 +800,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::StaticClassFromCPRecord *svmRecord = reinterpret_cast<TR::StaticClassFromCPRecord *>(relocation->getTargetAddress());
 
-         scpRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         scpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         scpRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         scpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          scpRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
          }
          break;
@@ -812,8 +812,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ArrayClassFromComponentClassRecord *svmRecord = reinterpret_cast<TR::ArrayClassFromComponentClassRecord *>(relocation->getTargetAddress());
 
-         acRecord->setArrayClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_arrayClass));
-         acRecord->setComponentClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_componentClass));
+         acRecord->setArrayClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_arrayClass));
+         acRecord->setComponentClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_componentClass));
          }
          break;
 
@@ -823,8 +823,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::SuperClassFromClassRecord *svmRecord = reinterpret_cast<TR::SuperClassFromClassRecord *>(relocation->getTargetAddress());
 
-         scRecord->setSuperClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_superClass));
-         scRecord->setChildClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_childClass));
+         scRecord->setSuperClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_superClass));
+         scRecord->setChildClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_childClass));
          }
          break;
 
@@ -837,8 +837,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          cicRecord->setObjectTypeIsFixed(reloTarget, svmRecord->_objectTypeIsFixed);
          cicRecord->setCastTypeIsFixed(reloTarget, svmRecord->_castTypeIsFixed);
          cicRecord->setIsInstanceOf(reloTarget, svmRecord->_isInstanceOf);
-         cicRecord->setClassOneID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_classOne));
-         cicRecord->setClassTwoID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_classTwo));
+         cicRecord->setClassOneID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_classOne));
+         cicRecord->setClassTwoID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_classTwo));
          }
          break;
 
@@ -855,7 +855,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          // this record eliminates the need for a separate class chain validation.
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
 
-         scmRecord->setSystemClassID(reloTarget, symValManager->getIDFromSymbol(classToValidate));
+         scmRecord->setSystemClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
          scmRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
                                         self(), svmRecord->getAOTCacheClassChainRecord());
          }
@@ -867,8 +867,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ClassFromITableIndexCPRecord *svmRecord = reinterpret_cast<TR::ClassFromITableIndexCPRecord *>(relocation->getTargetAddress());
 
-         cfitRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         cfitRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         cfitRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         cfitRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          cfitRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
          }
          break;
@@ -879,8 +879,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::DeclaringClassFromFieldOrStaticRecord *svmRecord = reinterpret_cast<TR::DeclaringClassFromFieldOrStaticRecord *>(relocation->getTargetAddress());
 
-         dcfsRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
-         dcfsRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         dcfsRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
+         dcfsRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          dcfsRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
          }
          break;
@@ -891,8 +891,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ConcreteSubClassFromClassRecord *svmRecord = reinterpret_cast<TR::ConcreteSubClassFromClassRecord *>(relocation->getTargetAddress());
 
-         csccRecord->setSuperClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_superClass));
-         csccRecord->setChildClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_childClass));
+         csccRecord->setSuperClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_superClass));
+         csccRecord->setChildClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_childClass));
          }
          break;
 
@@ -909,7 +909,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          // this record eliminates the need for a separate class chain validation.
          uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
 
-         ccRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(classToValidate));
+         ccRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
          ccRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
                                        self(), svmRecord->getAOTCacheClassChainRecord());
          }
@@ -921,8 +921,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::MethodFromClassRecord *svmRecord = reinterpret_cast<TR::MethodFromClassRecord *>(relocation->getTargetAddress());
 
-         mfcRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         mfcRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         mfcRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         mfcRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          mfcRecord->setIndex(reloTarget, svmRecord->_index);
          }
          break;
@@ -940,9 +940,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if ((svmRecord->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) != 0)
             smfcpRecord->setReloFlags(reloTarget, TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT);
 
-         smfcpRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         smfcpRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         smfcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         smfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         smfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         smfcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          smfcpRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK));
          }
          break;
@@ -960,9 +960,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if ((svmRecord->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) != 0)
             smfcpRecord->setReloFlags(reloTarget, TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT);
 
-         smfcpRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         smfcpRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         smfcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         smfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         smfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         smfcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          smfcpRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK));
          }
          break;
@@ -973,9 +973,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::VirtualMethodFromCPRecord *svmRecord = reinterpret_cast<TR::VirtualMethodFromCPRecord *>(relocation->getTargetAddress());
 
-         vmfcpRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         vmfcpRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         vmfcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         vmfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         vmfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         vmfcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          vmfcpRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex));
          }
          break;
@@ -994,9 +994,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uint16_t ignoreRtResolve = static_cast<uint16_t>(svmRecord->_ignoreRtResolve);
          uint16_t virtualCallOffset = static_cast<uint16_t>(svmRecord->_virtualCallOffset);
 
-         vmfoRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         vmfoRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         vmfoRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         vmfoRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         vmfoRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         vmfoRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          vmfoRecord->setVirtualCallOffsetAndIgnoreRtResolve(reloTarget, (virtualCallOffset | ignoreRtResolve));
          }
          break;
@@ -1007,10 +1007,10 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::InterfaceMethodFromCPRecord *svmRecord = reinterpret_cast<TR::InterfaceMethodFromCPRecord *>(relocation->getTargetAddress());
 
-         imfcpRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         imfcpRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         imfcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
-         imfcpRecord->setLookupID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_lookup));
+         imfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         imfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         imfcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
+         imfcpRecord->setLookupID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_lookup));
          imfcpRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex));
          }
          break;
@@ -1021,9 +1021,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ImproperInterfaceMethodFromCPRecord *svmRecord = reinterpret_cast<TR::ImproperInterfaceMethodFromCPRecord *>(relocation->getTargetAddress());
 
-         iimfcpRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         iimfcpRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         iimfcpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         iimfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         iimfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         iimfcpRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
          iimfcpRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex));
          }
          break;
@@ -1039,10 +1039,10 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromROMMethod(sharedCache, romMethod);
 
-         mfcsRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         mfcsRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         mfcsRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
-         mfcsRecord->setLookupClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_lookupClass));
+         mfcsRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         mfcsRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         mfcsRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
+         mfcsRecord->setLookupClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_lookupClass));
          mfcsRecord->setRomMethodOffsetInSCC(reloTarget, romMethodOffsetInSharedCache, self(),
                                              methodToValidate, svmRecord->_definingClass);
          }
@@ -1054,8 +1054,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::StackWalkerMaySkipFramesRecord *svmRecord = reinterpret_cast<TR::StackWalkerMaySkipFramesRecord *>(relocation->getTargetAddress());
 
-         swmsfRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         swmsfRecord->setMethodClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_methodClass));
+         swmsfRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         swmsfRecord->setMethodClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_methodClass));
          swmsfRecord->setSkipFrames(reloTarget, svmRecord->_skipFrames);
          }
          break;
@@ -1066,7 +1066,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ClassInfoIsInitialized *svmRecord = reinterpret_cast<TR::ClassInfoIsInitialized *>(relocation->getTargetAddress());
 
-         ciiiRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
+         ciiiRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
          ciiiRecord->setIsInitialized(reloTarget, svmRecord->_isInitialized);
          }
          break;
@@ -1077,11 +1077,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::MethodFromSingleImplementer *svmRecord = reinterpret_cast<TR::MethodFromSingleImplementer *>(relocation->getTargetAddress());
 
-         mfsiRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         mfsiRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         mfsiRecord->setThisClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_thisClass));
+         mfsiRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         mfsiRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         mfsiRecord->setThisClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_thisClass));
          mfsiRecord->setCpIndexOrVftSlot(reloTarget, svmRecord->_cpIndexOrVftSlot);
-         mfsiRecord->setCallerMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_callerMethod));
+         mfsiRecord->setCallerMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_callerMethod));
          mfsiRecord->setUseGetResolvedInterfaceMethod(reloTarget, svmRecord->_useGetResolvedInterfaceMethod);
          }
          break;
@@ -1092,10 +1092,10 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::MethodFromSingleInterfaceImplementer *svmRecord = reinterpret_cast<TR::MethodFromSingleInterfaceImplementer *>(relocation->getTargetAddress());
 
-         mfsiiRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         mfsiiRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         mfsiiRecord->setThisClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_thisClass));
-         mfsiiRecord->setCallerMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_callerMethod));
+         mfsiiRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         mfsiiRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         mfsiiRecord->setThisClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_thisClass));
+         mfsiiRecord->setCallerMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_callerMethod));
          mfsiiRecord->setCpIndex(reloTarget, static_cast<uint16_t>(svmRecord->_cpIndex));
          }
          break;
@@ -1106,10 +1106,10 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::MethodFromSingleAbstractImplementer *svmRecord = reinterpret_cast<TR::MethodFromSingleAbstractImplementer *>(relocation->getTargetAddress());
 
-         mfsaiRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
-         mfsaiRecord->setDefiningClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_definingClass));
-         mfsaiRecord->setThisClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_thisClass));
-         mfsaiRecord->setCallerMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_callerMethod));
+         mfsaiRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
+         mfsaiRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
+         mfsaiRecord->setThisClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_thisClass));
+         mfsaiRecord->setCallerMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_callerMethod));
          mfsaiRecord->setVftSlot(reloTarget, svmRecord->_vftSlot);
          }
          break;
@@ -1119,7 +1119,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_RelocationRecordSymbolFromManager *sfmRecord = reinterpret_cast<TR_RelocationRecordSymbolFromManager *>(reloRecord);
 
          uint8_t *symbol = relocation->getTargetAddress();
-         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+         uint16_t symbolID = comp->getSymbolValidationManager()->getSymbolIDFromValue(static_cast<void *>(symbol));
 
          uint16_t symbolType = (uint16_t)(uintptr_t)relocation->getTargetAddress2();
 
@@ -1133,7 +1133,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_RelocationRecordResolvedTrampolines *rtRecord = reinterpret_cast<TR_RelocationRecordResolvedTrampolines *>(reloRecord);
 
          uint8_t *symbol = relocation->getTargetAddress();
-         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+         uint16_t symbolID = comp->getSymbolValidationManager()->getSymbolIDFromValue(static_cast<void *>(symbol));
 
          rtRecord->setSymbolID(reloTarget, symbolID);
          }
@@ -1287,8 +1287,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          {
          auto *thunkRecord = reinterpret_cast<TR_RelocationRecordValidateJ2IThunkFromMethod *>(reloRecord);
          auto *svmRecord = reinterpret_cast<TR::J2IThunkFromMethodRecord *>(relocation->getTargetAddress());
-         thunkRecord->setThunkID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_thunk));
-         thunkRecord->setMethodID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_method));
+         thunkRecord->setThunkID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_thunk));
+         thunkRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
          }
          break;
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3189,7 +3189,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
    CHTableCommitData chTableData;
    std::vector<TR_OpaqueClassBlock *> classesThatShouldNotBeNewlyExtended;
    std::string logFileStr;
-   std::string svmSymbolToIdStr;
+   std::string svmValueToSymbolStr;
    std::vector<TR_ResolvedJ9Method *> resolvedMirrorMethodsPersistIPInfo;
    TR_OptimizationPlan modifiedOptPlan;
    std::vector<SerializedRuntimeAssumption> serializedRuntimeAssumptions;
@@ -3239,7 +3239,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          chTableData = std::get<2>(recv);
          classesThatShouldNotBeNewlyExtended = std::get<3>(recv);
          logFileStr = std::get<4>(recv);
-         svmSymbolToIdStr = std::get<5>(recv);
+         svmValueToSymbolStr = std::get<5>(recv);
          resolvedMirrorMethodsPersistIPInfo = std::get<6>(recv);
          modifiedOptPlan = std::get<7>(recv);
          serializedRuntimeAssumptions = std::get<8>(recv);
@@ -3476,7 +3476,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
             // so need to exit heuristic region.
             compiler->exitHeuristicRegion();
             // Populate symbol to id map
-            compiler->getSymbolValidationManager()->deserializeSymbolToIDMap(svmSymbolToIdStr);
+            compiler->getSymbolValidationManager()->deserializeValueToSymbolMap(svmValueToSymbolStr);
             }
 
          TR_ASSERT(codeCacheStr.size(), "must have code cache");

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -347,7 +347,7 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          TR_RelocationRecordInformation *recordInfo = (TR_RelocationRecordInformation*) relocation->getTargetAddress();
 
          uint8_t *symbol = (uint8_t *)recordInfo->data1;
-         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+         uint16_t symbolID = comp->getSymbolValidationManager()->getSymbolIDFromValue(static_cast<void *>(symbol));
 
          uint16_t symbolType = (uint16_t)recordInfo->data2;
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -5404,7 +5404,7 @@ TR_RelocationRecordSymbolFromManager::preparePrivateData(TR_RelocationRuntime *r
    uint16_t symbolID = this->symbolID(reloTarget);
    TR::SymbolType symbolType = this->symbolType(reloTarget);
 
-   reloPrivateData->_symbol = reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(symbolID, symbolType);
+   reloPrivateData->_symbol = reloRuntime->comp()->getSymbolValidationManager()->getValueFromSymbolID(symbolID, symbolType);
    reloPrivateData->_symbolType = symbolType;
    }
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -462,7 +462,7 @@ TR::SymbolValidationManager::getNewSymbolID()
    }
 
 void *
-TR::SymbolValidationManager::getSymbolFromID(uint16_t id, TR::SymbolType type, Presence presence)
+TR::SymbolValidationManager::getValueFromSymbolID(uint16_t id, TR::SymbolType type, Presence presence)
    {
    TypedValue *entry = NULL;
    if (id < _symbolToValueTable.size())
@@ -481,34 +481,34 @@ TR_OpaqueClassBlock *
 TR::SymbolValidationManager::getClassFromID(uint16_t id, Presence presence)
    {
    return static_cast<TR_OpaqueClassBlock*>(
-      getSymbolFromID(id, TR::SymbolType::typeClass, presence));
+      getValueFromSymbolID(id, TR::SymbolType::typeClass, presence));
    }
 
 J9Class *
 TR::SymbolValidationManager::getJ9ClassFromID(uint16_t id, Presence presence)
    {
    return static_cast<J9Class*>(
-      getSymbolFromID(id, TR::SymbolType::typeClass, presence));
+      getValueFromSymbolID(id, TR::SymbolType::typeClass, presence));
    }
 
 TR_OpaqueMethodBlock *
 TR::SymbolValidationManager::getMethodFromID(uint16_t id, Presence presence)
    {
    return static_cast<TR_OpaqueMethodBlock*>(
-      getSymbolFromID(id, TR::SymbolType::typeMethod, presence));
+      getValueFromSymbolID(id, TR::SymbolType::typeMethod, presence));
    }
 
 J9Method *
 TR::SymbolValidationManager::getJ9MethodFromID(uint16_t id, Presence presence)
    {
    return static_cast<J9Method*>(
-      getSymbolFromID(id, TR::SymbolType::typeMethod, presence));
+      getValueFromSymbolID(id, TR::SymbolType::typeMethod, presence));
    }
 
 uint16_t
-TR::SymbolValidationManager::tryGetIDFromSymbol(void *symbol)
+TR::SymbolValidationManager::tryGetSymbolIDFromValue(void *value)
    {
-   ValueToSymbolMap::iterator it = _valueToSymbolMap.find(symbol);
+   ValueToSymbolMap::iterator it = _valueToSymbolMap.find(value);
    if (it == _valueToSymbolMap.end())
       return NO_ID;
    else
@@ -518,7 +518,7 @@ TR::SymbolValidationManager::tryGetIDFromSymbol(void *symbol)
 uint16_t
 TR::SymbolValidationManager::getIDFromSymbol(void *symbol)
    {
-   uint16_t id = tryGetIDFromSymbol(symbol);
+   uint16_t id = tryGetSymbolIDFromValue(symbol);
    SVM_ASSERT(id != NO_ID, "Unknown symbol %p\n", symbol);
    return id;
    }

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -516,10 +516,10 @@ TR::SymbolValidationManager::tryGetSymbolIDFromValue(void *value)
    }
 
 uint16_t
-TR::SymbolValidationManager::getIDFromSymbol(void *symbol)
+TR::SymbolValidationManager::getSymbolIDFromValue(void *value)
    {
-   uint16_t id = tryGetSymbolIDFromValue(symbol);
-   SVM_ASSERT(id != NO_ID, "Unknown symbol %p\n", symbol);
+   uint16_t id = tryGetSymbolIDFromValue(value);
+   SVM_ASSERT(id != NO_ID, "Unknown value %p\n", value);
    return id;
    }
 
@@ -577,7 +577,7 @@ TR::SymbolValidationManager::appendNewRecord(void *symbol, TR::SymbolValidationR
 
    record->printFields();
    traceMsg(_comp, "\tkind=%d\n", record->_kind);
-   traceMsg(_comp, "\tid=%d\n", (uint32_t)getIDFromSymbol(symbol));
+   traceMsg(_comp, "\tid=%d\n", (uint32_t)getSymbolIDFromValue(symbol));
    traceMsg(_comp, "\n");
    }
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -81,7 +81,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _alreadyGeneratedRecords(LessSymbolValidationRecord(), _region),
      _classesFromAnyCPIndex(LessClassFromAnyCPIndex(), _region),
      _valueToSymbolMap((ValueToSymbolComparator()), _region),
-     _idToSymbolTable(_region),
+     _symbolToValueTable(_region),
      _seenSymbolsSet((SeenSymbolsComparator()), _region),
      _wellKnownClasses(_region),
      _loadersOkForWellKnownClasses(_region)
@@ -436,22 +436,22 @@ TR::SymbolValidationManager::classCanSeeWellKnownClasses(TR_OpaqueClassBlock *be
 bool
 TR::SymbolValidationManager::isDefinedID(uint16_t id)
    {
-   return id < _idToSymbolTable.size() && _idToSymbolTable[id]._hasValue;
+   return id < _symbolToValueTable.size() && _symbolToValueTable[id]._hasValue;
    }
 
 void
 TR::SymbolValidationManager::setSymbolOfID(uint16_t id, void *symbol, TR::SymbolType type)
    {
-   if (id >= _idToSymbolTable.size())
+   if (id >= _symbolToValueTable.size())
       {
       TypedValue unused = { NULL, typeOpaque, false };
-      _idToSymbolTable.resize(id + 1, unused);
+      _symbolToValueTable.resize(id + 1, unused);
       }
 
-   SVM_ASSERT(!_idToSymbolTable[id]._hasValue, "multiple definitions of ID %d", id);
-   _idToSymbolTable[id]._value = symbol;
-   _idToSymbolTable[id]._type = type;
-   _idToSymbolTable[id]._hasValue = true;
+   SVM_ASSERT(!_symbolToValueTable[id]._hasValue, "multiple definitions of ID %d", id);
+   _symbolToValueTable[id]._value = symbol;
+   _symbolToValueTable[id]._type = type;
+   _symbolToValueTable[id]._hasValue = true;
    }
 
 uint16_t
@@ -465,8 +465,8 @@ void *
 TR::SymbolValidationManager::getSymbolFromID(uint16_t id, TR::SymbolType type, Presence presence)
    {
    TypedValue *entry = NULL;
-   if (id < _idToSymbolTable.size())
-      entry = &_idToSymbolTable[id];
+   if (id < _symbolToValueTable.size())
+      entry = &_symbolToValueTable[id];
 
    SVM_ASSERT(entry != NULL && entry->_hasValue, "Unknown ID %d", id);
    if (entry->_value == NULL)
@@ -1131,8 +1131,8 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
    {
    bool valid = false;
    TypedValue *entry = NULL;
-   if (idToBeValidated < _idToSymbolTable.size())
-      entry = &_idToSymbolTable[idToBeValidated];
+   if (idToBeValidated < _symbolToValueTable.size())
+      entry = &_symbolToValueTable[idToBeValidated];
 
    if (entry == NULL || !entry->_hasValue)
       {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -67,7 +67,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
         _vmThread->javaVM->jitConfig,
         _vmThread,
 #if defined(J9VM_OPT_JITSERVER)
-        TR::CompilationInfo::get()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER ? TR_J9VMBase::J9_SERVER_VM : 
+        TR::CompilationInfo::get()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER ? TR_J9VMBase::J9_SERVER_VM :
 #endif /* defined(J9VM_OPT_JITSERVER) */
         TR_J9VMBase::DEFAULT_VM)),
      _trMemory(_comp->trMemory()),
@@ -444,12 +444,12 @@ TR::SymbolValidationManager::setSymbolOfID(uint16_t id, void *symbol, TR::Symbol
    {
    if (id >= _idToSymbolTable.size())
       {
-      TypedSymbol unused = { NULL, typeOpaque, false };
+      TypedValue unused = { NULL, typeOpaque, false };
       _idToSymbolTable.resize(id + 1, unused);
       }
 
    SVM_ASSERT(!_idToSymbolTable[id]._hasValue, "multiple definitions of ID %d", id);
-   _idToSymbolTable[id]._symbol = symbol;
+   _idToSymbolTable[id]._value = symbol;
    _idToSymbolTable[id]._type = type;
    _idToSymbolTable[id]._hasValue = true;
    }
@@ -464,17 +464,17 @@ TR::SymbolValidationManager::getNewSymbolID()
 void *
 TR::SymbolValidationManager::getSymbolFromID(uint16_t id, TR::SymbolType type, Presence presence)
    {
-   TypedSymbol *entry = NULL;
+   TypedValue *entry = NULL;
    if (id < _idToSymbolTable.size())
       entry = &_idToSymbolTable[id];
 
    SVM_ASSERT(entry != NULL && entry->_hasValue, "Unknown ID %d", id);
-   if (entry->_symbol == NULL)
+   if (entry->_value == NULL)
       SVM_ASSERT(presence != SymRequired, "ID must not map to null");
    else
       SVM_ASSERT(entry->_type == type, "ID has type %d when %d was expected", entry->_type, type);
 
-   return entry->_symbol;
+   return entry->_value;
    }
 
 TR_OpaqueClassBlock *
@@ -1130,7 +1130,7 @@ bool
 TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type)
    {
    bool valid = false;
-   TypedSymbol *entry = NULL;
+   TypedValue *entry = NULL;
    if (idToBeValidated < _idToSymbolTable.size())
       entry = &_idToSymbolTable[idToBeValidated];
 
@@ -1154,7 +1154,7 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
       }
    else
       {
-      valid = validSymbol == entry->_symbol
+      valid = validSymbol == entry->_value
          && (validSymbol == NULL || entry->_type == type);
       }
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -563,31 +563,31 @@ TR::SymbolValidationManager::anyClassFromCPRecordExists(
    }
 
 void
-TR::SymbolValidationManager::appendNewRecord(void *symbol, TR::SymbolValidationRecord *record)
+TR::SymbolValidationManager::appendNewRecord(void *value, TR::SymbolValidationRecord *record)
    {
    SVM_ASSERT(!inHeuristicRegion(), "Attempted to appendNewRecord in a heuristic region");
    TR_ASSERT(!recordExists(record), "record is not new");
 
-   if (!isAlreadyValidated(symbol))
+   if (!isAlreadyValidated(value))
       {
-      _valueToSymbolMap.insert(std::make_pair(symbol, getNewSymbolID()));
+      _valueToSymbolMap.insert(std::make_pair(value, getNewSymbolID()));
       }
    _symbolValidationRecords.push_front(record);
    _alreadyGeneratedRecords.insert(record);
 
    record->printFields();
    traceMsg(_comp, "\tkind=%d\n", record->_kind);
-   traceMsg(_comp, "\tid=%d\n", (uint32_t)getSymbolIDFromValue(symbol));
+   traceMsg(_comp, "\tid=%d\n", (uint32_t)getSymbolIDFromValue(value));
    traceMsg(_comp, "\n");
    }
 
 void
-TR::SymbolValidationManager::appendRecordIfNew(void *symbol, TR::SymbolValidationRecord *record)
+TR::SymbolValidationManager::appendRecordIfNew(void *value, TR::SymbolValidationRecord *record)
    {
    if (recordExists(record))
       _region.deallocate(record);
    else
-      appendNewRecord(symbol, record);
+      appendNewRecord(value, record);
    }
 
 bool

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -135,12 +135,12 @@ TR::SymbolValidationManager::populateSystemClassesNotWorthRemembering(ClientSess
 #endif
 
 void
-TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType type)
+TR::SymbolValidationManager::defineGuaranteedID(void *value, TR::SymbolType type)
    {
    uint16_t id = getNewSymbolID();
-   _valueToSymbolMap.insert(std::make_pair(symbol, id));
-   setSymbolOfID(id, symbol, type);
-   _seenValuesSet.insert(symbol);
+   _valueToSymbolMap.insert(std::make_pair(value, id));
+   setValueOfSymbolID(id, value, type);
+   _seenValuesSet.insert(value);
    }
 
 bool
@@ -370,7 +370,7 @@ TR::SymbolValidationManager::validateWellKnownClasses(const uintptr_t *wellKnown
          {
          _wellKnownClasses.push_back(clazz);
          if (clazz != _rootClass)
-            setSymbolOfID(getNewSymbolID(), clazz, TR::SymbolType::typeClass);
+            setValueOfSymbolID(getNewSymbolID(), clazz, TR::SymbolType::typeClass);
          }
       }
 
@@ -440,7 +440,7 @@ TR::SymbolValidationManager::isDefinedID(uint16_t id)
    }
 
 void
-TR::SymbolValidationManager::setSymbolOfID(uint16_t id, void *symbol, TR::SymbolType type)
+TR::SymbolValidationManager::setValueOfSymbolID(uint16_t id, void *value, TR::SymbolType type)
    {
    if (id >= _symbolToValueTable.size())
       {
@@ -449,7 +449,7 @@ TR::SymbolValidationManager::setSymbolOfID(uint16_t id, void *symbol, TR::Symbol
       }
 
    SVM_ASSERT(!_symbolToValueTable[id]._hasValue, "multiple definitions of ID %d", id);
-   _symbolToValueTable[id]._value = symbol;
+   _symbolToValueTable[id]._value = value;
    _symbolToValueTable[id]._type = type;
    _symbolToValueTable[id]._hasValue = true;
    }
@@ -654,12 +654,12 @@ TR::SymbolValidationManager::appendClassChainInfoRecords(
    }
 
 bool
-TR::SymbolValidationManager::addVanillaRecord(void *symbol, TR::SymbolValidationRecord *record)
+TR::SymbolValidationManager::addVanillaRecord(void *value, TR::SymbolValidationRecord *record)
    {
-   if (shouldNotDefineSymbol(symbol))
+   if (shouldNotDefineSymbol(value))
       return abandonRecord(record);
 
-   appendRecordIfNew(symbol, record);
+   appendRecordIfNew(value, record);
    return true;
    }
 
@@ -1127,7 +1127,7 @@ TR::SymbolValidationManager::addJ2IThunkFromMethodRecord(void *thunk, TR_OpaqueM
 
 
 bool
-TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type)
+TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *validValue, TR::SymbolType type)
    {
    bool valid = false;
    TypedValue *entry = NULL;
@@ -1136,26 +1136,26 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
 
    if (entry == NULL || !entry->_hasValue)
       {
-      if (_seenValuesSet.find(validSymbol) == _seenValuesSet.end())
+      if (_seenValuesSet.find(validValue) == _seenValuesSet.end())
          {
          valid = true;
          if (type == TR::SymbolType::typeClass)
             {
             valid = classCanSeeWellKnownClasses(
-               reinterpret_cast<TR_OpaqueClassBlock*>(validSymbol));
+               reinterpret_cast<TR_OpaqueClassBlock*>(validValue));
             }
 
          if (valid)
             {
-            setSymbolOfID(idToBeValidated, validSymbol, type);
-            _seenValuesSet.insert(validSymbol);
+            setValueOfSymbolID(idToBeValidated, validValue, type);
+            _seenValuesSet.insert(validValue);
             }
          }
       }
    else
       {
-      valid = validSymbol == entry->_value
-         && (validSymbol == NULL || entry->_type == type);
+      valid = validValue == entry->_value
+         && (validValue == NULL || entry->_type == type);
       }
 
    return valid;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -82,7 +82,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _classesFromAnyCPIndex(LessClassFromAnyCPIndex(), _region),
      _valueToSymbolMap((ValueToSymbolComparator()), _region),
      _symbolToValueTable(_region),
-     _seenSymbolsSet((SeenSymbolsComparator()), _region),
+     _seenValuesSet((SeenValuesComparator()), _region),
      _wellKnownClasses(_region),
      _loadersOkForWellKnownClasses(_region)
    {
@@ -140,7 +140,7 @@ TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType typ
    uint16_t id = getNewSymbolID();
    _valueToSymbolMap.insert(std::make_pair(symbol, id));
    setSymbolOfID(id, symbol, type);
-   _seenSymbolsSet.insert(symbol);
+   _seenValuesSet.insert(symbol);
    }
 
 bool
@@ -365,7 +365,7 @@ TR::SymbolValidationManager::validateWellKnownClasses(const uintptr_t *wellKnown
       if (!_fej9->sharedCache()->classMatchesCachedVersion(clazz, classChain))
          return false;
 
-      _seenSymbolsSet.insert(clazz);
+      _seenValuesSet.insert(clazz);
       if (assignNewIDs)
          {
          _wellKnownClasses.push_back(clazz);
@@ -1136,7 +1136,7 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
 
    if (entry == NULL || !entry->_hasValue)
       {
-      if (_seenSymbolsSet.find(validSymbol) == _seenSymbolsSet.end())
+      if (_seenValuesSet.find(validSymbol) == _seenValuesSet.end())
          {
          valid = true;
          if (type == TR::SymbolType::typeClass)
@@ -1148,7 +1148,7 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
          if (valid)
             {
             setSymbolOfID(idToBeValidated, validSymbol, type);
-            _seenSymbolsSet.insert(validSymbol);
+            _seenValuesSet.insert(validSymbol);
             }
          }
       }

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -732,9 +732,9 @@ public:
    uint16_t tryGetSymbolIDFromValue(void *value);
    uint16_t getSymbolIDFromValue(void *value);
 
-   bool isAlreadyValidated(void *symbol)
+   bool isAlreadyValidated(void *value)
       {
-      return inHeuristicRegion() || tryGetSymbolIDFromValue(symbol) != NO_ID;
+      return inHeuristicRegion() || tryGetSymbolIDFromValue(value) != NO_ID;
       }
 
    bool addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);
@@ -858,7 +858,7 @@ private:
 
    uint16_t getNewSymbolID();
 
-   bool shouldNotDefineSymbol(void *symbol) { return symbol == NULL || inHeuristicRegion(); }
+   bool shouldNotDefineSymbol(void *value) { return value == NULL || inHeuristicRegion(); }
    bool abandonRecord(TR::SymbolValidationRecord *record);
 
    bool recordExists(TR::SymbolValidationRecord *record);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -76,18 +76,18 @@ class AOTCacheWellKnownClassesRecord;
 #define SVM_ASSERT_NONFATAL(condition, format, ...) \
    SVM_ASSERT_IMPL("SVM_ASSERT_NONFATAL", true, condition, #condition, format, ##__VA_ARGS__)
 
-#define SVM_ASSERT_ALREADY_VALIDATED(svm, symbol)        \
+#define SVM_ASSERT_ALREADY_VALIDATED(svm, value)        \
    do                                                    \
       {                                                  \
-      void *_0symbol = (symbol);                         \
+      void *_0value = (value);                         \
       SVM_ASSERT_IMPL(                                   \
          "SVM_ASSERT_ALREADY_VALIDATED",                 \
          false,                                          \
-         (svm)->isAlreadyValidated(_0symbol),            \
-         "isAlreadyValidated(" #symbol ")",              \
+         (svm)->isAlreadyValidated(_0value),            \
+         "isAlreadyValidated(" #value ")",              \
          "%s %p should have already been validated",     \
-         #symbol,                                        \
-         _0symbol);                                      \
+         #value,                                        \
+         _0value);                                      \
       }                                                  \
    while (false)
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -723,18 +723,18 @@ public:
       SymOptional
       };
 
-   void* getSymbolFromID(uint16_t id, TR::SymbolType type, Presence presence = SymRequired);
+   void* getValueFromSymbolID(uint16_t id, TR::SymbolType type, Presence presence = SymRequired);
    TR_OpaqueClassBlock *getClassFromID(uint16_t id, Presence presence = SymRequired);
    J9Class *getJ9ClassFromID(uint16_t id, Presence presence = SymRequired);
    TR_OpaqueMethodBlock *getMethodFromID(uint16_t id, Presence presence = SymRequired);
    J9Method *getJ9MethodFromID(uint16_t id, Presence presence = SymRequired);
 
-   uint16_t tryGetIDFromSymbol(void *symbol);
+   uint16_t tryGetSymbolIDFromValue(void *value);
    uint16_t getIDFromSymbol(void *symbol);
 
    bool isAlreadyValidated(void *symbol)
       {
-      return inHeuristicRegion() || tryGetIDFromSymbol(symbol) != NO_ID;
+      return inHeuristicRegion() || tryGetSymbolIDFromValue(symbol) != NO_ID;
       }
 
    bool addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -730,7 +730,7 @@ public:
    J9Method *getJ9MethodFromID(uint16_t id, Presence presence = SymRequired);
 
    uint16_t tryGetSymbolIDFromValue(void *value);
-   uint16_t getIDFromSymbol(void *symbol);
+   uint16_t getSymbolIDFromValue(void *value);
 
    bool isAlreadyValidated(void *symbol)
       {

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -842,8 +842,8 @@ public:
    static int getSystemClassesNotWorthRememberingCount();
 
 #if defined(J9VM_OPT_JITSERVER)
-   std::string serializeSymbolToIDMap();
-   void deserializeSymbolToIDMap(const std::string &symbolToIdStr);
+   std::string serializeValueToSymbolMap();
+   void deserializeValueToSymbolMap(const std::string &valueToSymbolStr);
    static void populateSystemClassesNotWorthRemembering(ClientSessionData *clientData);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
@@ -939,9 +939,9 @@ private:
    typedef std::set<SymbolValidationRecord*, LessSymbolValidationRecord, RecordPtrAlloc> RecordSet;
    RecordSet _alreadyGeneratedRecords;
 
-   typedef TR::typed_allocator<std::pair<void* const, uint16_t>, TR::Region&> SymbolToIdAllocator;
-   typedef std::less<void*> SymbolToIdComparator;
-   typedef std::map<void*, uint16_t, SymbolToIdComparator, SymbolToIdAllocator> SymbolToIdMap;
+   typedef TR::typed_allocator<std::pair<void* const, uint16_t>, TR::Region&> ValueToSymbolAllocator;
+   typedef std::less<void*> ValueToSymbolComparator;
+   typedef std::map<void*, uint16_t, ValueToSymbolComparator, ValueToSymbolAllocator> ValueToSymbolMap;
 
    struct TypedValue
       {
@@ -958,7 +958,7 @@ private:
    typedef std::set<void*, SeenSymbolsComparator, SeenSymbolsAlloc> SeenSymbolsSet;
 
    /* Used for AOT Compile */
-   SymbolToIdMap _symbolToIdMap;
+   ValueToSymbolMap _valueToSymbolMap;
 
    /* Used for AOT Load */
    IdToSymbolTable _idToSymbolTable;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -863,8 +863,8 @@ private:
 
    bool recordExists(TR::SymbolValidationRecord *record);
    bool anyClassFromCPRecordExists(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);
-   void appendNewRecord(void *symbol, TR::SymbolValidationRecord *record);
-   void appendRecordIfNew(void *symbol, TR::SymbolValidationRecord *record);
+   void appendNewRecord(void *value, TR::SymbolValidationRecord *record);
+   void appendRecordIfNew(void *value, TR::SymbolValidationRecord *record);
 
    struct ClassChainInfo
       {

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -953,9 +953,9 @@ private:
    typedef TR::typed_allocator<TypedValue, TR::Region&> SymbolToValueAllocator;
    typedef std::vector<TypedValue, SymbolToValueAllocator> SymbolToValueTable;
 
-   typedef TR::typed_allocator<void*, TR::Region&> SeenSymbolsAlloc;
-   typedef std::less<void*> SeenSymbolsComparator;
-   typedef std::set<void*, SeenSymbolsComparator, SeenSymbolsAlloc> SeenSymbolsSet;
+   typedef TR::typed_allocator<void*, TR::Region&> SeenValuesAlloc;
+   typedef std::less<void*> SeenValuesComparator;
+   typedef std::set<void*, SeenValuesComparator, SeenValuesAlloc> SeenValuesSet;
 
    /* Used for AOT Compile */
    ValueToSymbolMap _valueToSymbolMap;
@@ -963,7 +963,7 @@ private:
    /* Used for AOT Load */
    SymbolToValueTable _symbolToValueTable;
 
-   SeenSymbolsSet _seenSymbolsSet;
+   SeenValuesSet _seenValuesSet;
 
    typedef TR::typed_allocator<TR_OpaqueClassBlock*, TR::Region&> ClassAllocator;
    typedef std::vector<TR_OpaqueClassBlock*, ClassAllocator> ClassVector;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -887,22 +887,22 @@ private:
    bool getClassChainInfo(TR_OpaqueClassBlock *clazz, TR::SymbolValidationRecord *record, ClassChainInfo &info);
    void appendClassChainInfoRecords(TR_OpaqueClassBlock *clazz, const ClassChainInfo &info);
 
-   bool addVanillaRecord(void *symbol, TR::SymbolValidationRecord *record);
+   bool addVanillaRecord(void *value, TR::SymbolValidationRecord *record);
    bool addClassRecord(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record);
    bool addClassRecordWithChain(TR::ClassValidationRecordWithChain *record);
    void addMultipleArrayRecords(TR_OpaqueClassBlock *clazz, int arrayDims);
    bool addMethodRecord(TR::MethodValidationRecord *record);
    bool skipFieldRefClassRecord(TR_OpaqueClassBlock *definingClass, TR_OpaqueClassBlock *beholder, uint32_t cpIndex);
 
-   bool validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type);
+   bool validateSymbol(uint16_t idToBeValidated, void *validValue, TR::SymbolType type);
    bool validateSymbol(uint16_t idToBeValidated, TR_OpaqueClassBlock *clazz);
    bool validateSymbol(uint16_t idToBeValidated, J9Class *clazz);
    bool validateSymbol(uint16_t methodID, uint16_t definingClassID, TR_OpaqueMethodBlock *method);
    bool validateSymbol(uint16_t methodID, uint16_t definingClassID, J9Method *method);
 
    bool isDefinedID(uint16_t id);
-   void setSymbolOfID(uint16_t id, void *symbol, TR::SymbolType type);
-   void defineGuaranteedID(void *symbol, TR::SymbolType type);
+   void setValueOfSymbolID(uint16_t id, void *value, TR::SymbolType type);
+   void defineGuaranteedID(void *value, TR::SymbolType type);
 
    /**
     * @brief Heuristic to determine whether a class is worth remembering (and hence

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -950,8 +950,8 @@ private:
       bool _hasValue;
       };
 
-   typedef TR::typed_allocator<TypedValue, TR::Region&> IdToSymbolAllocator;
-   typedef std::vector<TypedValue, IdToSymbolAllocator> IdToSymbolTable;
+   typedef TR::typed_allocator<TypedValue, TR::Region&> SymbolToValueAllocator;
+   typedef std::vector<TypedValue, SymbolToValueAllocator> SymbolToValueTable;
 
    typedef TR::typed_allocator<void*, TR::Region&> SeenSymbolsAlloc;
    typedef std::less<void*> SeenSymbolsComparator;
@@ -961,7 +961,7 @@ private:
    ValueToSymbolMap _valueToSymbolMap;
 
    /* Used for AOT Load */
-   IdToSymbolTable _idToSymbolTable;
+   SymbolToValueTable _symbolToValueTable;
 
    SeenSymbolsSet _seenSymbolsSet;
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -943,15 +943,15 @@ private:
    typedef std::less<void*> SymbolToIdComparator;
    typedef std::map<void*, uint16_t, SymbolToIdComparator, SymbolToIdAllocator> SymbolToIdMap;
 
-   struct TypedSymbol
+   struct TypedValue
       {
-      void *_symbol;
+      void *_value;
       TR::SymbolType _type;
       bool _hasValue;
       };
 
-   typedef TR::typed_allocator<TypedSymbol, TR::Region&> IdToSymbolAllocator;
-   typedef std::vector<TypedSymbol, IdToSymbolAllocator> IdToSymbolTable;
+   typedef TR::typed_allocator<TypedValue, TR::Region&> IdToSymbolAllocator;
+   typedef std::vector<TypedValue, IdToSymbolAllocator> IdToSymbolTable;
 
    typedef TR::typed_allocator<void*, TR::Region&> SeenSymbolsAlloc;
    typedef std::less<void*> SeenSymbolsComparator;


### PR DESCRIPTION
The SVM, at its core, maintains a mapping between the results of front end VM queries and `uint16_t` IDs. Conceptually, the ID is the symbol that is associated with the result which is the value. However, in the SVM, the term "symbol" was used to refer to the value. This is confusing for anyone new to the SVM, especially since it claims to be similar to a symbol table in a linker.

This PR improves the conceptual integrity of the SVM by actually referring to values as values and IDs as symbols.