### PR TITLE
AArch64 macOS: Add calls to pthread_jit_write_protect_np()

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2350,6 +2350,9 @@ static int32_t relocateAndRegisterThunk(
       // the old cache (which is not switched) will fail
       U_8 *thunkStart = TR::CodeCacheManager::instance()->allocateCodeMemory(firstDescriptor.length, 0, &codeCache, &coldCode, true);
       U_8 *thunkAddress;
+#if defined(OSX) && defined(AARCH64)
+      pthread_jit_write_protect_np(0);
+#endif
       if (thunkStart)
          {
          // Relocate the thunk


### PR DESCRIPTION
This commit adds calls to pthread_jit_write_protect_np() for AArch64
macOS, which were removed by #14542.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>