### PR TITLE
Disable the FFI specific test suites in Java 19

### DIFF
--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -99,24 +99,46 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-			<src path="${src}" />
-			<src path="${src_160}" />
-			<src path="${TestUtilities}" />
-			<exclude name="**/modules/**" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-			<compilerarg line='--add-modules jdk.incubator.foreign' />
-			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
-			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
-			<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
-			<compilerarg line='--add-opens java.base/java.lang=ALL-UNNAMED' />
-			<classpath>
-				<pathelement location="${LIB_DIR}/testng.jar" />
-				<pathelement location="${LIB_DIR}/jcommander.jar" />
-				<pathelement location="${LIB_DIR}/asm.jar" />
-				<pathelement location="${build}" />
-			</classpath>
-		</javac>
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="16"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${src_160}" />
+					<src path="${TestUtilities}" />
+					<exclude name="**/modules/**" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line='--add-modules jdk.incubator.foreign' />
+					<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/java.lang=ALL-UNNAMED' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<exclude name="**/modules/**" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/java.lang=ALL-UNNAMED' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</else>
+		</if>
 	</target>
 
 	<target name="dist" depends="compile,compile_modules" description="generate the distribution">

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -153,7 +153,7 @@
 			--add-opens java.base/java.lang=ALL-UNNAMED \
 			--add-modules jdk.incubator.foreign \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_160.xml$(Q) \
 			-testnames CloseScope0Tests \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
@@ -166,7 +166,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>16+</version>
+			<version>16</version>
 		</versions>
 	</test>
 

--- a/test/functional/Java16andUp/src_160/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
+++ b/test/functional/Java16andUp/src_160/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
@@ -1,7 +1,7 @@
 package org.openj9.test.foreignMemoryAccess;
 
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java16andUp/testng.xml
+++ b/test/functional/Java16andUp/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2021, 2021 IBM Corp. and others
+  Copyright (c) 2021, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,11 +27,6 @@
     <test name="Jep397Tests">
         <classes>
             <class name="org.openj9.test.java.lang.Test_Class"/>
-        </classes>
-    </test>
-    <test name="CloseScope0Tests">
-        <classes>
-            <class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
         </classes>
     </test>
 </suite>

--- a/test/functional/Java16andUp/testng_160.xml
+++ b/test/functional/Java16andUp/testng_160.xml
@@ -41,4 +41,9 @@
 			<class name="org.openj9.test.jep389.valist.VaListTests"/>
 		</classes>
 	</test>
+	<test name="CloseScope0Tests">
+		<classes>
+			<class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
+		</classes>
+	</test>
 </suite>

--- a/test/functional/Java17andUp/build.xml
+++ b/test/functional/Java17andUp/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2021, 2021 IBM Corp. and others
+Copyright (c) 2021, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<property name="build" location="bin" />
 	<property name="LIB" value="asm,testng,jcommander" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 
 	<if>
 		<equals arg1="${JDK_VERSION}" arg2="17" />
@@ -59,18 +60,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-			<src path="${src}" />
-			<src path="${src_170}" />
-			<compilerarg line='--add-modules jdk.incubator.foreign' />
-			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
-			<classpath>
-				<pathelement location="${LIB_DIR}/testng.jar" />
-				<pathelement location="${LIB_DIR}/jcommander.jar" />
-				<pathelement location="${LIB_DIR}/asm.jar" />
-				<pathelement location="${build}" />
-			</classpath>
-		</javac>
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="17"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${src_170}" />
+					<src path="${TestUtilities}" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line='--add-modules jdk.incubator.foreign' />
+					<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</else>
+		</if>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/Java17andUp/playlist.xml
+++ b/test/functional/Java17andUp/playlist.xml
@@ -38,7 +38,7 @@
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep389Tests_testClinkerFfi_DownCall \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_170.xml$(Q) -testnames Jep389Tests_testClinkerFfi_DownCall \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
@@ -67,7 +67,7 @@
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep389Tests_testClinkerFfi_VaList \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_170.xml$(Q) -testnames Jep389Tests_testClinkerFfi_VaList \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
@@ -82,6 +82,37 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<versions>
+			<version>17</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>CloseScope0Tests</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+			--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED \
+			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+			--add-opens java.base/java.lang=ALL-UNNAMED \
+			--add-modules jdk.incubator.foreign \
+			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_170.xml$(Q) \
+			-testnames CloseScope0Tests \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
 		<versions>
 			<version>17</version>
 		</versions>

--- a/test/functional/Java17andUp/src_170/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
@@ -1,0 +1,187 @@
+package org.openj9.test.foreignMemoryAccess;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+import org.openj9.test.util.VersionCheck;
+
+import java.lang.reflect.*;
+import java.lang.ref.Cleaner;
+import jdk.internal.misc.ScopedMemoryAccess.*;
+
+import org.objectweb.asm.*;
+import static org.objectweb.asm.Opcodes.*;
+
+@Test(groups = { "level.sanity" })
+public class TestCloseScope0 {
+	public static byte[] dump() throws Exception {
+		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+		MethodVisitor mv;
+		AnnotationVisitor av0;
+
+		cw.visit(V16, ACC_PUBLIC + ACC_SUPER, "jdk/internal/misc/RunInScoped", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		{
+			/**
+			 * @Scoped		// <-- package private annotation that isn't visible here.  This is why we use ASM to generate the class
+			 * public static void runInScoped(Runnable r, Scope scope) {
+			 *      r.run();
+			 *      Reference.reachabilityFence(scope);
+			 * }
+			 */
+			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "runInScoped", "(Ljava/lang/Runnable;Ljdk/internal/misc/ScopedMemoryAccess$Scope;)V", null, null);
+			{
+				av0 = mv.visitAnnotation("Ljdk/internal/misc/ScopedMemoryAccess$Scoped;", true);
+				av0.visitEnd();
+			}
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/Runnable", "run", "()V", true);
+			mv.visitVarInsn(ALOAD, 1);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/ref/Reference", "reachabilityFence", "(Ljava/lang/Object;)V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	private static Throwable expected = null;
+	private static volatile boolean t1Started = false;
+	private static volatile boolean t2Waiting = false;
+
+	@Test(expectedExceptions=java.lang.IllegalStateException.class)
+	public static void closeScopeDuringAccess() throws Throwable {
+		/* Reflect setup */
+		Class memoryOrResourceScope;
+		Method createShared;
+		Method close;
+		Object scope;
+
+		int version = VersionCheck.major();
+		if (version == 16) {
+			memoryOrResourceScope = Class.forName("jdk.internal.foreign.MemoryScope");
+			createShared = memoryOrResourceScope.getDeclaredMethod("createShared", new Class[] {Object.class, Runnable.class, Cleaner.class});
+			createShared.setAccessible(true);
+			scope = createShared.invoke(null, null, new Thread(), null);
+		} else {
+			memoryOrResourceScope = Class.forName("jdk.internal.foreign.ResourceScopeImpl");
+			createShared = memoryOrResourceScope.getDeclaredMethod("createShared", new Class[] {Cleaner.class});
+			createShared.setAccessible(true);
+			scope = createShared.invoke(null, Cleaner.create());
+		}
+		close = memoryOrResourceScope.getDeclaredMethod("close");
+		close.setAccessible(true);
+		/* End Reflect setup */
+
+		/* ASM setup */
+		final byte[] classBytes = dump();
+
+		ClassLoader loader = ClassLoader.getSystemClassLoader();
+		Class cls = Class.forName("java.lang.ClassLoader");
+		Method defineClass = cls.getDeclaredMethod(
+						"defineClass",
+						new Class[] { String.class, byte[].class, int.class, int.class });
+		defineClass.setAccessible(true);
+
+		Object[] dcArgs = new Object[] {"jdk.internal.misc.RunInScoped", classBytes, 0, classBytes.length};
+		Class RunInScoped = (Class)defineClass.invoke(loader, dcArgs);
+		Method runInScoped = RunInScoped.getDeclaredMethod("runInScoped", new Class[] {Runnable.class, Scope.class});
+		/* End ASM setup */
+
+		Synch synch1 = new Synch();
+		Synch synch2 = new Synch();
+
+		Thread t1 = new Thread(()->{
+			try {
+				synchronized (synch1) {
+					t1Started = true;
+					synch1.wait();
+				}
+				close.invoke(scope);
+			} catch (InvocationTargetException e) {
+				// This is the expected behaviour (throws IllegalStateException)
+				expected = e.getCause();
+			} catch (InterruptedException | IllegalAccessException e) {
+				e.printStackTrace();
+			} finally {
+				while (!t2Waiting) {
+					Thread.yield();
+				}
+				synchronized (synch2) {
+					synch2.notify();
+				}
+			}
+		}, "ScopeCloserThread");
+
+		class MyRunnable implements Runnable {
+			public void run() {
+				try {
+					while (!t1Started) {
+						Thread.yield();
+					}
+					synchronized (synch1) {
+						synch1.notify();
+					}
+					synchronized (synch2) {
+						t2Waiting = true;
+						synch2.wait();
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+
+		MyRunnable r = new MyRunnable();
+		Thread t2 = new Thread(()->{
+			try {
+				runInScoped.invoke(null, r, scope);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}, "RunInScopeThread");
+
+		t1.start();
+		t2.start();
+
+		t1.join();
+		t2.join();
+
+		if (expected != null) throw expected;
+	}
+}
+
+class Synch {}

--- a/test/functional/Java17andUp/testng_170.xml
+++ b/test/functional/Java17andUp/testng_170.xml
@@ -44,4 +44,9 @@
 			<class name="org.openj9.test.jep389.valist.VaListTests"/>
 		</classes>
 	</test>
+	<test name="CloseScope0Tests">
+		<classes>
+			<class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
+		</classes>
+	</test>
 </suite>

--- a/test/functional/Java18andUp/build.xml
+++ b/test/functional/Java18andUp/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2021, 2021 IBM Corp. and others
+Copyright (c) 2021, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<property name="build" location="bin" />
 	<property name="LIB" value="asm,testng,jcommander" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -48,17 +49,26 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-			<src path="${src}" />
-			<compilerarg line='--add-modules jdk.incubator.foreign' />
-			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
-			<classpath>
-				<pathelement location="${LIB_DIR}/testng.jar" />
-				<pathelement location="${LIB_DIR}/jcommander.jar" />
-				<pathelement location="${LIB_DIR}/asm.jar" />
-				<pathelement location="${build}" />
-			</classpath>
-		</javac>
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="18"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line='--add-modules jdk.incubator.foreign' />
+					<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</then>
+		</if>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/Java18andUp/playlist.xml
+++ b/test/functional/Java18andUp/playlist.xml
@@ -31,7 +31,7 @@
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep419Tests_testClinkerFfi_DownCall \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_180.xml$(Q) -testnames Jep419Tests_testClinkerFfi_DownCall \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
@@ -47,7 +47,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>18+</version>
+			<version>18</version>
 		</versions>
 	</test>
 	<test>
@@ -60,7 +60,7 @@
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testClinkerFfi.xml$(Q) -testnames Jep419Tests_testClinkerFfi_VaList \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_180.xml$(Q) -testnames Jep419Tests_testClinkerFfi_VaList \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
@@ -76,7 +76,38 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>18+</version>
+			<version>18</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>CloseScope0Tests</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+			--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED \
+			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+			--add-opens java.base/java.lang=ALL-UNNAMED \
+			--add-modules jdk.incubator.foreign \
+			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_180.xml$(Q) \
+			-testnames CloseScope0Tests \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>18</version>
 		</versions>
 	</test>
 </playlist>

--- a/test/functional/Java18andUp/src/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
+++ b/test/functional/Java18andUp/src/org/openj9/test/foreignMemoryAccess/TestCloseScope0.java
@@ -1,0 +1,187 @@
+package org.openj9.test.foreignMemoryAccess;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+import org.openj9.test.util.VersionCheck;
+
+import java.lang.reflect.*;
+import java.lang.ref.Cleaner;
+import jdk.internal.misc.ScopedMemoryAccess.*;
+
+import org.objectweb.asm.*;
+import static org.objectweb.asm.Opcodes.*;
+
+@Test(groups = { "level.sanity" })
+public class TestCloseScope0 {
+	public static byte[] dump() throws Exception {
+		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+		MethodVisitor mv;
+		AnnotationVisitor av0;
+
+		cw.visit(V16, ACC_PUBLIC + ACC_SUPER, "jdk/internal/misc/RunInScoped", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		{
+			/**
+			 * @Scoped		// <-- package private annotation that isn't visible here.  This is why we use ASM to generate the class
+			 * public static void runInScoped(Runnable r, Scope scope) {
+			 *      r.run();
+			 *      Reference.reachabilityFence(scope);
+			 * }
+			 */
+			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "runInScoped", "(Ljava/lang/Runnable;Ljdk/internal/misc/ScopedMemoryAccess$Scope;)V", null, null);
+			{
+				av0 = mv.visitAnnotation("Ljdk/internal/misc/ScopedMemoryAccess$Scoped;", true);
+				av0.visitEnd();
+			}
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/Runnable", "run", "()V", true);
+			mv.visitVarInsn(ALOAD, 1);
+			mv.visitMethodInsn(INVOKESTATIC, "java/lang/ref/Reference", "reachabilityFence", "(Ljava/lang/Object;)V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 0);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	private static Throwable expected = null;
+	private static volatile boolean t1Started = false;
+	private static volatile boolean t2Waiting = false;
+
+	@Test(expectedExceptions=java.lang.IllegalStateException.class)
+	public static void closeScopeDuringAccess() throws Throwable {
+		/* Reflect setup */
+		Class memoryOrResourceScope;
+		Method createShared;
+		Method close;
+		Object scope;
+
+		int version = VersionCheck.major();
+		if (version == 16) {
+			memoryOrResourceScope = Class.forName("jdk.internal.foreign.MemoryScope");
+			createShared = memoryOrResourceScope.getDeclaredMethod("createShared", new Class[] {Object.class, Runnable.class, Cleaner.class});
+			createShared.setAccessible(true);
+			scope = createShared.invoke(null, null, new Thread(), null);
+		} else {
+			memoryOrResourceScope = Class.forName("jdk.internal.foreign.ResourceScopeImpl");
+			createShared = memoryOrResourceScope.getDeclaredMethod("createShared", new Class[] {Cleaner.class});
+			createShared.setAccessible(true);
+			scope = createShared.invoke(null, Cleaner.create());
+		}
+		close = memoryOrResourceScope.getDeclaredMethod("close");
+		close.setAccessible(true);
+		/* End Reflect setup */
+
+		/* ASM setup */
+		final byte[] classBytes = dump();
+
+		ClassLoader loader = ClassLoader.getSystemClassLoader();
+		Class cls = Class.forName("java.lang.ClassLoader");
+		Method defineClass = cls.getDeclaredMethod(
+						"defineClass",
+						new Class[] { String.class, byte[].class, int.class, int.class });
+		defineClass.setAccessible(true);
+
+		Object[] dcArgs = new Object[] {"jdk.internal.misc.RunInScoped", classBytes, 0, classBytes.length};
+		Class RunInScoped = (Class)defineClass.invoke(loader, dcArgs);
+		Method runInScoped = RunInScoped.getDeclaredMethod("runInScoped", new Class[] {Runnable.class, Scope.class});
+		/* End ASM setup */
+
+		Synch synch1 = new Synch();
+		Synch synch2 = new Synch();
+
+		Thread t1 = new Thread(()->{
+			try {
+				synchronized (synch1) {
+					t1Started = true;
+					synch1.wait();
+				}
+				close.invoke(scope);
+			} catch (InvocationTargetException e) {
+				// This is the expected behaviour (throws IllegalStateException)
+				expected = e.getCause();
+			} catch (InterruptedException | IllegalAccessException e) {
+				e.printStackTrace();
+			} finally {
+				while (!t2Waiting) {
+					Thread.yield();
+				}
+				synchronized (synch2) {
+					synch2.notify();
+				}
+			}
+		}, "ScopeCloserThread");
+
+		class MyRunnable implements Runnable {
+			public void run() {
+				try {
+					while (!t1Started) {
+						Thread.yield();
+					}
+					synchronized (synch1) {
+						synch1.notify();
+					}
+					synchronized (synch2) {
+						t2Waiting = true;
+						synch2.wait();
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+
+		MyRunnable r = new MyRunnable();
+		Thread t2 = new Thread(()->{
+			try {
+				runInScoped.invoke(null, r, scope);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}, "RunInScopeThread");
+
+		t1.start();
+		t2.start();
+
+		t1.join();
+		t2.join();
+
+		if (expected != null) throw expected;
+	}
+}
+
+class Synch {}

--- a/test/functional/Java18andUp/testng_180.xml
+++ b/test/functional/Java18andUp/testng_180.xml
@@ -23,7 +23,7 @@
 -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Java18andUp test suite" parallel="none" verbose="2">
+<suite name="Java18 test suite" parallel="none" verbose="2">
 	<test name="Jep419Tests_testClinkerFfi_DownCall">
 		<classes>
 			<class name="org.openj9.test.jep419.downcall.InvalidDownCallTests"/>
@@ -41,6 +41,11 @@
 	<test name="Jep419Tests_testClinkerFfi_VaList">
 		<classes>
 			<class name="org.openj9.test.jep419.valist.VaListTests"/>
+		</classes>
+	</test>
+	<test name="CloseScope0Tests">
+		<classes>
+			<class name="org.openj9.test.foreignMemoryAccess.TestCloseScope0"/>
 		</classes>
 	</test>
 </suite>


### PR DESCRIPTION
The change is to only enable the FFI specific test suites
on Java 18 given there is on backward compatibility between
Java 19 and Java 18 in terms of FFI APIs.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>