### PR TITLE
cmdLineTester_AutoModuleClassloaderTest only runs at JDK 11+

### DIFF
--- a/test/functional/cmdLineTests/classLoaderTest/playlist.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/playlist.xml
@@ -59,6 +59,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Java 8 doesn't support modularity tests.

related to https://github.com/eclipse-openj9/openj9/pull/15028

Signed-off-by: Jason Feng <fengj@ca.ibm.com>