### PR TITLE
Loom Support: Pin Counters

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5126,7 +5126,9 @@ typedef struct J9VMThread {
 #endif /* JAVA_SPEC_VERSION >= 16 */
 #if JAVA_SPEC_VERSION >= 19
 	J9VMContinuation *currentContinuation;
-	UDATA pinnedStateCounter;
+	UDATA continuationPinCount;
+	UDATA ownedMonitorCount;
+	UDATA callOutCount;
 	j9object_t carrierThreadObject;
 	j9object_t extentLocalCache;
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -262,7 +262,9 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 
 #if JAVA_SPEC_VERSION >= 19
 	newThread->currentContinuation = NULL;
-	newThread->pinnedStateCounter = 0;
+	newThread->continuationPinCount = 0;
+	newThread->ownedMonitorCount = 0;
+	newThread->callOutCount = 0;
 	newThread->carrierThreadObject = threadObject;
 	newThread->extentLocalCache = NULL;
 #endif /* JAVA_SPEC_VERSION >= 19 */


### PR DESCRIPTION
**Reasons for pinning:**
```
	public enum Pinned {
		/** In native code */
		NATIVE,
		/** Holding monitor(s) */
		MONITOR,
		/** In critical section */
		CRITICAL_SECTION
	}
```
**Support for #15174 and #15175:**
- `J9VMThread->continuationPinCount` will support native methods in
   `class Continuation`: `pin()` and `unpin()`. It will also be associated to
   `Pinned.CRITICAL_SECTION`.
- `J9VMThread->ownedMonitorCount` will be associated to `Pinned.MONITOR`.
- `J9VMThread->callOutCount` will be associated to `Pinned.NATIVE`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>