### PR TITLE
Reduce unnecessary TLS usage in JITServer code

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1181,7 +1181,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
 #if defined(J9VM_OPT_JITSERVER)
             // This is currently the only place where this flag gets cleared. For JITServer, we should propagate it to the client,
             // to avoid having to call scanForNativeMethodsUntilMonitorNode again.
-            if (auto stream = TR::CompilationInfo::getStream())
+            if (auto stream = self()->comp()->getStream())
                {
                stream->write(JITServer::MessageType::CHTable_clearReservable, classPointer);
                stream->read<JITServer::Void>();

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -208,14 +208,14 @@ J9::Compilation::Compilation(int32_t id,
    _osrProhibitedOverRangeOfTrees(false),
    _wasFearPointAnalysisDone(false)
    {
-   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
+   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee, self());
 
    _aotClassClassPointer = NULL;
    _aotClassClassPointerInitialized = false;
 
-   _aotGuardPatchSites = new (m->trHeapMemory()) TR::list<TR_AOTGuardSite*>(getTypedAllocator<TR_AOTGuardSite*>(self()->allocator()));
+   _aotGuardPatchSites = new (m->trHeapMemory()) TR::list<TR_AOTGuardSite *>(getTypedAllocator<TR_AOTGuardSite *>(self()->allocator()));
 
-   _aotClassInfo = new (m->trHeapMemory()) TR::list<TR::AOTClassInfo*>(getTypedAllocator<TR::AOTClassInfo*>(self()->allocator()));
+   _aotClassInfo = new (m->trHeapMemory()) TR::list<TR::AOTClassInfo *>(getTypedAllocator<TR::AOTClassInfo *>(self()->allocator()));
 
    if (_updateCompYieldStats)
       _hiresTimeForPreviousCallingContext = TR::Compiler->vm.getHighResClock(self());

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3706,13 +3706,14 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
             // Intersect classesThatShouldNotBeNewlyExtended with newlyExtendedClasses
             // and abort on overlap
             auto newlyExtendedClasses = compInfo->getNewlyExtendedClasses();
-            for (TR_OpaqueClassBlock* clazz : classesThatShouldNotBeNewlyExtended)
+            for (TR_OpaqueClassBlock *clazz : classesThatShouldNotBeNewlyExtended)
                {
                auto it = newlyExtendedClasses->find(clazz);
-               if (it != newlyExtendedClasses->end() && (it->second & (1 << TR::compInfoPT->getCompThreadId())))
+               if (it != newlyExtendedClasses->end() && (it->second & (1 << compInfoPT->getCompThreadId())))
                   {
                   if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
-                     TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Class that should not be newly extended was extended when compiling %s", compiler->signature());
+                     TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Class that should not be newly extended was extended when compiling %s",
+                                                    compiler->signature());
                   compiler->failCompilation<J9::CHTableCommitFailure>("Class that should not be newly extended was extended");
                   }
                }

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -961,7 +961,7 @@ J9::ClassEnv::isZeroInitializable(TR_OpaqueClassBlock *clazz)
    }
 
 bool
-J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses)
+J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo> *subClasses)
    {
    int count = 0;
 #if defined(J9VM_OPT_JITSERVER)
@@ -971,7 +971,7 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
       TR_ScratchList<TR_PersistentClassInfo> subClassesNotCached(comp->trMemory());
 
       // Process classes cached at the server first
-      ClientSessionData * clientData = TR::compInfoPT->getClientData();
+      ClientSessionData *clientData = comp->getClientData();
       for (TR_PersistentClassInfo *ptClassInfo = j.getFirst(); ptClassInfo; ptClassInfo = j.getNext())
          {
          TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
@@ -1056,14 +1056,15 @@ J9::ClassEnv::flattenedArrayElementSize(TR::Compilation *comp, TR_OpaqueClassBlo
    if (auto stream = comp->getStream())
       {
       int32_t arrayElementSize = 0;
-      JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, TR::compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_ARRAY_ELEMENT_SIZE, (void *)&arrayElementSize);
+      JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, comp->getClientData(), stream,
+                                                JITServerHelpers::CLASSINFO_ARRAY_ELEMENT_SIZE, &arrayElementSize);
       return arrayElementSize;
       }
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
       J9JavaVM *vm = comp->fej9()->getJ9JITConfig()->javaVM;
-      return vm->internalVMFunctions->arrayElementSize((J9ArrayClass*)self()->convertClassOffsetToClassPtr(arrayClass));
+      return vm->internalVMFunctions->arrayElementSize((J9ArrayClass *)self()->convertClassOffsetToClassPtr(arrayClass));
       }
    }
 

--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -74,7 +74,7 @@ J9::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer)
    if (self()->comp()->isOutOfProcessCompilation())
       {
       TR_ASSERT_FATAL(false, "It is not safe to call getOrCreateIndex() at the server. The object pointer could have become stale at the client.");
-      auto stream = TR::CompilationInfo::getStream();
+      auto stream = self()->comp()->getStream();
       stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndex, objectPointer);
       auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
 
@@ -133,7 +133,7 @@ J9::KnownObjectTable::getOrCreateIndexAt(uintptr_t *objectReferenceLocation)
 #if defined(J9VM_OPT_JITSERVER)
    if (self()->comp()->isOutOfProcessCompilation())
       {
-      auto stream = TR::CompilationInfo::getStream();
+      auto stream = self()->comp()->getStream() ? self()->comp()->getStream() : TR::CompilationInfo::getStream();
       stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndexAt, objectReferenceLocation);
       auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
 
@@ -169,7 +169,7 @@ J9::KnownObjectTable::getExistingIndexAt(uintptr_t *objectReferenceLocation)
 #if defined(J9VM_OPT_JITSERVER)
    if (self()->comp()->isOutOfProcessCompilation())
       {
-      auto stream = TR::CompilationInfo::getStream();
+      auto stream = self()->comp()->getStream() ? self()->comp()->getStream() : TR::CompilationInfo::getStream();
       stream->write(JITServer::MessageType::KnownObjectTable_getExistingIndexAt, objectReferenceLocation);
       result = std::get<0>(stream->read<TR::KnownObjectTable::Index>());
       }
@@ -205,7 +205,7 @@ J9::KnownObjectTable::getPointer(Index index)
       if (self()->comp()->isOutOfProcessCompilation())
          {
          TR_ASSERT_FATAL(false, "It is not safe to call getPointer() at the server. The object pointer could have become stale at the client.");
-         auto stream = TR::CompilationInfo::getStream();
+         auto stream = self()->comp()->getStream();
          stream->write(JITServer::MessageType::KnownObjectTable_getPointer, index);
          return std::get<0>(stream->read<uintptr_t>());
          }
@@ -391,7 +391,7 @@ J9::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
 #if defined(J9VM_OPT_JITSERVER)
    if (comp->isOutOfProcessCompilation())
       {
-      auto stream = TR::CompilationInfo::getStream();
+      auto stream = comp->getStream();
       stream->write(JITServer::MessageType::KnownObjectTable_getKnownObjectTableDumpInfo, JITServer::Void());
 
       auto recv = stream->read<std::vector<TR_KnownObjectTableDumpInfo>>();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7851,7 +7851,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
             if (comp()->isOutOfProcessCompilation())
                {
-               auto stream = TR::CompilationInfo::getStream();
+               auto stream = comp()->getStream();
                stream->write(JITServer::MessageType::runFEMacro_invokeCollectHandleAllocateArray,
                              methodHandleNode->getSymbolReference()->getKnownObjectIndex());
                auto recv = stream->read<int32_t, int32_t, TR_OpaqueClassBlock *>();
@@ -7914,7 +7914,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeCollectHandleNumArgsToCollect,
                           thunkDetails->getHandleRef(), getCollectPosition);
             auto recv = stream->read<int32_t, int32_t, int32_t>();
@@ -7974,7 +7974,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeExplicitCastHandleConvertArgs, thunkDetails->getHandleRef());
             auto recv = stream->read<std::string>();
             auto &methodDescriptorString = std::get<0>(recv);
@@ -8082,9 +8082,9 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
                if (comp()->isOutOfProcessCompilation())
                   {
-                  auto stream = TR::CompilationInfo::getStream();
+                  auto stream = comp()->getStream();
                   stream->write(JITServer::MessageType::runFEMacro_targetTypeL, thunkDetails->getHandleRef(), argIndex);
-                  auto recv = stream->read<TR_OpaqueClassBlock*, TR_OpaqueClassBlock *>();
+                  auto recv = stream->read<TR_OpaqueClassBlock *, TR_OpaqueClassBlock *>();
                   sourceParmClass = std::get<0>(recv);
                   targetParmClass = std::get<1>(recv);
                   }
@@ -8177,7 +8177,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                {
                packReferenceChainOffsets(methodHandleExpression, listOfOffsets);
                }
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosInvokeExactAndFixup, thunkDetails->getHandleRef(), listOfOffsets);
             auto recv = stream->read<std::string>();
             auto &methodDescriptorString = std::get<0>(recv);
@@ -8287,7 +8287,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeArgumentMoverHandlePermuteArgs, thunkDetails->getHandleRef());
             auto recv = stream->read<std::string>();
             auto &methodDescString = std::get<0>(recv);
@@ -8339,7 +8339,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokePermuteHandlePermuteArgs, thunkDetails->getHandleRef());
 
             // Do the client-side operations
@@ -8533,7 +8533,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeGuardWithTestHandleNumGuardArgs, thunkDetails->getHandleRef());
             numGuardArgs = std::get<0>(stream->read<int32_t>());
             }
@@ -8569,7 +8569,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeInsertHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             insertionIndex = std::get<0>(recv);
@@ -8738,7 +8738,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeSpreadHandleArrayArg, thunkDetails->getHandleRef());
             auto recv = stream->read<J9ArrayClass *, int32_t, uintptr_t, J9Class *, std::string, bool>();
             arrayJ9Class = std::get<0>(recv);
@@ -8841,9 +8841,10 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
-            bool getSpreadPos = symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_SpreadHandle_spreadStart ||
-               symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_SpreadHandle_numArgsAfterSpreadArray;
+            auto stream = comp()->getStream();
+            auto recognizedMethod = symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
+            bool getSpreadPos = (recognizedMethod == TR::java_lang_invoke_SpreadHandle_spreadStart) ||
+                                (recognizedMethod == TR::java_lang_invoke_SpreadHandle_numArgsAfterSpreadArray);
             stream->write(JITServer::MessageType::runFEMacro_invokeSpreadHandle, thunkDetails->getHandleRef(), getSpreadPos);
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             numArguments = std::get<0>(recv);
@@ -8898,7 +8899,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFoldHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<std::vector<int32_t>, int32_t, int32_t>();
 
@@ -8977,7 +8978,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices, thunkDetails->getHandleRef());
 
             auto recv = stream->read<int32_t, std::vector<int32_t>>();
@@ -9019,7 +9020,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFoldHandle2, thunkDetails->getHandleRef());
             foldPosition = std::get<0>(stream->read<int32_t>());
             }
@@ -9048,7 +9049,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition, thunkDetails->getHandleRef());
             filterPosition = std::get<0>(stream->read<int32_t>());
             }
@@ -9111,7 +9112,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFinallyHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, std::string>();
             numArgsPassToFinallyTarget = std::get<0>(recv);
@@ -9162,7 +9163,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, int32_t>();
             numArguments = std::get<0>(recv);
@@ -9201,7 +9202,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsHandle2, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             numArguments = std::get<0>(recv);
@@ -9260,7 +9261,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsHandle, thunkDetails->getHandleRef(), knotEnabled);
             auto recv = stream->read<int32_t, std::string, std::vector<uint8_t>, std::vector<TR::KnownObjectTable::Index>, std::vector<uintptr_t *>>();
             startPos = std::get<0>(recv);
@@ -9415,7 +9416,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::runFEMacro_invokeCatchHandle, thunkDetails->getHandleRef());
             numCatchArguments = std::get<0>(stream->read<int32_t>());
             }
@@ -9446,7 +9447,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             std::vector<uintptr_t> listOfOffsets;
             packReferenceChainOffsets(pop(), listOfOffsets);
             stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosParameterCount, thunkDetails->getHandleRef(), listOfOffsets);
@@ -9479,7 +9480,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             std::vector<uintptr_t> listOfOffsets;
             packReferenceChainOffsets(pop(), listOfOffsets);
             stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosArrayLength, thunkDetails->getHandleRef(), listOfOffsets);
@@ -9516,7 +9517,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             std::vector<uintptr_t> listOfOffsets;
             packReferenceChainOffsets(baseObjectNode, listOfOffsets);
             TR_ASSERT(fieldSym->getDataType() == TR::Int32, "ILGenMacros.getField expecting int field; found load of %s", comp()->getDebug()->getName(symRef));

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -373,14 +373,14 @@ InterpreterEmulator::maintainStackForGetField()
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
             {
-            TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod*>(_calltarget->_calleeMethod);
+            TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod *>(_calltarget->_calleeMethod);
             TR_ResolvedMethod *clientMethod = serverMethod->getRemoteMirror();
 
-            auto stream = TR::CompilationInfo::getStream();
+            auto stream = comp()->getStream();
             stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField,
-                  baseObjectIndex, clientMethod, cpIndex);
+                          baseObjectIndex, clientMethod, cpIndex);
 
-            auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*, uintptr_t, uintptr_t, bool>();
+            auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *, uintptr_t, uintptr_t, bool>();
             resultIndex = std::get<0>(recv);
             uintptr_t *objectPointerReference = std::get<1>(recv);
             fieldAddress = std::get<2>(recv);
@@ -1016,10 +1016,10 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
    #if defined(J9VM_OPT_JITSERVER)
             if (comp()->isOutOfProcessCompilation())
                {
-               auto stream = TR::CompilationInfo::getStream();
+               auto stream = comp()->getStream();
                stream->write(JITServer::MessageType::KnownObjectTable_dereferenceKnownObjectField2, mutableCallsiteClass, callSiteIndex);
 
-               auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*>();
+               auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
                resultIndex = std::get<0>(recv);
                uintptr_t *objectPointerReference = std::get<1>(recv);
 

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1071,10 +1071,10 @@ bool TR_J9MutableCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inlin
          {
          vgs->_mutableCallSiteEpoch = TR::KnownObjectTable::UNKNOWN;
          bool knotEnabled = (knot != NULL);
-         auto stream = TR::CompilationInfo::getStream();
+         auto stream = comp()->getStream();
          stream->write(JITServer::MessageType::KnownObjectTable_mutableCallSiteEpoch, _mcsReferenceLocation, knotEnabled);
 
-         auto recv = stream->read<uintptr_t, TR::KnownObjectTable::Index, uintptr_t*>();
+         auto recv = stream->read<uintptr_t, TR::KnownObjectTable::Index, uintptr_t *>();
          uintptr_t mcsObject = std::get<0>(recv);
          TR::KnownObjectTable::Index knotIndex = std::get<1>(recv);
          uintptr_t *objectPointerReference = std::get<2>(recv);

--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -204,7 +204,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
          // sanity check
          // Ask the client again and see if the two sources of information match
-         auto stream = TR::CompilationInfo::getStream();
+         auto stream = comp->getStream();
          stream->write(JITServer::MessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptr_t)1);
          auto recv = stream->read<std::string, bool, bool, bool>();
          auto &ipdata = std::get<0>(recv);
@@ -240,8 +240,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
       }
 
    // Now ask the client
-   //
-   auto stream = TR::CompilationInfo::getStream();
+   auto stream = comp->getStream();
    stream->write(JITServer::MessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptr_t)(_useCaching ? 0 : 1));
    auto recv = stream->read<std::string, bool, bool, bool>();
    auto &ipdata = std::get<0>(recv);
@@ -554,7 +553,7 @@ JITServerIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
       }
    if (sendRemoteMessage)
       {
-      auto stream = TR::CompilationInfo::getStream();
+      auto stream = comp->getStream();
       stream->write(JITServer::MessageType::IProfiler_setCallCount, method, bcIndex, count);
       auto recv = stream->read<bool>();
       bool isCompiled = std::get<0>(recv);
@@ -582,8 +581,8 @@ void
 JITServerIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp)
    {
    // resolvedMethodSymbol is only used for debugging on the client, so we don't have to send it
-   auto stream = TR::CompilationInfo::getStream();
-   auto compInfoPT = (TR::CompilationInfoPerThreadRemote *)(comp->fej9()->_compInfoPT);
+   auto stream = comp->getStream();
+   auto compInfoPT = (TR::CompilationInfoPerThreadRemote *)comp->fej9()->_compInfoPT;
    ClientSessionData *clientSessionData = compInfoPT->getClientData();
 
    if (clientSessionData->getOrCacheVMInfo(stream)->_elgibleForPersistIprofileInfo)

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -707,7 +707,7 @@ TR_RelocationRuntime::relocateAOTCodeAndData(U_8 *tempDataStart,
       } //end if J9_JIT_DCE_EXCEPTION_INFO
 
 #if defined(J9VM_OPT_JITSERVER)
-   TR_ASSERT_FATAL(!TR::CompilationInfo::getStream(), "TR_RelocationRuntime::relocateAOTCodeAndData should not be called at the JITSERVER");
+   TR_ASSERT_FATAL(!_comp->getStream(), "TR_RelocationRuntime::relocateAOTCodeAndData should not be called at the JITSERVER");
 #endif /* defined(J9VM_OPT_JITSERVER) */
    if (startPC)
       {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -56,11 +56,11 @@ TR::SymbolValidationManager::_systemClassesNotWorthRemembering[] = {
    { "java/lang/StringBuffer", NULL, false }
 };
 
-TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee)
+TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee, TR::Compilation *comp)
    : _symbolID(FIRST_ID),
      _heuristicRegion(0),
      _region(region),
-     _comp(TR::comp()),
+     _comp(comp),
      _vmThread(_comp->j9VMThread()),
      _fej9((TR_J9VM *)TR_J9VMBase::get(
         _vmThread->javaVM->jitConfig,

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -711,9 +711,9 @@ struct IsClassVisibleRecord : public SymbolValidationRecord
 class SymbolValidationManager
    {
 public:
-   TR_ALLOC(TR_MemoryBase::SymbolValidationManager);
+   TR_ALLOC(TR_MemoryBase::SymbolValidationManager)
 
-   SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
+   SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee, TR::Compilation *comp);
 
    struct SystemClassNotWorthRemembering
       {


### PR DESCRIPTION
Avoid using the thread-local variable `TR::compInfoPT` (mostly through `TR::CompilationInfo::getStream()`) in contexts where the `compInfoPT` or the `Compilation` is readily available. TLS accesses in dynamically loaded shared libraries (such as the JIT) can have non-negligible overhead.