### PR TITLE
Adjust for signature change to NativeLibraries.load() in Java 19

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -759,11 +759,11 @@ static const char * const excludeArray[] = {
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/security/AccessController.doPrivileged(Ljava/security/PrivilegedExceptionAction;Ljava/security/AccessControlContext;[Ljava/security/Permission;)Ljava/lang/Object;",
    "java/lang/NullPointerException.fillInStackTrace()Ljava/lang/Throwable;",
-#if JAVA_SPEC_VERSION >= 17
+#if (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18)
    "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z",
-#else /* JAVA_SPEC_VERSION >= 17 */
+#elif JAVA_SPEC_VERSION >= 15 /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
    "jdk/internal/loader/NativeLibraries.load(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z",
-#endif /* JAVA_SPEC_VERSION >= 17 */
+#endif /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
 };
 
 bool
@@ -3023,15 +3023,17 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+#if JAVA_SPEC_VERSION >= 15
    static X NativeLibrariesMethods[] =
       {
-#if JAVA_SPEC_VERSION >= 17
+#if (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18)
       {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z")},
-#else /* JAVA_SPEC_VERSION >= 17 */
+#else /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
       {x(TR::jdk_internal_loader_NativeLibraries_load, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z")},
-#endif /* JAVA_SPEC_VERSION >= 17 */
+#endif /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
       {  TR::unknownMethod}
       };
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
    static X VectorSupportMethods[] =
       {
@@ -4164,7 +4166,9 @@ void TR_ResolvedJ9Method::construct()
    static Y class35[] =
       {
       { "java/lang/invoke/ExplicitCastHandle", ExplicitCastHandleMethods },
+#if JAVA_SPEC_VERSION >= 15
       { "jdk/internal/loader/NativeLibraries", NativeLibrariesMethods },
+#endif /* JAVA_SPEC_VERSION >= 15 */
       { "java/lang/invoke/DirectMethodHandle", DirectMethodHandleMethods },
       { 0 }
       };

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -195,11 +195,11 @@ standardInit( J9JavaVM *vm, char *dllName)
 				if (NULL == clz) {
 					goto _fail;
 				}
-#if JAVA_SPEC_VERSION >= 17
+#if (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18)
 				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z");
-#else /* JAVA_SPEC_VERSION >= 17 */
+#else /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
 				mid = (*env)->GetStaticMethodID(env, clz, "load", "(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z");
-#endif /* JAVA_SPEC_VERSION >= 17 */
+#endif /* (17 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 18) */
 				if (NULL == mid) {
 					goto _fail;
 				}

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -422,7 +422,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<!-- Static method references needed to support OpenJDK MethodHandles. -->
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="linkCallerMethod" signature="(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 
-	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="17-"/>
+	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="15-18"/>
+	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="19-"/>
 
 	<!-- Security manager check -->
 	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>


### PR DESCRIPTION
Fixes build failure seen at https://openj9-jenkins.osuosl.org/job/Pipeline-OpenJDK-Acceptance/252/ due to:

* 8282515: More clean up on NativeLibraries just for JNI library use

Fixes: #14650.