### PR TITLE
Un-exclude gcRegression check for memory corruption tests

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
@@ -27,10 +27,6 @@
 
 <suite id="J9 GC Regression Tests">
 
-<!-- Java 19 Porject Loom excluded tests -->
-<exclude id="-verbose:gc -Xcheck:memory - check for memory corruption" platform="19" shouldFix="true"><reason>Temp disable on Loom test failures</reason></exclude>
-<exclude id="-verbose:gc -Xcheck:memory -Xverbosegclog:foo.log - check for memory corruption" platform="19" shouldFix="true"><reason>Temp disable on Loom test failures</reason></exclude>
-
 <!-- Hard RTJ doesn't support dynamic class unloading, SRT: out of memory issues  -->
 <exclude id="Unload lots of classes using normal behaviour (JIT Disabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>
 <exclude id="Unload lots of classes using FVT stress argument to force finalization (JIT Disabled)" platform="Mode301 19" shouldFix="true"><reason>Class unloading not supported on RTJ</reason></exclude>


### PR DESCRIPTION
Tests were fixed by https://github.com/eclipse-openj9/openj9/pull/15255
Issue https://github.com/eclipse-openj9/openj9/issues/15235

Reverts part of https://github.com/eclipse-openj9/openj9/pull/15237