### PR TITLE
(0.33) Fix usage of pTOC with portableSCC code run in P10 container

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -855,7 +855,9 @@ J9::Compilation::compileRelocatableCode()
 bool
 J9::Compilation::compilePortableCode()
    {
-   return self()->fej9()->inSnapshotMode();
+   return (self()->fej9()->inSnapshotMode() ||
+             (self()->compileRelocatableCode() &&
+                self()->fej9()->isPortableSCCEnabled()));
    }
 
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8269,6 +8269,12 @@ TR_J9VMBase::isStringCompressionEnabledVM()
    return IS_STRING_COMPRESSION_ENABLED_VM(getJ9JITConfig()->javaVM);
    }
 
+bool
+TR_J9VMBase::isPortableSCCEnabled()
+   {
+   return (J9_ARE_ANY_BITS_SET(getJ9JITConfig()->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE));
+   }
+
 void *
 TR_J9VMBase::getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -331,6 +331,7 @@ public:
    virtual bool supportsGuardMerging()        { return true; }
    virtual bool canDevirtualizeDispatch()     { return true; }
    virtual bool doStringPeepholing()          { return true; }
+   virtual bool isPortableSCCEnabled();
 
    /**
     * \brief Determine whether resolved direct dispatch is guaranteed.

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2372,6 +2372,14 @@ TR_J9ServerVM::isForceInline(TR_ResolvedMethod *method)
    }
 
 bool
+TR_J9ServerVM::isPortableSCCEnabled()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
+   }
+
+bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    TR_ASSERT(vettedForAOT, "The TR_J9SharedCacheServerVM version of this method is expected to be called only from isClassLibraryMethod.\n"

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -55,6 +55,7 @@ public:
    virtual bool needRelocationsForPersistentInfoData() override          { return true; }
    virtual bool needRelocationsForLookupEvaluationData() override        { return true; }
    virtual bool needRelocationsForCurrentMethodPC() override                     { return true; }
+   virtual bool isPortableSCCEnabled() override;
    virtual void markHotField(TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool) override { return; }
    virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT) override;
    virtual bool isClassLibraryClass(TR_OpaqueClassBlock *clazz) override;

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -1929,7 +1929,7 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node             
       {
       if(comp()->target().isLinux() && comp()->target().is64Bit() && comp()->target().cpu.isLittleEndian())
          {
-         if (!comp()->getOption(TR_DisableTOC))
+         if (!comp()->getOption(TR_DisableTOC) && !comp()->compilePortableCode())
             {
             int32_t helperOffset = (callNode->getSymbolReference()->getReferenceNumber() - 1)*sizeof(intptr_t);
             generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr12),


### PR DESCRIPTION
This fixes an issue with the code generated for containers with
-XX:+PortableSharedCache option. AOT code generated on P8 uses
pTOC and if the same container is used on P10 environment causes
a crash as pTOC is not there on P10. The fix will generate
materialize sequence of instructions when -XX:+PortableSharedCache
option is enabled and not pTOC.

Added query apis in TRJ9VMBase class
Added isPortableSCCenabled for JIT server

Port of https://github.com/eclipse-openj9/openj9/pull/15095 for the 0.33 release.

Signed-off-by: Bhavani SN <bhavani.sn@ibm.com>