### PR TITLE
Fixing errors present when creating a build with PROD_WITH_ASSUMES enabled

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -46,7 +46,7 @@
 
 static const char* getOpCodeName(TR::ILOpCodes opcode) {
 
-   TR_ASSERT(opcode < TR::ILOpCode::NumAllIlOps, "Wrong opcode");
+   TR_ASSERT(opcode < TR::NumAllIlOps, "Wrong opcode");
 
    switch(opcode)
       {

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -560,7 +560,7 @@ void TR_RuntimeAssumptionTable::reclaimAssumptions(OMR::RuntimeAssumption **sent
                 kind != RuntimeAssumptionOnClassRedefinitionNOP)
                {
                fprintf(stderr, "%d assumptions were left after metadata %p assumption reclaiming\n", numAssumptionsNotReclaimed, metaData);
-               fprintf(stderr, "RA=%p kind=%d key=%p assumingPC=%p\n", cursor, cursor->getAssumptionKind(), cursor->getKey(), cursor->getFirstAssumingPC());
+               fprintf(stderr, "RA=%p kind=%d key=%p assumingPC=%p\n", cursor, cursor->getAssumptionKind(), (void*) cursor->getKey(), cursor->getFirstAssumingPC());
                TR_ASSERT(false, "non redefinition assumptions left after metadata reclamation\n");
                }
             cursor = cursor->getNextAssumptionForSameJittedBody();


### PR DESCRIPTION
Changed 'TR::ILOpCode::NumAllIlOps' to 'TR::NumAllIlOps'. 
Casted the argument so the type is void*.

Signed-off-by: Manasha Vetrivelu <manasha.vetrivelu@ibm.com>