### PR TITLE
SATB: TLH Batch Mark and Inline allocations

### DIFF
--- a/runtime/gc_glue_java/ObjectModelDelegate.cpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,3 +84,17 @@ GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, M
 	*hotFieldAlignmentDescriptor = clazz->instanceHotFieldDescription;
 }
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+
+void
+GC_ObjectModelDelegate::initializeMinimumSizeObject(MM_EnvironmentBase *env, void *allocAddr)
+{
+	J9JavaVM *javaVM = (J9JavaVM *)env->getLanguageVM();
+	J9Class *clazz = J9VMJAVALANGOBJECT_OR_NULL(javaVM);
+	j9object_t instance = (j9object_t) allocAddr;
+
+	memset(instance, 0, OMR_MINIMUM_OBJECT_SIZE);
+
+	MM_GCExtensions::getExtensions(env)->objectModel.setObjectClass(instance, clazz);
+
+	Assert_MM_true(J9GC_J9OBJECT_CLAZZ(allocAddr, env) == clazz);
+}

--- a/runtime/gc_glue_java/ObjectModelDelegate.hpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -460,6 +460,16 @@ public:
 	 */
 	void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, uintptr_t *hotFieldAlignmentDescriptor);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+
+	/**
+	 * Initialize an object of minimal object size at given addr. Specifically, java/lang/object is used.
+	 *
+	 * There is an assumption that the object is not visible (referred) by anyone, so the minimum initialization can be done.
+	 *
+	 * @param[in] env The environment for the calling thread.
+	 * @param[in] allocAddr address at which the object is created.
+	 */
+	void initializeMinimumSizeObject(MM_EnvironmentBase *env, void *allocAddr);
 
 	/**
 	 * Constructor receives a copy of OMR's object flags mask, normalized to low order byte. Delegate

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -2059,8 +2059,36 @@ public:
 		return vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_asConstantPoolObject(vmThread, toConvert, allocateFlags);
 	}
 
-protected:
+	VMINLINE bool
+	isSATBBarrierEnabled(J9VMThread *vmThread) const
+	{
+#if defined(J9VM_GC_REALTIME)
+		if (usingSATB()) {
+			MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
+			MM_GCRememberedSet *parent = fragment->fragmentParent;
+			return (0 != parent->globalFragmentIndex);
+		} else
+#endif /* J9VM_GC_REALTIME */
+		{
+			return false;
+		}
+	}
 
+	VMINLINE bool
+	isSATBDoubleBarrierEnabled(J9VMThread *vmThread) const
+	{
+#if defined(J9VM_GC_REALTIME)
+		if (usingSATB()) {
+			MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
+			return (0 == fragment->localFragmentIndex);
+		} else
+#endif /* J9VM_GC_REALTIME */
+		{
+			return false;
+		}
+	}
+
+protected:
 	/**
 	 * Called before object references are stored into mixed objects to perform an prebarrier work.
 	 *
@@ -2697,8 +2725,7 @@ private:
 	VMINLINE void
 	internalPreStoreObject(J9VMThread *vmThread, j9object_t object, fj9object_t *destAddress, j9object_t value)
 	{
-		if ((j9gc_modron_wrtbar_satb == _writeBarrierType) ||
-				(j9gc_modron_wrtbar_satb_and_oldcheck == _writeBarrierType)) {
+		if (usingSATB()) {
 			internalPreStoreObjectSATB(vmThread, object, destAddress, value);
 		}
 	}
@@ -2717,8 +2744,7 @@ private:
 	VMINLINE void
 	internalStaticPreStoreObject(J9VMThread *vmThread, j9object_t dstClassObject, j9object_t *destAddress, j9object_t value)
 	{
-		if ((j9gc_modron_wrtbar_satb == _writeBarrierType) ||
-				(j9gc_modron_wrtbar_satb_and_oldcheck == _writeBarrierType)) {
+		if (usingSATB()) {
 			internalStaticPreStoreObjectSATB(vmThread, dstClassObject, destAddress, value);
 		}
 	}
@@ -2735,12 +2761,10 @@ private:
 	internalPreStoreObjectSATB(J9VMThread *vmThread, j9object_t object, fj9object_t *destAddress, j9object_t value)
 	{
 #if defined(J9VM_GC_REALTIME)
-		MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
-		MM_GCRememberedSet *parent = fragment->fragmentParent;
 		/* Check if the barrier is enabled.  No work if barrier is not enabled */
-		if (0 != parent->globalFragmentIndex) {
+		if (isSATBBarrierEnabled(vmThread)) {
 			/* if the double barrier is enabled call OOL */
-			if (0 == fragment->localFragmentIndex) {
+			if (isSATBDoubleBarrierEnabled(vmThread)) {
 				vmThread->javaVM->memoryManagerFunctions->J9WriteBarrierPre(vmThread, object, destAddress, value);
 			} else {
 				j9object_t oldObject = readObjectImpl(vmThread, destAddress, false);
@@ -2766,12 +2790,10 @@ private:
 	internalStaticPreStoreObjectSATB(J9VMThread *vmThread, j9object_t dstClassObject, j9object_t *destAddress, j9object_t value)
 	{
 #if defined(J9VM_GC_REALTIME)
-		MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
-		MM_GCRememberedSet *parent = fragment->fragmentParent;
 		/* Check if the barrier is enabled.  No work if barrier is not enabled */
-		if (0 != parent->globalFragmentIndex) {
+		if (isSATBBarrierEnabled(vmThread)) {
 			/* if the double barrier is enabled call OOL */
-			if (0 == fragment->localFragmentIndex) {
+			if (isSATBDoubleBarrierEnabled(vmThread)) {
 				vmThread->javaVM->memoryManagerFunctions->J9WriteBarrierPreClass(vmThread, dstClassObject, destAddress, value);
 			} else {
 				j9object_t oldObject = *destAddress;
@@ -2988,6 +3010,12 @@ private:
 		return result;
 	}
 #endif /* J9VM_GC_GENERATIONAL */
+
+	VMINLINE bool
+	usingSATB() const
+	{
+		return ((j9gc_modron_wrtbar_satb == _writeBarrierType) || (j9gc_modron_wrtbar_satb_and_oldcheck == _writeBarrierType));
+	}
 
 
 };


### PR DESCRIPTION
- Implementation to seal TLH with java.lang.Object. (Relates to: https://github.com/eclipse/omr/pull/6388)

- Inline allocation path to account for SATB allocation (pre write barrier might scan newly alloced obj  object - always zero it with SATB)


Signed-off-by: Salman Rana <salman.rana@ibm.com>