### PR TITLE
CRIU add single parameter exception constructors to support native setCurrentExceptionUTF()

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/JVMCheckpointException.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,15 @@ public final class JVMCheckpointException extends JVMCRIUException {
 	private static final long serialVersionUID = 4486137934620495516L;
 
 	/**
+	 * Creates a JVMCheckpointException with the specified message and a default error code.
+	 *
+	 * @param message   the message
+	 */
+	public JVMCheckpointException(String message) {
+		super(message, 0);
+	}
+
+	/**
 	 * Creates a JVMCheckpointException with the specified message and error code.
 	 *
 	 * @param message   the message
@@ -43,7 +52,7 @@ public final class JVMCheckpointException extends JVMCRIUException {
 	 *
 	 * @param message   the message
 	 * @param errorCode the error code
-	 * @param causedBy  throwable that cuased the exception
+	 * @param causedBy  throwable that caused the exception
 	 */
 	public JVMCheckpointException(String message, int errorCode, Throwable causedBy) {
 		super(message, errorCode, causedBy);

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/RestoreException.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/RestoreException.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF CRIU_SUPPORT]*/
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,15 @@ public final class RestoreException extends JVMCRIUException {
 	private static final long serialVersionUID = 1539393473417716292L;
 
 	/**
+	 * Creates a RestoreException with the specified message and a default error code.
+	 *
+	 * @param message   the message
+	 */
+	public RestoreException(String message) {
+		super(message, 0);
+	}
+
+	/**
 	 * Creates a RestoreException with the specified message and error code.
 	 *
 	 * @param message   the message
@@ -43,7 +52,7 @@ public final class RestoreException extends JVMCRIUException {
 	 *
 	 * @param message   the message
 	 * @param errorCode the error code
-	 * @param causedBy  throwable that cuased the exception
+	 * @param causedBy  throwable that caused the exception
 	 */
 	public RestoreException(String message, int errorCode, Throwable causedBy) {
 		super(message, errorCode, causedBy);


### PR DESCRIPTION
Native `setCurrentExceptionUTF()` requires a constructor w/ single message parameter.

fixes https://github.com/eclipse-openj9/openj9/issues/15524

A sample stack trace w/ this PR:
```
org.eclipse.openj9.criu.JVMCheckpointException: Blocking operation is not allowed in CRIU single thread mode.
	at org.openj9.criu.TestSingleThreadModeCheckpointException$2.run(TestSingleThreadModeCheckpointException.java:77)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.lambda$registerPreSnapshotHook$3(CRIUSupport.java:471)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:116)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:80)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runPreCheckpointHooks(J9InternalCheckpointHookAPI.java:89)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVMImpl(Native Method)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVM(CRIUSupport.java:590)
	at org.openj9.criu.CRIUTestUtils.checkPointJVM(CRIUTestUtils.java:75)
	at org.openj9.criu.TestSingleThreadModeCheckpointException.testSingleThreadModeCheckpointException(TestSingleThreadModeCheckpointException.java:86)
	at org.openj9.criu.TestSingleThreadModeCheckpointException.main(TestSingleThreadModeCheckpointException.java:37)
org.eclipse.openj9.criu.JVMCheckpointException: Exception thrown when running user pre-checkpoint hook
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.lambda$registerPreSnapshotHook$3(CRIUSupport.java:474)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:116)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:80)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runPreCheckpointHooks(J9InternalCheckpointHookAPI.java:89)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVMImpl(Native Method)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVM(CRIUSupport.java:590)
	at org.openj9.criu.CRIUTestUtils.checkPointJVM(CRIUTestUtils.java:75)
	at org.openj9.criu.TestSingleThreadModeCheckpointException.testSingleThreadModeCheckpointException(TestSingleThreadModeCheckpointException.java:86)
	at org.openj9.criu.TestSingleThreadModeCheckpointException.main(TestSingleThreadModeCheckpointException.java:37)
Caused by: org.eclipse.openj9.criu.JVMCheckpointException: Blocking operation is not allowed in CRIU single thread mode.
	at org.openj9.criu.TestSingleThreadModeCheckpointException$2.run(TestSingleThreadModeCheckpointException.java:77)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.lambda$registerPreSnapshotHook$3(CRIUSupport.java:471)
	... 8 more
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>