### PR TITLE
Move AArch64 macOS from "Notable changes in this release"

### DIFF
--- a/doc/release-notes/0.33/0.33.md
+++ b/doc/release-notes/0.33/0.33.md
@@ -49,13 +49,6 @@ The following table covers notable changes in v0.33.0. Further information about
 <tbody>
 
 <tr>
-<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
-<td valign="top">Early access release for Apple Silicon macOS</td>
-<td valign="top">OpenJDK 11 and later / Apple Silicon macOS</td>
-<td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
-</tr>
-
-<tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/15234">#15234</a></td>
 <td valign="top">The undocumented option <tt>-XX:+AllowNonVirtualCalls</tt> is deprecated with OpenJDK 19 and will be removed in builds with OpenJDK 20.</td>
 <td valign="top">OpenJDK 19</td>
@@ -101,6 +94,13 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 </tr>
 
 <tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/11164">#11164</a></td>
+<td valign="top">Early access release for Apple Silicon macOS</td>
+<td valign="top">Apple Silicon macOS / OpenJDK 11 and later</td>
+<td valign="top">Build for Apple Silicon (AArch64) macOS is available as an early access release.  It is stable enough for evaluation but not suitable for production yet.</td>
+</tr>
+
+<tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/13767">#13767</a></td>
 <td valign="top">Compressed references mode is not available</td>
 <td valign="top">Apple Silicon macOS (early access)</td>
@@ -115,6 +115,7 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 <td valign="top">Enabling JIT field watch may cause bus errors.</td>
 <td valign="top">Avoid using the <tt>-XX:+JITInlineWatches</tt> option.</td>
 </tr>
+
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14803">#14803</a></td>
 <td valign="top">Using the <tt>-XX:+ShowHiddenFrames</tt> option in an OpenJ9 release built with OpenJDK 18 causes errors due to underlying problems in OpenJDK</td>


### PR DESCRIPTION
This commit moves the item for early access builds of AArch64 macOS from
"Notable changes in this release" to "Known issues" of v0.33.0 release notes.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>