### PR TITLE
Update ScopedMemoryAccess.closeScope0 for JDK19

### DIFF
--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1251,7 +1251,11 @@ void JNICALL
 Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass clazz);
 
 jboolean JNICALL
+#if JAVA_SPEC_VERSION >= 19
+Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject instance, jobject scope);
+#else /* JAVA_SPEC_VERSION >= 19 */
 Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject instance, jobject scope, jobject exception);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
**New definition (JDK19+):**
```
    native boolean closeScope0(MemorySessionImpl session);
```
**Old definition:**
```
    native boolean closeScope0(Scope scope, Scope.ScopedAccessError exception);
```
Also, it is illegal to set the current exception while holding VM exclusive
access. So, the NPE is set outside the scope of VM exclusive access.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>