### PR TITLE
Update jvmtiGetThreadGroupChildren for java 19

### DIFF
--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -23,6 +23,22 @@
 #include "jvmtiHelpers.h"
 #include "jvmti_internal.h"
 
+/**
+ * Fetches the threads and child ThreadGroups of the given threadgroup group. Also return
+ * the number of threads and child threadgroups.
+ *
+ * @param[in] vm java vm
+ * @param[in] currentThread the current thread
+ * @param[in] group the ThreadGroup to fetch threads and child ThreadGroups from
+ * @param[out] rv_thread_count pointer to number of threads returned in the thread array
+ * @param[out] rv_threads pointer to array of the ThreadGroup's threads
+ * @param[out] rv_group_count pointer to number of child ThreadGroups returned in the ThreadGroup array
+ * @param[out] rv_groups pointer to array of the ThreadGroup's child ThreadGroups
+ *
+ * @return JVMTI_ERROR_NONE on success, a JVMTI error code otherwise
+ */
+static jvmtiError getThreadGroupChildrenImpl(J9JavaVM *vm, J9VMThread *currentThread, jobject group, jint *rv_thread_count, jthread **rv_threads, jint *rv_group_count, jthreadGroup **rv_groups);
+
 jvmtiError JNICALL
 jvmtiGetTopThreadGroups(jvmtiEnv* env,
 	jint* group_count_ptr,
@@ -148,28 +164,17 @@ jvmtiGetThreadGroupChildren(jvmtiEnv* env,
 	jthread *rv_threads = NULL;
 	jint rv_group_count = 0;
 	jthreadGroup *rv_groups = NULL;
-#if JAVA_SPEC_VERSION < 19
 	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
-#endif /* JAVA_SPEC_VERSION < 19 */
 
 	Trc_JVMTI_jvmtiGetThreadGroupChildren_Entry(env);
-#if JAVA_SPEC_VERSION < 19
 	if (J9_ARE_ANY_BITS_SET(vm->jclFlags, J9_JCL_FLAG_THREADGROUPS)) {
 		J9VMThread *currentThread = NULL;
 		J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
-		PORT_ACCESS_FROM_JAVAVM(vm);
 
 		rc = getCurrentVMThread(vm, &currentThread);
 		if (JVMTI_ERROR_NONE == rc) {
-			j9object_t threadGroupObject = NULL;
-			j9object_t childrenThreadsLock = NULL;
-			j9object_t childrenGroupsLock = NULL;
-			jthreadGroup *groups = NULL;
-			jint numGroups = 0;
-			jthread *threads = NULL;
-			jint numThreads = 0;
-
 			vmFuncs->internalEnterVMFromJNI(currentThread);
+
 			ENSURE_PHASE_LIVE(env);
 			ENSURE_JTHREADGROUP_NON_NULL(group);
 			ENSURE_NON_NULL(thread_count_ptr);
@@ -177,97 +182,19 @@ jvmtiGetThreadGroupChildren(jvmtiEnv* env,
 			ENSURE_NON_NULL(group_count_ptr);
 			ENSURE_NON_NULL(groups_ptr);
 
-			/* Construct the Children Groups array under a lock */
-			threadGroupObject = *((j9object_t*)group);
-			childrenGroupsLock = J9VMJAVALANGTHREADGROUP_CHILDRENGROUPSLOCK(currentThread, threadGroupObject);
-			childrenGroupsLock = (j9object_t)vmFuncs->objectMonitorEnter(currentThread, childrenGroupsLock);
-			/* The threadGroupObject has to be reobtained as it might have been GC'ed while waiting for the lock */
-			threadGroupObject = *((j9object_t*)group);
-			if (J9_OBJECT_MONITOR_ENTER_FAILED(childrenGroupsLock)) {
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-				if (J9_OBJECT_MONITOR_CRIU_SINGLE_THREAD_MODE_THROW == (UDATA)childrenGroupsLock) {
-					vmFuncs->setCRIUSingleThreadModeJVMCRIUException(currentThread, 0, 0);
-					rc = JVMTI_ERROR_THREAD_SUSPENDED;
-				} else
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-				if (J9_OBJECT_MONITOR_OOM == (UDATA)childrenGroupsLock) {
-					rc = JVMTI_ERROR_OUT_OF_MEMORY;
-				}
-				goto done;
-			}
-
-			numGroups = J9VMJAVALANGTHREADGROUP_NUMGROUPS(currentThread, threadGroupObject);
-			groups = j9mem_allocate_memory(sizeof(jthreadGroup) * numGroups, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-			if (NULL == groups) {
-				rc = JVMTI_ERROR_OUT_OF_MEMORY;
-			} else {
-				jint i = 0;
-				j9object_t childrenGroups = (j9object_t)J9VMJAVALANGTHREADGROUP_CHILDRENGROUPS(currentThread, threadGroupObject);
-
-				for (i = 0; i < numGroups; ++i) {
-					j9object_t group = J9JAVAARRAYOFOBJECT_LOAD(currentThread, childrenGroups, i);
-
-					groups[i] = (jthreadGroup)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, group);
-				}
-			}
-
-			vmFuncs->objectMonitorExit(currentThread, childrenGroupsLock);
-
-			/* Construct the Children Threads array under a lock */
-			threadGroupObject = *((j9object_t*)group);
-			childrenThreadsLock = J9VMJAVALANGTHREADGROUP_CHILDRENTHREADSLOCK(currentThread, threadGroupObject);
-			childrenThreadsLock = (j9object_t)vmFuncs->objectMonitorEnter(currentThread, childrenThreadsLock);
-			/* The threadGroupObject has to be reobtained as it might have been GC'ed while waiting for the lock */
-			threadGroupObject = *((j9object_t*)group);
-			if (J9_OBJECT_MONITOR_ENTER_FAILED(childrenThreadsLock)) {
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-				if (J9_OBJECT_MONITOR_CRIU_SINGLE_THREAD_MODE_THROW == (UDATA)childrenThreadsLock) {
-					vmFuncs->setCRIUSingleThreadModeJVMCRIUException(currentThread, 0, 0);
-					rc = JVMTI_ERROR_THREAD_SUSPENDED;
-				} else
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-				if (J9_OBJECT_MONITOR_OOM == (UDATA)childrenThreadsLock) {
-					rc = JVMTI_ERROR_OUT_OF_MEMORY;
-				}
-				j9mem_free_memory(groups);
-				goto done;
-			}
-
-			numThreads = J9VMJAVALANGTHREADGROUP_NUMTHREADS(currentThread, threadGroupObject);
-			threads = j9mem_allocate_memory(sizeof(jthread) * numThreads, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-			if (NULL == threads) {
-				j9mem_free_memory(groups);
-				rc = JVMTI_ERROR_OUT_OF_MEMORY;
-			} else {
-				jint i = 0;
-				j9object_t childrenThreads = (j9object_t)J9VMJAVALANGTHREADGROUP_CHILDRENTHREADS(currentThread, threadGroupObject);
-				jint numLiveThreads = 0;
-
-				/* Include only live threads in the result */
-				numLiveThreads = 0;
-				for (i = 0; i < numThreads; ++i) {
-					j9object_t thread = J9JAVAARRAYOFOBJECT_LOAD(currentThread, childrenThreads, i);
-					J9VMThread *targetThread = NULL;
-
-					if (JVMTI_ERROR_NONE == getVMThread(currentThread, (jthread) &thread, &targetThread, FALSE, TRUE)) {
-						threads[numLiveThreads++] = (jthread)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, thread);
-						releaseVMThread(currentThread, targetThread);
-					}
-				}
-
-				rv_thread_count = numLiveThreads;
-				rv_threads = threads;
-				rv_group_count = numGroups;
-				rv_groups = groups; 
-			}
-
-			vmFuncs->objectMonitorExit(currentThread, childrenThreadsLock);
+			rc = getThreadGroupChildrenImpl(
+					vm,
+					currentThread,
+					group,
+					&rv_thread_count,
+					&rv_threads,
+					&rv_group_count,
+					&rv_groups);
 
 done:
 			vmFuncs->internalExitVMToJNI(currentThread);
 		}
 	}
-#endif /* JAVA_SPEC_VERSION < 19 */
 
 	if (NULL != thread_count_ptr) {
 		*thread_count_ptr = rv_thread_count;
@@ -283,3 +210,224 @@ done:
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadGroupChildren);
 }
+
+#if JAVA_SPEC_VERSION < 19
+static jvmtiError
+getThreadGroupChildrenImpl(J9JavaVM *vm, J9VMThread *currentThread, jobject group,
+		jint *rv_thread_count,
+		jthread **rv_threads,
+		jint *rv_group_count,
+		jthreadGroup **rv_groups)
+{
+	const J9InternalVMFunctions * const vmFuncs = vm->internalVMFunctions;
+	j9object_t threadGroupObject = NULL;
+	j9object_t childrenThreadsLock = NULL;
+	j9object_t childrenGroupsLock = NULL;
+	jthreadGroup *groups = NULL;
+	jint numGroups = 0;
+	jthread *threads = NULL;
+	jint numThreads = 0;
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	/* Construct the Children Groups array under a lock. */
+	threadGroupObject = J9_JNI_UNWRAP_REFERENCE(group);
+	childrenGroupsLock = J9VMJAVALANGTHREADGROUP_CHILDRENGROUPSLOCK(currentThread, threadGroupObject);
+	childrenGroupsLock = (j9object_t)vmFuncs->objectMonitorEnter(currentThread, childrenGroupsLock);
+	/* The threadGroupObject has to be reobtained as it might have been GC'ed while waiting for the lock. */
+	threadGroupObject = J9_JNI_UNWRAP_REFERENCE(group);
+	if (J9_OBJECT_MONITOR_ENTER_FAILED(childrenGroupsLock)) {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		if (J9_OBJECT_MONITOR_CRIU_SINGLE_THREAD_MODE_THROW == (UDATA)childrenGroupsLock) {
+			vmFuncs->setCRIUSingleThreadModeJVMCRIUException(currentThread, 0, 0);
+			rc = JVMTI_ERROR_THREAD_SUSPENDED;
+		} else
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+		if (J9_OBJECT_MONITOR_OOM == (UDATA)childrenGroupsLock) {
+			rc = JVMTI_ERROR_OUT_OF_MEMORY;
+		}
+		goto done;
+	}
+
+	numGroups = J9VMJAVALANGTHREADGROUP_NUMGROUPS(currentThread, threadGroupObject);
+	groups = j9mem_allocate_memory(sizeof(jthreadGroup) * numGroups, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+	if (NULL == groups) {
+		rc = JVMTI_ERROR_OUT_OF_MEMORY;
+	} else {
+		jint i = 0;
+		j9object_t childrenGroups = (j9object_t)J9VMJAVALANGTHREADGROUP_CHILDRENGROUPS(currentThread, threadGroupObject);
+
+		for (i = 0; i < numGroups; ++i) {
+			j9object_t childGroup = J9JAVAARRAYOFOBJECT_LOAD(currentThread, childrenGroups, i);
+
+			groups[i] = (jthreadGroup)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, childGroup);
+		}
+	}
+
+	vmFuncs->objectMonitorExit(currentThread, childrenGroupsLock);
+
+	/* Construct the Children Threads array under a lock. */
+	threadGroupObject = J9_JNI_UNWRAP_REFERENCE(group);
+	childrenThreadsLock = J9VMJAVALANGTHREADGROUP_CHILDRENTHREADSLOCK(currentThread, threadGroupObject);
+	childrenThreadsLock = (j9object_t)vmFuncs->objectMonitorEnter(currentThread, childrenThreadsLock);
+	/* The threadGroupObject has to be reobtained as it might have been GC'ed while waiting for the lock. */
+	threadGroupObject = J9_JNI_UNWRAP_REFERENCE(group);
+	if (J9_OBJECT_MONITOR_ENTER_FAILED(childrenThreadsLock)) {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		if (J9_OBJECT_MONITOR_CRIU_SINGLE_THREAD_MODE_THROW == (UDATA)childrenThreadsLock) {
+			vmFuncs->setCRIUSingleThreadModeJVMCRIUException(currentThread, 0, 0);
+			rc = JVMTI_ERROR_THREAD_SUSPENDED;
+		} else
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+		if (J9_OBJECT_MONITOR_OOM == (UDATA)childrenThreadsLock) {
+			rc = JVMTI_ERROR_OUT_OF_MEMORY;
+		}
+		j9mem_free_memory(groups);
+		goto done;
+	}
+
+	numThreads = J9VMJAVALANGTHREADGROUP_NUMTHREADS(currentThread, threadGroupObject);
+	threads = j9mem_allocate_memory(sizeof(jthread) * numThreads, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+	if (NULL == threads) {
+		j9mem_free_memory(groups);
+		rc = JVMTI_ERROR_OUT_OF_MEMORY;
+	} else {
+		jint i = 0;
+		j9object_t childrenThreads = (j9object_t)J9VMJAVALANGTHREADGROUP_CHILDRENTHREADS(currentThread, threadGroupObject);
+		jint numLiveThreads = 0;
+
+		/* Include only live threads in the result */
+		numLiveThreads = 0;
+		for (i = 0; i < numThreads; ++i) {
+			j9object_t thread = J9JAVAARRAYOFOBJECT_LOAD(currentThread, childrenThreads, i);
+			J9VMThread *targetThread = NULL;
+
+			if (JVMTI_ERROR_NONE == getVMThread(currentThread, (jthread)&thread, &targetThread, FALSE, TRUE)) {
+				threads[numLiveThreads++] = (jthread)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, thread);
+				releaseVMThread(currentThread, targetThread);
+			}
+		}
+
+		*rv_thread_count = numLiveThreads;
+		*rv_threads = threads;
+		*rv_group_count = numGroups;
+		*rv_groups = groups;
+	}
+
+	vmFuncs->objectMonitorExit(currentThread, childrenThreadsLock);
+
+done:
+	return rc;
+}
+#else /* JAVA_SPEC_VERSION < 19 */
+static jvmtiError
+getThreadGroupChildrenImpl(J9JavaVM *vm, J9VMThread *currentThread, jobject group,
+		jint *rv_thread_count,
+		jthread **rv_threads,
+		jint *rv_group_count,
+		jthreadGroup **rv_groups)
+{
+	const J9InternalVMFunctions * const vmFuncs = vm->internalVMFunctions;
+	j9object_t threadGroupObject = NULL;
+	jthreadGroup *groups = NULL;
+	jint nGroups = 0;
+	jint nWeaks = 0;
+	jint nGroupsTotal = 0;
+	jthread *threads = NULL;
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	/* Construct the child groups and threads arrays while locking on the parent group. */
+	threadGroupObject = J9_JNI_UNWRAP_REFERENCE(group);
+	threadGroupObject = (j9object_t)vmFuncs->objectMonitorEnter(currentThread, threadGroupObject);
+	if (J9_OBJECT_MONITOR_ENTER_FAILED(threadGroupObject)) {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		if (J9_OBJECT_MONITOR_CRIU_SINGLE_THREAD_MODE_THROW == (UDATA)threadGroupObject) {
+			vmFuncs->setCRIUSingleThreadModeJVMCRIUException(currentThread, 0, 0);
+			rc = JVMTI_ERROR_THREAD_SUSPENDED;
+		} else
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+		if (J9_OBJECT_MONITOR_OOM == (UDATA)threadGroupObject) {
+			rc = JVMTI_ERROR_OUT_OF_MEMORY;
+		}
+		goto done;
+	}
+
+	nGroups = J9VMJAVALANGTHREADGROUP_NGROUPS(currentThread, threadGroupObject);
+	nWeaks = J9VMJAVALANGTHREADGROUP_NWEAKS(currentThread, threadGroupObject);
+	groups = j9mem_allocate_memory(sizeof(jthreadGroup) * (nGroups + nWeaks), J9MEM_CATEGORY_JVMTI_ALLOCATE);
+	if (NULL == groups) {
+		rc = JVMTI_ERROR_OUT_OF_MEMORY;
+	} else {
+		jint i = 0;
+		jint j = 0;
+		j9object_t strongGroups = (j9object_t)J9VMJAVALANGTHREADGROUP_GROUPS(currentThread, threadGroupObject);
+		j9object_t weakGroupRefs = (j9object_t)J9VMJAVALANGTHREADGROUP_WEAKS(currentThread, threadGroupObject);
+
+		for (i = 0; i < nGroups; ++i) {
+			j9object_t strongGroup = J9JAVAARRAYOFOBJECT_LOAD(currentThread, strongGroups, i);
+
+			groups[i] = (jthreadGroup)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, strongGroup);
+		}
+
+		for (j = 0; j < nWeaks; ++j) {
+			/* Fetch WeakReference at index (weaks[j]). */
+			j9object_t weakRef = J9JAVAARRAYOFOBJECT_LOAD(currentThread, weakGroupRefs, j);
+			/* Get the ThreadGroup referent. */
+			j9object_t weakGroup = vm->memoryManagerFunctions->j9gc_objaccess_referenceGet(currentThread, weakRef);
+
+			/* The groups array may have unused space as weakGroup may not be added. */
+			if (NULL != weakGroup) {
+				groups[i] = (jthreadGroup)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, weakGroup);
+				i += 1;
+			}
+		}
+
+		nGroupsTotal = i;
+	}
+
+	vmFuncs->acquireExclusiveVMAccess(currentThread);
+
+	threads = j9mem_allocate_memory(sizeof(jthread) * vm->totalThreadCount, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+	if (NULL == threads) {
+		j9mem_free_memory(groups);
+		rc = JVMTI_ERROR_OUT_OF_MEMORY;
+	} else {
+		jthread *currentThreadPtr = threads;
+		J9VMThread *targetThread = vm->mainThread;
+		jint nLiveThreads = 0;
+
+		do {
+			j9object_t threadObject = targetThread->carrierThreadObject;
+
+			/* Only count live threads. */
+			if (NULL != threadObject) {
+				if (J9VMJAVALANGTHREAD_STARTED(currentThread, threadObject)
+					&& (NULL != J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject))
+				) {
+					j9object_t threadHolder = J9VMJAVALANGTHREAD_HOLDER(currentThread, threadObject);
+					if (NULL != threadHolder) {
+						j9object_t threadGroup = (j9object_t)J9VMJAVALANGTHREADFIELDHOLDER_GROUP(currentThread, threadHolder);
+						/* The threads array will have unused space since many threads will not belong to the given threadgroup. */
+						if (threadGroup == threadGroupObject) {
+							*currentThreadPtr++ = (jthread)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, threadObject);
+							nLiveThreads += 1;
+						}
+					}
+				}
+			}
+		} while ((targetThread = targetThread->linkNext) != vm->mainThread);
+
+		*rv_thread_count = nLiveThreads;
+		*rv_threads = threads;
+		*rv_group_count = nGroupsTotal;
+		*rv_groups = groups;
+	}
+
+	vmFuncs->releaseExclusiveVMAccess(currentThread);
+	vmFuncs->objectMonitorExit(currentThread, threadGroupObject);
+
+done:
+	return rc;
+}
+#endif /* JAVA_SPEC_VERSION < 19 */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -291,13 +291,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/ThreadGroup" name="maxPriority" signature="I"/>
 	<fieldref class="java/lang/ThreadGroup" name="parent" signature="Ljava/lang/ThreadGroup;"/>
 	<fieldref class="java/lang/ThreadGroup" name="numThreads" signature="I" versions="8-18"/>
-	<fieldref class="java/lang/ThreadGroup" name="numGroups" signature="I" versions="8-18">
-		<fieldalias name="ngroups" signature="I" versions="19-"/>
-	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="numGroups" signature="I" versions="8-18"/>
 	<fieldref class="java/lang/ThreadGroup" name="childrenThreads" signature="[Ljava/lang/Thread;" versions="8-18"/>
-	<fieldref class="java/lang/ThreadGroup" name="childrenGroups" signature="[Ljava/lang/ThreadGroup;" versions="8-18">
-		<fieldalias name="groups" signature="[Ljava/lang/ThreadGroup;" versions="19-"/>
-	</fieldref>
+	<fieldref class="java/lang/ThreadGroup" name="childrenGroups" signature="[Ljava/lang/ThreadGroup;" versions="8-18"/>
+	<fieldref class="java/lang/ThreadGroup" name="ngroups" signature="I" versions="19-"/>
+	<fieldref class="java/lang/ThreadGroup" name="groups" signature="[Ljava/lang/ThreadGroup;" versions="19-"/>
+	<fieldref class="java/lang/ThreadGroup" name="nweaks" signature="I" versions="19-"/>
+	<fieldref class="java/lang/ThreadGroup" name="weaks" signature="[Ljava/lang/ref/WeakReference;" versions="19-"/>
 	<fieldref class="java/lang/ThreadGroup" name="isDaemon" signature="Z" versions="8-18">
 		<fieldalias name="daemon" signature="Z" versions="19-"/>
 	</fieldref>

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_19.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_19.xml
@@ -56,8 +56,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<reason>Nestmates are not enabled on java10</reason>
 	</exclude>
 
-	<exclude id="gtgc001" platform="all">
-		<reason>GetThreadGroupChildren requires refactor for Project Loom</reason>
-	</exclude>
-
 </suite>


### PR DESCRIPTION
The ThreadGroup class does not store its threads anymore and child groups
are separated into "groups" and "weaks" ThreadGroup arrays.

The child ThreadGroups array is populated from the ThreadGroup's "groups"
and "weaks" arrays, which are the child ThreadGroups that are strongly
and weakly reachable from the parent.

The threads array is constructed by iterating over all J9VMThreads and
adding the threads that belong in the given ThreadGroup.

The returned arrays are constructed while locking on the ThreadGroup
object.

Fixes: #15244
Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>