### PR TITLE
Do not try to activate compilation thread during shutdown

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -476,6 +476,8 @@ TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
    if (isCheckpointInProgress())
       return TR_no;
 #endif
+   if (isInShutdownMode())
+      return TR_no;
 
    // If further compilations have been disabled we could be in a dire situation, for example virtual memory could be
    // really low, there could be failures when attempting to allocate persistent memory, a compilation thread could
@@ -3505,6 +3507,7 @@ void TR::CompilationInfo::stopCompilationThreads()
    acquireCompMonitor(vmThread);
 
    setIsInShutdownMode();
+   getPersistentInfo()->setDisableFurtherCompilation(true);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
    // Set the checkpoint status to interrupted regardless


### PR DESCRIPTION
The JIT heuristics should prevent the activation of a compilation thread
once `stopCompilationThreads()` has been called. There is no point in
attempting to compile during the shutdown process.

Fixes: #14142

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>