### PR TITLE
Use System.nanoTime() for elapsed time measurement

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -22,23 +22,24 @@
  *******************************************************************************/
 package java.lang;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.lang.reflect.Method;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+import java.util.Map;
 /*[IF Sidecar18-SE-OpenJ9]*/
 import jdk.internal.misc.TerminatingThreadLocal;
 /*[ENDIF] Sidecar18-SE-OpenJ9 */
-import sun.security.util.SecurityConstants;
 /*[IF JAVA_SPEC_VERSION >= 11]*/
 import java.util.Properties;
 import jdk.internal.reflect.CallerSensitive;
 /*[ELSE] JAVA_SPEC_VERSION >= 11 */
 import sun.reflect.CallerSensitive;
 /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
-import java.lang.reflect.Method;
 import sun.nio.ch.Interruptible;
+import sun.security.util.SecurityConstants;
 
 /**
  *	A Thread is a unit of concurrent execution in Java. It has its own call stack
@@ -104,7 +105,7 @@ public class Thread implements Runnable {
 /*[PR 1FENTZW]*/
 	private ClassLoader contextClassLoader;	// Used to find classes and resources in this Thread
 	ThreadLocal.ThreadLocalMap threadLocals;
-	private java.security.AccessControlContext inheritedAccessControlContext;
+	private AccessControlContext inheritedAccessControlContext;
 
 	/*[PR 96127]*/
 	/*[PR 122459] LIR646 - Remove use of generic object for synchronization */
@@ -816,9 +817,7 @@ private native boolean isInterruptedImpl();
  * @see			java.lang.ThreadDeath
  */
 public final synchronized void join() throws InterruptedException {
-	if (started)
-		while (!isDead())
-			wait(0);
+	join(0, 0);
 }
 
 /**
@@ -855,37 +854,39 @@ public final void join(long timeoutInMilliseconds) throws InterruptedException {
  * @see			java.lang.ThreadDeath
  */
 public final synchronized void join(long timeoutInMilliseconds, int nanos) throws InterruptedException {
-	if (timeoutInMilliseconds < 0 || nanos < 0 || nanos > NANOS_MAX)
+	if ((timeoutInMilliseconds < 0) || (nanos < 0) || (nanos > NANOS_MAX)) {
 		throw new IllegalArgumentException();
+	}
+	if (!started || isDead()) {
+		return;
+	}
+	if ((timeoutInMilliseconds == 0) && (nanos == 0)) {
+		while (!isDead()) {
+			wait(0);
+		}
+		return;
+	}
 
-	if (!started || isDead()) return;
-
-	// No nanosecond precision for now, we would need something like 'currentTimenanos'
-
-	long totalWaited = 0;
-	long toWait = timeoutInMilliseconds;
-	boolean timedOut = false;
-
-	/*[PR 1PQM757] Even though we do not have nano precision, we cannot wait(0) when any one of the parameters is not zero */
-	if (timeoutInMilliseconds == 0 & nanos > 0) {
-		// We either round up (1 millisecond) or down (no need to wait, just return)
-		if (nanos < 500000)
-			timedOut = true;
-		else
-			toWait = 1;
+	long toWaitNano = TimeUnit.MILLISECONDS.toNanos(timeoutInMilliseconds);
+	if ((Long.MAX_VALUE - toWaitNano) >= nanos) {
+		toWaitNano += nanos;
+	} else {
+		// Unlikely just for technical correctness.
+		toWaitNano = Long.MAX_VALUE;
 	}
 	/*[PR 1FJMO7Q] A Thread can be !isAlive() and still be in its ThreadGroup. Use isDead() */
-	while (!timedOut && !isDead()) {
-		long start = System.currentTimeMillis();
-		wait(toWait);
-		long waited = System.currentTimeMillis() - start;
-		totalWaited+= waited;
-		toWait -= waited;
+	while (!isDead()) {
+		final long start = System.nanoTime();
+		TimeUnit.NANOSECONDS.timedWait(this, toWaitNano);
+		final long waited = System.nanoTime() - start;
 		// Anyone could do a synchronized/notify on this thread, so if we wait
 		// less than the timeout, we must check if the thread really died
-		timedOut = (totalWaited >= timeoutInMilliseconds);
+		if (waited >= toWaitNano) {
+			break;
+		} else {
+			toWaitNano -= waited;
+		}
 	}
-
 }
 
 /**

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/util/CompressedRecordArray.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/util/CompressedRecordArray.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2006, 2017 IBM Corp. and others
+ * Copyright (c) 2006, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -461,7 +461,7 @@ public final class CompressedRecordArray implements Serializable {
         int[] record = new int[8];
         for (int blockSizeLog2 = 0; blockSizeLog2 < 10; blockSizeLog2++) {
             dis.reset();
-            long then = System.currentTimeMillis();
+            final long then = System.nanoTime();
             CompressedRecordArray ra = new CompressedRecordArray(blockSizeLog2, 8);
             boolean eof = false;
             for (int r = 0;; r++) {
@@ -494,8 +494,8 @@ public final class CompressedRecordArray implements Serializable {
                 }
                 if (eof) break;
             }
-            long now = System.currentTimeMillis();
-            System.out.println("block size " + (1 << blockSizeLog2) + " uses " + ra.memoryUsage() + " took " + (now - then) + " ms");
+            final long duration = System.nanoTime() - then;
+            System.out.println("block size " + (1 << blockSizeLog2) + " uses " + ra.memoryUsage() + " took " + duration + " ns");
         }
     }
 }

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -584,41 +584,43 @@ public class Session implements ISession {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Creates a DTFJ image from the supplied core or zip file
 	 */
 	private void imageFromCommandLine() {
-		// if -version, output the version and exit
+		// If -version, output the version and exit.
 		if (hasFlagBeenSet(ARG_VERSION)) {
 			ctxroot.execute("open", out.getPrintStream());
 			exit(null, 0);
-		}		
+		}
 
-	    String coreFilePath = null;
+		String coreFilePath = null;
 		if (hasFlagBeenSet(ARG_VERBOSE)) {
 			// If we are using DDR this will enable warnings.
 			// (If not it's irrelevant.)
 			Logger.getLogger("j9ddr.view.dtfj").setLevel(Level.WARNING);
 		}
-		//at this point the existence of either -core or -zip has been checked
-		long current = System.currentTimeMillis();
-		if(args.containsKey(ARG_CORE)) {
-			if(args.containsKey(ARG_ZIP)) {
+		// At this point the existence of either -core or -zip has been checked.
+		final long current = System.nanoTime();
+		if (args.containsKey(ARG_CORE)) {
+			if (args.containsKey(ARG_ZIP)) {
 				exit(ARG_ZIP + " and " + ARG_CORE + " cannot be specified at the same time", JDMPVIEW_SYNTAX_ERROR);
 			} else {
 				coreFilePath = args.get(ARG_CORE);
-				ctxroot.execute("open " + coreFilePath , out.getPrintStream());
+				ctxroot.execute("open " + coreFilePath, out.getPrintStream());
 			}
 		} else {
-			coreFilePath = args.get(ARG_ZIP);	//if -core has been set it is handled in the first part of this if statement
-			ctxroot.execute("open " + coreFilePath , out.getPrintStream());
+			// If -core has been set it is handled in the first part of this if statement.
+			coreFilePath = args.get(ARG_ZIP);
+			ctxroot.execute("open " + coreFilePath, out.getPrintStream());
 		}
-		logger.fine(String.format("Time taken to load image %d ms", System.currentTimeMillis() - current));
-		//Store the core file/zip file path in the variables. We need it for creating default filenames for heapdumps
+		final long duration = System.nanoTime() - current;
+		logger.fine(String.format("Time taken to load image %d ns", duration));
+		// Store the core file/zip file path in the variables. We need it for creating default filenames for heapdumps.
 		variables.put(CORE_FILE_PATH_PROPERTY, coreFilePath);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see com.ibm.jvm.dtfjview.spi.ISession#findAndSetContextWithJVM()
 	 */

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corp. and others
+ * Copyright (c) 2011, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ public class OpenCommand extends BaseJdmpviewCommand {
 				Logger.getLogger("j9ddr.view.dtfj").setLevel(Level.WARNING);
 			}
 			// at this point the existence of either -core or -zip has been checked
-			long current = System.currentTimeMillis();
+			final long current = System.nanoTime();
 			File file1 = new File(args[0]);
 			Image[] images = new Image[1]; // default to a single image
 			if (args.length == 1) {
@@ -119,7 +119,8 @@ public class OpenCommand extends BaseJdmpviewCommand {
 				File file2 = new File(args[1]);
 				images[0] = factory.getImage(file1, file2);
 			}
-			logger.fine(String.format("Time taken to load image %d ms", System.currentTimeMillis() - current));
+			final long duration = System.nanoTime() - current;
+			logger.fine(String.format("Time taken to load image %d ns", duration));
 			for (Image image : images) {
 				createContexts(image, args[0]);
 			}


### PR DESCRIPTION
Replaced `System.currentTimeMillis()` w/ `System.nanoTime()`;
Refactored the code affected.

This is related to https://github.com/eclipse-openj9/openj9/pull/15016, but not CRIU specific changes.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>