### PR TITLE
Adopt java.util.HashMap.newHashMap(numMappings)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -3686,8 +3686,14 @@ Map<String, T> enumConstantDirectory() {
 			/*[MSG "K0564", "{0} is not an Enum"]*/			
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0564", getName())); //$NON-NLS-1$
 		}
-		map = new HashMap<>(enums.length * 4 / 3);
-		for (int i = 0; i < enums.length; i++) {
+		int enumsLength = enums.length;
+		/*[IF JAVA_SPEC_VERSION >= 19]
+		map = HashMap.newHashMap(enumsLength);
+		/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+		// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+		map = new HashMap<>(enumsLength * 4 / 3);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+		for (int i = 0; i < enumsLength; i++) {
 			map.put(((Enum<?>) enums[i]).name(), enums[i]);
 		}
 		

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package java.lang;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -1381,7 +1382,13 @@ public static Map<Thread, StackTraceElement[]> getAllStackTraces() {
 	int count = systemThreadGroup.activeCount() + 20;
 	Thread[] threads = new Thread[count];
 	count = systemThreadGroup.enumerate(threads);
-	Map<Thread, StackTraceElement[]> result = new java.util.HashMap<>(count);
+	/*[IF JAVA_SPEC_VERSION >= 19]
+	Map<Thread, StackTraceElement[]> result = HashMap.newHashMap(count);
+	/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+	// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+	Map<Thread, StackTraceElement[]> result = new HashMap<>(count * 4 / 3);
+	/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+
 	for (int i = 0; i < count; i++) {
 		result.put(threads[i], threads[i].getStackTrace());
 	}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ComponentBuilder.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ComponentBuilder.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION > 8]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,7 +101,12 @@ public final class ComponentBuilder<T extends PlatformManagedObject> {
 			super(objectNameBase.concat(",name=*"), interfaceTypes); //$NON-NLS-1$
 
 			int beanCount = implementations.size();
-			Map<String, Object> beanMap = new HashMap<>(beanCount);
+			/*[IF JAVA_SPEC_VERSION >= 19]
+			Map<String, Object> beanMap = HashMap.newHashMap(beanCount);
+			/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+			// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+			Map<String, Object> beanMap = new HashMap<>(beanCount * 4 / 3);
+			/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 			String namePrefix = objectNameBase.concat(",name="); //$NON-NLS-1$
 
 			for (int i = 0; i < beanCount; ++i) {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2021 IBM Corp. and others
+ * Copyright (c) 2008, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,7 +242,12 @@ public final class ManagementUtils {
 
 		@SuppressWarnings("unchecked")
 		Collection<CompositeData> rows = (Collection<CompositeData>) data.values();
-		Map<Object, Object> result = new HashMap<>(rows.size());
+		/*[IF JAVA_SPEC_VERSION >= 19]
+		Map<Object, Object> result = HashMap.newHashMap(rows.size());
+		/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+		// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+		Map<Object, Object> result = new HashMap<>(rows.size() * 4 / 3);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
 		for (CompositeData rowCD : rows) {
 			result.put(rowCD.get(keys[0]), rowCD.get(keys[1]));
@@ -596,7 +601,7 @@ public final class ManagementUtils {
 	 */
 	public static final String BUFFERPOOL_MXBEAN_DOMAIN_TYPE = "java.nio:type=BufferPool"; //$NON-NLS-1$
 
-	/*[IF !Sidecar19-SE]*/
+	/*[IF JAVA_SPEC_VERSION == 8]*/
 
 	/**
 	 * @param mxbeanName
@@ -892,7 +897,8 @@ public final class ManagementUtils {
 			checkNames(beans, pattern);
 			/*[ENDIF]*/
 
-			this.beansByName = new HashMap<>(beans.size());
+			// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+			this.beansByName = new HashMap<>(beans.size() * 4 / 3);
 			this.interfaceTypes = new HashSet<>();
 			this.isSingleton = true;
 
@@ -1023,6 +1029,6 @@ public final class ManagementUtils {
 
 	}
 
-	/*[ENDIF] !Sidecar19-SE*/
+	/*[ENDIF] JAVA_SPEC_VERSION == 8 */
 
 }

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,8 +87,15 @@ public final class ExtendedGarbageCollectorMXBeanImpl
 		for (MemoryPoolMXBean bean : memoryPoolList) {
 			poolNames[idx++] = bean.getName();
 		}
-		Map<String, MemoryUsage> usageBeforeGc = new HashMap<>(poolNames.length);
-		Map<String, MemoryUsage> usageAfterGc = new HashMap<>(poolNames.length);
+		int poolNamesLength = poolNames.length;
+		/*[IF JAVA_SPEC_VERSION >= 19]
+		Map<String, MemoryUsage> usageBeforeGc = HashMap.newHashMap(poolNamesLength);
+		Map<String, MemoryUsage> usageAfterGc = HashMap.newHashMap(poolNamesLength);
+		/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+		// HashMap.DEFAULT_LOAD_FACTOR is 0.75
+		Map<String, MemoryUsage> usageBeforeGc = new HashMap<>(poolNamesLength * 4 / 3);
+		Map<String, MemoryUsage> usageAfterGc = new HashMap<>(poolNamesLength * 4 / 3);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 		for (int count = 0; count < poolNames.length; ++count) {
 			usageBeforeGc.put(poolNames[count], new MemoryUsage(initialSize[count], preUsed[count], preCommitted[count], preMax[count]));
 			usageAfterGc.put(poolNames[count], new MemoryUsage(initialSize[count], postUsed[count], postCommitted[count], postMax[count]));


### PR DESCRIPTION
Reference - https://bugs.openjdk.java.net/browse/JDK-8186958
_JDK contains number of usages of HashMap, which are created with non-optimal initial capacity.
It seems that people normally assume that the constructor HashMap(int) requires the expected size as the argument.
In fact, the argument is the initial capacity, which should be bigger than the expected size. As a result, unnecessary reallocations can occur while the maps are filled._

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/426 w/ https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/426/commits/dca73daef2bdcee73cd491532337e0c93929e03b

Signed-off-by: Jason Feng <fengj@ca.ibm.com>