### PR TITLE
Skip halt check after explict GC, with external exclusive VM access

### DIFF
--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -460,7 +460,7 @@ MM_ConcurrentMarkingDelegate::acquireExclusiveVMAccessAndSignalThreadsToActivate
 	_collector->acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(env);
 	VM_VMAccess::clearPublicFlags(vmThread, J9_PUBLIC_FLAGS_NOT_AT_SAFE_POINT);
 
-	if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_ANY)) {
+	if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_ANY) && (0 == vmThread->omrVMThread->exclusiveCount)) {
 		vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
 		vmThread->javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
 	}


### PR DESCRIPTION
If caller of explicit GC (for example RAS) already obtained exclusive VM
access, checking if the thread needs to halt after completing the GC
could lead to a deadlock. For example exclusive VM access could prevent
an inspector thread to proceed, while also this thread just blocked
expecting to be inspected.

The fix is to make an exception and skip the halt check if we know that
we hold exclusive VM access.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>