### PR TITLE
Add CompilationInfo pointer into the J9JITConfig

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -770,7 +770,7 @@ TR::CompilationInfo::createCompilationInfo(J9JITConfig * jitConfig)
          that we do memset this object to 0 */
       memset(alloc, 0, sizeof(TR::CompilationInfo));
       _compilationRuntime = new (alloc) TR::CompilationInfo(jitConfig);
-
+      jitConfig->compilationRuntime = (void*)_compilationRuntime;
       #ifdef DEBUG
          if (debug("traceThreadCompile"))
             _compilationRuntime->_traceCompiling = true;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4047,6 +4047,7 @@ typedef struct J9JITConfig {
 	void ( *jitMethodBreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitMethodUnbreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
+	void* compilationRuntime;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	void ( *jitSetMutableCallSiteTarget)(struct J9VMThread *vmThread, j9object_t mcs, j9object_t newTarget) ;
 #endif /* J9VM_OPT_OPENJDK_METHODHANDLE */


### PR DESCRIPTION
This adds a new field to J9JITConfig caled compilationRuntime and
initializes it appropriately in
TR::CompilationInfo::createCompilationInfo(J9JITConfig * jitConfig)
Issue: #15036

Signed-off-by: Manasha Vetrivelu <manasha.vetrivelu@ibm.com>