### PR TITLE
(v0.33.0)Fix conversion to UTF8 in encodeUTF8CharI8

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -939,7 +939,8 @@ done:
 		if ((unicode >= 0x01) && (unicode <= 0x7F)) {
 			utfChars[0] = (U_8)unicode;
 		} else {
-			utfChars[0] = (U_8)(((unicode >>6 ) & 0x1F) | 0xC0);
+			/* use 0x3 since we are using I_8, so only 2 bits matter here */
+			utfChars[0] = (U_8)(((unicode >> 6) & 0x3) | 0xC0);
 			utfChars[1] = (U_8)((unicode & 0x3F) | 0x80);
 			length = 2;
 		}


### PR DESCRIPTION
Use constant 0x3 to only get 2 bits so sign extension won't give us
an incorrect value.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Cherry-picked from https://github.com/eclipse-openj9/openj9/pull/15405

fyi @pshipton 