### PR TITLE
Add Relocation Error Codes

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2143,32 +2143,19 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
          TR_PersistentJittedBodyInfo *bodyInfo;
          switch (entry->_compErrCode)
             {
-            case compilationAotValidateFieldFailure:
-            case compilationAotStaticFieldReloFailure:
-            case compilationAotClassReloFailure:
-            case compilationAotThunkReloFailure:
             case compilationAotHasInvokehandle:
             case compilationAotHasInvokeVarHandle:
             case compilationAotPatchedCPConstant:
             case compilationAotHasInvokeSpecialInterface:
-            case compilationAotValidateMethodExitFailure:
-            case compilationAotValidateMethodEnterFailure:
             case compilationAotClassChainPersistenceFailure:
-            case compilationAotValidateStringCompressionFailure:
             case compilationSymbolValidationManagerFailure:
             case compilationAOTNoSupportForAOTFailure:
-            case compilationAOTValidateTMFailure:
             case compilationAOTRelocationRecordGenerationFailure:
-            case compilationAotValidateExceptionHookFailure:
-            case compilationAotBlockFrequencyReloFailure:
-            case compilationAotRecompQueuedFlagReloFailure:
-            case compilationAOTValidateOSRFailure:
             case compilationRelocationFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
                break;
-            //case compilationAotRelocationFailure:
             case compilationAotTrampolineReloFailure:
             case compilationAotPicTrampolineReloFailure:
             case compilationAotCacheFullReloFailure:

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10186,10 +10186,11 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
                         {
                         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
-                                                          "Failure while relocating for %s, return code = %d [%s]\n",
+                                                          "Failure while relocating for %s, return code = %d [%s], relo error code = %s\n",
                                                           comp->signature(),
                                                           returnCode,
-                                                          (returnCode >= 0) && (returnCode < compilationMaxError) ? compilationErrorNames[returnCode] : "unknown error");
+                                                          (returnCode >= 0) && (returnCode < compilationMaxError) ? compilationErrorNames[returnCode] : "unknown error",
+                                                          comp->reloRuntime()->getReloErrorCodeName(comp->reloRuntime()->getReloErrorCode()));
                         }
                      }
                   }
@@ -11154,7 +11155,7 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
             }
          else
             {
-            TR_VerboseLog::write(TR_Vlog_COMPFAIL, "(%s%s) %s Q_SZ=%d Q_SZI=%d QW=%d j9m=%p time=%dus %s memLimit=%zu KB",
+            TR_VerboseLog::write(TR_Vlog_COMPFAIL, "(%s%s) %s Q_SZ=%d Q_SZI=%d QW=%d j9m=%p time=%dus %s",
                                  compilationTypeString,
                                  hotnessString,
                                  compiler->signature(),
@@ -11163,8 +11164,15 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
                                  _compInfo.getQueueWeight(),
                                  _methodBeingCompiled->getMethodDetails().getMethod(),
                                  translationTime,
-                                 compilationErrorNames[_methodBeingCompiled->_compErrCode],
-                                 scratchSegmentProvider.allocationLimit() >> 10);
+                                 compilationErrorNames[_methodBeingCompiled->_compErrCode]);
+            if (entry->isAotLoad())
+               {
+               TR_RelocationRuntime *reloRuntime = compiler->reloRuntime();
+               if (reloRuntime)
+                  TR_VerboseLog::write(" (%s)", reloRuntime->getReloErrorCodeName(reloRuntime->getReloErrorCode()));
+               }
+            TR_VerboseLog::write(" memLimit=%zu KB", scratchSegmentProvider.allocationLimit() >> 10);
+
             if (TR::Options::getVerboseOption(TR_VerbosePerformance))
                {
                bool incomplete;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2163,6 +2163,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotBlockFrequencyReloFailure:
             case compilationAotRecompQueuedFlagReloFailure:
             case compilationAOTValidateOSRFailure:
+            case compilationRelocationFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
@@ -6786,6 +6787,7 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
             case compilationAotValidateFieldFailure:
             case compilationAotStaticFieldReloFailure:
             case compilationAotClassReloFailure:
+            case compilationRelocationFailure:
                if ((options->getInitialBCount() != 0) &&
                    (options->getInitialCount() != 0))
                   {

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -429,7 +429,8 @@ private:
       J9VMThread *vmThread,
       TR::SegmentAllocator const &scratchSegmentProvider,
       TR::Compilation * compiler,
-      const char *exceptionName);
+      const char *exceptionName,
+      TR_MethodToBeCompiled *entry);
 
 #if defined(TR_HOST_S390)
    void outputVerboseMMapEntry(

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -217,6 +217,7 @@ char *compilationErrorNames[]={
    "compilationAotBlockFrequencyReloFailure", //58
    "compilationAotRecompQueuedFlagReloFailure", //59
    "compilationAOTValidateOSRFailure", //60
+   "compilationRelocationFailure", //61
 #if defined(J9VM_OPT_JITSERVER)
    "compilationStreamFailure", // compilationFirstJITServerFailure = 61
    "compilationStreamLostMessage", // 62

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -156,77 +156,63 @@ TR::Monitor *vpMonitor = 0;
 
 
 char *compilationErrorNames[]={
-   "compilationOK",                  // 0
-   "compilationFailure",             // 1
-   "compilationRestrictionILNodes",  // 2
-   "compilationRestrictionRecDepth", // 3
-   "compilationRestrictedMethod",    // 4
-   "compilationExcessiveComplexity", // 5
-   "compilationNotNeeded",           // 6
-   "compilationSuspended",           // 7
-   "compilationExcessiveSize",       // 8
-   "compilationInterrupted",         // 9
-   "compilationMetaDataFailure",     //10
-   "compilationInProgress",          //11
-   "compilationCHTableCommitFailure",//12
-   "compilationMaxCallerIndexExceeded",//13
-   "compilationKilledByClassReplacement",//14
-   "compilationHeapLimitExceeded",   //15
-   "compilationNeededAtHigherLevel", //16
-   "compilationAotValidateFieldFailure", //17
-   "compilationAotStaticFieldReloFailure", //18
-   "compilationAotClassReloFailure", //19
-   "compilationAotThunkReloFailure", //20
-   "compilationAotTrampolineReloFailure", //21
-   "compilationAotPicTrampolineReloFailure", //22
-   "compilationAotCacheFullReloFailure", //23
-   "compilationAotUnknownReloTypeFailure", //24
-   "compilationCodeReservationFailure", //25
-   "compilationAotHasInvokehandle", //26
-   "compilationTrampolineFailure", //27
-   "compilationRecoverableTrampolineFailure", // 28
-   "compilationIlGenFailure", // 29
-   "compilationIllegalCodeCacheSwitch", // 30
-   "compilationNullSubstituteCodeCache", // 31
-   "compilationCodeMemoryExhausted", // 32
-   "compilationGCRPatchFailure", // 33
-   "compilationAotValidateMethodExitFailure", // 34
-   "compilationAotValidateMethodEnterFailure", // 35
-   "compilationAotArrayClassReloFailure", // 36
-   "compilationLambdaEnforceScorching", // 37
-   "compilationInternalPointerExceedLimit", // 38
-   "compilationAotRelocationInterrupted", // 39
-   "compilationAotClassChainPersistenceFailure", // 40
-   "compilationLowPhysicalMemory", // 41
-   "compilationDataCacheError", // 42
-   "compilationCodeCacheError", // 43
-   "compilationRecoverableCodeCacheError", // 44
-   "compilationAotHasInvokeVarHandle", //45
-   "compilationAotValidateStringCompressionFailure", // 46
-   "compilationFSDHasInvokeHandle", //47
-   "compilationVirtualAddressExhaustion", //48
-   "compilationEnforceProfiling", //49
-   "compilationSymbolValidationManagerFailure", //50
-   "compilationAOTNoSupportForAOTFailure", //51
-   "compilationAOTValidateTMFailure", //52
-   "compilationILGenUnsupportedValueTypeOperationFailure", //53
-   "compilationAOTRelocationRecordGenerationFailure", //54
-   "compilationAotPatchedCPConstant", //55
-   "compilationAotHasInvokeSpecialInterface", //56
-   "compilationAotValidateExceptionHookFailure", //57
-   "compilationAotBlockFrequencyReloFailure", //58
-   "compilationAotRecompQueuedFlagReloFailure", //59
-   "compilationAOTValidateOSRFailure", //60
-   "compilationRelocationFailure", //61
+   "compilationOK",                                        // 0
+   "compilationFailure",                                   // 1
+   "compilationRestrictionILNodes",                        // 2
+   "compilationRestrictionRecDepth",                       // 3
+   "compilationRestrictedMethod",                          // 4
+   "compilationExcessiveComplexity",                       // 5
+   "compilationNotNeeded",                                 // 6
+   "compilationSuspended",                                 // 7
+   "compilationExcessiveSize",                             // 8
+   "compilationInterrupted",                               // 9
+   "compilationMetaDataFailure",                           // 10
+   "compilationInProgress",                                // 11
+   "compilationCHTableCommitFailure",                      // 12
+   "compilationMaxCallerIndexExceeded",                    // 13
+   "compilationKilledByClassReplacement",                  // 14
+   "compilationHeapLimitExceeded",                         // 15
+   "compilationNeededAtHigherLevel",                       // 16
+   "compilationAotTrampolineReloFailure",                  // 17
+   "compilationAotPicTrampolineReloFailure",               // 18
+   "compilationAotCacheFullReloFailure",                   // 19
+   "compilationCodeReservationFailure",                    // 20
+   "compilationAotHasInvokehandle",                        // 21
+   "compilationTrampolineFailure",                         // 22
+   "compilationRecoverableTrampolineFailure",              // 23
+   "compilationILGenFailure",                              // 24
+   "compilationIllegalCodeCacheSwitch",                    // 25
+   "compilationNullSubstituteCodeCache",                   // 26
+   "compilationCodeMemoryExhausted",                       // 27
+   "compilationGCRPatchFailure",                           // 28
+   "compilationLambdaEnforceScorching",                    // 29
+   "compilationInternalPointerExceedLimit",                // 30
+   "compilationAotRelocationInterrupted",                  // 31
+   "compilationAotClassChainPersistenceFailure",           // 32
+   "compilationLowPhysicalMemory",                         // 33
+   "compilationDataCacheError",                            // 34
+   "compilationCodeCacheError",                            // 35
+   "compilationRecoverableCodeCacheError",                 // 36
+   "compilationAotHasInvokeVarHandle",                     // 37
+   "compilationFSDHasInvokeHandle",                        // 38
+   "compilationVirtualAddressExhaustion",                  // 39
+   "compilationEnforceProfiling",                          // 40
+   "compilationSymbolValidationManagerFailure",            // 41
+   "compilationAOTNoSupportForAOTFailure",                 // 42
+   "compilationILGenUnsupportedValueTypeOperationFailure", // 43
+   "compilationAOTRelocationRecordGenerationFailure",      // 44
+   "compilationAotPatchedCPConstant",                      // 45
+   "compilationAotHasInvokeSpecialInterface",              // 46
+   "compilationRelocationFailure",                         // 47
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", // compilationFirstJITServerFailure = 61
-   "compilationStreamLostMessage", // 62
-   "compilationStreamMessageTypeMismatch", // 63
-   "compilationStreamVersionIncompatible", // 64
-   "compilationStreamInterrupted", // 65
-   "aotCacheDeserializationFailure", // 66
+   "compilationStreamFailure",                             // compilationFirstJITServerFailure     = 48
+   "compilationStreamLostMessage",                         // compilationFirstJITServerFailure + 1 = 49
+   "compilationStreamMessageTypeMismatch",                 // compilationFirstJITServerFailure + 2 = 50
+   "compilationStreamVersionIncompatible",                 // compilationFirstJITServerFailure + 3 = 51
+   "compilationStreamInterrupted",                         // compilationFirstJITServerFailure + 4 = 52
+   "aotCacheDeserializationFailure",                       // compilationFirstJITServerFailure + 5 = 53
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   "compilationMaxError",
+   "compilationMaxError"
 };
 
 int32_t aggressiveOption = 0;

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -84,6 +84,7 @@ typedef enum {
    compilationAotBlockFrequencyReloFailure         = 58,
    compilationAotRecompQueuedFlagReloFailure       = 59,
    compilationAOTValidateOSRFailure                = 60,
+   compilationRelocationFailure                    = 61,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure, // 61

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,80 +23,69 @@
 #ifndef __ROSSA_H
 #define __ROSSA_H
 
+/* Please insert new codes before compilationMaxError and ensure the
+ * corresponding names are added in compilationErrorNames in rossa.cpp */
 typedef enum {
-   compilationOK                                   = 0,
-   compilationFailure                              = 1,  /* catch all error */
-   compilationRestrictionILNodes                   = 2,  /* Unused */
-   compilationRestrictionRecDepth                  = 3,  /* Unused */
-   compilationRestrictedMethod                     = 4,  /* filters, JNI, abstract */
-   compilationExcessiveComplexity                  = 5,
-   compilationNotNeeded                            = 6,
-   compilationSuspended                            = 7,
-   compilationExcessiveSize                        = 8,  /* full caches */
-   compilationInterrupted                          = 9,  /* GC wants to unload classes */
-   compilationMetaDataFailure                      = 10, /* cannot create metadata */
-   compilationInProgress                           = 11, /* for async compilations */
-   compilationCHTableCommitFailure                 = 12,
-   compilationMaxCallerIndexExceeded               = 13,
-   compilationKilledByClassReplacement             = 14,
-   compilationHeapLimitExceeded                    = 15,
-   compilationNeededAtHigherLevel                  = 16, /*rtj */
-   compilationAotValidateFieldFailure              = 17, /* aot failures */
-   compilationAotStaticFieldReloFailure            = 18,
-   compilationAotClassReloFailure                  = 19,
-   compilationAotThunkReloFailure                  = 20,
-   compilationAotTrampolineReloFailure             = 21,
-   compilationAotPicTrampolineReloFailure          = 22,
-   compilationAotCacheFullReloFailure              = 23, /* end of aot failures */
-   compilationAotUnknownReloTypeFailure            = 24,
-   compilationCodeReservationFailure               = 25,
-   compilationAotHasInvokehandle                   = 26,
-   compilationTrampolineFailure                    = 27,
-   compilationRecoverableTrampolineFailure         = 28, /* we should retry these */
-   compilationILGenFailure                         = 29,
-   compilationIllegalCodeCacheSwitch               = 30,
-   compilationNullSubstituteCodeCache              = 31,
-   compilationCodeMemoryExhausted                  = 32,
-   compilationGCRPatchFailure                      = 33,
-   compilationAotValidateMethodExitFailure         = 34,
-   compilationAotValidateMethodEnterFailure        = 35,
-   compilationLambdaEnforceScorching               = 37,
-   compilationInternalPointerExceedLimit           = 38,
-   compilationAotRelocationInterrupted             = 39,
-   compilationAotClassChainPersistenceFailure      = 40,
-   compilationLowPhysicalMemory                    = 41,
-   compilationDataCacheError                       = 42,
-   compilationCodeCacheError                       = 43,
-   compilationRecoverableCodeCacheError            = 44,
-   compilationAotHasInvokeVarHandle                = 45,
-   compilationAotValidateStringCompressionFailure  = 46,
-   compilationFSDHasInvokeHandle                   = 47,
-   compilationVirtualAddressExhaustion             = 48,
-   compilationEnforceProfiling                     = 49,
-   compilationSymbolValidationManagerFailure       = 50,
-   compilationAOTNoSupportForAOTFailure            = 51,
-   compilationAOTValidateTMFailure                 = 52,
-   compilationILGenUnsupportedValueTypeOperationFailure = 53,
-   compilationAOTRelocationRecordGenerationFailure = 54,
-   compilationAotPatchedCPConstant                 = 55,
-   compilationAotHasInvokeSpecialInterface         = 56,
-   compilationAotValidateExceptionHookFailure      = 57,
-   compilationAotBlockFrequencyReloFailure         = 58,
-   compilationAotRecompQueuedFlagReloFailure       = 59,
-   compilationAOTValidateOSRFailure                = 60,
-   compilationRelocationFailure                    = 61,
+   compilationOK                                        = 0,
+   compilationFailure                                   = 1,  /* catch all error */
+   compilationRestrictionILNodes                        = 2,  /* Unused */
+   compilationRestrictionRecDepth                       = 3,  /* Unused */
+   compilationRestrictedMethod                          = 4,  /* filters, JNI, abstract */
+   compilationExcessiveComplexity                       = 5,
+   compilationNotNeeded                                 = 6,
+   compilationSuspended                                 = 7,
+   compilationExcessiveSize                             = 8,  /* full caches */
+   compilationInterrupted                               = 9,  /* GC wants to unload classes */
+   compilationMetaDataFailure                           = 10, /* cannot create metadata */
+   compilationInProgress                                = 11, /* for async compilations */
+   compilationCHTableCommitFailure                      = 12,
+   compilationMaxCallerIndexExceeded                    = 13,
+   compilationKilledByClassReplacement                  = 14,
+   compilationHeapLimitExceeded                         = 15,
+   compilationNeededAtHigherLevel                       = 16, /*rtj */
+   compilationAotTrampolineReloFailure                  = 17,
+   compilationAotPicTrampolineReloFailure               = 18,
+   compilationAotCacheFullReloFailure                   = 19,
+   compilationCodeReservationFailure                    = 20,
+   compilationAotHasInvokehandle                        = 21,
+   compilationTrampolineFailure                         = 22,
+   compilationRecoverableTrampolineFailure              = 23, /* we should retry these */
+   compilationILGenFailure                              = 24,
+   compilationIllegalCodeCacheSwitch                    = 25,
+   compilationNullSubstituteCodeCache                   = 26,
+   compilationCodeMemoryExhausted                       = 27,
+   compilationGCRPatchFailure                           = 28,
+   compilationLambdaEnforceScorching                    = 29,
+   compilationInternalPointerExceedLimit                = 30,
+   compilationAotRelocationInterrupted                  = 31,
+   compilationAotClassChainPersistenceFailure           = 32,
+   compilationLowPhysicalMemory                         = 33,
+   compilationDataCacheError                            = 34,
+   compilationCodeCacheError                            = 35,
+   compilationRecoverableCodeCacheError                 = 36,
+   compilationAotHasInvokeVarHandle                     = 37,
+   compilationFSDHasInvokeHandle                        = 38,
+   compilationVirtualAddressExhaustion                  = 39,
+   compilationEnforceProfiling                          = 40,
+   compilationSymbolValidationManagerFailure            = 41,
+   compilationAOTNoSupportForAOTFailure                 = 42,
+   compilationILGenUnsupportedValueTypeOperationFailure = 43,
+   compilationAOTRelocationRecordGenerationFailure      = 44,
+   compilationAotPatchedCPConstant                      = 45,
+   compilationAotHasInvokeSpecialInterface              = 46,
+   compilationRelocationFailure                         = 47,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
-   compilationStreamFailure                        = compilationFirstJITServerFailure, // 61
-   compilationStreamLostMessage                    = compilationFirstJITServerFailure + 1, // 62
-   compilationStreamMessageTypeMismatch            = compilationFirstJITServerFailure + 2, // 63
-   compilationStreamVersionIncompatible            = compilationFirstJITServerFailure + 3, // 64
-   compilationStreamInterrupted                    = compilationFirstJITServerFailure + 4, // 65
-   aotCacheDeserializationFailure                  = compilationFirstJITServerFailure + 5, // 66
+   compilationStreamFailure                             = compilationFirstJITServerFailure,     // 48
+   compilationStreamLostMessage                         = compilationFirstJITServerFailure + 1, // 49
+   compilationStreamMessageTypeMismatch                 = compilationFirstJITServerFailure + 2, // 50
+   compilationStreamVersionIncompatible                 = compilationFirstJITServerFailure + 3, // 51
+   compilationStreamInterrupted                         = compilationFirstJITServerFailure + 4, // 52
+   aotCacheDeserializationFailure                       = compilationFirstJITServerFailure + 5, // 53
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
-   /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
-   compilationMaxError /* must be the last one */
+
+   /* must be the last one */
+   compilationMaxError
 } TR_CompilationErrorCode;
 
 #ifdef __cplusplus

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -488,7 +488,7 @@ TR_RelocationRecordGroup::wellKnownClassChainOffsets(
    return reinterpret_cast<const uintptr_t*>(classChains);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordGroup::applyRelocations(TR_RelocationRuntime *reloRuntime,
                                            TR_RelocationTarget *reloTarget,
                                            uint8_t *reloOrigin)
@@ -506,7 +506,7 @@ TR_RelocationRecordGroup::applyRelocations(TR_RelocationRuntime *reloRuntime,
          {
          if (aotStats)
             aotStats->numWellKnownClassesValidationsFailed++;
-         return compilationAotClassReloFailure;
+         return TR_RelocationErrorCode::wkcValidationFailure;
          }
       }
 
@@ -519,8 +519,8 @@ TR_RelocationRecordGroup::applyRelocations(TR_RelocationRuntime *reloRuntime,
       // Create a specific type of relocation record based on the information
       // in the binary record pointed to by `recordPointer`
       TR_RelocationRecord *reloRecord = TR_RelocationRecord::create(&storage, reloRuntime, reloTarget, recordPointer);
-      int32_t rc = handleRelocation(reloRuntime, reloTarget, reloRecord, reloOrigin);
-      if (rc != 0)
+      TR_RelocationErrorCode rc = handleRelocation(reloRuntime, reloTarget, reloRecord, reloOrigin);
+      if (rc != TR_RelocationErrorCode::relocationOK)
          {
          uint8_t reloType = recordPointer->type(reloTarget);
          aotStats->numRelocationsFailedByType[reloType]++;
@@ -530,11 +530,11 @@ TR_RelocationRecordGroup::applyRelocations(TR_RelocationRuntime *reloRuntime,
       recordPointer = reloRecord->nextBinaryRecord(reloTarget);
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordGroup::handleRelocation(TR_RelocationRuntime *reloRuntime,
                                            TR_RelocationTarget *reloTarget,
                                            TR_RelocationRecord *reloRecord,
@@ -553,12 +553,12 @@ TR_RelocationRecordGroup::handleRelocation(TR_RelocationRuntime *reloRuntime,
       case TR_RelocationRecordAction::ignore:
          {
          RELO_LOG(reloRuntime->reloLogger(), 6, "\tignore!\n");
-         return 0;
+         return TR_RelocationErrorCode::relocationOK;
          }
       case TR_RelocationRecordAction::failCompilation:
          {
          RELO_LOG(reloRuntime->reloLogger(), 6, "\tINTERNAL ERROR!\n");
-         return compilationAotClassReloFailure;
+         return TR_RelocationErrorCode::reloActionFailCompile;
          }
       default:
          {
@@ -566,7 +566,7 @@ TR_RelocationRecordGroup::handleRelocation(TR_RelocationRuntime *reloRuntime,
          }
       }
 
-   return compilationAotClassReloFailure;
+   return TR_RelocationErrorCode::unknownReloAction;
    }
 
 TR_RelocationRecord *
@@ -1004,12 +1004,12 @@ TR_RelocationRecord::action(TR_RelocationRuntime *reloRuntime)
    return TR_RelocationRecordAction::apply;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloOrigin)
    {
    int32_t sizeOfHeader = bytesInHeader(reloRuntime, reloTarget);
    if (sizeOfHeader <= 0)
-      return compilationAotUnknownReloTypeFailure;
+      return TR_RelocationErrorCode::unknownRelocation;
 
    if (reloTarget->isOrderedPairRelocation(this, reloTarget))
       {
@@ -1027,13 +1027,13 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(0);
 #endif
-            int32_t rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
+            TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(1);
 #endif
-            if (rc != 0)
+            if (rc != TR_RelocationErrorCode::relocationOK)
                {
-               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %d\n", rc);
+               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
                return rc;
                }
             }
@@ -1052,13 +1052,13 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(0);
 #endif
-            int32_t rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
+            TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(1);
 #endif
-            if (rc != 0)
+            if (rc != TR_RelocationErrorCode::relocationOK)
                {
-               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %d\n", rc);
+               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
                return rc;
                }
             }
@@ -1078,13 +1078,13 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(0);
 #endif
-            int32_t rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
+            TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(1);
 #endif
-            if (rc != 0)
+            if (rc != TR_RelocationErrorCode::relocationOK)
                {
-               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %d\n", rc);
+               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
                return rc;
                }
             }
@@ -1101,19 +1101,19 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(0);
 #endif
-            int32_t rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
+            TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
 #if defined(OSX) && defined(AARCH64)
             pthread_jit_write_protect_np(1);
 #endif
-            if (rc != 0)
+            if (rc != TR_RelocationErrorCode::relocationOK)
                {
-               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %d\n", rc);
+               RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
                return rc;
                }
             }
          }
       }
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    }
 
 // Handlers for individual relocation record types
@@ -1150,22 +1150,22 @@ TR_RelocationRecordWithOffset::preparePrivateData(TR_RelocationRuntime *reloRunt
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: addressToPatch: %p \n", reloPrivateData->_addressToPatch);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordWithOffset::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordWithOffsetPrivateData *reloPrivateData = &(privateData()->offset);
    reloTarget->storeAddressSequence(reloPrivateData->_addressToPatch, reloLocation, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordWithOffset::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordWithOffsetPrivateData *reloPrivateData = &(privateData()->offset);
    reloTarget->storeAddress(reloPrivateData->_addressToPatch, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_BlockFrequency
@@ -1216,28 +1216,28 @@ TR_RelocationRecordBlockFrequency::preparePrivateData(TR_RelocationRuntime *relo
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: addressToPatch: %p \n", reloPrivateData->_addressToPatch);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBlockFrequency::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordBlockFrequencyPrivateData *reloPrivateData = &(privateData()->blockFrequency);
    if (!reloPrivateData->_addressToPatch)
       {
-      return compilationAotBlockFrequencyReloFailure;
+      return TR_RelocationErrorCode::blockFrequencyRelocationFailure;
       }
    reloTarget->storeAddressSequence(reloPrivateData->_addressToPatch, reloLocation, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBlockFrequency::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordBlockFrequencyPrivateData *reloPrivateData = &(privateData()->blockFrequency);
    if (!reloPrivateData->_addressToPatch)
       {
-      return compilationAotBlockFrequencyReloFailure;
+      return TR_RelocationErrorCode::blockFrequencyRelocationFailure;
       }
    reloTarget->storeAddress(reloPrivateData->_addressToPatch, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_RecompQueuedFlag
@@ -1267,28 +1267,28 @@ TR_RelocationRecordRecompQueuedFlag::preparePrivateData(TR_RelocationRuntime *re
    }
 
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordRecompQueuedFlag::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordRecompQueuedFlagPrivateData *reloPrivateData = &(privateData()->recompQueuedFlag);
    if (!reloPrivateData->_addressToPatch)
       {
-      return compilationAotRecompQueuedFlagReloFailure;
+      return TR_RelocationErrorCode::recompQueuedFlagRelocationFailure;
       }
    reloTarget->storeAddressSequence(reloPrivateData->_addressToPatch, reloLocation, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordRecompQueuedFlag::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordRecompQueuedFlagPrivateData *reloPrivateData = &(privateData()->recompQueuedFlag);
    if (!reloPrivateData->_addressToPatch)
       {
-      return compilationAotRecompQueuedFlagReloFailure;
+      return TR_RelocationErrorCode::recompQueuedFlagRelocationFailure;
       }
    reloTarget->storeAddress(reloPrivateData->_addressToPatch, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_GlobalValue
@@ -1322,20 +1322,20 @@ TR_RelocationRecordBodyInfoLoad::preparePrivateData(TR_RelocationRuntime *reloRu
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: body info %p \n", reloPrivateData->_addressToPatch);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBodyInfoLoad::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordWithOffsetPrivateData *reloPrivateData = &(privateData()->offset);
    reloTarget->storeAddressSequence(reloPrivateData->_addressToPatch, reloLocation, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBodyInfoLoad::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordWithOffsetPrivateData *reloPrivateData = &(privateData()->offset);
    reloTarget->storeAddress(reloPrivateData->_addressToPatch, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_ArrayCopyHelper
@@ -1357,21 +1357,21 @@ TR_RelocationRecordArrayCopyHelper::preparePrivateData(TR_RelocationRuntime *rel
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: arraycopy helper %p\n", reloPrivateData->_addressToPatch);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordArrayCopyHelper::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordArrayCopyPrivateData *reloPrivateData = &(privateData()->arraycopy);
    reloTarget->storeAddressSequence(reloPrivateData->_addressToPatch, reloLocation, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordArrayCopyHelper::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordArrayCopyPrivateData *reloPrivateData = &(privateData()->arraycopy);
    reloTarget->storeAddress(reloPrivateData->_addressToPatch, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_ArrayCopyToc
@@ -1569,7 +1569,7 @@ TR_RelocationRecordConstantPool::computeNewConstantPool(TR_RelocationRuntime *re
    return newCP;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordConstantPool::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *baseLocation = 0;
@@ -1577,31 +1577,31 @@ TR_RelocationRecordConstantPool::applyRelocation(TR_RelocationRuntime *reloRunti
       {
       //j9tty_printf(PORTLIB, "\nInternal Error AOT: relocateConstantPool: Relocation type was IP-relative.\n");
       // TODO: better error condition exit(-1);
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
       }
 
    uintptr_t oldValue =  (uintptr_t) reloTarget->loadAddress(reloLocation);
    uintptr_t newCP = computeNewConstantPool(reloRuntime, reloTarget, oldValue);
    reloTarget->storeAddress((uint8_t *)newCP, reloLocation);
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordConstantPool::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    if (eipRelative(reloTarget))
       {
       //j9tty_printf(PORTLIB, "\nInternal Error AOT: relocateConstantPool: Relocation type was IP-relative.\n");
       // TODO: better error condition exit(-1);
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
       }
 
    uintptr_t oldValue = (uintptr_t) reloTarget->loadAddress(reloLocationHigh, reloLocationLow);
    uintptr_t newCP = computeNewConstantPool(reloRuntime, reloTarget, oldValue);
    reloTarget->storeAddress((uint8_t *)newCP, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // ConstantPoolWithIndex relocation base class
@@ -1836,7 +1836,7 @@ TR_RelocationRecordHelperAddress::preparePrivateData(TR_RelocationRuntime *reloR
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: helperAddress %p\n", reloPrivateData->_helper);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordHelperAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *baseLocation = 0;
@@ -1852,10 +1852,10 @@ TR_RelocationRecordHelperAddress::applyRelocation(TR_RelocationRuntime *reloRunt
    else
       reloTarget->storeAddress(helperOffset, reloLocation);
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordHelperAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_ASSERT(0, "TR_RelocationRecordHelperAddress::applyRelocation for ordered pair, we should never call this");
@@ -1865,7 +1865,7 @@ TR_RelocationRecordHelperAddress::applyRelocation(TR_RelocationRuntime *reloRunt
 
    reloTarget->storeAddress(helperOffset, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 char *
@@ -1874,7 +1874,7 @@ TR_RelocationRecordAbsoluteHelperAddress::name()
    return "TR_AbsoluteHelperAddress";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordAbsoluteHelperAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordHelperAddressPrivateData *reloPrivateData = &(privateData()->helperAddress);
@@ -1883,16 +1883,16 @@ TR_RelocationRecordAbsoluteHelperAddress::applyRelocation(TR_RelocationRuntime *
       reloTarget->storeAddressSequence(helperAddress, reloLocation, reloFlags(reloTarget));
    else
       reloTarget->storeAddress(helperAddress, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordAbsoluteHelperAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordHelperAddressPrivateData *reloPrivateData = &(privateData()->helperAddress);
    uint8_t *helperAddress = reloPrivateData->_helper;
    reloTarget->storeAddress(helperAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // Method Address Relocations
@@ -1910,7 +1910,7 @@ TR_RelocationRecordMethodAddress::currentMethodAddress(TR_RelocationRuntime *rel
    return oldMethodAddress - methodHdr->compileMethodCodeStartPC + (uintptr_t) reloRuntime->newMethodCodeStart();
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordMethodAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    bool eipRel = eipRelative(reloTarget);
@@ -1930,10 +1930,10 @@ TR_RelocationRecordMethodAddress::applyRelocation(TR_RelocationRuntime *reloRunt
    else
       reloTarget->storeAddress(newAddress, reloLocation);
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordMethodAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordWithOffsetPrivateData *reloPrivateData = &(privateData()->offset);
@@ -1942,7 +1942,7 @@ TR_RelocationRecordMethodAddress::applyRelocation(TR_RelocationRuntime *reloRunt
 
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: oldAddress %p newAddress %p\n", oldAddress, newAddress);
    reloTarget->storeAddress(newAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // Direct JNI Address Relocations
@@ -1991,7 +1991,7 @@ TR_RelocationRecordDirectJNICall::offsetToReloLocation(TR_RelocationTarget *relo
    return reloTarget->loadUnsigned8b(&((TR_RelocationRecordDirectToJNIBinaryTemplate *)_record)->_offsetToReloLocation);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordDirectJNICall::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    void *addressForAssumption = reloLocation;
@@ -2001,14 +2001,16 @@ TR_RelocationRecordDirectJNICall::applyRelocation(TR_RelocationRuntime *reloRunt
    J9ConstantPool * newConstantPool =(J9ConstantPool *) computeNewConstantPool(reloRuntime, reloTarget, constantPool(reloTarget));
    TR_OpaqueMethodBlock *ramMethod = getMethodFromCP(reloRuntime, newConstantPool, cpIndex(reloTarget));
 
-   if (!ramMethod) return compilationAotClassReloFailure;
+   if (!ramMethod)
+      return TR_RelocationErrorCode::directJNICallRelocationFailure;
 
    TR_ResolvedMethod *callerResolvedMethod = reloRuntime->fej9()->createResolvedMethod(reloRuntime->comp()->trMemory(), ramMethod, NULL);
    void * newAddress = NULL;
    if (callerResolvedMethod->isJNINative())
       newAddress = callerResolvedMethod->startAddressForJNIMethod(reloRuntime->comp());
 
-   if (!newAddress) return compilationAotClassReloFailure;
+   if (!newAddress)
+      return TR_RelocationErrorCode::directJNICallRelocationFailure;
 
    RELO_LOG(reloLogger, 6, "\tJNI call relocation: found JNI target address %p\n", newAddress);
 
@@ -2016,10 +2018,10 @@ TR_RelocationRecordDirectJNICall::applyRelocation(TR_RelocationRuntime *reloRunt
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: registered JNI Call redefinition site\n");
 
    reloTarget->storeRelativeAddressSequence((uint8_t *)newAddress, reloLocation, fixedSequence1);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordRamMethodConst::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
@@ -2027,12 +2029,10 @@ TR_RelocationRecordRamMethodConst::applyRelocation(TR_RelocationRuntime *reloRun
    TR_OpaqueMethodBlock *ramMethod = getMethodFromCP(reloRuntime, newConstantPool, cpIndex(reloTarget));
 
    if (!ramMethod)
-      {
-      return compilationAotClassReloFailure;
-      }
+      return TR_RelocationErrorCode::ramMethodConstRelocationFailure;
 
    reloTarget->storeAddressRAM((uint8_t *)ramMethod, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 
@@ -2107,7 +2107,7 @@ TR_RelocationRecordDataAddress::findDataAddress(TR_RelocationRuntime *reloRuntim
    return address;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *newAddress = findDataAddress(reloRuntime, reloTarget);
@@ -2117,7 +2117,7 @@ TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntim
 #endif
 
    if (!newAddress)
-      return compilationAotStaticFieldReloFailure;
+      return TR_RelocationErrorCode::staticFieldValidationFailure;
 
    TR_AOTStats *aotStats = reloRuntime->aotStats();
    if (aotStats)
@@ -2126,18 +2126,18 @@ TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntim
       }
 
    reloTarget->storeAddressSequence(newAddress, reloLocation, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    uint8_t *newAddress = findDataAddress(reloRuntime, reloTarget);
 
    if (!newAddress)
-      return compilationAotStaticFieldReloFailure;
+      return TR_RelocationErrorCode::staticFieldValidationFailure;
    reloTarget->storeAddress(newAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // Class Object Relocations
@@ -2187,7 +2187,7 @@ TR_RelocationRecordClassAddress::computeNewClassAddress(TR_RelocationRuntime *re
    return (TR_OpaqueClassBlock *)resolvedClass;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uintptr_t oldAddress = (uintptr_t) reloTarget->loadAddress(reloLocation);
@@ -2195,7 +2195,7 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
    uintptr_t newConstantPool = computeNewConstantPool(reloRuntime, reloTarget, constantPool(reloTarget));
    TR_OpaqueClassBlock *newAddress = computeNewClassAddress(reloRuntime, newConstantPool, inlinedSiteIndex(reloTarget), cpIndex(reloTarget));
 
-   if (!newAddress) return compilationAotClassReloFailure;
+   if (!newAddress) return TR_RelocationErrorCode::classValidationFailure;
 
    if (TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), newAddress, reloLocation))
       {
@@ -2205,17 +2205,17 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
       }
 
    reloTarget->storeAddressSequence((uint8_t *)newAddress, reloLocation, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    uintptr_t oldValue = (uintptr_t) reloTarget->loadAddress(reloLocationHigh, reloLocationLow);
    uintptr_t newConstantPool = computeNewConstantPool(reloRuntime, reloTarget, oldValue);
    TR_OpaqueClassBlock *newAddress = computeNewClassAddress(reloRuntime, newConstantPool, inlinedSiteIndex(reloTarget), cpIndex(reloTarget));
 
-   if (!newAddress) return compilationAotClassReloFailure;
+   if (!newAddress) return TR_RelocationErrorCode::classValidationFailure;
 
    if (TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), newAddress, reloLocationHigh))
       {
@@ -2226,7 +2226,7 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
       }
 
    reloTarget->storeAddress((uint8_t *) newAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // MethodObject Relocations
@@ -2236,22 +2236,22 @@ TR_RelocationRecordMethodObject::name()
    return "TR_MethodObject";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordMethodObject::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uintptr_t oldAddress = (uintptr_t) reloTarget->loadAddress(reloLocation);
    uintptr_t newAddress = currentConstantPool(reloRuntime, reloTarget, oldAddress);
    reloTarget->storeAddress((uint8_t *) newAddress, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordMethodObject::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    uintptr_t oldAddress = (uintptr_t) reloTarget->loadAddress(reloLocationHigh, reloLocationLow);
    uintptr_t newAddress = currentConstantPool(reloRuntime, reloTarget, oldAddress);
    reloTarget->storeAddress((uint8_t *) newAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_BodyInfoAddress Relocation
@@ -2261,7 +2261,7 @@ TR_RelocationRecordBodyInfo::name()
    return "TR_BodyInfo";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBodyInfo::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    J9JITExceptionTable *exceptionTable = reloRuntime->exceptionTable();
@@ -2271,7 +2271,7 @@ TR_RelocationRecordBodyInfo::applyRelocation(TR_RelocationRuntime *reloRuntime, 
 #else
    fixPersistentMethodInfo((void *)exceptionTable, false);
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_Thunks Relocation
@@ -2281,7 +2281,7 @@ TR_RelocationRecordThunks::name()
    return "TR_Thunks";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordThunks::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *oldAddress = reloTarget->loadAddress(reloLocation);
@@ -2297,7 +2297,7 @@ TR_RelocationRecordThunks::applyRelocation(TR_RelocationRuntime *reloRuntime, TR
 
 // Returns 0 for success, or a TR_CompilationErrorCode value on failure.
 // On success, the address of the J2I thunk is stored into *outThunkAddress.
-static int32_t relocateAndRegisterThunk(
+static TR_RelocationErrorCode relocateAndRegisterThunk(
    TR_RelocationRuntime *reloRuntime,
    TR_RelocationTarget *reloTarget,
    int32_t signatureLength,
@@ -2320,7 +2320,7 @@ static int32_t relocateAndRegisterThunk(
       /* Matching thunk found */
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\t\trelocateAndRegisterThunk: found matching thunk %p\n", existingThunk);
       *outThunkAddress = existingThunk;
-      return 0; // return successful
+      return TR_RelocationErrorCode::relocationOK; // return successful
       }
 
    // search shared cache for thunk, copy it over and create thunk entry
@@ -2378,19 +2378,19 @@ static int32_t relocateAndRegisterThunk(
          {
          codeCache->unreserve(); // cancel the reservation
          // return error
-         return compilationAotCacheFullReloFailure;
+         return TR_RelocationErrorCode::cacheFullRelocationFailure;
          }
       }
    else
       {
       // return error
-      return compilationAotThunkReloFailure;
+      return TR_RelocationErrorCode::thunkRelocationFailure;
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordThunks::relocateAndRegisterThunk(
    TR_RelocationRuntime *reloRuntime,
    TR_RelocationTarget *reloTarget,
@@ -2406,10 +2406,10 @@ TR_RelocationRecordThunks::relocateAndRegisterThunk(
    char *signatureString = (char *) J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature));
 
    void *thunkAddress;
-   int32_t err = ::relocateAndRegisterThunk(
+   TR_RelocationErrorCode err = ::relocateAndRegisterThunk(
       reloRuntime, reloTarget, signatureLength, signatureString, &thunkAddress);
 
-   if (err == 0)
+   if (err == TR_RelocationErrorCode::relocationOK)
       relocateJ2IVirtualThunkPointer(reloTarget, reloLocation, thunkAddress);
 
    return err;
@@ -2486,16 +2486,16 @@ TR_RelocationRecordPicTrampolines::numTrampolines(TR_RelocationTarget *reloTarge
    return reloTarget->loadUnsigned32b((uint8_t *) &(((TR_RelocationRecordPicTrampolineBinaryTemplate *)_record)->_numTrampolines));
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordPicTrampolines::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    if (reloRuntime->codeCache()->reserveSpaceForTrampoline_bridge(numTrampolines(reloTarget)) != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
       {
       RELO_LOG(reloRuntime->reloLogger(), 1,"\t\tapplyRelocation: aborting AOT relocation because pic trampoline was not reserved. Will be retried.\n");
-      return compilationAotPicTrampolineReloFailure;
+      return TR_RelocationErrorCode::picTrampolineRelocationFailure;
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_Trampolines Relocation
@@ -2506,7 +2506,7 @@ TR_RelocationRecordTrampolines::name()
    return "TR_Trampolines";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordTrampolines::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *oldAddress = reloTarget->loadAddress(reloLocation);
@@ -2519,10 +2519,10 @@ TR_RelocationRecordTrampolines::applyRelocation(TR_RelocationRuntime *reloRuntim
    if (reloRuntime->codeCache()->reserveUnresolvedTrampoline((void *)newConstantPool, cpIndex) != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: aborting AOT relocation because trampoline was not reserved. Will be retried.\n");
-      return compilationAotTrampolineReloFailure;
+      return TR_RelocationErrorCode::trampolineRelocationFailure;
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_InlinedAllocation relocation
@@ -2599,7 +2599,7 @@ TR_RelocationRecordInlinedAllocation::verifyClass(TR_RelocationRuntime *reloRunt
    return false;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordInlinedAllocation::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordInlinedAllocationPrivateData *reloPrivateData = &(privateData()->inlinedAllocation);
@@ -2617,7 +2617,7 @@ TR_RelocationRecordInlinedAllocation::applyRelocation(TR_RelocationRuntime *relo
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: inlined alloc looks OK\n");
       }
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_VerifyRefArrayForAlloc Relocation
@@ -2898,7 +2898,7 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
    return inlinedSiteIsValid;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordInlinedMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    reloRuntime->incNumInlinedMethodRelos();
@@ -2912,7 +2912,7 @@ TR_RelocationRecordInlinedMethod::applyRelocation(TR_RelocationRuntime *reloRunt
       if (!reloRuntime->comp()->getOption(TR_UseSymbolValidationManager))
          {
          RELO_LOG(reloRuntime->reloLogger(), 6,"\t\tapplyRelocation: Failing AOT Load\n");
-         return compilationAotClassReloFailure;
+         return TR_RelocationErrorCode::inlinedMethodRelocationFailure;
          }
 
       RELO_LOG(reloRuntime->reloLogger(), 6,"\t\tapplyRelocation: invalidating guard\n");
@@ -2939,7 +2939,7 @@ TR_RelocationRecordInlinedMethod::applyRelocation(TR_RelocationRuntime *reloRunt
          }
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_RelocationRecordNopGuard
@@ -3504,20 +3504,20 @@ TR_RelocationRecordRamMethod::name()
    return "TR_RamMethod";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordRamMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: method pointer %p\n", reloRuntime->exceptionTable()->ramMethod);
    reloTarget->storeAddress((uint8_t *)reloRuntime->exceptionTable()->ramMethod, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordRamMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: method pointer %p\n", reloRuntime->exceptionTable()->ramMethod);
    reloTarget->storeAddress((uint8_t *)reloRuntime->exceptionTable()->ramMethod, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_MethodTracingCheck Relocation
@@ -3552,12 +3552,12 @@ TR_RelocationRecordMethodTracingCheck::preparePrivateData(TR_RelocationRuntime *
    RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: check destination %p\n", reloPrivateData->_destinationAddress);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordMethodTracingCheck::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordMethodTracingCheckPrivateData *reloPrivateData = &(privateData()->methodTracingCheck);
    _patchVirtualGuard(reloLocation, reloPrivateData->_destinationAddress, 1 /* currently assume SMP only */);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 
@@ -3643,7 +3643,7 @@ TR_RelocationRecordValidateClass::validateClass(TR_RelocationRuntime *reloRuntim
    return reloRuntime->fej9()->sharedCache()->classMatchesCachedVersion(clazz, (uintptr_t *) classChain);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    reloRuntime->incNumValidations();
@@ -3653,7 +3653,7 @@ TR_RelocationRecordValidateClass::applyRelocation(TR_RelocationRuntime *reloRunt
    TR_OpaqueClassBlock *definingClass = getClassFromCP(reloRuntime, reloTarget, (void *) cp);
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: definingClass %p\n", definingClass);
 
-   int32_t returnCode = 0;
+   TR_RelocationErrorCode returnCode = TR_RelocationErrorCode::relocationOK;
    bool verified = false;
    if (definingClass)
       {
@@ -3692,10 +3692,10 @@ TR_RelocationRecordValidateClass::getClassFromCP(TR_RelocationRuntime *reloRunti
    return definingClass;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClass::failureCode()
    {
-   return compilationAotClassReloFailure;
+   return TR_RelocationErrorCode::classValidationFailure;
    }
 
 
@@ -3718,10 +3718,10 @@ TR_RelocationRecordValidateInstanceField::getClassFromCP(TR_RelocationRuntime *r
    return definingClass;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateInstanceField::failureCode()
    {
-   return compilationAotValidateFieldFailure;
+   return TR_RelocationErrorCode::instanceFieldValidationFailure;
    }
 
 // TR_VerifyStaticField
@@ -3844,7 +3844,7 @@ TR_RelocationRecordValidateArbitraryClass::preparePrivateData(TR_RelocationRunti
    {
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateArbitraryClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_AOTStats *aotStats = reloRuntime->aotStats();
@@ -3864,16 +3864,16 @@ TR_RelocationRecordValidateArbitraryClass::applyRelocation(TR_RelocationRuntime 
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tpreparePrivateData: clazz %p\n", clazz);
 
       if (clazz)
-         return 0;
+         return TR_RelocationErrorCode::relocationOK;
       }
 
    if (aotStats)
       aotStats->numClassValidationsFailed++;
 
-   return compilationAotClassReloFailure;
+   return TR_RelocationErrorCode::arbitraryClassValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -3882,9 +3882,9 @@ TR_RelocationRecordValidateClassByName::applyRelocation(TR_RelocationRuntime *re
    uintptr_t *classChain = (uintptr_t*)reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassByNameRecord(classID, beholderID, classChain))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classByNameValidationFailure;
    }
 
 void
@@ -3941,7 +3941,7 @@ TR_RelocationRecordValidateClassByName::classChainOffset(TR_RelocationTarget *re
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_classChainOffsetInSCC);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateProfiledClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -3953,9 +3953,9 @@ TR_RelocationRecordValidateProfiledClass::applyRelocation(TR_RelocationRuntime *
    void *classChain = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateProfiledClassRecord(classID, classChainForCL, classChain))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::profiledClassValidationFailure;
    }
 
 void
@@ -4019,7 +4019,7 @@ TR_RelocationRecordValidateProfiledClass::classChainOffsetForClassLoader(TR_Relo
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateProfiledClassBinaryTemplate *)_record)->_classChainOffsetForCLInScc);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4027,9 +4027,9 @@ TR_RelocationRecordValidateClassFromCP::applyRelocation(TR_RelocationRuntime *re
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromCPRecord(classID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classFromCPValidationFailure;
    }
 
 void
@@ -4079,7 +4079,7 @@ TR_RelocationRecordValidateClassFromCP::cpIndex(TR_RelocationTarget *reloTarget)
    return reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateClassFromCPBinaryTemplate *)_record)->_cpIndex);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateDefiningClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4088,9 +4088,9 @@ TR_RelocationRecordValidateDefiningClassFromCP::applyRelocation(TR_RelocationRun
    bool isStatic = this->isStatic(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateDefiningClassFromCPRecord(classID, beholderID, cpIndex, isStatic))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::definingClassFromCPValidationFailure;
    }
 
 void
@@ -4153,7 +4153,7 @@ TR_RelocationRecordValidateDefiningClassFromCP::cpIndex(TR_RelocationTarget *rel
    return reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *)_record)->_cpIndex);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateStaticClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4161,21 +4161,21 @@ TR_RelocationRecordValidateStaticClassFromCP::applyRelocation(TR_RelocationRunti
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticClassFromCPRecord(classID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::staticClassFromCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateArrayClassFromComponentClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t arrayClassID = this->arrayClassID(reloTarget);
    uint16_t componentClassID = this->componentClassID(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateArrayClassFromComponentClassRecord(arrayClassID, componentClassID))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::arrayClassFromComponentClassValidationFailure;
    }
 
 void
@@ -4212,16 +4212,16 @@ TR_RelocationRecordValidateArrayClassFromComponentClass::componentClassID(TR_Rel
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateArrayFromCompBinaryTemplate *)_record)->_componentClassID);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateSuperClassFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t superClassID = this->superClassID(reloTarget);
    uint16_t childClassID = this->childClassID(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateSuperClassFromClassRecord(superClassID, childClassID))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::superClassFromClassValidationFailure;
    }
 
 void
@@ -4258,7 +4258,7 @@ TR_RelocationRecordValidateSuperClassFromClass::childClassID(TR_RelocationTarget
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *)_record)->_childClassID);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassInstanceOfClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classOneID = this->classOneID(reloTarget);
@@ -4268,9 +4268,9 @@ TR_RelocationRecordValidateClassInstanceOfClass::applyRelocation(TR_RelocationRu
    bool isInstanceOf = this->isInstanceOf(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassInstanceOfClassRecord(classOneID, classTwoID, objectTypeIsFixed, castTypeIsFixed, isInstanceOf))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classInstanceOfClassValidationFailure;
    }
 
 void
@@ -4346,7 +4346,7 @@ TR_RelocationRecordValidateClassInstanceOfClass::classTwoID(TR_RelocationTarget 
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_classTwoID);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateSystemClassByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t systemClassID = this->systemClassID(reloTarget);
@@ -4354,9 +4354,9 @@ TR_RelocationRecordValidateSystemClassByName::applyRelocation(TR_RelocationRunti
    uintptr_t *classChain = (uintptr_t*)reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateSystemClassByNameRecord(systemClassID, classChain))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::systemClassByNameValidationFailure;
    }
 
 void
@@ -4400,7 +4400,7 @@ TR_RelocationRecordValidateSystemClassByName::classChainOffset(TR_RelocationTarg
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_classChainOffsetInSCC);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassFromITableIndexCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4408,12 +4408,12 @@ TR_RelocationRecordValidateClassFromITableIndexCP::applyRelocation(TR_Relocation
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromITableIndexCPRecord(classID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classFromITableIndexCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4421,24 +4421,24 @@ TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic::applyRelocation(TR_R
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateDeclaringClassFromFieldOrStaticRecord(classID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::declaringClassFromFieldOrStaticValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateConcreteSubClassFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t superClassID = this->superClassID(reloTarget);
    uint16_t childClassID = this->childClassID(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateConcreteSubClassFromClassRecord(childClassID, superClassID))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::concreteSubclassFromClassValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassChain::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
@@ -4446,9 +4446,9 @@ TR_RelocationRecordValidateClassChain::applyRelocation(TR_RelocationRuntime *rel
    void *classChain = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassChainRecord(classID, classChain))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classChainValidationFailure;
    }
 
 void
@@ -4492,7 +4492,7 @@ TR_RelocationRecordValidateClassChain::classChainOffset(TR_RelocationTarget *rel
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateClassChainBinaryTemplate *)_record)->_classChainOffsetInSCC);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateMethodFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4500,9 +4500,9 @@ TR_RelocationRecordValidateMethodFromClass::applyRelocation(TR_RelocationRuntime
    uint32_t index = this->index(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassRecord(methodID, beholderID, index))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::methodFromClassValidationFailure;
    }
 
 void
@@ -4612,7 +4612,7 @@ TR_RelocationRecordValidateMethodFromCP::cpIndex(TR_RelocationTarget *reloTarget
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromCPBinaryTemplate *)_record)->_cpIndex);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateStaticMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4624,12 +4624,12 @@ TR_RelocationRecordValidateStaticMethodFromCP::applyRelocation(TR_RelocationRunt
       cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::staticMethodFromCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateSpecialMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4641,12 +4641,12 @@ TR_RelocationRecordValidateSpecialMethodFromCP::applyRelocation(TR_RelocationRun
       cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateSpecialMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::specialMethodFromCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateVirtualMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4655,12 +4655,12 @@ TR_RelocationRecordValidateVirtualMethodFromCP::applyRelocation(TR_RelocationRun
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::virtualMethodFromCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateVirtualMethodFromOffset::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4671,9 +4671,9 @@ TR_RelocationRecordValidateVirtualMethodFromOffset::applyRelocation(TR_Relocatio
    bool ignoreRtResolve = (virtualCallOffsetAndIgnoreRtResolve & 1) != 0;
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromOffsetRecord(methodID, definingClassID, beholderID, virtualCallOffset, ignoreRtResolve))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::virtualMethodFromOffsetValidationFailure;
    }
 
 void
@@ -4742,7 +4742,7 @@ TR_RelocationRecordValidateVirtualMethodFromOffset::virtualCallOffsetAndIgnoreRt
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffsetAndIgnoreRtResolve);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4752,9 +4752,9 @@ TR_RelocationRecordValidateInterfaceMethodFromCP::applyRelocation(TR_RelocationR
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateInterfaceMethodFromCPRecord(methodID, definingClassID, beholderID, lookupID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::interfaceMethodFromCPValidationFailure;
    }
 
 
@@ -4831,7 +4831,7 @@ TR_RelocationRecordValidateInterfaceMethodFromCP::cpIndex(TR_RelocationTarget *r
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateImproperInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4840,12 +4840,12 @@ TR_RelocationRecordValidateImproperInterfaceMethodFromCP::applyRelocation(TR_Rel
    int32_t cpIndex = this->cpIndex(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateImproperInterfaceMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::improperInterfaceMethodFromCPValidationFailure;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4857,9 +4857,9 @@ TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationR
    J9ROMMethod *romMethod = reloRuntime->fej9()->sharedCache()->romMethodFromOffsetInSharedCache(romMethodOffset);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, definingClassID, lookupClassID, beholderID, romMethod))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::methodFromClassAndSigValidationFailure;
    }
 
 void
@@ -4942,7 +4942,7 @@ TR_RelocationRecordValidateMethodFromClassAndSig::romMethodOffsetInSCC(TR_Reloca
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_romMethodOffsetInSCC);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateStackWalkerMaySkipFrames::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -4950,9 +4950,9 @@ TR_RelocationRecordValidateStackWalkerMaySkipFrames::applyRelocation(TR_Relocati
    bool skipFrames = this->skipFrames(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateStackWalkerMaySkipFramesRecord(methodID, methodClassID, skipFrames))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::stackWalkerMaySkipFramesValidationFailure;
    }
 
 void
@@ -5002,16 +5002,16 @@ TR_RelocationRecordValidateStackWalkerMaySkipFrames::skipFrames(TR_RelocationTar
    return (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_skipFrames);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateClassInfoIsInitialized::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t classID = this->classID(reloTarget);
    bool wasInitialized = this->isInitialized(reloTarget);
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateClassInfoIsInitializedRecord(classID, wasInitialized))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::classInfoIsInitializedValidationFailure;
    }
 
 void
@@ -5048,7 +5048,7 @@ TR_RelocationRecordValidateClassInfoIsInitialized::isInitialized(TR_RelocationTa
    return (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *)_record)->_isInitialized);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -5064,9 +5064,9 @@ TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRu
                                                                                                     cpIndexOrVftSlot,
                                                                                                     callerMethodID,
                                                                                                     useGetResolvedInterfaceMethod))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::methodFromSingleImplValidationFailure;
    }
 
 void
@@ -5167,7 +5167,7 @@ TR_RelocationRecordValidateMethodFromSingleImpl::useGetResolvedInterfaceMethod(T
    return (TR_YesNoMaybe)reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_useGetResolvedInterfaceMethod);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateMethodFromSingleInterfaceImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -5181,9 +5181,9 @@ TR_RelocationRecordValidateMethodFromSingleInterfaceImpl::applyRelocation(TR_Rel
                                                                                                              thisClassID,
                                                                                                              cpIndex,
                                                                                                              callerMethodID))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::methodFromSingleInterfaceImplValidationFailure;
    }
 
 void
@@ -5260,7 +5260,7 @@ TR_RelocationRecordValidateMethodFromSingleInterfaceImpl::cpIndex(TR_RelocationT
    return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_cpIndex);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateMethodFromSingleAbstractImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = this->methodID(reloTarget);
@@ -5274,9 +5274,9 @@ TR_RelocationRecordValidateMethodFromSingleAbstractImpl::applyRelocation(TR_Relo
                                                                                                             thisClassID,
                                                                                                             vftSlot,
                                                                                                             callerMethodID))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::methodFromSingleAbstractImplValidationFailure;
    }
 
 void
@@ -5411,7 +5411,7 @@ TR_RelocationRecordSymbolFromManager::preparePrivateData(TR_RelocationRuntime *r
    reloPrivateData->_symbolType = symbolType;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordSymbolFromManager::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationSymbolFromManagerPrivateData *reloPrivateData = &(privateData()->symbolFromManager);
@@ -5431,10 +5431,10 @@ TR_RelocationRecordSymbolFromManager::applyRelocation(TR_RelocationRuntime *relo
       }
    else
       {
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::symbolFromManagerRelocationFailure;
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 bool
@@ -5559,7 +5559,7 @@ TR_RelocationRecordResolvedTrampolines::preparePrivateData(TR_RelocationRuntime 
    reloPrivateData->_method = reloRuntime->comp()->getSymbolValidationManager()->getMethodFromID(symbolID);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordResolvedTrampolines::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordResolvedTrampolinesPrivateData *reloPrivateData = &(privateData()->resolvedTrampolines);
@@ -5574,10 +5574,10 @@ TR_RelocationRecordResolvedTrampolines::applyRelocation(TR_RelocationRuntime *re
    if (reloRuntime->codeCache()->reserveResolvedTrampoline(method, true) != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: aborting AOT relocation because trampoline was not reserved. Will be retried.\n");
-      return compilationAotTrampolineReloFailure;
+      return TR_RelocationErrorCode::trampolineRelocationFailure;
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 
@@ -5596,7 +5596,7 @@ TR_RelocationRecordHCR::action(TR_RelocationRuntime *reloRuntime)
    return hcrEnabled ? TR_RelocationRecordAction::apply : TR_RelocationRecordAction::ignore;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordHCR::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    void *methodAddress = (void *)reloRuntime->exceptionTable()->ramMethod;
@@ -5613,7 +5613,7 @@ TR_RelocationRecordHCR::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_Re
       createClassRedefinitionPicSite((void *)-1, (void *)reloLocation, locationSize, true,
                                      getMetadataAssumptionList(reloRuntime->exceptionTable()));
       }
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_Pointer
@@ -5735,14 +5735,14 @@ TR_RelocationRecordPointer::registerHCRAssumption(TR_RelocationRuntime *reloRunt
    reloRuntime->comp()->setHasClassRedefinitionAssumptions();
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordPointer::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordPointerPrivateData *reloPrivateData = &(privateData()->pointer);
    reloTarget->storePointer((uint8_t *)reloPrivateData->_pointer, reloLocation);
    if (reloPrivateData->_activatePointer)
       activatePointer(reloRuntime, reloTarget, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 // TR_ClassPointer
@@ -5775,7 +5775,7 @@ TR_RelocationRecordArbitraryClassAddress::name()
    return "TR_ArbitraryClassAddress";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordArbitraryClassAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordPointerPrivateData *reloPrivateData = &(privateData()->pointer);
@@ -5783,10 +5783,10 @@ TR_RelocationRecordArbitraryClassAddress::applyRelocation(TR_RelocationRuntime *
    assertBootstrapLoader(reloRuntime, clazz);
    reloTarget->storeAddressSequence((uint8_t*)clazz, reloLocation, reloFlags(reloTarget));
    // No need to activatePointer(). See its definition below.
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordArbitraryClassAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR_RelocationRecordPointerPrivateData *reloPrivateData = &(privateData()->pointer);
@@ -5794,7 +5794,7 @@ TR_RelocationRecordArbitraryClassAddress::applyRelocation(TR_RelocationRuntime *
    assertBootstrapLoader(reloRuntime, clazz);
    reloTarget->storeAddress((uint8_t*)clazz, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
    // No need to activatePointer(). See its definition below.
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 void
@@ -5918,7 +5918,7 @@ TR_RelocationRecordInlinedMethodPointer::preparePrivateData(TR_RelocationRuntime
       }
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordInlinedMethodPointer::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordPointerPrivateData *reloPrivateData = &(privateData()->pointer);
@@ -5951,7 +5951,7 @@ TR_RelocationRecordInlinedMethodPointer::applyRelocation(TR_RelocationRuntime *r
                       "Not activating pointer but clazz=%p", reloPrivateData->_clazz);
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 void
@@ -5963,13 +5963,13 @@ TR_RelocationRecordEmitClass::preparePrivateData(TR_RelocationRuntime *reloRunti
    reloPrivateData->_method  = getInlinedSiteMethod(reloRuntime);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordEmitClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordEmitClassPrivateData *reloPrivateData = &(privateData()->emitClass);
 
    reloRuntime->addClazzRecord(reloLocation, reloPrivateData->_bcIndex, reloPrivateData->_method);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 void
@@ -6087,7 +6087,7 @@ TR_RelocationRecordDebugCounter::preparePrivateData(TR_RelocationRuntime *reloRu
    reloPrivateData->_name        =  reloRuntime->fej9()->sharedCache()->getDebugCounterName(offset);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordDebugCounter::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR::DebugCounterBase *counter = findOrCreateCounter(reloRuntime);
@@ -6099,16 +6099,16 @@ TR_RelocationRecordDebugCounter::applyRelocation(TR_RelocationRuntime *reloRunti
        * to have debug counters run, it's probably better to fail the relocation.
        *
        */
-      return -1;
+      return TR_RelocationErrorCode::debugCounterRelocationFailure;
       }
 
    // Update Counter Location
    reloTarget->storeAddressSequence((uint8_t *)counter->getBumpCountAddress(), reloLocation, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordDebugCounter::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
    {
    TR::DebugCounterBase *counter = findOrCreateCounter(reloRuntime);
@@ -6120,13 +6120,13 @@ TR_RelocationRecordDebugCounter::applyRelocation(TR_RelocationRuntime *reloRunti
        * to have debug counters run, it's probably better to fail the relocation.
        *
        */
-      return -1;
+      return TR_RelocationErrorCode::debugCounterRelocationFailure;
       }
 
    // Update Counter Location
    reloTarget->storeAddress((uint8_t *)counter->getBumpCountAddress(), reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 TR::DebugCounterBase *
@@ -6183,11 +6183,11 @@ TR_RelocationRecordClassUnloadAssumption::name()
    return "TR_ClassUnloadAssumption";
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordClassUnloadAssumption::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    reloTarget->addPICtoPatchPtrOnClassUnload((TR_OpaqueClassBlock *) -1, reloLocation);
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 uint8_t *
@@ -6224,7 +6224,8 @@ TR_RelocationRecordMethodCallAddress::setAddress(TR_RelocationTarget *reloTarget
    reloTarget->storeAddress(callTargetAddress, reinterpret_cast<uint8_t *>(&reloData->_methodAddress));
    }
 
-int32_t TR_RelocationRecordMethodCallAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+TR_RelocationErrorCode
+TR_RelocationRecordMethodCallAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint8_t *baseLocation = 0;
    if (eipRelative(reloTarget))
@@ -6244,7 +6245,7 @@ int32_t TR_RelocationRecordMethodCallAddress::applyRelocation(TR_RelocationRunti
    else
       reloTarget->storeAddress(callTargetOffset, reloLocation);
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
 void
@@ -6283,7 +6284,7 @@ TR_RelocationRecordBreakpointGuard::destinationAddress(TR_RelocationTarget *relo
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordBreapointGuardBinaryTemplate *)_record)->_destinationAddress);
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordBreakpointGuard::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    TR_RelocationRecordBreakpointGuardPrivateData *reloPrivateData = &(privateData()->breakpointGuard);
@@ -6300,10 +6301,10 @@ TR_RelocationRecordBreakpointGuard::applyRelocation(TR_RelocationRuntime *reloRu
                 getMetadataAssumptionList(reloRuntime->exceptionTable()));
       }
 
-   return 0;
+   return TR_RelocationErrorCode::relocationOK;
    }
 
-int32_t
+TR_RelocationErrorCode
 TR_RelocationRecordValidateJ2IThunkFromMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t thunkID = this->thunkID(reloTarget);
@@ -6316,16 +6317,16 @@ TR_RelocationRecordValidateJ2IThunkFromMethod::applyRelocation(TR_RelocationRunt
    char *sig = (char*)J9UTF8_DATA(sigUTF8);
 
    void *thunkAddress;
-   int32_t err = ::relocateAndRegisterThunk(
+   TR_RelocationErrorCode err = ::relocateAndRegisterThunk(
       reloRuntime, reloTarget, sigLen, sig, &thunkAddress);
 
-   if (err != 0)
+   if (err != TR_RelocationErrorCode::relocationOK)
       return err;
 
    if (svm->validateJ2IThunkFromMethodRecord(thunkID, thunkAddress))
-      return 0;
+      return TR_RelocationErrorCode::relocationOK;
    else
-      return compilationAotClassReloFailure;
+      return TR_RelocationErrorCode::j2iThunkFromMethodValidationFailure;
    }
 
 void

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -32,8 +32,8 @@
 #include "env/jittypes.h"
 #include "infra/Link.hpp"
 #include "infra/Flags.hpp"
+#include "runtime/RelocationRuntime.hpp"
 
-class TR_RelocationRuntime;
 class TR_RelocationRecord;
 class TR_RelocationTarget;
 struct TR_RelocationRecordBinaryTemplate;
@@ -56,11 +56,14 @@ class TR_RelocationRecordGroup
       TR_RelocationRecordBinaryTemplate *pastLastRecord(TR_RelocationTarget *reloTarget);
       const uintptr_t *wellKnownClassChainOffsets(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      int32_t applyRelocations(TR_RelocationRuntime *reloRuntime,
-                               TR_RelocationTarget *reloTarget,
-                               uint8_t *reloOrigin);
+      TR_RelocationErrorCode applyRelocations(TR_RelocationRuntime *reloRuntime,
+                                              TR_RelocationTarget *reloTarget,
+                                              uint8_t *reloOrigin);
    private:
-      int32_t handleRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_RelocationRecord *reloRecord, uint8_t *reloOrigin);
+      TR_RelocationErrorCode handleRelocation(TR_RelocationRuntime *reloRuntime,
+                                              TR_RelocationTarget *reloTarget,
+                                              TR_RelocationRecord *reloRecord,
+                                              uint8_t *reloOrigin);
 
       TR_RelocationRecordBinaryTemplate *_group;
    };
@@ -232,10 +235,10 @@ class TR_RelocationRecord
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *relocationOrigin);
+      virtual TR_RelocationErrorCode applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *relocationOrigin);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation) {return -1;}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow) {return -1;}
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation) {return TR_RelocationErrorCode::invalidRelocation;}
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow) {return TR_RelocationErrorCode::invalidRelocation;}
 
       TR_RelocationRecordBinaryTemplate *nextBinaryRecord(TR_RelocationTarget *reloTarget);
       TR_RelocationRecordBinaryTemplate *binaryRecord();
@@ -299,7 +302,7 @@ class TR_RelocationRecordBodyInfo : public TR_RelocationRecord
       TR_RelocationRecordBodyInfo(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual char *name();
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordWithOffset : public TR_RelocationRecord
@@ -313,8 +316,8 @@ class TR_RelocationRecordWithOffset : public TR_RelocationRecord
       uintptr_t offset(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordBlockFrequency : public TR_RelocationRecord
@@ -330,8 +333,8 @@ class TR_RelocationRecordBlockFrequency : public TR_RelocationRecord
       uintptr_t frequencyOffset(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordRecompQueuedFlag : public TR_RelocationRecord
@@ -343,8 +346,8 @@ class TR_RelocationRecordRecompQueuedFlag : public TR_RelocationRecord
       virtual char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordGlobalValue : public TR_RelocationRecordWithOffset
@@ -365,8 +368,8 @@ class TR_RelocationRecordBodyInfoLoad : public TR_RelocationRecord
       virtual char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordArrayCopyHelper : public TR_RelocationRecord
@@ -377,8 +380,8 @@ class TR_RelocationRecordArrayCopyHelper : public TR_RelocationRecord
       virtual char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordArrayCopyToc : public TR_RelocationRecordArrayCopyHelper
@@ -412,13 +415,15 @@ class TR_RelocationRecordWithInlinedSiteIndex : public TR_RelocationRecord
       uintptr_t inlinedSiteIndex(TR_RelocationTarget *reloTarget);
 
       // This relocation record is not used directly, only via subclasses
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
          {
-         return 1;
+         TR_ASSERT_FATAL(false, "Should not be called directly\n");
+         return TR_RelocationErrorCode::invalidRelocation;
          }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
          {
-         return 1;
+         TR_ASSERT_FATAL(false, "Should not be called directly\n");
+         return TR_RelocationErrorCode::invalidRelocation;
          }
 
       virtual TR_RelocationRecordAction action(TR_RelocationRuntime *reloRuntime);
@@ -441,8 +446,8 @@ class TR_RelocationRecordConstantPool : public TR_RelocationRecordWithInlinedSit
       void setConstantPool(TR_RelocationTarget *reloTarget, uintptr_t constantPool);
       uintptr_t constantPool(TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
 
    protected:
@@ -481,8 +486,8 @@ class TR_RelocationRecordHelperAddress : public TR_RelocationRecord
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
    };
 
@@ -492,8 +497,8 @@ class TR_RelocationRecordAbsoluteHelperAddress : public TR_RelocationRecordHelpe
       TR_RelocationRecordAbsoluteHelperAddress() {}
       TR_RelocationRecordAbsoluteHelperAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordHelperAddress(reloRuntime, record) {}
       virtual char *name();
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordDataAddress : public TR_RelocationRecordConstantPoolWithIndex
@@ -509,8 +514,8 @@ class TR_RelocationRecordDataAddress : public TR_RelocationRecordConstantPoolWit
 
       uint8_t *findDataAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
    };
 
@@ -522,8 +527,8 @@ class TR_RelocationRecordMethodAddress : public TR_RelocationRecord
       virtual char *name();
       uint8_t *currentMethodAddress(TR_RelocationRuntime *reloRuntime, uint8_t *oldMethodAddress);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordClassAddress : public TR_RelocationRecordConstantPoolWithIndex
@@ -535,8 +540,8 @@ class TR_RelocationRecordClassAddress : public TR_RelocationRecordConstantPoolWi
 
       TR_OpaqueClassBlock *computeNewClassAddress(TR_RelocationRuntime *reloRuntime, uintptr_t newConstantPool, uintptr_t inlinedSiteIndex, uintptr_t cpIndex);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordDirectJNICall : public TR_RelocationRecordConstantPoolWithIndex
@@ -549,7 +554,7 @@ class TR_RelocationRecordDirectJNICall : public TR_RelocationRecordConstantPoolW
    void setOffsetToReloLocation(TR_RelocationTarget *reloTarget, uint8_t offsetToReloLocation);
    uint8_t offsetToReloLocation(TR_RelocationTarget *reloTarget);
 
-   virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    private:
    virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex);
@@ -592,7 +597,7 @@ class TR_RelocationRecordRamMethodConst : public TR_RelocationRecordConstantPool
    TR_RelocationRecordRamMethodConst() {};
    TR_RelocationRecordRamMethodConst(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
    virtual char *name()=0;
-   virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    private:
    virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex)=0;
@@ -648,8 +653,8 @@ class TR_RelocationRecordMethodObject : public TR_RelocationRecordConstantPool
       TR_RelocationRecordMethodObject(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
       virtual char *name();
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordThunks : public TR_RelocationRecordConstantPool
@@ -658,10 +663,10 @@ class TR_RelocationRecordThunks : public TR_RelocationRecordConstantPool
       TR_RelocationRecordThunks() {}
       TR_RelocationRecordThunks(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
       virtual char *name();
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    protected:
-      int32_t relocateAndRegisterThunk(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uintptr_t cp, uintptr_t cpIndex, uint8_t *reloLocation);
+      TR_RelocationErrorCode relocateAndRegisterThunk(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uintptr_t cp, uintptr_t cpIndex, uint8_t *reloLocation);
 
       /** Relocate the J2I virtual thunk pointer, if applicable */
       virtual void relocateJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget, uint8_t *reloLocation, void *thunk)
@@ -694,7 +699,7 @@ class TR_RelocationRecordTrampolines : public TR_RelocationRecordConstantPool
       TR_RelocationRecordTrampolines() {}
       TR_RelocationRecordTrampolines(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
       virtual char *name();
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordPicTrampolines : public TR_RelocationRecord
@@ -708,7 +713,7 @@ class TR_RelocationRecordPicTrampolines : public TR_RelocationRecord
       void setNumTrampolines(TR_RelocationTarget *reloTarget, uint32_t numTrampolines);
       uint32_t numTrampolines(TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordInlinedAllocation : public TR_RelocationRecordConstantPoolWithIndex
@@ -721,7 +726,7 @@ class TR_RelocationRecordInlinedAllocation : public TR_RelocationRecordConstantP
       void setBranchOffset(TR_RelocationTarget *reloTarget, uintptr_t branchOffset);
       uintptr_t branchOffset(TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    protected:
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
@@ -768,7 +773,7 @@ class TR_RelocationRecordInlinedMethod : public TR_RelocationRecordConstantPoolW
       uintptr_t romClassOffsetInSharedCache(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual TR_RelocationRecordAction action(TR_RelocationRuntime *reloRuntime)
          {
@@ -1019,7 +1024,7 @@ class TR_RelocationRecordMethodTracingCheck : public TR_RelocationRecord
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordMethodEnterCheck : public TR_RelocationRecordMethodTracingCheck
@@ -1047,8 +1052,8 @@ class TR_RelocationRecordRamMethod : public TR_RelocationRecord
       TR_RelocationRecordRamMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual char *name();
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
 class TR_RelocationRecordValidateClass : public TR_RelocationRecordConstantPoolWithIndex
@@ -1065,13 +1070,13 @@ class TR_RelocationRecordValidateClass : public TR_RelocationRecordConstantPoolW
                                             TR::AheadOfTimeCompile *aotCompile, const AOTCacheClassChainRecord *classChainRecord);
       uintptr_t classChainOffsetInSharedCache(TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
    protected:
       virtual TR_OpaqueClassBlock *getClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, void *void_cp);
       virtual bool validateClass(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *clazz, void *classChainOrRomClass);
-      virtual int32_t failureCode();
+      virtual TR_RelocationErrorCode failureCode();
    };
 
 class TR_RelocationRecordValidateInstanceField : public TR_RelocationRecordValidateClass
@@ -1083,7 +1088,7 @@ class TR_RelocationRecordValidateInstanceField : public TR_RelocationRecordValid
 
    protected:
       virtual TR_OpaqueClassBlock *getClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, void *void_cp);
-      virtual int32_t failureCode();
+      virtual TR_RelocationErrorCode failureCode();
    };
 
 class TR_RelocationRecordValidateStaticField : public TR_RelocationRecordValidateInstanceField
@@ -1122,7 +1127,7 @@ class TR_RelocationRecordValidateArbitraryClass : public TR_RelocationRecord
       uintptr_t classChainOffsetForClassBeingValidated(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 
@@ -1135,7 +1140,7 @@ class TR_RelocationRecordValidateClassByName : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateClassByName"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1158,7 +1163,7 @@ class TR_RelocationRecordValidateProfiledClass : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateProfiledClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1182,7 +1187,7 @@ class TR_RelocationRecordValidateClassFromCP : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateClassFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1204,7 +1209,7 @@ class TR_RelocationRecordValidateDefiningClassFromCP : public TR_RelocationRecor
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateDefiningClassFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1227,7 +1232,7 @@ class TR_RelocationRecordValidateStaticClassFromCP : public TR_RelocationRecordV
       TR_RelocationRecordValidateStaticClassFromCP() {}
       TR_RelocationRecordValidateStaticClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateStaticClassFromCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateArrayClassFromComponentClass : public TR_RelocationRecord
@@ -1238,7 +1243,7 @@ class TR_RelocationRecordValidateArrayClassFromComponentClass : public TR_Reloca
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateArrayClassFromComponentClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1257,7 +1262,7 @@ class TR_RelocationRecordValidateSuperClassFromClass : public TR_RelocationRecor
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateSuperClassFromClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1276,7 +1281,7 @@ class TR_RelocationRecordValidateClassInstanceOfClass : public TR_RelocationReco
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateClassInstanceOfClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1304,7 +1309,7 @@ class TR_RelocationRecordValidateSystemClassByName : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateSystemClassByName"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1322,7 +1327,7 @@ class TR_RelocationRecordValidateClassFromITableIndexCP : public TR_RelocationRe
       TR_RelocationRecordValidateClassFromITableIndexCP() {}
       TR_RelocationRecordValidateClassFromITableIndexCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateClassFromITableIndexCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic : public TR_RelocationRecordValidateClassFromCP
@@ -1331,7 +1336,7 @@ class TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic : public TR_Rel
       TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic() {}
       TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateConcreteSubClassFromClass : public TR_RelocationRecordValidateSuperClassFromClass
@@ -1341,7 +1346,7 @@ class TR_RelocationRecordValidateConcreteSubClassFromClass : public TR_Relocatio
       TR_RelocationRecordValidateConcreteSubClassFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
          : TR_RelocationRecordValidateSuperClassFromClass(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateConcreteSubClassFromClass"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateClassChain : public TR_RelocationRecord
@@ -1352,7 +1357,7 @@ class TR_RelocationRecordValidateClassChain : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateClassChain"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1372,7 +1377,7 @@ class TR_RelocationRecordValidateMethodFromClass : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateMethodFromClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1415,7 +1420,7 @@ class TR_RelocationRecordValidateStaticMethodFromCP : public TR_RelocationRecord
       TR_RelocationRecordValidateStaticMethodFromCP() {}
       TR_RelocationRecordValidateStaticMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateStaticMethodFromCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateSpecialMethodFromCP : public TR_RelocationRecordValidateMethodFromCP
@@ -1424,7 +1429,7 @@ class TR_RelocationRecordValidateSpecialMethodFromCP : public TR_RelocationRecor
       TR_RelocationRecordValidateSpecialMethodFromCP() {}
       TR_RelocationRecordValidateSpecialMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateSpecialMethodFromCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateVirtualMethodFromCP : public TR_RelocationRecordValidateMethodFromCP
@@ -1433,7 +1438,7 @@ class TR_RelocationRecordValidateVirtualMethodFromCP : public TR_RelocationRecor
       TR_RelocationRecordValidateVirtualMethodFromCP() {}
       TR_RelocationRecordValidateVirtualMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateVirtualMethodFromOffset : public TR_RelocationRecord
@@ -1444,7 +1449,7 @@ class TR_RelocationRecordValidateVirtualMethodFromOffset : public TR_RelocationR
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromOffset"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1469,7 +1474,7 @@ class TR_RelocationRecordValidateInterfaceMethodFromCP : public TR_RelocationRec
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateInterfaceMethodFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1495,7 +1500,7 @@ class TR_RelocationRecordValidateImproperInterfaceMethodFromCP : public TR_Reloc
       TR_RelocationRecordValidateImproperInterfaceMethodFromCP() {}
       TR_RelocationRecordValidateImproperInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordValidateImproperInterfaceMethodFromCP"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordValidateMethodFromClassAndSig : public TR_RelocationRecord
@@ -1506,7 +1511,7 @@ class TR_RelocationRecordValidateMethodFromClassAndSig : public TR_RelocationRec
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateMethodFromClassAndSig"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1535,7 +1540,7 @@ class TR_RelocationRecordValidateStackWalkerMaySkipFrames : public TR_Relocation
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateStackWalkerMaySkipFrames"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1557,7 +1562,7 @@ class TR_RelocationRecordValidateClassInfoIsInitialized : public TR_RelocationRe
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateClassInfoIsInitialized"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1576,7 +1581,7 @@ class TR_RelocationRecordValidateMethodFromSingleImpl : public TR_RelocationReco
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1607,7 +1612,7 @@ class TR_RelocationRecordValidateMethodFromSingleInterfaceImpl : public TR_Reloc
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleInterfaceImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1635,7 +1640,7 @@ class TR_RelocationRecordValidateMethodFromSingleAbstractImpl : public TR_Reloca
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleAbstractImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1662,7 +1667,7 @@ class TR_RelocationRecordSymbolFromManager : public TR_RelocationRecord
       TR_RelocationRecordSymbolFromManager(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordSymbolFromManager"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual void storePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       bool needsUnloadAssumptions(TR::SymbolType symbolType);
@@ -1693,7 +1698,7 @@ class TR_RelocationRecordResolvedTrampolines : public TR_RelocationRecord
       TR_RelocationRecordResolvedTrampolines(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual char *name() { return "TR_RelocationRecordResolvedTrampolines"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1711,7 +1716,7 @@ class TR_RelocationRecordHCR : public TR_RelocationRecordWithOffset
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) { }
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual TR_RelocationRecordAction action(TR_RelocationRuntime *reloRuntime);
    };
@@ -1738,7 +1743,7 @@ class TR_RelocationRecordPointer : public TR_RelocationRecordWithInlinedSiteInde
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    protected:
       virtual uintptr_t computePointer(TR_RelocationTarget *reloTarget, TR_OpaqueClassBlock *classPointer) { return 0;}
       virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1766,8 +1771,8 @@ class TR_RelocationRecordArbitraryClassAddress : public TR_RelocationRecordClass
       TR_RelocationRecordArbitraryClassAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordClassPointer(reloRuntime, record) {}
       virtual char *name();
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
    protected:
       virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1800,7 +1805,7 @@ class TR_RelocationRecordInlinedMethodPointer : public TR_RelocationRecordWithIn
       virtual char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordEmitClass : public TR_RelocationRecordWithInlinedSiteIndex
@@ -1814,7 +1819,7 @@ class TR_RelocationRecordEmitClass : public TR_RelocationRecordWithInlinedSiteIn
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordDebugCounter : public TR_RelocationRecordWithInlinedSiteIndex
@@ -1828,8 +1833,8 @@ class TR_RelocationRecordDebugCounter : public TR_RelocationRecordWithInlinedSit
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
       void setBCIndex(TR_RelocationTarget *reloTarget, int32_t bcIndex);
       int32_t bcIndex(TR_RelocationTarget *reloTarget);
@@ -1858,7 +1863,7 @@ class TR_RelocationRecordClassUnloadAssumption : public TR_RelocationRecord
 
       virtual char *name();
 
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
 class TR_RelocationRecordMethodCallAddress : public TR_RelocationRecord
@@ -1868,7 +1873,7 @@ class TR_RelocationRecordMethodCallAddress : public TR_RelocationRecord
       TR_RelocationRecordMethodCallAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
       virtual char *name() { return "TR_MethodCallAddress"; }
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       uint8_t* address(TR_RelocationTarget *reloTarget);
       void setAddress(TR_RelocationTarget *reloTarget, uint8_t* callTargetAddress);
@@ -1888,7 +1893,7 @@ class TR_RelocationRecordBreakpointGuard : public TR_RelocationRecordWithInlined
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       void setDestinationAddress(TR_RelocationTarget *reloTarget, uintptr_t destinationAddress);
       uintptr_t destinationAddress(TR_RelocationTarget *reloTarget);
@@ -1902,7 +1907,7 @@ class TR_RelocationRecordValidateJ2IThunkFromMethod : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateJ2IThunkFromMethod"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -80,6 +80,73 @@
 
 #include "exceptions/AOTFailure.hpp"
 
+char *TR_RelocationRuntime::_reloErrorCodeNames[] =
+   {
+   "relocationOK",                                     // 0
+
+   "outOfMemory",                                      // 1
+   "reloActionFailCompile",                            // 2
+   "unknownRelocation",                                // 3
+   "unknownReloAction",                                // 4
+   "invalidRelocation",                                // 5
+   "exceptionThrown"                                   // 6
+
+   "methodEnterValidationFailure",                     // 7
+   "methodExitValidationFailure",                      // 8
+   "exceptionHookValidationFailure",                   // 9
+   "stringCompressionValidationFailure",               // 10
+   "tmValidationFailure",                              // 11
+   "osrValidationFailure",                             // 12
+   "instanceFieldValidationFailure",                   // 13
+   "staticFieldValidationFailure",                     // 14
+   "classValidationFailure",                           // 15
+   "arbitraryClassValidationFailure",                  // 16
+   "classByNameValidationFailure",                     // 17
+   "profiledClassValidationFailure",                   // 18
+   "classFromCPValidationFailure",                     // 19
+   "definingClassFromCPValidationFailure",             // 20
+   "staticClassFromCPValidationFailure",               // 21
+   "arrayClassFromComponentClassValidationFailure",    // 22
+   "superClassFromClassValidationFailure",             // 23
+   "classInstanceOfClassValidationFailure",            // 24
+   "systemClassByNameValidationFailure",               // 25
+   "classFromITableIndexCPValidationFailure",          // 26
+   "declaringClassFromFieldOrStaticValidationFailure", // 27
+   "concreteSubclassFromClassValidationFailure",       // 28
+   "classChainValidationFailure",                      // 29
+   "methodFromClassValidationFailure",                 // 30
+   "staticMethodFromCPValidationFailure",              // 31
+   "specialMethodFromCPValidationFailure",             // 32
+   "virtualMethodFromCPValidationFailure",             // 33
+   "virtualMethodFromOffsetValidationFailure",         // 34
+   "interfaceMethodFromCPValidationFailure",           // 35
+   "improperInterfaceMethodFromCPValidationFailure",   // 36
+   "methodFromClassAndSigValidationFailure",           // 37
+   "stackWalkerMaySkipFramesValidationFailure",        // 38
+   "classInfoIsInitializedValidationFailure",          // 39
+   "methodFromSingleImplValidationFailure",            // 40
+   "methodFromSingleInterfaceImplValidationFailure",   // 41
+   "methodFromSingleAbstractImplValidationFailure",    // 42
+   "j2iThunkFromMethodValidationFailure",              // 43
+   "svmValidationFailure",                             // 44
+   "wkcValidationFailure",                             // 45
+
+   "classAddressRelocationFailure",                    // 46
+   "inlinedMethodRelocationFailure",                   // 47
+   "symbolFromManagerRelocationFailure",               // 48
+   "thunkRelocationFailure",                           // 49
+   "trampolineRelocationFailure",                      // 50
+   "picTrampolineRelocationFailure",                   // 51
+   "cacheFullRelocationFailure",                       // 52
+   "blockFrequencyRelocationFailure",                  // 53
+   "recompQueuedFlagRelocationFailure",                // 54
+   "debugCounterRelocationFailure",                    // 55
+   "directJNICallRelocationFailure",                   // 56
+   "ramMethodConstRelocationFailure",                  // 57
+
+   "maxRelocationError"                                // 58
+   };
+
 TR_RelocationRuntime::TR_RelocationRuntime(J9JITConfig *jitCfg)
    {
    _method = NULL;
@@ -182,6 +249,7 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
    _relocationStatus = RelocationNoError;
    _haveReservedCodeCache = false; // MCT
    _returnCode = 0;
+   _reloErrorCode = TR_RelocationErrorCode::relocationOK;
 
    _comp = comp;
    _trMemory = comp->trMemory();

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -121,6 +121,96 @@ typedef struct TR_AOTRuntimeInfo {
 extern J9_CFUNC void
 printAOTHeaderProcessorFeatures(TR_AOTHeader * aotHeaderAddress, char * buff, const size_t BUFF_SIZE);
 
+struct TR_RelocationError
+   {
+   enum TR_RelocationErrorCodeType
+      {
+      NO_RELO_ERROR = 0x0,
+      MISC          = 0x1,
+      VALIDATION    = 0x2,
+      RELOCATION    = 0x4,
+      };
+
+   static const uint8_t RELO_ERRORCODE_SHIFT = 4;
+
+   /**
+    * @brief The relocation error codes. Low tagging allows quick inference of
+    *        the category of an error, and also does not require keeping all the
+    *        error codes belonging to a category together.
+    */
+   enum TR_RelocationErrorCode
+      {
+      relocationOK                                     = (0 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR,
+
+      outOfMemory                                      = (1 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+      reloActionFailCompile                            = (2 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+      unknownRelocation                                = (3 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+      unknownReloAction                                = (4 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+      invalidRelocation                                = (5 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+      exceptionThrown                                  = (6 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::MISC,
+
+      methodEnterValidationFailure                     = (7 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodExitValidationFailure                      = (8 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      exceptionHookValidationFailure                   = (9 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      stringCompressionValidationFailure               = (10 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      tmValidationFailure                              = (11 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      osrValidationFailure                             = (12 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      instanceFieldValidationFailure                   = (13 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      staticFieldValidationFailure                     = (14 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classValidationFailure                           = (15 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      arbitraryClassValidationFailure                  = (16 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classByNameValidationFailure                     = (17 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      profiledClassValidationFailure                   = (18 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classFromCPValidationFailure                     = (19 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      definingClassFromCPValidationFailure             = (20 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      staticClassFromCPValidationFailure               = (21 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      arrayClassFromComponentClassValidationFailure    = (22 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      superClassFromClassValidationFailure             = (23 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classInstanceOfClassValidationFailure            = (24 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      systemClassByNameValidationFailure               = (25 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classFromITableIndexCPValidationFailure          = (26 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      declaringClassFromFieldOrStaticValidationFailure = (27 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      concreteSubclassFromClassValidationFailure       = (28 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classChainValidationFailure                      = (29 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodFromClassValidationFailure                 = (30 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      staticMethodFromCPValidationFailure              = (31 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      specialMethodFromCPValidationFailure             = (32 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      virtualMethodFromCPValidationFailure             = (33 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      virtualMethodFromOffsetValidationFailure         = (34 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      interfaceMethodFromCPValidationFailure           = (35 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      improperInterfaceMethodFromCPValidationFailure   = (36 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodFromClassAndSigValidationFailure           = (37 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      stackWalkerMaySkipFramesValidationFailure        = (38 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      classInfoIsInitializedValidationFailure          = (39 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodFromSingleImplValidationFailure            = (40 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodFromSingleInterfaceImplValidationFailure   = (41 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodFromSingleAbstractImplValidationFailure    = (42 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      j2iThunkFromMethodValidationFailure              = (43 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      svmValidationFailure                             = (44 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      wkcValidationFailure                             = (45 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+
+      classAddressRelocationFailure                    = (46 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      inlinedMethodRelocationFailure                   = (47 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      symbolFromManagerRelocationFailure               = (48 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      thunkRelocationFailure                           = (49 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      trampolineRelocationFailure                      = (50 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      picTrampolineRelocationFailure                   = (51 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      cacheFullRelocationFailure                       = (52 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      blockFrequencyRelocationFailure                  = (53 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      recompQueuedFlagRelocationFailure                = (54 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      debugCounterRelocationFailure                    = (55 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      directJNICallRelocationFailure                   = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      ramMethodConstRelocationFailure                  = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+
+      maxRelocationError                               = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
+      };
+
+   static uint32_t decode(TR_RelocationErrorCode errorCode) { return static_cast<uint32_t>(errorCode >> RELO_ERRORCODE_SHIFT); }
+   };
+
+typedef TR_RelocationError::TR_RelocationErrorCode TR_RelocationErrorCode;
+typedef TR_RelocationError::TR_RelocationErrorCodeType TR_RelocationErrorCodeType;
+
 class TR_RelocationRuntime {
    public:
       TR_ALLOC(TR_Memory::Relocation)
@@ -211,8 +301,6 @@ class TR_RelocationRuntime {
       void initializeHWProfilerRecords(TR::Compilation *comp);
       void addClazzRecord(uint8_t *ia, uint32_t bcIndex, TR_OpaqueMethodBlock *method);
 
-#if 1 // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-      // Detect unexpected scenarios when build has assumes
       void incNumValidations() { _numValidations++; }
       void incNumFailedValidations() { _numFailedValidations++; }
       void incNumInlinedMethodRelos() { _numInlinedMethodRelos++; }
@@ -227,24 +315,17 @@ class TR_RelocationRuntime {
       uint32_t getNumInlinedAllocRelos() { return _numInlinedAllocRelos; }
       uint32_t getNumFailedAllocInlinedRelos() { return _numFailedInlinedAllocRelos; }
 
-#else
-      void incNumValidations() { }
-      void incNumFailedValidations() { }
-      void incNumInlinedMethodRelos() { }
-      void incNumFailedInlinedMethodRelos() { }
-      void incNumInlinedAllocRelos() { }
-      void incNumFailedAllocInlinedRelos() { }
-
-      uint32_t getNumValidations() { return 0; }
-      uint32_t getNumFailedValidations() { return 0; }
-      uint32_t getNumInlinedMethodRelos() { return 0; }
-      uint32_t getNumFailedInlinedMethodRelos() { return 0; }
-      uint32_t getNumInlinedAllocRelos() { return 0; }
-      uint32_t getNumFailedAllocInlinedRelos() { return 0; }
-#endif
 #if defined(J9VM_OPT_JITSERVER)
       virtual J9JITExceptionTable *copyMethodMetaData(J9JITDataCacheHeader *dataCacheHeader);
 #endif /* defined(J9VM_OPT_JITSERVER) */
+
+      const TR_RelocationErrorCode getReloErrorCode()                { return _reloErrorCode; }
+      void setReloErrorCode(TR_RelocationErrorCode errorCode)        { _reloErrorCode = errorCode; }
+      const bool isMiscError(TR_RelocationErrorCode errorCode)       { return (errorCode & TR_RelocationErrorCodeType::MISC); }
+      const bool isValidationError(TR_RelocationErrorCode errorCode) { return (errorCode & TR_RelocationErrorCodeType::VALIDATION); }
+      const bool isRelocationError(TR_RelocationErrorCode errorCode) { return (errorCode & TR_RelocationErrorCodeType::RELOCATION); }
+
+      static char *getReloErrorCodeName(TR_RelocationErrorCode errorCode) { return _reloErrorCodeNames[TR_RelocationError::decode(errorCode)]; }
 
    private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize)                           { return NULL; }
@@ -282,6 +363,8 @@ class TR_RelocationRuntime {
       static uint8_t    _globalValueSizeList[TR_NumGlobalValueItems];
       static char      *_globalValueNames[TR_NumGlobalValueItems];
 
+      TR_RelocationErrorCode _reloErrorCode;
+      static char *_reloErrorCodeNames[];
 
    protected:
 


### PR DESCRIPTION
* Add Relocation Error codes
* Update Relocation Infrastructure to return relocation error codes rather than compilation error codes
* Use generic compilation error code for most relocation failures
* Fix compilation failure verbose log line to print `AOT load` if the failed compile was an AOT load
* Update storing of validation failure SCC hints to capture all validation failures
* Delete unused compilation error codes