### PR TITLE
loadClass() continues if findClass via bootstrapClassLoader not succeed

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1216,16 +1216,15 @@ public final Module getUnnamedModule()
  * @exception	ClassNotFoundException
  *					If the class could not be found.
  */
-public Class<?> loadClass (String className) throws ClassNotFoundException {
-/*[IF Sidecar19-SE]*/
+public Class<?> loadClass(String className) throws ClassNotFoundException {
+/*[IF JAVA_SPEC_VERSION > 8]*/
 	if ((bootstrapClassLoader == null) || (this == bootstrapClassLoader)) {
 		Class<?> cls = VMAccess.findClassOrNull(className, bootstrapClassLoader);
-		if (cls == null) {
-			throw new ClassNotFoundException(className);
+		if (cls != null) {
+			return cls;
 		}
-		return cls;
 	}
-/*[ENDIF] Sidecar19-SE */	
+/*[ENDIF] JAVA_SPEC_VERSION > 8 */
 	return loadClass(className, false);
 }
 


### PR DESCRIPTION
`loadClass()` continues if `findClass` via `bootstrapClassLoader` not succeed

@ZainabF92 this is expected to fix the CNFE you had when loading security provider classes outside of `java.base`.

related https://github.com/eclipse-openj9/openj9/issues/14662

Signed-off-by: Jason Feng <fengj@ca.ibm.com>