### PR TITLE
Simplify Class.forName(String, Class)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -441,23 +441,18 @@ private static Class<?> forName(String className, Class<?> caller) throws ClassN
 	if (J9VMInternals.initialized) {
 		sm = System.getSecurityManager();
 	}
-	ClassLoader callerClassLoader = null;
-	if (null == sm) {
-		if (null != caller) {
-			callerClassLoader = caller.internalGetClassLoader();
-		/*[IF JAVA_SPEC_VERSION >= 19]*/
-		} else {
-			callerClassLoader = ClassLoader.internalGetSystemClassLoader();
-		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
-		}
-		return forNameImpl(className, true, callerClassLoader);
-	}
+	ClassLoader callerClassLoader;
 	if (null != caller) {
-		callerClassLoader = caller.getClassLoaderImpl();
-	/*[IF JAVA_SPEC_VERSION >= 19]*/
+		callerClassLoader = caller.internalGetClassLoader();
 	} else {
+		/*[IF JAVA_SPEC_VERSION >= 19]*/
 		callerClassLoader = ClassLoader.internalGetSystemClassLoader();
-	/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+		/*[ELSE] JAVA_SPEC_VERSION >= 19 */
+		callerClassLoader = null;
+		/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+	}
+	if (null == sm) {
+		return forNameImpl(className, true, callerClassLoader);
 	}
 	Class<?> c = forNameImpl(className, false, callerClassLoader);
 	forNameAccessCheck(sm, caller, c);


### PR DESCRIPTION
It's better to use NULL for the bootstrap loader when calling
forNameImpl() as the VM can access this loader directly without fetching
and checking the native loader from the class loader object.

Called out by a review comment
https://github.com/eclipse-openj9/openj9/pull/15328#pullrequestreview-1007542140
