### PR TITLE
Simplify cast methods and remove redundant cast method calls

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -906,17 +906,15 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 
             if (isStoreFlattenableArrayElement)
                {
-               ArrayElementStoreHelperCallTransform *storeCallToTransform =
+               callToTransform =
                      new (trStackMemory()) ArrayElementStoreHelperCallTransform(_curTree, node, flagsForTransform,
                                                  arrayLength, arrayConstraint->getClass());
-               callToTransform = storeCallToTransform->castToArrayOperationHelperCallTransform();
                }
             else
                {
-               ArrayElementLoadHelperCallTransform *loadCallToTransform =
+               callToTransform =
                      new (trStackMemory()) ArrayElementLoadHelperCallTransform(_curTree, node, flagsForTransform,
                                                  arrayLength, arrayConstraint->getClass());
-               callToTransform = loadCallToTransform->castToArrayOperationHelperCallTransform();
                }
             }
          else // if (canTransformUnflattenedVTArrayElementLoadStore || canTransformIdentityLoadStore)
@@ -989,16 +987,14 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 
             if (isStoreFlattenableArrayElement)
                {
-               ArrayElementStoreHelperCallTransform *storeCallToTransform =
+               callToTransform =
                      new (trStackMemory()) ArrayElementStoreHelperCallTransform(_curTree, node, flagsForTransform, arrayLength, NULL,
                                                  storeClassForCheck, componentClassForCheck);
-               callToTransform = storeCallToTransform->castToArrayOperationHelperCallTransform();
                }
             else
                {
-               ArrayElementLoadHelperCallTransform *loadCallToTransform =
+               callToTransform =
                      new (trStackMemory()) ArrayElementLoadHelperCallTransform(_curTree, node, flagsForTransform, arrayLength);
-               callToTransform = loadCallToTransform->castToArrayOperationHelperCallTransform();
                }
             }
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -237,7 +237,7 @@ class ValuePropagation : public OMR::ValuePropagation
        *        the value types <objectEqualityCompare> or <objectInequalityCompare> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <objectEqualityCompare> or <objectInequalityCompare> helper
+       *        call to the <objectEqualityCompare> or <objectInequalityCompare> helper
        */
       virtual bool isObjectComparisonHelperCallTransform()
          {
@@ -249,7 +249,7 @@ class ValuePropagation : public OMR::ValuePropagation
        *        types <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement>
+       *        call to the <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement>
        *        helper
        */
       virtual bool isArrayOperationHelperCallTransform()
@@ -262,7 +262,7 @@ class ValuePropagation : public OMR::ValuePropagation
        *        call to the value types <jitLoadFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitLoadFlattenableArrayElement>
+       *        call to the <jitLoadFlattenableArrayElement>
        */
       virtual bool isArrayElementLoadHelperCallTransform()
          {
@@ -274,7 +274,7 @@ class ValuePropagation : public OMR::ValuePropagation
        * a call to the value types <jitStoreFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitStoreFlattenableArrayElement>
+       *        call to the <jitStoreFlattenableArrayElement>
        */
       virtual bool isArrayElementStoreHelperCallTransform()
          {
@@ -285,36 +285,40 @@ class ValuePropagation : public OMR::ValuePropagation
        * \brief Casts this object to a pointer to \ref ObjectComparisonHelperCallTransform,
        * if possible; otherwise, reports a fatal assertion failure.
        */
-      virtual ObjectComparisonHelperCallTransform *castToObjectComparisonHelperCallTransform()
+      ObjectComparisonHelperCallTransform *castToObjectComparisonHelperCallTransform()
          {
-         TR_ASSERT_FATAL(false, "ValueTypesHelperCallTransform is not an ObjectComparisonHelperCallTransform\n");
+         TR_ASSERT_FATAL(isObjectComparisonHelperCallTransform(), "ValueTypesHelperCallTransform is not an ObjectComparisonHelperCallTransform\n");
+         return static_cast<ObjectComparisonHelperCallTransform *>(this);
          }
 
       /**
        * \brief Casts this object to a pointer to \ref ArrayOperationHelperCallTransform,
        * if possible; otherwise, reports a fatal assertion failure.
        */
-      virtual ArrayOperationHelperCallTransform *castToArrayOperationHelperCallTransform()
+      ArrayOperationHelperCallTransform *castToArrayOperationHelperCallTransform()
          {
-         TR_ASSERT_FATAL(false, "ValueTypesHelperCallTransform is not an ArrayOperationHelperCallTransform\n");
+         TR_ASSERT_FATAL(isArrayOperationHelperCallTransform(), "ValueTypesHelperCallTransform is not an ArrayOperationHelperCallTransform\n");
+         return static_cast<ArrayOperationHelperCallTransform *>(this);
          }
 
       /**
        * \brief Casts this object to a pointer to \ref ArrayElementLoadHelperCallTransform,
        * if possible; otherwise, reports a fatal assertion failure.
        */
-      virtual ArrayElementLoadHelperCallTransform *castToArrayElementLoadHelperCallTransform()
+      ArrayElementLoadHelperCallTransform *castToArrayElementLoadHelperCallTransform()
          {
-         TR_ASSERT_FATAL(false, "ValueTypesHelperCallTransform is not an ArrayElementLoadHelperCallTransform\n");
+         TR_ASSERT_FATAL(isArrayElementLoadHelperCallTransform(), "ValueTypesHelperCallTransform is not an ArrayElementLoadHelperCallTransform\n");
+         return static_cast<ArrayElementLoadHelperCallTransform *>(this);
          }
 
       /**
        * \brief Casts this object to a pointer to \ref ArrayElementStoreHelperCallTransform,
        * if possible; otherwise, reports a fatal assertion failure.
        */
-      virtual ArrayElementStoreHelperCallTransform *castToArrayElementStoreHelperCallTransform()
+      ArrayElementStoreHelperCallTransform *castToArrayElementStoreHelperCallTransform()
          {
-         TR_ASSERT_FATAL(false, "ValueTypesHelperCallTransform is not an ArrayElementStoreHelperCallTransform\n");
+         TR_ASSERT_FATAL(isArrayElementStoreHelperCallTransform(), "ValueTypesHelperCallTransform is not an ArrayElementStoreHelperCallTransform\n");
+         return static_cast<ArrayElementStoreHelperCallTransform *>(this);
          }
       };
 
@@ -332,20 +336,11 @@ class ValuePropagation : public OMR::ValuePropagation
        *        the value types <objectEqualityCompare> or <objectInequalityCompare> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <objectEqualityCompare> or <objectInequalityCompare> helper
+       *        call to the <objectEqualityCompare> or <objectInequalityCompare> helper
        */
       virtual bool isObjectComparisonHelperCallTransform()
          {
          return true;
-         }
-
-      /**
-       * \brief Casts this object to a pointer to \ref ObjectComparisonHelperCallTransform,
-       * if possible; otherwise, reports a fatal assertion failure.
-       */
-      virtual ObjectComparisonHelperCallTransform *castToObjectComparisonHelperCallTransform()
-         {
-         return static_cast<ObjectComparisonHelperCallTransform *>(this);
          }
       };
 
@@ -369,21 +364,12 @@ class ValuePropagation : public OMR::ValuePropagation
        *        types <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement>
+       *        call to the <jitLoadFlattenableArrayElement> or <jitStoreFlattenableArrayElement>
        *        helper
        */
       virtual bool isArrayOperationHelperCallTransform()
          {
          return true;
-         }
-
-      /**
-       * \brief Casts this object to a pointer to \ref ArrayOperationHelperCallTransform,
-       * if possible; otherwise, reports a fatal assertion failure.
-       */
-      virtual ArrayOperationHelperCallTransform *castToArrayOperationHelperCallTransform()
-         {
-         return static_cast<ArrayOperationHelperCallTransform *>(this);
          }
       };
 
@@ -402,20 +388,11 @@ class ValuePropagation : public OMR::ValuePropagation
        *        call to the value types <jitLoadFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitLoadFlattenableArrayElement>
+       *        call to the <jitLoadFlattenableArrayElement>
        */
       virtual bool isArrayElementLoadHelperCallTransform()
          {
          return true;
-         }
-
-      /**
-       * \brief Casts this object to a pointer to \ref ArrayElementLoadHelperCallTransform,
-       * if possible; otherwise, reports a fatal assertion failure.
-       */
-      virtual ArrayElementLoadHelperCallTransform *castToArrayElementLoadHelperCallTransform()
-         {
-         return static_cast<ArrayElementLoadHelperCallTransform *>(this);
          }
       };
 
@@ -440,20 +417,11 @@ class ValuePropagation : public OMR::ValuePropagation
        * a call to the value types <jitStoreFlattenableArrayElement> helper
        *
        * \return \c true if and only if this represents a delayed transformation for a
-       *        a call to the <jitStoreFlattenableArrayElement>
+       *        call to the <jitStoreFlattenableArrayElement>
        */
       virtual bool isArrayElementStoreHelperCallTransform()
          {
          return true;
-         }
-
-      /**
-       * \brief Casts this object to a pointer to \ref ArrayElementStoreHelperCallTransform,
-       * if possible; otherwise, reports a fatal assertion failure.
-       */
-      virtual ArrayElementStoreHelperCallTransform *castToArrayElementStoreHelperCallTransform()
-         {
-         return static_cast<ArrayElementStoreHelperCallTransform *>(this);
          }
       };
 


### PR DESCRIPTION
This change delivers a commit that addresses [some review comments from pull request #14411](https://github.com/eclipse-openj9/openj9/pull/14411#pullrequestreview-887973271), but that I had inadvertently failed to included in the commits for that pull request.  The changes were:

- Moved implementations of `castTo*HelperCallTransform` methods into the base class `ValueTypesHelperCallTransform` to allow for the possibility of having them inlined.
- Also removed some redundant calls to `castToArrayOperationHelperCallTransform` that were being used to cast pointers to instances of subclasses of `ArrayOperationHelperCallTransform` to pointers to their parent class.
- Finally, corrected some typographical errors in Doxygen comments.