### PR TITLE
Add missing NULL-check for jitConfig

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1075,15 +1075,17 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	_OutputStream.writeCharacters(" JVM\n");
 
 #if defined(J9VM_OPT_JITSERVER)
-	if (0 != jitConfig->clientUID) {
-		_OutputStream.writeCharacters("1CICLIENTID    Client UID ");
-		_OutputStream.writeInteger64(jitConfig->clientUID, "%" OMR_PRIu64);
-		_OutputStream.writeCharacters("\n");
-	}
-	if (0 != jitConfig->serverUID) {
-		_OutputStream.writeCharacters("1CISERVERID    Server UID ");
-		_OutputStream.writeInteger64(jitConfig->serverUID, "%" OMR_PRIu64);
-		_OutputStream.writeCharacters("\n");
+	if (NULL != jitConfig) {
+		if (0 != jitConfig->clientUID) {
+			_OutputStream.writeCharacters("1CICLIENTID    Client UID ");
+			_OutputStream.writeInteger64(jitConfig->clientUID, "%" OMR_PRIu64);
+			_OutputStream.writeCharacters("\n");
+		}
+		if (0 != jitConfig->serverUID) {
+			_OutputStream.writeCharacters("1CISERVERID    Server UID ");
+			_OutputStream.writeInteger64(jitConfig->serverUID, "%" OMR_PRIu64);
+			_OutputStream.writeCharacters("\n");
+		}
 	}
 #endif /* J9VM_OPT_JITSERVER */
 


### PR DESCRIPTION
Generating a java dump with `-Xint` in a VM configured with `--enable-jitserver` faults:
```
Thread 3 "Signal Reporter" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff7f6d700 (LWP 1296761)]
JavaCoreDumpWriter::writeEnvironmentSection (this=0x7ffff7f6a130) at /home/keithc/space/openj9/jdk11/openj9/runtime/rasdump/javadump.cpp:1078
1078		if (0 != jitConfig->clientUID) {
(gdb) print jitConfig
$1 = (J9JITConfig *) 0x0
```