### PR TITLE
Add InternalCRIUSupport.getCheckpointRestoreTimeDelta() & tests

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -30,9 +30,24 @@ package openj9.internal.criu;
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class InternalCRIUSupport {
 	private static boolean criuSupportEnabled = isCRIUSupportEnabledImpl();
+	private static long checkpointRestoreNanoTimeDelta;
 
 	private static native boolean isCRIUSupportEnabledImpl();
 	private static native boolean isCheckpointAllowedImpl();
+	private static native long getCheckpointRestoreNanoTimeDeltaImpl();
+
+	/**
+	 * Retrieve the elapsed time between Checkpoint and Restore.
+	 * Only support one Checkpoint.
+	 *
+	 * @return the time in nanoseconds.
+	 */
+	public static long getCheckpointRestoreNanoTimeDelta() {
+		if (checkpointRestoreNanoTimeDelta == 0) {
+			checkpointRestoreNanoTimeDelta = getCheckpointRestoreNanoTimeDeltaImpl();
+		}
+		return checkpointRestoreNanoTimeDelta;
+	}
 
 	/**
 	 * Queries if CRIU support is enabled.

--- a/runtime/criusupport/criusupport.hpp
+++ b/runtime/criusupport/criusupport.hpp
@@ -28,12 +28,6 @@
 
 extern "C" {
 
-jboolean JNICALL
-Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused);
-
-jboolean JNICALL
-Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
-
 void JNICALL
 Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory, jboolean unprivileged);
 

--- a/runtime/criusupport/exports.cmake
+++ b/runtime/criusupport/exports.cmake
@@ -22,8 +22,6 @@
 
 if(J9VM_OPT_CRIU_SUPPORT)
 	omr_add_exports(j9criu
-		Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl
-		Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl
 		Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl
 	)
 endif()

--- a/runtime/criusupport/uma/criusupport_exports.xml
+++ b/runtime/criusupport/uma/criusupport_exports.xml
@@ -20,7 +20,5 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="criusupport">
-	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl" />
-	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl" />
 	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl" />
 </exports>

--- a/runtime/jcl/common/criu.cpp
+++ b/runtime/jcl/common/criu.cpp
@@ -30,6 +30,14 @@ extern "C" {
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 
+jlong JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl(JNIEnv *env, jclass unused)
+{
+	PORT_ACCESS_FROM_ENV(env);
+
+	return PORTLIB->checkpointRestoreTimeDelta;
+}
+
 jboolean JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused)
 {

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -660,6 +660,7 @@ endif()
 # J9VM_OPT_CRIU_SUPPORT
 if(J9VM_OPT_CRIU_SUPPORT)
 	omr_add_exports(jclse
+		Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl
 	)

--- a/runtime/jcl/uma/criu_exports.xml
+++ b/runtime/jcl/uma/criu_exports.xml
@@ -20,6 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="criu">
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl" />
 	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl" />
 	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl" />
 </exports>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -50,8 +50,8 @@
     <output type="required" caseSensitive="yes" regex="no">Error</output>
   </test>
 
-  <test id="Create CRIU checkpoint image and restore three times">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_TIMECHANGE$ ThreeCheckpoints</command>
+  <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTime">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTime" ThreeCheckpoints</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
     <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
@@ -61,4 +61,47 @@
     <output type="required" caseSensitive="yes" regex="no">Error</output>
   </test>
 
+  <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayBeforeCheckpointDone" ThreeCheckpoints</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testMillisDelay</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: expected MILLIS_DELAY</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: expected MILLIS_DELAY</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayAfterCheckpointDone" ThreeCheckpoints</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testMillisDelay</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: expected MILLIS_DELAY</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: expected MILLIS_DELAY</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore three times - testDateScheduledBeforeCheckpointDone">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledBeforeCheckpointDone" ThreeCheckpoints</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testDateScheduledBeforeCheckpointDone</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: expected to run after timeMillisScheduledBeforeCheckpointDone</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: expected to run after timeMillisScheduledBeforeCheckpointDone</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore three times - testDateScheduledAfterCheckpointDone">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledAfterCheckpointDone" ThreeCheckpoints</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testDateScheduledAfterCheckpointDone</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: expected to run after timeMillisScheduledAfterCheckpointDone</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: expected to run after timeMillisScheduledAfterCheckpointDone</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
 </suite>


### PR DESCRIPTION
Return the time in milliseconds elapsed between Checkpoint and Restore;
Add tests for `Timer.schedule(TimerTask task, long delay)` and `Timer.schedule(TimerTask task, Date time)`.

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/531 https://github.com/eclipse-openj9/openj9/issues/14211

Signed-off-by: Jason Feng <fengj@ca.ibm.com>