### PR TITLE
Add verification for value objects

### DIFF
--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -887,10 +887,19 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			info = &(classfile->constantPool[classfile->constantPool[index].slot1]);
 			U_16 returnChar = getReturnTypeFromSignature(classfile->constantPool[classfile->constantPool[index].slot2].bytes, classfile->constantPool[classfile->constantPool[index].slot2].slot1, NULL);
 			if (info->bytes[0] == '<') {
-				if ((IS_QTYPE(returnChar) && (bc != CFR_BC_invokestatic))
-					|| (!IS_QTYPE(returnChar) && (bc != CFR_BC_invokespecial))
-					|| (info->tag != CFR_CONSTANT_Utf8)
+				if ((info->tag != CFR_CONSTANT_Utf8)
 					|| !J9UTF8_DATA_EQUALS("<init>", 6, info->bytes, info->slot1)
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+					|| (J9UTF8_DATA_EQUALS("<new>", 5, info->bytes, info->slot1) && (bc != CFR_BC_invokestatic))
+					|| (!J9UTF8_DATA_EQUALS("<new>", 5, info->bytes, info->slot1) && (bc != CFR_BC_invokespecial))
+#else /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+					|| ((IS_QTYPE(returnChar) || IS_LTYPE(returnChar)) && (bc != CFR_BC_invokestatic))
+					|| (!(IS_QTYPE(returnChar) || IS_LTYPE(returnChar)) && (bc != CFR_BC_invokespecial))
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#else /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+					|| (bc != CFR_BC_invokespecial)
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				) {
 					errorType = J9NLS_CFR_ERR_BC_METHOD_INVALID__ID;
 					goto _verifyError;
@@ -1544,7 +1553,13 @@ checkMethodStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile, UDATA
 
 	/* Throw a class format error if we are given a static <init> method (otherwise later we will throw a verify error due to back stack shape) */
 	info = &(classfile->constantPool[method->nameIndex]);
-	if (method->accessFlags & CFR_ACC_STATIC) {
+	if ((method->accessFlags & CFR_ACC_STATIC)
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if !defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+		&& (!J9_IS_CLASSFILE_VALUETYPE(classfile))
+#endif /* !defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+	) {
 		if (CFR_CONSTANT_Utf8 == info->tag) {
 			if (J9UTF8_DATA_EQUALS("<init>", 6, info->bytes, info->slot1)) {
 				/* The error code here is for modifiers, return type check is done in j9bcv_verifyClassStructure(). */
@@ -1766,8 +1781,16 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 #endif /* JAVA_SPEC_VERSION >= 18 */
 			) {
 				BOOLEAN invalidRetType = FALSE;
-				if ((CFR_METHOD_NAME_INIT == isInit) /* Check return type of <init> on VTs for now. It is drafted to be changed to <new>. */
-					&& J9_IS_CLASSFILE_VALUETYPE(classfile)
+				if (
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+				(CFR_METHOD_NAME_NEW == isInit)
+#else /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+				(CFR_METHOD_NAME_INIT == isInit) && J9_IS_CLASSFILE_VALUETYPE(classfile)
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#else /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+				FALSE
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				) {
 					U_16 returnChar = getReturnTypeFromSignature(info->bytes, info->slot1, NULL);
 					if (J9_IS_CLASSFILE_PRIMITIVE_VALUETYPE(classfile)) {
@@ -1809,17 +1832,34 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 				J9CfrConstantPoolInfo *methodref = &classfile->constantPool[info->slot2];
 				nameAndSig = &classfile->constantPool[methodref->slot2];
 				utf8 = &classfile->constantPool[nameAndSig->slot1];
-				isInit = bcvIsInitOrClinit(utf8);
+				isInit = bcvIsInitOrClinitOrNew(utf8);
 				if (CFR_METHOD_NAME_CLINIT == isInit) {
 					errorType = J9NLS_CFR_ERR_BAD_METHOD_NAME__ID;
 					goto _formatError;
 				}
 				if (CFR_METHOD_NAME_INIT == isInit) {
-					if (info->slot1 != MH_REF_NEWINVOKESPECIAL) {
+					if (
+						(info->slot1 != MH_REF_NEWINVOKESPECIAL)
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if !defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+						&& (info->slot1 != MH_REF_INVOKESTATIC)
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#endif /* #if !defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+					) {
 						errorType = J9NLS_CFR_ERR_BAD_METHOD_NAME__ID;
 						goto _formatError;
 					}
 				}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+				if (CFR_METHOD_NAME_NEW == isInit) {
+					if (info->slot1 != MH_REF_INVOKESTATIC) {
+						errorType = J9NLS_CFR_ERR_BAD_METHOD_NAME__ID;
+						goto _formatError;
+					}
+				}
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			}
 			break;
 
@@ -1893,8 +1933,17 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 		}
 		if (isInit) {
 			BOOLEAN invalidRetType = FALSE;
-			if ((CFR_METHOD_NAME_INIT == isInit) /* Check return type of <init> on VTs, it will eventually be changed to <new>. */
-				&& J9_IS_CLASSFILE_VALUETYPE(classfile)
+			if (
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+				(CFR_METHOD_NAME_NEW == isInit)
+#else /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+				/* Check if classfile is a valuetype to differentiate between a regular <init> and an <init> that behaves like a <new> */
+				(CFR_METHOD_NAME_INIT == isInit) && J9_IS_CLASSFILE_VALUETYPE(classfile)
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#else /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+				FALSE
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			) {
 				U_16 returnChar = getReturnTypeFromSignature(info->bytes, info->slot1, NULL);
 				if (J9_IS_CLASSFILE_PRIMITIVE_VALUETYPE(classfile)) {

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1625,9 +1625,46 @@ J9NLS_CFR_ERR_PERMITS_VALUE_ON_NON_ABSTRACT_CLASS.system_action=The JVM will thr
 J9NLS_CFR_ERR_PERMITS_VALUE_ON_NON_ABSTRACT_CLASS.user_response=Contact the provider of the class file for a corrected version.
 # END NON-TRANSLATABLE
 
-J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE__ID=Access flag ACC_PERMITS_VALUE should not be set on an interface.
+J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE=Access flag ACC_PERMITS_VALUE should not be set on an interface.
 # START NON-TRANSLATABLE
-J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE__ID.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
-J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE__ID.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
-J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE__ID.user_response=Contact the provider of the class file for a corrected version.
+J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_PERMITS_VALUE_ON_INTERFACE.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_VALUE_CLASS_FIELD_NOT_STATIC_OR_FINAL=Fields of value classes must have either ACC_STATIC or ACC_FINAL flags set.
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_VALUE_CLASS_FIELD_NOT_STATIC_OR_FINAL.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_VALUE_CLASS_FIELD_NOT_STATIC_OR_FINAL.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_VALUE_CLASS_FIELD_NOT_STATIC_OR_FINAL.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_MISSING_ACC_STATIC_ON_ABSTRACT_CLASS_FIELD=In an abstract class with ACC_PERMITS_VALUE flag, each field must be declared static.
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_MISSING_ACC_STATIC_ON_ABSTRACT_CLASS_FIELD.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_MISSING_ACC_STATIC_ON_ABSTRACT_CLASS_FIELD.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_MISSING_ACC_STATIC_ON_ABSTRACT_CLASS_FIELD.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_NON_STATIC_SYNCHRONIZED_VALUE_TYPE_METHOD=In value classes and in abstract classes with ACC_PERMITS_VALUE flag, a synchronized method must be static
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_NON_STATIC_SYNCHRONIZED_VALUE_TYPE_METHOD.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_NON_STATIC_SYNCHRONIZED_VALUE_TYPE_METHOD.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_NON_STATIC_SYNCHRONIZED_VALUE_TYPE_METHOD.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE
+
+# <new> is not translatable
+J9NLS_CFR_ERR_INVALID_FLAGS_ON_NEW=Methods named <new> must be static, and may not be final, synchronized, native, or abstract
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_INVALID_FLAGS_ON_NEW.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_INVALID_FLAGS_ON_NEW.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_INVALID_FLAGS_ON_NEW.user_response=Contact the provider of the class file for a corrected version.
+# END NON-TRANSLATABLE
+
+# <init> is not translatable
+J9NLS_CFR_ERR_INIT_ON_VALUE_CLASS=Methods of value classes cannot be named <init>
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_INIT_ON_VALUE_CLASS.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_INIT_ON_VALUE_CLASS.system_action=The JVM will throw a verification or class loading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_INIT_ON_VALUE_CLASS.user_response=Contact the provider of the class file for a corrected version.
 # END NON-TRANSLATABLE

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,7 +149,7 @@ bcvCheckMethodName (J9CfrConstantPoolInfo * info);
 * @return IDATA
 */
 I_32
-bcvIsInitOrClinit (J9CfrConstantPoolInfo * info);
+bcvIsInitOrClinitOrNew (J9CfrConstantPoolInfo * info);
 
 /* ---------------- clconstraints.c ---------------- */
 

--- a/runtime/oti/cfreader.h
+++ b/runtime/oti/cfreader.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,11 @@
 
 #define	CFR_METHOD_NAME_INIT	1
 #define	CFR_METHOD_NAME_CLINIT	2
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+#define	CFR_METHOD_NAME_NEW		3
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
+#endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #define	CFR_METHOD_NAME_INVALID	-1
 
 /* Macros. */

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -118,11 +118,16 @@
 #define J9ROMMETHOD_IS_STATIC(romMethod)	_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccStatic)
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD)
+#define J9ROMMETHOD_IS_UNNAMED_FACTORY(romMethod) \
+	(J9ROMMETHOD_IS_STATIC((romMethod)) \
+	&& (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<new>")))
+#else /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
 /* Currently value type's constructor is static <init>, it will be changed to static <new>. The check for <init> can be removed once OpenJDK is updated on this. */
 #define J9ROMMETHOD_IS_UNNAMED_FACTORY(romMethod) \
 	(J9ROMMETHOD_IS_STATIC((romMethod)) \
-	&& (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<new>")  \
-			|| J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<init>")))
+	&& (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<init>")))
+#endif /* #if defined(J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD) */
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #define J9ROMFIELD_IS_CONTENDED(romField)	J9_ARE_ALL_BITS_SET((romField)->modifiers, J9FieldFlagIsContended)

--- a/runtime/verbose/errormessagehelper.c
+++ b/runtime/verbose/errormessagehelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -356,10 +356,10 @@ prepareVerificationTypeBuffer(StackMapFrame* stackMapFrame, MethodContextInfo* m
 		cpInfo.bytes = (U_8*)methodInfo->signature.bytes;
 		cpInfo.slot1 = (U_32)methodInfo->signature.length;
 
-		/* Calls isInitOrClinitImpl() to determine whether the method is either "<init>" or "<clinit>".
-		 * It returns 1) 0 if name is a normal name 2) 1 if '<init>' or 3) 2 if '<clinit>'
+		/* Calls isInitOrClinitOrNewImpl() to determine whether the method is "<init>", "<clinit>", or "<new>".
+		 * It returns 0 if name is a normal name, CFR_METHOD_NAME_INIT if '<init>', CFR_METHOD_NAME_CLINIT if '<clinit>', and CFR_METHOD_NAME_NEW if '<new>'
 		 */
-		if (CFR_METHOD_NAME_INIT == bcvIsInitOrClinit(&cpInfo)) {
+		if (CFR_METHOD_NAME_INIT == bcvIsInitOrClinitOrNew(&cpInfo)) {
 			vrfyType = CFR_STACKMAP_TYPE_INIT_OBJECT;  /* "this" of an <init> method (cfreader.h) */
 		} else {
 			vrfyType = CFR_STACKMAP_TYPE_OBJECT;


### PR DESCRIPTION
Add verification for value objects

For issue #14741
    
- Check access flags on value type classes
    
- Ensure that correct VT related access flags are set on other
      methods/classes/fields
    
- Add verification of access flags and signature of the <new> method
    
- Add J9VM_OPT_VALHALLA_NEW_FACTORY_METHOD flag to specify whether the
      <new> method is being used or if <init> is being used instead
    
- Update isInitOrClinitImpl to check if a method name is "\<new\>"
    
- Add new error messages in cfrerr.nls


Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>