### PR TITLE
Correct usage of x86 directCallRequiresTrampoline() API 

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -673,10 +673,10 @@ TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Nod
       {
       // JMPImm4 helper
       //
-      *(uint8_t *)cursor++ = 0xe9;
+      *(uint8_t *)cursor = 0xe9;
       TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_methodHandleJ2IGlue);
-      int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, helper);
-      *(int32_t *)cursor = disp32;
+      int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helper);
+      *(int32_t *)(++cursor) = disp32;
       cursor += 4;
       }
    else

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,7 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSnippetBody()
       {
       TR_RuntimeHelper helper = (comp->getOption(TR_EnableNewX86PrefetchTLH)) ? TR_X86newPrefetchTLH : TR_X86prefetchTLH;
       helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(helper);
-      disp32 = cg()->branchDisplacementToHelperOrTrampoline(buffer+4, helperSymRef);
+      disp32 = cg()->branchDisplacementToHelperOrTrampoline(buffer-1, helperSymRef);
       if (fej9->needRelocationsForHelpers())
          {
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -182,9 +182,9 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       //
       _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86IPicLookupDispatch);
 
-      *cursor++ = 0xe8;  // CALL
-      disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, _dispatchSymRef);
-      *(int32_t *)cursor = disp32;
+      *cursor = 0xe8;  // CALL
+      disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, _dispatchSymRef);
+      *(int32_t *)(++cursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
@@ -358,9 +358,9 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
                  "Mis-aligned VPIC snippet");
          }
 
-      *cursor++ = 0xe8;  // CALL
-      disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, _dispatchSymRef);
-      *(int32_t *)cursor = disp32;
+      *cursor = 0xe8;  // CALL
+      disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, _dispatchSymRef);
+      *(int32_t *)(++cursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
@@ -422,9 +422,9 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
 
       // Patch first slot test with call to resolution helper.
       //
-      *picSlotCursor++ = 0xe8;    // CALL
-      disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor+4, resolveSlotHelperSymRef);
-      *(int32_t *)picSlotCursor = disp32;
+      *picSlotCursor = 0xe8;    // CALL
+      disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor, resolveSlotHelperSymRef);
+      *(int32_t *)(++picSlotCursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(picSlotCursor,
@@ -438,9 +438,9 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
          //
          while (--numPicSlots)
             {
-            *picSlotCursor++ = 0xe8;    // CALL
-            disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor+4, populateSlotHelperSymRef);
-            *(int32_t *)picSlotCursor = disp32;
+            *picSlotCursor = 0xe8;    // CALL
+            disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor, populateSlotHelperSymRef);
+            *(int32_t *)(++picSlotCursor) = disp32;
 
             cg()->addExternalRelocation(new (cg()->trHeapMemory())
                TR::ExternalRelocation(picSlotCursor,
@@ -860,8 +860,9 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       TR::SymbolReference *helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(resolutionHelper);
 
-      *cursor++ = 0xe8;    // CALL
-      *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, helperSymRef);
+      *cursor = 0xe8;    // CALL
+      int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
+      *(int32_t *)(++cursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                     (uint8_t *)helperSymRef,
@@ -889,8 +890,9 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       //
       helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
-      *cursor++ = 0xe9;    // JMP
-      *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, helperSymRef);
+      *cursor = 0xe9;    // JMP
+      disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
+      *(int32_t *)(++cursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                     (uint8_t*)helperSymRef,
@@ -992,13 +994,14 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       // JMP interpreterStaticAndSpecialGlue
       //
-      *cursor++ = 0xe9;
+      *cursor = 0xe9;
 
       TR::SymbolReference* dispatchSymRef =
           methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper() ? methodSymRef :
                                                                              cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
-      *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, dispatchSymRef);
+      int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, dispatchSymRef);
+      *(int32_t *)(++cursor) = disp32;
 
       cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                     (uint8_t *)dispatchSymRef,

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,10 +149,10 @@ uint8_t *TR::X86CheckFailureSnippet::emitCheckFailureSnippetBody(uint8_t *buffer
       *buffer++ = 0xd8;
       }
 
-   *buffer++ = 0xe8; // CallImm4
+   *buffer = 0xe8; // CallImm4
    intptr_t destinationAddress = (intptr_t)getDestination()->getMethodAddress();
 
-   if (NEEDS_TRAMPOLINE(destinationAddress, buffer+4, cg()))
+   if (cg()->directCallRequiresTrampoline(destinationAddress, reinterpret_cast<intptr_t>(buffer++)))
       {
       destinationAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(getDestination()->getReferenceNumber(), (void *)buffer);
       TR_ASSERT(IS_32BIT_RIP(destinationAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
@@ -313,11 +313,12 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
 
    // Call the glue routine
    //
-   *buffer++ = 0xe8;                      // call  Imm4 glue routine
+   *buffer = 0xe8;                      // call  Imm4 glue routine
 
    TR::SymbolReference * glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
    intptr_t glueAddress = (intptr_t)glueSymRef->getMethodAddress();
-   if (NEEDS_TRAMPOLINE(glueAddress, buffer+4, cg()))
+
+   if (cg()->directCallRequiresTrampoline(glueAddress, reinterpret_cast<intptr_t>(buffer++)))
       {
       glueAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(glueSymRef->getReferenceNumber(), (void *)buffer);
       TR_ASSERT(IS_32BIT_RIP(glueAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
@@ -340,10 +341,11 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
       *buffer++ = 0xd8;
       }
 
-   *buffer++ = 0xe8; // CallImm4
+   *buffer = 0xe8; // CallImm4
 
    intptr_t destinationAddress = (intptr_t)getDestination()->getMethodAddress();
-   if (NEEDS_TRAMPOLINE(destinationAddress, buffer+4, cg()))
+
+   if (cg()->directCallRequiresTrampoline(destinationAddress, reinterpret_cast<intptr_t>(buffer++)))
       {
       destinationAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(getDestination()->getReferenceNumber(), (void *)buffer);
       TR_ASSERT(IS_32BIT_RIP(destinationAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,8 +50,8 @@ uint8_t *TR::X86ForceRecompilationSnippet::emitSnippetBody()
 
    TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(cg()->comp()->target().is64Bit()? TR_AMD64induceRecompilation : TR_IA32induceRecompilation);
    intptr_t helperAddress = (intptr_t)helper->getMethodAddress();
-   *buffer++ = 0xe8; // CallImm4
-   if (NEEDS_TRAMPOLINE(helperAddress, buffer+4, cg()))
+   *buffer = 0xe8; // CallImm4
+   if (cg()->directCallRequiresTrampoline(helperAddress, reinterpret_cast<intptr_t>(buffer++)))
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(helper->getReferenceNumber(), (void *)buffer);
       TR_ASSERT(IS_32BIT_RIP(helperAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,7 @@ J9::X86::UnresolvedDataSnippet::emitResolveHelperCall(uint8_t *cursor)
    //
    const intptr_t rip = (intptr_t)(cursor+5);
    if ((cg()->needRelocationsForHelpers() && cg()->comp()->target().is64Bit()) ||
-       NEEDS_TRAMPOLINE(glueAddress, rip, cg()))
+       cg()->directCallRequiresTrampoline(glueAddress, reinterpret_cast<intptr_t>(cursor)))
       {
       TR_ASSERT(cg()->comp()->target().is64Bit(), "should not require a trampoline on 32-bit");
       glueAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(_glueSymRef->getReferenceNumber(), (void *)cursor);

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,8 +92,8 @@ uint8_t *TR::X86RecompilationSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(buffer);
 
    intptr_t helperAddress = (intptr_t)_destination->getMethodAddress();
-   *buffer++ = 0xe8; // CallImm4
-   if (NEEDS_TRAMPOLINE(helperAddress, buffer+4, cg()))
+   *buffer = 0xe8; // CallImm4
+   if (cg()->directCallRequiresTrampoline(helperAddress, reinterpret_cast<intptr_t>(buffer++)))
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(_destination->getReferenceNumber(), (void *)buffer);
       TR_ASSERT(IS_32BIT_RIP(helperAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -76,7 +76,7 @@ TR::S390ForceRecompilationSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      if (NEEDS_TRAMPOLINE(destAddr, cursor, cg()))
+      if (cg()->directCallRequiresTrampoline(destAddr, reinterpret_cast<intptr_t>(cursor)))
          {
          // Destination is beyond our reachable jump distance, we'll find the trampoline.
          destAddr = TR::CodeCacheManager::instance()->findHelperTrampoline(glueRef->getReferenceNumber(), (void *)cursor);

--- a/runtime/compiler/z/codegen/J9S390Snippet.cpp
+++ b/runtime/compiler/z/codegen/J9S390Snippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ TR::S390HeapAllocSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      if (NEEDS_TRAMPOLINE(destAddr, buffer, cg()))
+      if (cg()->directCallRequiresTrampoline(destAddr, reinterpret_cast<intptr_t>(buffer)))
          {
          uint32_t rEP = (uint32_t) cg()->getEntryPointRegister() - 1;
          // Destination is beyond our reachable jump distance, we'll find the

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -222,7 +222,7 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
       if (comp->getOption(TR_EnableRMODE64))
 #endif
          {
-         if (NEEDS_TRAMPOLINE(destAddr, cursor, cg))
+         if (cg->directCallRequiresTrampoline(destAddr, reinterpret_cast<intptr_t>(cursor)))
             destAddr = TR::CodeCacheManager::instance()->findHelperTrampoline(helper->getReferenceNumber(), (void *)cursor);
          }
 #endif
@@ -878,7 +878,7 @@ TR::S390InterfaceCallSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      if (NEEDS_TRAMPOLINE(destAddr, cursor, cg()))
+      if (cg()->directCallRequiresTrampoline(destAddr, reinterpret_cast<intptr_t>(cursor)))
          {
          // Destination is beyond our reachable jump distance, we'll find the
          // trampoline.

--- a/runtime/compiler/z/codegen/S390StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390StackCheckFailureSnippet.cpp
@@ -240,7 +240,7 @@ TR::S390StackCheckFailureSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      if (NEEDS_TRAMPOLINE(destAddr, cursor, cg()))
+      if (cg()->directCallRequiresTrampoline(destAddr, reinterpret_cast<intptr_t>(cursor)))
          {
          // Destination is beyond our reachable jump distance, we'll find the
          // trampoline.


### PR DESCRIPTION
* Correct usage of x86 directCallRequiresTrampoline() API
* Replace Z NEEDS_TRAMPOLINE macro with function call