### PR TITLE
Re-enables JNI-direct for AOT on Power

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -495,8 +495,6 @@ public:
 
    virtual TR::TreeTop *lowerTree(TR::Compilation *, TR::Node *, TR::TreeTop *);
 
-   virtual bool canRelocateDirectNativeCalls() {return true; }
-
    virtual bool storeOffsetToArgumentsInVirtualIndirectThunks() { return false; }
 
 
@@ -1408,7 +1406,6 @@ public:
    // replacing calls to isAOT
    virtual bool               canUseSymbolValidationManager() { return true; }
    virtual bool               supportsCodeCacheSnippets()                     { return false; }
-   virtual bool               canRelocateDirectNativeCalls()                  { return false; }
    virtual bool               needClassAndMethodPointerRelocations()          { return true; }
    virtual bool               inlinedAllocationsMustBeVerified()              { return true; }
    virtual bool               needRelocationsForHelpers()                     { return true; }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -274,7 +274,6 @@ public:
    // replacing calls to isAOT
    virtual bool       canUseSymbolValidationManager() override                 { return true; }
    virtual bool       supportsCodeCacheSnippets() override                     { return false; }
-   virtual bool       canRelocateDirectNativeCalls() override                  { return false; }
    virtual bool       needClassAndMethodPointerRelocations() override          { return true; }
    virtual bool       inlinedAllocationsMustBeVerified() override              { return true; }
    virtual bool       needRelocationsForHelpers() override                     { return true; }

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -747,7 +747,7 @@ J9::Power::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
    static char * disableDirectNativeCall = feGetEnv("TR_DisableDirectNativeCall");
 
    // Clean-up: the fej9 checking seemed unnecessary
-   if (!isIndirect && callee->isJNI() && fej9->canRelocateDirectNativeCalls() &&
+   if (!isIndirect && callee->isJNI() &&
        (node->isPreparedForDirectJNI() ||
         (disableDirectNativeCall == NULL && callee->getResolvedMethodSymbol()->canDirectNativeCall())))
       return self()->getLinkage(TR_J9JNILinkage);

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -111,6 +111,7 @@ public:
     * \brief Determines whether the code generator supports stack allocations
     */
    bool supportsStackAllocations() { return true; }
+   bool supportsDirectJNICallsForAOT() { return true; }
 
    // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
    bool guaranteesResolvedDirectDispatchForSVM() { return true; }


### PR DESCRIPTION
Overrides the supportsDirectJNICallsForAOT call on P and thus
enabling direct JNI for AOT compiles. Related to PR #14421.

Signed-off-by: Bhavani SN <bhavani.sn@ibm.com>