### PR TITLE
Fix issues with non-SVM aconst_init AOT compilation

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -247,12 +247,12 @@ private:
    void         genMonitorEnter();
    void         genMonitorExit(bool);
    TR_OpaqueClassBlock *loadValueClass(int32_t classCpIndex);
-   void         genAconst_init(uint16_t classCpIndex);
-   void         genAconst_init(TR_OpaqueClassBlock *valueTypeClass);
-   void         genWithField(uint16_t fieldCpIndex);
+   void         genAconst_init(int32_t classCpIndex);
+   void         genAconst_init(TR_OpaqueClassBlock *valueTypeClass, int32_t cpIndex);
+   void         genWithField(int32_t fieldCpIndex);
    void         genWithField(TR::SymbolReference *, TR_OpaqueClassBlock *);
-   void         genFlattenableWithField(uint16_t, TR_OpaqueClassBlock *);
-   void         genFlattenableWithFieldWithHelper(uint16_t fieldCpIndex);
+   void         genFlattenableWithField(int32_t, TR_OpaqueClassBlock *);
+   void         genFlattenableWithFieldWithHelper(int32_t fieldCpIndex);
    void         genFlush(int32_t nargs);
    void         genFullFence(TR::Node *node);
    void         handlePendingPushSaveSideEffects(TR::Node *, int32_t stackSize = -1);


### PR DESCRIPTION
ILGen:
- Pass `returnClassForAOT` as in `getClassFromConstantPool` which is required to retrieve class in non-SVM AOT compilation
- Pass cpindex in `findOrCreateClassSymbol` which is required for `TR_ClassAddress` relocation record
- When generating IL for `aconst_init`, if the class has a field which is also value type, the non-SVM AOT compilation is aborted in ILGen because the `cpIndex` for the field is unknown and it is required to materialize the class in AOT load
- Update `genWithField` methods and `genFlattenableWithField` to use `int32_t` instead of `uint16_t` for their cpIndex arguments

X86:
- Evaluate the class into a register for loadaddr under new
- Use ASSERT_FATAL if the classReg is NULL in non-SVM AOT

Fixes: #15423, #15424

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>