### PR TITLE
Remove limit on maxStackFrames during getStackFramePCs

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1455,9 +1455,7 @@ getStackFramePCs(J9VMThread *currentThread, J9VMThread *targetThread, ThreadInfo
 	walkState.flags = J9_STACKWALK_CACHE_PCS | J9_STACKWALK_WALK_TRANSLATE_PC
 		| J9_STACKWALK_SKIP_INLINES 
 		| J9_STACKWALK_INCLUDE_NATIVES 
-		| J9_STACKWALK_VISIBLE_ONLY
-		| J9_STACKWALK_COUNT_SPECIFIED;
-		walkState.maxFrames = maxStackDepth;
+		| J9_STACKWALK_VISIBLE_ONLY;
 	walkState.skipCount = 0;
 
 	rc = vm->walkStackFrames(currentThread, &walkState);


### PR DESCRIPTION
Only filter the maxStackFrames during pruneStacktrace as
getStackTrace API may remove hidden frames from the stacktrace
after stackwalk resulting in less frames being returned.

Fixes: #14738 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>