### PR TITLE
CRIU j9time_nano_time skips the elapsed time between Checkpoint/Restore

### DIFF
--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -33,7 +33,7 @@ TraceAssert=Assert_CRIU_mustNotHaveVMAccess noEnv Overhead=1 Level=1 Assert="0 =
 TraceException=Trc_CRIU_getNativeString_getStringSizeFail Overhead=1 Level=1 Template="Failed to get Java string size: mutf8String=%s mutf8StringSize=%zu"
 TraceException=Trc_CRIU_getNativeString_convertFail Overhead=1 Level=1 Template="Failed to convert Java string: mutf8String=%s mutf8StringSize=%zu requiredConvertedStringSize=%zd"
 
-TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump()"
-TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump()"
+TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump(), beforeCheckpoint = %lld"
+TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump(), afterRestore = %lld, checkpointRestoreTimeDelta = %lld"
 TraceEntry=Trc_CRIU_checkpointJVMImpl_Entry Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
 TraceExit=Trc_CRIU_checkpointJVMImpl_Exit Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"

--- a/test/functional/cmdLineTests/criu/criu.xml
+++ b/test/functional/cmdLineTests/criu/criu.xml
@@ -25,9 +25,10 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Criu Command-Line Option Tests" timeout="300">
+  <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ "SingleCheckpoint"</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ SingleCheckpoint</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -37,7 +38,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ TwoCheckpoints</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ TwoCheckpoints</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint 1</output>
@@ -47,8 +48,8 @@
     <output type="failure" caseSensitive="yes" regex="no">ERR</output>
   </test>
 
-    <test id="Create and Restore Criu Checkpoint Image three times">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ ThreeCheckpoints</command>
+  <test id="Create and Restore Criu Checkpoint Image three times">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ ThreeCheckpoints</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint 1</output>

--- a/test/functional/cmdLineTests/criu/criuRandomScript.sh
+++ b/test/functional/cmdLineTests/criu/criuRandomScript.sh
@@ -31,7 +31,7 @@ echo "start running script"
 if [ "$4" = "Checkpoint" ]
 then
     # append to the file to capture the output before checkpoint and after both restores
-    $2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar CRIURandomTest >>testOutput 2>&1
+    $2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar org.openj9.criu.CRIURandomTest >>testOutput 2>&1
 fi
 if [ "$4" = "FirstRestore" ] || [ "$4" = "SecondRestore" ]
 then

--- a/test/functional/cmdLineTests/criu/criuScript.sh
+++ b/test/functional/cmdLineTests/criu/criuScript.sh
@@ -23,15 +23,15 @@
 #
 
 echo "start running script";
-$2 -XX:+EnableCRIUSupport $3 -cp "$1/criu.jar" CRIUSimpleTest $4 >testOutput 2>&1;
+$2 -XX:+EnableCRIUSupport $3 -cp "$1/criu.jar" $4 $5 >testOutput 2>&1;
 sleep 2;
 criu restore -D ./cpData --shell-job;
-if [ "$4" == "TwoCheckpoints" ] || [ "$4" == "ThreeCheckpoints" ]
+if [ "$5" == "TwoCheckpoints" ] || [ "$5" == "ThreeCheckpoints" ]
 then
 sleep 2;
 criu restore -D ./cpData --shell-job;
 fi
-if [ "$4" == "ThreeCheckpoints" ]
+if [ "$5" == "ThreeCheckpoints" ]
 then
 sleep 2;
 criu restore -D ./cpData --shell-job;

--- a/test/functional/cmdLineTests/criu/criuSecurityScript.sh
+++ b/test/functional/cmdLineTests/criu/criuSecurityScript.sh
@@ -27,7 +27,7 @@ echo "start running script"
 # $1 is the TEST_ROOT
 # $2 is the JAVA_COMMAND
 # $3 is the JVM_OPTIONS
-$2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar CRIUSecurityTest >testOutput 2>&1
+$2 $3 -XX:+EnableCRIUSupport -cp $1/criu.jar org.openj9.criu.CRIUSecurityTest >testOutput 2>&1
 criu restore -D cpData --shell-job
 cat testOutput
 rm -rf testOutput

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -25,9 +25,11 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Criu Command-Line Option Tests" timeout="300">
+  <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
+  <variable name="MAINCLASS_TIMECHANGE" value="org.openj9.criu.TimeChangeTest" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "SingleCheckpoint"</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ SingleCheckpoint</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -37,7 +39,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" TwoCheckpoints</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ TwoCheckpoints</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint 1</output>
@@ -45,6 +47,17 @@
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">Post-checkpoint 2</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore three times">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_TIMECHANGE$ ThreeCheckpoints</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: System.nanoTime() after CRIU restore:</output>
     <output type="required" caseSensitive="yes" regex="no">Error</output>
   </test>
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIURandomTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIURandomTest.java
@@ -19,6 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.openj9.criu;
 
 import java.io.BufferedReader;
 import java.io.FileReader;

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSecurityTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSecurityTest.java
@@ -19,6 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.openj9.criu;
 
 import java.io.File;
 import java.io.PrintStream;

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSimpleTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSimpleTest.java
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  * Copyright (c) 2022, 2022 IBM Corp. and others
  *
@@ -19,61 +20,55 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.openj9.criu;
+
 import java.nio.file.Paths;
 import java.nio.file.Path;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.io.File;
-import java.io.IOException;
 
-import org.eclipse.openj9.criu.*;
+public class CRIUSimpleTest {
 
-public class CRIUTestUtils {
-	public static void deleteCheckpointDirectory(Path path) {
-		try {
-			if (path.toFile().exists()) {
-				Files.walk(path)
-				.map(Path::toFile)
-				.forEach(File::delete);
+	public static void main(String args[]) {
+		String test = args[0];
 
-				Files.deleteIfExists(path);
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
+		switch(test) {
+		case "SingleCheckpoint":
+			singleCheckpoint();
+			break;
+		case "TwoCheckpoints":
+			twoCheckpoints();
+			break;
+		case "ThreeCheckpoints":
+			threeCheckpoints();
+			break;
+		default:
+			throw new RuntimeException("incorrect parameters");
 		}
 	}
 
-	public static void createCheckpointDirectory(Path path) {
-		try {
-			path.toFile().mkdir();
-			Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxrwxrwx"));
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+	public static void singleCheckpoint() {
+		Path path = Paths.get("cpData");
+		System.out.println("Single checkpoint:\nPre-checkpoint");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint");
 	}
 
-	public static void checkPointJVM(Path path) {
-		checkPointJVM(path, true);
+	public static void twoCheckpoints() {
+		Path path = Paths.get("cpData");
+		System.out.println("Two checkpoints:\nPre-checkpoint");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint 1");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint 2");
 	}
 
-	public static void checkPointJVM(Path path, boolean deleteDir) {
-		if (CRIUSupport.isCRIUSupportEnabled()) {
-			deleteCheckpointDirectory(path);
-			createCheckpointDirectory(path);
-			try {
-				new CRIUSupport(path)
-				.setLeaveRunning(false)
-				.setShellJob(true)
-				.setFileLocks(true)
-				.checkpointJVM();
-			} catch (RestoreException e) {
-				e.printStackTrace();
-			}
-			if (deleteDir) {
-				deleteCheckpointDirectory(path);
-			}
-		} else {
-			System.err.println("CRIU is not enabled");
-		}
+	public static void threeCheckpoints() {
+		Path path = Paths.get("cpData");
+		System.out.println("Three checkpoints:\nPre-checkpoint");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint 1");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint 2");
+		CRIUTestUtils.checkPointJVM(path);
+		System.out.println("Post-checkpoint 3");
 	}
 }

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.openj9.criu.*;
+
+public class CRIUTestUtils {
+	public static void deleteCheckpointDirectory(Path path) {
+		try {
+			if (path.toFile().exists()) {
+				Files.walk(path)
+				.map(Path::toFile)
+				.forEach(File::delete);
+
+				Files.deleteIfExists(path);
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void createCheckpointDirectory(Path path) {
+		try {
+			path.toFile().mkdir();
+			Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxrwxrwx"));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void checkPointJVM(Path path) {
+		checkPointJVM(path, true);
+	}
+
+	public static void checkPointJVM(Path path, boolean deleteDir) {
+		if (CRIUSupport.isCRIUSupportEnabled()) {
+			deleteCheckpointDirectory(path);
+			createCheckpointDirectory(path);
+			try {
+				new CRIUSupport(path)
+				.setLeaveRunning(false)
+				.setShellJob(true)
+				.setFileLocks(true)
+				.checkpointJVM();
+			} catch (RestoreException e) {
+				e.printStackTrace();
+			}
+			if (deleteDir) {
+				deleteCheckpointDirectory(path);
+			}
+		} else {
+			System.err.println("CRIU is not enabled");
+		}
+	}
+}

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 2022, 2022 IBM Corp. and others
  *
@@ -20,53 +19,31 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package org.openj9.criu;
+
 import java.nio.file.Paths;
 import java.nio.file.Path;
 
-public class CRIUSimpleTest {
+public class TimeChangeTest {
+
+	// The elapsed time is expected less than 2 second.
+	private static long MAX_ELAPSED_TIME = 2000 * 1000 * 1000;
+	private static Path imagePath = Paths.get("cpData");
 
 	public static void main(String args[]) {
-		String test = args[0];
+		new TimeChangeTest().testSystemNanoTime();
+	}
 
-		switch(test) {
-		case "SingleCheckpoint":
-			singleCheckpoint();
-			break;
-		case "TwoCheckpoints":
-			twoCheckpoints();
-			break;
-		case "ThreeCheckpoints":
-			threeCheckpoints();
-			break;
-		default:
-			throw new RuntimeException("incorrect parameters");
+	public void testSystemNanoTime() {
+		final long beforeCheckpoint = System.nanoTime();
+		System.out.println("System.nanoTime() before CRIU checkpoint: " + beforeCheckpoint);
+		CRIUTestUtils.checkPointJVM(imagePath);
+		final long afterRestore = System.nanoTime();
+		final long elapsedTime = afterRestore - beforeCheckpoint;
+		if (elapsedTime < MAX_ELAPSED_TIME) {
+			System.out.println("PASSED: System.nanoTime() after CRIU restore: " + afterRestore + ", the elapse time is: " + elapsedTime);
+		} else {
+			System.out.println("FAILED: System.nanoTime() after CRIU restore: " + afterRestore + ", the elapse time is: " + elapsedTime);
 		}
-	}
-
-	public static void singleCheckpoint() {
-		Path path = Paths.get("cpData");
-		System.out.println("Single checkpoint:\nPre-checkpoint");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint");
-	}
-
-	public static void twoCheckpoints() {
-		Path path = Paths.get("cpData");
-		System.out.println("Two checkpoints:\nPre-checkpoint");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint 1");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint 2");
-	}
-
-	public static void threeCheckpoints() {
-		Path path = Paths.get("cpData");
-		System.out.println("Three checkpoints:\nPre-checkpoint");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint 1");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint 2");
-		CRIUTestUtils.checkPointJVM(path);
-		System.out.println("Post-checkpoint 3");
 	}
 }


### PR DESCRIPTION
Added a field `checkpointRestoreTimeDelta` within `J9PortLibrary`, which is to be set the time delta between `Checkpoint` and `Restore` of `j9time_nano_time()` return values;
Updated trace points to record the actual `j9time_nano_time()` values.

This is first part to address the issue https://github.com/eclipse-openj9/openj9/issues/14211, for `System.nanoTime()`. 

Tested w/ following code snippet:
```
long beforeSnapshot = System.nanoTime();
System.out.println("System.nanoTime() before snapshot: " + beforeSnapshot);
criuSupport.checkpointJVM();
long afterRestore = System.nanoTime();
System.out.println("System.nanoTime() after restore: " + afterRestore + ", the delta is: " + (afterRestore - beforeSnapshot));
```
Snapshot run w/ `-Xtrace:print={j9criu}`
```
System.nanoTime() before snapshot: 1923502764451872
20:46:59.339 0x1aa00          j9criu.7        - Before checkpoint criu_dump(), beforeSnapshot = 1923502857103461
```
Multiple restores
```
20:47:03.515 0x1aa00          j9criu.8        - After checkpoint criu_dump(), afterRestore = 1923507032477031, snapshotRestoreTimeDelta = 4175373570
System.nanoTime() after restore: 1923502933280333, the delta is: 168828461
```

```
20:47:16.307 0x1aa00          j9criu.8        - After checkpoint criu_dump(), afterRestore = 1923519824763404, snapshotRestoreTimeDelta = 16967659943
System.nanoTime() after restore: 1923502929966245, the delta is: 165514373
```

```
20:47:18.447 0x1aa00          j9criu.8        - After checkpoint criu_dump(), afterRestore = 1923521964335134, snapshotRestoreTimeDelta = 19107231673
System.nanoTime() after restore: 1923502946667346, the delta is: 182215474
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>