### PR TITLE
Rebalance Eden after Global GC

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1220,6 +1220,8 @@ MM_IncrementalGenerationalGC::runGlobalGarbageCollection(MM_EnvironmentVLHGC *en
 	env->_cycleState->_markMap = NULL;
 	env->_cycleState->_currentIncrement = 0;
 
+	_schedulingDelegate.checkEdenSizeAfterGlobalGC(env);
+
 	_extensions->globalVLHGCStats._heapSizingData.readyToResizeAtGlobalEnd = true;
 	if (attemptHeapResize(env, allocDescription)) {
 		/* Check was it successful contraction */

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -657,8 +657,10 @@ intptr_t
 MM_SchedulingDelegate::calculateRecommendedEdenChangeForExpandedHeap(MM_EnvironmentVLHGC *env)
 {
 
-	if (0 == _pgcCountSinceGMPEnd) {
-		/* No statistics have been collected - just return the current eden size */
+	if ((0 == _pgcCountSinceGMPEnd) && (OMR_GC_CYCLE_TYPE_VLHGC_GLOBAL_GARBAGE_COLLECT != env->_cycleState->_type)) {
+		/* No statistics have been collected - just return the current eden size.
+		 * Even if PGC did not occur, a Global GC might have, in which case we still want to re-eval Eden size
+		 */
 		return getCurrentEdenSizeInBytes(env);
 	}
 
@@ -1433,6 +1435,15 @@ MM_SchedulingDelegate::calculatePercentOfHeapExpanded(MM_EnvironmentVLHGC *env)
 	}
 	return ratioOfHeapExpanded;
 }
+
+void
+MM_SchedulingDelegate::checkEdenSizeAfterGlobalGC(MM_EnvironmentVLHGC *env)
+{
+	/* The logic is similar as if we did first PGC after GMP: we need to balanced out the cost of global GCs and GMPs  vs  PGCs */
+	checkEdenSizeAfterPgc(env, true);
+	calculateEdenSize(env);
+}
+
 
 void
 MM_SchedulingDelegate::checkEdenSizeAfterPgc(MM_EnvironmentVLHGC *env, bool globalSweepHappened)

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -139,6 +139,12 @@ public:
 
 	uintptr_t getPgcCountSinceGMPEnd(MM_EnvironmentVLHGC *env) { return _pgcCountSinceGMPEnd; }
 
+	/**
+	 * Following a Global STW GC, compare PGC overhead vs global&GMP overhead, and resize eden size if needed
+	 * @param env[in] the main GC thread
+	 */
+	void checkEdenSizeAfterGlobalGC(MM_EnvironmentVLHGC *env);
+
 private:
 	/**
 	 * Internal helper for determining the next taxation threshold. This does all


### PR DESCRIPTION
Add a missing capability to resize Eden at STW Global GC points.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>