### PR TITLE
Add CRIU security hooks

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -195,6 +195,11 @@ public final class CRIUSupport {
 	 */
 	private static final int RESTORE_ENVIRONMENT_VARIABLES_PRIORITY = 100;
 	private static final int USER_HOOKS_PRIORITY = 1;
+	/* RESET_DIGESTS_PRIORITY and RESTORE_SECURITY_PROVIDERS_PRIORITY need to
+	 * be higher than any other JVM hook that may require security providers.
+	 */
+	static final int RESET_DIGESTS_PRIORITY = 100;
+	static final int RESTORE_SECURITY_PROVIDERS_PRIORITY = 100;
 
 	private String imageDir;
 	private boolean leaveRunning;
@@ -580,8 +585,12 @@ public final class CRIUSupport {
 	 *                                       restore
 	 */
 	public synchronized void checkpointJVM() {
-		/* Add env variables restore hook */
+		/* Add env variables restore hook. */
 		registerRestoreEnvVariables();
+
+		/* Add security provider hooks. */
+		SecurityProviders.registerResetDigests();
+		SecurityProviders.registerRestoreSecurityProviders();
 
 		if (InternalCRIUSupport.isCheckpointAllowed()) {
 			init();

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/SecurityProviders.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/SecurityProviders.java
@@ -1,0 +1,67 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.eclipse.openj9.criu;
+
+import openj9.internal.criu.InternalCRIUSupport;
+import openj9.internal.criu.security.CRIUConfigurator;
+
+/**
+ * Handles the security providers.
+ * The CRIUSECProvider is a security provider that is used as follows when CRIU
+ * is enabled. During the checkpoint phase, all security providers are removed
+ * from the system properties (which are read from security.java) and CRIUSEC is
+ * added to the system properties. The pre-checkpoint hook clears the digests,
+ * to ensure that no state is saved during checkpoint that would be restored
+ * during the restore phase. During the resore phase, CRIUSEC is removed from
+ * the provider list and the other security providers are added back to the
+ * system properties. A new provider list is created from the system properties.
+ */
+public final class SecurityProviders {
+
+	private SecurityProviders() {}
+
+	/**
+	 * Resets the security digests during checkpoint.
+	 */
+	public static void registerResetDigests() {
+		J9InternalCheckpointHookAPI.registerPreCheckpointHook(
+				CRIUSupport.RESET_DIGESTS_PRIORITY,
+				"Reset the digests", //$NON-NLS-1$
+				() -> openj9.internal.criu.CRIUSECProvider.resetDigests()
+		);
+	}
+
+	/**
+	 * Adds the security providers during restore.
+	 */
+	public static void registerRestoreSecurityProviders() {
+		J9InternalCheckpointHookAPI.registerPostRestoreHook(
+				CRIUSupport.RESTORE_SECURITY_PROVIDERS_PRIORITY,
+				"Restore the security providers", //$NON-NLS-1$
+				() -> {
+					if (InternalCRIUSupport.isCheckpointAllowed()) {
+						CRIUConfigurator.setCRIURestoreMode();
+					}
+				});
+	}
+}

--- a/test/functional/cmdLineTests/criu/criuRandomScript.sh
+++ b/test/functional/cmdLineTests/criu/criuRandomScript.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2022, 2022 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+echo "start running script"
+# the expected arguments are:
+# $1 is the TEST_ROOT
+# $2 is the JAVA_COMMAND
+# $3 is the JVM_OPTIONS
+# $4 is the test type
+if [ "$4" = "Checkpoint" ]
+then
+    # append to the file to capture the output before checkpoint and after both restores
+    $2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar CRIURandomTest >>testOutput 2>&1
+fi
+if [ "$4" = "FirstRestore" ] || [ "$4" = "SecondRestore" ]
+then
+    sleep 2
+    criu restore -D cpData --shell-job
+fi
+cat testOutput
+if [ "$4" = "SecondRestore" ]
+then
+    rm -rf testOutput
+fi
+echo "finished script"

--- a/test/functional/cmdLineTests/criu/criuSecurityScript.sh
+++ b/test/functional/cmdLineTests/criu/criuSecurityScript.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2022, 2022 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+echo "start running script"
+# the expected arguments are:
+# $1 is the TEST_ROOT
+# $2 is the JAVA_COMMAND
+# $3 is the JVM_OPTIONS
+$2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar CRIUSecurityTest >testOutput 2>&1
+criu restore -D cpData --shell-job
+cat testOutput
+rm -rf testOutput
+echo "finished script"

--- a/test/functional/cmdLineTests/criu/criu_random.xml
+++ b/test/functional/cmdLineTests/criu/criu_random.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Option Tests" timeout="300">
+
+  <test id="Create Criu Checkpoint Image">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ "Checkpoint"</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+  </test>
+
+  <test id="First Restore of Criu Checkpoint Image">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ "FirstRestore"</command>
+    <output type="success" caseSensitive="yes" regex="no">First Restore</output>
+    <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+    <output type="failure" caseSensitive="yes" regex="no">Can't open dir cpData: No such file or directory</output>
+  </test>
+
+  <test id="Second Restore of Criu Checkpoint Image">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ "SecondRestore"</command>
+    <output type="success" caseSensitive="yes" regex="no">Different random values</output>
+    <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">Second Restore</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+    <output type="failure" caseSensitive="yes" regex="no">Can't open dir cpData: No such file or directory</output>
+  </test>
+
+</suite>

--- a/test/functional/cmdLineTests/criu/criu_security.xml
+++ b/test/functional/cmdLineTests/criu/criu_security.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Option Tests" timeout="300">
+
+  <test id="Create and Restore Criu Checkpoint Image">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+  </test>
+
+</suite>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -77,4 +77,56 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTester_criu_security</testCaseName>
+		<variations>
+			<variation>-Denable.j9internal.checkpoint.security.api.debug=true</variation>
+		</variations>
+		<command>
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuSecurityScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_security.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_criu_random</testCaseName>
+		<variations>
+			<variation>-Denable.j9internal.checkpoint.security.api.debug=true</variation>
+		</variations>
+		<command>
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuRandomScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_random.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/criu/src/CRIURandomTest.java
+++ b/test/functional/cmdLineTests/criu/src/CRIURandomTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Random;
+
+public class CRIURandomTest {
+
+	public static void main(String args[]) {
+		Random r1 = new Random();
+		System.out.println("Pre-checkpoint");
+
+		r1.nextInt();
+		r1.nextInt();
+
+		CRIUTestUtils.checkPointJVM(Paths.get("cpData"), false);
+		System.out.println("Post-checkpoint");
+
+		String testResultsFile = "testResults";
+		Path testResultsFilePath = Paths.get(testResultsFile);
+		try {
+			if (Files.exists(testResultsFilePath)) {
+				System.out.println("Second Restore");
+				BufferedReader reader = new BufferedReader(new FileReader(testResultsFile));
+				String line = null;
+				boolean sameValues = true;
+				while ((line = reader.readLine()) != null) {
+					int val = Integer.parseInt(line);
+					if (val != r1.nextInt()) {
+						sameValues = false;
+					}
+				}
+				reader.close();
+				if (sameValues) {
+					System.out.println("ERR: Same random values");
+				} else {
+					System.out.println("Different random values");
+				}
+				Files.deleteIfExists(testResultsFilePath);
+			} else {
+				System.out.println("First Restore");
+				PrintWriter writer = new PrintWriter(new FileWriter(testResultsFile));
+				writer.println(r1.nextInt());
+				writer.println(r1.nextInt());
+				writer.println(r1.nextInt());
+				writer.println(r1.nextInt());
+				writer.println(r1.nextInt());
+				writer.close();
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/test/functional/cmdLineTests/criu/src/CRIUSecurityTest.java
+++ b/test/functional/cmdLineTests/criu/src/CRIUSecurityTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+public class CRIUSecurityTest {
+
+	public static void main(String args[]) {
+		System.out.println("Pre-checkpoint");
+
+		// Make sure the only provider available during checkpoint is CRIUSEC.
+		Provider[] providerList = Security.getProviders();
+		assertEquals("Security provider list length", providerList.length, 1);
+		assertEquals("Security provider name", providerList[0].getName(), "CRIUSEC");
+
+		// Attempt to get an AES Cipher object for encryption, it should throw an exception.
+		try {
+			Cipher.getInstance("AES", "SunJCE");
+			error("Getting an AES Cipher did not throw an exception");
+		} catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+			// expected
+		} catch (NoSuchPaddingException e) {
+			error(e.toString());
+		}
+
+		CRIUTestUtils.checkPointJVM(Paths.get("cpData"));
+		System.out.println("Post-checkpoint");
+	}
+
+	private static void assertEquals(String name, int value, int expected) {
+		if (expected != value) {
+			error(name + " = " + value + " (expected " + expected + ")");
+		}
+	}
+
+	private static void assertEquals(String name, String value, String expected) {
+		if (!expected.equals(value)) {
+			error(name + " = " + value + " (expected " + expected + ")");
+		}
+	}
+
+	private static void error(String msg) {
+		System.out.println("ERR: " + msg);
+	}
+}

--- a/test/functional/cmdLineTests/criu/src/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/CRIUTestUtils.java
@@ -53,6 +53,10 @@ public class CRIUTestUtils {
 	}
 
 	public static void checkPointJVM(Path path) {
+		checkPointJVM(path, true);
+	}
+
+	public static void checkPointJVM(Path path, boolean deleteDir) {
 		if (CRIUSupport.isCRIUSupportEnabled()) {
 			deleteCheckpointDirectory(path);
 			createCheckpointDirectory(path);
@@ -65,8 +69,9 @@ public class CRIUTestUtils {
 			} catch (RestoreException e) {
 				e.printStackTrace();
 			}
-
-			deleteCheckpointDirectory(path);
+			if (deleteDir) {
+				deleteCheckpointDirectory(path);
+			}
 		} else {
 			System.err.println("CRIU is not enabled");
 		}


### PR DESCRIPTION
Ensures that CRIUSEC is the only provider available during checkpoint.
See PR: [ibmruntimes/openj9-openjdk-jdk11#510](https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/510)

Signed-off-by: Zainab Fatmi <zainab@ibm.com>