### PR TITLE
Use named type for unsafe.inlineTypesLock

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -187,7 +187,8 @@ public final class Unsafe {
 	private static final long BYTE_OFFSET_MASK = 0b11L;
 
 	/*[IF INLINE-TYPES]*/
-	private static final Object inlineTypesLock = new Object() {};
+	private static final class InlineTypesLock { InlineTypesLock() {} }
+	private static final InlineTypesLock inlineTypesLock = new InlineTypesLock();
 	/*[ENDIF] INLINE-TYPES */
 
 	static {


### PR DESCRIPTION
resolves https://github.com/eclipse-openj9/openj9/issues/14754

Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>