### PR TITLE
AArch64: Enable Vector API Expansion

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -264,7 +264,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    static TR::VectorLength supportedOnPlatform(TR::Compilation *comp, vec_sz_t vectorLength)
          {
          // General check for supported infrastructure
-         if (!comp->target().cpu.isPower() && !comp->target().cpu.isZ())
+         if (!comp->target().cpu.isPower() && !comp->target().cpu.isZ() && !comp->target().cpu.isARM64())
             return TR::NoVectorLength;
 
          if (vectorLength != 128)


### PR DESCRIPTION
Enable Vector API Expansion on AArch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>