### PR TITLE
loadClass throws CNFE if findClass via bootstrapClassLoader not succeed

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1223,6 +1223,7 @@ public Class<?> loadClass(String className) throws ClassNotFoundException {
 		if (cls != null) {
 			return cls;
 		}
+		throw new ClassNotFoundException(className);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION > 8 */
 	return loadClass(className, false);

--- a/test/functional/cmdLineTests/classLoaderTest/autoModuleClassloaderTest.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/autoModuleClassloaderTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,17 +24,22 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="Enable Assertion Status Tests in ClassLoder" timeout="300">
+<suite id="Classloader Tests For Classpath Jar and Automatic Module" timeout="300">
 
 	<variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$classloadertest.jar" />
+	<variable name="MODULEPATH" value="--module-path $Q$$TEST_RESROOT$$Q$classloadertest.jar" />
 
-	<test id="test with multiple -ea options to enable all types of assertion status in initialization">
-		<command>$EXE$ -ea  -ea:pkgname... -ea:classname $CLASSPATH$ org.openj9.test.assertionstatus.EnableAssertionStatusTest</command>
-		<output regex="no" type="success" caseSensitive="no">EnableAssertionStatusTest PASSED</output>
-		<output regex="no" type="failure" caseSensitive="no">EnableAssertionStatusTest FAILED</output>
-		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setDefaultAssertionStatus</output>
-		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setPackageAssertionStatus</output>
-		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setClassAssertionStatus</output>
-		<output regex="no" type="failure" caseSensitive="no">java.lang.Throwable</output>
+	<test id="test as classpath jar to verify a dummy class classloader">
+		<command>$EXE$ $CLASSPATH$ org.openj9.test.automodule.AutoModuleClassloaderTest</command>
+		<output regex="no" type="success" caseSensitive="no">AutoModuleClassloaderTest PASSED</output>
+		<output regex="no" type="failure" caseSensitive="no">AutoModuleClassloaderTest FAILED</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Exception</output>
+	</test>
+
+	<test id="test as automatic module to verify a dummy class classloader">
+		<command>$EXE$ $MODULEPATH$ -m classloadertest/org.openj9.test.automodule.AutoModuleClassloaderTest</command>
+		<output regex="no" type="success" caseSensitive="no">AutoModuleClassloaderTest PASSED</output>
+		<output regex="no" type="failure" caseSensitive="no">AutoModuleClassloaderTest FAILED</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Exception</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/classLoaderTest/enableAssertionStatusTest.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/enableAssertionStatusTest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="Enable Assertion Status Tests in ClassLoder" timeout="300">
+
+	<variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$classloadertest.jar" />
+
+	<test id="test with multiple -ea options to enable all types of assertion status in initialization">
+		<command>$EXE$ -ea  -ea:pkgname... -ea:classname $CLASSPATH$ org.openj9.test.assertionstatus.EnableAssertionStatusTest</command>
+		<output regex="no" type="success" caseSensitive="no">EnableAssertionStatusTest PASSED</output>
+		<output regex="no" type="failure" caseSensitive="no">EnableAssertionStatusTest FAILED</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setDefaultAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setPackageAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setClassAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Throwable</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/classLoaderTest/playlist.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2020, 2021 IBM Corp. and others
+  Copyright (c) 2020, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,11 +28,33 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)classloadertest.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)enableAssertionStatusTest.xml$(Q) \
 		-explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_AutoModuleClassloaderTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)autoModuleClassloaderTest.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>functional</group>

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/AutoModuleClassloaderTest.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/AutoModuleClassloaderTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.automodule;
+
+public class AutoModuleClassloaderTest {
+
+	public static void main(String[] args) throws Exception {
+		new AutoModuleClassloaderTest().test_autoModuleClassloader();
+	}
+
+	public void test_autoModuleClassloader() throws Exception {
+		CustomClassLoader ccl = new CustomClassLoader();
+		Class<?> clz = Class.forName("org.openj9.test.automodule.Dummy", true, ccl);
+		if (clz.getClassLoader() != ccl) {
+			System.out.println("AutoModuleClassloaderTest FAILED, expected classloader is " + ccl + ", but got " + clz.getClassLoader());
+		} else {
+			System.out.println("AutoModuleClassloaderTest PASSED");
+		}
+	}
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/CustomClassLoader.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/CustomClassLoader.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.automodule;
+
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+
+public class CustomClassLoader extends ClassLoader {
+	public CustomClassLoader() {
+		super(null);
+	}
+
+	protected Class<?> findClass(String className) throws ClassNotFoundException {
+		if ("org.openj9.test.automodule.Dummy".equalsIgnoreCase(className)) {
+			String classFile = className.replace('.', '/') + ".class";
+			DataInputStream dis = null;
+			try {
+				InputStream is = getClass().getClassLoader().getResourceAsStream(classFile);
+				if (is == null) {
+					throw new ClassNotFoundException();
+				}
+				byte classRep[] = new byte[is.available()];
+				dis = new DataInputStream(is);
+				dis.readFully(classRep);
+				return defineClass(className, classRep, 0, classRep.length);
+			} catch (IOException e) {
+				throw new ClassNotFoundException();
+			} finally {
+				if (dis != null) {
+					try {
+						dis.close();
+					} catch (IOException e) {
+					}
+				}
+			}
+		} else {
+			return super.loadClass(className);
+		}
+	}
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/Dummy.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/automodule/Dummy.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.automodule;
+
+public class Dummy {
+}


### PR DESCRIPTION
`loadClass(className)` should throw `ClassNotFoundException` if `findClass` via `bootstrapClassLoader` returns `null`;
`Class.forName(className)` in `java.base` can't load the classes outside of `java.base` module;
Add a test to verify the `classloader` of the class loaded via `automatic` module path, rename `classloadertest.xml` to
`enableAssertionStatusTest.xml`, add `autoModuleClassloaderTest.xml`, and update `playlist.xml`.

closes https://github.com/eclipse-openj9/openj9/issues/14975
This reverts https://github.com/eclipse-openj9/openj9/pull/14689

fyi @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>