### PR TITLE
Weaken subtyping assertion for invokevirtual of an interface method

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -625,7 +625,19 @@ bool TR_J9VirtualCallSite::findCallSiteTarget(TR_CallStack *callStack, TR_Inline
                _isCallingObjectMethod = TR_yes;
             else
                {
-               TR_ASSERT_FATAL(fe()->isInstanceOf(callSiteClass, _receiverClass, true, true, true) == TR_yes , "CallSiteClass is incompatible with the receiverClass.");
+               // Verify subtyping against the defining interface rather than
+               // _receiverClass, since the latter could have been refined to a
+               // more specific interface.
+               TR_OpaqueClassBlock *defInterface = getClassFromMethod();
+               TR_YesNoMaybe callSiteClassOk = fe()->isInstanceOf(
+                  callSiteClass, defInterface, true, true, true);
+
+               TR_ASSERT_FATAL(
+                  callSiteClassOk == TR_yes,
+                  "class %p inherits a method from interface %p without implementing it",
+                  callSiteClass,
+                  defInterface);
+
                _isCallingObjectMethod = TR_no;
                if (comp()->trace(OMR::inlining))
                   {


### PR DESCRIPTION
We don't necessarily know that `callSiteClass` is a subtype of the `_receiverClass`, which may have been refined to a more specific interface. In particular, the following situation can arise:

- This call site is calling `callSiteClass.callee()`, and `callSiteClass` inherits `callee()` from an interface `defInterface`, so the callee method appears to be `defInterface.callee()`.

- The receiver comes from somewhere in the calling context with signature `subInterface`, which is a sub-interface of `defInterface`.

- `_receiverClass` is refined from `defInterface` to `subInterface` based on the calling context.

- `callSiteClass` implements `defInterface` but not `subInterface`. We know for certain that it implements `defInterface` because it inherits the callee from there. The assertion now checks this less specific typing relationship instead of checking against `_receiverClass`.

- Actual receivers are most likely to be instances of subclasses of `callSiteClass` that do implement `subInterface`. They might also be instances of `callSiteClass` but not `subInterface` (e.g. instances of exactly `callSiteClass`), which can happen despite the signature because signatures are unreliable when they name interface types.

When this happens, `callSiteClass` is not a refinement of `_receiverClass` (i.e. of `subInterface`), but it is a better refinement of `defInterface`. It's fine to go on and replace `_receiverClass`, since effectively that's just forgetting the earlier refinement and then refining again with `callSiteClass` instead.

Fixes #14526