### PR TITLE
Update Generic template to add doc reminder

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic.md
+++ b/.github/ISSUE_TEMPLATE/generic.md
@@ -3,3 +3,5 @@ name: Generic issue
 about: Blank template
 
 ---
+
+REMINDER: Does this issue also affect the user documentation? If so, add labels and create a matching issue in the [openj9-docs](https://github.com/eclipse-openj9/openj9-docs/issues) repo, per the [contribution guidelines](https://github.com/eclipse-openj9/openj9/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Remind issue creators to consider docs and create an issue on the docs repo if necessary, as described in the contributing guidelines. 

Signed-off-by: Esther <doveye@uk.ibm.com>