### PR TITLE
Attach API removes file world permissions

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ public abstract class CommonDirectory {
 	private static final String ATTACH_LOCK = "_attachlock"; //$NON-NLS-1$
 	private static final String COM_IBM_TOOLS_ATTACH_DIRECTORY = "com.ibm.tools.attach.directory"; //$NON-NLS-1$
 	private static final int COMMON_DIRECTORY_PERMISSIONS = 01777; /* allow anyone to create directories, but only owner can delete */
-	private static final int COMMON_LOCK_FILE_PERMISSIONS = 0666; /* allow anyone to create and use the file */
+	private static final int COMMON_LOCK_FILE_PERMISSIONS = 0660; /* allow group users to create and use the file */
 	private static final String CONTROLLER_LOCKFILE = "_controller"; //$NON-NLS-1$
 	static final String CONTROLLER_NOTIFIER = "_notifier"; //$NON-NLS-1$
 	static final int SEMAPHORE_OKAY = 0;

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/TargetDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/TargetDirectory.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 package openj9.internal.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corp. and others
+ * Copyright (c) 2009, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,9 +40,9 @@ public final class TargetDirectory {
 	static final int ADVERTISEMENT_FILE_PERMISSIONS = 0600;
 	static final String ATTACH_NOTIFICATION_SYNC_FILENAME = "attachNotificationSync"; //$NON-NLS-1$
 	/**
-	 * All users must have write access in order to get an exclusive (i.e write) lock on the file.
+	 * All group users must have write access in order to get an exclusive (i.e write) lock on the file.
 	 */
-	public static final int SYNC_FILE_PERMISSIONS = 0666; 
+	public static final int SYNC_FILE_PERMISSIONS = 0660;
 	static final int TARGET_DIRECTORY_PERMISSIONS = 01711;
 
 	private volatile static  File targetDirectoryFileObject;


### PR DESCRIPTION
Attach API removes world permissions

Internal personal builds:
Java 8/11 `x86-64_linux` `sanity.functional` & `extended.functional` - `view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/13441/`
IBM Java 8 - `build_info.php?build_id=31582`

This addresses the concern raised at https://github.com/eclipse-openj9/openj9/issues/15459 - _/tmp/.com_ibm_tools_attach create files with world writeable files._

Signed-off-by: Jason Feng <fengj@ca.ibm.com>