### PR TITLE
AttachAPI improves selfAttach w/o notification & Reply files

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -214,10 +214,8 @@ public class AttachHandler extends Thread {
 			setVmId(myId); /* may need to tweak the ID */
 			setDisplayName(newDisplayName);
 			CommonDirectory.openSemaphore();
-			CommonDirectory.obtainAttachLock("AttachHandler.createFiles(" + newDisplayName + ")_3"); //$NON-NLS-1$ //$NON-NLS-2$
 			Advertisement.createAdvertisementFile(getVmId(), newDisplayName);
 		} finally {
-			CommonDirectory.releaseAttachLock("AttachHandler.createFiles(" + newDisplayName + ")_4"); //$NON-NLS-1$ //$NON-NLS-2$
 			CommonDirectory.releaseControllerLock("AttachHandler.createFiles(" + newDisplayName + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return true;
@@ -345,7 +343,7 @@ public class AttachHandler extends Thread {
 
 			IPC.logMessage(notificationCount+" connectToAttacher reply on port ", portNumber); //$NON-NLS-1$
 			if (portNumber >= 0) {
-				at = new Attachment(mainHandler, attacherReply);
+				at = new Attachment(mainHandler, attacherReply.getPortNumber(), attacherReply.getKey());
 				addAttachment(at);
 				at.start();
 			}
@@ -353,6 +351,19 @@ public class AttachHandler extends Thread {
 			IPC.logMessage("connectToAttacher ", notificationCount, " waitForNotification no reply file"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return at;
+	}
+
+	/**
+	 * This is called from tryAttachTarget() when a VM attaching to itself.
+	 *
+	 * @param portNumber port on which to attach self
+	 * @param key        Security key to validate transaction
+	 */
+	public void attachSelf(int portNumber, String key) {
+		IPC.logMessage(notificationCount + " attachSelf on port ", portNumber); //$NON-NLS-1$
+		Attachment at = new Attachment(mainHandler, portNumber, key);
+		addAttachment(at);
+		at.start();
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,15 +118,14 @@ final class Attachment extends Thread implements Response {
 	}
 
 	/**
-	 * @param attachHandler
-	 *            main handler object for this VM
-	 * @param rc
-	 *            information to connect to attacher
+	 * @param attachHandler main handler object for this VM
+	 * @param portNumber    port on which to attach
+	 * @param key           Security key to validate transaction
 	 */
-	Attachment(AttachHandler attachHandler, Reply rc) {
-		setName("Attachment " + rc.getPortNumber()); //$NON-NLS-1$
-		portNumber = rc.getPortNumber();
-		this.key = rc.getKey();
+	Attachment(AttachHandler attachHandler, int portNumber, String key) {
+		setName("Attachment portNumber: " + portNumber); //$NON-NLS-1$
+		this.portNumber = portNumber;
+		this.key = key;
 		this.handler = attachHandler;
 		setDaemon(true);
 	}

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -146,7 +146,7 @@ final class WaitLoop extends Thread {
 		try {
 			/*[PR Jazz 33224 Throttle the loop in to prevent the loop from occupying the semaphore ]*/
 			IPC.logMessage("WaitLoop.checkReplyAndCreateAttachment before sleep"); //$NON-NLS-1$
-			Thread.sleep(1000);
+			Thread.sleep(300);
 		} catch (InterruptedException e) { /* the attach handler thread is interrupted on shutdown */
 			IPC.logMessage("WaitLoop.checkReplyAndCreateAttachment Interrupted"); //$NON-NLS-1$
 			return at;

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,9 @@ public class OpenJ9AttachProvider extends AttachProvider {
 			throw new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0543")); //$NON-NLS-1$
 		}
 
-		OpenJ9VirtualMachine vm = new OpenJ9VirtualMachine(this, descriptor.id());
+		String id = descriptor.id();
+		OpenJ9VirtualMachine vm = new OpenJ9VirtualMachine(this, id);
+		IPC.logMessage("Attach target descriptor.id(): " + id); //$NON-NLS-1$
 		vm.attachTarget();
 		return vm;
 	}


### PR DESCRIPTION
Removed the need for `Rely` files and notification when a VM attaching itself;
Avoid continuous `attachTarget` attempts to allow other attachers a chance to run;
`unlockFile` & `timeout` adjustments and log message updates.

Internal RTC 145178

Signed-off-by: Jason Feng <fengj@ca.ibm.com>