### PR TITLE
Correctly handle JIT client option -Xjit:reconnectWaitTimeMs=0

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -929,7 +929,7 @@ bool
 JITServerHelpers::shouldRetryConnection(OMRPortLibrary *portLibrary)
    {
    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-   return omrtime_current_time_millis() > _nextConnectionRetryTime;
+   return omrtime_current_time_millis() >= _nextConnectionRetryTime;
    }
 
 bool


### PR DESCRIPTION
Allow the client to reconnect immediately (instead of after up to 1 millisecond) when the reconnect time option is set to 0.