### PR TITLE
(0.33) NPE extended message generation missed j9mem_free_memory calls

### DIFF
--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -152,6 +152,11 @@ JVM_GetExtendedNPEMessage(JNIEnv *env, jthrowable throwableObj)
 				}
 				j9mem_free_memory(npeMsg);
 			}
+			j9mem_free_memory(npeMsgData.liveStack);
+			j9mem_free_memory(npeMsgData.bytecodeOffset);
+			j9mem_free_memory(npeMsgData.bytecodeMap);
+			j9mem_free_memory(npeMsgData.stackMaps);
+			j9mem_free_memory(npeMsgData.unwalkedQueue);
 		} else {
 			Trc_SC_GetExtendedNPEMessage_Null_NPE_MSG(vmThread, userData.romClass, userData.romMethod, userData.bytecodeOffset);
 		}


### PR DESCRIPTION
NPE extended message generation missed `j9mem_free_memory()` calls

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/15550

Signed-off-by: Jason Feng <fengj@ca.ibm.com>