### PR TITLE
Invoke SharedSecrets.setJavaLangAccess() before ensureProperties()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -301,12 +301,10 @@ public final class System {
 		if (null == com.ibm.oti.vm.VM.getVMLangAccess()) {
 			com.ibm.oti.vm.VM.setVMLangAccess(new VMAccess());
 		}
+		SharedSecrets.setJavaLangAccess(new Access());
 
 		// Fill in the properties from the VM information.
 		ensureProperties(true);
-
-		/*[PR CMVC 150472] sun.misc.SharedSecrets needs access to java.lang. */
-		SharedSecrets.setJavaLangAccess(new Access());
 
 		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		initJCLPlatformEncoding();


### PR DESCRIPTION
Fix NPE due to `sun.nio.cs.UTF_8.JLA` is `null`.

W/ this PR and https://github.com/eclipse-openj9/openj9/pull/15073, `openj9-staging` builds and produces `-version` output:
```
openjdk version "19-internal" 2022-09-20
OpenJDK Runtime Environment (build 19-internal-adhoc.jasonfeng.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jdk19jlanull-ae35bc4868, JRE 19 Mac OS X amd64-64-Bit Compressed References 20220520_000000 (JIT enabled, AOT enabled)
OpenJ9   - ae35bc4868
OMR      - 42677ec34
JCL      - 7d835a41a65 based on jdk-19+23)
```

closes https://github.com/eclipse-openj9/openj9/issues/15098

Signed-off-by: Jason Feng <fengj@ca.ibm.com>