### PR TITLE
Delay loading JNI refs

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -88,13 +88,8 @@ Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *e
 
 	UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(vm));
 	if (vm->internalVMFunctions->isCRIUSupportEnabled(currentThread)) {
-#if defined(LINUX)
-		if (0 == criu_init_opts()) {
-			res = JNI_TRUE;
-		}
-#endif /* defined(LINUX) */
+		res = JNI_TRUE;
 	}
-	setupJNIFieldIDs(env);
 
 	return res;
 }
@@ -257,6 +252,10 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 	UDATA msgCharLength = 0;
 	IDATA systemReturnCode = 0;
 	PORT_ACCESS_FROM_VMC(currentThread);
+
+	if (NULL == vm->criuJVMCheckpointExceptionClass) {
+		setupJNIFieldIDs(env);
+	}
 
 	vm->checkpointState.checkpointThread = currentThread;
 


### PR DESCRIPTION
Delay loading JNI refs

The openj9.criu module is loaded after java.base so any operations that
require InternalCRIUSupport early on in JVM startup will hit an
assertion failure when attempting to setup the CRIU JNI refs.

Fixes: https://github.com/eclipse-openj9/openj9/issues/14821

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>