### PR TITLE
jilconst: don't redefine OMR_GC_CONCURRENT_SCAVENGER

### DIFF
--- a/runtime/compiler/aarch64/runtime/Recompilation.spp
+++ b/runtime/compiler/aarch64/runtime/Recompilation.spp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "aarch64/runtime/arm64asmdefs.inc"
+#include "j9cfg.h"
 #include "jilconsts.inc"
 
 	.file "Recompilation.s"

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -321,9 +321,11 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_machineSPSaveSlot", offsetof(J9VMEntryLocalStorage, machineSPSaveSlot)) |
 #endif /* J9VM_PORT_ZOS_CEEHDLRSUPPORT */
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+#if defined(J9VM_ARCH_AARCH64) || defined(J9VM_ARCH_ARM) || defined(J9VM_ARCH_POWER)
+			/* These platforms include j9cfg.h so don't redefine OMR_GC_CONCURRENT_SCAVENGER. */
+#elif defined(OMR_GC_CONCURRENT_SCAVENGER)
 			writeConstant(OMRPORTLIB, fd, "OMR_GC_CONCURRENT_SCAVENGER", 1) |
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+#endif /* defined(J9VM_ARCH_AARCH64) || defined(J9VM_ARCH_ARM) || defined(J9VM_ARCH_POWER) */
 
 			/* C stack frame */
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_sizeof", sizeof(J9CInterpreterStackFrame)) |


### PR DESCRIPTION
Noticed in https://openj9-jenkins.osuosl.org/job/Build_JDK19_aarch64_linux_gcc11_Personal/4/
```
[2022-06-21T22:03:04.360Z] [ 86%] Building ASM object runtime/compiler/CMakeFiles/j9jit.dir/aarch64/runtime/PicBuilder.spp.o
[2022-06-21T22:03:04.361Z] In file included from /home/jenkins/workspace/Build_JDK19_aarch64_linux_gcc11_Personal/openj9/runtime/compiler/aarch64/runtime/PicBuilder.spp:25:
[2022-06-21T22:03:04.361Z] /home/jenkins/workspace/Build_JDK19_aarch64_linux_gcc11_Personal/build/linux-aarch64-server-release/vm/runtime/oti/jilconsts.inc:10: warning: "OMR_GC_CONCURRENT_SCAVENGER" redefined
[2022-06-21T22:03:04.361Z]    10 | #define OMR_GC_CONCURRENT_SCAVENGER 1
[2022-06-21T22:03:04.361Z]       |
[2022-06-21T22:03:04.361Z] In file included from /home/jenkins/workspace/Build_JDK19_aarch64_linux_gcc11_Personal/build/linux-aarch64-server-release/vm/runtime/j9cfg.h:35,
[2022-06-21T22:03:04.361Z]                  from /home/jenkins/workspace/Build_JDK19_aarch64_linux_gcc11_Personal/openj9/runtime/compiler/aarch64/runtime/PicBuilder.spp:24:
[2022-06-21T22:03:04.361Z] /home/jenkins/workspace/Build_JDK19_aarch64_linux_gcc11_Personal/build/linux-aarch64-server-release/vm/runtime/omr/omrcfg.h:49: note: this is the location of the previous definition
[2022-06-21T22:03:04.361Z]    49 | #define OMR_GC_CONCURRENT_SCAVENGER
```
Avoid generating a duplicate, conflicting definition on platforms that include `j9cfg.h`.

Add missing include in `aarch64/runtime/Recompilation.spp`.