### PR TITLE
Ensure calls to feGetEnv are cached

### DIFF
--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -331,7 +331,8 @@ TR_J9VM::initializeProcessorType()
       {
       OMRProcessorDesc processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
       OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
-      if (feGetEnv("TR_DisableAVX"))
+      static const bool disableAVX = feGetEnv("TR_DisableAVX") != NULL;
+      if (disableAVX)
          {
          omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE, FALSE);
          }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1973,7 +1973,7 @@ char * feGetEnv2(const char * s, const void * vm)
             }
           else
             {
-            int32_t res = j9sysinfo_get_env("TR_silentEnv", NULL, 0);
+            static const int32_t res = j9sysinfo_get_env("TR_silentEnv", NULL, 0);
             // If TR_silentEnv is not found the result is -1. Setting TR_silentEnv prevents printing envVars
             bool verboseQuery = (res == -1 ? true : false);
 


### PR DESCRIPTION
Calls to feGetEnv are usually cached in static variables. There were a few cases where the variables weren't declared static and so more calls to getenv were being made than was necessary. These were mostly fixed in OMR PR https://github.com/eclipse/omr/pull/6545, but I also noticed two cases in OpenJ9 code that are addressed in this PR.

The call in initializeProcessorType is probably not much of a problem as it seems likely that the containing function is only called once per JVM instantiation. I've fixed it for completeness as there's hopefully not much downside and it will make any future code review for missed statics a little easier.

The read of TR_silentEnv in feGetEnv2 itself is hopefully ok for caching too - I couldn't see any reason to read it on every call.

Personal build ok: 29935