### PR TITLE
Add a note about cgroup v2 support in the 0.33 release

### DIFF
--- a/doc/release-notes/0.33/0.33.md
+++ b/doc/release-notes/0.33/0.33.md
@@ -70,6 +70,13 @@ The option cannot be supported with value types.</td>
 <td valign="top">The Visual Studio redistributable files included with the build are updated to match.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14190">#14190</a></td>
+<td valign="top">Control groups v2 support added</td>
+<td valign="top">All versions</td>
+<td valign="top">The Linux kernel has two variants of <a href="https://man7.org/linux/man-pages/man7/cgroups.7.html">control groups (cgroups): v1 and v2</a>. Many Linux operating systems are gradually transitioning from cgroups v1 to v2 as their default choice. OpenJ9 has added cgroups v2 support which is identical to the support for cgroups v1.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9-docs/pull/942

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>