### PR TITLE
Improve JITServer handling of socket timeouts

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3668,7 +3668,7 @@ void TR::CompilationInfo::stopCompilationThreads()
          }
       catch (const JITServer::StreamFailure &e)
          {
-         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary), this);
+         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary), this, e.retryConnectionImmediately());
          // catch the stream failure exception if the server dies before the dummy message is send for termination.
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamFailure (server unreachable before the termination message was sent): %s", e.what());

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2110,9 +2110,9 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             int32_t xxJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLocalSyncCompilesOption, 0);
             int32_t xxDisableJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLocalSyncCompilesOption, 0);
 
-            if (xxJITServerLocalSyncCompilesArgIndex > xxDisableJITServerLocalSyncCompilesArgIndex)
+            if (xxDisableJITServerLocalSyncCompilesArgIndex > xxJITServerLocalSyncCompilesArgIndex)
                {
-               compInfo->getPersistentInfo()->setLocalSyncCompiles(true);
+               compInfo->getPersistentInfo()->setLocalSyncCompiles(false);
                }
 
             const char *xxJITServerAOTCacheNameOption = "-XX:JITServerAOTCacheName=";

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -275,7 +275,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static bool _shareROMClasses;
    static int32_t _sharedROMClassCacheNumPartitions;
    static int32_t _reconnectWaitTimeMs;
-   static const uint32_t DEFAULT_JITCLIENT_TIMEOUT = 10000; // ms
+   static const uint32_t DEFAULT_JITCLIENT_TIMEOUT = 30000; // ms
    static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3083,7 +3083,8 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          }
       catch (const JITServer::StreamFailure &e)
          {
-         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo);
+         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo,
+                                             e.retryConnectionImmediately());
          if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
             TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
                "JITServer::StreamFailure: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
@@ -3349,7 +3350,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
             }
 
          // Since server has crashed, all compilations will switch to local
-         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo);
+         JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo, false);
          entry->_compErrCode = compilationFailure;
          compiler->failCompilation<JITServer::ServerCompilationFailure>("JITServer compilation thread has crashed.");
          }
@@ -3379,7 +3380,8 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
       }
    catch (const JITServer::StreamFailure &e)
       {
-      JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo);
+      JITServerHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary), compInfo,
+                                          e.retryConnectionImmediately());
 
       if (!details.isJitDumpMethod())
          {

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -118,7 +118,7 @@ public:
 
    // Functions used for allowing the client to compile locally when server is unavailable.
    // Should be used only on the client side.
-   static void postStreamFailure(OMRPortLibrary *portLibrary, TR::CompilationInfo *compInfo);
+   static void postStreamFailure(OMRPortLibrary *portLibrary, TR::CompilationInfo *compInfo, bool retryConnectionImmediately);
    static bool shouldRetryConnection(OMRPortLibrary *portLibrary);
    static void postStreamConnectionSuccess();
    static bool isServerAvailable() { return _serverAvailable; }

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -162,12 +162,12 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 #if defined(J9VM_OPT_JITSERVER)
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
-         _socketTimeoutMs(2000),
+         _socketTimeoutMs(0),
          _clientUID(0),
          _JITServerMetricsPort(38500),
          _JITServerUseAOTCache(false),
          _requireJITServer(false),
-         _localSyncCompiles(false),
+         _localSyncCompiles(true),
          _JITServerAOTCacheName(),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -113,7 +113,7 @@ private:
             if (bytesRead <= 0)
                {
                (*OERR_print_errors_fp)(stderr);
-               throw JITServer::StreamFailure("JITServer I/O error: read error");
+               throw JITServer::StreamFailure("JITServer I/O error: read error", (*OBIO_should_retry)(_ssl));
                }
             totalBytesRead += bytesRead;
             }
@@ -126,7 +126,7 @@ private:
             if (bytesRead <= 0)
                {
                throw JITServer::StreamFailure("JITServer I/O error: read error: " +
-                                              (bytesRead ? std::string(strerror(errno)) : "connection closed by peer"));
+                                              (bytesRead ? std::string(strerror(errno)) : "connection closed by peer"), EAGAIN == errno);
                }
             totalBytesRead += bytesRead;
             }
@@ -142,7 +142,7 @@ private:
          if (bytesRead <= 0)
             {
             (*OERR_print_errors_fp)(stderr);
-            throw JITServer::StreamFailure("JITServer I/O error: read error");
+            throw JITServer::StreamFailure("JITServer I/O error: read error", (*OBIO_should_retry)(_ssl));
             }
          }
       else
@@ -151,7 +151,7 @@ private:
          if (bytesRead <= 0)
             {
             throw JITServer::StreamFailure("JITServer I/O error: read error: " +
-                                           (bytesRead ? std::string(strerror(errno)) : "connection closed by peer"));
+                                           (bytesRead ? std::string(strerror(errno)) : "connection closed by peer"), EAGAIN == errno);
             }
          }
       return bytesRead;

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,11 +31,14 @@ namespace JITServer
 class StreamFailure: public virtual std::exception
    {
 public:
-   StreamFailure() : _message("Generic stream failure") { }
-   StreamFailure(const std::string &message) : _message(message) { }
+   StreamFailure() : _message("Generic stream failure"), _retryConnectionImmediately(false) { }
+   StreamFailure(const std::string &message) : _message(message), _retryConnectionImmediately(false) { }
+   StreamFailure(const std::string &message, bool shouldRetry) : _message(message), _retryConnectionImmediately(shouldRetry) { }
    virtual const char* what() const throw() { return _message.c_str(); }
+   bool retryConnectionImmediately() const { return _retryConnectionImmediately; }
 private:
    std::string _message;
+   bool _retryConnectionImmediately;
    };
 
 class StreamInterrupted: public virtual std::exception


### PR DESCRIPTION
If the JITServer is under very heavy load, the connection between it and
its clients may become overwhelmed, leading to stream failures from
socket read time outs in the client and consequently to large spikes in
client RSS. To remedy this:

- The default client socket timeout is now 30000ms.
- -XX:+JITServerLocalSyncCompiles is now on by default.
- If a connection is lost due to socket timeout on read, the client will
  immediately try to reconnect once before starting the usual
  exponential backoff in wait time.

Fixes: https://github.com/eclipse-openj9/openj9/issues/15396
Signed-off-by: Christian Despres <despresc@ibm.com>