### PR TITLE
(0.32.0) Disable StringLatin1.inflate on x86.

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,11 @@ J9::X86::CodeGenerator::initialize()
    if (!TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsReferenceArrayCopy();
-      cg->setSupportsInlineStringLatin1Inflate();
+      static char *enableSL1Inflate = feGetEnv("TR_enableStringLatin1InflateInlining");
+      if (enableSL1Inflate)
+         {
+         cg->setSupportsInlineStringLatin1Inflate();
+         }
       }
 
    if (comp->requiresSpineChecks())


### PR DESCRIPTION
Due to Issue #14654 it is now disabled and can be
enabled with the environment variable
TR_enableStringLatin1InflateInlining