### PR TITLE
Remove unused J9VMThread fields

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4963,8 +4963,6 @@ typedef struct J9VMThread {
 	U_32 osrFrameIndex;
 	void* codertTOC;
 	U_8* cardTableVirtualStart;
-	j9object_t allocateObjectSavePrivate1; /* deprecated -- use OMRVMThread::savedObject1 */
-	j9object_t allocateObjectSavePrivate2; /* deprecated -- use OMRVMThread::savedObject2 */
 	j9object_t stopThrowable;
 	j9object_t outOfMemoryError;
 	UDATA* jniCurrentReference;


### PR DESCRIPTION
Fields moved to OMR some time ago and the J9 ones are completely
unreferenced.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>