### PR TITLE
AArch64: Implement Locals Compaction

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,6 +105,11 @@ class PrivateLinkage : public J9::PrivateLinkage
    virtual uint32_t getRightToLeft();
 
    /**
+    * @brief Adjust stack index so that local references are aligned properly
+    * @param[in/out] stackIndex : index on stack
+    */
+   virtual void alignLocalReferences(uint32_t &stackIndex);
+   /**
     * @brief Maps symbols to locations on stack
     * @param[in] method : method for which symbols are mapped on stack
     */
@@ -115,6 +120,13 @@ class PrivateLinkage : public J9::PrivateLinkage
     * @param[in/out] stackIndex : index on stack
     */
    virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex);
+   /**
+    * @brief Maps an automatic symbol to an index on stack
+    * @param[in] p : automatic symbol
+    * @param[in] size : size
+    * @param[in/out] stackIndex : index on stack
+    */
+   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t size, uint32_t &stackIndex);
 
    /**
     * @brief Initializes ARM64 RealRegister linkage


### PR DESCRIPTION
This commit implements locals compaction on aarch64.
`mapStack` function is changed to call `mapCompactedStack` function
implemented in OMRLinkage class when locals compaction is enabled.
`mapSingleAutomatic` function is modified so that 8-byte (or larger)
alignment is applied only to stack allocated object without GC index,
because GC indices of stack allocated objects are already adjusted
in `createStackAtlas()` so that they are properly aligned.

Depends on https://github.com/eclipse/omr/pull/6379

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>