### PR TITLE
Continuation isPinned implementation

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -202,8 +202,10 @@ public class Continuation {
 
 	public static native void unpin();
 
+	private static native boolean isPinnedImpl();
+
 	public static boolean isPinned(ContinuationScope scope) {
-		throw new UnsupportedOperationException();
+		return isPinnedImpl();
 	}
 
 	public PreemptStatus tryPreempt(Thread t) {

--- a/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
+++ b/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
@@ -81,4 +81,27 @@ Java_jdk_internal_vm_Continuation_createContinuationImpl(JNIEnv *env, jobject co
 	return result ? JNI_TRUE : JNI_FALSE;
 }
 
+/**
+ * Determine if the current continuation is pinned.
+ *
+ * @param env instance of JNIEnv.
+ * @param unused.
+ * @return true if pinned; otherwise, false.
+ */
+jboolean JNICALL
+Java_jdk_internal_vm_Continuation_isPinnedImpl(JNIEnv *env, jclass unused)
+{
+	jboolean result = JNI_FALSE;
+	J9VMThread *currentThread = (J9VMThread *)env;
+
+	if ((currentThread->continuationPinCount > 0)
+	|| (currentThread->ownedMonitorCount > 0)
+	|| (currentThread->callOutCount > 0)
+	) {
+		result = JNI_TRUE;
+	}
+
+	return result;
+}
+
 } /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -679,5 +679,6 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		Java_jdk_internal_vm_Continuation_createContinuationImpl
 		Java_jdk_internal_vm_Continuation_pin
 		Java_jdk_internal_vm_Continuation_unpin
+		Java_jdk_internal_vm_Continuation_isPinnedImpl
 	)
 endif()

--- a/runtime/jcl/uma/se19_exports.xml
+++ b/runtime/jcl/uma/se19_exports.xml
@@ -30,4 +30,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_jdk_internal_vm_Continuation_createContinuationImpl" />
 	<export name="Java_jdk_internal_vm_Continuation_pin" />
 	<export name="Java_jdk_internal_vm_Continuation_unpin" />
+	<export name="Java_jdk_internal_vm_Continuation_isPinnedImpl" />
 </exports>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1279,6 +1279,9 @@ Java_jdk_internal_vm_Continuation_pin(JNIEnv *env, jclass unused);
 
 void JNICALL
 Java_jdk_internal_vm_Continuation_unpin(JNIEnv *env, jclass unused);
+
+jboolean JNICALL
+Java_jdk_internal_vm_Continuation_isPinnedImpl(JNIEnv *env, jclass unused);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
`isPinned` returns true if the current continuation is pinned.

**TODO:** Add support for nested continuations, which will utilize
`ContinuationScope`.

Related: #15174

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>