### PR TITLE
Fix register spill issue in StringLatin1.inflate

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11945,9 +11945,9 @@ J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, TR::CodeGenera
    TR::Register *destOffsetReg = cg->gprClobberEvaluate(node->getChild(3), TR::InstOpCode::MOV4RegReg);
    TR::Register *lengthReg = cg->gprClobberEvaluate(node->getChild(4), TR::InstOpCode::MOV4RegReg);
 
-   TR::Register *xmmHighReg = cg->allocateRegister(TR_FPR);
-   TR::Register *xmmLowReg = cg->allocateRegister(TR_FPR);
-   TR::Register *zeroReg = cg->allocateRegister(TR_FPR);
+   TR::Register *xmmHighReg = cg->allocateRegister(TR_VRF);
+   TR::Register *xmmLowReg = cg->allocateRegister(TR_VRF);
+   TR::Register *zeroReg = cg->allocateRegister(TR_VRF);
    TR::Register *scratchReg = cg->allocateRegister(TR_GPR);
 
    int depCount = 9;


### PR DESCRIPTION
The vector registers need to be allocated as TR_VRF not TR_FPR

Signed-off-by: BradleyWood <bradley.wood@ibm.com>