### PR TITLE
Delete AArch64 macOS field watch from known issues in release notes

### DIFF
--- a/doc/release-notes/0.33/0.33.md
+++ b/doc/release-notes/0.33/0.33.md
@@ -116,14 +116,6 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 </tr>
 
 <tr>
-<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14502">#14502</a></td>
-<td valign="top">JIT field watch fails to work</td>
-<td valign="top">Apple Silicon macOS (early access)</td>
-<td valign="top">Enabling JIT field watch may cause bus errors.</td>
-<td valign="top">Avoid using the <tt>-XX:+JITInlineWatches</tt> option.</td>
-</tr>
-
-<tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14803">#14803</a></td>
 <td valign="top">Using the <tt>-XX:+ShowHiddenFrames</tt> option in an OpenJ9 release built with OpenJDK 18 causes errors due to underlying problems in OpenJDK</td>
 <td valign="top">All platforms</td>


### PR DESCRIPTION
This commit deletes Issue #14502 (AArch64 macOS field watch) from the
known issues section of v0.33.0 release notes.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>