### PR TITLE
Temporarily disable capturing the command line on z/OS

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1965,7 +1965,15 @@ JNI_CreateJavaVM_impl(JavaVM **pvm, void **penv, void *vm_args, BOOLEAN isJITSer
 		return JNI_ERR;
 	}
 #endif /* defined(J9ZTPF) */
+
+#if !defined(J9ZOS390)
+	/*
+	 * Temporarily disable capturing the command line on z/OS.
+	 * See the discussion in https://github.com/eclipse-openj9/openj9/pull/14634.
+	 */
 	captureCommandLine();
+#endif /* !defined(J9ZOS390) */
+
 	/*
 	 * Linux uses LD_LIBRARY_PATH
 	 * z/OS uses LIBPATH

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1141,6 +1141,16 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	const char *envVarName = "OPENJ9_JAVA_COMMAND_LINE";
 	IDATA result = j9sysinfo_get_env(envVarName, commandLineBuffer, _MaximumCommandLineLength);
 
+#if defined(J9ZOS390)
+	/* captureCommandLine() in jvm.c does not yet support z/OS;
+	 * use IBM_JAVA_COMMAND_LINE if OPENJ9_JAVA_COMMAND_LINE is not defined
+	 */
+	if (result < 0) {
+		envVarName = "IBM_JAVA_COMMAND_LINE";
+		result = j9sysinfo_get_env(envVarName, commandLineBuffer, _MaximumCommandLineLength);
+	}
+#endif /* defined(J9ZOS390) */
+
 	if (0 == result) {
 		/* Ensure null-terminated */
 		commandLineBuffer[_MaximumCommandLineLength - 1] = '\0';


### PR DESCRIPTION
Restore workaround using IBM_JAVA_COMMAND_LINE on z/OS for java dumps.

Effectively reverts #14634; see https://github.com/eclipse-openj9/openj9/pull/14634#issuecomment-1076597653.