### PR TITLE
Use OpenSSL 1.1.1p for xmac

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -391,6 +391,7 @@ x86-32_windows:
 #========================================#
 x86-64_mac:
   extends: ['boot_jdk_default', 'debuginfo', 'openssl', 'openssl_bundle']
+  extra_getsource_options: '--openssl-version=1.1.1p'
   boot_jdk:
     arch: 'x64'
     os: 'mac'


### PR DESCRIPTION
After https://github.com/eclipse-openj9/openj9/pull/15433 was merged,
1.1.1q on xmac no longer compiles. See also
https://github.com/eclipse-openj9/openj9/pull/15484#issuecomment-1175181647

The problem is already fixed in OpenSSL for the next release.
https://github.com/openssl/openssl/commit/f9e578e720