### PR TITLE
Class.arrayType() throws UnsupportedOperationException in jdk19+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -5367,14 +5367,33 @@ SecurityException {
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Create class of an array. The component type will be this Class instance.
-	 * 
+	 *
 	 * @return array class where the component type is this Class instance
+	/*[IF JAVA_SPEC_VERSION >= 19]
+	 *
+	 * @throws UnsupportedOperationException when the receiver is the void type, or the dimensions of the new array type would exceed 255.
+	/*[ENDIF] JAVA_SPEC_VERSION >= 19
 	 */
 	public Class<?> arrayType() {
-		if (this == void.class) {
-			throw new IllegalArgumentException();
+		/*[IF JAVA_SPEC_VERSION >= 19]*/
+		try {
+			Class<?> baseType = this;
+			for (int arrayCount = 0; baseType.isArray(); arrayCount++) {
+				if (arrayCount == 254) {
+					throw new IllegalArgumentException();
+				}
+				baseType = baseType.getComponentType();
+			}
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+			if (this == void.class) {
+				throw new IllegalArgumentException();
+			}
+			return arrayTypeImpl();
+		/*[IF JAVA_SPEC_VERSION >= 19]*/
+		} catch (Exception e) {
+			throw new UnsupportedOperationException(e);
 		}
-		return arrayTypeImpl();
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 	}
 
 	private native Class<?> arrayTypeImpl();

--- a/test/functional/Java12andUp/build.xml
+++ b/test/functional/Java12andUp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2021 IBM Corp. and others
+  Copyright (c) 2018, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="LIB" value="testng,jcommander"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
@@ -52,6 +53,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<src path="${TestUtilities}" />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_Class.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_Class.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.util.Optional;
 import java.util.NoSuchElementException;
 
+import org.openj9.test.util.VersionCheck;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
@@ -147,12 +148,20 @@ public class Test_Class {
 	public void testClassArrayType() throws Throwable {
 		for (Object[] prim : primitiveTest) {
 			if ((Class<?>)prim[0] == void.class) {
-				/* test is expected to throw IllegalArgumentException */
+				/* test is expected to throw IllegalArgumentException up to jdk18, or UnsupportedOperationException from jdk19 */
 				try {
-					arrayTypeTestGeneral("testClassArrayType (primitive) this test should throw IllegalArgumentException", (Class<?>)prim[0], (String)prim[1]);
+					arrayTypeTestGeneral("testClassArrayType (primitive) this test should throw Exception", (Class<?>)prim[0], (String)prim[1]);
 					Assert.fail();
-				} catch(IllegalArgumentException e) {
-					/* test passed */
+				} catch(Exception e) {
+					if (VersionCheck.major() >= 19) {
+						if (e.getClass() != UnsupportedOperationException.class) {
+							Assert.fail();
+						}
+					} else {
+						if (e.getClass() != IllegalArgumentException.class) {
+							Assert.fail();
+						}
+					}
 				}
 			} else {				
 				arrayTypeTestGeneral("testClassArrayType (primitive)", (Class<?>)prim[0], (String)prim[1]);


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/14598

Continuing to throw IllegalArgumentException as the cause for the UnsupportedOperationException is done for compatibility.