### PR TITLE
Expand PR build depends pattern

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -163,7 +163,7 @@ def checkout_pullrequest() {
                     REPO = urlList[3]
                     PR_ID = urlList[5]
                     break
-                case ~/[^\s\/#]+\/[^\s\/#]+#[0-9]+/:
+                case ~/[^\s\/#]+\/[^\s\/#]+#[^\s\/#]+/:
                     REPO = DEPEND.substring(DEPEND.indexOf("/") + 1, DEPEND.indexOf("#"));
                     PR_ID = DEPEND.substring(DEPEND.indexOf("#") + 1, DEPEND.length());
                     break


### PR DESCRIPTION
Also support, e.g., `ibmruntimes/openj9-openjdk-jdk#openj9-staging`.

Fixes #15125.