### PR TITLE
jdk11: adjust signature of JVM_LoadLibrary()

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -290,7 +290,7 @@ jvm_add_exports(jvm
 	JVM_BeforeHalt
 )
 
-if(JAVA_SPEC_VERSION LESS 17)
+if(JAVA_SPEC_VERSION LESS 11)
 	jvm_add_exports(jvm _JVM_LoadLibrary@4)
 else()
 	jvm_add_exports(jvm _JVM_LoadLibrary@8)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -99,10 +99,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_LatestUserDefinedLoader@4" />
 		<export name="_JVM_Listen@8" />
 		<export name="_JVM_LoadLibrary@4">
-			<exclude-if condition="spec.java17"/>
+			<exclude-if condition="spec.java11"/>
 		</export>
 		<export name="_JVM_LoadLibrary@8">
-			<include-if condition="spec.java17"/>
+			<include-if condition="spec.java11"/>
 		</export>
 		<export name="_JVM_LoadSystemLibrary@4" />
 		<export name="_JVM_Lseek@16" />

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3953,10 +3953,10 @@ JVM_LoadSystemLibrary(const char *libName)
 }
 
 /**
- * Prior to jdk17:
+ * Prior to jdk11:
  *   void * JNICALL JVM_LoadLibrary(char *libName)
  *
- * Beginning in jdk17:
+ * Beginning in jdk11:
  *   void * JNICALL JVM_LoadLibrary(char *libName, jboolean throwOnFailure)
  *
  * Attempts to load the shared library specified by libName.
@@ -3975,11 +3975,11 @@ JVM_LoadSystemLibrary(const char *libName)
  * It is only invoked by jdk.internal.loader.BootLoader.loadLibrary().
  */
 void * JNICALL
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 JVM_LoadLibrary(const char *libName)
-#else /* JAVA_SPEC_VERSION < 17 */
+#else /* JAVA_SPEC_VERSION < 11 */
 JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 {
 	void *result = NULL;
 	J9JavaVM *javaVM = (J9JavaVM *)BFUjavaVM;

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -85,7 +85,7 @@ _X(JVM_InvokeMethod,JNICALL,true,jobject,JNIEnv *env, jobject method, jobject ob
 _X(JVM_IsNaN,JNICALL,true,jboolean,jdouble dbl)
 _X(JVM_LatestUserDefinedLoader,JNICALL,true,jobject,JNIEnv *env)
 _X(JVM_Listen,JNICALL,true,jint,jint descriptor, jint count)
-_IF([JAVA_SPEC_VERSION < 17],
+_IF([JAVA_SPEC_VERSION < 11],
 	_X(JVM_LoadLibrary,JNICALL,true,void *,const char *libName),
 	_X(JVM_LoadLibrary,JNICALL,true,void *,const char *libName, jboolean throwOnFailure))
 _X(JVM_Lseek,JNICALL,true,jlong,jint descriptor, jlong bytesToSeek, jint origin)


### PR DESCRIPTION
The openj9-staging branch now contains this back-port of a signature change to `JVM_LoadLibrary()`:
* 8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem