### PR TITLE
'NumAllIlOps' is not a member of 'TR::ILOpCode'

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -46,7 +46,7 @@
 
 static const char* getOpCodeName(TR::ILOpCodes opcode) {
 
-   TR_ASSERT(opcode < TR::ILOpCode::NumAllIlOps, "Wrong opcode");
+   TR_ASSERT(opcode < TR::NumAllIlOps, "Wrong opcode");
 
    switch(opcode)
       {


### PR DESCRIPTION
Changed 'TR::ILOpCode::NumAllIlOps' to 'TR::NumAllIlOps'

Signed-off-by: Manasha Vetrivelu <manasha.vetrivelu@ibm.com>