### PR TITLE
Fix behiavor of DREM bytecode with denormals

### DIFF
--- a/runtime/util/fltrem.c
+++ b/runtime/util/fltrem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,19 +71,6 @@ helperCDoubleRemainderDouble(jdouble a, jdouble b)
 	if (IS_ZERO_DBL(a)) {
 		return a;
 		
-	}
-
-	/* 
-	 * If the divisor is denormal, then the result equals zero  
-	 * with the same sign as the dividend. 
-	 */
-	if( IS_DENORMAL_DBL(b) ) {
-		if( IS_POSITIVE_DBL_PTR(&a) ) {
-			SETP_DP_PZERO(&result);
-		} else {
-			SETP_DP_NZERO(&result);
-		}
-		return result;            
 	}
 
 	/* In the remaining cases, (JVM spec page 193).... 


### PR DESCRIPTION
DREM should not return 0 just because the divisor is denormal.
Fixes #14874

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>