### PR TITLE
Exclude the FFI specific java code(Incubator) from Java19

### DIFF
--- a/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 16) & (JAVA_SPEC_VERSION <= 18) ]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 16) & (JAVA_SPEC_VERSION <= 18)]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2022 IBM Corp. and others
  *

--- a/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 16]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 16) & (JAVA_SPEC_VERSION <= 18)]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2022 IBM Corp. and others
  *

--- a/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/TypeLayoutCheckHelper.java
+++ b/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/TypeLayoutCheckHelper.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION <= 17]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 16) & (JAVA_SPEC_VERSION <= 17)]*/
 /*******************************************************************************
  * Copyright (c) 2021, 2022 IBM Corp. and others
  *


### PR DESCRIPTION
The change is to ensure that the FFI specific java code
in the incubator module only works for Java 17 & 18.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>