### PR TITLE
Add tracepoints to the shared cache impl, and tweak CacheFullTests

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -255,24 +255,28 @@ SH_CompositeCacheImpl::getFreeBlockBytes(void)
 		*	then free block bytes = freeBytes as calculated above
 		*/
 		retVal = freeBytes;
+		Trc_SHR_CC_freeBlockBytes_info(1, retVal, freeBytes, minAOT, aotBytes, minJIT, jitBytes);
 	} else if (minJIT > jitBytes && ((-1 == minAOT) || (minAOT <= aotBytes))) {
 		/*if jitBytes within the reserved space for JIT but no reserved space for AOT
 		 * or aotBytes is  equal to or crossed reserved space for AOT
 		 * then free block bytes =  freebytes - bytes not yet used in reserved space of JIT
 		*/
 		retVal = freeBytes - (minJIT - jitBytes) ;
+		Trc_SHR_CC_freeBlockBytes_info(2, retVal, freeBytes, minAOT, aotBytes, minJIT, jitBytes);
 	} else if ((minAOT > aotBytes) && ((-1 == minJIT) || minJIT <= jitBytes)) {
 		/*if aotBytes within the reserved space for AOT but no reserved space for JIT
 		 * or jitBytes is  equal to or crossed reserved space for JIT
 		 * then free block bytes =  freebytes - bytes not yet used in reserved space of AOT
 		*/
 		retVal = freeBytes - (minAOT - aotBytes) ;
+		Trc_SHR_CC_freeBlockBytes_info(3, retVal, freeBytes, minAOT, aotBytes, minJIT, jitBytes);
 	} else	{
 		 /* We are here if both jitBytes and aotBytes are within the their respective reserved space
 		 *  free block bytes = freebytes - bytes not yet used in reserved space of AOT -
 		 *       						   bytes not yet used in reserved space of JIT
 		 */
 		retVal = freeBytes - (minJIT - jitBytes) - (minAOT - aotBytes);
+		Trc_SHR_CC_freeBlockBytes_info(4, retVal, freeBytes, minAOT, aotBytes, minJIT, jitBytes);
 	}
 	/* When creating the cache with -Xscminaot/-Xscminjit > real cache size, minAOT/minJIT will be set to the same size to the real cache size by ensureCorrectCacheSizes(),
 	 * retVal calculated here can be < 0 in this case.

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2021 IBM Corp. and others
+// Copyright (c) 2006, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2991,3 +2991,4 @@ TraceEvent=Trc_SHR_API_j9shr_classStoreTransaction_start_cacheSoftFull_Event Ove
 TraceExit-Exception=Trc_SHR_CMI_Update_Exit5 Overhead=1 Level=2 Template="CMI Update: StoreIdentified failed to acquire _identifiedMutex. Returning -1."
 TraceExit-Exception=Trc_SHR_CMI_validate_Exit_IdentifiedMutex_Failed Overhead=1 Level=2 Template="CMI validate: Failed to acquire _identifiedMutex. Returning -1."
 TraceException=Trc_SHR_CC_changePartialPageProtection_NotDone_V1 Overhead=1 Level=1 Template="CC changePartialPageProtection: Returning without changing page protection for address %p to %s"
+TraceEvent=Trc_SHR_CC_freeBlockBytes_info NoEnv Overhead=1 Level=10 Template="CC getFreeBlockBytes: case %d, retVal %d, freeBytes %d, minAOT %d, aotBytes %d, minJIT %d, jitBytes %d"

--- a/runtime/tests/shared/CacheFullTests.cpp
+++ b/runtime/tests/shared/CacheFullTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2445,13 +2445,14 @@ IDATA test8(J9JavaVM* vm) {
 	cc = (SH_CompositeCacheImpl *)cacheMap->getCompositeCacheAPI();
 	ca = cc->getCacheHeaderAddress();
 
+	cc->enterWriteMutex(vm->mainThread, false, testName);
+
 	oldFreeBlockBytes = cc->getFreeBlockBytes();
 
 	/* Add enough metadata to the cache to mark it as full */
 	itemLen = (U_32) (oldFreeBlockBytes - (J9SHR_MIN_GAP_BEFORE_METADATA + ONE_K_BYTES) - (sizeof(ShcItem) + sizeof(ShcItemHdr)));
 	cc->initBlockData(&itemPtr, itemLen, TYPE_UNINDEXED_BYTE_DATA);
 
-	cc->enterWriteMutex(vm->mainThread, false, testName);
 	result = cc->allocateBlock(vm->mainThread, &item, SHC_WORDALIGN, 0);
 	if (NULL == result) {
 		ERRPRINTF1("Error: Did not expect allocateBlock to fail but it returned result=%p", result);


### PR DESCRIPTION
Acquire the write mutex in CacheFullTests before getFreeBlockBytes()

Tracepoints helped to debug
https://github.com/eclipse-openj9/openj9/pull/14668#issuecomment-1063660420
Having them in the code works around the z/OS compiler problem with
TUNE(12).

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>