### PR TITLE
(0.32.0) Enable JVMTI tests on AArch64 macOS

### DIFF
--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
@@ -116,14 +116,7 @@ public abstract class TestOptionsBase extends TestOptionsNonpersistent {
 	public void testVerboseData() { TestVerboseData.main(null); }
 	public void testVerboseHelper() { TestVerboseHelper.main(null); }
 	public void testVerboseAOT() { TestVerboseAOT.main(null); }
-	public void testSharedCacheJvmtiAPI() {
-		// JVMTI does not fully work on AArch64 macOS yet
-		// See https://github.com/eclipse-openj9/openj9/issues/14390
-		String spec = System.getenv("SPEC");
-		if (!spec.contains("osx_aarch64")) {
-			TestSharedCacheJvmtiAPI.main(null);
-		}
-	}
+	public void testSharedCacheJvmtiAPI() { TestSharedCacheJvmtiAPI.main(null); }
 	public void testSharedCacheJavaAPI() { TestSharedCacheJavaAPI.main(null); }
 	public void testDestroyCache() { TestDestroyCache.main(null); }
 	public void testExpireDestroyOnCorruptCache() { TestExpireDestroyOnCorruptCache.main(null); }

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -46,12 +46,6 @@
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -95,12 +89,6 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -144,12 +132,6 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -193,12 +175,6 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -241,12 +217,6 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -287,12 +257,6 @@
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -331,12 +295,6 @@
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>arch.390</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit enables the following JVMTI tests on AArch64 macOS back
again.

- cmdLineTester_jvmtitests_*
- testSharedCacheJvmtiAPI in testSCCacheManagement_0

Original PRs in master: #14622 #14655

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>