### PR TITLE
Fix padding in jvmtiCapabilities structure

### DIFF
--- a/runtime/include/jvmti.h.m4
+++ b/runtime/include/jvmti.h.m4
@@ -486,12 +486,18 @@ typedef struct {
 	unsigned int can_retransform_any_class : 1;
 	unsigned int can_generate_resource_exhaustion_heap_events : 1;
 	unsigned int can_generate_resource_exhaustion_threads_events : 1;
-ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	unsigned int can_generate_early_vmstart : 1;
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1,
+[	unsigned int can_generate_early_vmstart : 1;
 	unsigned int can_generate_early_class_hook_events : 1;
-ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [    unsigned int can_generate_sampled_object_alloc_events : 1;
-	unsigned int : 4;], [    unsigned int : 5;])], [	unsigned int : 7;])
-ifelse(eval(JAVA_SPEC_VERSION >= 19), 1, [	unsigned int can_support_virtual_threads : 1;
-	unsigned int : 15;], [	unsigned int : 16;])
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1,
+[	unsigned int can_generate_sampled_object_alloc_events : 1;
+ifelse(eval(JAVA_SPEC_VERSION >= 19), 1,
+[	unsigned int can_support_virtual_threads : 1;
+	unsigned int : 3;],
+[	unsigned int : 4;])],
+[	unsigned int : 5;])],
+[	unsigned int : 7;])
+	unsigned int : 16;
 	unsigned int : 16;
 	unsigned int : 16;
 	unsigned int : 16;


### PR DESCRIPTION
JvmtiCapabilities struct cannot have padding between fields.

Signed-off-by: Eric Yang <eric.yang@ibm.com>