### PR TITLE
(0.31) Update document dates missed when updating to zlib 1.2.12

### DIFF
--- a/longabout.html
+++ b/longabout.html
@@ -8,7 +8,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
 
-<p><em>Jan 12, 2022</em></p>
+<p><em>March 30, 2022</em></p>
 <h3>License</h3>
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.

--- a/runtime/zlib/about.html
+++ b/runtime/zlib/about.html
@@ -6,7 +6,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
  
-<p><em>January 3, 2020</em></p>
+<p><em>March 30, 2022</em></p>
 <h3>License</h3>
 
 <p>This program and the accompanying materials are made available under the terms of the


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/14809

Cherry pick https://github.com/eclipse-openj9/openj9/pull/14831 for the 0.31 release.