### PR TITLE
AArch64: Enable SymbolValidationManager

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2342,7 +2342,7 @@ J9::Options::fePreProcess(void * base)
          return false;
       }
 
-#if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER)) && defined(TR_TARGET_64BIT)
+#if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER) || defined(TR_HOST_ARM64)) && defined(TR_TARGET_64BIT)
    self()->setOption(TR_EnableSymbolValidationManager);
 #endif
 


### PR DESCRIPTION
This commit enables SymbolValidationManager on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>