### PR TITLE
Add thread local storage to java thread objects

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -644,6 +644,11 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 #if JAVA_SPEC_VERSION >= 19
+	/* TLS hidden field points to an array holding jvmti thread local data. */
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/Thread", "tls", "J", &vm->tlsOffset)) {
+		return 1;
+	}
+
 	/* Points to the next VirtualThread in the liveVirtualThreadList. */
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkNext", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkNextOffset)) {
 		return 1;

--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -635,3 +635,6 @@ TraceEntry=Trc_JVMTI_jvmtiHookVirtualThreadEnd_Entry Overhead=1 Level=5 Noenv Te
 TraceExit=Trc_JVMTI_jvmtiHookVirtualThreadEnd_Exit Overhead=1 Level=5 Noenv Template="HookVirtualThreadEnd"
 TraceEntry=Trc_JVMTI_jvmtiHookVirtualThreadStarted_Entry Overhead=1 Level=5 Noenv Template="HookVirtualThreadStarted"
 TraceExit=Trc_JVMTI_jvmtiHookVirtualThreadStarted_Exit Overhead=1 Level=5 Noenv Template="HookVirtualThreadStarted"
+
+TraceEntry=Trc_JVMTI_jvmtiHookVirtualThreadDestroy_Entry Overhead=1 Level=5 Noenv Template="HookVirtualThreadDestroy"
+TraceExit=Trc_JVMTI_jvmtiHookVirtualThreadDestroy_Exit Overhead=1 Level=5 Noenv Template="HookVirtualThreadDestroy"

--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -203,9 +203,6 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 #if JAVA_SPEC_VERSION >= 11
 			case  JVMTI_EVENT_SAMPLED_OBJECT_ALLOC:
 #endif /* JAVA_SPEC_VERSION >= 11 */
-#if JAVA_SPEC_VERSION >= 19
-			case JVMTI_EVENT_VIRTUAL_THREAD_START:
-#endif /* JAVA_SPEC_VERSION >= 19 */
 				if (event_thread != NULL) {
 					JVMTI_ERROR(JVMTI_ERROR_ILLEGAL_ARGUMENT);
 				}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -272,6 +272,11 @@
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_4BYTES 0xFFFFFFFF
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_2BYTES 0xFFFF
 
+#if JAVA_SPEC_VERSION >= 19
+#define J9JVMTI_MAX_TLS_KEYS 124
+typedef void(*j9_tls_finalizer_t)(void *);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 typedef enum {
 	J9FlushCompQueueDataBreakpoint
 } J9JITFlushCompilationQueueReason;
@@ -4885,6 +4890,7 @@ typedef struct J9InternalVMFunctions {
 	j9object_t* (*getDefaultValueSlotAddress)(struct J9Class *clazz);
 #if JAVA_SPEC_VERSION >= 19
 	BOOLEAN (*createContinuation)(struct J9VMThread *currentThread, j9object_t continuationObject);
+	void (*freeTLS)(struct J9VMThread *currentThread, j9object_t threadObj);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #if JAVA_SPEC_VERSION >= 16
 /*
@@ -5766,6 +5772,11 @@ typedef struct J9JavaVM {
 	UDATA virtualThreadLinkNextOffset;
 	UDATA virtualThreadLinkPreviousOffset;
 	UDATA virtualThreadInspectorCountOffset;
+	UDATA tlsOffset;
+	j9_tls_finalizer_t tlsFinalizers[J9JVMTI_MAX_TLS_KEYS];
+	omrthread_monitor_t tlsFinalizersMutex;
+	struct J9Pool *tlsPool;
+	omrthread_monitor_t tlsPoolMutex;
 	jclass jlThreadConstants;
 	jfieldID vthreadGroupID;
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -163,7 +163,11 @@ typedef struct J9JVMTIEnv {
 	J9JVMTIEventEnableMap globalEventEnable;
 	J9HashTable *watchedClasses;
 	J9Pool* breakpoints;
+#if JAVA_SPEC_VERSION >= 19
+	UDATA tlsKey;
+#else /* JAVA_SPEC_VERSION >= 19 */
 	omrthread_tls_key_t tlsKey;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	J9JVMTIHookInterfaceWithID vmHook;
 	J9JVMTIHookInterfaceWithID gcHook;
 	J9JVMTIHookInterfaceWithID gcOmrHook;
@@ -559,9 +563,6 @@ typedef struct jvmtiGcp_translation {
 #define GET_SUPERCLASS(clazz) \
 	((J9CLASS_DEPTH(clazz) == 0) ? NULL : \
 		(clazz)->superclasses[J9CLASS_DEPTH(clazz) - 1])
-
-#define THREAD_DATA_FOR_VMTHREAD(j9env, vmThread) \
-	((J9JVMTIThreadData *) omrthread_tls_get((vmThread)->osThread, (j9env)->tlsKey))
 
 #define IBMJVMTI_EXTENDED_CALLSTACK     1
 #define IBMJVMTI_UNEXTENDED_CALLSTACK   0

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4719,6 +4719,17 @@ createJoinableThreadWithCategory(omrthread_t* handle, UDATA stacksize, UDATA pri
 IDATA
 attachThreadWithCategory(omrthread_t* handle, U_32 category);
 
+#if JAVA_SPEC_VERSION >= 19
+/**
+ * Frees a thread object's TLS array.
+ *
+ * @param[in] currentThread the current thread
+ * @param[in] threadObj the thread object to free TLS from
+ */
+void
+freeTLS(J9VMThread *currentThread, j9object_t threadObj);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 /* -------------------- J9OMRHelpers.cpp ------------ */
 
 /**

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -417,6 +417,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getDefaultValueSlotAddress,
 #if JAVA_SPEC_VERSION >= 19
 	createContinuation,
+	freeTLS,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #if JAVA_SPEC_VERSION >= 16
 /*

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -230,6 +230,13 @@ deallocateVMThread(J9VMThread * vmThread, UDATA decrementZombieCount, UDATA send
 		TRIGGER_J9HOOK_VM_THREAD_DESTROY(vm->hookInterface, vmThread);
 	}
 
+#if JAVA_SPEC_VERSION >= 19
+	if (NULL != vmThread->threadObject) {
+		/* Deallocate thread object's tls array. */
+		freeTLS(vmThread, vmThread->threadObject);
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 	/* freeing the per thread buffers in the portlibrary */
 	j9port_tls_free();
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -824,6 +824,13 @@ freeJavaVM(J9JavaVM * vm)
 	}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
+#if JAVA_SPEC_VERSION >= 19
+	if (NULL != vm->tlsPool) {
+		pool_kill(vm->tlsPool);
+		vm->tlsPool = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 	j9mem_free_memory(vm->vTableScratch);
 	vm->vTableScratch = NULL;
 
@@ -2389,6 +2396,10 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 					goto _error;
 				}
 			}
+#if JAVA_SPEC_VERSION >= 19
+			if (NULL == (vm->tlsPool = pool_new(sizeof(void *) * J9JVMTI_MAX_TLS_KEYS,  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_JVMTI, POOL_FOR_PORT(vm->portLibrary))))
+				goto _error;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 			break;
 

--- a/runtime/vm/threadhelp.cpp
+++ b/runtime/vm/threadhelp.cpp
@@ -462,4 +462,25 @@ failedToSetAttr(IDATA rc)
 	return ((rc != J9THREAD_SUCCESS) && (rc != J9THREAD_ERR_UNSUPPORTED_ATTR));
 }
 
+#if JAVA_SPEC_VERSION >= 19
+/**
+ * Frees a thread object's TLS array.
+ *
+ * @param[in] currentThread the current thread
+ * @param[in] threadObj the thread object to free TLS from
+ */
+void
+freeTLS(J9VMThread *currentThread, j9object_t threadObj)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	void *tlsArray = J9OBJECT_ADDRESS_LOAD(currentThread, threadObj, vm->tlsOffset);
+	if (NULL != tlsArray) {
+		omrthread_monitor_enter(vm->tlsPoolMutex);
+		pool_removeElement(vm->tlsPool, tlsArray);
+		omrthread_monitor_exit(vm->tlsPoolMutex);
+		J9OBJECT_ADDRESS_STORE(currentThread, threadObj, vm->tlsOffset, NULL);
+	}
+}
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 }

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -92,6 +92,8 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 #if JAVA_SPEC_VERSION >= 19
 		/* Held when adding or removing a virtual thread from the list at virtual thread start or terminate. */
 		omrthread_monitor_init_with_name(&vm->liveVirtualThreadListMutex, 0, "Live virtual thread list mutex") ||
+		omrthread_monitor_init_with_name(&vm->tlsFinalizersMutex, 0, "TLS finalizers mutex") ||
+		omrthread_monitor_init_with_name(&vm->tlsPoolMutex, 0, "TLS pool mutex") ||
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 		initializeMonitorTable(vm)
@@ -189,6 +191,14 @@ void terminateVMThreading(J9JavaVM *vm)
 	if (NULL != vm->liveVirtualThreadListMutex) {
 		omrthread_monitor_destroy(vm->liveVirtualThreadListMutex);
 		vm->liveVirtualThreadListMutex = NULL;
+	}
+	if (NULL != vm->tlsFinalizersMutex) {
+		omrthread_monitor_destroy(vm->tlsFinalizersMutex);
+		vm->tlsFinalizersMutex = NULL;
+	}
+	if (NULL != vm->tlsPoolMutex) {
+		omrthread_monitor_destroy(vm->tlsPoolMutex);
+		vm->tlsPoolMutex = NULL;
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 


### PR DESCRIPTION
- Add an array hidden field to java/lang/Thread as the TLS for a given
thread object (JDK19+). JDK18 and below will continue to use the OMR TLS
- Implement JVMTI TLS functions to store env-thread-pair TLS data
- Add tls pool to vm to allocate threads' tls arrays from
- (JDK19+) Lazy allocate a thread's TLS array at first use
(SetThreadLocalStorage and SetEventNotificationMode)
- (JDK19+) Free the TLS array at VMThread destroy and virtual thread end
- Lazy allocate TLS thread data blocks at first use
(SetThreadLocalStorage and SetEventNotificationMode)
- Implement new hook events for platform and virtual thread end to free
the thread data block allocated by a JVMTI env

Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>