### PR TITLE
Loom Pinning: Manage J9VMThread->ownedMonitorCount

### DIFF
--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -262,6 +262,9 @@ done:
 		if (lock == compareAndSwapLockword(currentThread, lockEA, lock, mine, readBeforeCAS)) {
 			VM_AtomicSupport::readBarrier();
 			locked = true;
+#if JAVA_SPEC_VERSION >= 19
+			currentThread->ownedMonitorCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		}
 		return locked;
 	}
@@ -307,6 +310,9 @@ done:
 				VM_AtomicSupport::writeBarrier();
 				J9_STORE_LOCKWORD(currentThread, lockEA, 0);
 				unlocked = true;
+#if JAVA_SPEC_VERSION >= 19
+				currentThread->ownedMonitorCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 			}
 		}
 		return unlocked;

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -190,6 +190,9 @@ restart:
 			if (J9_ARE_ANY_BITS_SET(((J9ThreadMonitor*)monitor)->flags, J9THREAD_MONITOR_INFLATED)) {
 				Trc_VM_objectMonitorEnterBlocking_alreadyInflated(currentThread);
 				internalAcquireVMAccess(currentThread);
+#if JAVA_SPEC_VERSION >= 19
+				currentThread->ownedMonitorCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 				goto done;
 			}
 			if (0 != internalTryAcquireVMAccess(currentThread)) {
@@ -404,6 +407,9 @@ restart:
 					goto restart;
 				}
 			}
+#if JAVA_SPEC_VERSION >= 19
+			currentThread->ownedMonitorCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 			/* no barrier is required in the recursive case */
 		} else {
 			/* check to see if object is unlocked (JIT did not do initial inline sequence due to insufficient static type info) */
@@ -704,6 +710,9 @@ spinOnTryEnter(J9VMThread *currentThread, J9ObjectMonitor *objectMonitor, j9obje
 				if (J9_LOCK_IS_INFLATED(J9_LOAD_LOCKWORD(currentThread, lwEA))) {
 					/* try_enter succeeded - monitor is inflated */
 					rc = true;
+#if JAVA_SPEC_VERSION >= 19
+					currentThread->ownedMonitorCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 				} else {
 					/* try_enter succeeded - monitor is not inflated - would block */
 					SET_IGNORE_ENTER(monitor);


### PR DESCRIPTION
In order to support if a `Continuation` is pinned, `ownedMonitorCount` is
- incremented when a monitor is successfully acquired; and
- decremented when a monitor is successfully released.

`ownedMonitorCount` is updated closer to the `lockword` modification.

**monitor entry points:**
1. `ObjectMonitor.hpp::inlineFastObjectMonitorEnter`
   - `inlineFastInitAndEnterMonitor`: _increment_ counter
2. `ObjectMonitor.hpp::objectMonitorEnterNonBlocking`
   - flat / lock reservation case: _increment_ counter
   - `spinOnFlatLock`
     - `inlineFastInitAndEnterMonitor`: _increment_ counter
   - `spinOnTryEnter`
     - inflated case: _increment_ counter
3. `ObjectMonitor.hpp::objectMonitorEnterBlocking`:
   - inflated case: _increment_ counter
   - `inlineFastInitAndEnterMonitor`: _increment_ counter

**monitor exit points:**
1. `ObjectMonitor.hpp::inlineFastObjectMonitorExit`: _decrement_ counter
2. `monhelpers.c::objectMonitorExit`: _decrement_ counter

`ownedMonitorCount` will be reset when a `Continuation` is mounted and
unmounted.

Related: #15174

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>