### PR TITLE
Rename configuration DDR_VM to GENERIC for extension repo closed dir

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -322,8 +322,8 @@
 	This configuration is intended only for use by extension repos:
 	it is not expected to usable for generating an eclipse project.
 	-->
-	<configuration label="DDR_VM" outputpath="outputpath-not-used">
-		<source path="src"/>
+	<configuration label="GENERIC" outputpath="outputpath-not-used">
+		<source path="."/>
 	</configuration>
 
 </configurationreg>


### PR DESCRIPTION
Replaced `source path src` with `.` to support `JPP` for the java files within `openj9-openjdk-jdk8/closed/adds/jdk` and `DDR_VM`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>