### PR TITLE
Correctly close SSL connections in JITServer code

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -72,11 +72,10 @@ protected:
 
    virtual ~CommunicationStream()
       {
-      if (_connfd != -1)
-         close(_connfd);
-
       if (_ssl)
          (*OBIO_free_all)(_ssl);
+      if (_connfd != -1)
+         close(_connfd);
       }
 
    void initStream(int connfd, BIO *ssl)

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -142,12 +142,12 @@ handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMs
        TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "%s: errno=%d", errMsg, errno);
    (*OERR_print_errors_fp)(stderr);
 
-   close(connfd);
    if (bio)
       {
       (*OBIO_free_all)(bio);
       bio = NULL;
       }
+   close(connfd);
    return false;
    }
 


### PR DESCRIPTION
The SSL connection needs to be closed before the underlying TCP socket.