### PR TITLE
Do not set backfillOffset of VT to -1

### DIFF
--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1503,11 +1503,9 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 	I_32 hashCode = 0;
 	bool isDestObjectPreHashed = false;
 
-	if (!isValueType) {
-		isDestObjectPreHashed = _extensions->objectModel.hasBeenHashed(destObject);
-		if (isDestObjectPreHashed) {
-			hashCode = _extensions->objectModel.getObjectHashCode(vmThread->javaVM, destObject);
-		}
+	isDestObjectPreHashed = _extensions->objectModel.hasBeenHashed(destObject);
+	if (isDestObjectPreHashed) {
+		hashCode = _extensions->objectModel.getObjectHashCode(vmThread->javaVM, destObject);
 	}
 
 	UDATA offset = 0;
@@ -1597,16 +1595,15 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 		}
 	}
 
-	if (!isValueType) {
-		/* If an object was pre-hashed and a hash was stored within the fields of the object restore it.*/
-		if (isDestObjectPreHashed) {
-			UDATA hashcodeOffset = _extensions->mixedObjectModel.getHashcodeOffset(destObject);
-			if (hashcodeOffset <= limit) {
-				I_32 *hashcodePointer = (I_32*)((U_8*)destObject + hashcodeOffset);
-				*hashcodePointer = hashCode;
-			}
+	/* If an object was pre-hashed and a hash was stored within the fields of the object restore it.*/
+	if (isDestObjectPreHashed) {
+		UDATA hashcodeOffset = _extensions->mixedObjectModel.getHashcodeOffset(destObject);
+		if (hashcodeOffset <= limit) {
+			I_32 *hashcodePointer = (I_32*)((U_8*)destObject + hashcodeOffset);
+			*hashcodePointer = hashCode;
 		}
-
+	}
+	if (!isValueType) {
 		if (initializeLockWord) {
 			/* initialize lockword, if present */
 			lockwordAddress = getLockwordAddress(vmThread, destObject);

--- a/runtime/vm/description.c
+++ b/runtime/vm/description.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,12 +93,6 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 		 */
 		ramClass->totalInstanceSize = walkResult->totalInstanceSize;
 		ramClass->backfillOffset = objectHeaderSize + ((walkResult->backfillOffset == -1) ?	walkResult->totalInstanceSize : walkResult->backfillOffset);
-
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9ROMCLASS_IS_VALUE(ramClass->romClass)) {
-			ramClass->backfillOffset = walkResult->backfillOffset;
-		}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 		/* write lockword offset into ramClass */
 		ramClass->lockOffset =	walkState->lockOffset;


### PR DESCRIPTION
1. Set backfillOffset of VT to instance size as normal classes.
2. Copy the VT hash code when doing copyObjectFields().

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>