### PR TITLE
Loom Pinning: Manage J9VMThread->callOutCount

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2214,9 +2214,13 @@ done:
 		/* If the stack grew, receiverAddress is still pointing to the correct slot
 		 * in the old stack, so does not need to be updated here.
 		 */
-
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		ret = callCFunction(REGISTER_ARGS, jniMethodStartAddress, receiverAddress, javaArgs, &bp, isStatic, &returnType);
-
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		if (isSynchronized) {
 			j9object_t syncObject = NULL;
 			if (isStatic) {
@@ -4743,6 +4747,9 @@ done:
 		*--_sp = (UDATA)_sendMethod;
 		_arg0EA = bp + 5;
 		updateVMStruct(REGISTER_ARGS);
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		exitVMToJNI(_currentThread);
 		I_32 status = JNI_ERR;
 		JNIEnv *env = (JNIEnv*)_currentThread;
@@ -4759,6 +4766,9 @@ done:
 //		Trc_JCL_attach_loadAgentLibraryStatus(env, status);
 		env->ExceptionClear();
 		enterVMFromJNI(_currentThread);
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		bp = _arg0EA - 5;
 		J9SFJNINativeMethodFrame *nativeMethodFrame = recordJNIReturn(REGISTER_ARGS, bp);
@@ -4914,7 +4924,13 @@ nativeOOM:
 		}
 		/* vmStruct already up-to-date */
 		internalReleaseVMAccess(_currentThread);
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		registerRC = registerNativeLibrary(_currentThread, classLoader, cLibName, cLibPath, NULL, errBuf, bufLen);
+#if JAVA_SPEC_VERSION >= 19
+		_currentThread->callOutCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		internalAcquireVMAccess(_currentThread);
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		if (VM_VMHelpers::exceptionPending(_currentThread)) {

--- a/runtime/vm/OutOfLineINL.hpp
+++ b/runtime/vm/OutOfLineINL.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,6 +125,9 @@ public:
  		UDATA *bp = buildSpecialStackFrame(currentThread, J9SF_FRAME_TYPE_NATIVE_METHOD, jitStackFrameFlags(currentThread, 0), true);
  		*--currentThread->sp = (UDATA)method;
  		currentThread->arg0EA = bp + J9_ROM_METHOD_FROM_RAM_METHOD(method)->argCount;
+#if JAVA_SPEC_VERSION >= 19
+		currentThread->callOutCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
  		return bp;
  	}
  
@@ -134,6 +137,9 @@ public:
  		J9SFNativeMethodFrame *nativeMethodFrame = (J9SFNativeMethodFrame*)currentThread->sp;
  		currentThread->jitStackFrameFlags = nativeMethodFrame->specialFrameFlags & J9_SSF_JIT_NATIVE_TRANSITION_FRAME;
  		restoreSpecialStackFrameLeavingArgs(currentThread, ((UDATA*)(nativeMethodFrame + 1)) - 1);
+#if JAVA_SPEC_VERSION >= 19
+		currentThread->callOutCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
  	}
 };
 

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -319,6 +319,12 @@ buildCallInStackFrame(J9VMThread *currentThread, J9VMEntryLocalStorage *newELS, 
 				goto done;
 			}
 		}
+#if JAVA_SPEC_VERSION >= 19
+		/* Increment avoided for the first call-in where
+		 * currentThread->entryLocalStorage is NULL.
+		 */
+		currentThread->callOutCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	}
 	if (returnsObject) {
 		flags |= J9_SSF_RETURNS_OBJECT;
@@ -396,6 +402,12 @@ restoreCallInFrame(J9VMThread *currentThread)
 	if (NULL != oldELS) {
 		UDATA usedBytes = ((UDATA)oldELS - (UDATA)newELS);
 		currentThread->currentOSStackFree += usedBytes;
+#if JAVA_SPEC_VERSION >= 19
+		/* Decrement avoided for the last return where
+		 * currentThread->entryLocalStorage is set to NULL.
+		 */
+		currentThread->callOutCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	}
 #if defined(WIN32) && !defined(J9VM_ENV_DATA64)
 	if (J9_ARE_NO_BITS_SET(currentThread->javaVM->sigFlags, J9_SIG_XRS_SYNC)) {


### PR DESCRIPTION
In order to support if a `Continuation` is pinned, `callOutCount` is
- incremented when a frame of a below type is build.
- decremented when a frame of a below type is removed.

**Frame types**, which have been accounted:
- `J9SF_FRAME_TYPE_JNI_NATIVE_METHOD`
- `J9SF_FRAME_TYPE_NATIVE_METHOD`
- Call-in frame

**TODOs** for the JIT (#15175):
- Increment `callOutCount` in `JNILinkage::buildJNICallOutFrame`.
- Decrement `callOutCount` in `JNILinkage::restoreJNICallOutFrame`.
- Related frame type: `J9SF_FRAME_TYPE_JIT_JNI_CALLOUT`.

Related: #15174

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>