### PR TITLE
Allow verifier to run in valuetype tests

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2017, 2021 IBM Corp. and others
+  Copyright (c) 2017, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,6 @@
 			<variation>-Xnocompressedrefs -Xgcpolicy:gencon</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-		-Xverify:none \
 		-Xint \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
@@ -73,7 +72,6 @@
 			<variation>-Xjit:count=1,disableAsyncCompilation -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-		-Xverify:none \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTestsJIT \
@@ -103,7 +101,6 @@
 			<variation>-Xnocompressedrefs -XX:-EnableArrayFlattening</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-		-Xverify:none \
 		-Xint \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -3128,7 +3128,7 @@ public class ValueTypeTests {
 		valueTypeIdentityObjectTestHelper("testValueTypeSubClassInvisibleLightAbstractClass", superClassName, 0);
 	}
 
-	@Test(priority=1, expectedExceptions=VerifyError.class)
+	@Test(priority=1, expectedExceptions=ClassFormatError.class)
 	static public void testValueTypeHasSychMethods() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateIllegalValueClassWithSychMethods("testValueTypeHasSychMethods", fields);


### PR DESCRIPTION
For issue #14741

- Fix bugs in ValueTypeGenerator.java/ValueTypeTests.java
- Enable verification when running valuetype tests

Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>