### PR TITLE
Add stub implementation of NativeReferenceQueue

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
@@ -1,0 +1,29 @@
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package java.lang.ref;
+
+final class NativeReferenceQueue<T> extends ReferenceQueue<T> {
+	public NativeReferenceQueue() {
+		super(0);
+	}
+}


### PR DESCRIPTION
Add stub implementation of NativeReferenceQueue

NativeReferenceQueue was added in openjdk to address usage of
j.u.c.locks with virtual threads. OpenJ9 doesn't have that problem as we
only use internal synchronization. As a result we can simply define the
type but make use of the super class methods.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>