### PR TITLE
Replace VERSION_GREATER_EQUAL with NOT VERSION_LESS in gnu.cmake

### DIFF
--- a/runtime/cmake/platform/toolcfg/gnu.cmake
+++ b/runtime/cmake/platform/toolcfg/gnu.cmake
@@ -21,7 +21,7 @@
 ################################################################################
 
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g -fstack-protector)
-if(OMR_DDR AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
+if(OMR_DDR AND NOT (CMAKE_C_COMPILER_VERSION VERSION_LESS 11))
 	# In gcc 11+ the default is to use DWARF version 5 which is not yet
 	# supported by ddrgen: tell the compiler to use DWARF version 4.
 	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -gdwarf-4)


### PR DESCRIPTION
...for compatibility with CMake versions below 3.7.