### PR TITLE
Always call classMatchesCachedVersion in rememberClass

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -885,7 +885,15 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
    chainData = findChainForClass(clazz, key, keyLength);
    if (chainData != NULL)
       {
-      LOG(1, "\tchain exists (%p) so nothing to store\n", chainData);
+      if (classMatchesCachedVersion(clazz, chainData))
+         {
+         LOG(1, "\tcurrent class and class chain found (%p) are identical; returning the class chain\n", chainData);
+         }
+      else
+         {
+         LOG(1, "\tcurrent class and class chain found (%p) do not match, so cannot use class chain; returning NULL\n", chainData);
+         chainData = NULL;
+         }
       return chainData;
       }
 


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/issues/15013 for more details.

It is possible for two J9Classes to have the same J9ROMClass but have
different class chains. However, because a class chain is stored into
the SCC using a key derived from the J9ROMClass, it isn't possible to
store different class chains that have the same first J9ROMClass in the
chain. This can lead to undefined behaviour as invalid AOT code can be
executed.

This PR fixes the issue by changing the code that assumes that if it
can find an existing class chain in the SCC for a given J9Class, that it
is valid for said J9Class. The code now always validates the class
chain.

Closes https://github.com/eclipse-openj9/openj9/issues/15013