### PR TITLE
Add API getDefaultValueSlotAddress

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2079,6 +2079,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, TR::Compiler->cls.flattenedArrayElementSize(comp, arrayClass));
          }
          break;
+      case MessageType::ClassEnv_getDefaultValueSlotAddress:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *>();
+         auto clazz = std::get<0>(recv);
+         client->write(response, TR::Compiler->cls.getDefaultValueSlotAddress(comp, clazz));
+         }
+         break;
       case MessageType::ClassEnv_enumerateFields:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *>();

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -55,6 +55,7 @@ public:
       CLASSINFO_CONSTANT_POOL,
       CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
       CLASSINFO_ARRAY_ELEMENT_SIZE,
+      CLASSINFO_DEFAULT_VALUE_SLOT_ADDRESS,
       };
 
    // NOTE: when adding new elements to this tuple, add them to the end,
@@ -84,7 +85,8 @@ public:
       uintptr_t,                         // 20: _classChainOffsetIdentifyingLoader
       std::vector<J9ROMMethod *>,        // 21: _origROMMethods
       std::string,                       // 22: _classNameIdentifyingLoader
-      int32_t                            // 23: _arrayElementSize
+      int32_t,                           // 23: _arrayElementSize
+      j9object_t *                       // 24: _defaultValueSlotAddress
       >;
 
    // Packs a ROMClass to be transferred to the server.

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -277,6 +277,17 @@ public:
     * 2 concrete classses and false otherwise.
     */
    bool containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
+
+   /** \brief
+    *     Returns the reference to the address of the default value instance for a value class.
+    *
+    *  \param clazz
+    *     The class that the default value instance belongs to. Must be an initialized value class.
+    *
+    *  \return
+    *     The reference to the address of the default value instance.
+    */
+   j9object_t *getDefaultValueSlotAddress(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
    };
 
 }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -97,7 +97,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 39;
+   static const uint16_t MINOR_NUMBER = 40;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -211,6 +211,7 @@ const char *messageNames[] =
    "ClassEnv_enumerateFields",
    "ClassEnv_isClassRefPrimitiveValueType",
    "ClassEnv_flattenedArrayElementSize",
+   "ClassEnv_getDefaultValueSlotAddress",
    "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",
    "SharedCache_addHint",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -224,6 +224,7 @@ enum MessageType : uint16_t
    ClassEnv_enumerateFields,
    ClassEnv_isClassRefPrimitiveValueType,
    ClassEnv_flattenedArrayElementSize,
+   ClassEnv_getDefaultValueSlotAddress,
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetIdentifyingLoader,

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -415,6 +415,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _classNameIdentifyingLoader(),
    _aotCacheClassRecord(NULL),
    _arrayElementSize(0),
+   _defaultValueSlotAddress(NULL),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(persistentMemory->_persistentAllocator.get())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -210,6 +210,7 @@ public:
       std::string _classNameIdentifyingLoader;
       const AOTCacheClassRecord *_aotCacheClassRecord;
       int32_t _arrayElementSize;
+      j9object_t * _defaultValueSlotAddress;
 
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;


### PR DESCRIPTION
`getDefaultValueSlotAddress()` returns the reference to the address of the default value instance for a value class.

[edited]
~If the class is initialized, devalue value instance for the class is allocated. When generating `aconst_init`, we can load from the default value slot.~

~- [x] Depends on https://github.com/eclipse/omr/pull/6530~