### PR TITLE
Fix tracepoint matching

### DIFF
--- a/runtime/rastrace/trcmain.c
+++ b/runtime/rastrace/trcmain.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1093,17 +1093,14 @@ initializeTrace(UtThreadData **thr, void **gbl,
 	}
 
 	/*
-	 *  Check options for the debug switch. Options are in name / value pairs
-	 *  so only look at the first of each pair
+	 * Check options for the debug switch. Options are in name / value pairs
+	 * so only look at the first of each pair.
 	 */
-
-	for(i = 0; opts[i] != NULL; i += 2) {
-		if (0 == j9_cmdla_strnicmp(opts[i], UT_DEBUG_KEYWORD, strlen(UT_DEBUG_KEYWORD))) {
-			if (opts[i + 1] != NULL &&
-				strlen(opts[i + 1]) == 1 &&
-				*opts[i + 1] >= '0' &&
-				*opts[i + 1] <= '9') {
-				UT_GLOBAL(traceDebug) = atoi(opts[i + 1]);
+	for (i = 0; NULL != opts[i]; i += 2) {
+		if (0 == j9_cmdla_stricmp(opts[i], UT_DEBUG_KEYWORD)) {
+			const char *value = opts[i + 1];
+			if ((NULL != value) && ('0' <= value[0]) && (value[0] <= '9') && ('\0' == value[1])) {
+				UT_GLOBAL(traceDebug) = value[0] - '0';
 			} else {
 				UT_GLOBAL(traceDebug) = 9;
 			}
@@ -1501,28 +1498,24 @@ omr_error_t
 getComponentGroup(char *compName, char *groupName,
 					int32_t *count, int32_t **tracePts)
 {
-
-	UtComponentData *compData = NULL;
-	UtGroupDetails *groupDetails = NULL;
+	UtComponentData *compData = getComponentData(compName, UT_GLOBAL(componentList));
 
 	/*
-	 *  Find the component
+	 * Find the component.
 	 */
-	compData = getComponentData(compName, UT_GLOBAL(componentList));
-	if (compData != NULL && compData->moduleInfo != NULL) {
-		groupDetails = compData->moduleInfo->groupDetails;
-	}
+	if ((NULL != compData) && (NULL != compData->moduleInfo)) {
+		UtGroupDetails *groupDetails = compData->moduleInfo->groupDetails;
 
-	/*
-	 *  Now look for the group
-	 */
-	while ( groupDetails != NULL ) {
-		if ( !j9_cmdla_strnicmp(groupName, groupDetails->groupName, strlen(groupDetails->groupName))  ){
-			*count = groupDetails->count;
-			*tracePts = groupDetails->tpids;
-			return OMR_ERROR_NONE;
+		/*
+		 * Now look for the group.
+		 */
+		for (; NULL != groupDetails; groupDetails = groupDetails->next) {
+			if (0 == j9_cmdla_stricmp(groupName, groupDetails->groupName)) {
+				*count = groupDetails->count;
+				*tracePts = groupDetails->tpids;
+				return OMR_ERROR_NONE;
+			}
 		}
-		groupDetails = groupDetails->next;
 	}
 
 	*count = 0;

--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -246,9 +246,9 @@ setSleepTime(UtThreadData **thr, const char * str, BOOLEAN atRuntime)
 
 	if (*suffix != '\0') {
 		/* A suffix has been specified, parse it */
-		if (j9_cmdla_stricmp((char *)suffix, "s") == 0) {
+		if (j9_cmdla_stricmp(suffix, "s") == 0) {
 			unitsSeconds = TRUE;
-		} else if (j9_cmdla_stricmp((char *)suffix, "ms") == 0) {
+		} else if (j9_cmdla_stricmp(suffix, "ms") == 0) {
 			/* Do nothing - milliseconds is the default */
 		} else {
 			/* Unrecognised suffix */
@@ -362,12 +362,12 @@ decimalString2Int(const char *decString, int32_t signedAllowed, omr_error_t *rc,
 static uint32_t
 parseTriggerIndex(OMR_VMThread *thr, const char * name, BOOLEAN atRuntime)
 {
-	int i;
+	int i = 0;
 
 	for (i = 0; i < numTriggerActions; i++) {
 		const struct RasTriggerAction *action = &rasTriggerActions[i];
 
-		if (j9_cmdla_stricmp((char *)name, (char *)action->name) == 0) {
+		if (j9_cmdla_stricmp(name, action->name) == 0) {
 			return i;
 		}
 	}
@@ -847,35 +847,35 @@ processTriggerClause(OMR_VMThread *thr, const char *clause, BOOLEAN atRuntime)
 {
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(thr);
 	uintptr_t clauseLength = strlen(clause);
-	int i;
+	int i = 0;
 	BOOLEAN disableSet = FALSE;
 
-	if (clauseLength == 0) {
+	if (0 == clauseLength) {
 		reportCommandLineError(atRuntime, "Zero length clause in trigger statement.");
 		return OMR_ERROR_INTERNAL;
 	}
 
-	if (clause[clauseLength - 1] != '}') {
+	if ('}' != clause[clauseLength - 1]) {
 		reportCommandLineError(atRuntime, "Trigger clause must end with '}'");
 		return OMR_ERROR_INTERNAL;
 	}
 
-	if (*clause == '!') {
-		clause++;
+	if ('!' == *clause) {
+		clause += 1;
 		disableSet = TRUE;
 	}
 
 	for (i = 0; i < numTriggerTypes; i++) {
 		const struct RasTriggerType *type = &rasTriggerTypes[i];
+		uintptr_t typeLength = strlen(type->name);
 
-		if (j9_cmdla_strnicmp((char *)clause, (char *)type->name, strlen(type->name)) == 0) {
-			uintptr_t typeLength = strlen(type->name);
-			uintptr_t subClauseLength;
-			char *subClause;
-			int rc;
+		if (0 == j9_cmdla_strnicmp(clause, type->name, typeLength)) {
+			uintptr_t subClauseLength = 0;
+			char *subClause = NULL;
+			int rc = 0;
 
 			if (atRuntime && !type->runtimeModifiable) {
-				UT_DBGOUT(1, ("<UT> Trigger clause %s cannot be modified at run time\n",type->name));
+				UT_DBGOUT(1, ("<UT> Trigger clause %s cannot be modified at run time\n", type->name));
 				return OMR_ERROR_INTERNAL;
 			}
 
@@ -896,10 +896,9 @@ processTriggerClause(OMR_VMThread *thr, const char *clause, BOOLEAN atRuntime)
 				return OMR_ERROR_INTERNAL;
 			}
 
-			subClauseLength = clauseLength - typeLength - 2;
-
+			subClauseLength = clauseLength - typeLength - 2; /* 2 for { and } */
 			subClause = omrmem_allocate_memory(subClauseLength + 1, OMRMEM_CATEGORY_TRACE);
-			if (!subClause) {
+			if (NULL == subClause) {
 				UT_DBGOUT(1, ("<UT> Out of memory processing trigger property.\n"));
 				return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 			}
@@ -1242,7 +1241,6 @@ checkTriggerGroupsForTpid(OMR_VMThread *thr, char *compName, int traceId, const 
 static void
 checkTriggerTpidForTpid(OMR_VMThread *thr, char *compName, unsigned int traceId, const TriggerPhase phase, BOOLEAN actionArray[])
 {
-	size_t compNameLen = strlen(compName);
 	uintptr_t *refCountPtr = (uintptr_t *)&UT_GLOBAL(triggerOnTpidsReferenceCount);
 	RasTriggerTpidRange *ptr = NULL;
 	uint32_t oldDelay = 0;
@@ -1287,7 +1285,7 @@ checkTriggerTpidForTpid(OMR_VMThread *thr, char *compName, unsigned int traceId,
 			continue;
 		}
 
-		if (0 != j9_cmdla_strnicmp(compName, ptr->compName, compNameLen)) {
+		if (0 != j9_cmdla_stricmp(compName, ptr->compName)) {
 			/* wrong component name */
 			continue;
 		}


### PR DESCRIPTION
For example, before this change:
* these two options do the same thing even though there is no group named `staticmethodsXXXX`:
```
  "-Xtrace:print=mt,methods=java/lang/System.*,trigger=group{staticmethods,jstacktrace}"
  "-Xtrace:print=mt,methods=java/lang/System.*,trigger=group{staticmethodsXXXX,jstacktrace}"
```
* encountering tracepoint `j9utilcore.0` would trigger a java core if this option is used
```
  "-Xtrace:trigger=tpnid{j9util.0,javadump}"
```

Don't match abbreviated trace component names: use j9_cmdla_stricmp() instead of `j9_cmdla_strnicmp()` where appropriate.

Also remove redundant, inappropriate casts.