### PR TITLE
Refactor Thread.yield API

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -1313,11 +1313,7 @@ public String toString() {
  *
  * @version		initial
  */
-public static void yield() {
-	yield0();
-}
-
-private static native void yield0();
+public static native void yield();
 
 /**
  * Returns whether the current thread has a monitor lock on the specified object.

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -157,7 +157,7 @@ Java_java_lang_Thread_setNameImpl(JNIEnv *env, jobject thread, jlong threadRef, 
 }
 
 void JNICALL
-Java_java_lang_Thread_yield0(JNIEnv *env, jclass threadClass)
+Java_java_lang_Thread_yield(JNIEnv *env, jclass threadClass)
 {
 	J9VMThread *currentThread = (J9VMThread*)env;
 	/* Check whether Thread.Stop has been called */
@@ -512,6 +512,23 @@ Java_java_lang_Thread_getNextThreadIdOffset(JNIEnv *env, jclass clazz)
 {
 	J9JavaVM *vm = ((J9VMThread *)env)->javaVM;
 	return (U_64)(uintptr_t)&(vm->nextTID);
+}
+
+void JNICALL
+Java_java_lang_Thread_registerNatives(JNIEnv *env, jclass clazz)
+{
+	JNINativeMethod natives[] = {
+		{
+			(char*)"yield0",
+			(char*)"()V",
+			(void*)&Java_java_lang_Thread_yield
+		}
+	};
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
+	env->RegisterNatives(clazz, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 #endif /* JAVA_SPEC_VERSION >= 19 */
 

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -361,7 +361,7 @@ omr_add_exports(jclse
 	Java_java_lang_Thread_startImpl
 	Java_java_lang_Thread_stopImpl
 	Java_java_lang_Thread_suspendImpl
-	Java_java_lang_Thread_yield0
+	Java_java_lang_Thread_yield
 	Java_java_lang_invoke_MethodHandleResolver_getCPClassNameAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPMethodHandleAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPMethodTypeAt
@@ -676,5 +676,6 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		Java_java_lang_Thread_getThreads
 		Java_java_lang_Thread_setCurrentThread
 		Java_java_lang_Thread_setExtentLocalCache
+		Java_java_lang_Thread_registerNatives
 	)
 endif()

--- a/runtime/jcl/uma/se19_exports.xml
+++ b/runtime/jcl/uma/se19_exports.xml
@@ -27,4 +27,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_java_lang_Thread_getThreads" />
 	<export name="Java_java_lang_Thread_setCurrentThread" />
 	<export name="Java_java_lang_Thread_setExtentLocalCache" />
+	<export name="Java_java_lang_Thread_registerNatives" />
 </exports>

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -254,7 +254,7 @@
 	<export name="Java_java_lang_Thread_getStateImpl" />
 	<export name="Java_java_lang_Thread_setPriorityNoVMAccessImpl" />
 	<export name="Java_java_lang_Thread_setNameImpl" />
-	<export name="Java_java_lang_Thread_yield0" />
+	<export name="Java_java_lang_Thread_yield" />
 	<export name="Java_java_security_AccessController_initializeInternal" />
 	<export name="Java_java_lang_Class_allocateAndFillArray" />
 	<export name="Java_java_lang_Class_getConstructorImpl" />

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1118,7 +1118,7 @@ jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_requestToken(JNIEnv *env, job
 jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_getTokenBucketLimit(JNIEnv *env, jclass clazz, jlong resourceHandle);
 jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_getTokenBucketInterval(JNIEnv *env, jclass clazz, jlong resourceHandle);
 /* thread.c */
-void JNICALL Java_java_lang_Thread_yield0(JNIEnv *env, jclass threadClass);
+void JNICALL Java_java_lang_Thread_yield(JNIEnv *env, jclass threadClass);
 
 /* java_lang_Class.c */
 jboolean JNICALL


### PR DESCRIPTION
- Only export Thread.yield0 for Java19 through RegisterNatives

Depends on: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/461

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>