### PR TITLE
Adopt RI java.lang.Thread

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -378,7 +378,7 @@ final class J9VMInternals {
 			thread.group.remove(thread);
 			/*[ENDIF] OPENJDK_THREAD_SUPPORT */
 		} finally {
-			thread.cleanup();
+			thread.exit();
 
 			synchronized (thread) {
 				thread.notifyAll();

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -239,7 +239,7 @@ public Thread(Runnable runnable) {
  * @see			java.lang.Runnable
  */
 Thread(Runnable runnable, AccessControlContext acc) {
-	this(null, runnable, newName(), acc, true);
+	this(null, runnable, newName(), acc, false);
 }
 
 /**
@@ -1543,7 +1543,7 @@ void uncaughtException(Throwable e) {
  *
  * @see J9VMInternals#threadCleanup()
  */
-void cleanup() {
+void exit() {
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 	/* Refresh deadInterrupt value so it is accurate when thread reference is removed. */
 	deadInterrupt = interrupted();

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -195,7 +195,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</fieldref>
 	<fieldref class="java/lang/Thread" name="stackSize" signature="J"/>
 	<fieldref class="java/lang/Thread" name="tid" signature="J"/>
-	<fieldref class="java/lang/Thread" name="deadInterrupt" signature="Z" versions="14-"/>
+	<fieldref class="java/lang/Thread" name="deadInterrupt" signature="Z" versions="14-" flags="!opt_openjdkThreadSupport">
+		<fieldalias name="interrupted" signature="Z" versions="14-" flags="opt_openjdkThreadSupport"/>
+	</fieldref>
 	<fieldref class="java/lang/Thread" name="started" signature="Z"/>
 	<fieldref class="java/lang/Thread" name="name" signature="Ljava/lang/String;"/>
 


### PR DESCRIPTION
* Rename `Thread.cleanup()` to `exit()`;
* `Access.newThreadWithAcc()` doesn't inherit ThreadLocals;
* Add `interrupted` as `fieldalias` of `deadInterrupt`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>