### PR TITLE
Fix reference array element alignment test for stable arrays

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -606,8 +606,13 @@ static void *dereferenceStructPointerChain(void *baseStruct, TR::Node *baseNode,
                   {
                   // if stable array, check that we are loading from the beginning of an element that it's not Null
                   // size of the element was checked in verifyFieldAccess
-                  if (fieldAddress % symRef->getSymbol()->getSize() != 0 ||
-                      isNullValueAtAddress(comp, symRef->getSymbol()->getDataType(), fieldAddress, symRef->getSymbol()))
+                  TR::DataType type = symRef->getSymbol()->getDataType();
+                  int32_t width = TR::Symbol::convertTypeToSize(type);
+                  if (type == TR::Address)
+                     width = TR::Compiler->om.sizeofReferenceField();
+
+                  if ((fieldAddress % width) != 0 ||
+                      isNullValueAtAddress(comp, type, fieldAddress, symRef->getSymbol()))
                      return NULL;
                   }
                }


### PR DESCRIPTION
- we would spuriously fail to fold loads of reference array
elements at odd positions when compressed references were enabled
because the alignment test looked for 8-byte alignment even though
only 4-byte alignment is really required