### PR TITLE
NPE extended message generation missed j9mem_free_memory calls

### DIFF
--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -156,6 +156,11 @@ JVM_GetExtendedNPEMessage(JNIEnv *env, jthrowable throwableObj)
 				}
 				j9mem_free_memory(npeMsg);
 			}
+			j9mem_free_memory(npeMsgData.liveStack);
+			j9mem_free_memory(npeMsgData.bytecodeOffset);
+			j9mem_free_memory(npeMsgData.bytecodeMap);
+			j9mem_free_memory(npeMsgData.stackMaps);
+			j9mem_free_memory(npeMsgData.unwalkedQueue);
 		} else {
 			Trc_SC_GetExtendedNPEMessage_Null_NPE_MSG(vmThread, userData.romClass, userData.romMethod, userData.bytecodeOffset);
 		}


### PR DESCRIPTION
NPE extended message generation missed `j9mem_free_memory()` calls

[Internal personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/13581/)

fixes https://github.com/ibmruntimes/Semeru-Runtimes/issues/32

Signed-off-by: Jason Feng <fengj@ca.ibm.com>