### PR TITLE
Add tests in FIPS mode

### DIFF
--- a/test/functional/cmdLineTests/fips/build.xml
+++ b/test/functional/cmdLineTests/fips/build.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="fips" default="build" basedir=".">
+    <taskdef resource="net/sf/antcontrib/antlib.xml" />
+    <description>
+        Build cmdLineTests_fips
+    </description>
+
+    <import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
+    <!-- set properties for this build -->
+    <property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/fips" />
+    <property name="PROJECT_ROOT" location="." />
+    <property name="src" location="./src"/>
+    <property name="build" location="./bin"/>
+
+    <target name="init">
+        <mkdir dir="${DEST}" />
+        <mkdir dir="${build}" />
+	</target>
+
+    <target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+        <echo>Ant version is ${ant.version}</echo>
+        <echo>============COMPILER SETTINGS============</echo>
+        <echo>===fork:                         yes</echo>
+        <echo>===executable:                   ${compiler.javac}</echo>
+        <echo>===debug:                        on</echo>
+        <echo>===destdir:                      ${DEST}</echo>
+        <javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+        </javac>
+    </target>
+
+    <target name="dist" depends="compile" description="generate the distribution">
+        <jar jarfile="${DEST}/fips.jar" filesonly="true">
+            <fileset dir="${build}" />
+        </jar>
+        <copy todir="${DEST}">
+            <fileset dir="${src}/../" includes="*.xml,*.mk" />
+        </copy>
+    </target>
+
+    <target name="clean" depends="dist" description="clean up">
+        <!-- Delete the ${build} directory trees -->
+        <delete dir="${build}" />
+    </target>
+
+    <target name="build" depends="buildCmdLineTestTools">
+        <if>
+            <contains string="${TEST_FLAG}" substring="FIPS" />
+            <then>
+                <antcall target="clean" inheritall="true" />
+            </then>
+        </if>
+    </target>
+</project>

--- a/test/functional/cmdLineTests/fips/fips.xml
+++ b/test/functional/cmdLineTests/fips/fips.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 FIPS Command-Line Option Tests" timeout="300">
+
+  <variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$fips.jar" />
+
+  <test id="Verify providers in FIPS mode">
+    <command>$EXE$ $CLASSPATH$ org.openj9.test.fips.FIPSProvidersTest</command>
+    <output type="success" caseSensitive="no" regex="no">Verify providers in FIPS mode COMPLETED</output>
+    <output type="required" caseSensitive="yes" regex="no">Verify providers</output>
+    <output type="failure" caseSensitive="yes" regex="no">Could not find provider</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+  </test>
+
+  <test id="Import secret keys in FIPS mode">
+    <command>$EXE$ $CLASSPATH$ org.openj9.test.fips.FIPSKeyExtractImport encrypt</command>
+    <output type="success" caseSensitive="no" regex="no">Import secret key in FIPS mode test COMPLETED</output>
+    <output type="failure" caseSensitive="yes" regex="no">Import secret key in FIPS mode test FAILED</output>
+    <output type="failure" caseSensitive="yes" regex="no">incorrect parameters</output>
+    <output type="failure" caseSensitive="yes" regex="no">Could not create key</output>
+    <output type="failure" caseSensitive="yes" regex="no">No such provider</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+  </test>
+
+  <test id="Extract RSA keys in FIPS mode">
+    <command>$EXE$ $CLASSPATH$ org.openj9.test.fips.FIPSKeyExtractImport extractkey</command>
+    <output type="success" caseSensitive="no" regex="no">Extract RSA keys in FIPS mode test COMPLETED</output>
+    <output type="failure" caseSensitive="yes" regex="no">Extract RSA keys in FIPS mode test FAILED</output>
+    <output type="failure" caseSensitive="yes" regex="no">Could not create key</output>
+    <output type="failure" caseSensitive="yes" regex="no">incorrect parameters</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
+  </test>
+</suite>

--- a/test/functional/cmdLineTests/fips/playlist.xml
+++ b/test/functional/cmdLineTests/fips/playlist.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+    <test>
+        <testCaseName>cmdLineTester_fips</testCaseName>
+        <command>
+            $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+            -DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+            -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)fips.xml$(Q) \
+            -explainExcludes -nonZeroExitWhenError; \
+            $(TEST_STATUS)
+        </command>
+        <platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+        <features>
+            <feature>FIPS:required</feature>
+        </features>
+        <levels>
+            <level>sanity</level>
+        </levels>
+        <groups>
+            <group>functional</group>
+        </groups>
+        <impls>
+            <impl>openj9</impl>
+        </impls>
+    </test>
+</playlist>

--- a/test/functional/cmdLineTests/fips/src/org/openj9/test/fips/FIPSKeyExtractImport.java
+++ b/test/functional/cmdLineTests/fips/src/org/openj9/test/fips/FIPSKeyExtractImport.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.fips;
+
+import java.math.BigInteger;
+
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESedeKeySpec;
+
+public class FIPSKeyExtractImport {
+    private static final String key =        "78BCC9D7998EF944C69AE4E066376CE1";
+    private static final String initVector = "ij093kj4309d43jf";
+
+    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException {
+        String test = args[0];
+        switch(test) {
+        case "encrypt":
+            encrypt("TEST");
+            break;
+        case "extractkey":
+            extractkey();
+            break;
+        default:
+            throw new RuntimeException("incorrect parameters");
+        }
+    }
+
+    public static String encrypt(String value) {
+        try {
+            IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+            SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING", "SunPKCS11-NSS-FIPS");
+            cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
+
+            byte[] encrypted = cipher.doFinal(value.getBytes());
+            System.out.println("Import secret key in FIPS mode test COMPLETED");
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | NoSuchProviderException e) {
+            System.out.println("Import secret key in FIPS mode test FAILED");
+            System.out.println(e.toString());
+        } catch (Exception ex) {
+            System.out.println("Import secret key in FIPS mode test FAILED");
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
+    public static String extractkey() {
+        try {
+            KeyPair pair = null;
+            KeyPairGenerator keyGen = null;
+            SecureRandom random = null;
+
+            keyGen = KeyPairGenerator.getInstance("RSA");
+
+            random = new SecureRandom();
+            int len = 512;
+            keyGen.initialize(len * 8, random);
+
+            pair = keyGen.generateKeyPair();
+            RSAPublicKey rsaPubKey = (RSAPublicKey) pair.getPublic();
+            RSAPrivateCrtKey rsaPrivKey = (RSAPrivateCrtKey) pair.getPrivate();
+
+            BigInteger pe = rsaPrivKey.getPrivateExponent();
+            System.out.println(pe);
+            System.out.println("Extract RSA keys in FIPS mode test COMPLETED");
+            return "";
+        } catch (Exception ex) {
+            System.out.println("Extract RSA keys in FIPS mode test FAILED");
+            ex.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/test/functional/cmdLineTests/fips/src/org/openj9/test/fips/FIPSProvidersTest.java
+++ b/test/functional/cmdLineTests/fips/src/org/openj9/test/fips/FIPSProvidersTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.fips;
+
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
+
+public class FIPSProvidersTest {
+
+    public static void main(String args[]) throws Exception {
+        System.out.println("Verify providers");
+
+        // Make sure there are 4 providers available when FIPS mode is enabled.
+        Provider[] providers = Security.getProviders();
+
+        /*********************
+         * There should be four providers when FIPS mode is enabled.
+         * SunPKCS11-NSS-FIPS
+         * SUN
+         * SunEC
+         * SunJSSE
+         *********************/
+
+        // remove duplicate
+        Set<Provider> set = new HashSet<>();
+        for(Provider p : providers) {
+            set.add(p);
+        }
+
+        assertEquals("Security provider list length", set.size(), 4);
+
+        String[] fipsProvidersName = {"SunPKCS11-NSS-FIPS", "SUN", "SunEC", "SunJSSE"};
+
+        for(String fpn : fipsProvidersName) {
+            Provider provider = Security.getProvider(fpn);
+            if(provider == null || !set.contains(provider)) {
+                throw new NoSuchProviderException("Could not find provider " + fpn);
+            }
+        }
+        System.out.println("Verify providers in FIPS mode COMPLETED");
+    }
+
+    private static void assertEquals(String name, int value, int expected) {
+        if (expected != value) {
+            error(name + " = " + value + " (expected " + expected + ")");
+        }
+    }
+
+    private static void error(String msg) {
+        System.out.println("ERR: " + msg);
+    }
+}


### PR DESCRIPTION
This PR contains three tests in FIPS mode. `FIPSProviderTest` aims to ensure that a program in FIPS mode has 4 providers and they are the right ones. `FIPSKeyExtractImport` with `encrypt` args aims to make sure that importing secret keys work in FIPS mode. `FIPSKeyExtractImport` with `extractkey` args aims to check that extracting RSA keys work in FIPS mode.