### PR TITLE
(0.33.0) AArch64 macOS: Enable DDR build

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -413,7 +413,7 @@ aarch64_mac:
     8: 'macosx-aarch64-normal-server-release'
     11: 'macosx-aarch64-normal-server-release'
   extra_configure_options:
-    all: '--disable-warnings-as-errors --with-noncompressedrefs --disable-ddr'
+    all: '--disable-warnings-as-errors --with-noncompressedrefs'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:
     build: 'ci.role.build && hw.arch.aarch64 && sw.os.mac'

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -28,12 +28,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -51,12 +45,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestClassExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -74,12 +62,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -97,12 +79,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -120,12 +96,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestSharedClassesExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -143,12 +113,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestCollisionResilientHashtable$(Q) -DEXTRADUMPOPT=$(Q)-XX:stringTableListToTreeThreshold=64$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -166,12 +130,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestStackMap$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -194,12 +152,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase1$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -225,12 +177,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase2$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -256,12 +202,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase3$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -287,12 +227,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase4$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -318,12 +252,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase5$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -349,12 +277,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase6$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -375,12 +297,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestFindExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -83,10 +83,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 				<platform>.*zos.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -64,12 +64,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	${TEST_STATUS}</command>
 		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
 		<platformRequirements>^os.zos</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/dumpromtests/playlist.xml
+++ b/test/functional/cmdLineTests/dumpromtests/playlist.xml
@@ -28,10 +28,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<comment>https://github.com/eclipse-openj9/openj9/issues/3562</comment>
 				<platform>.*aix.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
 		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \

--- a/test/functional/cmdLineTests/gcCheck/playlist.xml
+++ b/test/functional/cmdLineTests/gcCheck/playlist.xml
@@ -37,12 +37,6 @@
 	-config $(Q)$(TEST_RESROOT)$(D)gcchecktests.xml$(Q) -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcchecktests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -37,12 +37,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-plats all,$(PLATFORM),$(VARIATION) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -74,12 +68,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-plats all,$(PLATFORM),$(VARIATION) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -28,10 +28,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<comment>https://github.com/eclipse-openj9/openj9/issues/1511</comment>
 				<platform>.*zos.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14387</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
 		</disables>
 		<variations>
 			<variation>Mode110</variation>


### PR DESCRIPTION
This commit enables DDR of AArch64 macOS builds.
It also enables related testcases.

Original PR in master: #14420

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>