### PR TITLE
Average Copy Forward Rate fix

### DIFF
--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -374,10 +374,12 @@ private:
 	void updatePgcTimePrediction(MM_EnvironmentVLHGC *env);
 
 	/**
-	 * Called after a copy forward rate to update the averageCopyForwardRate
+	 * Calculate copy forward rate in this PGC cycle
+	 * Order of magnitude is 1000 Bytes/microsec (10MB copied for 10ms), but it will depend a lot on machine.
+	 * Also, very short PGCs might have some more extreme values.
 	 * @param env[in] the main GC thread
 	 */
-	double calculateAverageCopyForwardRate(MM_EnvironmentVLHGC *env);
+	double calculateCurrentCopyForwardRate(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Estimate total free memory


### PR DESCRIPTION
Don't calculate average CopyFoward _rate_ (mostly characteristic of h/w
expressed in Bytes/microsec units) if no bytes are copied (for example
due to abort, all have been subject to Mark-Compact). Otherwise we would
incorrectly drag down the averages, potentially to 0, which may later
cause problems.

We still calculate average _amount of bytes_ that are Copy-Forwarded per
PGC, and it's ok to drag down the average if we indeed do all or mostly
Mark-Compact work.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>