### PR TITLE
AArch64 macOS: Call fieldWatchHelper in rewriting data in snippets

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -334,7 +334,7 @@ L_USSGclinitCase:
 	mov	x30, x10					// send helpers expect link register to contain snippet return address
 	br	x1						// in <clinit> case, dispatch method directly without patching
 
-FUNC_LABEL(_interpreterUnresolvedStaticGlue:)
+FUNC_LABEL(_interpreterUnresolvedStaticGlue):
 	LOAD_FUNC_PTR(x3, const_jitResolveStaticMethod)
 	b	L_mergedUnresolvedSpecialStaticGlue
 
@@ -1216,3 +1216,22 @@ FUNC_LABEL(_patchGCRHelper):
 	FINISH_MODIFYING_CODE
 	mov	x1, #4						// 1 instruction to flush
 	b	flushICache
+
+#if defined(OSX)
+	.globl	FUNC_LABEL(_fieldWatchHelper)
+
+// Rewrite a slot in data snippet for field watch
+//
+// in:     x0  = address in data snippet
+//         x1  = value to be written
+FUNC_LABEL(_fieldWatchHelper):
+	SAVE_REGS_IN_NATIVE_STACK
+	mov	x0, #0
+	bl	FUNC_LABEL(pthread_jit_write_protect_np)
+	ldp	x0, x1, [sp]
+	str	x1, [x0]
+	mov	x1, #1
+	bl	FUNC_LABEL(pthread_jit_write_protect_np)
+	RESTORE_REGS_FROM_NATIVE_STACK
+	ret
+#endif

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -618,6 +618,7 @@ JIT_HELPER(__bwWordArrayCopy);
 JIT_HELPER(__bwDoubleWordArrayCopy);
 JIT_HELPER(__bwQuadWordArrayCopy);
 JIT_HELPER(_patchGCRHelper);
+JIT_HELPER(_fieldWatchHelper);
 
 #elif defined(TR_HOST_S390)
 JIT_HELPER(__double2Long);
@@ -1599,7 +1600,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARM64interpreterDoubleStaticGlue,       (void *) _interpreterDoubleStaticGlue,     TR_Helper);
    SET(TR_ARM64interpreterSyncDoubleStaticGlue,   (void *) _interpreterSyncDoubleStaticGlue, TR_Helper);
    SET(TR_ARM64nativeStaticHelper,                (void *) _nativeStaticHelper,              TR_Helper);
-   SET(TR_ARM64interfaceCompleteSlot2,            (void *) _interfaceCompleteSlot2,           TR_Helper);
+   SET(TR_ARM64interfaceCompleteSlot2,            (void *) _interfaceCompleteSlot2,          TR_Helper);
    SET(TR_ARM64interfaceSlotsUnavailable,         (void *) _interfaceSlotsUnavailable,       TR_Helper);
    SET(TR_ARM64floatRemainder,                    (void *) helperCFloatRemainderFloat,       TR_Helper);
    SET(TR_ARM64doubleRemainder,                   (void *) helperCDoubleRemainderDouble,     TR_Helper);
@@ -1611,11 +1612,16 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARM64forwardDoubleWordArrayCopy,        (void *) __fwDoubleWordArrayCopy,          TR_Helper);
    SET(TR_ARM64forwardWordArrayCopy,              (void *) __fwWordArrayCopy,                TR_Helper);
    SET(TR_ARM64forwardHalfWordArrayCopy,          (void *) __fwHalfWordArrayCopy,            TR_Helper);
-   SET(TR_ARM64backwardQuadWordArrayCopy,         (void *) __bwQuadWordArrayCopy,             TR_Helper);
+   SET(TR_ARM64backwardQuadWordArrayCopy,         (void *) __bwQuadWordArrayCopy,            TR_Helper);
    SET(TR_ARM64backwardDoubleWordArrayCopy,       (void *) __bwDoubleWordArrayCopy,          TR_Helper);
    SET(TR_ARM64backwardWordArrayCopy,             (void *) __bwWordArrayCopy,                TR_Helper);
    SET(TR_ARM64backwardHalfWordArrayCopy,         (void *) __bwHalfWordArrayCopy,            TR_Helper);
    SET(TR_ARM64PatchGCRHelper,                    (void *) _patchGCRHelper,                  TR_Helper);
+#if defined(OSX)
+   SET(TR_ARM64fieldWatchHelper,                  (void *) _fieldWatchHelper,                TR_Helper);
+#else
+   SET(TR_ARM64fieldWatchHelper,                  (void *) 0,                                TR_Helper);
+#endif
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390double2Long,                                (void *) 0,                                              TR_Helper);

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -444,12 +444,6 @@
 	${TEST_STATUS}</command>
 		<!-- Option -XX:+JitInlineWatches is currently unsupported on arm -->
 		<platformRequirements>^arch.arm</platformRequirements>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14502</comment>
-				<platform>aarch64.*mac.*</platform>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit adds code for rewriting data in snippets for field watch
on AArch64 macOS.

Fixes: #14502

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>