### PR TITLE
APIs in Class.java should search VT <new> method as constructor

### DIFF
--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,13 @@ static UDATA
 isConstructor(J9Method *ramMethod)
 {
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	return (0 == (romMethod->modifiers & J9AccStatic)) && ('<' == J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod))[0]);
+	UDATA rc = (!J9ROMMETHOD_IS_STATIC(romMethod)) && ('<' == J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod))[0]);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (!rc) {
+		rc = J9ROMMETHOD_IS_UNNAMED_FACTORY(romMethod);
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+	return rc;
 }
 
 /*

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -25,6 +25,7 @@
 
 /* @ddr_namespace: default */
 #include "j9cfg.h"
+#include "j9.h"
 
 #define _J9ROMCLASS_J9MODIFIER_IS_SET(romClass,j9Modifiers) \
 				J9_ARE_ALL_BITS_SET((romClass)->extraModifiers, j9Modifiers)
@@ -114,6 +115,15 @@
 #define J9ROMMETHOD_HAS_EXTENDED_MODIFIERS(romMethod)	_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccMethodHasExtendedModifiers)
 #define J9ROMMETHOD_IS_OBJECT_CONSTRUCTOR(romMethod)	_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccMethodObjectConstructor)
 #define J9ROMMETHOD_IS_CALLER_SENSITIVE(romMethod)	_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccMethodCallerSensitive)
+#define J9ROMMETHOD_IS_STATIC(romMethod)	_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccStatic)
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+/* Currently value type's constructor is static <init>, it will be changed to static <new>. The check for <init> can be removed once OpenJDK is updated on this. */
+#define J9ROMMETHOD_IS_UNNAMED_FACTORY(romMethod) \
+	(J9ROMMETHOD_IS_STATIC((romMethod)) \
+	&& (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<new>")  \
+			|| J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(J9ROMMETHOD_NAME((romMethod))), J9UTF8_LENGTH(J9ROMMETHOD_NAME((romMethod))), "<init>")))
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #define J9ROMFIELD_IS_CONTENDED(romField)	J9_ARE_ALL_BITS_SET((romField)->modifiers, J9FieldFlagIsContended)
 

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -634,6 +634,7 @@ public class Constants {
 	public static final String DEADLOCK_FIRST_MON = "First Monitor lock";
 	public static final String DEADLOCK_SECOND_MON = "Second Monitor lock";
 	public static final String DEADLOCK_JAVA_OBJ = "java/lang/Object";
+	public static final String DEADLOCK_JAVA_IDENTITY = "java/lang/Identity";
 	public static final String DEADLOCK_CMD = "deadlock";
 
 	/* Constants related to testing of runtime type resolution */

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,7 @@ public class TestDeadlockCase1 extends DDRExtTesterBase
 		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 2) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 2));
 	}
 
 }

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,7 @@ public class TestDeadlockCase2 extends DDRExtTesterBase
 		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 1));
 		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
 	}
 

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ public class TestDeadlockCase6 extends DDRExtTesterBase
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
 		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 1));
 	}
 
 }

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/ComplexIndyTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/ComplexIndyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,11 @@ public class ComplexIndyTest{
 	@Test(groups = { "level.extended" })
 	public void test_gwtTest_Object() {
 		String s = com.ibm.j9.jsr292.indyn.ComplexIndy.gwtTest(new Object());
-		if (!s.equals("DoesNotUnderStand: class java.lang.Object message: double")) Assert.fail("Wrong string returned'" + s +"'");
+		if (!s.equals("DoesNotUnderStand: class java.lang.Object message: double")
+			&& !s.equals("DoesNotUnderStand: class java.lang.Identity message: double")
+		) {
+			Assert.fail("Wrong string returned'" + s +"'");
+		}
 	}
 
 	@Test(groups = { "level.extended" })


### PR DESCRIPTION
APIs in Class.java should search VT `<new>` method as constructor

`Class.getDeclaredConstructors()` and `Class.getDeclaredConstructor()`
should search the unnamed factory method `<new>` rather than instance
initialization methods for value types.

Object is initialized via java.util.Objects.newIdentity() in Valhalla.
Update tests that check for Object to also check for Identity.

Closes #14813

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>