### PR TITLE
Set Java main thread name

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -72,7 +72,7 @@ public class Thread implements Runnable {
 	 */
 	public final static int NORM_PRIORITY = 5;		// Normal priority for a thread
 	/*[PR 97331] Initial thread name should be Thread-0 */
-	private static int createCount = -1;					// Used internally to compute Thread names that comply with the Java specification
+	private static int createCount;					// Used internally to compute Thread names that comply with the Java specification
 	/*[PR 122459] LIR646 - Remove use of generic object for synchronization */
 	private static final class TidLock {
 		TidLock() {}
@@ -907,12 +907,7 @@ public final synchronized void join(long timeoutInMilliseconds, int nanos) throw
  */
 private synchronized static String newName() {
 	/*[PR 97331] Initial thread name should be Thread-0 */
-	if (createCount == -1) {
-		createCount++;
-		return "main"; //$NON-NLS-1$
-	} else {
-		return "Thread-" + createCount++; //$NON-NLS-1$
-	}
+	return "Thread-" + createCount++; //$NON-NLS-1$
 }
 
 /**

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -513,7 +513,6 @@ initializeAttachedThreadImpl(J9VMThread *currentThread, const char *name, j9obje
 		if (NULL != cachedOOM) {
 			initializee->outOfMemoryError = cachedOOM;
 			J9MemoryManagerFunctions const * const mmFuncs = vm->memoryManagerFunctions;
-			/* See if a name was given for the thread (if so, this implies that it will be a daemon thread) */
 			j9object_t threadName = NULL;
 			if (NULL != name) {
 				/* Allocate a String for the thread name */


### PR DESCRIPTION
Invoke `initializeAttachedThread()` with thread name `main`;
Format refactoring.

closes https://github.com/eclipse-openj9/openj9/issues/15205

Signed-off-by: Jason Feng <fengj@ca.ibm.com>