### PR TITLE
(0.31.0) Update SystemPropertiesTest to work on jdk18

### DIFF
--- a/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2020, 2021 IBM Corp. and others
+  Copyright (c) 2020, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/SystemPropertiesTest" />
 	<property name="src" location="./src"/>
+	<property name="TestUtilities" location="../../TestUtilities/src"/>
 	<property name="build" location="./bin"/>
 
 	<target name="init">
@@ -48,6 +49,11 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
 		</javac>
 	</target>
 
@@ -55,6 +61,7 @@
 		<jar jarfile="${DEST}/SystemPropertiesTest.jar" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}" />
+			<fileset dir="${TestUtilities}" />
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.xml" />

--- a/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
@@ -39,11 +39,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<versions>
-			<version>8</version>
-			<version>11</version>
-			<version>17</version>
-		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-Copyright (c) 2020, 2021 IBM Corp. and others
+Copyright (c) 2020, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<versions>
+			<version>8</version>
+			<version>11</version>
+			<version>17</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -23,21 +23,23 @@
 import java.util.*;
 import java.io.*;
 import java.nio.charset.Charset;
+import org.openj9.test.util.VersionCheck;
 
-public class SysPropTest 
+public class SysPropTest
 {
-	/* TestVa&#187;lue&#161; */	
-	static final byte[] B = { (byte)0x54, (byte)0x65, (byte)0x73, (byte)0x74,  (byte)0x56, (byte)0x61,(byte) 187, (byte)0x6C, (byte)0x75, (byte)0x65, (byte) 161};	
+	/* TestVa&#187;lue&#161; */
+	static final byte[] inputBytes = { (byte)'T', (byte)'e', (byte)'s', (byte)'t', (byte)'V', (byte)'a', (byte)187, (byte)'l', (byte)'u', (byte)'e', (byte)161};
+	static final byte[] inputBytesUtf8 = { (byte)'T', (byte)'e', (byte)'s', (byte)'t', (byte)'V', (byte)'a', (byte)0xC2, (byte)187, (byte)'l', (byte)'u', (byte)'e', (byte)0xC2, (byte)161};
 
 	public static void main(String args[])
 	{
 		boolean isWindows = false;
-		if ( args.length == 0) {
-			System.out.println("test failed"); 
+		if (args.length == 0) {
+			System.out.println("test failed");
 			return;
 		}
 		String argEncoding = args[0];
-		/* check -Dtestkey=Test?Va?lue?  */
+		/* check -Dtestkey=TestVa?lue? */
 		try {
 			String osEncoding = "";
 			String strTestProp;
@@ -45,44 +47,52 @@ public class SysPropTest
 				isWindows = true;
 			}
 
+			/* On jdk18+ with JEP 400 UTF-8 by default, the non-ascii characters in the testkey property
+			 * are converted to UTF8 by the test (not the JVM).
+			 */
+			final byte[] expectedBytes = ((VersionCheck.major() >= 18) && !isWindows) ? inputBytesUtf8 : inputBytes;
+
 			if (argEncoding.equals("DEFAULT")) {
 				osEncoding = System.getProperty("os.encoding");
 			}
 
 			/* Windows converts from the platform default to UTF8 internally to the VM and
-			   sets os.encoding to UTF8. To replicate this behavior, on Windows use the default encoding
-			   and not the os.encoding. */
-			if (osEncoding != null && osEncoding.length() != 0 && isWindows == false) {  
-				strTestProp = new String(B,osEncoding);
+			 * sets os.encoding to UTF8. To replicate this behavior, on Windows use the default encoding
+			 * and not the os.encoding.
+			 */
+			if (osEncoding != null && osEncoding.length() != 0 && isWindows == false) {
+				strTestProp = new String(expectedBytes, osEncoding);
 			} else {
 				if ((argEncoding.equals("UTF-8") || argEncoding.equals("ISO-8859-1"))) {
-					strTestProp = new String(B,argEncoding);
+					strTestProp = new String(expectedBytes, argEncoding);
 				} else {
-					strTestProp = new String(B, System.getProperty("native.encoding", Charset.defaultCharset().name()));
+					strTestProp = new String(expectedBytes, System.getProperty("native.encoding", Charset.defaultCharset().name()));
 				}
 			}
-			
-			String strProp = System.getProperty("testkey"); 
+
+			String strProp = System.getProperty("testkey");
 			if (strProp == null || strTestProp.compareTo(strProp) != 0) {
-				System.out.println("test failed"); 
-				System.out.println("os.encoding: " + System.getProperty("os.encoding"));	
-				System.out.println("file.encoding: " + System.getProperty("file.encoding"));				
+				System.out.println("test failed");
+				System.out.println("os.encoding: " + System.getProperty("os.encoding"));
+				System.out.println("native.encoding: " + System.getProperty("native.encoding"));
+				System.out.println("defaultCharset(): " + Charset.defaultCharset().name());
+				System.out.println("file.encoding: " + System.getProperty("file.encoding"));
 				System.out.print("strProp    : ");
-				for (int i=0; i < strProp.length(); i++) {
+				for (int i = 0; i < strProp.length(); i++) {
 					System.out.print(Integer.toHexString(strProp.charAt(i)) + " ");
 				}
 				System.out.println();
 				System.out.print("strTestProp: ");
-				for (int i=0; i < strTestProp.length(); i++) {
+				for (int i = 0; i < strTestProp.length(); i++) {
 					System.out.print(Integer.toHexString(strTestProp.charAt(i)) + " ");
 				}
-				System.out.println();				
-				
+				System.out.println();
+
 			} else {
-				System.out.println("test succeeded"); 
+				System.out.println("test succeeded");
 			}
-		} catch(UnsupportedEncodingException e) {
-			System.out.println("test failed"); 
+		} catch (UnsupportedEncodingException e) {
+			System.out.println("test failed");
 			e.printStackTrace();
 		}
 	}

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 import java.util.*;
 import java.io.*;
+import java.nio.charset.Charset;
 
 public class SysPropTest 
 {
@@ -57,7 +58,7 @@ public class SysPropTest
 				if ((argEncoding.equals("UTF-8") || argEncoding.equals("ISO-8859-1"))) {
 					strTestProp = new String(B,argEncoding);
 				} else {
-					strTestProp = new String(B);
+					strTestProp = new String(B, System.getProperty("native.encoding", Charset.defaultCharset().name()));
 				}
 			}
 			


### PR DESCRIPTION
Cherry pick https://github.com/eclipse-openj9/openj9/pull/14507 and https://github.com/eclipse-openj9/openj9/pull/14579 for the 0.31 release.