### PR TITLE
Only enable extended register support on JDK17+

### DIFF
--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,6 +107,11 @@
 #elif defined(J9VM_ENV_DATA64) && defined(J9VM_ARCH_POWER)
 /* increase stack space on PPC64 (AIX & Linux) since we are now preserving the
  * 32 128-bit Vector (VSCR) registers.
+ */
+#define J9_OS_STACK_SIZE (512 * 1024)
+#elif defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17)
+/* Increase default stack space on JDK17 as ymm/zmm registers are being preserved
+ * for vector API support
  */
 #define J9_OS_STACK_SIZE (512 * 1024)
 #else /* defined(J9VM_ENV_DATA64) && defined(J9ZOS390) */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1057,7 +1057,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	}
 #endif /* J9VM_OPT_JITSERVER */
 
-#if defined(J9HAMMER)
+#if defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17)
 	J9ProcessorDesc desc;
 	j9sysinfo_get_processor_description(&desc);
 
@@ -1069,7 +1069,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	} else if (j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX)) {
 		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
 	}
-#endif
+#endif /* defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) */
 
 	initArgs.j2seVersion = createParams->j2seVersion;
 	initArgs.j2seRootDirectory = createParams->j2seRootDirectory;


### PR DESCRIPTION
Only enable extended register support on JDK17+

Current ymm/zmm registers are used for vector API. No need to save extra
vector registers on older releases.

Closes https://github.com/eclipse-openj9/openj9/issues/15011

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>