### PR TITLE
Add VirtualThread native stubs and the active VirtualThread list

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -644,6 +644,15 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if JAVA_SPEC_VERSION >= 19
+	/* These fields point to the next and previous VirtualThreads in the liveVirtualThreadList. */
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkNext", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkNextOffset)) {
+		return 1;
+	}
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkPrevious", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkPreviousOffset)) {
+		return 1;
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 	vmThread->privateFlags |= J9_PRIVATE_FLAGS_REPORT_ERROR_LOADING_CLASS;
 

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -519,6 +519,105 @@ Java_java_lang_Thread_registerNatives(JNIEnv *env, jclass clazz)
 	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
+
+/* private native void notifyJvmtiMountBegin(boolean firstMount); */
+void JNICALL
+Java_java_lang_VirtualThread_notifyJvmtiMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
+{
+	if (firstMount) {
+		J9VMThread *currentThread = (J9VMThread *)env;
+		J9JavaVM *vm = currentThread->javaVM;
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
+
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+
+		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
+		if (NULL == vm->liveVirtualThreadList) {
+			J9Class *virtualThreadClass = J9OBJECT_CLAZZ(currentThread, J9_JNI_UNWRAP_REFERENCE(thread));
+
+			/* Allocate empty virtual thread and create a global reference to it as root for the linked list.
+			 * This prevents the root reference from becoming stale if the GC moves the object.
+			 */
+			j9object_t rootVirtualThread = mmFuncs->J9AllocateObject(currentThread, virtualThreadClass, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+			if (NULL != rootVirtualThread) {
+				/* The global ref will be freed at vm death. */
+				jobject globalRef = vmFuncs->j9jni_createGlobalRef((JNIEnv *)currentThread, rootVirtualThread, JNI_FALSE);
+				if (NULL != globalRef) {
+					vm->liveVirtualThreadList = (j9object_t *)globalRef;
+
+					/* Set linkNext/linkPrevious to itself. */
+					J9OBJECT_OBJECT_STORE(currentThread, rootVirtualThread, vm->virtualThreadLinkNextOffset, rootVirtualThread);
+					J9OBJECT_OBJECT_STORE(currentThread, rootVirtualThread, vm->virtualThreadLinkPreviousOffset, rootVirtualThread);
+				} else {
+					vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+				}
+			} else {
+				vmFuncs->setHeapOutOfMemoryError(currentThread);
+			}
+		}
+
+		if (NULL != vm->liveVirtualThreadList) {
+			j9object_t root = *(vm->liveVirtualThreadList);
+			j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+			j9object_t rootPrev = J9OBJECT_OBJECT_LOAD(currentThread, root, vm->virtualThreadLinkPreviousOffset);
+
+			/* Add thread to the end of the list. */
+			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkNextOffset, root);
+			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset, rootPrev);
+			J9OBJECT_OBJECT_STORE(currentThread, rootPrev, vm->virtualThreadLinkNextOffset, threadObj);
+			J9OBJECT_OBJECT_STORE(currentThread, root, vm->virtualThreadLinkPreviousOffset, threadObj);
+		}
+		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+
+		vmFuncs->internalExitVMToJNI(currentThread);
+	}
+}
+
+/* private native void notifyJvmtiMountEnd(boolean firstMount); */
+void JNICALL
+Java_java_lang_VirtualThread_notifyJvmtiMountEnd(JNIEnv *env, jobject thread, jboolean firstMount)
+{
+}
+
+/* private native void notifyJvmtiUnmountBegin(boolean lastUnmount); */
+void JNICALL
+Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin(JNIEnv *env, jobject thread, jboolean lastUnmount)
+{
+}
+
+/* private native void notifyJvmtiUnmountEnd(boolean lastUnmount); */
+void JNICALL
+Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
+{
+	if (lastUnmount) {
+		J9VMThread *currentThread = (J9VMThread *)env;
+		J9JavaVM *vm = currentThread->javaVM;
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+
+		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
+		if (NULL != vm->liveVirtualThreadList) {
+			j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+			j9object_t threadPrev = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset);
+			j9object_t threadNext = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkNextOffset);
+
+			/* Remove thread from list. The root will never be removed. */
+			J9OBJECT_OBJECT_STORE(currentThread, threadPrev, vm->virtualThreadLinkNextOffset, threadNext);
+			J9OBJECT_OBJECT_STORE(currentThread, threadNext, vm->virtualThreadLinkPreviousOffset, threadPrev);
+		}
+		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+
+		vmFuncs->internalExitVMToJNI(currentThread);
+	}
+}
+
+/* private static native void registerNatives(); */
+void JNICALL
+Java_java_lang_VirtualThread_registerNatives(JNIEnv *env, jclass clazz)
+{
+}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -676,6 +676,11 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		Java_java_lang_Thread_getThreads
 		Java_java_lang_Thread_setExtentLocalCache
 		Java_java_lang_Thread_registerNatives
+		Java_java_lang_VirtualThread_notifyJvmtiMountBegin
+		Java_java_lang_VirtualThread_notifyJvmtiMountEnd
+		Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin
+		Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd
+		Java_java_lang_VirtualThread_registerNatives
 		Java_jdk_internal_vm_Continuation_createContinuationImpl
 		Java_jdk_internal_vm_Continuation_pin
 		Java_jdk_internal_vm_Continuation_unpin

--- a/runtime/jcl/uma/se19_exports.xml
+++ b/runtime/jcl/uma/se19_exports.xml
@@ -27,6 +27,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_java_lang_Thread_getThreads" />
 	<export name="Java_java_lang_Thread_setExtentLocalCache" />
 	<export name="Java_java_lang_Thread_registerNatives" />
+	<export name="Java_java_lang_VirtualThread_notifyJvmtiMountBegin" />
+	<export name="Java_java_lang_VirtualThread_notifyJvmtiMountEnd" />
+	<export name="Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin" />
+	<export name="Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd" />
+	<export name="Java_java_lang_VirtualThread_registerNatives" />
 	<export name="Java_jdk_internal_vm_Continuation_createContinuationImpl" />
 	<export name="Java_jdk_internal_vm_Continuation_pin" />
 	<export name="Java_jdk_internal_vm_Continuation_unpin" />

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5669,6 +5669,10 @@ typedef struct J9JavaVM {
 	struct J9HashTable* ensureHashedClasses;
 #if JAVA_SPEC_VERSION >= 19
 	U_64 nextTID;
+	j9object_t *liveVirtualThreadList;
+	omrthread_monitor_t liveVirtualThreadListMutex;
+	UDATA virtualThreadLinkNextOffset;
+	UDATA virtualThreadLinkPreviousOffset;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9JavaVM;
 

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -89,6 +89,11 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 		omrthread_monitor_init_with_name(&vm->cifArgumentTypesCacheMutex, 0, "CIF argument types mutex") ||
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
+#if JAVA_SPEC_VERSION >= 19
+		/* Held when adding or removing a virtual thread from the list at virtual thread start or terminate. */
+		omrthread_monitor_init_with_name(&vm->liveVirtualThreadListMutex, 0, "Live virtual thread list mutex") ||
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 		initializeMonitorTable(vm)
 	)
 	{
@@ -179,6 +184,13 @@ void terminateVMThreading(J9JavaVM *vm)
 		vm->cifArgumentTypesCacheMutex = NULL;
 	}
 #endif /* JAVA_SPEC_VERSION >= 16 */
+
+#if JAVA_SPEC_VERSION >= 19
+	if (NULL != vm->liveVirtualThreadListMutex) {
+		omrthread_monitor_destroy(vm->liveVirtualThreadListMutex);
+		vm->liveVirtualThreadListMutex = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 	destroyMonitorTable(vm);
 }


### PR DESCRIPTION
notifyJvmtiMountBegin() will be used to add a virtual thread to the list
and allocate thread local storage, while notifyJvmtiUnmountEnd() will be
used to remove a virtual thread from the list and deallocate thread
local storage. The list's root is a global jni ref to an empty virtual
thread to prevent references to it from becoming stale.

Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>