### PR TITLE
Use qemu for running ddrgen in AArch64 Linux cross build

### DIFF
--- a/runtime/ddr/run_omrddrgen.mk.ftl
+++ b/runtime/ddr/run_omrddrgen.mk.ftl
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,8 +114,12 @@ clean :
 
 $(DDR_BLOB) : $(TOP_DIR)/ddrgen$(UMA_DOT_EXE) $(DDR_MACRO_LIST) excludes $(wildcard overrides*)
 	@echo "Running ddrgen to generate $(notdir $@) and $(notdir $(DDR_SUPERSET_FILE))"
+<#if uma.spec.type.linux && uma.spec.processor.aarch64 && uma.spec.flags.env_crossbuild.enabled>
+	@qemu-aarch64 $(TOP_DIR)/ddrgen $(DDR_OPTIONS) $(DDR_INPUT_FILES)
+<#else>
 	@$(DDR_LIB_PATH) $(TOP_DIR)/ddrgen $(DDR_OPTIONS) \
 		$(DDR_INPUT_FILES)
+</#if>
 <#if uma.spec.type.zos>
 	chtag -t -c ISO8859-1 $(DDR_SUPERSET_FILE)
 </#if>


### PR DESCRIPTION
This commit adds support for enabling DDR in cross build for AArch64 Linux,
by running ddrgen with qemu-aarch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>