### PR TITLE
(0.31.0) Add AArch64 macOS known issues to release notes

### DIFF
--- a/doc/release-notes/0.31/0.31.md
+++ b/doc/release-notes/0.31/0.31.md
@@ -55,6 +55,13 @@ The following table covers notable changes in v0.31.0. Further information about
 <td valign="top">This option controls if hidden method frames generated for MethodHandles are displayed in a stacktrace. This option is disabled by default and can be enabled for debugging purposes.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
+<td valign="top">Early access release for Apple Silicon macOS</td>
+<td valign="top">Apple Silicon macOS</td>
+<td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
+</tr>
+
 </tbody>
 </table>
 
@@ -71,9 +78,40 @@ The v0.31.0 release contains the following known issues and limitations:
 <th valign="bottom">Impact</th>
 <th valign="bottom">Workaround</th>
 </tr>
-
 </thead>
+
 <tbody>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/13767">#13767</a></td>
+<td valign="top">Compressed references mode is not available</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You can use only the large heap (non-compressed references) mode.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14387">#14387</a></td>
+<td valign="top">DDR is not enabled</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">You cannot use DDR (Direct Dump Reader) functionalities.</td>
+<td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14390">#14390</a></td>
+<td valign="top">Restriction with JVMTI extension functions</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">A number of JVMTI extension functions do not work as expected.</td>
+<td valign="top">Avoid using JVMTI extension functions.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14502">#14502</a></td>
+<td valign="top">JIT field watch fails to work</td>
+<td valign="top">Apple Silicon macOS (early access)</td>
+<td valign="top">Enabling JIT field watch may cause bus errors.</td>
+<td valign="top">Avoid using the <tt>-XX:+JITInlineWatches</tt> option.</td>
+</tr>
 
 </tbody>
 </table>


### PR DESCRIPTION
This commit adds known issues of AArch64 macOS build to the release
notes of v.0.31.0.

Original PR in master: #14690

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>