### PR TITLE
Relocate clearNonZAAPEligibleBit implementation to vm_scar.c

### DIFF
--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1000,38 +1000,6 @@ setClassLoadingConstraintLinkageError(J9VMThread *vmThread, J9Class *methodOrFie
 	vmFuncs->setCurrentExceptionUTF(vmThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, msg);
 	j9mem_free_memory(msg);
 }
-
-#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
-/**
- * Clear the non-ZAAP eligible bit for JCL natives to allow them to run on zAAP.
- *
- * @param[in] env                 The JNI interface pointer
- * @param[in] nativeClass         The class containing the native method
- * @param[in] nativeMethods       The JNI native method pointer
- * @param[in] nativeMethodCount  The count of native methods
- */
-void
-clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *nativeMethods, jint nativeMethodCount)
-{
-	J9VMThread *vmThread = (J9VMThread *) env;
-	J9JavaVM *vm = vmThread->javaVM;
-	J9InternalVMFunctions* vmFuncs = vm->internalVMFunctions;
-	const JNINativeMethod *nativeMethod = nativeMethods;
-	jint count = nativeMethodCount;
-	J9Class *j9clazz = NULL;
-
-	vmFuncs->internalEnterVMFromJNI(vmThread);
-	j9clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(nativeClass));
-
-	while (0 < count) {
-		J9Method *jniMethod = vmFuncs->findJNIMethod(vmThread, j9clazz, nativeMethod->name, nativeMethod->signature);
-		vmFuncs->atomicAndIntoConstantPool(vm, jniMethod, ~(UDATA)J9_STARTPC_NATIVE_REQUIRES_SWITCHING);
-		count -= 1;
-		nativeMethod +=1;
-	}
-	vmFuncs->internalExitVMToJNI(vmThread);
-}
-#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 
 #if JAVA_SPEC_VERSION >= 15
 void JNICALL

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -633,3 +633,35 @@ addVMSpecificDirectories(J9JavaVM *vm, UDATA *cursor, char * subdirName)
 
 	return 0;
 }
+
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+/**
+ * Clear the non-ZAAP eligible bit for JCL natives to allow them to run on zAAP.
+ *
+ * @param[in] env                 The JNI interface pointer
+ * @param[in] nativeClass         The class containing the native method
+ * @param[in] nativeMethods       The JNI native method pointer
+ * @param[in] nativeMethodCount  The count of native methods
+ */
+void
+clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *nativeMethods, jint nativeMethodCount)
+{
+	J9VMThread *vmThread = (J9VMThread *) env;
+	J9JavaVM *vm = vmThread->javaVM;
+	J9InternalVMFunctions* vmFuncs = vm->internalVMFunctions;
+	const JNINativeMethod *nativeMethod = nativeMethods;
+	jint count = nativeMethodCount;
+	J9Class *j9clazz = NULL;
+
+	vmFuncs->internalEnterVMFromJNI(vmThread);
+	j9clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(nativeClass));
+
+	while (0 < count) {
+		J9Method *jniMethod = vmFuncs->findJNIMethod(vmThread, j9clazz, nativeMethod->name, nativeMethod->signature);
+		vmFuncs->atomicAndIntoConstantPool(vm, jniMethod, ~(UDATA)J9_STARTPC_NATIVE_REQUIRES_SWITCHING);
+		count -= 1;
+		nativeMethod +=1;
+	}
+	vmFuncs->internalExitVMToJNI(vmThread);
+}
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */


### PR DESCRIPTION
The current home of `clearNonZAAPEligibleBit` implementation in java_dyn_methodhandle.c
is only compiled if `J9VM_OPT_METHOD_HANDLE` is set. Moving the implementation to vm_scar.c
as a more generic home that is always compiled, to avoid any unresolved symbol errors
during linking when `J9VM_OPT_METHOD_HANDLE` is not set.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>