### PR TITLE
Fix Xmns value under -Xtune:throughput

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2067,7 +2067,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 				 * space to Xmos
 				 */
 				if ((candidateXmosValue + candidateXmnsValue) > maximumXmsValue) {
-					candidateXmnsValue = newSpaceSizeMinimum;
+					candidateXmnsValue = OMR_MAX(newSpaceSizeMinimum, maximumXmsValue - candidateXmosValue);
 					candidateXmosValue = maximumXmsValue - candidateXmnsValue;
 
 					/* Verify not too large */


### PR DESCRIPTION
Testing with -Xtune:throughput has shown a flaw when maximum heap size
is not a multiple of 8k (double the page size). Details follow:

Under Xtune:throughput, the initial size of heap (Xms value) is set to
equal the maximum size of the heap (Xmx value). This is done in
`gcInitializeCalculatedValues(J9JavaVM *javaVM, IDATA* memoryParameters)`
which computes Xms, Xmns, Xmno values and stores them into "gc extensions"
for future use. The logic assigns Xms=Xmx, Xmns=Xmx/4 and Xmos=Xmx/4*3.
In this process, `MM_Math::roundToCeiling()` is used and the Xmns value may
receive an extra 4K (nursery is rounded up on a 8K boundary).
Later-on, in `combinationMemoryParameterVerification()` there is some checking
that all the computed/selected values are fine. In particular, we check whether
`Xmos+Xmns > Xms`. Because of the rounding, this condition is indeed true and
therefore the GC takes corrective action by setting Xmns to the smallest size
allowed. In turn, this greatly affects performance because the nursery space
wil not grow if the heap is expanded from the very beginning (Xms==Xmx).

This commit chnages the corrective action described above to compute the
Xmns value as the diference between Xms and Xmos.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>