### PR TITLE
Add j.l.Access.parkVirtualThread methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -575,11 +575,19 @@ final class Access implements JavaLangAccess {
 	}
 
 	public void parkVirtualThread() {
-		throw new UnsupportedOperationException();
+		if (Thread.currentThread() instanceof BaseVirtualThread bvt) {
+			bvt.park();
+		} else {
+			throw new WrongThreadException();
+		}
 	}
 
 	public void parkVirtualThread(long nanos) {
-		throw new UnsupportedOperationException();
+		if (Thread.currentThread() instanceof BaseVirtualThread bvt) {
+			bvt.parkNanos(nanos);
+		} else {
+			throw new WrongThreadException();
+		}
 	}
 
 	public void unparkVirtualThread(Thread thread) {


### PR DESCRIPTION
Add `j.l.Access.parkVirtualThread` methods

```
j.l.Access.parkVirtualThread()
j.l.Access.parkVirtualThread(nanos)
```

closes https://github.com/eclipse-openj9/openj9/issues/15213

Signed-off-by: Jason Feng <fengj@ca.ibm.com>