### PR TITLE
Correct J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2558,7 +2558,7 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 				}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-					errorCode = NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR__ID;
+					errorCode = J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR__ID;
 					goto _errorFound;
 				}
 #endif /* #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
@@ -3891,4 +3891,3 @@ checkClassBytes(J9VMThread *currentThread, U_8* classBytes, UDATA classBytesLeng
 	return rc;
 }
 #endif /* JAVA_SPEC_VERSION >= 15 */
-

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1680,8 +1680,9 @@ J9NLS_CFR_ERR_OUTER_CLASS_REFERENCETYPE_DESCRIPTOR.user_response=Contact the pro
 # END NON-TRANSLATABLE
 
 # ReferenceType is not translatable
-NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR=Nest member classes cannot be ReferenceType descriptors
+J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR=Nest member classes cannot be ReferenceType descriptors
 # START NON-TRANSLATABLE
-J9NLS_CFR_ERR_NEST_HOST_INVALID_REFERENCETYPE_DESCRIPTOR.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
-J9NLS_CFR_ERR_NEST_HOST_INVALID_REFERENCETYPE_DESCRIPTOR.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
-J9NLS_CFR_ERR_NEST_HOST_INVALID_REFERENCETYPE_DESCRIPTOR.user_response=Contact the provider of the classfile for a corrected version.
+J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/15053#pullrequestreview-1036454386

* fix related descriptions
* add `END NON-TRANSLATABLE` comment