### PR TITLE
(0.32.0) Fix reference to array that is out of scope

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -333,23 +333,25 @@ jobject getPropertyList(JNIEnv *env)
 {
 	PORT_ACCESS_FROM_ENV(env);
 	int propIndex = 0;
-	jobject propertyList;
+	jobject propertyList = NULL;
 #define PROPERTY_COUNT 137
-	char *propertyKey= NULL;
-	const char * language;
-	const char * region;
-	const char * variant;
+	char *propertyKey = NULL;
+	const char * language = NULL;
+	const char * region = NULL;
+	const char * variant = NULL;
 	const char *strings[PROPERTY_COUNT];
 #define USERNAME_LENGTH 128
 	char username[USERNAME_LENGTH];
 	char *usernameAlloc = NULL;
-	IDATA result;
+	/* buffer to hold the size of the maximum direct byte buffer allocations */
+	char maxDirectMemBuff[24];
+	IDATA result = 0;
 
 	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	OMR_VM *omrVM = javaVM->omrVM;
 
-	/* Change the allocation value PROPERTY_COUNT above as you add/remove properties, 
-	 * then follow the propIndex++ convention and consume 2 * slots for each property. 2 * number of property keys is the 
+	/* Change the allocation value PROPERTY_COUNT above as you add/remove properties,
+	 * then follow the propIndex++ convention and consume 2 * slots for each property. 2 * number of property keys is the
 	 * correct allocation.
 	 * Also note the call to addSystemProperties below, which may add some configuration-specific properties.  Be sure to leave
 	 * enough room in the property list for all possibilities.
@@ -426,7 +428,6 @@ jobject getPropertyList(JNIEnv *env)
 
 	/*[PR 95709]*/
 
-
 	/* Get the language, region and variant */
 	language = j9nls_get_language();	
 	region = j9nls_get_region();
@@ -477,8 +478,6 @@ jobject getPropertyList(JNIEnv *env)
 	}
 #endif /* defined(OPENJ9_BUILD) && JAVA_SPEC_VERSION == 8 */
 	if ((UDATA) -1 != javaVM->directByteBufferMemoryMax) {
-		/* buffer to hold the size of the maximum direct byte buffer allocations */
-		char maxDirectMemBuff[24];
 		strings[propIndex] = "sun.nio.MaxDirectMemorySize";
 		propIndex += 1;
 		j9str_printf(PORTLIB, maxDirectMemBuff, sizeof(maxDirectMemBuff), "%zu", javaVM->directByteBufferMemoryMax);


### PR DESCRIPTION
Cherry-pick #14644 for the 0.32.0 release branch.