### PR TITLE
Move CRIU.isCRIUSupportEnabled() & related APIs into java.base

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -34,6 +34,7 @@ uses com.ibm.sharedclasses.spi.SharedClassProvider;
 uses com.ibm.gpu.spi.GPUAssist.Provider;
 exports com.ibm.gpu.spi to openj9.gpu;
 /*[IF CRIU_SUPPORT]*/
+exports openj9.internal.criu to openj9.criu;
 exports jdk.internal.misc to openj9.criu;
 opens jdk.internal.misc to openj9.criu;
 opens java.lang to openj9.criu;

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -1,0 +1,119 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package openj9.internal.criu;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Internal CRIU Support API
+ */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings({ "deprecation", "removal" })
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+public final class InternalCRIUSupport {
+
+	private static boolean criuSupportEnabled;
+	private static boolean nativeLoaded;
+	private static boolean initComplete;
+
+	private static native boolean isCRIUSupportEnabledImpl();
+
+	private static native boolean isCheckpointAllowedImpl();
+
+	private static void init() {
+		if (!initComplete) {
+			if (loadNativeLibrary()) {
+				criuSupportEnabled = isCRIUSupportEnabledImpl();
+			}
+			initComplete = true;
+		}
+	}
+
+	/**
+	 * Queries if CRIU support is enabled.
+	 *
+	 * @return true is support is enabled, false otherwise
+	 */
+	public synchronized static boolean isCRIUSupportEnabled() {
+		if (!initComplete) {
+			init();
+		}
+
+		return criuSupportEnabled;
+	}
+
+	/**
+	 * Returns an error message describing why isCRIUSupportEnabled() returns false,
+	 * and what can be done to remediate the issue.
+	 *
+	 * @return null if isCRIUSupportEnabled() returns true. Otherwise the error
+	 *         message
+	 */
+	public static String getErrorMessage() {
+		String s = null;
+		if (!isCRIUSupportEnabled()) {
+			if (nativeLoaded) {
+				s = "To enable criu support, please run java with the `-XX:+EnableCRIUSupport` option.";
+			} else {
+				s = "There was a problem loaded the criu native library.\n"
+						+ "Please check that criu is installed on the machine by running `criu check`.\n"
+						+ "Also, please ensure that the JDK is criu enabled by contacting your JDK provider.";
+			}
+		}
+		return s;
+	}
+
+	private static boolean loadNativeLibrary() {
+		if (!nativeLoaded) {
+			try {
+				AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+					System.loadLibrary("j9criu29"); //$NON-NLS-1$
+					nativeLoaded = true;
+					return null;
+				});
+			} catch (UnsatisfiedLinkError e) {
+				if (System.getProperty("enable.j9internal.checkpoint.hook.api.debug") != null) { //$NON-NLS-1$
+					e.printStackTrace();
+				}
+			}
+		}
+
+		return nativeLoaded;
+	}
+
+	/**
+	 * Queries if CRIU Checkpoint is allowed. isCRIUSupportEnabled() is invoked
+	 * first to ensure proper j9criu29 library loading.
+	 *
+	 * @return true if Checkpoint is allowed, otherwise false
+	 */
+	public static boolean isCheckpointAllowed() {
+		boolean checkpointAllowed = false;
+		if (isCRIUSupportEnabled()) {
+			checkpointAllowed = isCheckpointAllowedImpl();
+		}
+
+		return checkpointAllowed;
+	}
+}

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -23,9 +23,7 @@
 package org.eclipse.openj9.criu;
 
 import java.nio.file.Path;
-/*[IF JAVA_SPEC_VERSION < 17] */
 import java.security.AccessController;
-/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 import java.security.PrivilegedAction;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -45,25 +43,19 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import openj9.internal.criu.InternalCRIUSupport;
+
 /**
  * CRIU Support API
  */
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+@SuppressWarnings({ "deprecation", "removal" })
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class CRIUSupport {
 
 	@SuppressWarnings("restriction")
 	private static Unsafe unsafe;
-
 	private static final CRIUDumpPermission CRIU_DUMP_PERMISSION = new CRIUDumpPermission();
-
-	private static boolean criuSupportEnabled = false;
-
-	private static native boolean isCRIUSupportEnabledImpl();
-
-	private static native boolean isCheckpointAllowed();
-
-	private static boolean nativeLoaded = false;
-
-	private static boolean initComplete = false;
 
 	private static native void checkpointJVMImpl(String imageDir,
 			boolean leaveRunning,
@@ -76,6 +68,20 @@ public final class CRIUSupport {
 			boolean tcpEstablished,
 			boolean autoDedup,
 			boolean trackMemory);
+
+	static {
+		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+			try {
+				Field f = Unsafe.class.getDeclaredField("theUnsafe"); //$NON-NLS-1$
+				f.setAccessible(true);
+				unsafe = (Unsafe) f.get(null);
+			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException
+					| IllegalAccessException e) {
+				throw new InternalError(e);
+			}
+			return null;
+		});
+	}
 
 	/**
 	 * Constructs a new {@code CRIUSupport}.
@@ -107,9 +113,6 @@ public final class CRIUSupport {
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public CRIUSupport(Path imageDir) {
-		/* [IF JAVA_SPEC_VERSION < 17] */
-		@SuppressWarnings({"deprecation" })
-		/* [ENDIF] JAVA_SPEC_VERSION < 17 */
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkPermission(CRIU_DUMP_PERMISSION);
@@ -118,39 +121,13 @@ public final class CRIUSupport {
 		setImageDir(imageDir);
 	}
 
-	@SuppressWarnings({ "restriction", "deprecation" })
-	private static synchronized void init() {
-		if (!initComplete) {
-			if (loadNativeLibrary()) {
-				criuSupportEnabled = isCRIUSupportEnabledImpl();
-				AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-					try {
-						Field f = Unsafe.class.getDeclaredField("theUnsafe"); //$NON-NLS-1$
-						f.setAccessible(true);
-						unsafe = (Unsafe) f.get(null);
-					} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-						throw new InternalError(e);
-					}
-					return null;
-				});
-
-			}
-
-			initComplete = true;
-		}
-	}
-
 	/**
 	 * Queries if CRIU support is enabled.
 	 *
-	 * @return TRUE is support is enabled, FALSE otherwise
+	 * @return TRUE if support is enabled, FALSE otherwise
 	 */
-	public synchronized static boolean isCRIUSupportEnabled() {
-		if (!initComplete) {
-			init();
-		}
-
-		return criuSupportEnabled;
+	public static boolean isCRIUSupportEnabled() {
+		return InternalCRIUSupport.isCRIUSupportEnabled();
 	}
 
 	/**
@@ -160,18 +137,9 @@ public final class CRIUSupport {
 	 * @return NULL if isCRIUSupportEnabled() returns true. Otherwise the error message
 	 */
 	public static String getErrorMessage() {
-		String s = null;
-		if (!isCRIUSupportEnabled()) {
-			if (nativeLoaded) {
-				s = "To enable criu support, please run java with the `-XX:+EnableCRIUSupport` option.";
-			} else {
-				s = "There was a problem loaded the criu native library.\n"
-						+ "Please check that criu is installed on the machine by running `criu check`.\n"
-						+ "Also, please ensure that the JDK is criu enabled by contacting your JDK provider.";
-			}
-		}
-		return s;
+		return InternalCRIUSupport.getErrorMessage();
 	}
+
 	/* Higher priority hooks are run last in pre-checkoint hooks, and are run
 	 * first in post restore hooks.
 	 */
@@ -191,25 +159,6 @@ public final class CRIUSupport {
 	private boolean trackMemory;
 	private Path envFile;
 
-	@SuppressWarnings("deprecation")
-	private synchronized static boolean loadNativeLibrary() {
-		if (!nativeLoaded) {
-			try {
-				AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-					System.loadLibrary("j9criu29"); //$NON-NLS-1$
-					nativeLoaded = true;
-					return null;
-				});
-			} catch (UnsatisfiedLinkError e) {
-				if (System.getProperty("enable.j9internal.checkpoint.hook.api.debug") != null) { //$NON-NLS-1$
-					e.printStackTrace();
-				}
-			}
-		}
-
-		return nativeLoaded;
-	}
-
 	/**
 	 * Sets the directory that will hold the images upon checkpoint. This must be
 	 * set before calling {@link #checkpointJVM()}.
@@ -227,9 +176,6 @@ public final class CRIUSupport {
 		}
 		String dir = imageDir.toAbsolutePath().toString();
 
-		/* [IF JAVA_SPEC_VERSION < 17] */
-		@SuppressWarnings({"deprecation" })
-		/* [ENDIF] JAVA_SPEC_VERSION < 17 */
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkWrite(dir);
@@ -391,9 +337,6 @@ public final class CRIUSupport {
 		}
 		String dir = workDir.toAbsolutePath().toString();
 
-		/* [IF JAVA_SPEC_VERSION < 17] */
-		@SuppressWarnings({"deprecation" })
-		/* [ENDIF] JAVA_SPEC_VERSION < 17 */
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkWrite(dir);
@@ -564,6 +507,8 @@ public final class CRIUSupport {
 	 * options setters.
 	 *
 	 * @throws UnsupportedOperationException if CRIU is not supported
+	 *  or running in non-portable mode (only one checkpoint is allowed),
+	 *  and we have already checkpointed once.
 	 * @throws JVMCheckpointException        if a JVM error occurred before
 	 *                                       checkpoint
 	 * @throws SystemCheckpointException     if a CRIU operation failed
@@ -574,11 +519,16 @@ public final class CRIUSupport {
 		/* Add env variables restore hook */
 		registerRestoreEnvVariables();
 
-		if (isCRIUSupportEnabled()) {
+		if (InternalCRIUSupport.isCheckpointAllowed()) {
 			checkpointJVMImpl(imageDir, leaveRunning, shellJob, extUnixSupport, logLevel, logFile, fileLocks, workDir,
 					tcpEstablished, autoDedup, trackMemory);
 		} else {
-			throw new UnsupportedOperationException("CRIU support is not enabled");
+			if (InternalCRIUSupport.isCRIUSupportEnabled()) {
+				throw new UnsupportedOperationException(
+					"Running in non-portable mode (only one checkpoint is allowed), and we have already checkpointed once"); //$NON-NLS-1$
+			} else {
+				throw new UnsupportedOperationException("CRIU support is not enabled"); //$NON-NLS-1$
+			}
 		}
 	}
 }

--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -80,7 +80,7 @@ setupJNIFieldIDs(JNIEnv *env)
 }
 
 jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused)
+Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused)
 {
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
@@ -100,7 +100,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, j
 }
 
 jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused)
+Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused)
 {
 	J9VMThread *currentThread = (J9VMThread *) env;
 	jboolean res = JNI_FALSE;

--- a/runtime/criusupport/criusupport.hpp
+++ b/runtime/criusupport/criusupport.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,10 +29,10 @@
 extern "C" {
 
 jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
+Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused);
 
 jboolean JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed(JNIEnv *env, jclass unused);
+Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
 
 void JNICALL
 Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory);

--- a/runtime/criusupport/exports.cmake
+++ b/runtime/criusupport/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021, 2021 IBM Corp. and others
+# Copyright (c) 2021, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,8 +22,8 @@
 
 if(J9VM_OPT_CRIU_SUPPORT)
 	omr_add_exports(j9criu
+		Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl
+		Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl
 		Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl
-		Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl
-		Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed
 	)
 endif()

--- a/runtime/criusupport/uma/criusupport_exports.xml
+++ b/runtime/criusupport/uma/criusupport_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-Copyright (c) 2021, 2021 IBM Corp. and others
+Copyright (c) 2021, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="criusupport">
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl" />
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl" />
 	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl" />
-	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_isCheckpointAllowed" />
-	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_isCRIUSupportEnabledImpl" />
 </exports>


### PR DESCRIPTION
This makes it straightforward to check `isCRIUSupportEnabled()` from `java.base` (particularly for security related JCL patches).
`isCheckpointAllowed()` invokes `isCRIUSupportEnabled()` first to load library `j9criu29` and complete initialization.

close https://github.com/eclipse-openj9/openj9/issues/14642
close https://github.com/eclipse-openj9/openj9/issues/14676

Signed-off-by: Jason Feng <fengj@ca.ibm.com>