### PR TITLE
Don't regress the default stack size in non-OpenJ9 builds

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2517,7 +2517,9 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args) {
 
 	switch (requestedVersion) {
 	case JNI_VERSION_1_1:
+#if defined(OPENJ9_BUILD)
 		((JDK1_1InitArgs *)vm_args)->javaStackSize = J9_OS_STACK_SIZE;
+#endif /* defined(OPENJ9_BUILD) */
 		break;
 	case JNI_VERSION_1_2:
 	case JNI_VERSION_1_4:

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -915,7 +915,9 @@ JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 
 		switch (jniVersion) {
 		case JNI_VERSION_1_1:
+#if defined(OPENJ9_BUILD)
 			((JDK1_1InitArgs *)vm_args)->javaStackSize = J9_OS_STACK_SIZE;
+#endif /* defined(OPENJ9_BUILD) */
 			break;
 		case JNI_VERSION_1_2:
 		case JNI_VERSION_1_4:


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/15011

Effectively revert https://github.com/eclipse-openj9/openj9/pull/14282 for non-OpenJ9 builds.