### PR TITLE
Remove assert invalidated by "Recognize Class.cast and transform calls to it into checkcast"

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1340,7 +1340,6 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
    else if (!OMR::TreeEvaluator::isStaticClassSymRef(castClassSymRef))
       {
       traceMsg(cg->comp(),"Cast Class runtimeVariable\n");
-      TR_ASSERT(isInstanceOf, "Expecting instanceof when cast class is a runtime variable");
       if (mayBeNull)
          sequences[i++] = NullTest;
       sequences[i++] = ClassEqualityTest;


### PR DESCRIPTION
PR #15079 made it possible for a checkcast node to have a runtime variable cast class, invalidating the assertion in `calculateInstanceOfOrCheckCastSequences`.

Fixes: #15449
Signed-off-by: Spencer Comin <spencer.comin@ibm.com>