### PR TITLE
Update openssl to version 1.1.1p

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -134,7 +134,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1o'
+  extra_getsource_options: '--openssl-version=1.1.1p'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
The tag `OpenSSL_1_1_1p` appeared today: https://github.com/openssl/openssl/tree/OpenSSL_1_1_1p.