### PR TITLE
Freetype is not required on OS for AIX with jdk11+

### DIFF
--- a/buildenv/aix/jdk11/yum_install_aix-ppc64.txt
+++ b/buildenv/aix/jdk11/yum_install_aix-ppc64.txt
@@ -34,7 +34,6 @@ update bzip2.ppc
 install cpio-2.12-2.ppc
 update  glib2.ppc
 install pkg-config-0.19-6.ppc
-install freetype2-2.8-1.ppc
 install gawk-3.1.3-1.ppc
 install popt-1.16-3.ppc
 update curl.ppc

--- a/buildenv/aix/jdk17/yum_install_aix-ppc64.txt
+++ b/buildenv/aix/jdk17/yum_install_aix-ppc64.txt
@@ -34,7 +34,6 @@ update bzip2.ppc
 install cpio-2.12-2.ppc
 update  glib2.ppc
 install pkg-config-0.19-6.ppc
-install freetype2-2.8-1.ppc
 install gawk-3.1.3-1.ppc
 install popt-1.16-3.ppc
 update curl.ppc

--- a/buildenv/aix/jdk18/yum_install_aix-ppc64.txt
+++ b/buildenv/aix/jdk18/yum_install_aix-ppc64.txt
@@ -34,7 +34,6 @@ update bzip2.ppc
 install cpio-2.12-2.ppc
 update  glib2.ppc
 install pkg-config-0.19-6.ppc
-install freetype2-2.8-1.ppc
 install gawk-3.1.3-1.ppc
 install popt-1.16-3.ppc
 update curl.ppc


### PR DESCRIPTION
freetype is built with openjdk and bundled with jdk11+.
See https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/484

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>