### PR TITLE
Continuation: pin and unpin implementation

### DIFF
--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -223,6 +223,14 @@ if(NOT JAVA_SPEC_VERSION LESS 16)
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 19)
+	# sources for Java 19+
+	target_sources(jclse
+		PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/common/jdk_internal_vm_Continuation.cpp
+	)
+endif()
+
 include(exports.cmake)
 
 target_enable_ddr(jclse)

--- a/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
+++ b/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "jni.h"
+#include "jcl.h"
+#include "jclprots.h"
+#include "ut_j9jcl.h"
+
+extern "C" {
+
+/**
+ * Increment the counter to pin a continuation.
+ *
+ * @param env instance of JNIEnv.
+ * @param unused.
+ * @return void.
+ * @throws IllegalStateException for counter overflow.
+ */
+void JNICALL
+Java_jdk_internal_vm_Continuation_pin(JNIEnv *env, jclass unused)
+{
+	J9VMThread *currentThread = (J9VMThread *)env;
+	if (UDATA_MAX == currentThread->continuationPinCount) {
+		throwNewIllegalStateException(env, (char *)"Overflow detected");
+	} else {
+		currentThread->continuationPinCount += 1;
+	}
+}
+
+/**
+ * Decrement the counter to unpin a continuation.
+ *
+ * @param env instance of JNIEnv.
+ * @param unused.
+ * @return void.
+ * @throws IllegalStateException for counter underflow.
+ */
+void JNICALL
+Java_jdk_internal_vm_Continuation_unpin(JNIEnv *env, jclass unused)
+{
+	J9VMThread *currentThread = (J9VMThread *)env;
+	if (0 == currentThread->continuationPinCount) {
+		throwNewIllegalStateException(env, (char *)"Underflow detected");
+	} else {
+		currentThread->continuationPinCount -= 1;
+	}
+}
+
+} /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -677,5 +677,7 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		Java_java_lang_Thread_setCurrentThread
 		Java_java_lang_Thread_setExtentLocalCache
 		Java_java_lang_Thread_registerNatives
+		Java_jdk_internal_vm_Continuation_pin
+		Java_jdk_internal_vm_Continuation_unpin
 	)
 endif()

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -60,6 +60,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<xi:include href="uma/se8only_objects.xml"></xi:include>
 	<xi:include href="uma/se9_objects.xml"></xi:include>
 	<xi:include href="uma/se16_objects.xml"></xi:include>
+	<xi:include href="uma/se19_objects.xml"></xi:include>
 
 	<!-- vendor_jcl.xml can contain vendor specific configuration -->
 	<xi:include href="uma/vendor_jcl.xml">

--- a/runtime/jcl/uma/se19_objects.xml
+++ b/runtime/jcl/uma/se19_objects.xml
@@ -19,15 +19,6 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-<exports group="se19">
-	<export name="Java_java_lang_Thread_currentCarrierThread" />
-	<export name="Java_java_lang_Thread_dumpThreads" />
-	<export name="Java_java_lang_Thread_extentLocalCache" />
-	<export name="Java_java_lang_Thread_getNextThreadIdOffset" />
-	<export name="Java_java_lang_Thread_getThreads" />
-	<export name="Java_java_lang_Thread_setCurrentThread" />
-	<export name="Java_java_lang_Thread_setExtentLocalCache" />
-	<export name="Java_java_lang_Thread_registerNatives" />
-	<export name="Java_jdk_internal_vm_Continuation_pin" />
-	<export name="Java_jdk_internal_vm_Continuation_unpin" />
-</exports>
+<objects group="se19">
+	<object name="jdk_internal_vm_Continuation" />
+</objects>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1263,10 +1263,23 @@ Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject insta
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 /* criu.cpp */
-jlong JNICALL Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl(JNIEnv *env, jclass unused);
-jboolean JNICALL Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused);
-jboolean JNICALL Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
+jlong JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl(JNIEnv *env, jclass unused);
+
+jboolean JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused);
+
+jboolean JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *env, jclass unused);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
+#if JAVA_SPEC_VERSION >= 19
+void JNICALL
+Java_jdk_internal_vm_Continuation_pin(JNIEnv *env, jclass unused);
+
+void JNICALL
+Java_jdk_internal_vm_Continuation_unpin(JNIEnv *env, jclass unused);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
- `Continuation.pin()`: Increment the counter to pin a continuation. Throws
  `IllegalStateException` in case of an overflow.
- `Continuation.unpin()`: Decrement the counter to unpin a continuation. Throws
  `IllegalStateException` in case of an underflow.

Related: #15174

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>