### PR TITLE
(v0.31.0-release) loadClass() continues if findClass via bootstrapClassLoader not succeed

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1219,16 +1219,15 @@ public final Module getUnnamedModule()
  * @exception	ClassNotFoundException
  *					If the class could not be found.
  */
-public Class<?> loadClass (String className) throws ClassNotFoundException {
-/*[IF Sidecar19-SE]*/
+public Class<?> loadClass(String className) throws ClassNotFoundException {
+/*[IF JAVA_SPEC_VERSION > 8]*/
 	if ((bootstrapClassLoader == null) || (this == bootstrapClassLoader)) {
 		Class<?> cls = VMAccess.findClassOrNull(className, bootstrapClassLoader);
-		if (cls == null) {
-			throw new ClassNotFoundException(className);
+		if (cls != null) {
+			return cls;
 		}
-		return cls;
 	}
-/*[ENDIF] Sidecar19-SE */	
+/*[ENDIF] JAVA_SPEC_VERSION > 8 */
 	return loadClass(className, false);
 }
 


### PR DESCRIPTION
`loadClass()` continues if `findClass` via `bootstrapClassLoader` not succeed

Cherry-Pick https://github.com/eclipse-openj9/openj9/pull/14689

Signed-off-by: Jason Feng <fengj@ca.ibm.com>