### PR TITLE
Fix compiler warning

### DIFF
--- a/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
+++ b/runtime/jcl/common/jdk_internal_vm_Continuation.cpp
@@ -68,19 +68,17 @@ Java_jdk_internal_vm_Continuation_unpin(JNIEnv *env, jclass unused)
 jboolean JNICALL
 Java_jdk_internal_vm_Continuation_createContinuationImpl(JNIEnv *env, jobject continuation)
 {
-	J9VMThread *currentThread = (J9VMThread*)env;
+	J9VMThread *currentThread = (J9VMThread *)env;
 	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
-	jboolean result = JNI_FALSE;
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	j9object_t continuationObject = J9_JNI_UNWRAP_REFERENCE(continuation);
-
-	result = vmFuncs->createContinuation(currentThread, continuationObject);
+	BOOLEAN result = vmFuncs->createContinuation(currentThread, continuationObject);
 
 	vmFuncs->internalExitVMToJNI(currentThread);
 
-	return result;
+	return result ? JNI_TRUE : JNI_FALSE;
 }
 
 } /* extern "C" */


### PR DESCRIPTION
Visual Studio warns of possible data loss converting from 'UDATA' to 'jboolean'.