### PR TITLE
Avoid GREATER_EQUAL in CMake files

### DIFF
--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -636,8 +636,7 @@ if(J9VM_OPT_OPENJDK_METHODHANDLE)
 	)
 	if(JAVA_SPEC_VERSION EQUAL 8)
 		omr_add_exports(jclse Java_java_lang_invoke_MethodHandleNatives_getConstant)
-	endif()
-	if(JAVA_SPEC_VERSION GREATER_EQUAL 11)
+	else()
 		omr_add_exports(jclse
 			Java_java_lang_invoke_MethodHandleNatives_copyOutBootstrapArguments
 			Java_java_lang_invoke_MethodHandleNatives_clearCallSiteContext


### PR DESCRIPTION
GREATER_EQUAL is not available in the minimum CMake version that OpenJ9
supports.

So, Java version >= 11 is rewritten as an "else()".

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>