### PR TITLE
[0.32] Only CONSTANT_Methodref requires the void return type check

### DIFF
--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1746,6 +1746,10 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 			/* No static constraints defined (so far) on slot1 */
 		case CFR_CONSTANT_Methodref:
 		case CFR_CONSTANT_InterfaceMethodref:
+		{
+#if JAVA_SPEC_VERSION >= 18
+			BOOLEAN isConstantInvokeDynamic = (CFR_CONSTANT_InvokeDynamic == info->tag);
+#endif /* JAVA_SPEC_VERSION >= 18 */
 			nameAndSig = &classfile->constantPool[info->slot2];
 			utf8 = &classfile->constantPool[nameAndSig->slot1];
 			isInit = bcvCheckMethodName(utf8);
@@ -1758,7 +1762,11 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 				errorType = J9NLS_CFR_ERR_BC_METHOD_INVALID_SIG__ID;
 				goto _formatError;
 			}
-			if (isInit) {
+			if (isInit
+#if JAVA_SPEC_VERSION >= 18
+			&& !isConstantInvokeDynamic
+#endif /* JAVA_SPEC_VERSION >= 18 */
+			) {
 				U_16 returnChar = getReturnTypeFromSignature(info->bytes, info->slot1, NULL);
 				if ((info->bytes[info->slot1 - 1] != 'V') && !IS_QTYPE(returnChar)) {
 					errorType = J9NLS_CFR_ERR_BC_METHOD_INVALID_SIG__ID;
@@ -1771,7 +1779,7 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 				goto _formatError;
 			}
 			break;
-
+		}
 		case CFR_CONSTANT_MethodType:
 			if (j9bcv_checkMethodSignature(&classfile->constantPool[info->slot1], FALSE) < 0) {
 				errorType = J9NLS_CFR_ERR_METHODTYPE_INVALID_SIG__ID;


### PR DESCRIPTION
During bytecode verification, only CONSTANT_Methodref requires the void return
type check if the method descriptor is <init>. CONSTANT_InvokeDynamic and
CONSTANT_InterfaceMethodref do not have this requirement. See excerpts from
the JVM spec below:

CONSTANT_Methodref (Section 4.4.2; page 88); name_and_type_index: If the name
of the method in a CONSTANT_Methodref_info structure begins with a
'<' ('\u003c'), then the name must be the special name <init>, representing
an instance initialization method (§2.9.1). The return type of such a method
must be void.

CONSTANT_Methodref and CONSTANT_InterfaceMethodref share the same
section 4.4.2. There is no specific requirement for
CONSTANT_InterfaceMethodref's name_and_type_index. So, I assume that it just
needs to be a method descriptor.

CONSTANT_InvokeDynamic (Section 4.4.10); name_and_type_index: In a
CONSTANT_InvokeDynamic_info structure, the indicated descriptor must be a
method descriptor (§4.3.3).

JVM spec:
https://cr.openjdk.java.net/~iris/se/18/latestSpec/java-se-18-jvms-fr-diffs.pdf

In this PR, the void return type check won't be performed for
CONSTANT_InvokeDynamic in OpenJ9 JDK18 and onwards in order to match the RI.

Internal issue 147145

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>