### PR TITLE
Improve DDR deadlock tests

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/DeadlockCoreGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/DeadlockCoreGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,26 @@ package j9vm.test.corehelper;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 public final class DeadlockCoreGenerator {
+
+	private static final class LockObject {
+
+		final String name;
+
+		LockObject(String name) {
+			super();
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return "lock: " + name;
+		}
+
+	}
 
 	/*
 	 * **********
@@ -39,13 +57,11 @@ public final class DeadlockCoreGenerator {
 	 *
 	 * N.B. A native thread can never hold/want an object monitor,
 	 * because it must be attached first (i.e. it's a J9VMThread / Java thread).
-	 *
-	 */	
-	
-	public static final long WAIT_TIME_MILIS = 5000; // 5 seconds.
-	
-	static 
-	{
+	 */
+
+	public static final long WAIT_TIME_MILIS = TimeUnit.SECONDS.toMillis(5);
+
+	static {
 		try {
 			System.loadLibrary("j9ben");
 		} catch (UnsatisfiedLinkError e) {
@@ -55,37 +71,33 @@ public final class DeadlockCoreGenerator {
 			System.exit(1);
 		}
 	}
-	
-	public static void main(final String[] args) throws InterruptedException, NoSuchMethodException, 
-		SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		
+
+	public static void main(final String[] args) throws Exception {
 		System.out.println("Running deadlock tester...");
-		
-		final Method testCase = DeadlockCoreGenerator.class.getDeclaredMethod("testCase"  + args[0]);
-		
+
+		String testName = "testCase" + args[0];
+		final Method testCase = DeadlockCoreGenerator.class.getDeclaredMethod(testName);
+
 		Thread testThread = new Thread() {
-			
+			@Override
 			public void run() {
 				try {
-					
-					testCase.invoke(null, new Object[] {});
-					
-				} catch (IllegalAccessException e) {
+					testCase.invoke(null);
+				} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 					e.printStackTrace();
-				} catch (IllegalArgumentException e) {
-					e.printStackTrace();
-				} catch (InvocationTargetException e) {
-					e.printStackTrace();
-				}	
+				}
 			}
 		};
-		
+
 		testThread.setName("Java Deadlock Test Thread");
 		testThread.start();
-				
+
+		// Wait for positive indication that threads are about to deadlock.
+		waitForThreadsToApproachDeadlock(testName);
+
 		System.out.println("Waiting...");
 		Thread.sleep(WAIT_TIME_MILIS); // This is a guesstimate, but should be long enough to reach the desired state.
-		
+
 		try {
 			throw new HelperExceptionForCoreGeneration();
 		} catch (HelperExceptionForCoreGeneration e) {
@@ -94,171 +106,200 @@ public final class DeadlockCoreGenerator {
 			// In all but the native-only deadlock, the JVM won't quit since not all threads died.
 			System.exit(0); // Note that this will only run once the dump is done (exclusive!).
 		}
-		
 	}
-	
+
 	/* *****************************
 	 * Utility Methods for all Tests
 	 * *****************************/
-	
+
 	public static native void setup();
 	public static native void enterFirstMonitor();
 	public static native void enterSecondMonitor();
 	public static native void spawnNativeThread();
 	public static native void createNativeDeadlock();
-	
-	private static final Object mutex = new Object();
-	
+
+	private static final Object mutex = new LockObject("mutex");
+
+	private static final Semaphore deadlock = new Semaphore(0);
+
+	private static void aboutToDeadlock() {
+		deadlock.release();
+	}
+
+	private static void waitForThreadsToApproachDeadlock(String testName) throws InterruptedException {
+		int permits;
+
+		switch (testName) {
+		case "testCase4":
+			permits = 1;
+			break;
+		case "testCase5":
+			permits = 0;
+			break;
+		default:
+			permits = 2;
+			break;
+		}
+
+		if (permits != 0) {
+			System.out.println("Waiting for threads to approach deadlock...");
+			deadlock.acquire(permits);
+		}
+	}
+
 	/* *****************************
 	 *         Test Case #1
-	 *	     JOO, JOO deadlock.
+	 *       JOO, JOO deadlock.
 	 * *****************************/
-	
-	public static void testCase1() throws InterruptedException 
-	{
-		final Object firstLock = new Object();
-		final Object secondLock = new Object();
-		
-		synchronized (firstLock) {
 
+	public static void testCase1() throws InterruptedException {
+		final Object firstLock = new LockObject("firstLock");
+		final Object secondLock = new LockObject("secondLock");
+
+		synchronized (firstLock) {
 			Thread otherThread = new Thread() {
+				@Override
 				public void run() {
 					System.out.println("testCase1 :: Secondary thread trying to acquire lock on secondLock");
 					synchronized (secondLock) {
-						synchronized(mutex) {
+						synchronized (mutex) {
 							mutex.notify();
 						}
 						System.out.println("testCase1 :: Secondary thread trying to acquire lock on firstLock");
-						synchronized(firstLock) {
+						aboutToDeadlock();
+						synchronized (firstLock) {
 							System.out.println("Should not see me, testCase1()");
 						}
 					}
 				}
 			};
-			
-			synchronized(mutex) {
+
+			synchronized (mutex) {
 				otherThread.start();
 				mutex.wait();
 				System.out.println("testCase1 :: Main thread trying to acquire lock on secondLock");
+				aboutToDeadlock();
 				synchronized (secondLock) {
 					System.out.println("Should not see me, testCase1().");
 				}
 			}
 		}
 	}
-	
+
 	/* *****************************
 	 *         Test Case #2
-	 *	     JOS, JSO deadlock.
+	 *       JOS, JSO deadlock.
 	 * *****************************/
-	
-	public static void testCase2() throws InterruptedException 
-	{
+
+	public static void testCase2() throws InterruptedException {
 		setup();
-		
-		final Object javaObjMon = new Object();
-		
+
+		final Object javaObjMon = new LockObject("javaObjMon");
+
 		synchronized (javaObjMon) {
-			
 			Thread otherThread = new Thread() {
+				@Override
 				public void run() {
 					System.out.println("testCase2 :: Secondary thread trying to acquire lock on native monitor.");
-						enterFirstMonitor();
-						synchronized(mutex) {
-							mutex.notify();
-						}
-						System.out.println("testCase2 :: Secondary thread trying to acquire lock on Java object monitor.");
-						synchronized(javaObjMon) {
-							System.out.println("Should not see me, testCase2()");
-						}
+					enterFirstMonitor();
+					synchronized (mutex) {
+						mutex.notify();
+					}
+					System.out.println("testCase2 :: Secondary thread trying to acquire lock on Java object monitor.");
+					aboutToDeadlock();
+					synchronized (javaObjMon) {
+						System.out.println("Should not see me, testCase2()");
+					}
 				}
 			};
-			
-			synchronized(mutex) {
+
+			synchronized (mutex) {
 				otherThread.start();
 				mutex.wait();
 				System.out.println("testCase2 :: Main thread trying to acquire lock on native monitor.");
-				enterFirstMonitor(); // Deadlock
+				aboutToDeadlock();
+				enterFirstMonitor(); // deadlock
 				System.out.println("Should not see me, testCase2().");
-			}	
+			}
 		}
 	}
-	
+
 	/* *****************************
 	 *         Test Case #3
-	 *	     JSS, JSS deadlock.
+	 *       JSS, JSS deadlock.
 	 * *****************************/
-	
-	public static void testCase3() throws InterruptedException 
-	{
+
+	public static void testCase3() throws InterruptedException {
 		setup();
-		
+
 		enterFirstMonitor();
 
 		Thread otherThread = new Thread() {
+			@Override
 			public void run() {
 				System.out.println("testCase3 :: Secondary thread trying to acquire lock on secondLock");
-					enterSecondMonitor();
-					synchronized(mutex) {
-						mutex.notify();
-					}
-					System.out.println("testCase3 :: Secondary thread trying to acquire lock on firstLock");
-					enterFirstMonitor(); // Deadlock
-					System.out.println("Should not see me, testCase3()");
+				enterSecondMonitor();
+				synchronized (mutex) {
+					mutex.notify();
+				}
+				System.out.println("testCase3 :: Secondary thread trying to acquire lock on firstLock");
+				aboutToDeadlock();
+				enterFirstMonitor(); // deadlock
+				System.out.println("Should not see me, testCase3()");
 			}
 		};
 
-		synchronized(mutex) {	
+		synchronized (mutex) {
 			otherThread.start();
 			mutex.wait(); // Make sure the other thread has the monitor we want to block on first.
 			System.out.println("testCase3 :: Main thread trying to acquire lock on secondLock");
-			enterSecondMonitor(); // Deadlock
-			System.out.println("Should not see me, testCase3().");	
+			aboutToDeadlock();
+			enterSecondMonitor(); // deadlock
+			System.out.println("Should not see me, testCase3().");
 		}
 	}
-	
+
 	/* *****************************
 	 *         Test Case #4
-	 *	     JSS, NSS deadlock.
+	 *       JSS, NSS deadlock.
 	 * *****************************/
-	
-	public static void testCase4() 
-	{
+
+	public static void testCase4() {
 		setup();
 		enterFirstMonitor();
 		spawnNativeThread(); // Will return once second monitor has been acquired by the new native thread.
-		enterSecondMonitor(); // Deadlock.
+		aboutToDeadlock();
+		enterSecondMonitor(); // deadlock
 	}
-	
+
 	/* *****************************
 	 *         Test Case #5
-	 *	     NSS, NSS deadlock.
+	 *       NSS, NSS deadlock.
 	 * *****************************/
-	
-	public static void testCase5() 
-	{
+
+	public static void testCase5() {
 		setup();
 		createNativeDeadlock();
 	}
-	
+
 	/* *****************************
 	 *         Test Case #6
 	 * Test JOS, NSS, JSO deadlock.
 	 * *****************************/
-	
-	private static final Object lock1Test6 = new Object();
-	
-	public static void testCase6() 
-	{
+
+	private static final Object lock1Test6 = new LockObject("lock1Test6");
+
+	public static void testCase6() {
 		setup(); // Initializes native monitors.
-		
+
 		Thread thread1test6 = new Thread() {
+			@Override
 			public void run() {
 				synchronized (lock1Test6) { // Get O1
 					System.out.println("spawnFirstThreadtest6 :: run()");
 					spawnSecondThreadtest6();
 					try {
-						synchronized(mutex) {
+						synchronized (mutex) {
 							mutex.wait(); // Make sure second Java thread has the system monitor first!
 						}
 					} catch (InterruptedException e) {
@@ -267,25 +308,27 @@ public final class DeadlockCoreGenerator {
 					spawnNativeThread();
 					// At this point the native thread acquired S2 and wants S1.
 					System.out.println("spawnFirstThreadtest6 :: wait() indefinitely on enterSecondMonitor()");
-					enterSecondMonitor(); // Deadlock
+					aboutToDeadlock();
+					enterSecondMonitor(); // deadlock
 					System.out.println("Should not see me, spawnFirstThreadtest6().");
 				}
 			}
 		};
 		thread1test6.start();
 	}
-	
-	private static void spawnSecondThreadtest6()
-	{
+
+	private static void spawnSecondThreadtest6() {
 		Thread thread2test6 = new Thread() {
+			@Override
 			public void run() {
 				System.out.println("spawnSecondThreadtest6 :: run()");
 				enterFirstMonitor();
-				synchronized(mutex) {
+				synchronized (mutex) {
 					mutex.notify();
 				}
 				System.out.println("spawnSecondThreadtest6 :: block indefinitely on lock1test6");
-				synchronized(lock1Test6) { // Deadlock
+				aboutToDeadlock();
+				synchronized (lock1Test6) { // deadlock
 					System.out.println("Should not see me, spawnSecondThreadtest6().");
 				}
 			}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -633,8 +633,7 @@ public class Constants {
 	public static final String DEADLOCK_OWNED_BY = "which is owned by:";
 	public static final String DEADLOCK_FIRST_MON = "First Monitor lock";
 	public static final String DEADLOCK_SECOND_MON = "Second Monitor lock";
-	public static final String DEADLOCK_JAVA_OBJ = "java/lang/Object";
-	public static final String DEADLOCK_JAVA_IDENTITY = "java/lang/Identity";
+	public static final String DEADLOCK_JAVA_OBJ = "j9vm/test/corehelper/DeadlockCoreGenerator\\$LockObject";
 	public static final String DEADLOCK_CMD = "deadlock";
 
 	/* Constants related to testing of runtime type resolution */

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
@@ -29,22 +29,22 @@ public class TestDeadlockCase1 extends DDRExtTesterBase
 	/**
 	 * Test !monitors deadlock
 	 *      Test Case #1
-	 *	  JOO, JOO deadlock.
+	 *    JOO, JOO deadlock.
 	 */
-	
+
 	public void testDeadlock1()
 	{
 		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
-		
+
 		if (null == output) {
 			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
 			return;
 		}
-		
+
 		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 2) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 2));
 	}
 
 }

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
@@ -29,22 +29,22 @@ public class TestDeadlockCase2 extends DDRExtTesterBase
 	/**
 	 * Test !monitors deadlock
 	 *     Test Case #2
-	 *	 JOS, JSO deadlock.
+	 *   JOS, JSO deadlock.
 	 */
-	
+
 	public void testDeadlock2()
 	{
 		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
-		
+
 		if (null == output) {
 			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
 			return;
 		}
-		
+
 		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
 		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
 	}
 

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
@@ -31,26 +31,26 @@ public class TestDeadlockCase6 extends DDRExtTesterBase
 	 *        Test Case #6
 	 * Test JOS, NSS, JSO deadlock.
 	 */
-	
+
 	public void testDeadlock6()
 	{
 		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
-		
+
 		if (null == output) {
 			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
 			return;
 		}
-		
+
 		// N.B. The order in which the threads are found is not well defined,
 		// thus in this case we may have "OS Thread" or "Thread" appear twice.
-		
+
 		assertTrue(validate(output, Constants.DEADLOCK_THREAD, null));
 		assertTrue(validate(output, Constants.DEADLOCK_OS_THREAD, null));
 		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 3));
 		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
 		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
-		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1) || validate(output, Constants.DEADLOCK_JAVA_IDENTITY, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
 	}
 
 }


### PR DESCRIPTION
This should greatly reduce the likelihood of producing a core dump before the threads have actually deadlocked; fixes #12656.

* use a semaphore to signal threads are close to deadlock
* use `DeadlockCoreGenerator$LockObject` instead of `java.lang.Object` for locks (and remove references to `java.lang.Identity`)

General cleanup
* add missing `@Override` annotations
* distinguish between null and empty failure modes
* remove extra space before first argument
* fix typo
* format, remove trailing whitespace