### PR TITLE
Add optional encryption to the JITServer metrics server

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1236,6 +1236,12 @@ public:
    void  addJITServerSslCert(const std::string &cert) { _sslCerts.push_back(cert); }
    const std::string &getJITServerSslRootCerts() const { return _sslRootCerts; }
    void  setJITServerSslRootCerts(const std::string &cert) { _sslRootCerts = cert; }
+   const PersistentVector<std::string> &getJITServerMetricsSslKeys() const { return _metricsSslKeys; }
+   void  addJITServerMetricsSslKey(const std::string &key) { _metricsSslKeys.push_back(key); }
+   const PersistentVector<std::string> &getJITServerMetricsSslCerts() const { return _metricsSslCerts; }
+   void  addJITServerMetricsSslCert(const std::string &cert) { _metricsSslCerts.push_back(cert); }
+   bool  useSSL() const { return (_sslKeys.size() || _sslCerts.size() || _sslRootCerts.size() ||
+                                  _metricsSslKeys.size() || _metricsSslCerts.size()); }
 
    void setCompThreadActivationPolicy(JITServer::CompThreadActivationPolicy newPolicy) { _activationPolicy = newPolicy; }
    JITServer::CompThreadActivationPolicy getCompThreadActivationPolicy() const { return _activationPolicy; }
@@ -1465,6 +1471,8 @@ private:
    std::string                   _sslRootCerts;
    PersistentVector<std::string> _sslKeys;
    PersistentVector<std::string> _sslCerts;
+   PersistentVector<std::string> _metricsSslKeys;
+   PersistentVector<std::string> _metricsSslCerts;
    JITServer::CompThreadActivationPolicy _activationPolicy;
    JITServerSharedROMClassCache *_sharedROMClassCache;
    JITServerAOTCacheMap *_JITServerAOTCacheMap;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1105,6 +1105,8 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
 #if defined(J9VM_OPT_JITSERVER)
    _sslKeys(decltype(_sslKeys)::allocator_type(TR::Compiler->persistentAllocator())),
    _sslCerts(decltype(_sslCerts)::allocator_type(TR::Compiler->persistentAllocator())),
+   _metricsSslKeys(decltype(_metricsSslKeys)::allocator_type(TR::Compiler->persistentAllocator())),
+   _metricsSslCerts(decltype(_metricsSslCerts)::allocator_type(TR::Compiler->persistentAllocator())),
    _classesCachedAtServer(decltype(_classesCachedAtServer)::allocator_type(TR::Compiler->persistentAllocator())),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _persistentMemory(pointer_cast<TR_PersistentMemory *>(jitConfig->scratchSegment)),

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4358,6 +4358,11 @@ void JitShutdown(J9JITConfig * jitConfig)
       {
       statsThreadObj->stopStatisticsThread(jitConfig);
       }
+
+   if (compInfo->useSSL())
+      {
+      (*OEVP_cleanup)();
+      }
 #endif
 
    TR_DebuggingCounters::report();
@@ -6926,6 +6931,12 @@ int32_t startJITServer(J9JITConfig *jitConfig)
    PORT_ACCESS_FROM_JAVAVM(javaVM);
 
    TR_ASSERT(compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER, "startJITServer cannot be called in non-server mode\n");
+
+   if (compInfo->useSSL())
+      {
+      (*OSSL_load_error_strings)();
+      (*OSSL_library_init)();
+      }
 
    listener->startListenerThread(javaVM);
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2018,6 +2018,33 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                if (ret == OPTION_OK)
                   compInfo->getPersistentInfo()->setJITServerMetricsPort(port);
                }
+
+            // For optional metrics server encryption. Key and cert have to be set as a pair.
+            const char *xxJITServerMetricsSSLKeyOption = "-XX:JITServerMetricsSSLKey=";
+            const char *xxJITServerMetricsSSLCertOption = "-XX:JITServerMetricsSSLCert=";
+            int32_t xxJITServerMetricsSSLKeyArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerMetricsSSLKeyOption, 0);
+            int32_t xxJITServerMetricsSSLCertArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerMetricsSSLCertOption, 0);
+
+            if ((xxJITServerMetricsSSLKeyArgIndex >= 0) && (xxJITServerMetricsSSLCertArgIndex >= 0))
+               {
+               char *keyFileName = NULL;
+               char *certFileName = NULL;
+               GET_OPTION_VALUE(xxJITServerMetricsSSLKeyArgIndex, '=', &keyFileName);
+               GET_OPTION_VALUE(xxJITServerMetricsSSLCertArgIndex, '=', &certFileName);
+               std::string key = readFileToString(keyFileName);
+               std::string cert = readFileToString(certFileName);
+
+               if (!key.empty() && !cert.empty())
+                  {
+                  compInfo->addJITServerMetricsSslKey(key);
+                  compInfo->addJITServerMetricsSslCert(cert);
+                  }
+               else
+                  {
+                  j9tty_printf(PORTLIB, "Fatal Error: The metrics server SSL key and cert cannot be empty\n");
+                  return false;
+                  }
+               }
             }
          else
             {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1691,7 +1691,7 @@ onLoadInternal(
       }
 
 #if defined(J9VM_OPT_JITSERVER)
-   if (JITServer::CommunicationStream::useSSL())
+   if (compInfo->useSSL())
       {
       if (!JITServer::loadLibsslAndFindSymbols())
          return -1;

--- a/runtime/compiler/net/LoadSSLLibs.hpp
+++ b/runtime/compiler/net/LoadSSLLibs.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,7 @@ typedef int OSSL_accept_t(SSL *ssl);
 typedef int OSSL_connect_t(SSL *ssl);
 typedef X509 * OSSL_get_peer_certificate_t(const SSL *ssl);
 typedef long OSSL_get_verify_result_t(const SSL *ssl);
+typedef int OSSL_get_error_t(const SSL *ssl, int ret);
 
 typedef SSL_CTX * OSSL_CTX_new_t(const SSL_METHOD *method);
 typedef int OSSL_CTX_set_session_id_context_t(SSL_CTX *ctx, const unsigned char *sid_ctx, unsigned int sid_ctx_len);
@@ -80,6 +81,10 @@ typedef void OBIO_free_all_t(BIO *a);
 typedef BIO * OBIO_new_ssl_t(SSL_CTX *ctx, int client);
 typedef int OBIO_write_t(BIO *b, const void *data, int dlen);
 typedef int OBIO_read_t(BIO *b, void *data, int dlen);
+typedef int OBIO_test_flags_t(const BIO *b, int flags);
+typedef int OBIO_should_retry_t(BIO *b);
+typedef int OBIO_should_read_t(BIO *b);
+typedef int OBIO_should_write_t(BIO *b);
 
 typedef EVP_PKEY * OPEM_read_bio_PrivateKey_t(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u);
 typedef X509 * OPEM_read_bio_X509_t(BIO *bp, X509 **x, pem_password_cb *cb, void *u);
@@ -129,6 +134,7 @@ extern "C" OSSL_accept_t * OSSL_accept;
 extern "C" OSSL_connect_t * OSSL_connect;
 extern "C" OSSL_get_peer_certificate_t * OSSL_get_peer_certificate;
 extern "C" OSSL_get_verify_result_t * OSSL_get_verify_result;
+extern "C" OSSL_get_error_t * OSSL_get_error;
 
 extern "C" OSSLv23_server_method_t * OSSLv23_server_method;
 extern "C" OSSLv23_client_method_t * OSSLv23_client_method;
@@ -147,6 +153,10 @@ extern "C" OBIO_free_all_t * OBIO_free_all;
 extern "C" OBIO_new_ssl_t * OBIO_new_ssl;
 extern "C" OBIO_write_t * OBIO_write;
 extern "C" OBIO_read_t * OBIO_read;
+extern "C" OBIO_test_flags_t * OBIO_test_flags;
+extern "C" OBIO_should_retry_t * OBIO_should_retry;
+extern "C" OBIO_should_read_t * OBIO_should_read;
+extern "C" OBIO_should_write_t * OBIO_should_write;
 
 extern "C" OPEM_read_bio_PrivateKey_t * OPEM_read_bio_PrivateKey;
 extern "C" OPEM_read_bio_X509_t * OPEM_read_bio_X509;

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -187,7 +187,6 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
    SSL_CTX *sslCtx = NULL;
    if (JITServer::CommunicationStream::useSSL())
       {
-      JITServer::CommunicationStream::initSSL();
       sslCtx = createSSLContext(compInfo);
       }
 
@@ -311,7 +310,6 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
    if (sslCtx)
       {
       (*OSSL_CTX_free)(sslCtx);
-      (*OEVP_cleanup)();
       }
    }
 

--- a/runtime/compiler/runtime/MetricsServer.hpp
+++ b/runtime/compiler/runtime/MetricsServer.hpp
@@ -177,8 +177,12 @@ public:
       };
    enum ReturnCodes
       {
+      SSL_CONNECTION_ESTABLISHED = 0,
       FULL_REQUEST_RECEIVED = 0,
-      INCOMPLETE_REQUEST    = -1,
+      FULL_RESPONSE_SENT    = 0,
+      WANT_READ    = -1,
+      WANT_WRITE   = -2,
+      SSL_CONNECTION_ERROR = -3,
 
       HTTP_OK               = 0,
       MALFORMED_REQUEST     = -400,
@@ -188,30 +192,63 @@ public:
       REQUEST_TOO_LARGE     = -413,
       REQUEST_URI_TOO_LONG  = -414,
       READ_ERROR            = -500,
+      WRITE_ERROR           = -500,
       INVALID_HTTP_PROTOCOL = -505,
       };
+   enum RequestState
+      {
+      Inactive = 0,
+      EstablishingSSLConnection,
+      ReadingRequest,
+      WritingResponse
+      };
 
-   HttpGetRequest(int sockfd) : _sockfd(sockfd), _path(Path::Undefined), _msgLength(0)
+   HttpGetRequest() : _requestState(Inactive), _sockfd(-1), _path(Path::Undefined), _msgLength(0), _ssl(NULL),
+                      _incompleteSSLConnection(NULL), _responseBytesSent(0)
       {}
    HttpGetRequest(const HttpGetRequest &other)
       {
       if (this != &other)
          {
          _sockfd = other.getSockFd();
+         _requestState = other.getRequestState();
          _msgLength = other.getMsgLength();
          memcpy(_buf, other._buf, other.getMsgLength());
+         if (_ssl)
+            {
+            (*OBIO_free_all)(_ssl);
+            }
+         _ssl = other._ssl;
+         _response = other._response;
+         _responseBytesSent = other._responseBytesSent;
+         _incompleteSSLConnection = other._incompleteSSLConnection;
          // The following are not really needed
          _path = other.getPath();
          memcpy(_httpVersion, other._httpVersion, 4);
          }
       }
+   ~HttpGetRequest();
+   void clear();
+   RequestState getRequestState() const { return _requestState; }
+   void setRequestState(RequestState requestState) { _requestState = requestState; }
    int getSockFd() const { return _sockfd; }
+   void setSockFd(int sockfd) { _sockfd = sockfd; }
+   void setSSL(BIO *ssl) { _ssl = ssl; }
+   BIO *getSSL() const { return _ssl; }
+   void setIncompleteSSLConnection(SSL *conn) { _incompleteSSLConnection = conn; }
    size_t getMsgLength() const { return _msgLength; }
    Path getPath() const { return _path; }
+   void setResponse(std::string response) { _response = response; _responseBytesSent = 0; }
 
+   bool setupSSLConnection(SSL_CTX *sslCtx);
+   /**
+      @brief Accept an SSL connection
+      @return An error code: SSL_CONNECTION_ERROR, WANT_READ, WANT_WRITE, SSL_CONNECTION_ESTABLISHED
+   */
+   ReturnCodes acceptSSLConnection();
    /**
       @brief Read from a socket and validate that the received data is a valid HTTP GET request
-      @return An error code: READ_ERROR, REQUEST_TOO_LARGE, NO_GET_REQUEST, INCOMPLETE_REQUEST, FULL_REQUEST_RECEIVED
+      @return An error code: READ_ERROR, WANT_READ, WANT_WRITE, REQUEST_TOO_LARGE, NO_GET_REQUEST, FULL_REQUEST_RECEIVED
    */
    ReturnCodes readHttpGetRequest();
    /**
@@ -220,16 +257,28 @@ public:
       @return An error code: MALFORMED_REQUEST, REQUEST_URI_TOO_LONG, INVALID_PATH, INVALID_HTTP_PROTOCOL, HTTP_OK
    */
    ReturnCodes parseHttpGetRequest();
-
+   /**
+      @brief Write the response to the socket
+      @return An error code: WRITE_ERROR, WANT_READ, WANT_WRITE, FULL_RESPONSE_SENT
+   */
+   ReturnCodes sendHttpResponse();
 private:
    static const size_t BUF_SZ = 1024; // Size of internal buffer for receiving data
    static const size_t MAX_PATH_LENGTH = 16; // Max size of the URI received
 
+   bool handleSSLConnectionError(const char *errMsg);
+
+   RequestState _requestState;
    int _sockfd; // Socket descriptor for reading the data
    Path _path; // Enum that encodes well defined paths like "/metrics" or "/liveness" or "/readiness"
    char _httpVersion[4]; // 1.0 1.1  2.0, etc
    size_t _msgLength; // How much of the buffer is filled
    char _buf[BUF_SZ]; // Buffer for holding incoming data
+   BIO *_ssl;
+   SSL *_incompleteSSLConnection; // Stored in _ssl, but kept separate for accepting an SSL connection
+
+   std::string _response;
+   size_t _responseBytesSent;
    }; // class HttpRequest
 
 /**
@@ -271,12 +320,14 @@ public:
 
 private:
    int openSocketForListening(uint32_t port);
-   int sendOneMsg(int sock, const char *buf, int len);
-   int sendErrorCode(int sock, int err);
+   std::string messageForErrorCode(int err);
    void handleConnectionRequest();
-   void handleIncomingDataForConnectedSocket(nfds_t i, MetricsDatabase &metricsDatabase);
+   void handleDataForConnectedSocket(nfds_t i, MetricsDatabase &metricsDatabase);
    void reArmSocketForReading(int sockIndex);
+   void reArmSocketForWriting(int sockIndex);
    void closeSocket(int sockIndex);
+   void freeSSLConnection(int sockIndex);
+   bool useSSL(TR::CompilationInfo *compInfo);
 
    J9VMThread *_metricsThread;
    TR::Monitor *_metricsMonitor;
@@ -287,7 +338,9 @@ private:
 
    nfds_t _numActiveSockets = 0;
    struct pollfd _pfd[1 + MAX_CONCURRENT_REQUESTS] = {{0}}; // poll file descriptors; first entry is for connection requests
-   HttpGetRequest *_incompleteRequests[1 + MAX_CONCURRENT_REQUESTS] = {0};
+   HttpGetRequest _requests[1 + MAX_CONCURRENT_REQUESTS];
+
+   SSL_CTX *_sslCtx;
    }; // class MetricsServer
 
 #endif // #ifndef METRICSSERVER_HPP


### PR DESCRIPTION
The new options `-XX:JITServerMetricsSSLKey` and `-XX:JITServerMetricsSSLCert` behave like their JITServer counterparts, automatically enabling SSL/TLS communication between the JITServer metrics server and clients like Prometheus.

Fixes: #15052