### PR TITLE
Prevent hangs when preparing the JIT for checkpoint

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2613,13 +2613,40 @@ void TR::CompilationInfo::resumeCompilationThread()
    }
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+
+class ReleaseVMAccessAndAcquireMonitor
+   {
+   public:
+   ReleaseVMAccessAndAcquireMonitor(J9VMThread *vmThread, TR::Monitor *monitor)
+      : _hadVMAccess(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS),
+        _vmThread(vmThread),
+        _monitor(monitor)
+      {
+      if (_hadVMAccess)
+         releaseVMAccessNoSuspend(_vmThread);
+      _monitor->enter();
+      }
+
+   ~ReleaseVMAccessAndAcquireMonitor()
+      {
+      _monitor->exit();
+      if (_hadVMAccess)
+         acquireVMAccessNoSuspend(_vmThread);
+      }
+
+   private:
+   bool         _hadVMAccess;
+   J9VMThread  *_vmThread;
+   TR::Monitor *_monitor;
+   };
+
 void TR::CompilationInfo::prepareForCheckpoint()
    {
    J9JavaVM   *vm       = _jitConfig->javaVM;
    J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
 
    {
-   OMR::CriticalSection suspendCompThreadsForCheckpoint(getCompilationMonitor());
+   ReleaseVMAccessAndAcquireMonitor suspendCompThreadsForCheckpoint(vmThread, getCompilationMonitor());
 
    if (shouldCheckpointBeInterrupted())
       return;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2635,6 +2635,9 @@ void TR::CompilationInfo::prepareForCheckpoint()
    bool purgeMethodQueue = false;
    suspendCompilationThread(purgeMethodQueue);
 
+   /* With the thread state now updated, notify any active comp threads waiting for work */
+   getCompilationMonitor()->notifyAll();
+
    /* Wait until all compilation threads are suspended. */
    for (int32_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {


### PR DESCRIPTION
Prevent hangs when preparing the JIT for checkpoint; there are two different circumstances that can lead to a hang:
1. Active comp threads waiting for work will wait on the comp monitor; if the hook thread does not notify them, then it will wait indefinitely for those comp threads.
2. Comp threads actively compiling will try to acquire Exclusive VMAccess; if the hook thread does not release VMAccess, then it will wait indefinitely for those comp threads.

Fixes https://github.com/eclipse-openj9/openj9/issues/15191