### PR TITLE
Replace powerpc/libffi with the latest version in GitHub

### DIFF
--- a/runtime/libffi/powerpc/aix.S
+++ b/runtime/libffi/powerpc/aix.S
@@ -106,6 +106,10 @@ ffi_call_AIX:
 	.llong .ffi_call_AIX, TOC[tc0], 0
 	.csect .text[PR]
 .ffi_call_AIX:
+	.function .ffi_call_AIX,.ffi_call_AIX,16,044,LFE..0-LFB..0
+	.bf __LINE__
+	.line 1
+LFB..0:
 	/* Save registers we use.  */
 	mflr	r0
 
@@ -115,8 +119,10 @@ ffi_call_AIX:
 	std	r31, -8(r1)
 
 	std	r0, 16(r1)
+LCFI..0:
 	mr	r28, r1		/* our AP.  */
 	stdux	r1, r1, r4
+LCFI..1:
 
 	/* Save arguments over call...  */
 	mr	r31, r5	/* flags, */
@@ -202,12 +208,16 @@ L(fp_return_value):
 L(float_return_value):
 	stfs	f1, 0(r30)
 	b	L(done_return_value)
-
+LFE..0:
 #else /* ! __64BIT__ */
 	
 	.long .ffi_call_AIX, TOC[tc0], 0
 	.csect .text[PR]
 .ffi_call_AIX:
+	.function .ffi_call_AIX,.ffi_call_AIX,16,044,LFE..0-LFB..0
+	.bf __LINE__
+	.line 1
+LFB..0:
 	/* Save registers we use.  */
 	mflr	r0
 
@@ -217,8 +227,10 @@ L(float_return_value):
 	stw	r31, -4(r1)
 
 	stw	r0, 8(r1)
+LCFI..0:
 	mr	r28, r1		/* out AP.  */
 	stwux	r1, r1, r4
+LCFI..1:
 
 	/* Save arguments over call...  */
 	mr	r31, r5	/* flags, */
@@ -304,10 +316,143 @@ L(fp_return_value):
 L(float_return_value):
 	stfs	f1, 0(r30)
 	b	L(done_return_value)
+LFE..0:
 #endif
+	.ef __LINE__
 	.long 0
 	.byte 0,0,0,1,128,4,0,0
 /* END(ffi_call_AIX) */
+
+	/* void ffi_call_go_AIX(extended_cif *ecif, unsigned long bytes,
+	 *		        unsigned int flags, unsigned int *rvalue,
+	 *		        void (*fn)(),
+	 *		        void (*prep_args)(extended_cif*, unsigned *const),
+	 *                      void *closure);
+	 * r3=ecif, r4=bytes, r5=flags, r6=rvalue, r7=fn, r8=prep_args, r9=closure
+	 */
+
+.csect .text[PR]
+	.align 2
+	.globl ffi_call_go_AIX
+	.globl .ffi_call_go_AIX
+.csect ffi_call_go_AIX[DS]
+ffi_call_go_AIX:
+#ifdef __64BIT__
+	.llong .ffi_call_go_AIX, TOC[tc0], 0
+	.csect .text[PR]
+.ffi_call_go_AIX:
+	.function .ffi_call_go_AIX,.ffi_call_go_AIX,16,044,LFE..1-LFB..1
+	.bf __LINE__
+	.line 1
+LFB..1:
+	/* Save registers we use.  */
+	mflr	r0
+
+	std	r28,-32(r1)
+	std	r29,-24(r1)
+	std	r30,-16(r1)
+	std	r31, -8(r1)
+
+	std	r9, 8(r1)	/* closure, saved in cr field. */
+	std	r0, 16(r1)
+LCFI..2:
+	mr	r28, r1		/* our AP.  */
+	stdux	r1, r1, r4
+LCFI..3:
+
+	/* Save arguments over call...  */
+	mr	r31, r5	/* flags, */
+	mr	r30, r6	/* rvalue, */
+	mr	r29, r7	/* function address,  */
+	std	r2, 40(r1)
+
+	/* Call ffi_prep_args.  */
+	mr	r4, r1
+	bl	.ffi_prep_args
+	nop
+
+	/* Now do the call.  */
+	ld	r0, 0(r29)
+	ld	r2, 8(r29)
+	ld      r11, 8(r28)	/* closure */
+	/* Set up cr1 with bits 4-7 of the flags.  */
+	mtcrf	0x40, r31
+	mtctr	r0
+	/* Load all those argument registers.  */
+	/* We have set up a nice stack frame, just load it into registers. */
+	ld	r3, 40+(1*8)(r1)
+	ld	r4, 40+(2*8)(r1)
+	ld	r5, 40+(3*8)(r1)
+	ld	r6, 40+(4*8)(r1)
+	nop
+	ld	r7, 40+(5*8)(r1)
+	ld	r8, 40+(6*8)(r1)
+	ld	r9, 40+(7*8)(r1)
+	ld	r10,40+(8*8)(r1)
+
+	b	L1
+LFE..1:
+#else /* ! __64BIT__ */
+	
+	.long .ffi_call_go_AIX, TOC[tc0], 0
+	.csect .text[PR]
+.ffi_call_go_AIX:
+	.function .ffi_call_go_AIX,.ffi_call_go_AIX,16,044,LFE..1-LFB..1
+	.bf __LINE__
+	.line 1
+	/* Save registers we use.  */
+LFB..1:
+	mflr	r0
+
+	stw	r28,-16(r1)
+	stw	r29,-12(r1)
+	stw	r30, -8(r1)
+	stw	r31, -4(r1)
+
+	stw	r9, 4(r1)	/* closure, saved in cr field.  */
+	stw	r0, 8(r1)
+LCFI..2:
+	mr	r28, r1		/* out AP.  */
+	stwux	r1, r1, r4
+LCFI..3:
+
+	/* Save arguments over call...  */
+	mr	r31, r5	/* flags, */
+	mr	r30, r6	/* rvalue, */
+	mr	r29, r7	/* function address, */
+	stw	r2, 20(r1)
+
+	/* Call ffi_prep_args.  */
+	mr	r4, r1
+	bl	.ffi_prep_args
+	nop
+
+	/* Now do the call.  */
+	lwz	r0, 0(r29)
+	lwz	r2, 4(r29)
+	lwz	r11, 4(r28)	/* closure */
+	/* Set up cr1 with bits 4-7 of the flags.  */
+	mtcrf	0x40, r31
+	mtctr	r0
+	/* Load all those argument registers.  */
+	/* We have set up a nice stack frame, just load it into registers. */
+	lwz	r3, 20+(1*4)(r1)
+	lwz	r4, 20+(2*4)(r1)
+	lwz	r5, 20+(3*4)(r1)
+	lwz	r6, 20+(4*4)(r1)
+	nop
+	lwz	r7, 20+(5*4)(r1)
+	lwz	r8, 20+(6*4)(r1)
+	lwz	r9, 20+(7*4)(r1)
+	lwz	r10,20+(8*4)(r1)
+
+	b	L1
+LFE..1:
+#endif
+	.ef __LINE__
+	.long 0
+	.byte 0,0,0,1,128,4,0,0
+/* END(ffi_call_go_AIX) */
 
 .csect .text[PR]
 	.align 2
@@ -326,3 +471,96 @@ ffi_call_DARWIN:
 	.long 0
 	.byte 0,0,0,0,0,0,0,0
 /* END(ffi_call_DARWIN) */
+
+/* EH frame stuff.  */
+
+#define LR_REGNO		0x41		/* Link Register (65), see rs6000.md */
+#ifdef __64BIT__
+#define PTRSIZE			8
+#define LOG2_PTRSIZE		3
+#define FDE_ENCODING		0x1c		/* DW_EH_PE_pcrel|DW_EH_PE_sdata8 */
+#define EH_DATA_ALIGN_FACT	0x78		/* LEB128 -8 */
+#else
+#define PTRSIZE			4
+#define LOG2_PTRSIZE		2
+#define FDE_ENCODING		0x1b		/* DW_EH_PE_pcrel|DW_EH_PE_sdata4 */
+#define EH_DATA_ALIGN_FACT	0x7c		/* LEB128 -4 */
+#endif
+	.csect	_unwind.ro_[RO],4
+	.align	LOG2_PTRSIZE
+	.globl	_GLOBAL__F_libffi_src_powerpc_aix
+_GLOBAL__F_libffi_src_powerpc_aix:
+Lframe..1:
+	.vbyte	4,LECIE..1-LSCIE..1	/* CIE Length */
+LSCIE..1:
+	.vbyte	4,0			/* CIE Identifier Tag */
+	.byte	0x3			/* CIE Version */
+	.byte	"zR"			/* CIE Augmentation */
+	.byte	0
+	.byte	0x1			/* uleb128 0x1; CIE Code Alignment Factor */
+	.byte	EH_DATA_ALIGN_FACT	/* leb128 -4/-8; CIE Data Alignment Factor */
+	.byte	0x41			/* CIE RA Column */
+	.byte	0x1			/* uleb128 0x1; Augmentation size */
+	.byte	FDE_ENCODING		/* FDE Encoding (pcrel|sdata4/8) */
+	.byte	0xc			/* DW_CFA_def_cfa */
+	.byte	0x1			/*     uleb128 0x1; Register r1 */
+	.byte	0			/*     uleb128 0x0; Offset 0 */
+	.align	LOG2_PTRSIZE
+LECIE..1:
+LSFDE..1:
+	.vbyte	4,LEFDE..1-LASFDE..1	/* FDE Length */
+LASFDE..1:
+	.vbyte	4,LASFDE..1-Lframe..1	/* FDE CIE offset */
+	.vbyte	PTRSIZE,LFB..0-$	/* FDE initial location */
+	.vbyte	PTRSIZE,LFE..0-LFB..0	/* FDE address range */
+	.byte   0			/* uleb128 0x0; Augmentation size */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..0-LFB..0
+	.byte	0x11			/* DW_CFA_def_offset_extended_sf */
+	.byte	LR_REGNO		/*     uleb128 LR_REGNO; Register LR */
+	.byte	0x7e			/*     leb128 -2; Offset -2 (8/16) */
+	.byte	0x9f			/* DW_CFA_offset Register r31 */
+	.byte	0x1			/*     uleb128 0x1; Offset 1 (-4/-8) */
+	.byte	0x9e			/* DW_CFA_offset Register r30 */
+	.byte	0x2			/*     uleb128 0x2; Offset 2 (-8/-16) */
+	.byte	0x9d			/* DW_CFA_offset Register r29 */
+	.byte	0x3			/*     uleb128 0x3; Offset 3 (-12/-24) */
+	.byte	0x9c			/* DW_CFA_offset Register r28 */
+	.byte	0x4			/*     uleb128 0x4; Offset 4 (-16/-32) */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..1-LCFI..0
+	.byte	0xd			/* DW_CFA_def_cfa_register */
+	.byte	0x1c			/*     uleb128 28; Register r28 */
+	.align	LOG2_PTRSIZE
+LEFDE..1:
+LSFDE..2:
+	.vbyte	4,LEFDE..2-LASFDE..2	/* FDE Length */
+LASFDE..2:
+	.vbyte	4,LASFDE..2-Lframe..1	/* FDE CIE offset */
+	.vbyte	PTRSIZE,LFB..1-$	/* FDE initial location */
+	.vbyte	PTRSIZE,LFE..1-LFB..1	/* FDE address range */
+	.byte   0			/* uleb128 0x0; Augmentation size */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..2-LFB..1
+	.byte	0x11			/* DW_CFA_def_offset_extended_sf */
+	.byte	LR_REGNO		/*     uleb128 LR_REGNO; Register LR */
+	.byte	0x7e			/*     leb128 -2; Offset -2 (8/16) */
+	.byte	0x9f			/* DW_CFA_offset Register r31 */
+	.byte	0x1			/*     uleb128 0x1; Offset 1 (-4/-8) */
+	.byte	0x9e			/* DW_CFA_offset Register r30 */
+	.byte	0x2			/*     uleb128 0x2; Offset 2 (-8/-16) */
+	.byte	0x9d			/* DW_CFA_offset Register r29 */
+	.byte	0x3			/*     uleb128 0x3; Offset 3 (-12/-24) */
+	.byte	0x9c			/* DW_CFA_offset Register r28 */
+	.byte	0x4			/*     uleb128 0x4; Offset 4 (-16/-32) */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..3-LCFI..2
+	.byte	0xd			/* DW_CFA_def_cfa_register */
+	.byte	0x1c			/*     uleb128 28; Register r28 */
+	.align	LOG2_PTRSIZE
+LEFDE..2:
+	.vbyte	4,0			/* End of FDEs */
+
+	.csect	.text[PR]
+	.ref	_GLOBAL__F_libffi_src_powerpc_aix	/* Prevents garbage collection by AIX linker */
+

--- a/runtime/libffi/powerpc/aix_closure.S
+++ b/runtime/libffi/powerpc/aix_closure.S
@@ -80,6 +80,7 @@
 	.set f21,21
 
 	.extern .ffi_closure_helper_DARWIN
+	.extern .ffi_go_closure_helper_DARWIN
 
 #define LIBFFI_ASM
 #define JUMPTARGET(name) name
@@ -101,6 +102,10 @@ ffi_closure_ASM:
 	.llong .ffi_closure_ASM, TOC[tc0], 0
 	.csect .text[PR]
 .ffi_closure_ASM:
+	.function .ffi_closure_ASM,.ffi_closure_ASM,16,044,LFE..0-LFB..0
+	.bf __LINE__
+	.line 1
+LFB..0:
 /* we want to build up an area for the parameters passed */
 /* in registers (both floating point and integer) */
 
@@ -117,8 +122,7 @@ ffi_closure_ASM:
 	std   r9, 48+(6*8)(r1)
 	std   r10, 48+(7*8)(r1)
 	std   r0, 16(r1)	/* save the return address */
-
-
+LCFI..0:
 	/* 48  Bytes (Linkage Area) */
 	/* 64  Bytes (params) */
 	/* 16  Bytes (result) */
@@ -128,6 +132,7 @@ ffi_closure_ASM:
 
 	stdu  r1, -240(r1)	/* skip over caller save area
 				   keep stack aligned to 16  */
+LCFI..1:
 
 	/* next save fpr 1 to fpr 13 (aligned to 8) */
 	stfd  f1, 128+(0*8)(r1)
@@ -160,6 +165,8 @@ ffi_closure_ASM:
 	/* make the call */
 	bl .ffi_closure_helper_DARWIN
 	nop
+
+.Ldoneclosure:
 
 	/* now r3 contains the return type */
 	/* so use it to look up in a table */
@@ -270,12 +277,17 @@ L..finish:
 	mtlr r0
 	addi r1, r1, 240
 	blr
+LFE..0:
 
 #else /* ! __64BIT__ */
 	
 	.long .ffi_closure_ASM, TOC[tc0], 0
 	.csect .text[PR]
 .ffi_closure_ASM:
+	.function .ffi_closure_ASM,.ffi_closure_ASM,16,044,LFE..0-LFB..0
+	.bf __LINE__
+	.line 1
+LFB..0:
 /* we want to build up an area for the parameters passed */
 /* in registers (both floating point and integer) */
 
@@ -292,7 +304,7 @@ L..finish:
 	stw   r9, 24+(6*4)(r1)
 	stw   r10, 24+(7*4)(r1)
 	stw   r0, 8(r1)
-
+LCFI..0:
 	/* 24 Bytes (Linkage Area) */
 	/* 32 Bytes (params) */
 	/* 16  Bytes (result) */
@@ -301,6 +313,7 @@ L..finish:
 
 	stwu  r1, -176(r1)	/* skip over caller save area
 				   keep stack aligned to 16  */
+LCFI..1:
 
 	/* next save fpr 1 to fpr 13 (aligned to 8) */
 	stfd  f1, 72+(0*8)(r1)
@@ -333,6 +346,8 @@ L..finish:
 	/* make the call */
 	bl .ffi_closure_helper_DARWIN
 	nop
+
+.Ldoneclosure:
 
 	/* now r3 contains the return type */
 	/* so use it to look up in a table */
@@ -443,5 +458,237 @@ L..60:
 L..finish:
 	addi r1, r1, 176
 	blr
+LFE..0:
 #endif
+	.ef __LINE__
 /* END(ffi_closure_ASM) */
+
+
+.csect .text[PR]
+	.align 2
+	.globl ffi_go_closure_ASM
+	.globl .ffi_go_closure_ASM
+.csect ffi_go_closure_ASM[DS]
+ffi_go_closure_ASM:
+#ifdef __64BIT__
+	.llong .ffi_go_closure_ASM, TOC[tc0], 0
+	.csect .text[PR]
+.ffi_go_closure_ASM:
+	.function .ffi_go_closure_ASM,.ffi_go_closure_ASM,16,044,LFE..1-LFB..1
+	.bf __LINE__
+	.line 1
+LFB..1:
+/* we want to build up an area for the parameters passed */
+/* in registers (both floating point and integer) */
+
+	/* we store gpr 3 to gpr 10 (aligned to 4)
+	in the parents outgoing area  */
+	std   r3, 48+(0*8)(r1)
+	std   r4, 48+(1*8)(r1)
+	std   r5, 48+(2*8)(r1)
+	std   r6, 48+(3*8)(r1)
+	mflr  r0
+
+	std   r7, 48+(4*8)(r1)
+	std   r8, 48+(5*8)(r1)
+	std   r9, 48+(6*8)(r1)
+	std   r10, 48+(7*8)(r1)
+	std   r0, 16(r1)	/* save the return address */
+LCFI..2:
+	/* 48  Bytes (Linkage Area) */
+	/* 64  Bytes (params) */
+	/* 16  Bytes (result) */
+	/* 104 Bytes (13*8 from FPR) */
+	/* 8   Bytes (alignment) */
+	/* 240 Bytes */
+
+	stdu  r1, -240(r1)	/* skip over caller save area
+				   keep stack aligned to 16  */
+LCFI..3:
+
+	/* next save fpr 1 to fpr 13 (aligned to 8) */
+	stfd  f1, 128+(0*8)(r1)
+	stfd  f2, 128+(1*8)(r1)
+	stfd  f3, 128+(2*8)(r1)
+	stfd  f4, 128+(3*8)(r1)
+	stfd  f5, 128+(4*8)(r1)
+	stfd  f6, 128+(5*8)(r1)
+	stfd  f7, 128+(6*8)(r1)
+	stfd  f8, 128+(7*8)(r1)
+	stfd  f9, 128+(8*8)(r1)
+	stfd  f10, 128+(9*8)(r1)
+	stfd  f11, 128+(10*8)(r1)
+	stfd  f12, 128+(11*8)(r1)
+	stfd  f13, 128+(12*8)(r1)
+
+	/* set up registers for the routine that actually does the work */
+	mr r3, r11	/* go closure */
+
+	/* now load up the pointer to the result storage */
+	addi r4, r1, 112
+
+	/* now load up the pointer to the saved gpr registers */
+	addi r5, r1, 288
+
+	/* now load up the pointer to the saved fpr registers */
+	addi r6, r1, 128
+
+	/* make the call */
+	bl .ffi_go_closure_helper_DARWIN
+	nop
+
+	b .Ldoneclosure
+LFE..1:
+
+#else /* ! __64BIT__ */
+	
+	.long .ffi_go_closure_ASM, TOC[tc0], 0
+	.csect .text[PR]
+.ffi_go_closure_ASM:
+	.function .ffi_go_closure_ASM,.ffi_go_closure_ASM,16,044,LFE..1-LFB..1
+	.bf __LINE__
+	.line 1
+LFB..1:
+/* we want to build up an area for the parameters passed */
+/* in registers (both floating point and integer) */
+
+	/* we store gpr 3 to gpr 10 (aligned to 4)
+	in the parents outgoing area  */
+	stw   r3, 24+(0*4)(r1)
+	stw   r4, 24+(1*4)(r1)
+	stw   r5, 24+(2*4)(r1)
+	stw   r6, 24+(3*4)(r1)
+	mflr  r0
+
+	stw   r7, 24+(4*4)(r1)
+	stw   r8, 24+(5*4)(r1)
+	stw   r9, 24+(6*4)(r1)
+	stw   r10, 24+(7*4)(r1)
+	stw   r0, 8(r1)
+LCFI..2:
+	/* 24 Bytes (Linkage Area) */
+	/* 32 Bytes (params) */
+	/* 16  Bytes (result) */
+	/* 104 Bytes (13*8 from FPR) */
+	/* 176 Bytes */
+
+	stwu  r1, -176(r1)	/* skip over caller save area
+				   keep stack aligned to 16  */
+LCFI..3:
+
+	/* next save fpr 1 to fpr 13 (aligned to 8) */
+	stfd  f1, 72+(0*8)(r1)
+	stfd  f2, 72+(1*8)(r1)
+	stfd  f3, 72+(2*8)(r1)
+	stfd  f4, 72+(3*8)(r1)
+	stfd  f5, 72+(4*8)(r1)
+	stfd  f6, 72+(5*8)(r1)
+	stfd  f7, 72+(6*8)(r1)
+	stfd  f8, 72+(7*8)(r1)
+	stfd  f9, 72+(8*8)(r1)
+	stfd  f10, 72+(9*8)(r1)
+	stfd  f11, 72+(10*8)(r1)
+	stfd  f12, 72+(11*8)(r1)
+	stfd  f13, 72+(12*8)(r1)
+
+	/* set up registers for the routine that actually does the work */
+	mr   r3, 11	/* go closure */
+
+	/* now load up the pointer to the result storage */
+	addi r4, r1, 56
+
+	/* now load up the pointer to the saved gpr registers */
+	addi r5, r1, 200
+
+	/* now load up the pointer to the saved fpr registers */
+	addi r6, r1, 72
+
+	/* make the call */
+	bl .ffi_go_closure_helper_DARWIN
+	nop
+
+	b    .Ldoneclosure
+LFE..1:
+#endif
+	.ef __LINE__
+/* END(ffi_go_closure_ASM) */
+
+/* EH frame stuff.  */
+
+#define LR_REGNO		0x41		/* Link Register (65), see rs6000.md */
+#ifdef __64BIT__
+#define PTRSIZE			8
+#define LOG2_PTRSIZE		3
+#define CFA_OFFSET		0xf0,0x01	/* LEB128 240 */
+#define FDE_ENCODING		0x1c		/* DW_EH_PE_pcrel|DW_EH_PE_sdata8 */
+#define EH_DATA_ALIGN_FACT	0x78		/* LEB128 -8 */
+#else
+#define PTRSIZE			4
+#define LOG2_PTRSIZE		2
+#define CFA_OFFSET		0xb0,0x01	/* LEB128 176 */
+#define FDE_ENCODING		0x1b		/* DW_EH_PE_pcrel|DW_EH_PE_sdata4 */
+#define EH_DATA_ALIGN_FACT	0x7c		/* LEB128 -4 */
+#endif
+
+	.csect	_unwind.ro_[RO],4
+	.align	LOG2_PTRSIZE
+	.globl	_GLOBAL__F_libffi_src_powerpc_aix_closure
+_GLOBAL__F_libffi_src_powerpc_aix_closure:
+Lframe..1:
+	.vbyte	4,LECIE..1-LSCIE..1	/* CIE Length */
+LSCIE..1:
+	.vbyte	4,0			/* CIE Identifier Tag */
+	.byte	0x3			/* CIE Version */
+	.byte	"zR"			/* CIE Augmentation */
+	.byte	0
+	.byte	0x1			/* uleb128 0x1; CIE Code Alignment Factor */
+	.byte	EH_DATA_ALIGN_FACT	/* leb128 -4/-8; CIE Data Alignment Factor */
+	.byte	LR_REGNO		/* CIE RA Column */
+	.byte	0x1			/* uleb128 0x1; Augmentation size */
+	.byte	FDE_ENCODING		/* FDE Encoding (pcrel|sdata4/8) */
+	.byte	0xc			/* DW_CFA_def_cfa */
+	.byte	0x1			/*     uleb128 0x1; Register r1 */
+	.byte	0			/*     uleb128 0x0; Offset 0 */
+	.align	LOG2_PTRSIZE
+LECIE..1:
+LSFDE..1:
+	.vbyte	4,LEFDE..1-LASFDE..1	/* FDE Length */
+LASFDE..1:
+	.vbyte	4,LASFDE..1-Lframe..1	/* FDE CIE offset */
+	.vbyte	PTRSIZE,LFB..0-$	/* FDE initial location */
+	.vbyte	PTRSIZE,LFE..0-LFB..0	/* FDE address range */
+	.byte	0			/* uleb128 0x0; Augmentation size */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..1-LCFI..0
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	CFA_OFFSET		/*     uleb128 176/240 */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..0-LFB..0
+	.byte	0x11			/* DW_CFA_offset_extended_sf */
+	.byte	LR_REGNO		/*     uleb128 LR_REGNO; Register LR */
+	.byte	0x7e			/*     leb128 -2; Offset -2 (8/16) */
+	.align	LOG2_PTRSIZE
+LEFDE..1:
+LSFDE..2:
+	.vbyte	4,LEFDE..2-LASFDE..2	/* FDE Length */
+LASFDE..2:
+	.vbyte	4,LASFDE..2-Lframe..1	/* FDE CIE offset */
+	.vbyte	PTRSIZE,LFB..1-$	/* FDE initial location */
+	.vbyte	PTRSIZE,LFE..1-LFB..1	/* FDE address range */
+	.byte	0			/* uleb128 0x0; Augmentation size */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..3-LCFI..2
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	CFA_OFFSET		/*     uleb128 176/240 */
+	.byte	0x4			/* DW_CFA_advance_loc4 */
+	.vbyte	4,LCFI..2-LFB..1
+	.byte	0x11			/* DW_CFA_offset_extended_sf */
+	.byte	LR_REGNO		/*     uleb128 LR_REGNO; Register LR */
+	.byte	0x7e			/*     leb128 -2; Offset -2 (8/16) */
+	.align	LOG2_PTRSIZE
+LEFDE..2:
+	.vbyte	4,0			/* End of FDEs */
+
+	.csect	.text[PR]
+	.ref	_GLOBAL__F_libffi_src_powerpc_aix_closure	/* Prevents garbage collection by AIX linker */
+

--- a/runtime/libffi/powerpc/asm.h
+++ b/runtime/libffi/powerpc/asm.h
@@ -23,6 +23,12 @@
    OTHER DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #define ASM_GLOBAL_DIRECTIVE .globl
 
 
@@ -74,6 +80,9 @@
 #define CALL_MCOUNT		/* Do nothing.  */
 #endif /* PROF */
 
+/* Replace @function with %function as suggested by the bug document of
+ * the XLC compiler at https://www.ibm.com/support/pages/apar/LI73704.
+ */
 #define	ENTRY(name)							      \
   ASM_GLOBAL_DIRECTIVE C_SYMBOL_NAME(name);				      \
   ASM_TYPE_DIRECTIVE (C_SYMBOL_NAME(name),%function)			      \
@@ -93,7 +102,10 @@
 /* EALIGN is like ENTRY, but does alignment to 'words'*4 bytes
    past a 2^align boundary.  */
 #ifdef PROF
-#define EALIGN(name, alignt, words)					      \
+/* Replace @function with %function as suggested by the bug document of
+ * the XLC compiler at https://www.ibm.com/support/pages/apar/LI73704.
+ */
+#define EFFI_ALIGN(name, alignt, words)					      \
   ASM_GLOBAL_DIRECTIVE C_SYMBOL_NAME(name);				      \
   ASM_TYPE_DIRECTIVE (C_SYMBOL_NAME(name),%function)			      \
   .align ALIGNARG(2);							      \
@@ -104,7 +116,10 @@
   EALIGN_W_##words;							      \
   0:
 #else /* PROF */
-#define EALIGN(name, alignt, words)					      \
+/* Replace @function with %function as suggested by the bug document of
+ * the XLC compiler at https://www.ibm.com/support/pages/apar/LI73704.
+ */
+#define EFFI_ALIGN(name, alignt, words)					      \
   ASM_GLOBAL_DIRECTIVE C_SYMBOL_NAME(name);				      \
   ASM_TYPE_DIRECTIVE (C_SYMBOL_NAME(name),%function)			      \
   .align ALIGNARG(alignt);						      \

--- a/runtime/libffi/powerpc/darwin_closure.S
+++ b/runtime/libffi/powerpc/darwin_closure.S
@@ -353,7 +353,7 @@ Lret_type13:
 	bgt	Lstructend		; not a special small case
 	b	Lsmallstruct		; see if we need more.
 #else
-	cmpi	0,r0,4
+	cmpwi	0,r0,4
 	bgt	Lfinish		; not by value
 	lg	r3,0(r5)
 	b	Lfinish
@@ -494,8 +494,8 @@ LSFDE1:
 LASFDE1:
 	.long	LASFDE1-EH_frame1	; FDE CIE offset
 	.g_long	Lstartcode-.	; FDE initial location
-	.set	L$set$3,LFE1-Lstartcode
-	.g_long	L$set$3	; FDE address range
+	.set	L$set$2,LFE1-Lstartcode
+	.g_long	L$set$2	; FDE address range
 	.byte   0x0     ; uleb128 0x0; Augmentation size
 	.byte	0x4	; DW_CFA_advance_loc4
 	.set	L$set$3,LCFI1-LCFI0

--- a/runtime/libffi/powerpc/ffi_linux64.c
+++ b/runtime/libffi/powerpc/ffi_linux64.c
@@ -38,7 +38,8 @@
 /* About the LINUX64 ABI.  */
 enum {
   NUM_GPR_ARG_REGISTERS64 = 8,
-  NUM_FPR_ARG_REGISTERS64 = 13
+  NUM_FPR_ARG_REGISTERS64 = 13,
+  NUM_VEC_ARG_REGISTERS64 = 12,
 };
 enum { ASM_NEEDS_REGISTERS64 = 4 };
 
@@ -62,12 +63,32 @@ ffi_prep_types_linux64 (ffi_abi abi)
 #endif
 
 
-#if _CALL_ELF == 2
 static unsigned int
-discover_homogeneous_aggregate (const ffi_type *t, unsigned int *elnum)
+discover_homogeneous_aggregate (ffi_abi abi,
+                                const ffi_type *t,
+                                unsigned int *elnum)
 {
   switch (t->type)
     {
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+    case FFI_TYPE_LONGDOUBLE:
+      /* 64-bit long doubles are equivalent to doubles. */
+      if ((abi & FFI_LINUX_LONG_DOUBLE_128) == 0)
+        {
+          *elnum = 1;
+          return FFI_TYPE_DOUBLE;
+        }
+      /* IBM extended precision values use unaligned pairs
+         of FPRs, but according to the ABI must be considered
+         distinct from doubles. They are also limited to a
+         maximum of four members in a homogeneous aggregate. */
+      else if ((abi & FFI_LINUX_LONG_DOUBLE_IEEE128) == 0)
+        {
+          *elnum = 2;
+          return FFI_TYPE_LONGDOUBLE;
+        }
+      /* Fall through. */
+#endif
     case FFI_TYPE_FLOAT:
     case FFI_TYPE_DOUBLE:
       *elnum = 1;
@@ -80,14 +101,19 @@ discover_homogeneous_aggregate (const ffi_type *t, unsigned int *elnum)
 	while (*el)
 	  {
 	    unsigned int el_elt, el_elnum = 0;
-	    el_elt = discover_homogeneous_aggregate (*el, &el_elnum);
+	    el_elt = discover_homogeneous_aggregate (abi, *el, &el_elnum);
 	    if (el_elt == 0
 		|| (base_elt && base_elt != el_elt))
 	      return 0;
 	    base_elt = el_elt;
 	    total_elnum += el_elnum;
+#if _CALL_ELF == 2
 	    if (total_elnum > 8)
 	      return 0;
+#else
+	    if (total_elnum > 1)
+	      return 0;
+#endif
 	    el++;
 	  }
 	*elnum = total_elnum;
@@ -98,7 +124,6 @@ discover_homogeneous_aggregate (const ffi_type *t, unsigned int *elnum)
       return 0;
     }
 }
-#endif
 
 
 /* Perform machine dependent cif processing */
@@ -107,15 +132,23 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 {
   ffi_type **ptr;
   unsigned bytes;
-  unsigned i, fparg_count = 0, intarg_count = 0;
+  unsigned i, fparg_count = 0, intarg_count = 0, vecarg_count = 0;
   unsigned flags = cif->flags;
-#if _CALL_ELF == 2
-  unsigned int elt, elnum;
-#endif
+  unsigned elt, elnum, rtype;
 
 #if FFI_TYPE_LONGDOUBLE == FFI_TYPE_DOUBLE
-  /* If compiled without long double support..  */
-  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
+  /* If compiled without long double support... */
+  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0 ||
+      (cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+    return FFI_BAD_ABI;
+#elif !defined(__VEC__)
+  /* If compiled without vector register support (used by assembly)... */
+  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+    return FFI_BAD_ABI;
+#else
+  /* If the IEEE128 flag is set, but long double is only 64 bits wide... */
+  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) == 0 &&
+      (cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
     return FFI_BAD_ABI;
 #endif
 
@@ -137,10 +170,19 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 #endif
 
   /* Return value handling.  */
-  switch (cif->rtype->type)
+  rtype = cif->rtype->type;
+#if _CALL_ELF == 2
+homogeneous:
+#endif
+  switch (rtype)
     {
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
     case FFI_TYPE_LONGDOUBLE:
+      if ((cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+        {
+          flags |= FLAG_RETURNS_VEC;
+          break;
+        }
       if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
 	flags |= FLAG_RETURNS_128BITS;
       /* Fall through.  */
@@ -157,24 +199,24 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
       /* Fall through.  */
     case FFI_TYPE_UINT64:
     case FFI_TYPE_SINT64:
+    case FFI_TYPE_POINTER:
       flags |= FLAG_RETURNS_64BITS;
       break;
 
     case FFI_TYPE_STRUCT:
 #if _CALL_ELF == 2
-      elt = discover_homogeneous_aggregate (cif->rtype, &elnum);
+      elt = discover_homogeneous_aggregate (cif->abi, cif->rtype, &elnum);
       if (elt)
-	{
-	  if (elt == FFI_TYPE_DOUBLE)
-	    flags |= FLAG_RETURNS_64BITS;
-	  flags |= FLAG_RETURNS_FP | FLAG_RETURNS_SMST;
-	  break;
-	}
+        {
+          flags |= FLAG_RETURNS_SMST;
+          rtype = elt;
+          goto homogeneous;
+        }
       if (cif->rtype->size <= 16)
-	{
-	  flags |= FLAG_RETURNS_SMST;
-	  break;
-	}
+        {
+          flags |= FLAG_RETURNS_SMST;
+          break;
+        }
 #endif
       intarg_count++;
       flags |= FLAG_RETVAL_REFERENCE;
@@ -196,6 +238,15 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 	{
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 	case FFI_TYPE_LONGDOUBLE:
+          if ((cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+            {
+              vecarg_count++;
+              /* Align to 16 bytes, plus the 16-byte argument. */
+              intarg_count = (intarg_count + 3) & ~0x1;
+              if (vecarg_count > NUM_VEC_ARG_REGISTERS64)
+                flags |= FLAG_ARG_NEEDS_PSAVE;
+              break;
+            }
 	  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
 	    {
 	      fparg_count++;
@@ -219,11 +270,21 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 		align = 16;
 	      align = align / 8;
 	      if (align > 1)
-		intarg_count = ALIGN (intarg_count, align);
+		intarg_count = FFI_ALIGN (intarg_count, align);
 	    }
 	  intarg_count += ((*ptr)->size + 7) / 8;
-#if _CALL_ELF == 2
-	  elt = discover_homogeneous_aggregate (*ptr, &elnum);
+	  elt = discover_homogeneous_aggregate (cif->abi, *ptr, &elnum);
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+          if (elt == FFI_TYPE_LONGDOUBLE &&
+              (cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+            {
+              vecarg_count += elnum;
+              if (vecarg_count > NUM_VEC_ARG_REGISTERS64)
+                flags |= FLAG_ARG_NEEDS_PSAVE;
+              break;
+            }
+	  else
+#endif
 	  if (elt)
 	    {
 	      fparg_count += elnum;
@@ -231,7 +292,6 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 		flags |= FLAG_ARG_NEEDS_PSAVE;
 	    }
 	  else
-#endif
 	    {
 	      if (intarg_count > NUM_GPR_ARG_REGISTERS64)
 		flags |= FLAG_ARG_NEEDS_PSAVE;
@@ -263,10 +323,17 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
     flags |= FLAG_FP_ARGUMENTS;
   if (intarg_count > 4)
     flags |= FLAG_4_GPR_ARGUMENTS;
+  if (vecarg_count != 0)
+    flags |= FLAG_VEC_ARGUMENTS;
 
   /* Space for the FPR registers, if needed.  */
   if (fparg_count != 0)
     bytes += NUM_FPR_ARG_REGISTERS64 * sizeof (double);
+  /* Space for the vector registers, if needed, aligned to 16 bytes. */
+  if (vecarg_count != 0) {
+    bytes = (bytes + 15) & ~0xF;
+    bytes += NUM_VEC_ARG_REGISTERS64 * sizeof (float128);
+  }
 
   /* Stack space.  */
 #if _CALL_ELF == 2
@@ -349,6 +416,8 @@ ffi_prep_cif_linux64_var (ffi_cif *cif,
    |--------------------------------------------| |
    |   FPR registers f1-f13 (optional)	13*8	| |
    |--------------------------------------------| |
+   |   VEC registers v2-v13 (optional)  12*16   | |
+   |--------------------------------------------| |
    |   Parameter save area		        | |
    |--------------------------------------------| |
    |   TOC save area			8	| |
@@ -378,6 +447,7 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
     unsigned long *ul;
     float *f;
     double *d;
+    float128 *f128;
     size_t p;
   } valp;
 
@@ -391,10 +461,15 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
   valp rest;
   valp next_arg;
 
-  /* 'fpr_base' points at the space for fpr3, and grows upwards as
+  /* 'fpr_base' points at the space for f1, and grows upwards as
      we use FPR registers.  */
   valp fpr_base;
   unsigned int fparg_count;
+
+  /* 'vec_base' points at the space for v2, and grows upwards as
+     we use vector registers.  */
+  valp vec_base;
+  unsigned int vecarg_count;
 
   unsigned int i, words, nargs, nfixedargs;
   ffi_type **ptr;
@@ -412,6 +487,7 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
     unsigned long **ul;
     float **f;
     double **d;
+    float128 **f128;
   } p_argv;
   unsigned long gprvalue;
   unsigned long align;
@@ -426,11 +502,21 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 #endif
   fpr_base.d = gpr_base.d - NUM_FPR_ARG_REGISTERS64;
   fparg_count = 0;
+  /* Place the vector args below the FPRs, if used, else the GPRs. */
+  if (ecif->cif->flags & FLAG_FP_ARGUMENTS)
+    vec_base.p = fpr_base.p & ~0xF;
+  else
+    vec_base.p = gpr_base.p;
+  vec_base.f128 -= NUM_VEC_ARG_REGISTERS64;
+  vecarg_count = 0;
   next_arg.ul = gpr_base.ul;
 
   /* Check that everything starts aligned properly.  */
   FFI_ASSERT (((unsigned long) (char *) stack & 0xF) == 0);
   FFI_ASSERT (((unsigned long) stacktop.c & 0xF) == 0);
+  FFI_ASSERT (((unsigned long) gpr_base.c & 0xF) == 0);
+  FFI_ASSERT (((unsigned long) gpr_end.c  & 0xF) == 0);
+  FFI_ASSERT (((unsigned long) vec_base.c & 0xF) == 0);
   FFI_ASSERT ((bytes & 0xF) == 0);
 
   /* Deal with return values that are actually pass-by-reference.  */
@@ -449,14 +535,28 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
        i < nargs;
        i++, ptr++, p_argv.v++)
     {
-#if _CALL_ELF == 2
       unsigned int elt, elnum;
-#endif
 
       switch ((*ptr)->type)
 	{
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 	case FFI_TYPE_LONGDOUBLE:
+          if ((ecif->cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+            {
+              next_arg.p = FFI_ALIGN (next_arg.p, 16);
+              if (next_arg.ul == gpr_end.ul)
+                next_arg.ul = rest.ul;
+              if (vecarg_count < NUM_VEC_ARG_REGISTERS64 && i < nfixedargs)
+		memcpy (vec_base.f128++, *p_argv.f128, sizeof (float128));
+              else
+		memcpy (next_arg.f128, *p_argv.f128, sizeof (float128));
+              if (++next_arg.f128 == gpr_end.f128)
+                next_arg.f128 = rest.f128;
+              vecarg_count++;
+              FFI_ASSERT (__LDBL_MANT_DIG__ == 113);
+              FFI_ASSERT (flags & FLAG_VEC_ARGUMENTS);
+              break;
+            }
 	  if ((ecif->cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
 	    {
 	      double_tmp = (*p_argv.d)[0];
@@ -494,6 +594,9 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 	  /* Fall through.  */
 #endif
 	case FFI_TYPE_DOUBLE:
+#if _CALL_ELF != 2
+	do_double:
+#endif
 	  double_tmp = **p_argv.d;
 	  if (fparg_count < NUM_FPR_ARG_REGISTERS64 && i < nfixedargs)
 	    {
@@ -512,17 +615,32 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 	  break;
 
 	case FFI_TYPE_FLOAT:
+#if _CALL_ELF != 2
+	do_float:
+#endif
 	  double_tmp = **p_argv.f;
 	  if (fparg_count < NUM_FPR_ARG_REGISTERS64 && i < nfixedargs)
 	    {
 	      *fpr_base.d++ = double_tmp;
 #if _CALL_ELF != 2
 	      if ((flags & FLAG_COMPAT) != 0)
-		*next_arg.f = (float) double_tmp;
+		{
+# ifndef __LITTLE_ENDIAN__
+		  next_arg.f[1] = (float) double_tmp;
+# else
+		  next_arg.f[0] = (float) double_tmp;
+# endif
+		}
 #endif
 	    }
 	  else
-	    *next_arg.f = (float) double_tmp;
+	    {
+# ifndef __LITTLE_ENDIAN__
+	      next_arg.f[1] = (float) double_tmp;
+# else
+	      next_arg.f[0] = (float) double_tmp;
+# endif
+	    }
 	  if (++next_arg.ul == gpr_end.ul)
 	    next_arg.ul = rest.ul;
 	  fparg_count++;
@@ -536,19 +654,43 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 	      if (align > 16)
 		align = 16;
 	      if (align > 1)
-		next_arg.p = ALIGN (next_arg.p, align);
+                {
+                  next_arg.p = FFI_ALIGN (next_arg.p, align);
+                  if (next_arg.ul == gpr_end.ul)
+                    next_arg.ul = rest.ul;
+                }
 	    }
-#if _CALL_ELF == 2
-	  elt = discover_homogeneous_aggregate (*ptr, &elnum);
+	  elt = discover_homogeneous_aggregate (ecif->cif->abi, *ptr, &elnum);
 	  if (elt)
 	    {
+#if _CALL_ELF == 2
 	      union {
 		void *v;
 		float *f;
 		double *d;
+		float128 *f128;
 	      } arg;
 
 	      arg.v = *p_argv.v;
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+              if (elt == FFI_TYPE_LONGDOUBLE &&
+                  (ecif->cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+                {
+                  do
+                    {
+                      if (vecarg_count < NUM_VEC_ARG_REGISTERS64
+                          && i < nfixedargs)
+		        memcpy (vec_base.f128++, arg.f128++, sizeof (float128));
+                      else
+		        memcpy (next_arg.f128, arg.f128++, sizeof (float128));
+                      if (++next_arg.f128 == gpr_end.f128)
+                        next_arg.f128 = rest.f128;
+                      vecarg_count++;
+                    }
+                  while (--elnum != 0);
+                }
+              else
+#endif
 	      if (elt == FFI_TYPE_FLOAT)
 		{
 		  do
@@ -564,11 +706,9 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 		      fparg_count++;
 		    }
 		  while (--elnum != 0);
-		  if ((next_arg.p & 3) != 0)
-		    {
-		      if (++next_arg.f == gpr_end.f)
-			next_arg.f = rest.f;
-		    }
+		  if ((next_arg.p & 7) != 0)
+                    if (++next_arg.f == gpr_end.f)
+                      next_arg.f = rest.f;
 		}
 	      else
 		do
@@ -583,9 +723,14 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 		    fparg_count++;
 		  }
 		while (--elnum != 0);
+#else
+	      if (elt == FFI_TYPE_FLOAT)
+		goto do_float;
+	      else
+		goto do_double;
+#endif
 	    }
 	  else
-#endif
 	    {
 	      words = ((*ptr)->size + 7) / 8;
 	      if (next_arg.ul >= gpr_base.ul && next_arg.ul + words > gpr_end.ul)
@@ -667,7 +812,8 @@ flush_icache (char *wraddr, char *xaddr, int size)
 }
 #endif
 
-ffi_status
+
+ffi_status FFI_HIDDEN
 ffi_prep_closure_loc_linux64 (ffi_closure *closure,
 			      ffi_cif *cif,
 			      void (*fun) (ffi_cif *, void *, void **, void *),
@@ -688,17 +834,17 @@ ffi_prep_closure_loc_linux64 (ffi_closure *closure,
 				/* 2:	.quad	context		*/
   *(void **) &tramp[4] = (void *) ffi_closure_LINUX64;
   *(void **) &tramp[6] = codeloc;
-  flush_icache ((char *)tramp, (char *)codeloc, FFI_TRAMPOLINE_SIZE);
+  flush_icache ((char *) tramp, (char *) codeloc, 4 * 4);
 #else
   void **tramp = (void **) &closure->tramp[0];
 
   if (cif->abi < FFI_LINUX || cif->abi >= FFI_LAST_ABI)
     return FFI_BAD_ABI;
 
-  /* Copy function address and TOC from ffi_closure_LINUX64.  */
-  memcpy (tramp, (char *) ffi_closure_LINUX64, 16);
-  tramp[2] = tramp[1];
+  /* Copy function address and TOC from ffi_closure_LINUX64 OPD.  */
+  memcpy (&tramp[0], (void **) ffi_closure_LINUX64, sizeof (void *));
   tramp[1] = codeloc;
+  memcpy (&tramp[2], (void **) ffi_closure_LINUX64 + 1, sizeof (void *));
 #endif
 
   closure->cif = cif;
@@ -710,22 +856,27 @@ ffi_prep_closure_loc_linux64 (ffi_closure *closure,
 
 
 int FFI_HIDDEN
-ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
-			    unsigned long *pst, ffi_dblfl *pfr)
+ffi_closure_helper_LINUX64 (ffi_cif *cif,
+			    void (*fun) (ffi_cif *, void *, void **, void *),
+			    void *user_data,
+			    void *rvalue,
+			    unsigned long *pst,
+                            ffi_dblfl *pfr,
+                            float128 *pvec)
 {
   /* rvalue is the pointer to space for return value in closure assembly */
   /* pst is the pointer to parameter save area
      (r3-r10 are stored into its first 8 slots by ffi_closure_LINUX64) */
   /* pfr is the pointer to where f1-f13 are stored in ffi_closure_LINUX64 */
+  /* pvec is the pointer to where v2-v13 are stored in ffi_closure_LINUX64 */
 
   void **avalue;
   ffi_type **arg_types;
   unsigned long i, avn, nfixedargs;
-  ffi_cif *cif;
   ffi_dblfl *end_pfr = pfr + NUM_FPR_ARG_REGISTERS64;
+  float128 *end_pvec = pvec + NUM_VEC_ARG_REGISTERS64;
   unsigned long align;
 
-  cif = closure->cif;
   avalue = alloca (cif->nargs * sizeof (void *));
 
   /* Copy the caller's structure return value address so that the
@@ -791,19 +942,18 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 	      if (align > 16)
 		align = 16;
 	      if (align > 1)
-		pst = (unsigned long *) ALIGN ((size_t) pst, align);
+		pst = (unsigned long *) FFI_ALIGN ((size_t) pst, align);
 	    }
-	  elt = 0;
-#if _CALL_ELF == 2
-	  elt = discover_homogeneous_aggregate (arg_types[i], &elnum);
-#endif
+	  elt = discover_homogeneous_aggregate (cif->abi, arg_types[i], &elnum);
 	  if (elt)
 	    {
+#if _CALL_ELF == 2
 	      union {
 		void *v;
 		unsigned long *ul;
 		float *f;
 		double *d;
+		float128 *f128;
 		size_t p;
 	      } to, from;
 
@@ -811,6 +961,17 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 		 aggregate size is not greater than the space taken by
 		 the registers so store back to the register/parameter
 		 save arrays.  */
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+              if (elt == FFI_TYPE_LONGDOUBLE &&
+                  (cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+                {
+                  if (pvec + elnum <= end_pvec)
+                    to.v = pvec;
+                  else
+                    to.v = pst;
+                }
+              else
+#endif
 	      if (pfr + elnum <= end_pfr)
 		to.v = pfr;
 	      else
@@ -818,6 +979,23 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 
 	      avalue[i] = to.v;
 	      from.ul = pst;
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+              if (elt == FFI_TYPE_LONGDOUBLE &&
+                  (cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+                {
+                  do
+                    {
+                      if (pvec < end_pvec && i < nfixedargs)
+		        memcpy (to.f128, pvec++, sizeof (float128));
+                      else
+		        memcpy (to.f128, from.f128, sizeof (float128));
+                      to.f128++;
+                      from.f128++;
+                    }
+                  while (--elnum != 0);
+                }
+              else
+#endif
 	      if (elt == FFI_TYPE_FLOAT)
 		{
 		  do
@@ -850,6 +1028,12 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 		    }
 		  while (--elnum != 0);
 		}
+#else
+	      if (elt == FFI_TYPE_FLOAT)
+		goto do_float;
+	      else
+		goto do_double;
+#endif
 	    }
 	  else
 	    {
@@ -867,7 +1051,18 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 	case FFI_TYPE_LONGDOUBLE:
-	  if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
+          if ((cif->abi & FFI_LINUX_LONG_DOUBLE_IEEE128) != 0)
+            {
+              if (((unsigned long) pst & 0xF) != 0)
+                ++pst;
+              if (pvec < end_pvec && i < nfixedargs)
+                avalue[i] = pvec++;
+              else
+                avalue[i] = pst;
+              pst += 2;
+              break;
+            }
+          else if ((cif->abi & FFI_LINUX_LONG_DOUBLE_128) != 0)
 	    {
 	      if (pfr + 1 < end_pfr && i + 1 < nfixedargs)
 		{
@@ -891,6 +1086,9 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 	  /* Fall through.  */
 #endif
 	case FFI_TYPE_DOUBLE:
+#if _CALL_ELF != 2
+	do_double:
+#endif
 	  /* On the outgoing stack all values are aligned to 8 */
 	  /* there are 13 64bit floating point registers */
 
@@ -905,6 +1103,9 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 	  break;
 
 	case FFI_TYPE_FLOAT:
+#if _CALL_ELF != 2
+	do_float:
+#endif
 	  if (pfr < end_pfr && i < nfixedargs)
 	    {
 	      /* Float values are stored as doubles in the
@@ -914,7 +1115,13 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
 	      pfr++;
 	    }
 	  else
-	    avalue[i] = pst;
+	    {
+#ifndef __LITTLE_ENDIAN__
+	      avalue[i] = (char *) pst + 4;
+#else
+	      avalue[i] = pst;
+#endif
+	    }
 	  pst++;
 	  break;
 
@@ -925,19 +1132,22 @@ ffi_closure_helper_LINUX64 (ffi_closure *closure, void *rvalue,
       i++;
     }
 
-
-  (closure->fun) (cif, rvalue, avalue, closure->user_data);
+  (*fun) (cif, rvalue, avalue, user_data);
 
   /* Tell ffi_closure_LINUX64 how to perform return type promotions.  */
   if ((cif->flags & FLAG_RETURNS_SMST) != 0)
     {
-      if ((cif->flags & FLAG_RETURNS_FP) == 0)
+      if ((cif->flags & (FLAG_RETURNS_FP | FLAG_RETURNS_VEC)) == 0)
 	return FFI_V2_TYPE_SMALL_STRUCT + cif->rtype->size - 1;
+      else if ((cif->flags & FLAG_RETURNS_VEC) != 0)
+        return FFI_V2_TYPE_VECTOR_HOMOG;
       else if ((cif->flags & FLAG_RETURNS_64BITS) != 0)
 	return FFI_V2_TYPE_DOUBLE_HOMOG;
       else
 	return FFI_V2_TYPE_FLOAT_HOMOG;
     }
+  if ((cif->flags & FLAG_RETURNS_VEC) != 0)
+    return FFI_V2_TYPE_VECTOR;
   return cif->rtype->type;
 }
 #endif

--- a/runtime/libffi/powerpc/ffi_powerpc.h
+++ b/runtime/libffi/powerpc/ffi_powerpc.h
@@ -31,22 +31,24 @@
 enum {
   /* The assembly depends on these exact flags.  */
   /* These go in cr7 */
-  FLAG_RETURNS_SMST	= 1 << (31-31), /* Used for FFI_SYSV small structs.  */
+  FLAG_RETURNS_SMST     = 1 << (31-31), /* Used for FFI_SYSV small structs.  */
   FLAG_RETURNS_NOTHING  = 1 << (31-30),
   FLAG_RETURNS_FP       = 1 << (31-29),
-  FLAG_RETURNS_64BITS   = 1 << (31-28),
+  FLAG_RETURNS_VEC      = 1 << (31-28),
 
-  /* This goes in cr6 */
-  FLAG_RETURNS_128BITS  = 1 << (31-27),
+  /* These go in cr6 */
+  FLAG_RETURNS_64BITS   = 1 << (31-27),
+  FLAG_RETURNS_128BITS  = 1 << (31-26),
 
-  FLAG_COMPAT		= 1 << (31- 8), /* Not used by assembly */
+  FLAG_COMPAT           = 1 << (31- 8), /* Not used by assembly */
 
   /* These go in cr1 */
   FLAG_ARG_NEEDS_COPY   = 1 << (31- 7), /* Used by sysv code */
   FLAG_ARG_NEEDS_PSAVE  = FLAG_ARG_NEEDS_COPY, /* Used by linux64 code */
   FLAG_FP_ARGUMENTS     = 1 << (31- 6), /* cr1.eq; specified by ABI */
   FLAG_4_GPR_ARGUMENTS  = 1 << (31- 5),
-  FLAG_RETVAL_REFERENCE = 1 << (31- 4)
+  FLAG_RETVAL_REFERENCE = 1 << (31- 4),
+  FLAG_VEC_ARGUMENTS    = 1 << (31- 3),
 };
 
 typedef union
@@ -55,23 +57,49 @@ typedef union
   double d;
 } ffi_dblfl;
 
+#if defined(__FLOAT128_TYPE__) && defined(__HAVE_FLOAT128)
+typedef _Float128 float128;
+#elif defined(__FLOAT128__)
+typedef __float128 float128;
+#else
+typedef char float128[16] __attribute__((aligned(16)));
+#endif
+
 void FFI_HIDDEN ffi_closure_SYSV (void);
-void FFI_HIDDEN ffi_call_SYSV(extended_cif *, unsigned, unsigned, unsigned *,
-			      void (*)(void));
+void FFI_HIDDEN ffi_go_closure_sysv (void);
+void FFI_HIDDEN ffi_call_SYSV(extended_cif *, void (*)(void), void *,
+			      unsigned, void *, int);
 
 void FFI_HIDDEN ffi_prep_types_sysv (ffi_abi);
 ffi_status FFI_HIDDEN ffi_prep_cif_sysv (ffi_cif *);
-int FFI_HIDDEN ffi_closure_helper_SYSV (ffi_closure *, void *, unsigned long *,
+ffi_status FFI_HIDDEN ffi_prep_closure_loc_sysv (ffi_closure *,
+						 ffi_cif *,
+						 void (*) (ffi_cif *, void *,
+							   void **, void *),
+						 void *, void *);
+int FFI_HIDDEN ffi_closure_helper_SYSV (ffi_cif *,
+					void (*) (ffi_cif *, void *,
+						  void **, void *),
+					void *, void *, unsigned long *,
 					ffi_dblfl *, unsigned long *);
 
-void FFI_HIDDEN ffi_call_LINUX64(extended_cif *, unsigned long, unsigned long,
-				 unsigned long *, void (*)(void));
+void FFI_HIDDEN ffi_call_LINUX64(extended_cif *, void (*) (void), void *,
+				 unsigned long, void *, long);
 void FFI_HIDDEN ffi_closure_LINUX64 (void);
+void FFI_HIDDEN ffi_go_closure_linux64 (void);
 
 void FFI_HIDDEN ffi_prep_types_linux64 (ffi_abi);
 ffi_status FFI_HIDDEN ffi_prep_cif_linux64 (ffi_cif *);
 ffi_status FFI_HIDDEN ffi_prep_cif_linux64_var (ffi_cif *, unsigned int,
 						unsigned int);
 void FFI_HIDDEN ffi_prep_args64 (extended_cif *, unsigned long *const);
-int FFI_HIDDEN ffi_closure_helper_LINUX64 (ffi_closure *, void *,
-					   unsigned long *, ffi_dblfl *);
+ffi_status FFI_HIDDEN ffi_prep_closure_loc_linux64 (ffi_closure *, ffi_cif *,
+						    void (*) (ffi_cif *, void *,
+							      void **, void *),
+						    void *, void *);
+int FFI_HIDDEN ffi_closure_helper_LINUX64 (ffi_cif *,
+					   void (*) (ffi_cif *, void *,
+						     void **, void *),
+					   void *, void *,
+					   unsigned long *, ffi_dblfl *,
+					   float128 *);

--- a/runtime/libffi/powerpc/ffi_sysv.c
+++ b/runtime/libffi/powerpc/ffi_sysv.c
@@ -36,7 +36,7 @@
 
 
 /* About the SYSV ABI.  */
-#define ASM_NEEDS_REGISTERS 4
+#define ASM_NEEDS_REGISTERS 6
 #define NUM_GPR_ARG_REGISTERS 8
 #define NUM_FPR_ARG_REGISTERS 8
 
@@ -643,18 +643,18 @@ ffi_prep_closure_loc_sysv (ffi_closure *closure,
 
   tramp = (unsigned int *) &closure->tramp[0];
   tramp[0] = 0x7c0802a6;  /*   mflr    r0 */
-  tramp[1] = 0x4800000d;  /*   bl      10 <trampoline_initial+0x10> */
-  tramp[4] = 0x7d6802a6;  /*   mflr    r11 */
-  tramp[5] = 0x7c0803a6;  /*   mtlr    r0 */
-  tramp[6] = 0x800b0000;  /*   lwz     r0,0(r11) */
-  tramp[7] = 0x816b0004;  /*   lwz     r11,4(r11) */
-  tramp[8] = 0x7c0903a6;  /*   mtctr   r0 */
-  tramp[9] = 0x4e800420;  /*   bctr */
-  *(void **) &tramp[2] = (void *) ffi_closure_SYSV; /* function */
-  *(void **) &tramp[3] = codeloc;                   /* context */
+  tramp[1] = 0x429f0005;  /*   bcl     20,31,.+4 */
+  tramp[2] = 0x7d6802a6;  /*   mflr    r11 */
+  tramp[3] = 0x7c0803a6;  /*   mtlr    r0 */
+  tramp[4] = 0x800b0018;  /*   lwz     r0,24(r11) */
+  tramp[5] = 0x816b001c;  /*   lwz     r11,28(r11) */
+  tramp[6] = 0x7c0903a6;  /*   mtctr   r0 */
+  tramp[7] = 0x4e800420;  /*   bctr */
+  *(void **) &tramp[8] = (void *) ffi_closure_SYSV; /* function */
+  *(void **) &tramp[9] = codeloc;                   /* context */
 
   /* Flush the icache.  */
-  flush_icache ((char *)tramp, (char *)codeloc, FFI_TRAMPOLINE_SIZE);
+  flush_icache ((char *)tramp, (char *)codeloc, 8 * 4);
 
   closure->cif = cif;
   closure->fun = fun;
@@ -671,8 +671,12 @@ ffi_prep_closure_loc_sysv (ffi_closure *closure,
    following helper function to do most of the work.  */
 
 int
-ffi_closure_helper_SYSV (ffi_closure *closure, void *rvalue,
-			 unsigned long *pgr, ffi_dblfl *pfr,
+ffi_closure_helper_SYSV (ffi_cif *cif,
+			 void (*fun) (ffi_cif *, void *, void **, void *),
+			 void *user_data,
+			 void *rvalue,
+			 unsigned long *pgr,
+			 ffi_dblfl *pfr,
 			 unsigned long *pst)
 {
   /* rvalue is the pointer to space for return value in closure assembly */
@@ -688,7 +692,6 @@ ffi_closure_helper_SYSV (ffi_closure *closure, void *rvalue,
 #endif
   long             ng = 0;   /* number of general registers already used */
 
-  ffi_cif *cif = closure->cif;
   unsigned       size     = cif->rtype->size;
   unsigned short rtypenum = cif->rtype->type;
 
@@ -904,7 +907,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure, void *rvalue,
     i++;
   }
 
-  (closure->fun) (cif, rvalue, avalue, closure->user_data);
+  (*fun) (cif, rvalue, avalue, user_data);
 
   /* Tell ffi_closure_SYSV how to perform return type promotions.
      Because the FFI_SYSV ABI returns the structures <= 8 bytes in

--- a/runtime/libffi/powerpc/ffitarget.h
+++ b/runtime/libffi/powerpc/ffitarget.h
@@ -91,15 +91,19 @@ typedef enum ffi_abi {
   /* This and following bits can reuse FFI_COMPAT values.  */
   FFI_LINUX_STRUCT_ALIGN = 1,
   FFI_LINUX_LONG_DOUBLE_128 = 2,
+  FFI_LINUX_LONG_DOUBLE_IEEE128 = 4,
   FFI_DEFAULT_ABI = (FFI_LINUX
 #  ifdef __STRUCT_PARM_ALIGN__
 		     | FFI_LINUX_STRUCT_ALIGN
 #  endif
 #  ifdef __LONG_DOUBLE_128__
 		     | FFI_LINUX_LONG_DOUBLE_128
+#   ifdef __LONG_DOUBLE_IEEE128__
+		     | FFI_LINUX_LONG_DOUBLE_IEEE128
+#   endif
 #  endif
 		     ),
-  FFI_LAST_ABI = 12
+  FFI_LAST_ABI = 16
 
 # else
   /* This bit, always set in new code, must not be set in any of the
@@ -138,23 +142,40 @@ typedef enum ffi_abi {
 #define FFI_CLOSURES 1
 #define FFI_NATIVE_RAW_API 0
 #if defined (POWERPC) || defined (POWERPC_FREEBSD)
+# define FFI_GO_CLOSURES 1
 # define FFI_TARGET_SPECIFIC_VARIADIC 1
 # define FFI_EXTRA_CIF_FIELDS unsigned nfixedargs
 #endif
+#if defined (POWERPC_AIX)
+# define FFI_GO_CLOSURES 1
+#endif
 
-/* For additional types like the below, take care about the order in
-   ppc_closures.S. They must follow after the FFI_TYPE_LAST.  */
+/* ppc_closure.S and linux64_closure.S expect this.  */
+#define FFI_PPC_TYPE_LAST FFI_TYPE_POINTER
+
+/* We define additional types below.  If generic types are added that
+   must be supported by powerpc libffi then it is likely that
+   FFI_PPC_TYPE_LAST needs increasing *and* the jump tables in
+   ppc_closure.S and linux64_closure.S be extended.  */
+
+#if !(FFI_TYPE_LAST == FFI_PPC_TYPE_LAST		\
+      || (FFI_TYPE_LAST == FFI_TYPE_COMPLEX		\
+	  && !defined FFI_TARGET_HAS_COMPLEX_TYPE))
+# error "You likely have a broken powerpc libffi"
+#endif
 
 /* Needed for soft-float long-double-128 support.  */
-#define FFI_TYPE_UINT128 (FFI_TYPE_LAST + 1)
+#define FFI_TYPE_UINT128 (FFI_PPC_TYPE_LAST + 1)
 
 /* Needed for FFI_SYSV small structure returns.  */
-#define FFI_SYSV_TYPE_SMALL_STRUCT (FFI_TYPE_LAST + 2)
+#define FFI_SYSV_TYPE_SMALL_STRUCT (FFI_PPC_TYPE_LAST + 2)
 
 /* Used by ELFv2 for homogenous structure returns.  */
-#define FFI_V2_TYPE_FLOAT_HOMOG		(FFI_TYPE_LAST + 1)
-#define FFI_V2_TYPE_DOUBLE_HOMOG	(FFI_TYPE_LAST + 2)
-#define FFI_V2_TYPE_SMALL_STRUCT	(FFI_TYPE_LAST + 3)
+#define FFI_V2_TYPE_VECTOR		(FFI_PPC_TYPE_LAST + 1)
+#define FFI_V2_TYPE_VECTOR_HOMOG	(FFI_PPC_TYPE_LAST + 2)
+#define FFI_V2_TYPE_FLOAT_HOMOG		(FFI_PPC_TYPE_LAST + 3)
+#define FFI_V2_TYPE_DOUBLE_HOMOG	(FFI_PPC_TYPE_LAST + 4)
+#define FFI_V2_TYPE_SMALL_STRUCT	(FFI_PPC_TYPE_LAST + 5)
 
 #if _CALL_ELF == 2
 # define FFI_TRAMPOLINE_SIZE 32

--- a/runtime/libffi/powerpc/linux64.S
+++ b/runtime/libffi/powerpc/linux64.S
@@ -32,11 +32,14 @@
 #ifdef POWERPC64
 	.hidden	ffi_call_LINUX64
 	.globl	ffi_call_LINUX64
-# if _CALL_ELF == 2
 	.text
+	.cfi_startproc
+# if _CALL_ELF == 2
 ffi_call_LINUX64:
+#  ifndef __PCREL__
 	addis	%r2, %r12, .TOC.-ffi_call_LINUX64@ha
 	addi	%r2, %r2, .TOC.-ffi_call_LINUX64@l
+#  endif
 	.localentry ffi_call_LINUX64, . - ffi_call_LINUX64
 # else
 	.section	".opd","aw"
@@ -57,20 +60,26 @@ ffi_call_LINUX64:
 .ffi_call_LINUX64:
 #  endif
 # endif
-.LFB1:
 	mflr	%r0
 	std	%r28, -32(%r1)
 	std	%r29, -24(%r1)
 	std	%r30, -16(%r1)
 	std	%r31, -8(%r1)
+	std	%r7, 8(%r1)	/* closure, saved in cr field.  */
 	std	%r0, 16(%r1)
 
 	mr	%r28, %r1	/* our AP.  */
-.LCFI0:
-	stdux	%r1, %r1, %r4
-	mr	%r31, %r5	/* flags, */
-	mr	%r30, %r6	/* rvalue, */
-	mr	%r29, %r7	/* function address.  */
+	.cfi_def_cfa_register 28
+	.cfi_offset 65, 16
+	.cfi_offset 31, -8
+	.cfi_offset 30, -16
+	.cfi_offset 29, -24
+	.cfi_offset 28, -32
+
+	stdux	%r1, %r1, %r8
+	mr	%r31, %r6	/* flags, */
+	mr	%r30, %r5	/* rvalue, */
+	mr	%r29, %r4	/* function address.  */
 /* Save toc pointer, not for the ffi_prep_args64 call, but for the later
    bctrl function call.  */
 # if _CALL_ELF == 2
@@ -82,9 +91,15 @@ ffi_call_LINUX64:
 	/* Call ffi_prep_args64.  */
 	mr	%r4, %r1
 # if defined _CALL_LINUX || _CALL_ELF == 2
+#  ifdef __PCREL__
+	bl	ffi_prep_args64@notoc
+#  else
 	bl	ffi_prep_args64
+	nop
+#  endif
 # else
 	bl	.ffi_prep_args64
+	nop
 # endif
 
 # if _CALL_ELF == 2
@@ -92,44 +107,74 @@ ffi_call_LINUX64:
 # else
 	ld	%r12, 0(%r29)
 	ld	%r2, 8(%r29)
-	ld	%r11, 16(%r29)
 # endif
 	/* Now do the call.  */
-	/* Set up cr1 with bits 4-7 of the flags.  */
-	mtcrf	0x40, %r31
+	/* Set up cr1 with bits 3-7 of the flags.  */
+	mtcrf	0xc0, %r31
 
 	/* Get the address to call into CTR.  */
 	mtctr	%r12
 	/* Load all those argument registers.  */
-	ld	%r3, -32-(8*8)(%r28)
-	ld	%r4, -32-(7*8)(%r28)
-	ld	%r5, -32-(6*8)(%r28)
-	ld	%r6, -32-(5*8)(%r28)
+	addi	%r29, %r28, -32-(8*8)
+	ld	%r3,  (0*8)(%r29)
+	ld	%r4,  (1*8)(%r29)
+	ld	%r5,  (2*8)(%r29)
+	ld	%r6,  (3*8)(%r29)
 	bf-	5, 1f
-	ld	%r7, -32-(4*8)(%r28)
-	ld	%r8, -32-(3*8)(%r28)
-	ld	%r9, -32-(2*8)(%r28)
-	ld	%r10, -32-(1*8)(%r28)
+	ld	%r7,  (4*8)(%r29)
+	ld	%r8,  (5*8)(%r29)
+	ld	%r9,  (6*8)(%r29)
+	ld	%r10, (7*8)(%r29)
 1:
 
 	/* Load all the FP registers.  */
 	bf-	6, 2f
-	lfd	%f1, -32-(21*8)(%r28)
-	lfd	%f2, -32-(20*8)(%r28)
-	lfd	%f3, -32-(19*8)(%r28)
-	lfd	%f4, -32-(18*8)(%r28)
-	lfd	%f5, -32-(17*8)(%r28)
-	lfd	%f6, -32-(16*8)(%r28)
-	lfd	%f7, -32-(15*8)(%r28)
-	lfd	%f8, -32-(14*8)(%r28)
-	lfd	%f9, -32-(13*8)(%r28)
-	lfd	%f10, -32-(12*8)(%r28)
-	lfd	%f11, -32-(11*8)(%r28)
-	lfd	%f12, -32-(10*8)(%r28)
-	lfd	%f13, -32-(9*8)(%r28)
+	addi	%r29, %r29, -(14*8)
+	lfd	%f1,  ( 1*8)(%r29)
+	lfd	%f2,  ( 2*8)(%r29)
+	lfd	%f3,  ( 3*8)(%r29)
+	lfd	%f4,  ( 4*8)(%r29)
+	lfd	%f5,  ( 5*8)(%r29)
+	lfd	%f6,  ( 6*8)(%r29)
+	lfd	%f7,  ( 7*8)(%r29)
+	lfd	%f8,  ( 8*8)(%r29)
+	lfd	%f9,  ( 9*8)(%r29)
+	lfd	%f10, (10*8)(%r29)
+	lfd	%f11, (11*8)(%r29)
+	lfd	%f12, (12*8)(%r29)
+	lfd	%f13, (13*8)(%r29)
 2:
 
+	/* Load all the vector registers.  */
+	bf-	3, 3f
+	addi	%r29, %r29, -16
+	lvx	%v13, 0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v12, 0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v11, 0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v10, 0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v9,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v8,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v7,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v6,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v5,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v4,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v3,  0, %r29
+	addi	%r29, %r29, -16
+	lvx	%v2,  0, %r29
+3:
+
 	/* Make the call.  */
+	ld	%r11, 8(%r28)
 	bctrl
 
 	/* This must follow the call immediately, the unwinder
@@ -145,12 +190,14 @@ ffi_call_LINUX64:
 	bt	31, .Lstruct_return_value
 	bt	30, .Ldone_return_value
 	bt	29, .Lfp_return_value
+	bt	28, .Lvec_return_value
 	std	%r3, 0(%r30)
 	/* Fall through...  */
 
 .Ldone_return_value:
 	/* Restore the registers we used and return.  */
 	mr	%r1, %r28
+	.cfi_def_cfa_register 1
 	ld	%r0, 16(%r28)
 	ld	%r28, -32(%r28)
 	mtlr	%r0
@@ -159,11 +206,16 @@ ffi_call_LINUX64:
 	ld	%r31, -8(%r1)
 	blr
 
+.Lvec_return_value:
+	stvx	%v2, 0, %r30
+	b	.Ldone_return_value
+
 .Lfp_return_value:
-	bf	28, .Lfloat_return_value
-	stfd	%f1, 0(%r30)
+	.cfi_def_cfa_register 28
 	mtcrf	0x02, %r31 /* cr6  */
-	bf	27, .Ldone_return_value
+	bf	27, .Lfloat_return_value
+	stfd	%f1, 0(%r30)
+	bf	26, .Ldone_return_value
 	stfd	%f2, 8(%r30)
 	b	.Ldone_return_value
 .Lfloat_return_value:
@@ -171,8 +223,9 @@ ffi_call_LINUX64:
 	b	.Ldone_return_value
 
 .Lstruct_return_value:
-	bf	29, .Lsmall_struct
-	bf	28, .Lfloat_homog_return_value
+	bf	29, .Lvec_homog_or_small_struct
+	mtcrf	0x02, %r31 /* cr6  */
+	bf	27, .Lfloat_homog_return_value
 	stfd	%f1, 0(%r30)
 	stfd	%f2, 8(%r30)
 	stfd	%f3, 16(%r30)
@@ -194,65 +247,42 @@ ffi_call_LINUX64:
 	stfs	%f8, 28(%r30)
 	b	.Ldone_return_value
 
+.Lvec_homog_or_small_struct:
+	bf	28, .Lsmall_struct
+	stvx	%v2, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v3, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v4, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v5, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v6, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v7, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v8, 0, %r30
+	addi	%r30, %r30, 16
+	stvx	%v9, 0, %r30
+	b	.Ldone_return_value
+
 .Lsmall_struct:
 	std	%r3, 0(%r30)
 	std	%r4, 8(%r30)
 	b	.Ldone_return_value
 
-.LFE1:
-	.long	0
-	.byte	0,12,0,1,128,4,0,0
+	.cfi_endproc
 # if _CALL_ELF == 2
 	.size	ffi_call_LINUX64,.-ffi_call_LINUX64
 # else
 #  ifdef _CALL_LINUX
 	.size	ffi_call_LINUX64,.-.L.ffi_call_LINUX64
 #  else
+	.long	0
+	.byte	0,12,0,1,128,4,0,0
 	.size	.ffi_call_LINUX64,.-.ffi_call_LINUX64
 #  endif
 # endif
-
-	.section	.eh_frame,EH_FRAME_FLAGS,@progbits
-.Lframe1:
-	.4byte	.LECIE1-.LSCIE1	 # Length of Common Information Entry
-.LSCIE1:
-	.4byte	0x0	 # CIE Identifier Tag
-	.byte	0x1	 # CIE Version
-	.ascii "zR\0"	 # CIE Augmentation
-	.uleb128 0x1	 # CIE Code Alignment Factor
-	.sleb128 -8	 # CIE Data Alignment Factor
-	.byte	0x41	 # CIE RA Column
-	.uleb128 0x1	 # Augmentation size
-	.byte	0x14	 # FDE Encoding (pcrel udata8)
-	.byte	0xc	 # DW_CFA_def_cfa
-	.uleb128 0x1
-	.uleb128 0x0
-	.align 3
-.LECIE1:
-.LSFDE1:
-	.4byte	.LEFDE1-.LASFDE1	 # FDE Length
-.LASFDE1:
-	.4byte	.LASFDE1-.Lframe1	 # FDE CIE offset
-	.8byte	.LFB1-.	 # FDE initial location
-	.8byte	.LFE1-.LFB1	 # FDE address range
-	.uleb128 0x0	 # Augmentation size
-	.byte	0x2	 # DW_CFA_advance_loc1
-	.byte	.LCFI0-.LFB1
-	.byte	0xd	 # DW_CFA_def_cfa_register
-	.uleb128 0x1c
-	.byte	0x11	 # DW_CFA_offset_extended_sf
-	.uleb128 0x41
-	.sleb128 -2
-	.byte	0x9f	 # DW_CFA_offset, column 0x1f
-	.uleb128 0x1
-	.byte	0x9e	 # DW_CFA_offset, column 0x1e
-	.uleb128 0x2
-	.byte	0x9d	 # DW_CFA_offset, column 0x1d
-	.uleb128 0x3
-	.byte	0x9c	 # DW_CFA_offset, column 0x1c
-	.uleb128 0x4
-	.align 3
-.LEFDE1:
 
 #endif
 

--- a/runtime/libffi/powerpc/linux64_closure.S
+++ b/runtime/libffi/powerpc/linux64_closure.S
@@ -33,11 +33,14 @@
 #ifdef POWERPC64
 	FFI_HIDDEN (ffi_closure_LINUX64)
 	.globl  ffi_closure_LINUX64
-# if _CALL_ELF == 2
 	.text
+	.cfi_startproc
+# if _CALL_ELF == 2
 ffi_closure_LINUX64:
+#  ifndef __PCREL__
 	addis	%r2, %r12, .TOC.-ffi_closure_LINUX64@ha
 	addi	%r2, %r2, .TOC.-ffi_closure_LINUX64@l
+#  endif
 	.localentry ffi_closure_LINUX64, . - ffi_closure_LINUX64
 # else
 	.section        ".opd","aw"
@@ -60,9 +63,15 @@ ffi_closure_LINUX64:
 # endif
 
 # if _CALL_ELF == 2
-#  32 byte special reg save area + 64 byte parm save area
-#  + 64 byte retval area + 13*8 fpr save area + round to 16
-#  define STACKFRAME 272
+#  ifdef __VEC__
+#   32 byte special reg save area + 64 byte parm save area
+#   + 128 byte retval area + 13*8 fpr save area + 12*16 vec save area + round to 16
+#   define STACKFRAME 528
+#  else
+#   32 byte special reg save area + 64 byte parm save area
+#   + 64 byte retval area + 13*8 fpr save area + round to 16
+#   define STACKFRAME 272
+#  endif
 #  define PARMSAVE 32
 #  define RETVAL PARMSAVE+64
 # else
@@ -73,20 +82,18 @@ ffi_closure_LINUX64:
 #  define RETVAL PARMSAVE+64
 # endif
 
-.LFB1:
 # if _CALL_ELF == 2
 	ld	%r12, FFI_TRAMPOLINE_SIZE(%r11)		# closure->cif
 	mflr	%r0
 	lwz	%r12, 28(%r12)				# cif->flags
 	mtcrf	0x40, %r12
 	addi	%r12, %r1, PARMSAVE
-	bt	7, .Lparmsave
+	bt	7, 0f
 	# Our caller has not allocated a parameter save area.
 	# We need to allocate one here and use it to pass gprs to
 	# ffi_closure_helper_LINUX64.
 	addi	%r12, %r1, -STACKFRAME+PARMSAVE
-.Lparmsave:
-	std	%r0, 16(%r1)
+0:
 	# Save general regs into parm save area
 	std	%r3, 0(%r12)
 	std	%r4, 8(%r12)
@@ -98,11 +105,11 @@ ffi_closure_LINUX64:
 	std	%r10, 56(%r12)
 
 	# load up the pointer to the parm save area
-	mr	%r5, %r12
+	mr	%r7, %r12
 # else
 	# copy r2 to r11 and load TOC into r2
 	mr	%r11, %r2
-	ld	%r2, 16(%r11)
+	ld	%r2, 16(%r2)
 
 	mflr	%r0
 	# Save general regs into parm save area
@@ -116,12 +123,19 @@ ffi_closure_LINUX64:
 	std	%r9, PARMSAVE+48(%r1)
 	std	%r10, PARMSAVE+56(%r1)
 
+	# load up the pointer to the parm save area
+	addi	%r7, %r1, PARMSAVE
+# endif
 	std	%r0, 16(%r1)
 
-	# load up the pointer to the parm save area
-	addi	%r5, %r1, PARMSAVE
-# endif
+	# closure->cif
+	ld	%r3, FFI_TRAMPOLINE_SIZE(%r11)
+	# closure->fun
+	ld	%r4, FFI_TRAMPOLINE_SIZE+8(%r11)
+	# closure->user_data
+	ld	%r5, FFI_TRAMPOLINE_SIZE+16(%r11)
 
+.Ldoclosure:
 	# next save fpr 1 to fpr 13
 	stfd	%f1, -104+(0*8)(%r1)
 	stfd	%f2, -104+(1*8)(%r1)
@@ -137,25 +151,60 @@ ffi_closure_LINUX64:
 	stfd	%f12, -104+(11*8)(%r1)
 	stfd	%f13, -104+(12*8)(%r1)
 
-	# load up the pointer to the saved fpr registers */
-	addi	%r6, %r1, -104
+	# load up the pointer to the saved fpr registers
+	addi	%r8, %r1, -104
+
+# ifdef __VEC__
+	# load up the pointer to the saved vector registers
+	# 8 bytes padding for 16-byte alignment at -112(%r1)
+	addi	%r9, %r8, -24
+	stvx	%v13, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v12, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v11, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v10, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v9, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v8, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v7, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v6, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v5, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v4, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v3, 0, %r9
+	addi	%r9, %r9, -16
+	stvx	%v2, 0, %r9
+# endif
 
 	# load up the pointer to the result storage
-	addi	%r4, %r1, -STACKFRAME+RETVAL
+	addi	%r6, %r1, -STACKFRAME+RETVAL
 
 	stdu	%r1, -STACKFRAME(%r1)
-.LCFI0:
-
-	# get the context pointer from the trampoline
-	mr	%r3, %r11
+	.cfi_def_cfa_offset STACKFRAME
+	.cfi_offset 65, 16
 
 	# make the call
 # if defined _CALL_LINUX || _CALL_ELF == 2
+#  ifdef __PCREL__
+	bl ffi_closure_helper_LINUX64@notoc
+.Lret:
+#  else
 	bl ffi_closure_helper_LINUX64
+.Lret:
+	nop
+#  endif
 # else
 	bl .ffi_closure_helper_LINUX64
-# endif
 .Lret:
+	nop
+# endif
 
 	# now r3 contains the return type
 	# so use it to look up in a table
@@ -182,7 +231,9 @@ ffi_closure_LINUX64:
 # case FFI_TYPE_VOID
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 	nop
 # case FFI_TYPE_INT
 # ifdef __LITTLE_ENDIAN__
@@ -192,17 +243,23 @@ ffi_closure_LINUX64:
 # endif
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_FLOAT
 	lfs %f1, RETVAL+0(%r1)
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_DOUBLE
 	lfd %f1, RETVAL+0(%r1)
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_LONGDOUBLE
 	lfd %f1, RETVAL+0(%r1)
 	mtlr %r0
@@ -216,7 +273,9 @@ ffi_closure_LINUX64:
 # endif
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_SINT8
 # ifdef __LITTLE_ENDIAN__
 	lbz %r3, RETVAL+0(%r1)
@@ -235,7 +294,9 @@ ffi_closure_LINUX64:
 	mtlr %r0
 .Lfinish:
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_SINT16
 # ifdef __LITTLE_ENDIAN__
 	lha %r3, RETVAL+0(%r1)
@@ -244,7 +305,9 @@ ffi_closure_LINUX64:
 # endif
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_UINT32
 # ifdef __LITTLE_ENDIAN__
 	lwz %r3, RETVAL+0(%r1)
@@ -253,7 +316,9 @@ ffi_closure_LINUX64:
 # endif
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_SINT32
 # ifdef __LITTLE_ENDIAN__
 	lwa %r3, RETVAL+0(%r1)
@@ -262,27 +327,47 @@ ffi_closure_LINUX64:
 # endif
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_UINT64
 	ld %r3, RETVAL+0(%r1)
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_SINT64
 	ld %r3, RETVAL+0(%r1)
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 # case FFI_TYPE_STRUCT
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 	nop
 # case FFI_TYPE_POINTER
 	ld %r3, RETVAL+0(%r1)
 	mtlr %r0
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
+# case FFI_V2_TYPE_VECTOR
+	addi %r3, %r1, RETVAL
+	lvx %v2, 0, %r3
+	mtlr %r0
+	b .Lfinish
+# case FFI_V2_TYPE_VECTOR_HOMOG
+	addi %r3, %r1, RETVAL
+	lvx %v2, 0, %r3
+	addi %r3, %r3, 16
+	b .Lmorevector
 # case FFI_V2_TYPE_FLOAT_HOMOG
 	lfs %f1, RETVAL+0(%r1)
 	lfs %f2, RETVAL+4(%r1)
@@ -299,7 +384,28 @@ ffi_closure_LINUX64:
 	lfd %f7, RETVAL+48(%r1)
 	lfd %f8, RETVAL+56(%r1)
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
+.Lmorevector:
+	lvx %v3, 0, %r3
+	addi %r3, %r3, 16
+	lvx %v4, 0, %r3
+	addi %r3, %r3, 16
+	lvx %v5, 0, %r3
+	mtlr %r0
+	addi %r3, %r3, 16
+	lvx %v6, 0, %r3
+	addi %r3, %r3, 16
+	lvx %v7, 0, %r3
+	addi %r3, %r3, 16
+	lvx %v8, 0, %r3
+	addi %r3, %r3, 16
+	lvx %v9, 0, %r3
+	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
+	blr
+	.cfi_def_cfa_offset STACKFRAME
 .Lmorefloat:
 	lfs %f4, RETVAL+12(%r1)
 	mtlr %r0
@@ -308,13 +414,16 @@ ffi_closure_LINUX64:
 	lfs %f7, RETVAL+24(%r1)
 	lfs %f8, RETVAL+28(%r1)
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 .Lsmall:
 # ifdef __LITTLE_ENDIAN__
 	ld %r3,RETVAL+0(%r1)
 	mtlr %r0
 	ld %r4,RETVAL+8(%r1)
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
 # else
 	# A struct smaller than a dword is returned in the low bits of r3
@@ -328,63 +437,126 @@ ffi_closure_LINUX64:
 	mtlr %r0
 	ld %r4,RETVAL+8(%r1)
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset STACKFRAME
 .Lsmalldown:
 	addi %r5, %r5, FFI_V2_TYPE_SMALL_STRUCT + 7
 	mtlr %r0
 	sldi %r5, %r5, 3
 	addi %r1, %r1, STACKFRAME
+	.cfi_def_cfa_offset 0
 	srd %r3, %r3, %r5
 	blr
 # endif
 
-.LFE1:
-	.long	0
-	.byte	0,12,0,1,128,0,0,0
+	.cfi_endproc
 # if _CALL_ELF == 2
 	.size	ffi_closure_LINUX64,.-ffi_closure_LINUX64
 # else
 #  ifdef _CALL_LINUX
 	.size	ffi_closure_LINUX64,.-.L.ffi_closure_LINUX64
 #  else
+	.long	0
+	.byte	0,12,0,1,128,0,0,0
 	.size	.ffi_closure_LINUX64,.-.ffi_closure_LINUX64
 #  endif
 # endif
 
-	.section	.eh_frame,EH_FRAME_FLAGS,@progbits
-.Lframe1:
-	.4byte	.LECIE1-.LSCIE1	 # Length of Common Information Entry
-.LSCIE1:
-	.4byte	0x0	 # CIE Identifier Tag
-	.byte	0x1	 # CIE Version
-	.ascii "zR\0"	 # CIE Augmentation
-	.uleb128 0x1	 # CIE Code Alignment Factor
-	.sleb128 -8	 # CIE Data Alignment Factor
-	.byte	0x41	 # CIE RA Column
-	.uleb128 0x1	 # Augmentation size
-	.byte	0x14	 # FDE Encoding (pcrel udata8)
-	.byte	0xc	 # DW_CFA_def_cfa
-	.uleb128 0x1
-	.uleb128 0x0
-	.align 3
-.LECIE1:
-.LSFDE1:
-	.4byte	.LEFDE1-.LASFDE1	 # FDE Length
-.LASFDE1:
-	.4byte	.LASFDE1-.Lframe1	 # FDE CIE offset
-	.8byte	.LFB1-.	 # FDE initial location
-	.8byte	.LFE1-.LFB1	 # FDE address range
-	.uleb128 0x0	 # Augmentation size
-	.byte	0x2	 # DW_CFA_advance_loc1
-	.byte	.LCFI0-.LFB1
-	.byte	0xe	 # DW_CFA_def_cfa_offset
-	.uleb128 STACKFRAME
-	.byte	0x11	 # DW_CFA_offset_extended_sf
-	.uleb128 0x41
-	.sleb128 -2
-	.align 3
-.LEFDE1:
 
+	FFI_HIDDEN (ffi_go_closure_linux64)
+	.globl  ffi_go_closure_linux64
+	.text
+	.cfi_startproc
+# if _CALL_ELF == 2
+ffi_go_closure_linux64:
+#  ifndef __PCREL__
+	addis	%r2, %r12, .TOC.-ffi_go_closure_linux64@ha
+	addi	%r2, %r2, .TOC.-ffi_go_closure_linux64@l
+#  endif
+	.localentry ffi_go_closure_linux64, . - ffi_go_closure_linux64
+# else
+	.section        ".opd","aw"
+	.align  3
+ffi_go_closure_linux64:
+#  ifdef _CALL_LINUX
+	.quad   .L.ffi_go_closure_linux64,.TOC.@tocbase,0
+	.type   ffi_go_closure_linux64,@function
+	.text
+.L.ffi_go_closure_linux64:
+#  else
+	FFI_HIDDEN (.ffi_go_closure_linux64)
+	.globl  .ffi_go_closure_linux64
+	.quad   .ffi_go_closure_linux64,.TOC.@tocbase,0
+	.size   ffi_go_closure_linux64,24
+	.type   .ffi_go_closure_linux64,@function
+	.text
+.ffi_go_closure_linux64:
+#  endif
+# endif
+
+# if _CALL_ELF == 2
+	ld	%r12, 8(%r11)				# closure->cif
+	mflr	%r0
+	lwz	%r12, 28(%r12)				# cif->flags
+	mtcrf	0x40, %r12
+	addi	%r12, %r1, PARMSAVE
+	bt	7, 0f
+	# Our caller has not allocated a parameter save area.
+	# We need to allocate one here and use it to pass gprs to
+	# ffi_closure_helper_LINUX64.
+	addi	%r12, %r1, -STACKFRAME+PARMSAVE
+0:
+	# Save general regs into parm save area
+	std	%r3, 0(%r12)
+	std	%r4, 8(%r12)
+	std	%r5, 16(%r12)
+	std	%r6, 24(%r12)
+	std	%r7, 32(%r12)
+	std	%r8, 40(%r12)
+	std	%r9, 48(%r12)
+	std	%r10, 56(%r12)
+
+	# load up the pointer to the parm save area
+	mr	%r7, %r12
+# else
+	mflr	%r0
+	# Save general regs into parm save area
+	# This is the parameter save area set up by our caller.
+	std	%r3, PARMSAVE+0(%r1)
+	std	%r4, PARMSAVE+8(%r1)
+	std	%r5, PARMSAVE+16(%r1)
+	std	%r6, PARMSAVE+24(%r1)
+	std	%r7, PARMSAVE+32(%r1)
+	std	%r8, PARMSAVE+40(%r1)
+	std	%r9, PARMSAVE+48(%r1)
+	std	%r10, PARMSAVE+56(%r1)
+
+	# load up the pointer to the parm save area
+	addi	%r7, %r1, PARMSAVE
+# endif
+	std	%r0, 16(%r1)
+
+	# closure->cif
+	ld	%r3, 8(%r11)
+	# closure->fun
+	ld	%r4, 16(%r11)
+	# user_data
+	mr	%r5, %r11
+	b	.Ldoclosure
+
+	.cfi_endproc
+# if _CALL_ELF == 2
+	.size	ffi_go_closure_linux64,.-ffi_go_closure_linux64
+# else
+#  ifdef _CALL_LINUX
+	.size	ffi_go_closure_linux64,.-.L.ffi_go_closure_linux64
+#  else
+	.long	0
+	.byte	0,12,0,1,128,0,0,0
+	.size	.ffi_go_closure_linux64,.-.ffi_go_closure_linux64
+#  endif
+# endif
 #endif
 
 #if (defined __ELF__ && defined __linux__) || _CALL_ELF == 2

--- a/runtime/libffi/powerpc/ppc_closure.S
+++ b/runtime/libffi/powerpc/ppc_closure.S
@@ -33,13 +33,14 @@
 
 #ifndef POWERPC64
 
+FFI_HIDDEN(ffi_closure_SYSV)
 ENTRY(ffi_closure_SYSV)
-.LFB1:
+	.cfi_startproc
 	stwu %r1,-144(%r1)
-.LCFI0:
+	.cfi_def_cfa_offset 144
 	mflr %r0
-.LCFI1:
 	stw %r0,148(%r1)
+	.cfi_offset 65, 4
 
 # we want to build up an areas for the parameters passed
 # in registers (both floating point and integer)
@@ -48,6 +49,17 @@ ENTRY(ffi_closure_SYSV)
 	stw   %r3, 16(%r1)
 	stw   %r4, 20(%r1)
 	stw   %r5, 24(%r1)
+
+	# set up registers for the routine that does the work
+
+	# closure->cif
+	lwz %r3,FFI_TRAMPOLINE_SIZE(%r11)
+	# closure->fun
+	lwz %r4,FFI_TRAMPOLINE_SIZE+4(%r11)
+	# closure->user_data
+	lwz %r5,FFI_TRAMPOLINE_SIZE+8(%r11)
+
+.Ldoclosure:
 	stw   %r6, 28(%r1)
 	stw   %r7, 32(%r1)
 	stw   %r8, 36(%r1)
@@ -66,23 +78,18 @@ ENTRY(ffi_closure_SYSV)
 	stfd  %f8, 104(%r1)
 #endif
 
-	# set up registers for the routine that actually does the work
-	# get the context pointer from the trampoline
-	mr %r3,%r11
+	# pointer to the result storage
+	addi %r6,%r1,112
 
-	# now load up the pointer to the result storage
-	addi %r4,%r1,112
+	# pointer to the saved gpr registers
+	addi %r7,%r1,16
 
-	# now load up the pointer to the saved gpr registers
-	addi %r5,%r1,16
+	# pointer to the saved fpr registers
+	addi %r8,%r1,48
 
-	# now load up the pointer to the saved fpr registers */
-	addi %r6,%r1,48
-
-	# now load up the pointer to the outgoing parameter
-	# stack in the previous frame
+	# pointer to the outgoing parameter save area in the previous frame
 	# i.e. the previous frame pointer + 8
-	addi %r7,%r1,152
+	addi %r9,%r1,152
 
 	# make the call
 	bl ffi_closure_helper_SYSV@local
@@ -101,7 +108,6 @@ ENTRY(ffi_closure_SYSV)
 	add %r3,%r3,%r4		# add contents of table to table address
 	mtctr %r3
 	bctr			# jump to it
-.LFE1:
 
 # Each of the ret_typeX code fragments has to be exactly 16 bytes long
 # (4 instructions). For cache effectiveness we align to a 16 byte boundary
@@ -111,7 +117,9 @@ ENTRY(ffi_closure_SYSV)
 .Lret_type0:
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 	nop
 
 # case FFI_TYPE_INT
@@ -119,31 +127,33 @@ ENTRY(ffi_closure_SYSV)
 	mtlr %r0
 .Lfinish:
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_FLOAT
 #ifndef __NO_FPRS__
 	lfs %f1,112+0(%r1)
-	mtlr %r0
-	addi %r1,%r1,144
 #else
 	nop
-	nop
-	nop
 #endif
+	mtlr %r0
+	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_DOUBLE
 #ifndef __NO_FPRS__
 	lfd %f1,112+0(%r1)
-	mtlr %r0
-	addi %r1,%r1,144
 #else
 	nop
-	nop
-	nop
 #endif
+	mtlr %r0
+	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_LONGDOUBLE
 #ifndef __NO_FPRS__
@@ -152,10 +162,12 @@ ENTRY(ffi_closure_SYSV)
 	mtlr %r0
 	b .Lfinish
 #else
-	nop
-	nop
-	nop
+	mtlr %r0
+	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
+	nop
 #endif
 
 # case FFI_TYPE_UINT8
@@ -166,7 +178,9 @@ ENTRY(ffi_closure_SYSV)
 #endif
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_SINT8
 #ifdef __LITTLE_ENDIAN__
@@ -186,7 +200,9 @@ ENTRY(ffi_closure_SYSV)
 #endif
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_SINT16
 #ifdef __LITTLE_ENDIAN__
@@ -196,19 +212,25 @@ ENTRY(ffi_closure_SYSV)
 #endif
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_UINT32
 	lwz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_SINT32
 	lwz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_UINT64
 	lwz %r3,112+0(%r1)
@@ -225,14 +247,18 @@ ENTRY(ffi_closure_SYSV)
 # case FFI_TYPE_STRUCT
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 	nop
 
 # case FFI_TYPE_POINTER
 	lwz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_TYPE_UINT128
 	lwz %r3,112+0(%r1)
@@ -245,20 +271,26 @@ ENTRY(ffi_closure_SYSV)
 	lbz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_SYSV_TYPE_SMALL_STRUCT + 2. Two byte struct.
 	lhz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_SYSV_TYPE_SMALL_STRUCT + 3. Three byte struct.
 	lwz %r3,112+0(%r1)
 #ifdef __LITTLE_ENDIAN__
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 #else
 	srwi %r3,%r3,8
 	mtlr %r0
@@ -269,7 +301,9 @@ ENTRY(ffi_closure_SYSV)
 	lwz %r3,112+0(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 
 # case FFI_SYSV_TYPE_SMALL_STRUCT + 5. Five byte struct.
 	lwz %r3,112+0(%r1)
@@ -319,64 +353,43 @@ ENTRY(ffi_closure_SYSV)
 	or %r4,%r6,%r4
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
+	.cfi_def_cfa_offset 144
 #endif
 
 .Luint128:
 	lwz %r6,112+12(%r1)
 	mtlr %r0
 	addi %r1,%r1,144
+	.cfi_def_cfa_offset 0
 	blr
-	
+	.cfi_endproc
 END(ffi_closure_SYSV)
 
-	.section	".eh_frame",EH_FRAME_FLAGS,@progbits
-.Lframe1:
-	.4byte	.LECIE1-.LSCIE1	 # Length of Common Information Entry
-.LSCIE1:
-	.4byte	0x0	 # CIE Identifier Tag
-	.byte	0x1	 # CIE Version
-#if defined _RELOCATABLE || defined __PIC__
-	.ascii "zR\0"	 # CIE Augmentation
-#else
-	.ascii "\0"	 # CIE Augmentation
-#endif
-	.uleb128 0x1	 # CIE Code Alignment Factor
-	.sleb128 -4	 # CIE Data Alignment Factor
-	.byte	0x41	 # CIE RA Column
-#if defined _RELOCATABLE || defined __PIC__
-	.uleb128 0x1	 # Augmentation size
-	.byte	0x1b	 # FDE Encoding (pcrel sdata4)
-#endif
-	.byte	0xc	 # DW_CFA_def_cfa
-	.uleb128 0x1
-	.uleb128 0x0
-	.align 2
-.LECIE1:
-.LSFDE1:
-	.4byte	.LEFDE1-.LASFDE1	 # FDE Length
-.LASFDE1:
-	.4byte	.LASFDE1-.Lframe1	 # FDE CIE offset
-#if defined _RELOCATABLE || defined __PIC__
-	.4byte	.LFB1-.	 # FDE initial location
-#else
-	.4byte	.LFB1	 # FDE initial location
-#endif
-	.4byte	.LFE1-.LFB1	 # FDE address range
-#if defined _RELOCATABLE || defined __PIC__
-	.uleb128 0x0	 # Augmentation size
-#endif
-	.byte	0x4	 # DW_CFA_advance_loc4
-	.4byte	.LCFI0-.LFB1
-	.byte	0xe	 # DW_CFA_def_cfa_offset
-	.uleb128 144
-	.byte	0x4	 # DW_CFA_advance_loc4
-	.4byte	.LCFI1-.LCFI0
-	.byte	0x11	 # DW_CFA_offset_extended_sf
-	.uleb128 0x41
-	.sleb128 -1
-	.align 2
-.LEFDE1:
+
+FFI_HIDDEN(ffi_go_closure_sysv)
+ENTRY(ffi_go_closure_sysv)
+	.cfi_startproc
+	stwu %r1,-144(%r1)
+	.cfi_def_cfa_offset 144
+	mflr %r0
+	stw %r0,148(%r1)
+	.cfi_offset 65, 4
+
+	stw   %r3, 16(%r1)
+	stw   %r4, 20(%r1)
+	stw   %r5, 24(%r1)
+
+	# closure->cif
+	lwz %r3,4(%r11)
+	# closure->fun
+	lwz %r4,8(%r11)
+	# user_data
+	mr %r5,%r11
+	b .Ldoclosure
+	.cfi_endproc
+END(ffi_go_closure_sysv)
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",@progbits

--- a/runtime/libffi/powerpc/sysv.S
+++ b/runtime/libffi/powerpc/sysv.S
@@ -31,34 +31,35 @@
 #include <powerpc/asm.h>
 
 #ifndef POWERPC64
-	.globl ffi_prep_args_SYSV
+FFI_HIDDEN(ffi_call_SYSV)
 ENTRY(ffi_call_SYSV)
-.LFB1:
+	.cfi_startproc
 	/* Save the old stack pointer as AP.  */
-	mr	%r8,%r1
+	mr	%r10,%r1
+	.cfi_def_cfa_register 10
 
-.LCFI0:
 	/* Allocate the stack space we need.  */
-	stwux	%r1,%r1,%r4
+	stwux	%r1,%r1,%r8
 	/* Save registers we use.  */
 	mflr	%r9
-	stw	%r28,-16(%r8)
-.LCFI1:
-	stw	%r29,-12(%r8)
-.LCFI2:
-	stw	%r30, -8(%r8)
-.LCFI3:
-	stw	%r31, -4(%r8)
-.LCFI4:
-	stw	%r9,   4(%r8)
-.LCFI5:
+	stw	%r28,-16(%r10)
+	stw	%r29,-12(%r10)
+	stw	%r30, -8(%r10)
+	stw	%r31, -4(%r10)
+	stw	%r9,   4(%r10)
+	.cfi_offset 65, 4
+	.cfi_offset 31, -4
+	.cfi_offset 30, -8
+	.cfi_offset 29, -12
+	.cfi_offset 28, -16
 
 	/* Save arguments over call...  */
-	mr	%r31,%r5	/* flags, */
-	mr	%r30,%r6	/* rvalue, */
-	mr	%r29,%r7	/* function address, */
-	mr	%r28,%r8	/* our AP. */
-.LCFI6:
+	stw	%r7,   -20(%r10)	/* closure, */
+	mr	%r31,%r6		/* flags, */
+	mr	%r30,%r5		/* rvalue, */
+	mr	%r29,%r4		/* function address, */
+	mr	%r28,%r10		/* our AP. */
+	.cfi_def_cfa_register 28
 
 	/* Call ffi_prep_args_SYSV.  */
 	mr	%r4,%r1
@@ -70,49 +71,49 @@ ENTRY(ffi_call_SYSV)
 	/* Get the address to call into CTR.  */
 	mtctr	%r29
 	/* Load all those argument registers.  */
-	lwz	%r3,-16-(8*4)(%r28)
-	lwz	%r4,-16-(7*4)(%r28)
-	lwz	%r5,-16-(6*4)(%r28)
-	lwz	%r6,-16-(5*4)(%r28)
+	lwz	%r3,-24-(8*4)(%r28)
+	lwz	%r4,-24-(7*4)(%r28)
+	lwz	%r5,-24-(6*4)(%r28)
+	lwz	%r6,-24-(5*4)(%r28)
 	bf-	5,1f
 	nop
-	lwz	%r7,-16-(4*4)(%r28)
-	lwz	%r8,-16-(3*4)(%r28)
-	lwz	%r9,-16-(2*4)(%r28)
-	lwz	%r10,-16-(1*4)(%r28)
+	lwz	%r7,-24-(4*4)(%r28)
+	lwz	%r8,-24-(3*4)(%r28)
+	lwz	%r9,-24-(2*4)(%r28)
+	lwz	%r10,-24-(1*4)(%r28)
 	nop
 1:
 
 #ifndef __NO_FPRS__
 	/* Load all the FP registers.  */
 	bf-	6,2f
-	lfd	%f1,-16-(8*4)-(8*8)(%r28)
-	lfd	%f2,-16-(8*4)-(7*8)(%r28)
-	lfd	%f3,-16-(8*4)-(6*8)(%r28)
-	lfd	%f4,-16-(8*4)-(5*8)(%r28)
+	lfd	%f1,-24-(8*4)-(8*8)(%r28)
+	lfd	%f2,-24-(8*4)-(7*8)(%r28)
+	lfd	%f3,-24-(8*4)-(6*8)(%r28)
+	lfd	%f4,-24-(8*4)-(5*8)(%r28)
 	nop
-	lfd	%f5,-16-(8*4)-(4*8)(%r28)
-	lfd	%f6,-16-(8*4)-(3*8)(%r28)
-	lfd	%f7,-16-(8*4)-(2*8)(%r28)
-	lfd	%f8,-16-(8*4)-(1*8)(%r28)
+	lfd	%f5,-24-(8*4)-(4*8)(%r28)
+	lfd	%f6,-24-(8*4)-(3*8)(%r28)
+	lfd	%f7,-24-(8*4)-(2*8)(%r28)
+	lfd	%f8,-24-(8*4)-(1*8)(%r28)
 #endif
 2:
 
 	/* Make the call.  */
+	lwz	%r11, -20(%r28)
 	bctrl
 
 	/* Now, deal with the return value.  */
-	mtcrf	0x01,%r31 /* cr7  */
+	mtcrf	0x03,%r31 /* cr6-cr7  */
 	bt-	31,L(small_struct_return_value)
 	bt-	30,L(done_return_value)
 #ifndef __NO_FPRS__
 	bt-	29,L(fp_return_value)
 #endif
 	stw	%r3,0(%r30)
-	bf+	28,L(done_return_value)
+	bf+	27,L(done_return_value)
 	stw	%r4,4(%r30)
-	mtcrf	0x02,%r31 /* cr6  */
-	bf	27,L(done_return_value)
+	bf	26,L(done_return_value)
 	stw     %r5,8(%r30)
 	stw	%r6,12(%r30)
 	/* Fall through...  */
@@ -125,15 +126,27 @@ L(done_return_value):
 	lwz	%r30, -8(%r28)
 	lwz	%r29,-12(%r28)
 	lwz	%r28,-16(%r28)
+	.cfi_remember_state
+	/* At this point we don't have a cfa register.  Say all our
+	   saved regs have been restored.  */
+	.cfi_same_value 65
+	.cfi_same_value 31
+	.cfi_same_value 30
+	.cfi_same_value 29
+	.cfi_same_value 28
+	/* Hopefully this works..  */
+	.cfi_def_cfa_register 1
+	.cfi_offset 1, 0
 	lwz	%r1,0(%r1)
+	.cfi_same_value 1
 	blr
 
 #ifndef __NO_FPRS__
 L(fp_return_value):
-	bf	28,L(float_return_value)
+	.cfi_restore_state
+	bf	27,L(float_return_value)
 	stfd	%f1,0(%r30)
-	mtcrf   0x02,%r31 /* cr6  */
-	bf	27,L(done_return_value)
+	bf	26,L(done_return_value)
 	stfd	%f2,8(%r30)
 	b	L(done_return_value)
 L(float_return_value):
@@ -150,69 +163,9 @@ L(small_struct_return_value):
 	stw %r3, 0(%r30)
 	stw %r4, 4(%r30)
 	b L(done_return_value)
+	.cfi_endproc
 
-.LFE1:
 END(ffi_call_SYSV)
-
-      .section	".eh_frame",EH_FRAME_FLAGS,@progbits
-.Lframe1:
-      .4byte    .LECIE1-.LSCIE1  /*  Length of Common Information Entry */
-.LSCIE1:
-      .4byte    0x0      /*  CIE Identifier Tag */
-      .byte     0x1      /*  CIE Version */
-#if defined _RELOCATABLE || defined __PIC__
-      .ascii	"zR\0"   /*  CIE Augmentation */
-#else
-      .ascii	"\0"	 /*  CIE Augmentation */
-#endif
-      .uleb128  0x1      /*  CIE Code Alignment Factor */
-      .sleb128  -4	 /*  CIE Data Alignment Factor */
-      .byte     0x41     /*  CIE RA Column */
-#if defined _RELOCATABLE || defined __PIC__
-      .uleb128  0x1      /*  Augmentation size */
-      .byte	0x1b	 /*  FDE Encoding (pcrel sdata4) */
-#endif
-      .byte     0xc      /*  DW_CFA_def_cfa */
-      .uleb128  0x1
-      .uleb128  0x0
-      .align 2
-.LECIE1:
-.LSFDE1:
-      .4byte    .LEFDE1-.LASFDE1         /*  FDE Length */
-.LASFDE1:
-      .4byte    .LASFDE1-.Lframe1         /*  FDE CIE offset */
-#if defined _RELOCATABLE || defined __PIC__
-      .4byte    .LFB1-.  /*  FDE initial location */
-#else
-      .4byte    .LFB1    /*  FDE initial location */
-#endif
-      .4byte    .LFE1-.LFB1      /*  FDE address range */
-#if defined _RELOCATABLE || defined __PIC__
-      .uleb128  0x0	 /*  Augmentation size */
-#endif
-      .byte     0x4      /*  DW_CFA_advance_loc4 */
-      .4byte    .LCFI0-.LFB1
-      .byte     0xd      /*  DW_CFA_def_cfa_register */
-      .uleb128  0x08
-      .byte     0x4      /*  DW_CFA_advance_loc4 */
-      .4byte    .LCFI5-.LCFI0
-      .byte     0x11     /*  DW_CFA_offset_extended_sf */
-      .uleb128  0x41
-      .sleb128  -1
-      .byte     0x9f     /*  DW_CFA_offset, column 0x1f */
-      .uleb128  0x1
-      .byte     0x9e     /*  DW_CFA_offset, column 0x1e */
-      .uleb128  0x2
-      .byte     0x9d     /*  DW_CFA_offset, column 0x1d */
-      .uleb128  0x3
-      .byte     0x9c     /*  DW_CFA_offset, column 0x1c */
-      .uleb128  0x4
-      .byte     0x4      /*  DW_CFA_advance_loc4 */
-      .4byte    .LCFI6-.LCFI5
-      .byte     0xd      /*  DW_CFA_def_cfa_register */
-      .uleb128  0x1c
-      .align 2
-.LEFDE1:
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",@progbits

--- a/runtime/libffi/preconf/ap32/ffi.h
+++ b/runtime/libffi/preconf/ap32/ffi.h
@@ -50,6 +50,12 @@
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -117,6 +123,34 @@ typedef struct _ffi_type
   struct _ffi_type **elements;
 } ffi_type;
 
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+ * autoimport and autoexport.  Always mark externally visible symbols
+ * as dllimport for MSVC clients, even if it means an extra indirection
+ * when using the static version of the library.
+ * Besides, as a workaround, they can define FFI_BUILDING if they
+ * *know* they are going to link with the static library.
+ */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+ * decorations, or they will not be exported from the object file.
+ */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
 #ifndef LIBFFI_HIDE_BASIC_TYPES
 #if SCHAR_MAX == 127
 # define ffi_type_uchar                ffi_type_uint8
@@ -164,20 +198,6 @@ typedef struct _ffi_type
 # define ffi_type_slong        ffi_type_sint64
 #else
  #error "long size not supported"
-#endif
-
-/* Need minimal decorations for DLLs to works on Windows. */
-/* GCC has autoimport and autoexport.  Rely on Libtool to */
-/* help MSVC export from a DLL, but always declare data   */
-/* to be imported for MSVC clients.  This costs an extra  */
-/* indirection for MSVC clients using the static version  */
-/* of the library, but don't worry about that.  Besides,  */
-/* as a workaround, they can define FFI_BUILDING if they  */
-/* *know* they are going to link with the static library. */
-#if defined _MSC_VER && !defined FFI_BUILDING
-#define FFI_EXTERN extern __declspec(dllimport)
-#else
-#define FFI_EXTERN extern
 #endif
 
 /* These are defined in types.c */
@@ -427,6 +447,22 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void *codeloc);
 
 #endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+typedef struct {
+  void      *tramp;
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ---- Public interface definition -------------------------------------- */
 

--- a/runtime/libffi/preconf/ap64/ffi.h
+++ b/runtime/libffi/preconf/ap64/ffi.h
@@ -50,6 +50,12 @@
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -117,6 +123,34 @@ typedef struct _ffi_type
   struct _ffi_type **elements;
 } ffi_type;
 
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+ * autoimport and autoexport.  Always mark externally visible symbols
+ * as dllimport for MSVC clients, even if it means an extra indirection
+ * when using the static version of the library.
+ * Besides, as a workaround, they can define FFI_BUILDING if they
+ * *know* they are going to link with the static library.
+ */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+ * decorations, or they will not be exported from the object file.
+ */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
 #ifndef LIBFFI_HIDE_BASIC_TYPES
 #if SCHAR_MAX == 127
 # define ffi_type_uchar                ffi_type_uint8
@@ -164,20 +198,6 @@ typedef struct _ffi_type
 # define ffi_type_slong        ffi_type_sint64
 #else
  #error "long size not supported"
-#endif
-
-/* Need minimal decorations for DLLs to works on Windows. */
-/* GCC has autoimport and autoexport.  Rely on Libtool to */
-/* help MSVC export from a DLL, but always declare data   */
-/* to be imported for MSVC clients.  This costs an extra  */
-/* indirection for MSVC clients using the static version  */
-/* of the library, but don't worry about that.  Besides,  */
-/* as a workaround, they can define FFI_BUILDING if they  */
-/* *know* they are going to link with the static library. */
-#if defined _MSC_VER && !defined FFI_BUILDING
-#define FFI_EXTERN extern __declspec(dllimport)
-#else
-#define FFI_EXTERN extern
 #endif
 
 /* These are defined in types.c */
@@ -427,6 +447,22 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void *codeloc);
 
 #endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+typedef struct {
+  void      *tramp;
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ---- Public interface definition -------------------------------------- */
 

--- a/runtime/libffi/preconf/xl64/ffi.h
+++ b/runtime/libffi/preconf/xl64/ffi.h
@@ -50,6 +50,12 @@
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -117,6 +123,34 @@ typedef struct _ffi_type
   struct _ffi_type **elements;
 } ffi_type;
 
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+ * autoimport and autoexport.  Always mark externally visible symbols
+ * as dllimport for MSVC clients, even if it means an extra indirection
+ * when using the static version of the library.
+ * Besides, as a workaround, they can define FFI_BUILDING if they
+ * *know* they are going to link with the static library.
+ */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+ * decorations, or they will not be exported from the object file.
+ */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
 #ifndef LIBFFI_HIDE_BASIC_TYPES
 #if SCHAR_MAX == 127
 # define ffi_type_uchar                ffi_type_uint8
@@ -164,20 +198,6 @@ typedef struct _ffi_type
 # define ffi_type_slong        ffi_type_sint64
 #else
  #error "long size not supported"
-#endif
-
-/* Need minimal decorations for DLLs to works on Windows. */
-/* GCC has autoimport and autoexport.  Rely on Libtool to */
-/* help MSVC export from a DLL, but always declare data   */
-/* to be imported for MSVC clients.  This costs an extra  */
-/* indirection for MSVC clients using the static version  */
-/* of the library, but don't worry about that.  Besides,  */
-/* as a workaround, they can define FFI_BUILDING if they  */
-/* *know* they are going to link with the static library. */
-#if defined _MSC_VER && !defined FFI_BUILDING
-#define FFI_EXTERN extern __declspec(dllimport)
-#else
-#define FFI_EXTERN extern
 #endif
 
 /* These are defined in types.c */
@@ -427,6 +447,22 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void *codeloc);
 
 #endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+typedef struct {
+  void      *tramp;
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ---- Public interface definition -------------------------------------- */
 

--- a/runtime/libffi/preconf/xp32/ffi.h
+++ b/runtime/libffi/preconf/xp32/ffi.h
@@ -50,6 +50,12 @@
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -117,6 +123,34 @@ typedef struct _ffi_type
   struct _ffi_type **elements;
 } ffi_type;
 
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+ * autoimport and autoexport.  Always mark externally visible symbols
+ * as dllimport for MSVC clients, even if it means an extra indirection
+ * when using the static version of the library.
+ * Besides, as a workaround, they can define FFI_BUILDING if they
+ * *know* they are going to link with the static library.
+ */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+ * decorations, or they will not be exported from the object file.
+ */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
 #ifndef LIBFFI_HIDE_BASIC_TYPES
 #if SCHAR_MAX == 127
 # define ffi_type_uchar                ffi_type_uint8
@@ -164,20 +198,6 @@ typedef struct _ffi_type
 # define ffi_type_slong        ffi_type_sint64
 #else
  #error "long size not supported"
-#endif
-
-/* Need minimal decorations for DLLs to works on Windows. */
-/* GCC has autoimport and autoexport.  Rely on Libtool to */
-/* help MSVC export from a DLL, but always declare data   */
-/* to be imported for MSVC clients.  This costs an extra  */
-/* indirection for MSVC clients using the static version  */
-/* of the library, but don't worry about that.  Besides,  */
-/* as a workaround, they can define FFI_BUILDING if they  */
-/* *know* they are going to link with the static library. */
-#if defined _MSC_VER && !defined FFI_BUILDING
-#define FFI_EXTERN extern __declspec(dllimport)
-#else
-#define FFI_EXTERN extern
 #endif
 
 /* These are defined in types.c */
@@ -427,6 +447,23 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void *codeloc);
 
 #endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+/* Replace *tramp with (*tramp)(void) to pass the compilation */
+typedef struct {
+  void      (*tramp)(void);
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ---- Public interface definition -------------------------------------- */
 

--- a/runtime/libffi/preconf/xp64/ffi.h
+++ b/runtime/libffi/preconf/xp64/ffi.h
@@ -50,6 +50,12 @@
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -117,6 +123,34 @@ typedef struct _ffi_type
   struct _ffi_type **elements;
 } ffi_type;
 
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+ * autoimport and autoexport.  Always mark externally visible symbols
+ * as dllimport for MSVC clients, even if it means an extra indirection
+ * when using the static version of the library.
+ * Besides, as a workaround, they can define FFI_BUILDING if they
+ * *know* they are going to link with the static library.
+ */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+ * decorations, or they will not be exported from the object file.
+ */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
 #ifndef LIBFFI_HIDE_BASIC_TYPES
 #if SCHAR_MAX == 127
 # define ffi_type_uchar                ffi_type_uint8
@@ -164,20 +198,6 @@ typedef struct _ffi_type
 # define ffi_type_slong        ffi_type_sint64
 #else
  #error "long size not supported"
-#endif
-
-/* Need minimal decorations for DLLs to works on Windows. */
-/* GCC has autoimport and autoexport.  Rely on Libtool to */
-/* help MSVC export from a DLL, but always declare data   */
-/* to be imported for MSVC clients.  This costs an extra  */
-/* indirection for MSVC clients using the static version  */
-/* of the library, but don't worry about that.  Besides,  */
-/* as a workaround, they can define FFI_BUILDING if they  */
-/* *know* they are going to link with the static library. */
-#if defined _MSC_VER && !defined FFI_BUILDING
-#define FFI_EXTERN extern __declspec(dllimport)
-#else
-#define FFI_EXTERN extern
 #endif
 
 /* These are defined in types.c */
@@ -427,6 +447,22 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void *codeloc);
 
 #endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+typedef struct {
+  void      *tramp;
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ---- Public interface definition -------------------------------------- */
 


### PR DESCRIPTION
The changes entirely replace the outdated powerpc/libffi
with the latest version at
https://github.com/libffi/libffi/tree/master/src/powerpc
so as to better support the upcall with struct in JEP389/419
(Foreign Linker API) which is part of the Panama project.

The latest committed SHA: ab1677106605aba1c27665964ff90bea59612ce3

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>