### PR TITLE
Capture command line on z/OS

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1141,16 +1141,6 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	const char *envVarName = "OPENJ9_JAVA_COMMAND_LINE";
 	IDATA result = j9sysinfo_get_env(envVarName, commandLineBuffer, _MaximumCommandLineLength);
 
-#if defined(J9ZOS390)
-	/* captureCommandLine() in jvm.c does not yet support z/OS;
-	 * use IBM_JAVA_COMMAND_LINE if OPENJ9_JAVA_COMMAND_LINE is not defined
-	 */
-	if (result < 0) {
-		envVarName = "IBM_JAVA_COMMAND_LINE";
-		result = j9sysinfo_get_env(envVarName, commandLineBuffer, _MaximumCommandLineLength);
-	}
-#endif /* defined(J9ZOS390) */
-
 	if (0 == result) {
 		/* Ensure null-terminated */
 		commandLineBuffer[_MaximumCommandLineLength - 1] = '\0';


### PR DESCRIPTION
Also remove workaround of using `IBM_JAVA_COMMAND_LINE` on z/OS.
This should be the final piece of addressing #947.