### PR TITLE
Share implementation of AOT processRelocations() across platforms

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -35,63 +35,7 @@ J9::ARM64::AheadOfTimeCompile::AheadOfTimeCompile(TR::CodeGenerator *cg) :
 
 void J9::ARM64::AheadOfTimeCompile::processRelocations()
    {
-   TR::Compilation *comp = self()->comp();
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
-   TR::IteratedExternalRelocation *r;
-
-   for (auto aotIterator = _cg->getExternalRelocationList().begin(); aotIterator != _cg->getExternalRelocationList().end(); ++aotIterator)
-      {
-      (*aotIterator)->addExternalRelocation(_cg);
-      }
-
-   for (r = getAOTRelocationTargets().getFirst(); r != NULL; r = r->getNext())
-      {
-      addToSizeOfAOTRelocations(r->getSizeOfRelocationData());
-      }
-
-   // now allocate the memory  size of all iterated relocations + the header (total length field)
-
-   // Note that when using the SymbolValidationManager, the well-known classes
-   // must be checked even if no explicit records were generated, since they
-   // might be responsible for the lack of records.
-   bool useSVM = comp->getOption(TR_UseSymbolValidationManager);
-
-   if (self()->getSizeOfAOTRelocations() != 0 || useSVM)
-      {
-      // It would be more straightforward to put the well-known classes offset
-      // in the AOT method header, but that would use space for AOT bodies that
-      // don't use the SVM.
-      int wellKnownClassesOffsetSize = useSVM ? SIZEPOINTER : 0;
-      uintptr_t reloBufferSize =
-         self()->getSizeOfAOTRelocations() + SIZEPOINTER + wellKnownClassesOffsetSize;
-      uint8_t *relocationDataCursor =
-         self()->setRelocationData(fej9->allocateRelocationData(comp, reloBufferSize));
-
-      // set up the size for the region
-      *(uintptr_t *)relocationDataCursor = reloBufferSize;
-      relocationDataCursor += SIZEPOINTER;
-
-      if (useSVM)
-         {
-         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
-         void *offsets = const_cast<void *>(svm->wellKnownClassChainOffsets());
-         uintptr_t *wkcOffsetAddr = (uintptr_t *)relocationDataCursor;
-         *wkcOffsetAddr = self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
-#if defined(J9VM_OPT_JITSERVER)
-         self()->addWellKnownClassesSerializationRecord(svm->aotCacheWellKnownClassesRecord(), wkcOffsetAddr);
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         relocationDataCursor += SIZEPOINTER;
-         }
-
-      // set up pointers for each iterated relocation and initialize header
-      TR::IteratedExternalRelocation *s;
-      for (s = getAOTRelocationTargets().getFirst(); s != NULL; s = s->getNext())
-         {
-         s->setRelocationData(relocationDataCursor);
-         s->initializeRelocation(_cg);
-         relocationDataCursor += s->getSizeOfRelocationData();
-         }
-      }
+   J9::AheadOfTimeCompile::processRelocations();
    }
 
 bool

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -2333,3 +2333,68 @@ void J9::AheadOfTimeCompile::interceptAOTRelocation(TR::ExternalRelocation *relo
          }
       }
    }
+
+void J9::AheadOfTimeCompile::processRelocations()
+   {
+   TR::Compilation *comp = self()->comp();
+   TR::CodeGenerator *cg = comp->cg();
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
+
+   for (auto aotIterator = cg->getExternalRelocationList().begin(); aotIterator != cg->getExternalRelocationList().end(); ++aotIterator)
+      {
+      (*aotIterator)->addExternalRelocation(cg);
+      }
+
+   for (TR::IteratedExternalRelocation *r = self()->getAOTRelocationTargets().getFirst();
+        r != NULL;
+        r = r->getNext())
+      {
+      self()->addToSizeOfAOTRelocations(r->getSizeOfRelocationData());
+      }
+
+   // Allocate the memory size of all iterated relocations + the header (total length field)
+   //
+   // Note that when using the SymbolValidationManager, the well-known classes
+   // must be checked even if no explicit records were generated, since they
+   // might be responsible for the lack of records.
+   //
+   bool useSVM = comp->getOption(TR_UseSymbolValidationManager);
+   if (self()->getSizeOfAOTRelocations() != 0 || useSVM)
+      {
+      // It would be more straightforward to put the well-known classes offset
+      // in the AOT method header, but that would use space for AOT bodies that
+      // don't use the SVM. TODO: Move it once SVM takes over?
+      //
+      int32_t wellKnownClassesOffsetSize = useSVM ? SIZEPOINTER : 0;
+      uintptr_t reloBufferSize =
+         self()->getSizeOfAOTRelocations() + SIZEPOINTER + wellKnownClassesOffsetSize;
+      uint8_t *relocationDataCursor = self()->setRelocationData(
+         fej9->allocateRelocationData(comp, reloBufferSize));
+
+      // set up the size for the region
+      *(uintptr_t *)relocationDataCursor = reloBufferSize;
+      relocationDataCursor += SIZEPOINTER;
+
+      if (useSVM)
+         {
+         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+         void *offsets = const_cast<void *>(svm->wellKnownClassChainOffsets());
+         uintptr_t *wkcOffsetAddr = (uintptr_t *)relocationDataCursor;
+         *wkcOffsetAddr = self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
+#if defined(J9VM_OPT_JITSERVER)
+         self()->addWellKnownClassesSerializationRecord(svm->aotCacheWellKnownClassesRecord(), wkcOffsetAddr);
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         relocationDataCursor += SIZEPOINTER;
+         }
+
+      // set up pointers for each iterated relocation and initialize header
+      for (TR::IteratedExternalRelocation *s = self()->getAOTRelocationTargets().getFirst();
+           s != NULL;
+           s = s->getNext())
+         {
+         s->setRelocationData(relocationDataCursor);
+         s->initializeRelocation(cg);
+         relocationDataCursor += s->getSizeOfRelocationData();
+         }
+      }
+   }

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -250,8 +250,13 @@ protected:
     * @param kind the TR_ExternalRelocationTargetKind enum value
     */
    void initializeCommonAOTRelocationHeader(TR::IteratedExternalRelocation *relocation, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t kind);
+
+   /**
+    * @brief Common relocation processing for AOT
+    */
+   void processRelocations();
    };
 
 }
 
-#endif // TR_J9AHEADOFTIMECOMPILE_HPP
+#endif // J9_AHEADOFTIMECOMPILE_HPP

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,14 +43,9 @@
 #include "runtime/RelocationRecord.hpp"
 #include "runtime/SymbolValidationManager.hpp"
 
-#define NON_HELPER   0x00
-
 void J9::X86::AheadOfTimeCompile::processRelocations()
    {
    TR::Compilation *comp = _cg->comp();
-
-   // calculate the amount of memory needed to hold the relocation data
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
 
    if (comp->target().is64Bit()
        && TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines()
@@ -64,61 +59,7 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
                             NULL);
       }
 
-
-   for (auto aotIterator = _cg->getExternalRelocationList().begin(); aotIterator != _cg->getExternalRelocationList().end(); ++aotIterator)
-	  (*aotIterator)->addExternalRelocation(_cg);
-
-   TR::IteratedExternalRelocation *r;
-   for (r = self()->getAOTRelocationTargets().getFirst();
-        r != NULL;
-        r = r->getNext())
-      {
-      self()->addToSizeOfAOTRelocations(r->getSizeOfRelocationData());
-      }
-
-   // now allocate the memory  size of all iterated relocations + the header (total length field)
-
-   // Note that when using the SymbolValidationManager, the well-known classes
-   // must be checked even if no explicit records were generated, since they
-   // might be responsible for the lack of records.
-   bool useSVM = comp->getOption(TR_UseSymbolValidationManager);
-   if (self()->getSizeOfAOTRelocations() != 0 || useSVM)
-      {
-      // It would be more straightforward to put the well-known classes offset
-      // in the AOT method header, but that would use space for AOT bodies that
-      // don't use the SVM. TODO: Move it once SVM takes over?
-      int wellKnownClassesOffsetSize = useSVM ? SIZEPOINTER : 0;
-      uintptr_t reloBufferSize =
-         self()->getSizeOfAOTRelocations() + SIZEPOINTER + wellKnownClassesOffsetSize;
-      uint8_t *relocationDataCursor = self()->setRelocationData(
-         fej9->allocateRelocationData(comp, reloBufferSize));
-      // set up the size for the region
-      *(uintptr_t *)relocationDataCursor = reloBufferSize;
-      relocationDataCursor += SIZEPOINTER;
-
-      if (useSVM)
-         {
-         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
-         void *offsets = const_cast<void *>(svm->wellKnownClassChainOffsets());
-         uintptr_t *wkcOffsetAddr = (uintptr_t *)relocationDataCursor;
-         *wkcOffsetAddr = self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
-#if defined(J9VM_OPT_JITSERVER)
-         self()->addWellKnownClassesSerializationRecord(svm->aotCacheWellKnownClassesRecord(), wkcOffsetAddr);
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         relocationDataCursor += SIZEPOINTER;
-         }
-
-      // set up pointers for each iterated relocation and initialize header
-      TR::IteratedExternalRelocation *s;
-      for (s = self()->getAOTRelocationTargets().getFirst();
-           s != 0;
-           s = s->getNext())
-         {
-         s->setRelocationData(relocationDataCursor);
-         s->initializeRelocation(_cg);
-         relocationDataCursor += s->getSizeOfRelocationData();
-         }
-      }
+   J9::AheadOfTimeCompile::processRelocations();
    }
 
 bool

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,70 +59,14 @@ J9::Z::AheadOfTimeCompile::AheadOfTimeCompile(TR::CodeGenerator *cg)
 
 void J9::Z::AheadOfTimeCompile::processRelocations()
    {
-   TR::Compilation *comp = self()->comp();
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
-   TR::IteratedExternalRelocation  *r;
-
    for (auto iterator = self()->getRelocationList().begin();
         iterator != self()->getRelocationList().end();
         ++iterator)
       {
-	   (*iterator)->mapRelocation(_cg);
+      (*iterator)->mapRelocation(_cg);
       }
 
-   for (auto aotIterator = _cg->getExternalRelocationList().begin(); aotIterator != _cg->getExternalRelocationList().end(); ++aotIterator)
-	  (*aotIterator)->addExternalRelocation(_cg);
-
-   for (r = self()->getAOTRelocationTargets().getFirst();
-        r != NULL;
-        r = r->getNext())
-      {
-      self()->addToSizeOfAOTRelocations(r->getSizeOfRelocationData());
-      }
-
-   // now allocate the memory  size of all iterated relocations + the header (total length field)
-
-   // Note that when using the SymbolValidationManager, the well-known classes
-   // must be checked even if no explicit records were generated, since they
-   // might be responsible for the lack of records.
-   bool useSVM = comp->getOption(TR_UseSymbolValidationManager);
-   if (self()->getSizeOfAOTRelocations() != 0 || useSVM)
-      {
-      // It would be more straightforward to put the well-known classes offset
-      // in the AOT method header, but that would use space for AOT bodies that
-      // don't use the SVM. TODO: Move it once SVM takes over?
-      int wellKnownClassesOffsetSize = useSVM ? SIZEPOINTER : 0;
-      uintptr_t reloBufferSize =
-         self()->getSizeOfAOTRelocations() + SIZEPOINTER + wellKnownClassesOffsetSize;
-      uint8_t *relocationDataCursor = self()->setRelocationData(
-         fej9->allocateRelocationData(comp, reloBufferSize));
-      // set up the size for the region
-      *(uintptr_t *)relocationDataCursor = reloBufferSize;
-      relocationDataCursor += SIZEPOINTER;
-
-      if (useSVM)
-         {
-         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
-         void *offsets = const_cast<void *>(svm->wellKnownClassChainOffsets());
-         uintptr_t *wkcOffsetAddr = (uintptr_t *)relocationDataCursor;
-         *wkcOffsetAddr = self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
-#if defined(J9VM_OPT_JITSERVER)
-         self()->addWellKnownClassesSerializationRecord(svm->aotCacheWellKnownClassesRecord(), wkcOffsetAddr);
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         relocationDataCursor += SIZEPOINTER;
-         }
-
-      // set up pointers for each iterated relocation and initialize header
-      TR::IteratedExternalRelocation *s;
-      for (s = self()->getAOTRelocationTargets().getFirst();
-           s != NULL;
-           s = s->getNext())
-         {
-         s->setRelocationData(relocationDataCursor);
-         s->initializeRelocation(_cg);
-         relocationDataCursor += s->getSizeOfRelocationData();
-         }
-      }
+   J9::AheadOfTimeCompile::processRelocations();
    }
 
 bool


### PR DESCRIPTION
The majority of each platform's implementation of
`AheadOfTimeCompile::processRelocations()` is identical and should
be shared.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>

Fixes #6265