### PR TITLE
Add support for primitive value type classes to JIT compiler

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -727,10 +727,10 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       if (clazz == NULL)
          return -1;
 
-      // Arrays of value type classes must have all their elements initialized with the
+      // Arrays of primitive value type classes must have all their elements initialized with the
       // default value of the component type.  For now, prevent inline allocation of them.
       //
-      if (areValueTypesEnabled && TR::Compiler->cls.isValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
+      if (areValueTypesEnabled && TR::Compiler->cls.isPrimitiveValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
          {
          return -1;
          }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2067,12 +2067,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, TR::Compiler->cls.superClassesOf(clazz)[index]);
          }
          break;
-      case MessageType::ClassEnv_isClassRefValueType:
+      case MessageType::ClassEnv_isClassRefPrimitiveValueType:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *, int32_t>();
          auto clazz = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);
-         client->write(response, TR::Compiler->cls.isClassRefValueType(comp, clazz, cpIndex));
+         client->write(response, TR::Compiler->cls.isClassRefPrimitiveValueType(comp, clazz, cpIndex));
          }
          break;
       case MessageType::ClassEnv_flattenedArrayElementSize:

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -978,12 +978,12 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
    }
 
 bool
-J9::ClassEnv::isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex)
+J9::ClassEnv::isClassRefPrimitiveValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex)
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITServer::MessageType::ClassEnv_isClassRefValueType, cpContextClass, cpIndex);
+      stream->write(JITServer::MessageType::ClassEnv_isClassRefPrimitiveValueType, cpContextClass, cpIndex);
       return std::get<0>(stream->read<bool>());
       }
    else // non-jitserver
@@ -1009,7 +1009,7 @@ J9::ClassEnv::classNameToSignature(const char *name, int32_t &len, TR::Compilati
       {
       len += 2;
       sig = (char *)comp->trMemory()->allocateMemory(len+1, allocKind);
-      if (clazz && TR::Compiler->om.areValueTypesEnabled() && self()->isValueTypeClass(clazz))
+      if (clazz && TR::Compiler->om.areValueTypesEnabled() && self()->isPrimitiveValueTypeClass(clazz))
          sig[0] = 'Q';
       else
          sig[0] = 'L';

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -141,9 +141,9 @@ public:
     * \brief
     *    Checks whether instances of the specified class can be trivially initialized by
     *    "zeroing" their fields.
-    *    In the case of OpenJ9, this tests whether any field is of a value type that has not been
-    *    "flattened" (that is, had the value type's fields inlined into this class).  Such a value
-    *    type field must be initialized with the default value of the type.
+    *    In the case of OpenJ9, this tests whether any field is of a primitive value type that
+    *    has not been "flattened" (that is, had the value type's fields inlined into this class).
+    *    Such a value type field must be initialized with the default value of the type.
     *
     * \param clazz
     *    The class that is to be checked
@@ -184,7 +184,7 @@ public:
    bool jitFieldsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2, int32_t isStatic);
    /*
     * \brief
-    *    Tells whether a class reference entry in the constant pool represents a value type class.
+    *    Tells whether a class reference entry in the constant pool represents a primitive value type class.
     *
     * \param cpContextClass
     *    The class whose constant pool contains the class reference entry being looked at. In another words,
@@ -196,7 +196,7 @@ public:
     * \note
     *    The class reference entry doesn't need to be resolved because the information is encoded in class name string
     */
-   bool isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex);
+   bool isClassRefPrimitiveValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex);
 
    /** \brief
     *	    Populates a TypeLayout object.

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1188,7 +1188,7 @@ public:
 
    /**
     * \brief Load class flags field of the specified class and test whether the value type
-    *        field is set.
+    *        flag is set.
     * \param j9ClassRefNode A node representing a reference to a \ref J9Class
     * \return \ref TR::Node that evaluates to a non-zero integer if the class is a value type,
     *         or zero if the class is an identity type
@@ -1196,12 +1196,38 @@ public:
    TR::Node * testIsClassValueType(TR::Node *j9ClassRefNode);
 
    /**
+    * \brief Load class flags field of the specified class and test whether the primitive value type
+    *        flag is set.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return \ref TR::Node that evaluates to a non-zero integer if the class is a primitive value type,
+    *         or zero otherwise
+    */
+   TR::Node * testIsClassPrimitiveValueType(TR::Node *j9ClassRefNode);
+
+   /**
+    * \brief Test whether any of the specified flags is set on the array's component class
+    * \param arrayBaseAddressNode A node representing a reference to the array base address
+    * \param ifCmpOp If comparison opCode such as ificmpeq or ificmpne
+    * \param flagsToTest The class field flags that are to be checked
+    * \return \ref TR::Node that compares the masked array component class flags to a zero integer
+    */
+   TR::Node * checkSomeArrayCompClassFlags(TR::Node *arrayBaseAddressNode, TR::ILOpCodes ifCmpOp, uint32_t flagsToTest);
+
+   /**
     * \brief Check whether or not the array component class is value type
     * \param arrayBaseAddressNode A node representing a reference to the array base address
-    * \param ifCmpOp If comparison opCode such as ifcmpeq or ificmpne
+    * \param ifCmpOp If comparison opCode such as ificmpeq or ificmpne
     * \return \ref TR::Node that compares the array component class J9ClassIsValueType flag to a zero integer
     */
    TR::Node * checkArrayCompClassValueType(TR::Node *arrayBaseAddressNode, TR::ILOpCodes ifCmpOp);
+
+   /**
+    * \brief Check whether or not the array component class is a primitive value type
+    * \param arrayBaseAddressNode A node representing a reference to the array base address
+    * \param ifCmpOp If comparison opCode such as ificmpeq or ificmpne
+    * \return \ref TR::Node that compares the array component class J9ClassIsPrimitiveValueType flag to a zero integer
+    */
+   TR::Node * checkArrayCompClassPrimitiveValueType(TR::Node *arrayBaseAddressNode, TR::ILOpCodes ifCmpOp);
 
    virtual J9JITConfig *getJ9JITConfig() { return _jitConfig; }
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -556,9 +556,10 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
       if (currNode->getOpCodeValue() == TR::checkcast
           && currNode->getSecondChild()->getOpCodeValue() == TR::loadaddr
           && currNode->getSecondChild()->getSymbolReference()->isUnresolved()
-          && // check whether the checkcast class is valuetype. Expansion is only needed for checkcast to reference type.
+          && // check whether the checkcast class is primitive valuetype. Expansion is only needed for checkcast to reference type.
             (!TR::Compiler->om.areValueTypesEnabled()
-            || !TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), currNode->getSecondChild()->getSymbolReference()->getCPIndex())))
+            || !TR::Compiler->cls.isClassRefPrimitiveValueType(comp(), method()->classOfMethod(),
+                                        currNode->getSecondChild()->getSymbolReference()->getCPIndex())))
           {
           unresolvedCheckcastTopsNeedingNullGuard.add(currTree);
           }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2394,8 +2394,8 @@ TR_J9ByteCodeIlGenerator::genCheckCast()
  *
  * If the class specified in the bytecode is unresolved, this leaves out the
  * ResolveCHK since it has to be conditional on a non-null object.
- * If the class specified in the bytecode is a value type, it has to be resolved
- * unconditionally, regardless of whether the value is null.
+ * If the class specified in the bytecode is a primitive value type, it has to
+ * be resolved unconditionally, regardless of whether the value is null.
  *
  * @param cpIndex The constant pool entry of the class given in the bytecode
  *
@@ -2405,7 +2405,8 @@ TR_J9ByteCodeIlGenerator::genCheckCast()
 void
 TR_J9ByteCodeIlGenerator::genCheckCast(int32_t cpIndex)
    {
-   if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), cpIndex))
+   if (TR::Compiler->om.areValueTypesEnabled()
+       && TR::Compiler->cls.isClassRefPrimitiveValueType(comp(), method()->classOfMethod(), cpIndex))
       {
       TR::Node * objNode = _stack->top();
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -209,7 +209,7 @@ const char *messageNames[] =
    "ClassEnv_iTableRomClass",
    "ClassEnv_getITable",
    "ClassEnv_enumerateFields",
-   "ClassEnv_isClassRefValueType",
+   "ClassEnv_isClassRefPrimitiveValueType",
    "ClassEnv_flattenedArrayElementSize",
    "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -222,7 +222,7 @@ enum MessageType : uint16_t
    ClassEnv_iTableRomClass,
    ClassEnv_getITable,
    ClassEnv_enumerateFields,
-   ClassEnv_isClassRefValueType,
+   ClassEnv_isClassRefPrimitiveValueType,
    ClassEnv_flattenedArrayElementSize,
 
    // For TR_J9SharedCache

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -1076,7 +1076,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
                traceMsg(comp(), "   Make [%p] non-local because we can't have locking when candidate escapes in cold blocks\n", candidate->_node);
             }
 
-         // Value type fields of objects created with a NEW bytecode must be initialized
+         // Primitive value type fields of objects created with a NEW bytecode must be initialized
          // with their default values.  EA is not yet set up to perform such iniitialization
          // if the value type's own fields have not been inlined into the class that
          // has a field of that type, so remove the candidate from consideration.
@@ -1087,7 +1087,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
             if (!TR::Compiler->cls.isZeroInitializable(clazz))
                {
                if (trace())
-                  traceMsg(comp(), "   Fail [%p] because the candidate is not zero initializable (that is, it has a field of a value type whose fields have not been inlined into this candidate's class)\n", candidate->_node);
+                  traceMsg(comp(), "   Fail [%p] because the candidate is not zero initializable (that is, it has a field of a primitive value type whose fields have not been inlined into this candidate's class)\n", candidate->_node);
                rememoize(candidate);
                _candidates.remove(candidate);
                continue;
@@ -1174,7 +1174,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
          {
          // Array Candidates for contiguous allocation that have unresolved
          // base classes must be rejected, since we cannot initialize the array
-         // header.  If the component type is a value type, reject the array
+         // header.  If the component type is a primitive value type, reject the array
          // as we can't initialize the elements to the default value yet.
          //
          if (candidate->isContiguousAllocation())
@@ -1192,10 +1192,10 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
                {
                TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock*)classNode->getSymbol()->castToStaticSymbol()->getStaticAddress();
 
-               if (TR::Compiler->cls.isValueTypeClass(clazz))
+               if (TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
                   {
                   if (trace())
-                     traceMsg(comp(), "   Fail [%p] because array has value type elements\n", candidate->_node);
+                     traceMsg(comp(), "   Fail [%p] because array has primitive value type elements\n", candidate->_node);
                   rememoize(candidate);
                   _candidates.remove(candidate);
                   }

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -291,7 +291,7 @@ J9::Simplifier::simplifyiCallMethods(TR::Node * node, TR::Block * block)
             && rhs->getConstValue() == 0;
 
          // If either operand is null, no need to use the equality/inequality comparison
-         // helper, as value types cannot have null references.  Also, if both operands
+         // helper, as direct comparison of the two references will suffice.  Also, if both operands
          // are the same node, no need to use the comparison helper - the references must be
          // equal.  Fold both cases to use acmpeq or acmpne which might be further simplified
          //

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -60,14 +60,14 @@ class ValuePropagation : public OMR::ValuePropagation
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
 
    /**
-    * Determine whether the component type of an array is, or might be, a value
+    * Determine whether the component type of an array is, or might be, a primitive value
     * type.
     * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
-    * \returns \c TR_yes if the array's component type is definitely a value type;\n
-    *          \c TR_no if it is definitely not a value type; or\n
+    * \returns \c TR_yes if the array's component type is definitely a primitive value type;\n
+    *          \c TR_no if it is definitely not a primitive value type; or\n
     *          \c TR_maybe otherwise.
     */
-   virtual TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
+   virtual TR_YesNoMaybe isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint);
 
    /**
     * \brief

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -201,7 +201,7 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
             }
          else
             {
-            if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isValueTypeClass(clazz))
+            if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
                sigStr[0] = 'Q';
             else
                sigStr[0] = 'L';

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeArrayTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeArrayTests.java
@@ -1,0 +1,359 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.lworld;
+
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Test array element assignment involving arrays of type {@code Object},
+ * of an interface type, and of value types, with values of those types,
+ * or possibly, a null reference.
+ */
+@Test(groups = { "level.sanity" })
+public class ValueTypeArrayTests {
+	private ValueTypeArrayTests() {}
+
+	/**
+	 * A simple interface class
+	 */
+	interface SomeIface {}
+
+	/**
+	 * A simple value type class
+	 */
+	static value class PointV implements SomeIface {
+		double x;
+		double y;
+
+		PointV(double x, double y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+
+	/**
+	 * A simple primitive value type class
+	 */
+	static primitive class PointPV implements SomeIface {
+		double x;
+		double y;
+
+		PointPV(double x, double y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+
+	/**
+	 * A simple identity class
+	 */
+	static class Bogus implements SomeIface {};
+
+	static Object nullObj = null;
+	static SomeIface bogusIfaceObj = new Bogus();
+	static PointV pointVal = new PointV(1.0, 2.0);
+	static PointPV pointPrimVal = new PointPV(1.0, 2.0);
+
+	static void assign(Object[] arr, int idx, Object value) {
+		arr[idx] = value;
+	}
+
+	static void assign(Object[] arr, int idx, SomeIface value) {
+		arr[idx] = value;
+	}
+
+	static void assign(Object[] arr, int idx, PointV value) {
+		arr[idx] = value;
+	}
+
+	static void assign(Object[] arr, int idx, PointPV value) {
+		arr[idx] = value;
+	}
+
+	static void assign(SomeIface[] arr, int idx, SomeIface value) {
+		arr[idx] = value;
+	}
+
+	static void assign(SomeIface[] arr, int idx, PointV value) {
+		arr[idx] = value;
+	}
+
+	static void assign(SomeIface[] arr, int idx, PointPV value) {
+		arr[idx] = value;
+	}
+
+	static void assign(PointV[] arr, int idx, PointV value) {
+		arr[idx] = value;
+	}
+
+	static void assign(PointPV[] arr, int idx, PointPV value) {
+		arr[idx] = value;
+	}
+
+	static void assignDispatch(Object[] arr, int idx, Object src, int arrKind, int srcKind) {
+		if (arrKind == OBJ_TYPE) {
+			if (srcKind == OBJ_TYPE) {
+				assign(arr, idx, src);
+			} else if (srcKind == IFACE_TYPE) {
+				assign(arr, idx, (SomeIface) src);
+			} else if (srcKind == VAL_TYPE) {
+				assign(arr, idx, (PointV) src);
+			} else if (srcKind == PRIM_TYPE) {
+				assign(arr, idx, (PointPV) src);
+			} else {
+				fail("Unexpected source type requested "+srcKind);
+			}
+		} else if (arrKind == IFACE_TYPE) {
+			if (srcKind == OBJ_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == IFACE_TYPE) {
+				assign((SomeIface[]) arr, idx, (SomeIface) src);
+			} else if (srcKind == VAL_TYPE) {
+				assign((SomeIface[]) arr, idx, (PointV) src);
+			} else if (srcKind == PRIM_TYPE) {
+				assign((SomeIface[]) arr, idx, (PointPV) src);
+			} else {
+				fail("Unexpected source type requested "+srcKind);
+			}
+		} else if (arrKind == VAL_TYPE) {
+			if (srcKind == OBJ_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == IFACE_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == VAL_TYPE) {
+				assign((PointV[]) arr, idx, (PointV) src);
+			} else if (srcKind == PRIM_TYPE) {
+				// Meaningless combination
+			} else {
+				fail("Unexpected source type requested "+srcKind);
+			}
+		} else if (arrKind == PRIM_TYPE) {
+			if (srcKind == OBJ_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == IFACE_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == VAL_TYPE) {
+				// Meaningless combination
+			} else if (srcKind == PRIM_TYPE) {
+				assign((PointPV[])arr, idx, (PointPV) src);
+			} else {
+				fail("Unexpected source type requested "+srcKind);
+			}
+		} else {
+			fail("Unexpected array type requested "+arrKind);
+		}
+	}
+
+	/**
+	 * Represents a null reference.
+	 */
+	static final int NULL_REF = 0;
+
+	/**
+	 * Represents the type <code>Object</code> or <code>Object[]</code>
+	 */
+	static final int OBJ_TYPE = 1;
+
+	/**
+	 * Represents the types <code>SomeIface</code> or <code>SomeIface[]</code>.
+	 * {@link SomeIface} is an interface class defined by this test.
+	 */
+	static final int IFACE_TYPE = 2;
+
+	/**
+	 * Represents the type <code>PointV</code> or <code>PointV[]</code>.
+	 * {@link PointV} is a non-primitive value type class defined by this test.
+	 */
+	static final int VAL_TYPE = 3;
+
+	/**
+	 * Represents the type <code>PointPV</code> or <code>PointPV[]</code>.
+	 * {@link PointPV} is a primitive value type class defined by this test.
+	 */
+	static final int PRIM_TYPE = 4;
+
+	/**
+	 * Convenient constant reference to the <code>ArrayIndexOutOfBoundsException</code> class
+	 */
+	static final Class AIOOBE = ArrayIndexOutOfBoundsException.class;
+
+	/**
+	 * Convenient constant reference to the <code>ArrayStoreException</code> class
+	 */
+	static final Class ASE = ArrayStoreException.class;
+
+	/**
+	 * Convenient constant reference to the <code>NullPointerException</code> class
+	 */
+	static final Class NPE = NullPointerException.class;
+
+	/**
+	 * The expected kind of exception that will be thrown, if any, for an
+	 * assignment to an array whose component type is one of {@link #OBJ_TYPE},
+	 * {@link #IFACE_TYPE}, {@link #VAL_TYPE} or {@link #PRIM_TYPE} with a source
+	 * of one of those same types or {@link #NULL_REF}.
+	 *
+	 * <p><code>expectedAssignmentExceptions[actualArrayKind][actualSourceKind]</code>
+	 */
+	static Class expectedAssignmentExceptions[][] =
+		new Class[][] {
+						null,									// NULL_REF for array is not a possibility
+						new Class[] {null, null, null, null, null}, // All values can be assigned to Object[]
+						new Class[] {null, ASE,  null, null, null}, // ASE for SomeIface[] = Object
+						new Class[] {null, ASE,  ASE,  null, ASE},  // ASE for PointV[] = PointPV, SomeIface
+						new Class[] {NPE,  ASE,  ASE,  ASE,  null}, // NPE for PointPV[] = null; ASE for PointPV[] = PointV
+					};
+
+	/**
+	 * Indicates whether a value or an array with component class
+	 * that is one of {@link #NULL_REF}, {@link #OBJ_TYPE},
+         * {@link #IFACE_TYPE}, {@link #VAL_TYPE} or {@link #PRIM_TYPE} can be
+	 * cast to another member of that same set of types without triggering a
+	 * <code>ClassCastException</code> or <code>NullPointerException</code>
+	 *
+	 * <p><code>permittedCast[actual][static]</code>
+	 */
+	static boolean permittedCast[][] =
+		new boolean[][] {
+						new boolean[] { false, true, true,  true,  false },	// NULL_REF cannot be cast to primitive value
+						new boolean[] { false, true, false, false, false },	// OBJ_TYPE to Object
+						new boolean[] { false, true, true, false,  false },	// IFACE_TYPE to Object, SomeIface
+						new boolean[] { false, true, true, true ,  false },	// VAL_TYPE to Object, SomeIface, PointV
+						new boolean[] { false, true, true, false,  true }	// PRIM_TYPE to Object, SomeIface, PointPV
+					};
+
+	/**
+	 * Dispatch to a particular test method that will test with parameters cast to a specific pair
+	 * of static types.  Those types are specified by the <code>staticArrayKind</code> and
+	 * <code>staticSourceKind</code> parameters, each of which has one of the values
+	 * {@link #OBJ_TYPE}, {@link #IFACE_TYPE}, {@link #VAL_TYPE} or {@link #PRIM_TYPE}.
+	 *
+	 * @param arr Array to which <code>sourceVal</code> will be assigned
+	 * @param sourceVal Value that will be assigned to an element of <code>arr</code>
+	 * @param staticArrayKind A value indicating the static type of array that is to be tested
+	 * @param staticSourceKind A value indicating the static type that is to be tested for the source of the assignmentt
+	 */
+	static void runTest(Object[] arr, Object sourceVal, int staticArrayKind, int staticSourceKind) throws Throwable {
+		boolean caughtThrowable = false;
+		int actualArrayKind = arr instanceof PointPV[]
+								? PRIM_TYPE
+								: arr instanceof PointV[]
+									? VAL_TYPE
+									: arr instanceof SomeIface[]
+										? IFACE_TYPE
+										: OBJ_TYPE;
+		int actualSourceKind = sourceVal == null
+								? NULL_REF
+								: sourceVal instanceof PointPV
+									? PRIM_TYPE
+									: sourceVal instanceof PointV
+										? VAL_TYPE
+										: sourceVal instanceof SomeIface
+											? IFACE_TYPE
+											: OBJ_TYPE;
+
+		// Would a cast from the actual type of array to the specified static array type, or the actual type of the
+		// source value to the specified static type trigger a ClassCastException or NPE?  If so, skip the test.
+		if (!permittedCast[actualArrayKind][staticArrayKind] || !permittedCast[actualSourceKind][staticSourceKind]) {
+			return;
+		}
+
+		Class expectedExceptionClass = expectedAssignmentExceptions[actualArrayKind][actualSourceKind];
+
+		try {
+			assignDispatch(arr, 1, sourceVal, staticArrayKind, staticSourceKind);
+		} catch (Throwable t) {
+			caughtThrowable = true;
+			assertEquals(t.getClass(), expectedExceptionClass, "ActualArrayKind == "+actualArrayKind+"; StaticArrayKind == "
+				+staticArrayKind+"; actualSourceKind == "+actualSourceKind+"; staticSourceKind == "+staticSourceKind);
+		}
+
+		if (expectedExceptionClass != null) {
+			assertTrue(caughtThrowable,
+				"Expected exception kind "+expectedExceptionClass.getName()+" to be thrown.  ActualArrayKind == "+actualArrayKind
+				+"; StaticArrayKind == "+staticArrayKind+"; actualSourceKind == "+actualSourceKind+"; staticSourceKind == "
+				+staticSourceKind);
+		}
+
+		// ArrayIndexOutOfBoundsException must be checked before both
+		// NullPointerException for primitive value type and ArrayStoreException.
+		// This call to assignDispatch will attempt an out-of-bounds element assignment,
+		// and is always expected to throw an ArrayIndexOutOfBoundsException.
+		boolean caughtAIOOBE = false;
+
+		try {
+			assignDispatch(arr, 2, sourceVal, staticArrayKind, staticSourceKind);
+		} catch(ArrayIndexOutOfBoundsException aioobe) {
+			caughtAIOOBE = true;
+		} catch (Throwable t) {
+			assertTrue(false, "Expected ArrayIndexOutOfBoundsException, but saw "+t.getClass().getName());
+		}
+
+		assertTrue(caughtAIOOBE, "Expected ArrayIndexOutOfBoundsException");
+	}
+
+	/**
+	 * Test various types of arrays and source values along with various statically declared types
+	 * for the arrays and source values to ensure required <code>ArrayStoreExceptions</code>,
+	 * <code>ArrayIndexOutOfBoundsExceptions</code> and <code>NullPointerExceptions</code> are
+	 * detected.
+	 * @throws java.lang.Throwable if the attempted array element assignment throws an exception
+	 */
+	@Test(priority=1,invocationCount=2)
+	static public void testValueTypeArrayAssignments() throws Throwable {
+		Object[][] testArrays = new Object[][] {new Object[2], new SomeIface[2], new PointV[2], new PointPV[2]};
+		int[] kinds = {OBJ_TYPE, IFACE_TYPE, VAL_TYPE, PRIM_TYPE};
+		Object[] vals = new Object[] {null, bogusIfaceObj, new PointV(1.0, 2.0), new PointPV(3.0, 4.0)};
+
+		for (int i = 0; i < testArrays.length; i++) {
+			Object[] testArray = testArrays[i];
+
+			for (int j = 0; j < kinds.length; j++) {
+				int staticArrayKind = kinds[j];
+
+				for (int k = 0; k < kinds.length; k++) {
+					int staticValueKind = kinds[k];
+					// runTest's parameters are of type Object[] and Object.  It ultimately dispatches to an assign
+					// method whose parameters have more specific static types.  This condition filters out the
+					// combinations of static types that aren't permitted from the point of view of the Java language.
+					//
+					// Cases:
+					//  - the two types are the same  (staticArrayKind == staticValueKind)
+					//  OR
+					//    - the type of the array is Object[] or SomeIface[]  (staticArrayKind < VAL_TYPE)
+					//      AND
+					//    - the type of the array is less specific than that of the source (staticArrayKind < staticValueKind)
+					//
+					if (staticArrayKind == staticValueKind
+						 || (staticArrayKind < staticValueKind && staticArrayKind < VAL_TYPE)) {
+						runTest(testArrays[i], nullObj, staticArrayKind, staticValueKind);
+						runTest(testArrays[i], bogusIfaceObj, staticArrayKind, staticValueKind);
+						runTest(testArrays[i], pointVal, staticArrayKind, staticValueKind);
+						runTest(testArrays[i], pointPrimVal, staticArrayKind, staticValueKind);
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017, 2021 IBM Corp. and others
+  Copyright (c) 2017, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,11 +28,13 @@
 	<test name="ValueTypeTests">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeTests"/>
+			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
 		</classes>
 	</test>
 	<test name="ValueTypeTestsJIT">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeTests"/>
+			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
 		</classes>
 	</test>
 	<test name="ValueTypeUnsafeTests">


### PR DESCRIPTION
Pull request #14763 added support to the JVM and GC for the distinction between primitive value type classes and non-primitive value type classes.  This pull request adds support to the JIT for this distinction.  In particular, only primitive value type classes can be flattened in OpenJ9, and non-primitive value types permit null references.  The 'Q' descriptor is only used with primitive value type classes.

This pull request also adds some tests to exercise the various combinations of assignments to array elements, where the static type might be used to refer to an array whose component type might be a value type or a primitive value type class.