### PR TITLE
Fix >4k field offset path for unresolved field load/store in Z codegen

### DIFF
--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -367,18 +367,24 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
          *(int16_t *) cursor = 0x0014;
          cursor += sizeof(int16_t);
 
-         *(int32_t *) cursor = 0xb90800e0;                       // 64Bit: AGR R14, Rbase
-         TR::RealRegister::setRegisterField((uint32_t*)cursor, 0, base);
-         cursor += sizeof(int32_t);
+         if (base != TR::RealRegister::NoReg)
+            {
+            *(int32_t *) cursor = 0xb90800e0;                    // 64Bit: AGR R14, Rbase
+            TR::RealRegister::setRegisterField((uint32_t*)cursor, 0, base);
+            cursor += sizeof(int32_t);
+            }
          }
       else
          {
          *(int32_t *) cursor = 0x58e0e000;                       // 31Bit: L   R14,6(R14)
          cursor += sizeof(int32_t);
 
-         *(uint32_t *) cursor = (int32_t)0x1ae00000;             // 31Bit: AR  R14, Rbase
-         TR::RealRegister::setRegisterField((uint32_t*)cursor, 4, base);
-         cursor += sizeof(int16_t);
+         if (base != TR::RealRegister::NoReg)
+            {
+            *(uint32_t *) cursor = (int32_t)0x1ae00000;          // 31Bit: AR  R14, Rbase
+            TR::RealRegister::setRegisterField((uint32_t*)cursor, 4, base);
+            cursor += sizeof(int16_t);
+            }
          }
 
       uint8_t*  returnAddress = (getBranchInstruction()->getNext())->getBinaryEncoding();


### PR DESCRIPTION
Under some IL configurations the Z codegen will set the index register
for a load/store memref leaving the base register NULL. This results
in a load/store instruction using R0 as the base register. Normally
this would be a small performance problem, not a functional issue.
But for the unresolved large offset case, patching will update the base
register of the load/store  with R14 which is set to the field offset
plus the contents of R0. R0 is used because the memref base register is
NULL leaving us with NoReg, but NoReg and R0 have the same 0 definition.
In such a scenario R0 contains an undefined value and can result in
storing/loading to/form a random location.

This fix will only emit the `agr` instruction adding the base register
contents to r14 when the base register is not equal to NoReg. This
solution results in a proper load/store offset under all scenarios
including shift-by-one and shift-by>1 compressedref configurations.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>