### PR TITLE
Use auto include for variable JAVA_SECURITY_MANAGER in testing

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -21,7 +21,6 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
-	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>JLM_Tests_interface_SE80</testCaseName>
 		<variations>

--- a/test/functional/Java8andUp/java8andUpSettings.mk
+++ b/test/functional/Java8andUp/java8andUpSettings.mk
@@ -20,8 +20,6 @@
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
 
-include $(TEST_ROOT)$(D)functional$(D)variables.mk
-
 ADD_MODULE_JAVA_SE_EE=
 # java.se.ee should only used for jdk 9 and 10
 # if JDK_VERSION is 9 10

--- a/test/functional/Jsr292/variables.mk
+++ b/test/functional/Jsr292/variables.mk
@@ -20,8 +20,6 @@
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
 
-include $(TEST_ROOT)$(D)functional$(D)variables.mk
-
 ifeq ($(JDK_VERSION), 8)
   XMLSUFFIX = _8
 else

--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -21,7 +21,6 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
-	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_J9securityTests_SE80</testCaseName>
 		<variations>

--- a/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -21,7 +21,6 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
-	<include>$(TEST_ROOT)$(D)functional$(D)variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_ProxyFieldAccess_SE80</testCaseName>
 		<variations>

--- a/test/functional/testVars.mk
+++ b/test/functional/testVars.mk
@@ -25,7 +25,7 @@
 # For OpenJ9 tests to work as expected, -Djava.security.manager=allow behaviour is
 # needed in JDK18+.
 ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
-  JAVA_SECURITY_MANAGER = -Djava.security.manager=allow
+  export JAVA_SECURITY_MANAGER = -Djava.security.manager=allow
 else
-  JAVA_SECURITY_MANAGER =
+  export JAVA_SECURITY_MANAGER =
 endif


### PR DESCRIPTION
- rename variables.mk to testVars.mk for auto inclusion
- use export to pass down to all subfolders

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>