### PR TITLE
Re-include "Unload lots of classes" GC regression tests on jdk19

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
@@ -32,10 +32,10 @@
 <exclude id="-verbose:gc -Xcheck:memory -Xverbosegclog:foo.log - check for memory corruption" platform="19" shouldFix="true"><reason>Temp disable on Loom test failures</reason></exclude>
 
 <!-- Hard RTJ doesn't support dynamic class unloading, SRT: out of memory issues  -->
-<exclude id="Unload lots of classes using normal behaviour (JIT Disabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
-<exclude id="Unload lots of classes using FVT stress argument to force finalization (JIT Disabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
-<exclude id="Unload lots of classes using normal behaviour (with JIT if JIT is Enabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
-<exclude id="Unload lots of classes using FVT stress argument to force finalization (with JIT if JIT is Enabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
+<exclude id="Unload lots of classes using normal behaviour (JIT Disabled)" platform="Mode301" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
+<exclude id="Unload lots of classes using FVT stress argument to force finalization (JIT Disabled)" platform="Mode301" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
+<exclude id="Unload lots of classes using normal behaviour (with JIT if JIT is Enabled)" platform="Mode301" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
+<exclude id="Unload lots of classes using FVT stress argument to force finalization (with JIT if JIT is Enabled)" platform="Mode301" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
 
 <!-- Metronome and Staccato do not support contraction -->
 <exclude id="Run with arguments which will make contraction very unlikely" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not support contraction</reason></exclude>


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9/issues/15238

Reverts part of https://github.com/eclipse-openj9/openj9/pull/15237