### PR TITLE
Update README for Jenkins jobs

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2021 IBM Corp. and others
+Copyright (c) 2017, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,13 +74,16 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
         - Shortname: win32
     - OSX on x86-64
         - Spec: x86-64_mac
-        - Shortname: osx
+        - Shortname: osx or xmac
     - OSX on x86-64 largeheap/non-compressed references
         - Spec: x86-64_mac_xl
         - Shortname: osxlargeheap or osxxl
+    - OSX on aarch64 (currently largeheap only)
+        - Spec: aarch64_mac
+        - Shortname: amac
     - ALL
         - Launches a subset of 'all' platforms
-        - ppc64le_linux, ppc64le_linux_xl, s390x_linux, s390x_linux_xl, x86-64_linux, x86-64_linux_xl, ppc64_aix, x86-64_windows, x86-32_windows, x86-64_mac
+        - ppc64le_linux, s390x_linux, x86-64_linux, aarch64_linux, ppc64_aix, x86-64_windows, x86-32_windows, x86-64_mac, aarch64_mac
 - Many specs support a suffix of `_cm` or `_uma` (omit the leading underscore for shortnames) to override the default build system.
 - OpenJ9 committers can request builds by commenting in a pull request
     - Format: `Jenkins <build type> <level>.<group>[+<test_flag>] <platform>[,<platform>,...,<platform>] jdk<version>[,jdk<version>,...,jdk<version>]`


### PR DESCRIPTION
This commit adds aarch64_mac to buildenv/jenkins/README.md

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>