### PR TITLE
Disable AOT compilation when SCC is read only

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2019,6 +2019,12 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
 #endif /* defined(J9VM_OPT_JITSERVER) */
          }
+
+      if (javaVM->sharedClassConfig->runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_READONLY)
+         {
+         TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
+         TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
+         }
       }
 #endif /* defined(J9VM_OPT_SHARED_CLASSES) */
 


### PR DESCRIPTION
This commit adds a check for disabling AOT compilation when SCC is
read only.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>