### PR TITLE
Recognize Class.cast and transform calls to it into checkcast

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -64,6 +64,7 @@
    java_lang_Class_isAssignableFrom,
    java_lang_Class_isInstance,
    java_lang_Class_isInterface,
+   java_lang_Class_cast,
    java_lang_ClassLoader_callerClassLoader,
    java_lang_ClassLoader_getCallerClassLoader,
    java_lang_ClassLoader_getStackClassLoader,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2091,6 +2091,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Class_isAssignableFrom,     "isAssignableFrom",     "(Ljava/lang/Class;)Z")},
       {x(TR::java_lang_Class_isInstance,           "isInstance",           "(Ljava/lang/Object;)Z")},
       {x(TR::java_lang_Class_isInterface,          "isInterface",          "()Z")},
+      {x(TR::java_lang_Class_cast,                 "cast",                 "(Ljava/lang/Object;)Ljava/lang/Object;")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4987,6 +4987,8 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          // VP transforms this into a plain new if it can get a non-null
          // known object java/lang/Class representing an initialized class
          return true;
+      case TR::java_lang_Class_cast:
+         return true; // Call will be transformed into checkcast
       case TR::java_lang_String_hashCodeImplDecompressed:
          /*
           * X86 and z want to avoid inlining both java_lang_String_hashCodeImplDecompressed and java_lang_String_hashCodeImplCompressed

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -85,6 +85,26 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     *     \endcode
     */
    void process_java_lang_Class_IsAssignableFrom(TR::TreeTop* treetop, TR::Node* node);
+
+   /** \brief
+    *     Transforms java/lang/Class.cast(Ljava/lang/Object;)Ljava/lang/Object;
+    *     into a checkcast node.
+    *
+    *  \param treetop
+    *     The treetop which anchors the call node.
+    *
+    *  \param node
+    *     The call node for java/lang/Class.cast(Ljava/lang/Object;)Ljava/lang/Object;
+    *     which has the following shape:
+    *
+    *     \code
+    *     acall java/lang/Class.cast(Ljava/lang/Object;)Ljava/lang/Object;
+    *       <cast class object>
+    *       <instance to be checked>
+    *     \endcode
+    */
+   void process_java_lang_Class_cast(TR::TreeTop* treetop, TR::Node* node);
+
    /** \brief
     *     Transforms java/lang/StringCoding.encodeASCII(B[B)[B into a compiler intrinsic for codegen acceleration (i.e encodeASCII symbol).
     *


### PR DESCRIPTION
This provides the opportunity to convert the call into a completely typical `checkcast` with a compile-time constant class bound (`loadaddr`). Even if the class bound can't be constant-folded, or if for some reason we simply fail to fold it, a `checkcast` whose class bound is not constant at compile time should still be at least as good as a call to `Class.cast` regardless of whether the call is inlined.

When the cast fails, the innermost frame listed in the stack trace will identify the call to `Class.cast` rather than an explicit throw within `Class.cast` itself. Additionally, the exception message will be generated in the same way as for `checkcast` bytecode instructions, which may (and appears to currently) differ cosmetically from the message used in `Class.cast`. Neither of these discrepancies should impede debugging.

`Class.cast` calls occur very often in compilations involving OpenJDK MethodHandles.