### PR TITLE
Do unprivileged CRIU dump if requested+supported

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -67,7 +67,8 @@ public final class CRIUSupport {
 			String workDir,
 			boolean tcpEstablished,
 			boolean autoDedup,
-			boolean trackMemory);
+			boolean trackMemory,
+			boolean unprivileged);
 
 	static {
 		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -157,6 +158,7 @@ public final class CRIUSupport {
 	private boolean tcpEstablished;
 	private boolean autoDedup;
 	private boolean trackMemory;
+	private boolean unprivileged;
 	private Path envFile;
 
 	/**
@@ -347,6 +349,19 @@ public final class CRIUSupport {
 	}
 
 	/**
+	 * Controls whether CRIU will be invoked in privileged or unprivileged mode.
+	 * <p>
+	 * Default: false
+	 *
+	 * @param unprivileged
+	 * @return this
+	 */
+	public CRIUSupport setUnprivileged(boolean unprivileged) {
+		this.unprivileged = unprivileged;
+		return this;
+	}
+
+	/**
 	 * Append new environment variables to the set returned by ProcessEnvironment.getenv(...) upon
 	 * restore. All pre-existing (environment variables from checkpoint run) env
 	 * vars are retained. All environment variables specified in the envFile are
@@ -521,7 +536,7 @@ public final class CRIUSupport {
 
 		if (InternalCRIUSupport.isCheckpointAllowed()) {
 			checkpointJVMImpl(imageDir, leaveRunning, shellJob, extUnixSupport, logLevel, logFile, fileLocks, workDir,
-					tcpEstablished, autoDedup, trackMemory);
+					tcpEstablished, autoDedup, trackMemory, unprivileged);
 		} else {
 			if (InternalCRIUSupport.isCRIUSupportEnabled()) {
 				throw new UnsupportedOperationException(

--- a/runtime/criusupport/CMakeLists.txt
+++ b/runtime/criusupport/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021, 2021 IBM Corp. and others
+# Copyright (c) 2021, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ target_link_libraries(j9criu
 		j9vm_interface
 		j9util
 		j9thr
+		dl
 )
 
 include(exports.cmake)

--- a/runtime/criusupport/criusupport.hpp
+++ b/runtime/criusupport/criusupport.hpp
@@ -35,7 +35,7 @@ jboolean JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
 
 void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory);
+Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory, jboolean unprivileged);
 
 } /* extern "C" */
 

--- a/runtime/criusupport/module.xml
+++ b/runtime/criusupport/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2021, 2021 IBM Corp. and others
+Copyright (c) 2021, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<libraries>
 			<library name="criu" type="external">
+				<include-if condition="spec.linux.*"/>
+			</library>
+			<library name="dl" type="external">
 				<include-if condition="spec.linux.*"/>
 			</library>
 			<library name="j9thr"/>

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -523,3 +523,11 @@ J9NLS_JCL_CRIU_FAILED_DELAY_LOCK_RELATED_OPS.explanation=An error occured when t
 J9NLS_JCL_CRIU_FAILED_DELAY_LOCK_RELATED_OPS.system_action=The JVM will throw a RestoreException.
 J9NLS_JCL_CRIU_FAILED_DELAY_LOCK_RELATED_OPS.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED=Cannot set CRIU unprivileged mode, errno=%li
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.sample_input_1=1
+J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.explanation=An error occured when the JVM attempted set CRIU unprivileged mode.
+J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.system_action=The JVM will throw a SystemCheckpointException.
+J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.user_response=Ensure that CRIU supports unprivileged mode.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
If the user requests an unprivileged CRIU dump we check
if a non-NULL `criu_set_unprivileged` symbol can be found via
dlsym() and if so call it with `true` as the parameter.

If the user requests an unprivileged CRIU dump but the symbol
cannot be found we throw an exception.

If the user does not request an unprivileged CRIU dump we do
nothing as CRIU (currently) defaults to privileged.

Also link against libdl to get access to dlsym().

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>