### PR TITLE
Skip hidden frames during iterateStackTrace call

### DIFF
--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -114,11 +114,13 @@ JVM_GetExtendedNPEMessage(JNIEnv *env, jthrowable throwableObj)
 		J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
 		char *npeMsg = NULL;
 		GetStackTraceElementUserData userData = {0};
+		/* If -XX:+ShowHiddenFrames option has not been set, skip hidden method frames */
+		UDATA skipHiddenFrames = J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES);
 
 		Trc_SC_GetExtendedNPEMessage_Entry2(vmThread, throwableObj);
 		vmFuncs->internalEnterVMFromJNI(vmThread);
 		userData.bytecodeOffset = UDATA_MAX;
-		vmFuncs->iterateStackTrace(vmThread, (j9object_t*)throwableObj, getStackTraceElementIterator, &userData, TRUE);
+		vmFuncs->iterateStackTrace(vmThread, (j9object_t*)throwableObj, getStackTraceElementIterator, &userData, TRUE, skipHiddenFrames);
 		if ((NULL != userData.romClass)
 			&& (NULL != userData.romMethod)
 			&& (UDATA_MAX != userData.bytecodeOffset)

--- a/runtime/jcl/common/getstacktrace.c
+++ b/runtime/jcl/common/getstacktrace.c
@@ -49,10 +49,6 @@ getStackTraceForThread(J9VMThread *currentThread, J9VMThread *targetThread, UDAT
 	/* walk stack and cache PCs */
 	walkState.walkThread = targetThread;
 	walkState.flags = J9_STACKWALK_CACHE_PCS | J9_STACKWALK_WALK_TRANSLATE_PC | J9_STACKWALK_SKIP_INLINES | J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
-	/* If -XX:+ShowHiddenFrames option has not been set, skip hidden method frames */
-	if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)) {
-		walkState.flags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
-	}
 	walkState.skipCount = skipCount;
 	rc = vm->walkStackFrames(currentThread, &walkState);
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4622,7 +4622,7 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	void  ( *cleanUpClassLoader)(struct J9VMThread *vmThread, struct J9ClassLoader* classLoader) ;
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
-	UDATA  ( *iterateStackTrace)(struct J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (struct J9VMThread * vmThread, void * userData, UDATA bytecodeOffset, struct J9ROMClass * romClass, struct J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, struct J9ClassLoader* classLoader, struct J9Class* ramClass), void * userData, UDATA pruneConstructors) ;
+	UDATA  ( *iterateStackTrace)(struct J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (struct J9VMThread * vmThread, void * userData, UDATA bytecodeOffset, struct J9ROMClass * romClass, struct J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, struct J9ClassLoader* classLoader, struct J9Class* ramClass), void * userData, UDATA pruneConstructors, UDATA skipHiddenFrames) ;
 	char*  ( *getNPEMessage)(struct J9NPEMessageData *npeMsgData);
 	void  ( *internalReleaseVMAccessNoMutex)(struct J9VMThread * vmThread) ;
 	struct J9HookInterface**  ( *getVMHookInterface)(struct J9JavaVM* vm) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -670,10 +670,11 @@ internalExceptionDescribe(J9VMThread *vmThread);
 * @param ramClass)
 * @param userData
 * @param pruneConstructors
+* @param skipHiddenFrames
 * @return UDATA
 */
 UDATA
-iterateStackTrace(J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (J9VMThread * vmThread, void * userData, UDATA bytecodeOffset, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass), void * userData, UDATA pruneConstructors);
+iterateStackTrace(J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (J9VMThread * vmThread, void * userData, UDATA bytecodeOffset, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass), void * userData, UDATA pruneConstructors, UDATA skipHiddenFrames);
 
 
 /* ---------------- exceptionsupport.c ---------------- */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5650,7 +5650,7 @@ protectedIterateStackTrace(struct J9PortLibrary *portLibrary, void *args)
 	J9VMThread* vmThread = (J9VMThread*) parameters[0];
 	closure->jcw->_VirtualMachine->internalVMFunctions->iterateStackTrace(vmThread, (j9object_t*) parameters[1],
 										writeExceptionFrameCallBack, (J9StackWalkState*)parameters[2],
-										FALSE);
+										FALSE, FALSE);
 
 	return 0;
 }

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -386,7 +386,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 				}
 			} else {
 				/* For other events, walk the stack to find the desired frame */
-				vmThread->javaVM->internalVMFunctions->iterateStackTrace(vmThread, (j9object_t*) eventData->exceptionRef, countExceptionStackFrame, &throwSite, TRUE);
+				vmThread->javaVM->internalVMFunctions->iterateStackTrace(vmThread, (j9object_t*) eventData->exceptionRef, countExceptionStackFrame, &throwSite, TRUE, FALSE);
 			}
 		}
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3038,10 +3038,6 @@ done:
 					walkFlags |= J9_STACKWALK_HIDE_EXCEPTION_FRAMES;
 					walkState->restartException = receiver;
 				}
-				/* If -XX:+ShowHiddenFrames option has not been set, skip hidden method frames */
-				if (J9_ARE_NO_BITS_SET(_vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)) {
-					walkFlags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
-				}
 				walkState->flags = walkFlags;
 				walkState->skipCount = 1;	/* skip the INL frame */
 #if JAVA_SPEC_VERSION >= 15

--- a/runtime/vm/FastJNI_java_lang_Throwable.cpp
+++ b/runtime/vm/FastJNI_java_lang_Throwable.cpp
@@ -57,10 +57,6 @@ Fast_java_lang_Throwable_fillInStackTrace(J9VMThread *currentThread, j9object_t 
 				walkFlags |= J9_STACKWALK_HIDE_EXCEPTION_FRAMES;
 				walkState->restartException = receiver;
 			}
-			/* If -XX:+ShowHiddenFrames option has not been set, skip hidden method frames */
-			if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)) {
-				walkFlags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
-			}
 			walkState->flags = walkFlags;
 			walkState->skipCount = 1;	/* skip the INL frame */
 #if JAVA_SPEC_VERSION >= 15

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -233,7 +233,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
  * @note Assumes VM access
  **/
 UDATA
-iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t callback, void * userData, UDATA pruneConstructors)
+iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t callback, void * userData, UDATA pruneConstructors, UDATA skipHiddenFrames)
 {
 	J9JavaVM * vm = vmThread->javaVM;
 	UDATA totalEntries = 0;
@@ -247,7 +247,6 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 		U_32 arraySize = J9INDEXABLEOBJECT_SIZE(vmThread, walkback);
 		U_32 currentElement = 0;
 		UDATA callbackResult = TRUE;
-
 #ifndef J9VM_INTERP_NATIVE_SUPPORT
 		pruneConstructors = FALSE;
 #endif
@@ -293,7 +292,7 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 
 			++currentElement; /* can't increment in J9JAVAARRAYOFUDATA_LOAD macro, so must increment here. */
 			++totalEntries;
-			if ((callback != NULL) || pruneConstructors) {
+			if ((callback != NULL) || pruneConstructors || skipHiddenFrames) {
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 				if (metaData) {
 					J9Method *ramMethod;
@@ -391,7 +390,13 @@ foundROMMethod: ;
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 				}
 #endif
-
+				if (skipHiddenFrames && (NULL != romMethod)) {
+					/* Skip Hidden methods and methods from Hidden or Anonymous classes */
+					if (J9ROMCLASS_IS_ANON_OR_HIDDEN(romClass) || J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccMethodFrameIteratorSkip)) {
+						--totalEntries;
+						goto nextInline;
+					}
+				}
 #ifdef J9VM_OPT_DEBUG_INFO_SERVER
 				if (romMethod != NULL) {
 					lineNumber = getLineNumberForROMClassFromROMMethod(vm, romMethod, romClass, classLoader, methodPC);
@@ -503,13 +508,16 @@ internalExceptionDescribe(J9VMThread * vmThread)
 		}
 
 		do {
+			/* If -XX:+ShowHiddenFrames option has not been set, skip hidden method frames */
+			UDATA skipHiddenFrames = J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES);
+
 			/* Print the exception class name and detail message */
 
 			printExceptionMessage(vmThread, exception);
 
 			/* Print the stack trace entries */
 
-			iterateStackTrace(vmThread, &exception, printStackTraceEntry, NULL, TRUE);
+			iterateStackTrace(vmThread, &exception, printStackTraceEntry, NULL, TRUE, skipHiddenFrames);
 
 			/* If the exception is an instance of ExceptionInInitializerError, print the wrapped exception */
 


### PR DESCRIPTION
Removed J9_STACKWALK_SKIP_HIDDEN_FRAMES flag from `fillInStackTracecalls`
and added skip logic to `iterateStackTrace` call.

With JIT inlined frames, only the outer frame will be visible during to
swalk which is used by `fillInStackTracecalls`. This will cause stacktrace
inner frames that are not marked as Hidden to also be skipped.

As inlined frames will be unfolded during `iterateStackTrace`, code can
properly handle inlined frames and only skip methods that are hidden.

StackTrace created for dump files will not skip any Hidden frames to
retain verbose info for debugging purposes

Fixes: #14395 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>