### PR TITLE
Increase timeout for decompilation tests

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2020 IBM Corp. and others
+  Copyright (c) 2004, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="Decompilation Tests" timeout="300"> <!-- CMVC 161669: some machines take a long time to run decomp002 -->
+<suite id="Decompilation Tests" timeout="600"> <!-- CMVC 161669: some machines take a long time to run decomp002 -->
 	<variable name="JVM_OPTS" value="-Xdump:system:events=abort " />
 	<variable name="AGENTLIB" value="-agentlib:jvmtitest" />
 	<variable name="TESTRUNNER" value="com.ibm.jvmti.tests.util.TestRunner" />


### PR DESCRIPTION
Timeout increased from 300 to 600 seconds since decomp002 takes more time
on some machines. **Ref:** https://github.com/eclipse-openj9/openj9/issues/15245#issuecomment-1149087197.

Related: https://github.com/eclipse-openj9/openj9/issues/15245

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>