### PR TITLE
JDK19 unparkVirtualThread adopts BaseVirtualThread

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -591,9 +591,10 @@ final class Access implements JavaLangAccess {
 	}
 
 	public void unparkVirtualThread(Thread thread) {
-		if (thread.isVirtual()) {
-			VirtualThread t = (VirtualThread)thread;
-			t.unpark();
+		if (thread instanceof BaseVirtualThread bvt) {
+			bvt.unpark();
+		} else {
+			throw new WrongThreadException();
 		}
 	}
 


### PR DESCRIPTION
JDK19 `unparkVirtualThread` adopts `BaseVirtualThread`.

This passes `java/lang/Thread/virtual/ThreadAPI.java#id0` https://github.com/eclipse-openj9/openj9/issues/15152#issuecomment-1148960818.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>