### PR TITLE
Enable DDR for platforms with no JIT compiler

### DIFF
--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,7 @@ target_include_directories(j9ddr_misc
 		${j9vm_SOURCE_DIR}/bcutil
 		${j9vm_BINARY_DIR}/bcutil
 		${j9vm_SOURCE_DIR}/shared_common/include
+		${j9vm_SOURCE_DIR}/compiler
 		${omr_SOURCE_DIR}/compiler
 )
 

--- a/runtime/ddr/jitflagsddr.c
+++ b/runtime/ddr/jitflagsddr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,25 @@
 #include "j9ddr.h"
 #include "ddrtable.h"
 #include "env/defines.h" /* for TR_HOST_XXX */
+#include "runtime/MethodMetaData.h"
+
+#if !defined(INTERNAL_PTR_REG_MASK)
+/*
+ * Make INTERNAL_PTR_REG_MASK visible to DDR even for platforms without
+ * a JIT compiler.
+ *
+ * A definition of INTERNAL_PTR_REG_MASK is provided by MethodMetaData.h,
+ * so this code is excluded by the compiler. On the other hand, the macro
+ * recognition that supports DDR won't know that and will contribute the
+ * line
+ *   MACRO_INTERNAL_PTR_REG_MASK INTERNAL_PTR_REG_MASK
+ * to jitflagsddr.stub.c, which will be expanded by the preprocessor and
+ * ultimately included in j9ddr.macros, making the actual value available
+ * to DDR (not the one provided here).
+ */
+/* @ddr_namespace: map_to_type=MethodMetaDataConstants */
+#define INTERNAL_PTR_REG_MASK 0
+#endif /* !defined(INTERNAL_PTR_REG_MASK) */
 
 /* @ddr_namespace: map_to_type=TRBuildFlags */
 


### PR DESCRIPTION
DDR requires the constant `INTERNAL_PTR_REG_MASK` defined in `MethodMetaData.h`, which was previously only included in JIT code. This change exposes that constant to the DDR macro extraction process so it can be included in the generated code for DDR, even for platforms with no JIT compiler yet (e.g. RISC-V).
