### PR TITLE
Avoid NullPointerException reading SONAME

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
@@ -801,6 +801,9 @@ public abstract class ELFFileReader {
 	 */
 	public String readSONAME(ELFFileReader coreFileReader) {
 		ProgramHeaderEntry dynamicTableEntry = getDynamicTableEntry();
+		if (dynamicTableEntry == null) {
+			return null;
+		}
 		try {
 			long imageStart = dynamicTableEntry.virtualAddress;
 


### PR DESCRIPTION
If a dynamic program header cannot be found, we can't determine the SONAME of the object.
See also [`NewElfDump.ElfFile.getSONAME()`](https://github.com/eclipse-openj9/openj9/blob/master/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java#L1222).

Fixes: #15547.