### PR TITLE
Enable inlineEncodeASCII optimization for Java 17

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -195,6 +195,7 @@
    java_lang_String_regionMatches_bool,
    java_lang_String_regionMatchesInternal,
    java_lang_String_equalsIgnoreCase,
+   java_lang_String_encodeASCII,
    java_lang_String_compareToIgnoreCase,
    java_lang_String_compress,
    java_lang_String_andOR,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3029,6 +3029,7 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
                }
             break;
          case TR::java_lang_StringCoding_encodeASCII:
+         case TR::java_lang_String_encodeASCII:
             if (comp->cg()->getSupportsInlineEncodeASCII())
                {
                dontInlineRecognizedMethod = true;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2762,6 +2762,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_decompressedArrayCopy_BICII,              "decompressedArrayCopy",              "([BI[CII)V")},
       {x(TR::java_lang_String_decompressedArrayCopy_CIBII,              "decompressedArrayCopy",              "([CI[BII)V")},
       {x(TR::java_lang_String_decompressedArrayCopy_CICII,              "decompressedArrayCopy",              "([CI[CII)V")},
+      {x(TR::java_lang_String_encodeASCII,         "encodeASCII",        "(B[B)[B")},
       {x(TR::java_lang_String_equals,              "equals",              "(Ljava/lang/Object;)Z")},
       {x(TR::java_lang_String_indexOf_String,      "indexOf",             "(Ljava/lang/String;)I")},
       {x(TR::java_lang_String_indexOf_String_int,  "indexOf",             "(Ljava/lang/String;I)I")},

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6739,6 +6739,7 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
         {
         case TR::java_lang_StringCoding_encode8859_1:
         case TR::java_lang_StringCoding_encodeASCII:
+        case TR::java_lang_String_encodeASCII:
         case TR::java_lang_StringCoding_encodeUTF8:
            node->setCanSkipZeroInitialization(true);
            break;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1030,6 +1030,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          case TR::java_lang_Long_reverseBytes:
             return comp()->cg()->supportsByteswap();
          case TR::java_lang_StringCoding_encodeASCII:
+         case TR::java_lang_String_encodeASCII:
             return comp()->cg()->getSupportsInlineEncodeASCII();
          default:
             return false;
@@ -1146,6 +1147,7 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
             process_java_lang_StringUTF16_toBytes(treetop, node);
             break;
          case TR::java_lang_StringCoding_encodeASCII:
+         case TR::java_lang_String_encodeASCII:
             process_java_lang_StringCoding_encodeASCII(treetop, node);
             break;
          case TR::java_lang_StrictMath_sqrt:

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -118,7 +118,7 @@ J9::Z::CodeGenerator::initialize()
       }
 
    static char *disableInlineEncodeASCII = feGetEnv("TR_disableInlineEncodeASCII");
-   if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !disableInlineEncodeASCII)
+   if (comp->fej9()->isStringCompressionEnabledVM() && cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !disableInlineEncodeASCII)
       {
       cg->setSupportsInlineEncodeASCII();
       }


### PR DESCRIPTION
 Also restrict the optimization to when string compression
is enabled only.