### PR TITLE
[Part 2&3] FFI Upcall: generating thunk with the encoded signature

### DIFF
--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -222,6 +222,7 @@ if(NOT JAVA_SPEC_VERSION LESS 16)
 	# sources for Java 16+
 	target_sources(jclse
 		PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/common/jdk_internal_foreign_abi_UpcallStubs.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/common/jdk_internal_misc_ScopedMemoryAccess.cpp
 			${CMAKE_CURRENT_SOURCE_DIR}/common/vectornatives.cpp
 	)

--- a/runtime/jcl/common/jdk_internal_foreign_abi_UpcallStubs.cpp
+++ b/runtime/jcl/common/jdk_internal_foreign_abi_UpcallStubs.cpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9protos.h"
+#include "jcl.h"
+#include "jclglob.h"
+#include "jclprots.h"
+#include "jcl_internal.h"
+#include "jni.h"
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> /* for pthread_jit_write_protect_np */
+#endif
+
+/**
+ * A memory segment is associated with a native scope/session owned by a thread, in which case
+ * the memory segment belonging to the scope/session will be automatically released in OpenJDK
+ * by invoking this function when the native scope/session is terminated.
+ * See src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+ * in OpenJDK for details.
+ *
+ * To adapt to the calling mechanism in our implementation, a hashtable is created to stored
+ * the metadata for each generated thunk, which means the allocated memories associated with
+ * the metadata and the thunk are released in this way to ensure we have sufficient memory
+ * to be allocated on the heap for thunk (especially on AIX only with 4KB virtual memory).
+ */
+jboolean JNICALL
+Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0(JNIEnv *env, jobject receiver, jlong address)
+{
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+#if defined(AIXPPC) || (defined(S390) && defined(zOS))
+	/* The first element of the function pointer holds the thunk memory address,
+	 * as specified in vm/ap64/UpcallThunkGen.cpp
+	 */
+	UDATA *functionPtr = (UDATA *)address;
+	void *thunkAddr = (void *)functionPtr[0];
+#else /* defined(AIXPPC) || (defined(S390) && defined(zOS)) */
+	void *thunkAddr = (void *)(UDATA)address;
+#endif /* defined(AIXPPC) || (defined(S390) && defined(zOS)) */
+
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	omrthread_monitor_enter(vm->thunkHeapWrapperMutex);
+	if (NULL != thunkAddr) {
+		J9UpcallThunkHeapWrapper *thunkHeapWrapper = vm->thunkHeapWrapper;
+		J9HashTable *metaDataHashTable = thunkHeapWrapper->metaDataHashTable;
+		J9Heap *thunkHeap = thunkHeapWrapper->heap;
+
+		if (NULL != metaDataHashTable) {
+			J9UpcallMetaDataEntry metaDataEntry = {0};
+			metaDataEntry.thunkAddrValue = (UDATA)(uintptr_t)thunkAddr;
+			metaDataEntry.upcallMetaData = NULL;
+			J9UpcallMetaDataEntry * result = (J9UpcallMetaDataEntry *)hashTableFind(metaDataHashTable, &metaDataEntry);
+			if (NULL != result) {
+				J9UpcallMetaData *metaData = result->upcallMetaData;
+				J9UpcallNativeSignature *nativeFuncSig = metaData->nativeFuncSignature;
+				if (NULL != nativeFuncSig) {
+					j9mem_free_memory(nativeFuncSig->sigArray);
+					j9mem_free_memory(nativeFuncSig);
+					nativeFuncSig = NULL;
+				}
+				vmFuncs->internalEnterVMFromJNI(currentThread);
+				vmFuncs->j9jni_deleteGlobalRef(env, metaData->mhMetaData, JNI_FALSE);
+				vmFuncs->internalExitVMToJNI(currentThread);
+				j9mem_free_memory(metaData);
+				hashTableRemove(metaDataHashTable, result);
+
+				if (NULL != thunkHeap) {
+#if defined(OSX) && defined(AARCH64)
+					pthread_jit_write_protect_np(0);
+#endif
+					j9heap_free(thunkHeap, thunkAddr);
+#if defined(OSX) && defined(AARCH64)
+					pthread_jit_write_protect_np(1);
+#endif
+				}
+			}
+		}
+	}
+	omrthread_monitor_exit(vm->thunkHeapWrapperMutex);
+
+	return true;
+}
+
+/**
+ * The function is unused in OpenJ9 which is only invoked in OpenJDK
+ * so as to avoid modifying the existing code in OpenJDK.
+ */
+void JNICALL
+Java_jdk_internal_foreign_abi_UpcallStubs_registerNatives(JNIEnv *env, jclass clazz)
+{
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -615,6 +615,8 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 16)
 	omr_add_exports(jclse
 		Java_java_lang_ref_Reference_refersTo
+		Java_jdk_internal_foreign_abi_UpcallStubs_registerNatives
+		Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0
 		Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives
 		Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0
 		Java_jdk_internal_vm_vector_VectorSupport_registerNatives

--- a/runtime/jcl/uma/se16_exports.xml
+++ b/runtime/jcl/uma/se16_exports.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 <exports group="se16">
 	<export name="Java_java_lang_ref_Reference_refersTo"/>
+	<export name="Java_jdk_internal_foreign_abi_UpcallStubs_registerNatives"/>
+	<export name="Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0"/>
 	<export name="Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives"/>
 	<export name="Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0"/>
 	<export name="Java_jdk_internal_vm_vector_VectorSupport_registerNatives"/>

--- a/runtime/jcl/uma/se16_objects.xml
+++ b/runtime/jcl/uma/se16_objects.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <objects group="se16">
+	<object name="jdk_internal_foreign_abi_UpcallStubs" />
 	<object name="jdk_internal_misc_ScopedMemoryAccess" />
 	<object name="vectornatives" />
 </objects>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4889,7 +4889,6 @@ typedef struct J9InternalVMFunctions {
 	void (*freeTLS)(struct J9VMThread *currentThread, j9object_t threadObj);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #if JAVA_SPEC_VERSION >= 16
-/*
 	void * ( *createUpcallThunk)(struct J9UpcallMetaData *data);
 	void * ( *getArgPointer)(struct J9UpcallNativeSignature *nativeSig, void *argListPtr, int argIdx);
 	void * ( *allocateUpcallThunkMemory)(struct J9UpcallMetaData *data);
@@ -4900,7 +4899,6 @@ typedef struct J9InternalVMFunctions {
 	float (JNICALL *native2InterpJavaUpcallF)(struct J9UpcallMetaData *data, void *argsListPointer);
 	double (JNICALL *native2InterpJavaUpcallD)(struct J9UpcallMetaData *data, void *argsListPointer);
 	U_8 * (JNICALL *native2InterpJavaUpcallStruct)(struct J9UpcallMetaData *data, void *argsListPointer);
-*/
 #endif /* JAVA_SPEC_VERSION >= 16 */
 } J9InternalVMFunctions;
 

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1258,6 +1258,12 @@ jboolean JNICALL
 Java_java_lang_ref_Reference_refersTo(JNIEnv *env, jobject reference, jobject target);
 
 void JNICALL
+Java_jdk_internal_foreign_abi_UpcallStubs_registerNatives(JNIEnv *env, jclass clazz);
+
+jboolean JNICALL
+Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0(JNIEnv *env, jobject receiver, jlong address);
+
+void JNICALL
 Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass clazz);
 
 jboolean JNICALL

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4867,6 +4867,124 @@ throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
 void
 throwNewJavaIoIOException(JNIEnv *env, const char *message);
 
+#if JAVA_SPEC_VERSION >= 16
+
+/* ------------------- UpcallThunkGen.cpp ----------------- */
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *data);
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig a pointer to the J9UpcallNativeSignature
+ * @param argListPtr a pointer to the argument list prepared by the thunk
+ * @param argIdx the requested argument index
+ * @return the address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, int argIdx);
+
+/**
+ * @brief Allocate a piece of thunk memory with a given size from the existing virtual memory block
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @return the start address of the upcall thunk memory, or NULL on failure.
+ */
+void *
+allocateUpcallThunkMemory(J9UpcallMetaData *data);
+
+
+/**
+ * @brief Flush the generated thunk to the memory
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param thunkAddress the address of the generated thunk
+ * @return void
+ */
+void
+doneUpcallThunkGeneration(J9UpcallMetaData *data, void *thunkAddress);
+
+/* ------------------- UpcallVMHelpers.cpp ----------------- */
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and ignore the return value in the case of void.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return void
+ */
+void JNICALL
+native2InterpJavaUpcall0(J9UpcallMetaData *data, void *argsListPointer);
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return an I_32 value in the case of byte/char/short/int.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return an I_32 value
+ */
+I_32 JNICALL
+native2InterpJavaUpcall1(J9UpcallMetaData *data, void *argsListPointer);
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return an I_64 value in the case of long/pointer.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return an I_64 value
+ */
+I_64 JNICALL
+native2InterpJavaUpcallJ(J9UpcallMetaData *data, void *argsListPointer);
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a float value as specified in the return type.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a float
+ */
+float JNICALL
+native2InterpJavaUpcallF(J9UpcallMetaData *data, void *argsListPointer);
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a double value as specified in the return type.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a double
+ */
+double JNICALL
+native2InterpJavaUpcallD(J9UpcallMetaData *data, void *argsListPointer);
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a U_8 pointer to the requested struct.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a U_8 pointer
+ */
+U_8 * JNICALL
+native2InterpJavaUpcallStruct(J9UpcallMetaData *data, void *argsListPointer);
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -168,6 +168,8 @@ set(main_sources
 	threadhelp.cpp
 	threadpark.c
 	throwexception.c
+	UpcallThunkMem.cpp
+	UpcallVMHelpers.cpp
 	ValueTypeHelpers.cpp
 	visible.c
 	VMAccess.cpp
@@ -266,10 +268,14 @@ if(OMR_ARCH_X86)
 			xa64/stackswap.m4
 			xa64/unsafeHelper.m4
 		)
-		target_sources(j9vm PRIVATE unsafeHelper.s)
+		target_sources(j9vm PRIVATE
+			unsafeHelper.s
+			xa64/UpcallThunkGen.cpp
+		)
 	elseif(OMR_OS_WINDOWS)
 		if(OMR_ENV_DATA64)
 			j9vm_gen_asm(wa64/stackswap.m4)
+			target_sources(j9vm PRIVATE wa64/UpcallThunkGen.cpp)
 		else()
 			j9vm_gen_asm(wi32/stackswap.m4)
 			target_sources(j9vm PRIVATE
@@ -295,10 +301,16 @@ elseif(OMR_ARCH_POWER)
 		if(NOT (OMR_ENV_DATA64 AND OMR_ENV_LITTLE_ENDIAN))
 			message(SEND_ERROR "Only PPC64 LE is currently supported")
 		endif()
-		target_sources(j9vm PRIVATE xl64/unsafeHelper.s)
+		target_sources(j9vm PRIVATE
+			xl64/unsafeHelper.s
+			xl64/UpcallThunkGen.cpp
+		)
 	elseif(OMR_OS_AIX)
 		if(OMR_ENV_DATA64)
-			target_sources(j9vm PRIVATE ap64/unsafeHelper.s)
+			target_sources(j9vm PRIVATE
+				ap64/unsafeHelper.s
+				ap64/UpcallThunkGen.cpp
+			)
 		else()
 			target_sources(j9vm PRIVATE ap32/unsafeHelper.s)
 		endif()
@@ -314,7 +326,10 @@ elseif(OMR_ARCH_S390)
 	target_sources(j9vm PRIVATE zcinterp.s)
 	if(OMR_OS_LINUX)
 		if(OMR_ENV_DATA64)
-			target_sources(j9vm PRIVATE xz64/unsafeHelper.s)
+			target_sources(j9vm PRIVATE
+				xz64/unsafeHelper.s
+				xz64/UpcallThunkGen.cpp
+			)
 		else()
 			target_sources(j9vm PRIVATE xz31/unsafeHelper.s)
 		endif()
@@ -344,7 +359,10 @@ elseif(OMR_ARCH_AARCH64)
 	target_sources(j9vm PRIVATE arm64cinterp.s)
 	if(OMR_OS_LINUX OR OMR_OS_OSX)
 		j9vm_gen_asm(xr64/unsafeHelper.m4)
-		target_sources(j9vm PRIVATE unsafeHelper.s)
+		target_sources(j9vm PRIVATE
+			unsafeHelper.s
+			xr64/UpcallThunkGen.cpp
+			)
 	else()
 		message(SEND_ERROR "Unsupported OS")
 	endif()

--- a/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler.cpp
+++ b/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler.cpp
@@ -45,7 +45,7 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler_allocateUpcallStu
 {
 	VM_BytecodeAction rc = EXECUTE_BYTECODE;
 	J9JavaVM *vm = currentThread->javaVM;
-	//J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9UpcallMetaData *upcallMetaData = NULL;
 	j9object_t mhMetaData = NULL;
 	J9UpcallNativeSignature *nativeSig = NULL;
@@ -129,11 +129,7 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler_allocateUpcallStu
 	}
 	VM_OutOfLineINL_Helpers::restoreInternalNativeStackFrame(currentThread);
 
-	/* Disable caling the thunk generation code for the moment
-	 * to pass compilation in Jenkins and will re-enable along
-	 * with the code in Part 2 & 3.
-	 */
-	//thunkAddr = vmFuncs->createUpcallThunk(upcallMetaData);
+	thunkAddr = vmFuncs->createUpcallThunk(upcallMetaData);
 	if (NULL == thunkAddr) {
 		rc = GOTO_THROW_CURRENT_EXCEPTION;
 		setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/vm/UpcallThunkMem.cpp
+++ b/runtime/vm/UpcallThunkMem.cpp
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "j9protos.h"
+#include "ut_j9vm.h"
+#include "vm_internal.h"
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
+static void * subAllocateThunkFromHeap(J9UpcallMetaData *data);
+static J9Heap * allocateThunkHeap(J9UpcallMetaData *data);
+static UDATA upcallMetaDataHashFn(void *key, void *userData);
+static UDATA upcallMetaDataEqualFn(void *leftKey, void *rightKey, void *userData);
+
+/**
+ * @brief Flush the generated thunk to the memory
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param thunkAddress The address of the generated thunk
+ * @return void
+ */
+void
+doneUpcallThunkGeneration(J9UpcallMetaData *data, void *thunkAddress)
+{
+	J9JavaVM * vm = data->vm;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	if (NULL != thunkAddress) {
+		/* Flash the generated thunk to the memory */
+		j9cpu_flush_icache(thunkAddress, data->thunkSize);
+	}
+}
+
+/**
+ * @brief Allocate a piece of thunk memory with a given size from the existing virtual memory block
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @return the start address of the upcall thunk memory, or NULL on failure.
+ */
+void *
+allocateUpcallThunkMemory(J9UpcallMetaData *data)
+{
+	J9JavaVM * vm = data->vm;
+	void *thunkAddress = NULL;
+
+	Assert_VM_true(data->thunkSize > 0);
+
+	omrthread_monitor_enter(vm->thunkHeapWrapperMutex);
+	thunkAddress = subAllocateThunkFromHeap(data);
+	omrthread_monitor_exit(vm->thunkHeapWrapperMutex);
+
+	return thunkAddress;
+}
+
+/**
+ * Suballocate a piece of thunk memory on the heap and return the
+ * allocated thunk address on success; otherwise return NULL.
+ */
+static void *
+subAllocateThunkFromHeap(J9UpcallMetaData *data)
+{
+	J9JavaVM * vm = data->vm;
+	UDATA thunkSize = data->thunkSize;
+	J9Heap *thunkHeap = NULL;
+	void *subAllocThunkPtr = NULL;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	Trc_VM_subAllocateThunkFromHeap_Entry(thunkSize);
+
+	if (NULL == vm->thunkHeapWrapper) {
+		thunkHeap = allocateThunkHeap(data);
+		if (NULL == thunkHeap) {
+			/* The thunk address is NULL if VM fails to allocate the thunk heap */
+			goto done;
+		}
+	} else {
+		thunkHeap = vm->thunkHeapWrapper->heap;
+	}
+
+#if defined(OSX) && defined(AARCH64)
+	pthread_jit_write_protect_np(0);
+#endif
+	subAllocThunkPtr = j9heap_allocate(thunkHeap, thunkSize);
+	if (NULL != subAllocThunkPtr) {
+		J9UpcallMetaDataEntry metaDataEntry = {0};
+		metaDataEntry.thunkAddrValue = (UDATA)(uintptr_t)subAllocThunkPtr;
+		metaDataEntry.upcallMetaData = data;
+
+		/* Store the address of the generated thunk plus the corresponding metadata as an entry to
+		 * a hashtable which will be used to release the memory automatically via freeUpcallStub
+		 * in OpenJDK when their native scope is terminated or VM exits.
+		 */
+		if (NULL == hashTableAdd(vm->thunkHeapWrapper->metaDataHashTable, &metaDataEntry)) {
+			j9heap_free(thunkHeap, subAllocThunkPtr);
+			subAllocThunkPtr = NULL;
+			Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_add_hashtable_failed(thunkSize, thunkHeap);
+		} else {
+			Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_success(subAllocThunkPtr, thunkSize, thunkHeap);
+		}
+	} else {
+		Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_failed(thunkSize, thunkHeap);
+	}
+#if defined(OSX) && defined(AARCH64)
+	pthread_jit_write_protect_np(1);
+#endif
+
+done:
+	Trc_VM_subAllocateThunkFromHeap_Exit(subAllocThunkPtr);
+	return subAllocThunkPtr;
+}
+
+/**
+ * The memory of the thunk heap will be allocated using vmem. If the overhead
+ * of omrheap precludes using suballocation, omrheap will not be used and the
+ * memory will be used directly instead.
+ */
+static J9Heap *
+allocateThunkHeap(J9UpcallMetaData *data)
+{
+	J9JavaVM * vm = data->vm;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	UDATA pageSize = j9vmem_supported_page_sizes()[0];
+	UDATA thunkSize = data->thunkSize;
+	J9UpcallThunkHeapWrapper *thunkHeapWrapper = NULL;
+	J9HashTable *metaDataHashTable = NULL;
+	void *allocMemPtr = NULL;
+	J9Heap *thunkHeap = NULL;
+	J9PortVmemIdentifier vmemID;
+
+	Trc_VM_allocateThunkHeap_Entry(thunkSize);
+
+	/* Create the wrapper struct for the thunk heap */
+	thunkHeapWrapper = (J9UpcallThunkHeapWrapper *)j9mem_allocate_memory(sizeof(J9UpcallThunkHeapWrapper), J9MEM_CATEGORY_VM_FFI);
+	if (NULL == thunkHeapWrapper) {
+		Trc_VM_allocateThunkHeap_allocate_thunk_heap_wrapper_failed();
+		goto done;
+	}
+
+	metaDataHashTable = hashTableNew(OMRPORT_FROM_J9PORT(vm->portLibrary), "Upcall metadata table", 0,
+			sizeof(J9UpcallMetaDataEntry), 0, 0, J9MEM_CATEGORY_VM_FFI, upcallMetaDataHashFn, upcallMetaDataEqualFn, NULL, NULL);
+	if (NULL == metaDataHashTable) {
+		Trc_VM_allocateThunkHeap_create_metadata_hash_table_failed();
+		goto freeAllMemoryThenExit;
+	}
+	thunkHeapWrapper->metaDataHashTable = metaDataHashTable;
+
+	/* Reserve a block of memory with the fixed page size for heap creation */
+	allocMemPtr = j9vmem_reserve_memory(NULL, pageSize, &vmemID,
+		J9PORT_VMEM_MEMORY_MODE_READ | J9PORT_VMEM_MEMORY_MODE_WRITE | J9PORT_VMEM_MEMORY_MODE_EXECUTE | J9PORT_VMEM_MEMORY_MODE_COMMIT,
+		pageSize, J9MEM_CATEGORY_VM_FFI);
+	if (NULL == allocMemPtr) {
+		Trc_VM_allocateThunkHeap_reserve_memory_failed(pageSize);
+		goto freeAllMemoryThenExit;
+	}
+
+#if defined(OSX) && defined(AARCH64)
+	pthread_jit_write_protect_np(0);
+#endif
+
+	/* Initialize the allocated memory as a J9Heap */
+	thunkHeap = j9heap_create(allocMemPtr, pageSize, 0);
+	if (NULL == thunkHeap) {
+		Trc_VM_allocateThunkHeap_create_heap_failed(allocMemPtr, pageSize);
+		goto freeAllMemoryThenExit;
+	}
+
+	/* Store the heap handle in J9UpcallThunkHeapWrapper if the thunk heap is successfully created */
+	thunkHeapWrapper->heap = thunkHeap;
+	thunkHeapWrapper->heapSize = pageSize;
+	thunkHeapWrapper->vmemID = vmemID;
+	vm->thunkHeapWrapper = thunkHeapWrapper;
+
+#if defined(OSX) && defined(AARCH64)
+	pthread_jit_write_protect_np(1);
+#endif
+
+done:
+	Trc_VM_allocateThunkHeap_Exit(thunkHeap);
+	return thunkHeap;
+
+freeAllMemoryThenExit:
+	if (NULL != thunkHeapWrapper) {
+		if (NULL != metaDataHashTable) {
+			hashTableFree(metaDataHashTable);
+			metaDataHashTable = NULL;
+		}
+		j9mem_free_memory(thunkHeapWrapper);
+		thunkHeapWrapper = NULL;
+	}
+	if (NULL != allocMemPtr) {
+#if defined(OSX) && defined(AARCH64)
+		pthread_jit_write_protect_np(1);
+#endif
+		j9vmem_free_memory(allocMemPtr, pageSize, &vmemID);
+		allocMemPtr = NULL;
+	}
+	goto done;
+}
+
+/**
+ * Compute the hash code (namely the thunk address value) for the supplied J9UpcallMetaDataEntry
+ */
+static UDATA
+upcallMetaDataHashFn(void *key, void *userData)
+{
+	return ((J9UpcallMetaDataEntry *)key)->thunkAddrValue;
+}
+
+/**
+ * Determines if leftKey and rightKey refer to the same entry in the upcall metadata hashtable
+ */
+static UDATA
+upcallMetaDataEqualFn(void *leftKey, void *rightKey, void *userData)
+{
+	return ((J9UpcallMetaDataEntry *)leftKey)->thunkAddrValue == ((J9UpcallMetaDataEntry *)rightKey)->thunkAddrValue;
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/UpcallVMHelpers.cpp
+++ b/runtime/vm/UpcallVMHelpers.cpp
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "j9protos.h"
+#include "j9vmnls.h"
+#include "objhelp.h"
+#include "ut_j9vm.h"
+#include "vm_internal.h"
+#include "AtomicSupport.hpp"
+#include "ObjectAllocationAPI.hpp"
+#include "VMAccess.hpp"
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and ignore the return value in the case of void.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return void
+ */
+void JNICALL
+native2InterpJavaUpcall0(J9UpcallMetaData *data, void *argsListPointer)
+{
+}
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return an I_32 value in the case of byte/char/short/int.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return an I_32 value
+ */
+I_32 JNICALL
+native2InterpJavaUpcall1(J9UpcallMetaData *data, void *argsListPointer)
+{
+	return (I_32)0;
+}
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return an I_64 value in the case of long/pointer.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return an I_64 value
+ */
+I_64 JNICALL
+native2InterpJavaUpcallJ(J9UpcallMetaData *data, void *argsListPointer)
+{
+	return (I_64)0;
+}
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a float value as specified in the return type.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a float
+ */
+float JNICALL
+native2InterpJavaUpcallF(J9UpcallMetaData *data, void *argsListPointer)
+{
+	return (float)0;
+}
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a double value as specified in the return type.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a double
+ */
+double JNICALL
+native2InterpJavaUpcallD(J9UpcallMetaData *data, void *argsListPointer)
+{
+	return (double)0;
+}
+
+/**
+ * @brief Call into the interpreter via native2InterpJavaUpcallImpl to invoke the upcall
+ * specific method handle and return a U_8 pointer to the requested struct.
+ *
+ * @param data a pointer to J9UpcallMetaData
+ * @param argsListPointer a pointer to the argument list
+ * @return a U_8 pointer
+ */
+U_8 * JNICALL
+native2InterpJavaUpcallStruct(J9UpcallMetaData *data, void *argsListPointer)
+{
+	return NULL;
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/ap64/UpcallThunkGen.cpp
+++ b/runtime/vm/ap64/UpcallThunkGen.cpp
@@ -1,0 +1,513 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * Macros for instructions expected to be used in thunk generation
+ */
+#define LD(rt, ra, si)        (0xE8000000 | ((rt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STD(rs, ra, si)       (0xF8000000 | ((rs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define LFS(frt, ra, si)      (0xC0000000 | ((frt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STFS(frs, ra, si)     (0xD0000000 | ((frs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define LFD(frt, ra, si)      (0xC8000000 | ((frt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STFD(frs, ra, si)     (0xD8000000 | ((frs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define ADDI(rt, ra, si)      (0x38000000 | ((rt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STDU(rs, ra, si)      (0xF8000001 | ((rs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define MFLR(rt)              (0x7C0802A6 | ((rt) << 21))
+#define MTLR(rs)              (0x7C0803A6 | ((rs) << 21))
+#define MTCTR(rs)             (0x7C0903A6 | ((rs) << 21))
+#define BCTR()                (0x4E800420)
+#define BCTRL()               (0x4E800421)
+#define BDNZ(si)              (0x42000000 | ((si) & 0x0000ffff))
+#define BLR()                 (0x4E800020)
+
+#define ROUND_UP_SLOT(si)     (((si) + 7) / 8)
+
+/**
+ * @brief Generate straight sequence of instructions to copy back result
+ * @param instrArray[in/out] A pointer to the thunk memory
+ * @param currIdx[in/out] A pointer to the current instruction index
+ * @param resSize[in] The size in byte to copy, guarantee to be not more than 64
+ * @param paramOffset[in] Offset to the parameter area
+ * @return none
+ *
+ * Details:
+ *   a static routine to generate instructions to copy back the upcall result
+ *   fixed registers are used
+ *     load the hidden parameter into register number 4
+ *     load the result in sequence in no more than 8 registers starting from register 5
+ *     store these registers back into the memory designated by the hidden parameter
+ *
+ *     short-cut convenience in handling the residue
+ */
+static void
+copyBackStraight(I_32 *instrArray, I_32 *currIdx, I_32 resSize, I_32 paramOffset)
+{
+	I_32 localIdx = *currIdx;
+	I_32 roundUpSlots = ROUND_UP_SLOT(resSize);
+
+	instrArray[localIdx++] = LD(4, 1, paramOffset);
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = LD(gIdx + 5, 3, gIdx * 8);
+	}
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = STD(gIdx + 5, 4, gIdx * 8);
+	}
+
+	*currIdx = localIdx;
+}
+
+/**
+ * @brief Generate instruction loop to copy back result
+ * @param instrArray[in/out] A pointer to the thunk memory
+ * @param currIdx[in/out]    A pointer to the current instruction index
+ * @param resSize[in] The size in byte to copy, guarantee to be more than 64
+ * @param paramOffset[in] Offset to the parameter area
+ * @return none
+ *
+ * Details:
+ *   a static routine to generate instruction loop to copy back the upcall result
+ *   fixed registers are used
+ *     load the hidden parameter into register number 4
+ *     set up the loop:  2 instructions
+ *     loop itself: 11 instructions (4 load, 4 store, 2 addi, and branch)
+ *     load the residue in sequence in no more than 4 registers starting from register 5
+ *     store these registers back into the memory designated by the hidden parameter
+ *
+ *     short-cut convenience in handling the residue
+ */
+static void
+copyBackLoop(I_32 *instrArray, I_32 *currIdx, I_32 resSize, I_32 paramOffset)
+{
+	I_32 localIdx = *currIdx;
+	I_32 roundUpSlots = ROUND_UP_SLOT(resSize & 31);
+
+	instrArray[localIdx++] = LD(4, 1, paramOffset);
+	instrArray[localIdx++] = ADDI(0, 0, resSize >> 5);
+	instrArray[localIdx++] = MTCTR(0);
+
+	instrArray[localIdx++] = LD(5, 3, 0);
+	instrArray[localIdx++] = LD(6, 3, 8);
+	instrArray[localIdx++] = LD(7, 3, 16);
+	instrArray[localIdx++] = LD(8, 3, 24);
+	instrArray[localIdx++] = STD(5, 4, 0);
+	instrArray[localIdx++] = STD(6, 4, 8);
+	instrArray[localIdx++] = STD(7, 4, 16);
+	instrArray[localIdx++] = STD(8, 4, 24);
+	instrArray[localIdx++] = ADDI(3, 3, 32);
+	instrArray[localIdx++] = ADDI(4, 4, 32);
+	instrArray[localIdx++] = BDNZ(-40);
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = LD(gIdx + 5, 3, gIdx * 8);
+	}
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = STD(gIdx + 5, 4, gIdx * 8);
+	}
+
+	*currIdx = localIdx;
+}
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	J9JavaVM *vm = metaData->vm;
+	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9UpcallSigType *sigArray = metaData->nativeFuncSignature->sigArray;
+	/* The index of the return type in the signature array */
+	I_32 lastSigIdx = (I_32)(metaData->nativeFuncSignature->numSigs - 1);
+	I_32 stackSlotCount = 0;
+	I_32 fprCovered = 0;
+	I_32 tempInt = 0;
+	I_32 instructionCount = 0;
+	bool hiddenParameter = false;
+
+	Assert_VM_true(lastSigIdx >= 0);
+
+	/* To call the dispatcher: mv r11 to r3(metaData), load target-desc, load target-addr, set-up argListPtr, mtctr, bctr
+	 * Assuming: coming in r11 with metaData (we will fill in the thunk descriptor), r2 already with the right TOC
+	 */
+	instructionCount = 6;
+
+	/* Testing the return type */
+	tempInt = sigArray[lastSigIdx].sizeInByte;
+	switch (sigArray[lastSigIdx].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+		case J9_FFI_UPCALL_SIG_TYPE_VOID:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcall0;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_CHAR:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_SHORT: /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_INT32:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcall1;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallJ;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_FLOAT:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallF;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallD;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+		{
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallStruct;
+			hiddenParameter = true;
+			stackSlotCount += 1;
+			if (tempInt <= 64) {
+				/* Straight-forward copy: load hidden pointer, sequence of copy */
+				instructionCount += 1 + (ROUND_UP_SLOT(tempInt) * 2);
+			} else {
+				/* Loop 32-byte per iteration: load hidden pointer, set-up CTR for loop-count
+				 * 11-instruction loop body, residue copy
+				 * Note: didn't optimize for loop-entry alignment
+				 */
+				instructionCount += 3 + 11 + (ROUND_UP_SLOT(tempInt & 31) * 2);
+			}
+			break;
+		}
+		default:
+			Assert_VM_unreachable();
+	}
+
+	if (hiddenParameter) {
+		instructionCount += 1;
+	}
+
+	/* Loop through the arguments */
+	for (I_32 i = 0; i < lastSigIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			{
+				stackSlotCount += 1;
+				if (stackSlotCount <= 8) {
+					instructionCount += 1;
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			{
+				stackSlotCount += 1;
+				fprCovered += 1;
+
+				/* GPR portion definitely runs out before FPR does */
+				if (stackSlotCount <= 8) {
+					instructionCount += 1;
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+			{
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				if (stackSlotCount > 8) {
+					if ((stackSlotCount - ROUND_UP_SLOT(tempInt)) < 8) {
+						instructionCount += 8 + ROUND_UP_SLOT(tempInt) - stackSlotCount;
+					}
+				} else {
+					instructionCount += ROUND_UP_SLOT(tempInt);
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_VA_LIST: /* Unused */
+				/* This must be the last argument */
+				Assert_VM_true(i == (lastSigIdx - 1));
+				break;
+			default:
+				Assert_VM_unreachable();
+		}
+
+		/* Saturate what we want to know: if there are any in-register arguments to be pushed back */
+		if (stackSlotCount > 8) {
+			break;
+		}
+	}
+
+	/* 7 instructions to build frame: mflr, save-return-addr, stdu-frame,
+	 * addi-tear-down-frame, load-return-addr, mtlr, blr
+	 */
+	I_32 frameSize = 0;
+	I_32 offsetToParamArea = 0;
+	I_32 roundedCodeSize = 0;
+	I_32 *thunkMem = NULL;  /* always 4-byte instruction: convenient to use int-pointer */
+
+	/* Always use the caller frame */
+	if (hiddenParameter) {
+		instructionCount += 7;
+		frameSize = 112;
+		offsetToParamArea = 160;
+	} else {
+		frameSize = 0;
+		offsetToParamArea = 48;
+	}
+
+	/* Hopefully thunk memory is 8-byte aligned. We also make sure thunkSize is multiple of 8
+	 * another 8-byte to store metaData pointer itself
+	 */
+	roundedCodeSize = ((instructionCount + 1) / 2) * 8;
+	metaData->thunkSize = roundedCodeSize;
+	thunkMem = (I_32 *)vmFuncs->allocateUpcallThunkMemory(metaData);
+	if (NULL == thunkMem) {
+		return NULL;
+	}
+
+	metaData->thunkAddress = (void *)thunkMem;
+
+	/* Generate the instruction sequence according to the signature, looping over them again */
+	I_32 gprIdx = 3;
+	I_32 fprIdx = 1;
+	I_32 slotIdx = 0;
+	I_32 instrIdx = 0;
+	I_32 C_SP = 1;
+
+	if (hiddenParameter) {
+		thunkMem[instrIdx++] = MFLR(0);
+		thunkMem[instrIdx++] = STD(0, C_SP, 16);
+		thunkMem[instrIdx++] = STDU(C_SP, C_SP, -frameSize);
+		thunkMem[instrIdx++] = STD(gprIdx++, C_SP, offsetToParamArea);
+		slotIdx += 1;
+	}
+
+	/* Loop through the arguments again */
+	for (I_32 i = 0; i < lastSigIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			{
+				if (slotIdx < 8) {
+					thunkMem[instrIdx++] = STD(gprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				}
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT:
+			{
+				if (slotIdx < 8) {
+					thunkMem[instrIdx++] = STFS(fprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				}
+				fprIdx += 1;
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			{
+				if (slotIdx < 8) {
+					thunkMem[instrIdx++] = STFD(fprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				}
+				fprIdx += 1;
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+			{
+				if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+					if (slotIdx < 8) {
+						for (I_32 gIdx=0; gIdx < (8 - slotIdx); gIdx++) {
+							thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+								 offsetToParamArea + (slotIdx + gIdx) * 8);
+						}
+					}
+				} else {
+					for (I_32 gIdx=0; gIdx < ROUND_UP_SLOT(tempInt); gIdx++) {
+						thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+								offsetToParamArea + (slotIdx + gIdx) * 8);
+					}
+				}
+				gprIdx += ROUND_UP_SLOT(tempInt);
+				slotIdx += ROUND_UP_SLOT(tempInt);
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_VA_LIST: /* Unused */
+				break;
+
+			default:
+				Assert_VM_unreachable();
+		}
+
+		/* No additional argument instructions are expected */
+		if (slotIdx > 8) {
+			break;
+		}
+	}
+
+	/* Make the jump or call to the common dispatcher.
+	 * gr11 is currently pointing at metaData (since we fill it in the thunk-descriptor)
+	 * as the env pointer.Also, we assumed TOC register is set up as well during call to
+	 * this thunk (we will fill in the thunk-descriptor too).
+	 */
+	thunkMem[instrIdx++] = LD(12, 11, offsetof(J9UpcallMetaData, upCallCommonDispatcher));
+	thunkMem[instrIdx++] = ADDI(3, 11, 0);
+	thunkMem[instrIdx++] = LD(0, 12, 0);
+	thunkMem[instrIdx++] = ADDI(4, C_SP, offsetToParamArea);
+	thunkMem[instrIdx++] = MTCTR(0);
+
+	if (hiddenParameter) {
+		thunkMem[instrIdx++] = BCTRL();
+
+		/* Distribute result if needed, then tear down the frame and return */
+		tempInt = sigArray[lastSigIdx].sizeInByte;
+		switch (sigArray[lastSigIdx].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+			{
+				if (tempInt <= 64) {
+					copyBackStraight(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+				} else {
+					/* Note: didn't optimize for loop-entry alignment */
+					copyBackLoop(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+				}
+				break;
+			}
+			default:
+				Assert_VM_unreachable();
+		}
+
+		thunkMem[instrIdx++] = ADDI(C_SP, C_SP, frameSize);
+		thunkMem[instrIdx++] = LD(0, C_SP, 16);
+		thunkMem[instrIdx++] = MTLR(0);
+		thunkMem[instrIdx++] = BLR();
+	} else {
+		thunkMem[instrIdx++] = BCTR();
+	}
+
+	Assert_VM_true(instrIdx == instructionCount);
+
+	/* Set up the thunk descriptor */
+	metaData->functionPtr[0] = (UDATA)thunkMem;
+	metaData->functionPtr[1] = *(UDATA *)((char *)(metaData->upCallCommonDispatcher) + 8);
+	metaData->functionPtr[2] = (UDATA)metaData;
+
+	/* Finish up before returning */
+	vmFuncs->doneUpcallThunkGeneration(metaData, (void *)thunkMem);
+
+	/* Return the thunk descriptor */
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	J9UpcallSigType *sigArray = nativeSig->sigArray;
+	/* The index for the return type in the signature array */
+	I_32 lastSigIdx = (I_32)(nativeSig->numSigs - 1);
+	I_32 stackSlotCount = 0;
+	I_32 tempInt = 0;
+
+	Assert_VM_true((argIdx >= 0) && (argIdx < lastSigIdx));
+
+	/* Testing the return type */
+	tempInt = sigArray[lastSigIdx].sizeInByte;
+	if (J9_ARE_ALL_BITS_SET(sigArray[lastSigIdx].type, J9_FFI_UPCALL_SIG_TYPE_STRUCT)) {
+		stackSlotCount += 1;
+	}
+
+	/* Loop through the arguments */
+	for (I_32 i = 0; i < argIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+				stackSlotCount += 1;
+				break;
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				break;
+			default:
+				Assert_VM_unreachable();
+		}
+	}
+
+	return (void *)((char *)argListPtr + (stackSlotCount * 8));
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -420,7 +420,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	freeTLS,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #if JAVA_SPEC_VERSION >= 16
-/*
 	createUpcallThunk,
 	getArgPointer,
 	allocateUpcallThunkMemory,
@@ -431,6 +430,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	native2InterpJavaUpcallF,
 	native2InterpJavaUpcallD,
 	native2InterpJavaUpcallStruct,
-*/
 #endif /* JAVA_SPEC_VERSION >= 16 */
 };

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -910,3 +910,16 @@ TraceExit=Trc_VM_sendResolveUpcallInvokeHandle_Exit Overhead=1 Level=3 Template=
 
 TraceEntry=Trc_VM_resolveUpcallInvokeHandle_Entry Overhead=1 Level=3 Template="resolveUpcallInvokeHandle"
 TraceExit=Trc_VM_resolveUpcallInvokeHandle_Exit Overhead=1 Level=3 Template="resolveUpcallInvokeHandle --> invokeCache=%p"
+
+TraceEntry=Trc_VM_subAllocateThunkFromHeap_Entry NoEnv Overhead=1 Level=3 Template="Enter subAllocateThunkFromHeap - The requested thunk size(%zu)"
+TraceEvent=Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_add_hashtable_failed NoEnv Overhead=1 Level=3 Template="subAllocateThunkFromHeap - Failed to add an entry of the hashtable for a thunk with the requested size(%zu) from the heap(%p)"
+TraceEvent=Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_success NoEnv Overhead=1 Level=3 Template="subAllocateThunkFromHeap - A thunk(%p) with the requested size(%zu) is successfully suballocated from the heap(%p)"
+TraceEvent=Trc_VM_subAllocateThunkFromHeap_suballoc_thunk_failed NoEnv Overhead=1 Level=3 Template="subAllocateThunkFromHeap - Failed to suballocate a thunk with the requested size(%zu) from the heap(%p)"
+TraceExit=Trc_VM_subAllocateThunkFromHeap_Exit NoEnv Overhead=1 Level=3 Template="Exit subAllocateThunkFromHeap - The suballocated thunk address is %p"
+
+TraceEntry=Trc_VM_allocateThunkHeap_Entry NoEnv Overhead=1 Level=3 Template="Enter allocateThunkHeap - The requested thunk size(%zu)"
+TraceEvent=Trc_VM_allocateThunkHeap_allocate_thunk_heap_wrapper_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate memory for the thunk heap wrapper"
+TraceEvent=Trc_VM_allocateThunkHeap_create_metadata_hash_table_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to create hashtable for the generated thunk and the corresponding metadata in upcall"
+TraceEvent=Trc_VM_allocateThunkHeap_reserve_memory_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate reserve the memory with the requested page size(%zu)"
+TraceEvent=Trc_VM_allocateThunkHeap_create_heap_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to create a heap from the reserved memory (%p) with the requested page size(%zu)"
+TraceExit=Trc_VM_allocateThunkHeap_Exit NoEnv Overhead=1 Level=3 Template="Exit allocateThunkHeap - The suballocated thunk heap is %p"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -43,6 +43,9 @@
 #include "util_api.h"
 #if JAVA_SPEC_VERSION >= 16
 #include "vm_internal.h"
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> /* for pthread_jit_write_protect_np */
+#endif
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if !defined(stdout)
@@ -319,6 +322,10 @@ static UDATA parseGlrOption(J9JavaVM* jvm, char* option);
 
 static void cleanupEnsureHashedConfig(J9JavaVM *jvm);
 static UDATA parseEnsureHashedConfig(J9JavaVM *jvm, char *options, BOOLEAN isAdd);
+
+#if JAVA_SPEC_VERSION >= 16
+static UDATA freeUpcallMetaDataDoFn(J9UpcallMetaDataEntry *entry, void *userData);
+#endif /* JAVA_SPEC_VERSION >= 16 */
 
 J9_DECLARE_CONSTANT_UTF8(j9_int_void, "(I)V");
 J9_DECLARE_CONSTANT_UTF8(j9_dispatch, "dispatch");
@@ -650,6 +657,29 @@ freeJavaVM(J9JavaVM * vm)
 		}
 		pool_kill(vm->cifArgumentTypesCache);
 		vm->cifArgumentTypesCache = NULL;
+	}
+
+	/* Clean up all resources created via allocateUpcallThunkMemory, including the generatered thunk
+	 * and the corresponding metadata of each entry stored in the hashtable.
+	 * See UpcallThunkMem.cpp for details.
+	 */
+	if (NULL != vm->thunkHeapWrapper) {
+		J9UpcallThunkHeapWrapper *thunkHeapWrapper = vm->thunkHeapWrapper;
+		J9PortVmemIdentifier vmemID = thunkHeapWrapper->vmemID;
+		UDATA byteAmount = j9vmem_supported_page_sizes()[0];
+
+		if (NULL != thunkHeapWrapper->metaDataHashTable) {
+			J9HashTable *metaDataHashTable = thunkHeapWrapper->metaDataHashTable;
+			UDATA entryCount = hashTableGetCount(metaDataHashTable);
+			if (entryCount > 0) {
+				hashTableForEachDo(metaDataHashTable, (J9HashTableDoFn)freeUpcallMetaDataDoFn, NULL);
+			}
+			hashTableFree(metaDataHashTable);
+			metaDataHashTable = NULL;
+		}
+		j9vmem_free_memory(vmemID.address, byteAmount, &vmemID);
+		j9mem_free_memory(thunkHeapWrapper);
+		thunkHeapWrapper = NULL;
 	}
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
@@ -6702,6 +6732,8 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	/* ffi_cif should be allocated on demand */
 	vm->cifNativeCalloutDataCache = NULL;
 	vm->cifArgumentTypesCache = NULL;
+	/* The thunk block should be allocated on demand */
+	vm->thunkHeapWrapper = NULL;
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if defined(J9X86) || defined(J9HAMMER)
@@ -8334,3 +8366,50 @@ parseEnsureHashedConfig(J9JavaVM *jvm, char *options, BOOLEAN isAdd)
 
 	return result;
 }
+
+#if JAVA_SPEC_VERSION >= 16
+/**
+ * This function free the memory of the generated thunk and the metadata
+ * in the specified entry of the metadata hashtable intended for upcall.
+ *
+ * @param entry A pointer to J9UpcallMetaDataEntry
+ * @param userData An optional parameter which is unused
+ * @returns JNI_OK on success
+ */
+static UDATA
+freeUpcallMetaDataDoFn(J9UpcallMetaDataEntry *entry, void *userData)
+{
+	void *thunkAddr = (void *)(entry->thunkAddrValue);
+	J9UpcallMetaData *metaData = entry->upcallMetaData;
+
+	if ((NULL != thunkAddr) && (NULL != metaData)) {
+		J9JavaVM *vm = metaData->vm;
+		const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		J9VMThread *currentThread = vmFuncs->currentVMThread(vm);
+		J9UpcallNativeSignature *nativeFuncSig = metaData->nativeFuncSignature;
+		J9Heap *thunkHeap = vm->thunkHeapWrapper->heap;
+		PORT_ACCESS_FROM_JAVAVM(vm);
+
+		if (NULL != nativeFuncSig) {
+			j9mem_free_memory(nativeFuncSig->sigArray);
+			j9mem_free_memory(nativeFuncSig);
+			nativeFuncSig = NULL;
+		}
+		vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, metaData->mhMetaData, JNI_FALSE);
+		j9mem_free_memory(metaData);
+		metaData = NULL;
+
+		if (NULL != thunkHeap) {
+#if defined(OSX) && defined(AARCH64)
+			pthread_jit_write_protect_np(0);
+#endif
+			j9heap_free(thunkHeap, thunkAddr);
+#if defined(OSX) && defined(AARCH64)
+			pthread_jit_write_protect_np(1);
+#endif
+		}
+		entry->thunkAddrValue = 0;
+	}
+	return JNI_OK;
+}
+#endif /* JAVA_SPEC_VERSION >= 16 */

--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -122,6 +122,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<vpath pattern="stackswap.m4" path="wa64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.win_x86.* and spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="wa64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.win_x86.* and spec.flags.J9VM_ENV_DATA64"/>
+			</vpath>
 			<vpath pattern="stackswap.m4" path="xi32" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_x86.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
@@ -133,10 +136,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux_x86.* and spec.flags.J9VM_ENV_DATA64"/>
 				<include-if condition="spec.osx_x86.* and spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="xa64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_x86.* and spec.flags.J9VM_ENV_DATA64"/>
+				<include-if condition="spec.osx_x86.* and spec.flags.J9VM_ENV_DATA64"/>
+			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xi32" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_x86.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xl64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_ppc-64.* and spec.flags.env_littleEndian"/>
+			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="xl64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_ppc-64.* and spec.flags.env_littleEndian"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="ap32" augmentObjects="true" type="relativepath">
@@ -145,10 +155,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<vpath pattern="unsafeHelper.s" path="ap64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.aix_ppc.* and spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="ap64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.aix_ppc.* and spec.flags.J9VM_ENV_DATA64"/>
+			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xz31" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_390.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xz64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_390.* and spec.flags.J9VM_ENV_DATA64"/>
+			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="xz64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_390.* and spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xz64" augmentObjects="true" type="relativepath">
@@ -164,6 +180,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux_arm.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.m4" path="xr64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_aarch64.*"/>
+			</vpath>
+			<vpath pattern="UpcallThunkGen.cpp" path="xr64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_aarch64.*"/>
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="rv64" augmentObjects="true" type="relativepath">

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -87,6 +87,7 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 #if JAVA_SPEC_VERSION >= 16
 		omrthread_monitor_init_with_name(&vm->cifNativeCalloutDataCacheMutex, 0, "CIF cache mutex") ||
 		omrthread_monitor_init_with_name(&vm->cifArgumentTypesCacheMutex, 0, "CIF argument types mutex") ||
+		omrthread_monitor_init_with_name(&vm->thunkHeapWrapperMutex, 0, "Wait mutex for allocating the upcall thunk memory") ||
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 19
@@ -184,6 +185,11 @@ void terminateVMThreading(J9JavaVM *vm)
 	if (NULL != vm->cifArgumentTypesCacheMutex) {
 		omrthread_monitor_destroy(vm->cifArgumentTypesCacheMutex);
 		vm->cifArgumentTypesCacheMutex = NULL;
+	}
+
+	if (NULL != vm->thunkHeapWrapperMutex) {
+		omrthread_monitor_destroy(vm->thunkHeapWrapperMutex);
+		vm->thunkHeapWrapperMutex = NULL;
 	}
 #endif /* JAVA_SPEC_VERSION >= 16 */
 

--- a/runtime/vm/wa64/UpcallThunkGen.cpp
+++ b/runtime/vm/wa64/UpcallThunkGen.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	// Return the thunk descriptor
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	return (void *)((char *)argListPtr);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/xa64/UpcallThunkGen.cpp
+++ b/runtime/vm/xa64/UpcallThunkGen.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	// Return the thunk descriptor
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	return (void *)((char *)argListPtr);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/xl64/UpcallThunkGen.cpp
+++ b/runtime/vm/xl64/UpcallThunkGen.cpp
@@ -1,0 +1,927 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * Macros for instructions expected to be used in thunk generation
+ */
+#define LD(rt, ra, si)        (0xE8000000 | ((rt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STD(rs, ra, si)       (0xF8000000 | ((rs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define LFS(frt, ra, si)      (0xC0000000 | ((frt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STFS(frs, ra, si)     (0xD0000000 | ((frs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define LFD(frt, ra, si)      (0xC8000000 | ((frt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STFD(frs, ra, si)     (0xD8000000 | ((frs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define ADDI(rt, ra, si)      (0x38000000 | ((rt) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define STDU(rs, ra, si)      (0xF8000001 | ((rs) << 21) | ((ra) << 16) | ((si) & 0x0000ffff))
+#define MFLR(rt)              (0x7C0802A6 | ((rt) << 21))
+#define MTLR(rs)              (0x7C0803A6 | ((rs) << 21))
+#define MTCTR(rs)             (0x7C0903A6 | ((rs) << 21))
+#define BCTR()                (0x4E800420)
+#define BCTRL()               (0x4E800421)
+#define BDNZ(si)              (0x42000000 | ((si) & 0x0000ffff))
+#define BLR()                 (0x4E800020)
+
+#define ROUND_UP_SLOT(si)     (((si) + 7) / 8)
+
+/**
+ * @brief Generate straight sequence of instructions to copy back result
+ * @param instrArray[in/out] A pointer to the thunk memory
+ * @param currIdx[in/out] A pointer to the current instruction index
+ * @param resSize[in] The size in byte to copy, guarantee to be not more than 64
+ * @param paramOffset[in] Offset to the parameter area
+ * @return none
+ *
+ * Details:
+ *   a static routine to generate instructions to copy back the upcall result
+ *   fixed registers are used
+ *     load the hidden parameter into register number 4
+ *     load the result in sequence in no more than 8 registers starting from register 5
+ *     store these registers back into the memory designated by the hidden parameter
+ *
+ *     short-cut convenience in handling the residue
+ */
+static void
+copyBackStraight(I_32 *instrArray, I_32 *currIdx, I_32 resSize, I_32 paramOffset)
+{
+	I_32 localIdx = *currIdx;
+	I_32 roundUpSlots = ROUND_UP_SLOT(resSize);
+
+	instrArray[localIdx++] = LD(4, 1, paramOffset);
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = LD(gIdx + 5, 3, gIdx * 8);
+	}
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = STD(gIdx + 5, 4, gIdx * 8);
+	}
+
+	*currIdx = localIdx;
+}
+
+/**
+ * @brief Generate instruction loop to copy back result
+ * @param instrArray[in/out] A pointer to the thunk memory
+ * @param currIdx[in/out]    A pointer to the current instruction index
+ * @param resSize[in] The size in byte to copy, guarantee to be more than 64
+ * @param paramOffset[in] Offset to the parameter area
+ * @return none
+ *
+ * Details:
+ *   a static routine to generate instruction loop to copy back the upcall result
+ *   fixed registers are used
+ *     load the hidden parameter into register number 4
+ *     set up the loop:  2 instructions
+ *     loop itself: 11 instructions (4 load, 4 store, 2 addi, and branch)
+ *     load the residue in sequence in no more than 4 registers starting from register 5
+ *     store these registers back into the memory designated by the hidden parameter
+ *
+ *     short-cut convenience in handling the residue
+ */
+static void
+copyBackLoop(I_32 *instrArray, I_32 *currIdx, I_32 resSize, I_32 paramOffset)
+{
+	I_32 localIdx = *currIdx;
+	I_32 roundUpSlots = ROUND_UP_SLOT(resSize & 31);
+
+	instrArray[localIdx++] = LD(4, 1, paramOffset);
+	instrArray[localIdx++] = ADDI(0, 0, resSize >> 5);
+	instrArray[localIdx++] = MTCTR(0);
+
+	instrArray[localIdx++] = LD(5, 3, 0);
+	instrArray[localIdx++] = LD(6, 3, 8);
+	instrArray[localIdx++] = LD(7, 3, 16);
+	instrArray[localIdx++] = LD(8, 3, 24);
+	instrArray[localIdx++] = STD(5, 4, 0);
+	instrArray[localIdx++] = STD(6, 4, 8);
+	instrArray[localIdx++] = STD(7, 4, 16);
+	instrArray[localIdx++] = STD(8, 4, 24);
+	instrArray[localIdx++] = ADDI(3, 3, 32);
+	instrArray[localIdx++] = ADDI(4, 4, 32);
+	instrArray[localIdx++] = BDNZ(-40);
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = LD(gIdx + 5, 3, gIdx * 8);
+	}
+
+	for (I_32 gIdx = 0; gIdx < roundUpSlots; gIdx++) {
+		instrArray[localIdx++] = STD(gIdx + 5, 4, gIdx * 8);
+	}
+
+	*currIdx = localIdx;
+}
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, either in newly-built frame or caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     2) is most likely needed, since the caller frame might not contain the parameter area in most cases;
+ *     4) implies needing 2), since this adaptor expects a return from java side before returning
+ *        to the native caller.
+ *
+ *   there are two different scenarios under 4):
+ *      a) distribute  result back into register-containable aggregates (either homogeneous FP or not)
+ *      b) copy the result back to the area designated by the hidden-parameter
+ *
+ *   most of the complexities are due to handling ALL_SP homogeneous struct: the register image and
+ *   memory image are different, such that it can lead to the situation in which FPR parameter registers
+ *   run out before GPR parameter registers. In that case, floating point arguments need to be passed
+ *   in GPRs (and in the right position if it is an SP).
+ *
+ *   when a new frame is needed, it is at least 32bytes in size and 16-byte-aligned. this implementation
+ *   going as follows: if caller-frame parameter area can be used, the new frame will be of fixed 48-byte
+ *   size; otherwise, it will be of [64 + round-up-16(parameterArea)].
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	J9JavaVM *vm = metaData->vm;
+	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9UpcallSigType *sigArray = metaData->nativeFuncSignature->sigArray;
+	/* The index of the return type in the signature array */
+	I_32 lastSigIdx = (I_32)(metaData->nativeFuncSignature->numSigs - 1);
+	I_32 stackSlotCount = 0;
+	I_32 fprCovered = 0;
+	I_32 tempInt = 0;
+	I_32 instructionCount = 0;
+	bool hiddenParameter = false;
+	bool resultDistNeeded = false;
+	bool paramAreaNeeded = true;
+
+	Assert_VM_true(lastSigIdx >= 0);
+
+	/* To call the dispatcher: load metaData, load targetAddress, set-up argListPtr, mtctr, bctr */
+	instructionCount = 5;
+
+	/* Testing the return type */
+	tempInt = sigArray[lastSigIdx].sizeInByte;
+	switch (sigArray[lastSigIdx].type) {
+		case J9_FFI_UPCALL_SIG_TYPE_VOID:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcall0;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_CHAR:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_SHORT: /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_INT32:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcall1;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_POINTER:
+		case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallJ;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_FLOAT:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallF;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallD;
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_SP:
+		{
+			Assert_VM_true(0 == (tempInt % sizeof(float)));
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallStruct;
+			resultDistNeeded = true;
+			if (tempInt <= (I_32)(8 * sizeof(float))) {
+				/* Distribute result back into FPRs */
+				instructionCount += tempInt/sizeof(float);
+			} else {
+				/* Copy back to memory area designated by a hidden parameter
+				 * Temporarily take a convenient short-cut of always 8-byte
+				 */
+				stackSlotCount += 1;
+				hiddenParameter = true;
+				if (tempInt <= 64) {
+					/* Straight-forward copy: load hidden pointer, sequence of copy */
+					instructionCount += 1 + (ROUND_UP_SLOT(tempInt) * 2);
+				} else {
+					/* Loop 32-byte per iteration: load hidden pointer, set-up CTR for loop-count
+					 * 11-instruction loop body, residue copy
+					 * Note: didn't optimize for loop-entry alignment
+					 */
+					instructionCount += 3 + 11 + (ROUND_UP_SLOT(tempInt & 31) * 2);
+				}
+			}
+			break;
+		}
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_DP:
+		{
+			Assert_VM_true(0 == (tempInt % sizeof(double)));
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallStruct;
+			resultDistNeeded = true;
+			if (tempInt <= (I_32)(8 * sizeof(double))) {
+				/* Distribute back into FPRs */
+				instructionCount += tempInt/sizeof(double);
+			} else {
+				/* Loop 32-byte per iteration: load hidden pointer, set-up CTR for loop-count
+				 * 11-instruction loop body, residue copy
+				 * Note: didn't optimize for loop-entry alignment
+				 */
+				stackSlotCount += 1;
+				hiddenParameter = true;
+				instructionCount += 3 + 11 + (ROUND_UP_SLOT(tempInt & 31) * 2);
+			}
+			break;
+		}
+		/* Definitely <= 16-byte */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_DP:    /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_SP_DP: /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP:    /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP_SP: /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_SP:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_DP:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_MISC:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_MISC:  /* Fall through */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC:
+		{
+			Assert_VM_true(tempInt <= 16);
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallStruct;
+			resultDistNeeded = true;
+			instructionCount += ROUND_UP_SLOT(tempInt);
+			break;
+		}
+		/* Definitely > 16-byte */
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_OTHER:
+		{
+			Assert_VM_true(tempInt > 16);
+			metaData->upCallCommonDispatcher = (void *)vmFuncs->native2InterpJavaUpcallStruct;
+			resultDistNeeded = true;
+			hiddenParameter = true;
+			stackSlotCount += 1;
+			if (tempInt <= 64) {
+				/* Straight-forward copy: load hidden pointer, sequence of copy */
+				instructionCount += 1 + (ROUND_UP_SLOT(tempInt) * 2);
+			} else {
+				/* Loop 32-byte per iteration: load hidden pointer, set-up CTR for loop-count
+				 * 11-instruction loop body, residue copy
+				 * Note: didn't optimize for loop-entry alignment
+				 */
+				instructionCount += 3 + 11 + (ROUND_UP_SLOT(tempInt & 31) * 2);
+			}
+			break;
+		}
+		default:
+			Assert_VM_unreachable();
+	}
+
+	if (hiddenParameter) {
+		instructionCount += 1;
+	}
+
+	/* Loop through the arguments */
+	for (I_32 i = 0; i < lastSigIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			{
+				stackSlotCount += 1;
+				if (stackSlotCount > 8) {
+					paramAreaNeeded = false;
+				} else {
+					instructionCount += 1;
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			{
+				stackSlotCount += 1;
+				fprCovered += 1;
+				if (fprCovered > 13) {
+					if (stackSlotCount > 8) {
+						paramAreaNeeded = false;
+					} else {
+						instructionCount += 1;
+					}
+				} else {
+					instructionCount += 1;
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_SP:
+			{
+				Assert_VM_true(0 == (tempInt % sizeof(float)));
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				if (tempInt <= (I_32)(8 * sizeof(float))) {
+					if ((fprCovered + (tempInt / sizeof(float))) > 13) {
+						/* It is really tricky here. some remaining SPs are passed in
+						 * GPRs if there are free GPR parameter registers.
+						 */
+						I_32 restSlots = 0;
+						if (fprCovered < 13) {
+							instructionCount += 13 - fprCovered;
+							/* Round-down the already passed in FPRs */
+							restSlots = ROUND_UP_SLOT(tempInt) - ((13 - fprCovered) / 2);
+						} else {
+							restSlots = ROUND_UP_SLOT(tempInt);
+						}
+
+						Assert_VM_true(restSlots > 0);
+						if ((stackSlotCount - restSlots) < 8) {
+							if (stackSlotCount > 8) {
+								paramAreaNeeded = false;
+								instructionCount += 8 - (stackSlotCount - restSlots);
+							} else {
+								instructionCount += restSlots;
+							}
+						} else {
+							paramAreaNeeded = false;
+						}
+					} else {
+						instructionCount += tempInt / sizeof(float);
+					}
+					fprCovered += tempInt / sizeof(float);
+				} else {
+					if (stackSlotCount > 8) {
+						paramAreaNeeded = false;
+						if ((stackSlotCount - ROUND_UP_SLOT(tempInt)) < 8) {
+							instructionCount += 8 + ROUND_UP_SLOT(tempInt) - stackSlotCount;
+						}
+					} else {
+						instructionCount += ROUND_UP_SLOT(tempInt);
+					}
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_DP:
+			{
+				Assert_VM_true(0 == (tempInt % sizeof(double)));
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				if (tempInt <= (I_32)(8 * sizeof(double))) {
+					if ((fprCovered + (tempInt / sizeof(double))) > 13) {
+						I_32 restSlots = 0;
+						if (fprCovered < 13) {
+							instructionCount += 13 - fprCovered;
+							restSlots = ROUND_UP_SLOT(tempInt) - (13 - fprCovered);
+						} else {
+							restSlots = ROUND_UP_SLOT(tempInt);
+						}
+
+						Assert_VM_true(restSlots > 0);
+						if ((stackSlotCount - restSlots) < 8) {
+							if (stackSlotCount > 8) {
+								paramAreaNeeded = false;
+								instructionCount += 8 - (stackSlotCount - restSlots);
+							} else {
+								instructionCount += restSlots;
+							}
+						} else {
+							paramAreaNeeded = false;
+						}
+					} else {
+						instructionCount += tempInt / sizeof(double);
+					}
+					fprCovered += tempInt / sizeof(double);
+				} else {
+					if (stackSlotCount > 8) {
+						paramAreaNeeded = false;
+						if ((stackSlotCount - ROUND_UP_SLOT(tempInt)) < 8) {
+							instructionCount += 8 + ROUND_UP_SLOT(tempInt) - stackSlotCount;
+						}
+					} else {
+						instructionCount += ROUND_UP_SLOT(tempInt);
+					}
+				}
+				break;
+			}
+			/* Definitely <= 16-byte */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_DP:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_SP_DP: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP_SP: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_SP:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_DP:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_MISC:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_MISC:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC:
+			{
+				Assert_VM_true(tempInt <= 16);
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				if (stackSlotCount > 8) {
+					paramAreaNeeded = false;
+					if ((stackSlotCount - ROUND_UP_SLOT(tempInt)) < 8) {
+						instructionCount += 8 + ROUND_UP_SLOT(tempInt) - stackSlotCount;
+					}
+				} else {
+					instructionCount += ROUND_UP_SLOT(tempInt);
+				}
+				break;
+			}
+			/* Definitely > 16-byte */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_OTHER:
+			{
+				Assert_VM_true(tempInt > 16);
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				if (stackSlotCount > 8) {
+					paramAreaNeeded = false;
+					if ((stackSlotCount - ROUND_UP_SLOT(tempInt)) < 8) {
+						instructionCount += 8 + ROUND_UP_SLOT(tempInt) - stackSlotCount;
+					}
+				} else {
+					instructionCount += ROUND_UP_SLOT(tempInt);
+				}
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_VA_LIST: /* Unused */
+				/* This must be the last argument */
+				Assert_VM_true(i == (lastSigIdx - 1));
+				paramAreaNeeded = false;
+				break;
+			default:
+				Assert_VM_unreachable();
+		}
+
+		/* Saturate what we want to know: if there are any in-register args to be pushed back */
+		if ((stackSlotCount > 8) && (fprCovered > 13)) {
+			Assert_VM_true(paramAreaNeeded == false);
+			break;
+		}
+	}
+
+	/* 7 instructions to build frame: mflr, save-return-addr, stdu-frame,
+	 * addi-tear-down-frame, load-return-addr, mtlr, blr
+	 */
+	I_32 frameSize = 0;
+	I_32 offsetToParamArea = 0;
+	I_32 roundedCodeSize = 0;
+	I_32 *thunkMem = NULL;  /* always 4-byte instruction: convenient to use int-pointer */
+
+	if (resultDistNeeded || paramAreaNeeded) {
+		instructionCount += 7;
+		if (paramAreaNeeded) {
+			frameSize = 64 + ((stackSlotCount + 1) / 2) * 16;
+			offsetToParamArea = 48;
+		} else {
+			frameSize = 48;
+			/* Using the caller frame paramArea */
+			offsetToParamArea = 80;
+		}
+	} else {
+		frameSize = 0;
+		/* Using the caller frame paramArea */
+		offsetToParamArea = 32;
+	}
+
+	/* If a frame is needed, less than 22 slots are expected (8 GPR + 13 FPR) */
+	Assert_VM_true(frameSize <= 240);
+
+	/* Hopefully a thunk memory is 8-byte aligned. We also make sure thunkSize is multiple of 8
+	 * another 8-byte to store metaData pointer itself
+	 */
+	roundedCodeSize = ((instructionCount + 1) / 2) * 8;
+	metaData->thunkSize = roundedCodeSize + 8;
+	thunkMem = (I_32 *)vmFuncs->allocateUpcallThunkMemory(metaData);
+	if (NULL == thunkMem) {
+		return NULL;
+	}
+	metaData->thunkAddress = (void *)thunkMem;
+
+	/* Generate the instruction sequence according to the signature, looping over them again */
+	I_32 gprIdx = 3;
+	I_32 fprIdx = 1;
+	I_32 slotIdx = 0;
+	I_32 instrIdx = 0;
+	I_32 C_SP = 1;
+
+	if (resultDistNeeded || paramAreaNeeded) {
+		thunkMem[instrIdx++] = MFLR(0);
+		thunkMem[instrIdx++] = STD(0, C_SP, 16);
+		thunkMem[instrIdx++] = STDU(C_SP, C_SP, -frameSize);
+	}
+
+	if (hiddenParameter) {
+		thunkMem[instrIdx++] = STD(gprIdx++, C_SP, offsetToParamArea);
+		slotIdx += 1;
+	}
+
+	/* Loop through the arguments again */
+	for (I_32 i = 0; i < lastSigIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:
+			{
+				if (slotIdx < 8) {
+					thunkMem[instrIdx++] = STD(gprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				}
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT:
+			{
+				if (fprIdx <= 13) {
+					thunkMem[instrIdx++] = STFS(fprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				} else {
+					if (slotIdx < 8) {
+						thunkMem[instrIdx++] = STD(gprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+					}
+				}
+				fprIdx += 1;
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+			{
+				if (fprIdx <= 13) {
+					thunkMem[instrIdx++] = STFD(fprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+				} else {
+					if (slotIdx < 8) {
+						thunkMem[instrIdx++] = STD(gprIdx, C_SP, offsetToParamArea + (slotIdx * 8));
+					}
+				}
+				fprIdx += 1;
+				gprIdx += 1;
+				slotIdx += 1;
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_SP:
+			{
+				if (tempInt <= (I_32)(8 * sizeof(float))) {
+					if ((fprIdx + (tempInt / sizeof(float))) > 14) {
+						I_32 restSlots = 0;
+						I_32 gprStartSlot = 0;
+
+						if (fprIdx <= 13) {
+							for (I_32 eIdx = 0; eIdx < (14 - fprIdx); eIdx++) {
+								thunkMem[instrIdx++] = STFS(fprIdx + eIdx, C_SP,
+									offsetToParamArea + (slotIdx * 8) + (eIdx * sizeof(float)));
+							}
+							/* Round-down the already passed in FPRs */
+							restSlots = ROUND_UP_SLOT(tempInt) - ((14 - fprIdx) / 2);
+						} else {
+							restSlots = ROUND_UP_SLOT(tempInt);
+						}
+
+						if ((gprStartSlot = (slotIdx + ROUND_UP_SLOT(tempInt) - restSlots)) < 8) {
+							if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+								for (I_32 gIdx = 0; gIdx < (8 - gprStartSlot); gIdx++) {
+									thunkMem[instrIdx++] = STD(3 + gprStartSlot + gIdx, C_SP,
+										offsetToParamArea + ((gprStartSlot + gIdx) * 8));
+								}
+							} else {
+								for (I_32 gIdx = 0; gIdx < restSlots; gIdx++) {
+									thunkMem[instrIdx++] = STD(3 + gprStartSlot + gIdx, C_SP,
+										offsetToParamArea + ((gprStartSlot + gIdx) * 8));
+								}
+							}
+						}
+					} else {
+						for (I_32 eIdx = 0; eIdx < (I_32)(tempInt / sizeof(float)); eIdx++) {
+							thunkMem[instrIdx++] = STFS(fprIdx + eIdx, C_SP,
+								 offsetToParamArea + (slotIdx * 8) + (eIdx * sizeof(float)));
+						}
+					}
+
+					fprIdx += tempInt / sizeof(float);
+				} else {
+					if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+						if (slotIdx < 8) {
+							for (I_32 gIdx = 0; gIdx < (8 - slotIdx); gIdx++) {
+								thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+									 offsetToParamArea + (slotIdx + gIdx) * 8);
+							}
+						}
+					} else {
+						for (I_32 gIdx = 0; gIdx < ROUND_UP_SLOT(tempInt); gIdx++) {
+							thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP, offsetToParamArea + (slotIdx + gIdx) * 8);
+						}
+					}
+				}
+				gprIdx += ROUND_UP_SLOT(tempInt);
+				slotIdx += ROUND_UP_SLOT(tempInt);
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_DP:
+			{
+				if (tempInt <= (I_32)(8 * sizeof(double))) {
+					if ((fprIdx + (tempInt / sizeof(double))) > 14) {
+						I_32 restSlots = 0;
+						I_32 gprStartSlot = 0;
+
+						if (fprIdx <= 13) {
+							for (I_32 eIdx = 0; eIdx < (14 - fprIdx); eIdx++) {
+								thunkMem[instrIdx++] = STFD(fprIdx + eIdx, C_SP,
+									offsetToParamArea + (slotIdx + eIdx) * 8);
+							}
+							restSlots = ROUND_UP_SLOT(tempInt) - (14 - fprIdx);
+						} else {
+							restSlots = ROUND_UP_SLOT(tempInt);
+						}
+
+						if ((gprStartSlot = (slotIdx + ROUND_UP_SLOT(tempInt) - restSlots)) < 8) {
+							if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+								for (I_32 gIdx = 0; gIdx < (8 - gprStartSlot); gIdx++) {
+									thunkMem[instrIdx++] = STD(3 + gprStartSlot + gIdx, C_SP,
+										offsetToParamArea + ((gprStartSlot + gIdx) * 8));
+								}
+							} else {
+								for (I_32 gIdx = 0; gIdx < restSlots; gIdx++) {
+									thunkMem[instrIdx++] = STD(3 + gprStartSlot + gIdx, C_SP,
+										offsetToParamArea + ((gprStartSlot + gIdx) * 8));
+								}
+							}
+						}
+					} else {
+						for (I_32 eIdx = 0; eIdx < (I_32)(tempInt / sizeof(double)); eIdx++) {
+							thunkMem[instrIdx++] = STFD(fprIdx + eIdx, C_SP,
+									offsetToParamArea + (slotIdx + eIdx) * 8);
+						}
+					}
+
+					fprIdx += tempInt / sizeof(double);
+				} else {
+					if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+						if (slotIdx < 8) {
+							for (I_32 gIdx = 0; gIdx < (8 - slotIdx); gIdx++) {
+								thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+									 offsetToParamArea + (slotIdx + gIdx) * 8);
+							}
+						}
+					} else {
+						for (I_32 gIdx = 0; gIdx < ROUND_UP_SLOT(tempInt); gIdx++) {
+							thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+									offsetToParamArea + (slotIdx + gIdx) * 8);
+						}
+					}
+				}
+				gprIdx += ROUND_UP_SLOT(tempInt);
+				slotIdx += ROUND_UP_SLOT(tempInt);
+				break;
+			}
+			/* Definitely <= 16-byte */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_DP:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_SP_DP: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP_SP: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_SP:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_DP:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_MISC:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_MISC:  /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC:
+			{
+				if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+					if (slotIdx < 8) {
+						for (I_32 gIdx = 0; gIdx < (8 - slotIdx); gIdx++) {
+							thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+									offsetToParamArea + (slotIdx + gIdx) * 8);
+						}
+					}
+				} else {
+					for (I_32 gIdx = 0; gIdx < ROUND_UP_SLOT(tempInt); gIdx++) {
+						thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+								offsetToParamArea + (slotIdx + gIdx) * 8);
+					}
+				}
+				slotIdx += ROUND_UP_SLOT(tempInt);
+				gprIdx += ROUND_UP_SLOT(tempInt);
+				break;
+			}
+			/* Definitely > 16-byte */
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_OTHER:
+			{
+				if ((slotIdx + ROUND_UP_SLOT(tempInt)) > 8) {
+					if (slotIdx < 8) {
+						for (I_32 gIdx = 0; gIdx < (8 - slotIdx); gIdx++) {
+							thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+									offsetToParamArea + (slotIdx + gIdx) * 8);
+						}
+					}
+				} else {
+					for (I_32 gIdx = 0; gIdx < ROUND_UP_SLOT(tempInt); gIdx++) {
+						thunkMem[instrIdx++] = STD(gprIdx + gIdx, C_SP,
+								offsetToParamArea + (slotIdx + gIdx) * 8);
+					}
+				}
+				slotIdx += ROUND_UP_SLOT(tempInt);
+				gprIdx += ROUND_UP_SLOT(tempInt);
+				break;
+			}
+			case J9_FFI_UPCALL_SIG_TYPE_VA_LIST: /* Unused */
+				break;
+			default:
+				Assert_VM_unreachable();
+		}
+
+		/* No additional arg instructions are expected */
+		if ((slotIdx > 8) && (fprIdx > 13)) {
+			break;
+		}
+	}
+
+	/* Make the jump or call to the common dispatcher.
+	 * gr12 is currently pointing at thunkMem (by ABI requirement),
+	 * in which case we can load the metaData by a fixed offset
+	 */
+	thunkMem[instrIdx++] = LD(3, 12, roundedCodeSize);
+	thunkMem[instrIdx++] = LD(12, 3, offsetof(J9UpcallMetaData, upCallCommonDispatcher));
+	thunkMem[instrIdx++] = ADDI(4, C_SP, offsetToParamArea);
+	thunkMem[instrIdx++] = MTCTR(12);
+
+	if (resultDistNeeded || paramAreaNeeded) {
+		thunkMem[instrIdx++] = BCTRL();
+
+		/* Distribute result if needed, then tear down the frame and return */
+		if (resultDistNeeded) {
+			tempInt = sigArray[lastSigIdx].sizeInByte;
+			switch (sigArray[lastSigIdx].type) {
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_SP:
+				{
+					if (tempInt <= (I_32)(8 * sizeof(float))) {
+						for (I_32 fIdx = 0; fIdx < (I_32)(tempInt/sizeof(float)); fIdx++) {
+							thunkMem[instrIdx++] = LFS(1+fIdx, 3, fIdx * sizeof(float));
+						}
+					} else {
+						if (tempInt <= 64) {
+							copyBackStraight(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+						} else {
+							/* Note: didn't optimize for loop-entry alignment */
+							copyBackLoop(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+						}
+					}
+					break;
+				}
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_DP:
+				{
+					if (tempInt <= (I_32)(8 * sizeof(double))) {
+						for (I_32 fIdx = 0; fIdx < (I_32)(tempInt/sizeof(double)); fIdx++) {
+							thunkMem[instrIdx++] = LFD(1+fIdx, 3, fIdx * sizeof(double));
+						}
+					} else {
+						/* Note: didn't optimize for loop-entry alignment */
+						copyBackLoop(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+					}
+					break;
+				}
+				/* Definitely <= 16-byte */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_DP:    /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_SP_DP: /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP:    /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_SP_SP: /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_SP:  /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC_DP:  /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_SP_MISC:  /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_DP_MISC:  /* Fall through */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_MISC:
+				{
+					if (tempInt > 8) {
+						thunkMem[instrIdx++] = LD(4, 3, 8);
+					}
+					thunkMem[instrIdx++] = LD(3, 3, 0);
+					break;
+				}
+				/* Definitely > 16-byte */
+				case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_OTHER:
+				{
+					if (tempInt <= 64) {
+						copyBackStraight(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+					} else {
+						/* Note: didn't optimize for loop-entry alignment */
+						copyBackLoop(thunkMem, &instrIdx, tempInt, offsetToParamArea);
+					}
+					break;
+				}
+				default:
+					Assert_VM_unreachable();
+			}
+		}
+
+		thunkMem[instrIdx++] = ADDI(C_SP, C_SP, frameSize);
+		thunkMem[instrIdx++] = LD(0, C_SP, 16);
+		thunkMem[instrIdx++] = MTLR(0);
+		thunkMem[instrIdx++] = BLR();
+	} else {
+		thunkMem[instrIdx++] = BCTR();
+	}
+
+	Assert_VM_true(instrIdx == instructionCount);
+
+	/* Store the metaData pointer */
+	*(J9UpcallMetaData **)((char *)thunkMem + roundedCodeSize) = metaData;
+
+	/* Finish up before returning */
+	vmFuncs->doneUpcallThunkGeneration(metaData, (void *)thunkMem);
+
+	return (void *)thunkMem;
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	J9UpcallSigType *sigArray = nativeSig->sigArray;
+	/* The index for the return type in the signature array */
+	I_32 lastSigIdx = (I_32)(nativeSig->numSigs - 1);
+	I_32 stackSlotCount = 0;
+	I_32 tempInt = 0;
+
+	Assert_VM_true((argIdx >= 0) && (argIdx < lastSigIdx));
+
+	/* Testing the return type */
+	tempInt = sigArray[lastSigIdx].sizeInByte;
+	switch (sigArray[lastSigIdx].type) {
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_SP:
+			if (tempInt > (I_32)(8 * sizeof(float))) {
+				stackSlotCount += 1;
+			}
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_ALL_DP:
+			if (tempInt > (I_32)(8 * sizeof(double))) {
+				stackSlotCount += 1;
+			}
+			break;
+		case J9_FFI_UPCALL_SIG_TYPE_STRUCT_AGGREGATE_OTHER:
+			stackSlotCount += 1;
+			break;
+		default:
+			break;
+	}
+
+	/* Loop through the arguments */
+	for (I_32 i = 0; i < argIdx; i++) {
+		/* Testing this argument */
+		tempInt = sigArray[i].sizeInByte;
+		switch (sigArray[i].type & J9_FFI_UPCALL_SIG_TYPE_MASK) {
+			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_SHORT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT32:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_POINTER: /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_INT64:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_FLOAT:   /* Fall through */
+			case J9_FFI_UPCALL_SIG_TYPE_DOUBLE:
+				stackSlotCount += 1;
+				break;
+			case J9_FFI_UPCALL_SIG_TYPE_STRUCT:
+				stackSlotCount += ROUND_UP_SLOT(tempInt);
+				break;
+			default:
+				Assert_VM_unreachable();
+		}
+	}
+
+	return (void *)((char *)argListPtr + (stackSlotCount * 8));
+}
+
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/xr64/UpcallThunkGen.cpp
+++ b/runtime/vm/xr64/UpcallThunkGen.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	// Return the thunk descriptor
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	return (void *)((char *)argListPtr);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/xz64/UpcallThunkGen.cpp
+++ b/runtime/vm/xz64/UpcallThunkGen.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	// Return the thunk descriptor
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	return (void *)((char *)argListPtr);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */


### PR DESCRIPTION
The changes mainly include the following code for thunk generation:
1) the thunk memory allocation & release
2) the encoding of the native signature intended for thunk
3) the thunk generation (created by JIT)

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>