### PR TITLE
UMA: Enable DDR for platforms with no JIT compiler

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2010, 2020 IBM Corp. and others
+Copyright (c) 2010, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -413,6 +413,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</include>
 			<include path="j9gcvlhgc"/>
 			<include path="$(OMR_DIR)/include_core" type="relativepath"/>
+			<include path="../compiler" type="relativepath">
+				<include-if condition="spec.flags.J9VM_INTERP_NATIVE_SUPPORT"/>
+			</include>
 			<include path="$(OMR_DIR)/compiler" type="relativepath">
 				<include-if condition="spec.flags.J9VM_INTERP_NATIVE_SUPPORT"/>
 			</include>


### PR DESCRIPTION
Update include path for UMA builds as was done in #15093 for cmake builds.
