### PR TITLE
Add error handling for JVMTI functions for Loom

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -364,6 +364,11 @@ jvmtiStopThread(jvmtiEnv* env,
 
 		ENSURE_JOBJECT_NON_NULL(exception);
 
+		ENSURE_JTHREAD_NON_NULL(thread);
+#if JAVA_SPEC_VERSION >= 19
+		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 		rc = getVMThread(currentThread, thread, &targetThread, FALSE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
 			omrthread_monitor_enter(targetThread->publicFlagsMutex);
@@ -805,6 +810,9 @@ jvmtiRunAgentThread(jvmtiEnv* env,
 		ENSURE_PHASE_LIVE(env);
 
 		ENSURE_JTHREAD_NON_NULL(thread);
+#if JAVA_SPEC_VERSION >= 19
+		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		/* Perhaps verify that thread has not already been started? */
 		ENSURE_NON_NULL(proc);
 		if ((priority < JVMTI_THREAD_MIN_PRIORITY) || (priority > JVMTI_THREAD_MAX_PRIORITY)) {

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -356,6 +356,9 @@ static const struct { \
 #define J9_IS_HIDDEN_METHOD(method) \
 	((NULL != (method)) && (J9ROMCLASS_IS_ANON_OR_HIDDEN(J9_CLASS_FROM_METHOD((method))->romClass) || J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD((method))->modifiers, J9AccMethodFrameIteratorSkip)))
 
+#define IS_VIRTUAL_THREAD(vmThread, object) \
+	isSameOrSuperClassOf(J9VMJAVALANGBASEVIRTUALTHREAD_OR_NULL(((vmThread)->javaVM)), J9OBJECT_CLAZZ((vmThread), (object)))
+
 #if defined(OPENJ9_BUILD)
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE
 #else /* defined(OPENJ9_BUILD) */

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -482,6 +482,22 @@ typedef struct jvmtiGcp_translation {
 		} \
 	} while(0)
 
+#if JAVA_SPEC_VERSION >= 19
+#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd) \
+	do { \
+		if (IS_VIRTUAL_THREAD((vmThread), J9_JNI_UNWRAP_REFERENCE(jthrd))) { \
+			JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_OPERATION); \
+		} \
+	} while(0)
+
+#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject) \
+	do { \
+		if (IS_VIRTUAL_THREAD((vmThread), (jthrdObject))) { \
+			JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_OPERATION); \
+		} \
+	} while(0)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 #else
 
 #define ENSURE_PHASE_START_OR_LIVE(env) 
@@ -499,6 +515,10 @@ typedef struct jvmtiGcp_translation {
 #define ENSURE_JTHREADGROUP_NON_NULL(var)
 #define ENSURE_VALID_HEAP_OBJECT_FILTER(var)
 #define ENSURE_MONITOR_NON_NULL(var)
+#if JAVA_SPEC_VERSION >= 19
+#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd)
+#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject)
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 #endif
 

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -50,6 +50,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<classref name="java/lang/IllegalThreadStateException"/>
 	<classref name="java/lang/Thread"/>
 	<classref name="java/lang/Thread$FieldHolder" versions="19-"/>
+	<classref name="java/lang/BaseVirtualThread" versions="19-"/>
 	<classref name="java/lang/ArithmeticException"/>
 	<classref name="java/lang/ThreadGroup"/>
 	<classref name="java/lang/InterruptedException"/>


### PR DESCRIPTION
Return JVMTI_ERROR_UNSUPPORTED_OPERATION from JVMTI functions that do not
accept virtual threads as their current thread or parameters.

Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>