### PR TITLE
Revert "auto exclude test jit_compareAndBranch_0 testflag=aot"

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -180,13 +180,6 @@
 	</test>
 	<test>
 		<testCaseName>jit_compareAndBranch</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14459#issuecomment-1033015284</comment>
-				<variation>-Xjit:count=1,limit={*testAddressCompare*},optlevel=hot,disableCFGSimplification,disableGRA,disableAsyncCompilation</variation>
-				<testflag>aot</testflag>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit:count=1,limit={*testAddressCompare*},optlevel=hot,disableCFGSimplification,disableGRA,disableAsyncCompilation</variation>
 		</variations>


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#14462

This test was excluded due to #14459, which now should have been fixed by eclipse/omr#6363