### PR TITLE
Return early in String.indexOf if substring is longer than string

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION < 17]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2021 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2158,8 +2158,11 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		if (s2Length == 0) {
-			// At this point we know fromIndex < s1Length so there is a hit at fromIndex
+			// At this point we know fromIndex <= s1Length so there is a hit at fromIndex
 			return fromIndex;
+		} else if (s2Length > (s1Length - fromIndex)) {
+			// impossible for substring to be found in string if it is longer than the string starting from fromIndex
+			return -1;
 		}
 
 		byte[] s1Value = value;


### PR DESCRIPTION
If substring is longer than string, then it should return -1 early since
it is impossible for the substring to be found in the original string.
This early return also avoids an assertion failure when compact strings
are enabled in the StringUTF16 indexOf helpers which checks that the
source string is longer than the substring.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

fyi: @tajila @dchopra001 

Internal build: `job/Build_JDK11_s390x_linux_Personal/1253/`
Internal openjdk test run, with `-XX:+CompactStrings` option: `job/Grinder/25000/`
Internal failing test without this change: `job/Grinder/24991/`
Though trying to call `"ââ".indexOf("âââ")` in a Java program with the options `-esa -XX:+CompactStrings` will also show the error:
```
Exception in thread "main" java.lang.AssertionError
	at java.base/java.lang.StringUTF16.indexOfUnsafe(StringUTF16.java:395)
	at java.base/java.lang.StringUTF16.indexOf(StringUTF16.java:387)
	at java.base/java.lang.String.indexOf(String.java:2061)
	at java.base/java.lang.String.indexOf(String.java:2034)
	at java.base/java.lang.String.indexOf(String.java:2008)
	at CompStrTest.main(CompStrTest.java:3)
```