### PR TITLE
Disable known object table in AOT compilation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8365,6 +8365,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_DisableEDO);
                options->setDisabled(OMR::invariantArgumentPreexistence, true);
                options->setOption(TR_DisableHierarchyInlining);
+               options->setOption(TR_DisableKnownObjectTable);
                if (options->getInitialBCount() == 0 || options->getInitialCount() == 0)
                   options->setOption(TR_DisableDelayRelocationForAOTCompilations, true);
 


### PR DESCRIPTION
This commit disables known object table in AOT compilation.

Fixes: #15059

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>