### PR TITLE
Remove dependencies on J9JavaAccessFlags.J9AccPermitsValue

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
@@ -45,7 +45,6 @@ J9Consts.J9_ITABLE_OFFSET_TAG_BITS = 0
 J9Consts.J9_ITABLE_OFFSET_VIRTUAL = 0
 
 J9JavaAccessFlags.J9AccClassIsUnmodifiable = 0
-J9JavaAccessFlags.J9AccPermitsValue = 0
 J9JavaAccessFlags.J9AccRecord = 0
 J9JavaAccessFlags.J9AccSealed = 0
 J9JavaAccessFlags.J9AccValueType = 0

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -221,11 +221,6 @@ public class ValueTypeHelper {
 		}
 
 		@Override
-		public boolean doesRomClassPermitsValue(J9ROMClassPointer romClass) throws CorruptDataException {
-			return romClass.modifiers().allBitsIn(J9JavaAccessFlags.J9AccPermitsValue);
-		}
-
-		@Override
 		public boolean isJ9ClassAValueType(J9ClassPointer clazz) throws CorruptDataException {
 			return clazz.classFlags().allBitsIn(J9JavaClassFlags.J9ClassIsValueType);
 		}
@@ -391,17 +386,6 @@ public class ValueTypeHelper {
 	 * @throws CorruptDataException
 	 */
 	public boolean isRomClassAValueType(J9ROMClassPointer romClass) throws CorruptDataException {
-		return false;
-	}
-
-	/**
-	 * Queries if a J9ROMClass can be extended by a value class
-	 *
-	 * @param romClass class to query
-	 * @return true if the romClass is atomic, false otherwise.
-	 * @throws CorruptDataException
-	 */
-	public boolean doesRomClassPermitsValue(J9ROMClassPointer romClass) throws CorruptDataException {
 		return false;
 	}
 


### PR DESCRIPTION
This removes unnecessary uses of a constant that broke internal builds.