### PR TITLE
Add newInstanceImpl check guard for profile guided devirtualization on Z JIT

### DIFF
--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1800,6 +1800,7 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
 
          if (!performGuardedDevirtualization &&
              !comp()->getOption(TR_DisableInterpreterProfiling) &&
+             (callNode->getSymbolReference() != comp()->getSymRefTab()->findObjectNewInstanceImplSymbol()) &&
              TR_ValueProfileInfoManager::get(comp()) && resolvedMethod
              )
             {


### PR DESCRIPTION
`Class.newInstance` is treated specially by the JIT. The `newInstanceImpl` call in this method is a static call to a native method, and it is incorrect to look it up in the class vtable.

This check is already done in [X codegen](https://github.com/eclipse-openj9/openj9/blob/d4df04f898bf16503d0e404e3b11acb9ff893dd8/runtime/compiler/x/codegen/X86PrivateLinkage.cpp#L1321); this patch brings Z in line with X.

Fixes: #15220