### PR TITLE
Add AArch64 macOS known issues to v.0.31.0 / v.0.32.0 release notes

### DIFF
--- a/doc/release-notes/0.31/0.31.md
+++ b/doc/release-notes/0.31/0.31.md
@@ -71,6 +71,13 @@ For more details see the API documentation. Only the Java 18 API documentation i
 Direct Byte Buffers to the same value as the maximum heap size. Previously the limit was 87.5% of the maximum heap size.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
+<td valign="top">Early access release for Apple Silicon macOS</td>
+<td valign="top">Apple Silicon macOS</td>
+<td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
+</tr>
+
 </tbody>
 </table>
 
@@ -87,9 +94,40 @@ The v0.31.0 release contains the following known issues and limitations:
 <th valign="bottom">Impact</th>
 <th valign="bottom">Workaround</th>
 </tr>
-
 </thead>
+
 <tbody>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/13767">#13767</a></td>
+<td valign="top">Compressed references mode is not available</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You can use only the large heap (non-compressed references) mode.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14387">#14387</a></td>
+<td valign="top">DDR is not enabled</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You cannot use DDR (Direct Dump Reader) functionalities.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14390">#14390</a></td>
+<td valign="top">Restriction with JVMTI extension functions</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">A number of JVMTI extension functions do not work as expected.</td>
+<td valign="top">Avoid using JVMTI extension functions.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14502">#14502</a></td>
+<td valign="top">JIT field watch fails to work</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">Enabling JIT field watch may cause bus errors.</td>
+<td valign="top">Avoid using the <tt>-XX:+JITInlineWatches</tt> option.</td>
+</tr>
 
 </tbody>
 </table>

--- a/doc/release-notes/0.32/0.32.md
+++ b/doc/release-notes/0.32/0.32.md
@@ -62,6 +62,13 @@ The following table covers notable changes in v0.32.0. Further information about
 <td valign="top">The libfreetype.so native library is bundled on Java 11 for AIX, similarly to Java 17 and later. This removes the requirement of having to install this prerequisite when using the java.desktop module.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
+<td valign="top">Early access release for Apple Silicon macOS</td>
+<td valign="top">Java 11 and later / Apple Silicon macOS</td>
+<td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
+</tr>
+
 </tbody>
 </table>
 
@@ -78,9 +85,32 @@ The v0.32.0 release contains the following known issues and limitations:
 <th valign="bottom">Impact</th>
 <th valign="bottom">Workaround</th>
 </tr>
-
 </thead>
+
 <tbody>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/13767">#13767</a></td>
+<td valign="top">Compressed references mode is not available</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You can use only the large heap (non-compressed references) mode.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14387">#14387</a></td>
+<td valign="top">DDR is not enabled</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You cannot use DDR (Direct Dump Reader) functionalities.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14502">#14502</a></td>
+<td valign="top">JIT field watch fails to work</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">Enabling JIT field watch may cause bus errors.</td>
+<td valign="top">Avoid using the <tt>-XX:+JITInlineWatches</tt> option.</td>
+</tr>
 
 </tbody>
 </table>


### PR DESCRIPTION
This commit adds known issues of AArch64 macOS build to the release
notes of v.0.31.0  / v.0.32.0.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>