### PR TITLE
Enable Idiom Recognition outside of jitserver

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1042,181 +1042,189 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
    if (c->isOutOfProcessCompilation())
       {
       JITServer::GlobalAllocationRegion globalAllocationRegion(c->fej9()->_compInfoPT);
-#else
-      {
+      initializeGraphs(c);
+      }
+   else
 #endif
-      int32_t num = 0;
-      bool genTRxx = c->cg()->getSupportsArrayTranslateTRxx();
-      bool genSIMD = c->cg()->getSupportsVectorRegisters() && !c->getOption(TR_DisableSIMDArrayTranslate);
-      bool genTRTO255 = c->cg()->getSupportsArrayTranslateTRTO255();
-      bool genTRTO = c->cg()->getSupportsArrayTranslateTRTO();
-      bool genTROTNoBreak = c->cg()->getSupportsArrayTranslateTROTNoBreak();
-      bool genTROT = c->cg()->getSupportsArrayTranslateTROT();
-      bool genTRT =  c->cg()->getSupportsArrayTranslateAndTest();
-      bool genMemcpy = c->cg()->getSupportsReferenceArrayCopy() || c->cg()->getSupportsPrimitiveArrayCopy();
-      bool genMemset = c->cg()->getSupportsArraySet();
-      bool genMemcmp = c->cg()->getSupportsArrayCmp();
-      bool genIDiv2Mul = c->cg()->getSupportsLoweringConstIDiv();
-      bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();
-      // FIXME: We need getSupportsCountDecimalDigit() like interface
-      // this idiom is only enabled on 390 for the moment
+      {
+      initializeGraphs(c);
+      }
+   }
+
+void
+TR_CISCGraph::initializeGraphs(TR::Compilation *c)
+   {
+   int32_t num = 0;
+   bool genTRxx = c->cg()->getSupportsArrayTranslateTRxx();
+   bool genSIMD = c->cg()->getSupportsVectorRegisters() && !c->getOption(TR_DisableSIMDArrayTranslate);
+   bool genTRTO255 = c->cg()->getSupportsArrayTranslateTRTO255();
+   bool genTRTO = c->cg()->getSupportsArrayTranslateTRTO();
+   bool genTROTNoBreak = c->cg()->getSupportsArrayTranslateTROTNoBreak();
+   bool genTROT = c->cg()->getSupportsArrayTranslateTROT();
+   bool genTRT =  c->cg()->getSupportsArrayTranslateAndTest();
+   bool genMemcpy = c->cg()->getSupportsReferenceArrayCopy() || c->cg()->getSupportsPrimitiveArrayCopy();
+   bool genMemset = c->cg()->getSupportsArraySet();
+   bool genMemcmp = c->cg()->getSupportsArrayCmp();
+   bool genIDiv2Mul = c->cg()->getSupportsLoweringConstIDiv();
+   bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();
+   // FIXME: We need getSupportsCountDecimalDigit() like interface
+   // this idiom is only enabled on 390 for the moment
 
 #if defined(J9VM_OPT_JITSERVER)
-      // Enabling genDecimal generates the TROT instruction on Z which is currently not
-      // relocatable for remote compiles. Thus we disable this option for remote compiles for now.
-      bool genDecimal = c->target().cpu.isZ() && !c->isOutOfProcessCompilation();
+   // Enabling genDecimal generates the TROT instruction on Z which is currently not
+   // relocatable for remote compiles. Thus we disable this option for remote compiles for now.
+   bool genDecimal = c->target().cpu.isZ() && !c->isOutOfProcessCompilation();
 #else
-      bool genDecimal = c->target().cpu.isZ();
+   bool genDecimal = c->target().cpu.isZ();
 #endif /* defined(J9VM_OPT_JITSERVER) */
-      bool genBitOpMem = c->target().cpu.isZ();
-      bool is64Bit = c->target().is64Bit();
-      bool isBig = c->target().cpu.isBigEndian();
-      int32_t ctrl = (is64Bit ? CISCUtilCtl_64Bit : 0) | (isBig ? CISCUtilCtl_BigEndian : 0);
+   bool genBitOpMem = c->target().cpu.isZ();
+   bool is64Bit = c->target().is64Bit();
+   bool isBig = c->target().cpu.isBigEndian();
+   int32_t ctrl = (is64Bit ? CISCUtilCtl_64Bit : 0) | (isBig ? CISCUtilCtl_BigEndian : 0);
 
-      // THESE ARE NOT GUARANTEED OR TESTED TO WORK ON WCODE.
-      // Problems encountered include ahSize=0 on WCode leading to hash collision when adding node for make*CISCGraphs.
-      if (genMemcmp)
-         {
-         preparedCISCGraphs[num] =  makeMemCmpGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCmpIndexOfGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCmpSpecialGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         }
-      if (genTRT)
-         {
-         preparedCISCGraphs[num] =  makeTRTGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeTRTGraph2(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeTRT4NestedArrayGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         //preparedCISCGraphs[num] =  makeTRT4NestedArrayIfGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-         }
-      if (genMemset)
-         {
-         preparedCISCGraphs[num] =  makeMemSetGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
+   // THESE ARE NOT GUARANTEED OR TESTED TO WORK ON WCODE.
+   // Problems encountered include ahSize=0 on WCode leading to hash collision when adding node for make*CISCGraphs.
+   if (genMemcmp)
+      {
+      preparedCISCGraphs[num] =  makeMemCmpGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCmpIndexOfGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCmpSpecialGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      }
+   if (genTRT)
+      {
+      preparedCISCGraphs[num] =  makeTRTGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeTRTGraph2(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeTRT4NestedArrayGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      //preparedCISCGraphs[num] =  makeTRT4NestedArrayIfGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+      }
+   if (genMemset)
+      {
+      preparedCISCGraphs[num] =  makeMemSetGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
 #if STRESS_TEST
-         preparedCISCGraphs[num] =  makeMixedMemSetGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMixedMemSetGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
 #endif
-         preparedCISCGraphs[num] = makePtrArraySetGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         // Causes perf degradations on Xalan strlen16 opportunities. SRSTU is only better on long strings.
-         //preparedCISCGraphs[num] = makeStrlen16Graph(c, ctrl);
-         //setEssentialNodes(preparedCISCGraphs[num++]);
-         }
-      if (genMemcpy)
-         {
-         preparedCISCGraphs[num] =  makeMemCpyGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCpyDecGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCpySpecialGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCpyByteToCharGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCpyByteToCharBndchkGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMemCpyCharToByteGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMEMCPYChar2ByteGraph2(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeMEMCPYChar2ByteMixedGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         // disabled for now
+      preparedCISCGraphs[num] = makePtrArraySetGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      // Causes perf degradations on Xalan strlen16 opportunities. SRSTU is only better on long strings.
+      //preparedCISCGraphs[num] = makeStrlen16Graph(c, ctrl);
+      //setEssentialNodes(preparedCISCGraphs[num++]);
+      }
+   if (genMemcpy)
+      {
+      preparedCISCGraphs[num] =  makeMemCpyGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCpyDecGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCpySpecialGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCpyByteToCharGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCpyByteToCharBndchkGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMemCpyCharToByteGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMEMCPYChar2ByteGraph2(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeMEMCPYChar2ByteMixedGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      // disabled for now
 #if STRESS_TEST
-         preparedCISCGraphs[num] =  makeMEMCPYByte2IntGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-         preparedCISCGraphs[num] =  makeMEMCPYInt2ByteGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+      preparedCISCGraphs[num] =  makeMEMCPYByte2IntGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+      preparedCISCGraphs[num] =  makeMEMCPYInt2ByteGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
 #endif
-         }
+      }
 
-      if (genTRTO255 || genTRTO || genSIMD || genTRxx)
+   if (genTRTO255 || genTRTO || genSIMD || genTRxx)
+      {
+      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 0);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 1);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 2);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTxThreeIfsGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 0);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 1);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 2);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+
+      }
+
+   if (genTROTNoBreak || genTROT || genSIMD || genTRxx)
+      {
+      preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 0);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 1);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      }
+
+   if (genTRxx)
+      {
+      if (c->getOption(TR_EnableCopyingTROTInduction1Idioms))
          {
-         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 0);
+         preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 0);
          setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 1);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 2);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTxThreeIfsGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 0);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 1);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 2);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-
-         }
-
-      if (genTROTNoBreak || genTROT || genSIMD || genTRxx)
-         {
-         preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 0);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 1);
+         preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 1);
          setEssentialNodes(preparedCISCGraphs[num++]);
          }
-
-      if (genTRxx)
-         {
-         if (c->getOption(TR_EnableCopyingTROTInduction1Idioms))
-            {
-            preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 0);
-            setEssentialNodes(preparedCISCGraphs[num++]);
-            preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 1);
-            setEssentialNodes(preparedCISCGraphs[num++]);
-            }
-         preparedCISCGraphs[num] =  makeCopyingTROOSpecialGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTROOSpecialGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
 #if STRESS_TEST
-         preparedCISCGraphs[num] =  makeCopyingTRTTSpecialGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCopyingTRTTSpecialGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
 #endif
-         if (is64Bit)
-            {
-            preparedCISCGraphs[num] =  makeCopyingTRTOGraphSpecial(c, ctrl);
-            setEssentialNodes(preparedCISCGraphs[num++]);
-            }
-         preparedCISCGraphs[num] =  makeTROTArrayGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeTRTOArrayGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeTRTOArrayGraphSpecial(c, ctrl);
+      if (is64Bit)
+         {
+         preparedCISCGraphs[num] =  makeCopyingTRTOGraphSpecial(c, ctrl);
          setEssentialNodes(preparedCISCGraphs[num++]);
          }
-      if (genDecimal)
-         {
-         // Needs to be modified
-         preparedCISCGraphs[num] =  makeCountDecimalDigitIntGraph(c, ctrl, genIDiv2Mul);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeIntToStringGraph(c, ctrl, genIDiv2Mul);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCountDecimalDigitLongGraph(c, ctrl, genLDiv2Mul);
-         setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeTROTArrayGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeTRTOArrayGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeTRTOArrayGraphSpecial(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      }
+   if (genDecimal)
+      {
+      // Needs to be modified
+      preparedCISCGraphs[num] =  makeCountDecimalDigitIntGraph(c, ctrl, genIDiv2Mul);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeIntToStringGraph(c, ctrl, genIDiv2Mul);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      preparedCISCGraphs[num] =  makeCountDecimalDigitLongGraph(c, ctrl, genLDiv2Mul);
+      setEssentialNodes(preparedCISCGraphs[num++]);
 #if STRESS_TEST
-         preparedCISCGraphs[num] =  makeLongToStringGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+      preparedCISCGraphs[num] =  makeLongToStringGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
 #endif
-         }
-      if (genBitOpMem)
-         {
-         preparedCISCGraphs[num] =  makeBitOpMemGraph(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         }
+      }
+   if (genBitOpMem)
+      {
+      preparedCISCGraphs[num] =  makeBitOpMemGraph(c, ctrl);
+      setEssentialNodes(preparedCISCGraphs[num++]);
+      }
 
-      TR_ASSERT(num <= MAX_PREPARED_GRAPH, "incorrect number of graphs!");
-      numPreparedCISCGraphs = num;
+   TR_ASSERT(num <= MAX_PREPARED_GRAPH, "incorrect number of graphs!");
+   numPreparedCISCGraphs = num;
 
-      // set minimumHotnessPrepared;
-      minimumHotnessPrepared = scorching;
-      for (;--num >= 0;)
-         {
-         TR_Hotness hotness = preparedCISCGraphs[num]->getHotness();
-         if (minimumHotnessPrepared > hotness)
-            minimumHotnessPrepared = hotness;
-         }
+   // set minimumHotnessPrepared;
+   minimumHotnessPrepared = scorching;
+   for (;--num >= 0;)
+      {
+      TR_Hotness hotness = preparedCISCGraphs[num]->getHotness();
+      if (minimumHotnessPrepared > hotness)
+         minimumHotnessPrepared = hotness;
       }
    }
 

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -765,6 +765,7 @@ public:
 
    static void setEssentialNodes(TR_CISCGraph*);
    static void makePreparedCISCGraphs(TR::Compilation *c);
+   static void initializeGraphs(TR::Compilation *c);
 
    TR_CISCGraph(TR_Memory * m, const char *title = 0, int32_t numHashTrNode = 31, int32_t numHashOpc = 17)
       : _titleOfCISC(title), _entryNode(0), _exitNode(0), _numNodes(0), _numDagIds(0),


### PR DESCRIPTION
Consider the following test case.

```
public class TestIdiomRecognition {
    public static final void main(String[] args) {
        char[] dst = new char[256];
        char[] src = new char[256];

        docopy(dst, src, 0, 0, 256);
        docopy(dst, src, 0, 0, 256);
        docompare(dst, src, 0, 0, 256, true);
        docompare(dst, src, 0, 0, 256, true);
    }

    public static final void docopy(char[] dst, char[] src, int start1, int start2, int len) {
        if (len < dst.length && len < src.length) {
            for (int i = 0; i < len; i++) {
                dst[i + start1] = src[i + start2];
            }
        }
    }

    public static final boolean docompare(char[] dst, char[] src, int start1, int start2, int len, boolean b) {
        boolean same = true;

        if (len < dst.length && len < src.length) {
            for (int i = 0; i < len; i++) {
                if (dst[i + start1] != src[i + start2]) {
                    same = false;
                    break;
                }
            }
        }

        return same;
    }
}
```

Running it with the following command invocation with a recent OpenJ9 build that was configured using `--enable-jitserver` shows that Idiom Recognition fails to transform the loop in `docopy` into an `arraycopy` operation and the loop in `docompare` into an `arraycmp` operation.

```
java -Xjit:limit={TestIdiomRecognition.do*},count=1,disableAsyncCompilation,{TestIdiomRecognition.do*}\(optLevel=hot,traceIdiomRecognition,log=testidiom.log\) TestIdiomRecognition
```

The problem appears to lie in part of [Idiom Recognition's set up code in `TR_CISCGraph::makePreparedCISCGraphs`](https://github.com/eclipse-openj9/openj9/blob/245cd10a22729c572ceb588b99f884cbddc49cad/runtime/compiler/optimizer/IdiomRecognition.cpp#L1038-L1060).  If `J9VM_OPT_JITSERVER` is defined, CISC graphs are only created for out-of-process compilations.

It looks like this problem was introduced in commit https://github.com/eclipse-openj9/openj9/commit/d5b3d8a2e5755d95e3e392831e65a523c70ffd11.  That was intended to ensure the allocation of the CISC graphs was performed with a `GlobalAllocationRegion` in scope for out-of-process compilations, but inadvertently placed the creation of the prepared CISC graphs always under the check for out-of-process compilations.

This pull request corrects the problem by ensuring the graphs are always created, but that the `GlobalAllocationRegion` is in scope if the graphs are being created for an out-of-process compilation.