### PR TITLE
CRIU fix Timer.schedule test and show checkpointRestoreTimeDelta value

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -374,7 +374,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 				criuSetUnprivileged(JNI_FALSE != unprivileged);
 			} else {
 				currentExceptionClass = vm->criuSystemCheckpointExceptionClass;
-				systemReturnCode = NULL != dlerrorReturnString ? J9_CRIU_UNPRIVILEGED_DLSYM_ERROR : J9_CRIU_UNPRIVILEGED_DLSYM_NULL_SYMBOL;
+				systemReturnCode = (NULL != dlerrorReturnString) ? J9_CRIU_UNPRIVILEGED_DLSYM_ERROR : J9_CRIU_UNPRIVILEGED_DLSYM_NULL_SYMBOL;
 				nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED, NULL);
 				goto closeWorkDirFD;
 			}
@@ -435,6 +435,11 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 			goto wakeJavaThreadsWithExclusiveVMAccess;
 		}
 		if (vm->portLibrary->checkpointRestoreTimeDelta < 0) {
+			/* A negative value was calculated for checkpointRestoreTimeDelta,
+			 * Trc_CRIU_before_checkpoint & Trc_CRIU_after_checkpoint can be used for further investigation.
+			 * Currently OpenJ9 CRIU only supports 64-bit systems, and IDATA is equivalent to int64_t here.
+			 */
+			systemReturnCode = (IDATA)vm->portLibrary->checkpointRestoreTimeDelta;
 			currentExceptionClass = vm->criuRestoreExceptionClass;
 			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
 					J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA, NULL);

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -532,7 +532,7 @@ J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.system_action=The JVM will throw a System
 J9NLS_JCL_CRIU_CANNOT_SET_UNPRIVILEGED.user_response=Ensure that CRIU supports unprivileged mode.
 # END NON-TRANSLATABLE
 
-J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA=A negative value calculated for checkpointRestoreTimeDelta =%lld
+J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA=A negative value calculated for checkpointRestoreTimeDelta =%zd
 # START NON-TRANSLATABLE
 J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA.sample_input_1=1
 J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA.explanation=checkpointRestoreTimeDelta is expectd not to be negative.

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -101,8 +101,7 @@ public class TimeChangeTest {
 			final long endNanoTime = System.nanoTime();
 			final long elapsedTime = (endNanoTime - startNanoTime) / 1000000;
 			boolean pass = false;
-			if ((elapsedTime >= MILLIS_DELAY_BEFORECHECKPOINTDONE)
-					&& (elapsedTime < (MILLIS_DELAY_BEFORECHECKPOINTDONE + MAX_TARDINESS_MS))) {
+			if (elapsedTime >= MILLIS_DELAY_BEFORECHECKPOINTDONE) {
 				pass = true;
 			}
 			showThreadCurrentTime("taskMillisDelayBeforeCheckpointDone");
@@ -128,8 +127,7 @@ public class TimeChangeTest {
 			final long endNanoTime = System.nanoTime();
 			final long elapsedTime = (endNanoTime - startNanoTime) / 1000000;
 			boolean pass = false;
-			if ((elapsedTime >= MILLIS_DELAY_AFTERCHECKPOINTDONE)
-					&& (elapsedTime < (MILLIS_DELAY_AFTERCHECKPOINTDONE + MAX_TARDINESS_MS))) {
+			if (elapsedTime >= MILLIS_DELAY_AFTERCHECKPOINTDONE) {
 				pass = true;
 			}
 			showThreadCurrentTime("taskMillisDelayAfterCheckpointDone");
@@ -155,8 +153,7 @@ public class TimeChangeTest {
 		public void run() {
 			final long taskRunTimeMillis = System.currentTimeMillis();
 			boolean pass = false;
-			if ((taskRunTimeMillis >= timeMillisScheduledBeforeCheckpointDone)
-					&& (taskRunTimeMillis < (timeMillisScheduledBeforeCheckpointDone + MAX_TARDINESS_MS))) {
+			if (taskRunTimeMillis >= timeMillisScheduledBeforeCheckpointDone) {
 				pass = true;
 			}
 			showThreadCurrentTime("taskDateScheduledBeforeCheckpointDone");
@@ -185,8 +182,7 @@ public class TimeChangeTest {
 		public void run() {
 			final long taskRunTimeMillis = System.currentTimeMillis();
 			boolean pass = false;
-			if ((taskRunTimeMillis >= timeMillisScheduledAfterCheckpointDone)
-					&& (taskRunTimeMillis < (timeMillisScheduledAfterCheckpointDone + MAX_TARDINESS_MS))) {
+			if (taskRunTimeMillis >= timeMillisScheduledAfterCheckpointDone) {
 				pass = true;
 			}
 			showThreadCurrentTime("taskDateScheduledAfterCheckpoint");


### PR DESCRIPTION
* Removed `elapsedTime < (MILLIS_DELAY_AFTERCHECKPOINTDONE + MAX_TARDINESS_MS))` (and a few others) which depend on the checkpoint process time. This test mainly ensures that the scheduled task skips the JVM down time between checkpoint and restore, and won't be fired right after restore. This addresses https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/110#issuecomment-1157549598 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/462#issuecomment-1160364594;
* Set `systemReturnCode` w/ `vm->portLibrary->checkpointRestoreTimeDelta`, and to be printed out via `J9NLS_JCL_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA`. This addresses https://github.com/eclipse-openj9/openj9/pull/15232#discussion_r899135664.

FYI @keithc-ca 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>