### PR TITLE
AArch64 macOS: Include pthread.h explicitly

### DIFF
--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -35,6 +35,10 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 
+#if defined(OSX)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 static uint8_t *storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, TR::RealRegister *reg, int32_t offset, TR::CodeGenerator *cg)
    {
    TR::RealRegister *stackPtr = cg->getStackPointerRegister();

--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -29,6 +29,10 @@
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/J9Runtime.hpp"
 
+#if defined(OSX)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 extern void arm64CodeSync(uint8_t *, uint32_t);
 
 #define DEBUG_ARM64_RECOMP false

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -144,6 +144,10 @@ static void printCompFailureInfo(TR::Compilation * comp, const char * reason);
 #include "runtime/IProfiler.hpp"
 #endif
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 IDATA J9THREAD_PROC compilationThreadProc(void *jitconfig);
 IDATA J9THREAD_PROC protectedCompilationThreadProc(J9PortLibrary *portLib, TR::CompilationInfoPerThread*compInfoPT/*void *vmthread*/);
 

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -40,6 +40,10 @@
 #endif
 #include "omrformatconsts.h"
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 extern TR::Monitor *assumptionTableMutex;
 
 bool

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -55,6 +55,10 @@
 #include "env/VerboseLog.hpp"
 #include "omrformatconsts.h"
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 OMR::CodeCacheMethodHeader *getCodeCacheMethodHeader(char *p, int searchLimit, J9JITExceptionTable * metaData);
 
 #define addFreeBlock2(start, end) addFreeBlock2WithCallSite((start), (end), __FILE__, __LINE__)

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -62,6 +62,9 @@
 #include "control/MethodToBeCompiled.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
 
 // TODO: move this someplace common for RuntimeAssumptions.cpp and here
 #if defined(__IBMCPP__) && !defined(AIXPPC) && !defined(LINUXPPC)

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -80,6 +80,10 @@
 
 #include "exceptions/AOTFailure.hpp"
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 char *TR_RelocationRuntime::_reloErrorCodeNames[] =
    {
    "relocationOK",                                     // 0

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -32,6 +32,10 @@
 #include "runtime/J9Runtime.hpp"
 #include "control/CompilationRuntime.hpp"
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 #define PPC_INSTRUCTION_LENGTH 4
 
 #if defined(TR_TARGET_POWER)


### PR DESCRIPTION
This commit adds "#include <pthread.h>" to the files that call
pthread_jit_write_protect_np() on AArch64 macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>