### PR TITLE
Build jdknext with Semeru jdk18 now it's available

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -153,7 +153,7 @@ boot_jdk_default:
       11: '11'
       17: '17'
       18: '17'
-      next: '17'
+      next: '18'
     dir_strip:
       all: '1'
     url:


### PR DESCRIPTION
Mac is not available yet, should be available sometime this week.