### PR TITLE
Disable libpathTestRtfChild on headless platforms

### DIFF
--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2021 IBM Corp. and others
+  Copyright (c) 2016, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,10 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/3787</comment>
 				<platform>.*mac.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/2877</comment>
+				<platform>aarch64_alpine-linux|x86-64_alpine-linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DEXTRA_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \


### PR DESCRIPTION
Fix #15119 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>