### PR TITLE
OpenJDK 11.0.16 AIX compilation now requires xlc 16

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -264,7 +264,7 @@ ppc64_aix:
   build_env:
     vars:
       8: 'PATH+XLC=/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin'
-      11: 'PATH+XLC=/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin'
+      11: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
       17: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
       18: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
       next: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'


### PR DESCRIPTION
Related to
[8261169: Upgrade HarfBuzz to the latest 2.8.0](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/4a9d42be39263fef6d5e603417be8771526c17e2)
[8282588: [11] set harfbuzz compilation flag to -std=c++11](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/54e22919c2ae12c33ba330aa341aaebb688a09cd)
[8218965: aix: support xlclang++ in the compiler detection](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/d62444f6ace8fbc6cdf9b4f12f1298e33e9bceff)
