### PR TITLE
  Disable regex usage since cmdlinetester does not correctly process it

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -352,7 +352,7 @@
   <output regex="no" type="required">&lt;/verbosegc&gt;</output>
   <output regex="no" type="success">All allocated blocks were freed.</output>
   <!-- allow memory leaks since the JIT leaks, unfortunately -->
-  <output regex="yes" type="success">[0-9]* allocated blocks totaling [0-9]* bytes were not freed before shutdown!</output>
+  <output regex="no" type="success">bytes were not freed before shutdown!</output>
   <output regex="no" type="failure">Unhandled exception</output>
  </test>
  <test id="-verbose:gc -Xcheck:memory -Xverbosegclog:foo.log - check for memory corruption">
@@ -360,7 +360,7 @@
   <command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -verbose:gc -Xverbosegclog -Dibm.java9.forceCommonCleanerShutdown=true -Xcheck:memory:quick,ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper -version</command>
   <output regex="no" type="success">All allocated blocks were freed.</output>
   <!-- allow memory leaks since the JIT leaks, unfortunately -->
-  <output regex="yes" type="success">[0-9]* allocated blocks totaling [0-9]* bytes were not freed before shutdown!</output>
+  <output regex="no" type="success">bytes were not freed before shutdown!</output>
   <output regex="no" type="failure">Unhandled exception</output>
  </test>
 


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/15235

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>