### PR TITLE
Consume new capture command line Java options

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2979,6 +2979,10 @@ consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args)
 	findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XLP_CODECACHE, NULL, TRUE);
 	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XTLHPREFETCH, NULL, TRUE);
 
+	/* consume options for capturing command line in environment variable, handled earlier in initialArgumentScan */
+	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXOPENJ9COMMANDLINEENV, NULL, TRUE);
+	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXNOOPENJ9COMMANDLINEENV, NULL, TRUE);
+
 	/* Consume these without asking questions for now. Ultimately, if/when we use these, we will need logic
 		so that the VM knows that -ea = -enableassertions. */
 	assertOptionFound = findArgInVMArgs( PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_EA, NULL, TRUE) >= 0;


### PR DESCRIPTION
Consume VMOPT_XXOPENJ9COMMANDLINEENV and VMOPT_XXNOOPENJ9COMMANDLINEENV
options so that they will be recognized by the VM when not ignoring
unrecognized -XX options.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

@pshipton can you take a look