### PR TITLE
Deprecate -XX:+AllowNonVirtualCalls

### DIFF
--- a/doc/release-notes/0.31/0.31.md
+++ b/doc/release-notes/0.31/0.31.md
@@ -26,7 +26,7 @@
 
 These release notes support the [Eclipse OpenJ9 0.31.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.31.0/plan).
 
-**Note:** Due to delays in the 0.31 release, a final build was not created. See the 0.32 release for Java 18 support.
+**Note:** Due to delays in the 0.31 release, a final build was not created. See the 0.32 release for OpenJDK 18 support.
 
 ## Supported environments
 
@@ -62,14 +62,14 @@ The following table covers notable changes in v0.31.0. Further information about
 <td valign="top">New <tt>SharedClassStatistics</tt> API added</td>
 <td valign="top">All versions</td>
 <td valign="top">New shared classes API is added in <tt>SharedClassStatistics</tt> for <tt>cacheDir()</tt>, <tt>cacheName()</tt>, <tt>cachePath()</tt>, <tt>numberAttached()</tt>.
-For more details see the API documentation. Only the Java 18 API documentation is updated in this release, API documentation for the other versions will be updated in the next release.</td>
+For more details see the API documentation. Only the OpenJDK 18 API documentation is updated in this release, API documentation for the other versions will be updated in the next release.</td>
 </tr>
 
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/14623">#14623</a></td>
 <td valign="top">Modified default for <tt>-XX:MaxDirectMemorySize</tt></td>
-<td valign="top">Java 11 and later</td>
-<td valign="top">In Java 11 and later, <tt>-XX:MaxDirectMemorySize</tt> is no longer set by default and the class library limits the amount of heap memory used for
+<td valign="top">OpenJDK 11 and later</td>
+<td valign="top">In builds with OpenJDK 11 and later, <tt>-XX:MaxDirectMemorySize</tt> is no longer set by default and the class library limits the amount of heap memory used for
 Direct Byte Buffers to the same value as the maximum heap size. Previously the limit was 87.5% of the maximum heap size.</td>
 </tr>
 

--- a/doc/release-notes/0.32/0.32.md
+++ b/doc/release-notes/0.32/0.32.md
@@ -60,28 +60,28 @@ The following table covers notable changes in v0.32.0. Further information about
 <td valign="top">New <tt>SharedClassStatistics</tt> API added</td>
 <td valign="top">All versions</td>
 <td valign="top">New shared classes API is added in <tt>SharedClassStatistics</tt> for <tt>cacheDir()</tt>, <tt>cacheName()</tt>, <tt>cachePath()</tt>, <tt>numberAttached()</tt>.
-For more details see the API documentation. Only the Java 18 API documentation is updated in this release, API documentation for the other versions will be updated in the next release.</td>
+For more details see the API documentation. Only the OpenJDK 18 API documentation is updated in this release, API documentation for the other versions will be updated in the next release.</td>
 </tr>
 
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/14623">#14623</a></td>
 <td valign="top">Modified default for <tt>-XX:MaxDirectMemorySize</tt></td>
-<td valign="top">Java 11 and later</td>
-<td valign="top">In Java 11 and later, <tt>-XX:MaxDirectMemorySize</tt> is no longer set by default and the class library limits the amount of heap memory used for
+<td valign="top">OpenJDK 11 and later</td>
+<td valign="top">In builds with OpenJDK 11 and later, <tt>-XX:MaxDirectMemorySize</tt> is no longer set by default and the class library limits the amount of heap memory used for
 Direct Byte Buffers to the same value as the maximum heap size. Previously the limit was 87.5% of the maximum heap size.</td>
 </tr>
 
 <tr>
 <td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/484">ibmruntimes/openj9-openjdk-jdk11#484</a></td>
 <td valign="top">libfreetype.so native library is bundled on AIX</td>
-<td valign="top">Java 11 on AIX only</td>
-<td valign="top">The libfreetype.so native library is bundled on Java 11 for AIX, similarly to Java 17 and later. This removes the requirement of having to install this prerequisite when using the java.desktop module.</td>
+<td valign="top">OpenJDK 11 on AIX only</td>
+<td valign="top">The libfreetype.so native library is bundled with OpenJDK 11 for AIX, similarly to builds with OpenJDK 17 and later. This removes the requirement of having to install this prerequisite when using the java.desktop module.</td>
 </tr>
 
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
 <td valign="top">Early access release for Apple Silicon macOS</td>
-<td valign="top">Java 11 and later / Apple Silicon macOS</td>
+<td valign="top">OpenJDK 11 and later / Apple Silicon macOS</td>
 <td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
 </tr>
 

--- a/doc/release-notes/0.33/0.33.md
+++ b/doc/release-notes/0.33/0.33.md
@@ -51,8 +51,16 @@ The following table covers notable changes in v0.33.0. Further information about
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
 <td valign="top">Early access release for Apple Silicon macOS</td>
-<td valign="top">Java 11 and later / Apple Silicon macOS</td>
+<td valign="top">OpenJDK 11 and later / Apple Silicon macOS</td>
 <td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/15234">#15234</a></td>
+<td valign="top">The undocumented option <tt>-XX:+AllowNonVirtualCalls</tt> is deprecated with OpenJDK 19 and will be removed in builds with OpenJDK 20.</td>
+<td valign="top">OpenJDK 19</td>
+<td valign="top">From builds with OpenJDK 20, the option <tt>-XX:+AllowNonVirtualCalls</tt> will be ignored, or will cause an error if <tt>-XX:-IgnoreUnrecognizedXXColonOptions</tt> is used.
+The option cannot be supported with value types.</td>
 </tr>
 
 </tbody>
@@ -80,7 +88,7 @@ The v0.33.0 release contains the following known issues and limitations:
 <td valign="top">All</td>
 <td valign="top">The main thread stack size was 1MB in releases prior to 0.32. In the 0.32 release and later it's modified to a smaller
 platform-dependent value, the same value as the <tt>-Xmso</tt> setting. The 0.33 release increases the default <tt>-Xmso</tt> stack size
-on x64 platforms, but Java 17 and later also require more stack space to run. These changes may result in a
+on x64 platforms, but builds with OpenJDK 17 and later also require more stack space to run. These changes may result in a
 <tt>java.lang.StackOverflowError: operating system stack overflow</tt>.</td>
 <td valign="top">Use <tt>-Xmso</tt> to set the default stack size. See the default value by using <tt>-verbose:sizes</tt>.</td>
 </tr>

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3546,7 +3546,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		}
 	}
 
-#if !defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if (JAVA_SPEC_VERSION <= 19) && !defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	{
 		/**
 		 * From the spec, the ACC_SUPER semantics became mandatory. The bit CFR_ACC_SUPER is reused as CFR_ACC_IDENTITY in Valhalla.
@@ -3560,7 +3560,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			vm->extendedRuntimeFlags &= ~(UDATA)J9_EXTENDED_RUNTIME_ALLOW_NON_VIRTUAL_CALLS;
 		}
 	}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#endif /* (JAVA_SPEC_VERSION <= 19) && !defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	{
 		IDATA debugInterpreter = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXDEBUGINTERPRETER, NULL);


### PR DESCRIPTION
Also replace "Java" with "OpenJDK" in recent release notes to match the convention.