### PR TITLE
Disable Inlining of VectorIntrinsic Methods

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4796,7 +4796,8 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
    // Methods we may prefer not to inline, for heuristic reasons.
    // (Methods we must not inline for correctness don't go in the next switch below.)
    //
-   switch (initialCalleeMethod->getRecognizedMethod())
+   TR::RecognizedMethod rm = initialCalleeMethod->getRecognizedMethod();
+   switch (rm)
       {
       /*
        * Inline this group of methods when the compiling method is shared method handle thunk.
@@ -5045,6 +5046,11 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          break;
       }
 
+   // Disabling the inlining of VectorIntrinsic methods so that
+   // VectorAPIExpansion can vectorize the intrinsics
+   if (rm >= TR::FirstVectorMethod &&
+       rm <= TR::LastVectorIntrinsicMethod)
+      return true;
    // Methods we must not inline for correctness
    //
    switch (initialCalleeMethod->convertToMethod()->getMandatoryRecognizedMethod())


### PR DESCRIPTION
To allow vectorAPI expansion to scalarize or vectorize Vector API
intrinsic methods, we need to make sure that inliner does not inline it.
This commit adds a check in inliner policy to disable inlining of
VectorAPI intrinsics during inlining.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>