### PR TITLE
Add release note for -XX:MaxDirectMemorySize change in Java 11+

### DIFF
--- a/doc/release-notes/0.31/0.31.md
+++ b/doc/release-notes/0.31/0.31.md
@@ -55,6 +55,14 @@ The following table covers notable changes in v0.31.0. Further information about
 <td valign="top">This option controls if hidden method frames generated for MethodHandles are displayed in a stacktrace. This option is disabled by default and can be enabled for debugging purposes.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/14623">#14623</a></td>
+<td valign="top">Modified default for <tt>-XX:MaxDirectMemorySize</tt></td>
+<td valign="top">Java 11 and later</td>
+<td valign="top">In Java 11 and later, <tt>-XX:MaxDirectMemorySize</tt> is no longer set by default and the class library limits the amount of heap memory used for
+Direct Byte Buffers to the same value as the maximum heap size. Previously the limit was 87.5% of the maximum heap size.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
PR https://github.com/eclipse-openj9/openj9/pull/14623