### PR TITLE
Use internalRunStaticMethod to pass object pointer arguments

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -403,7 +403,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 <!--
 	NOTE: the resolution code in jclcinit.c only looks at the J9ROMClassRef->runtimeFlags to determine
-	whether or not to attempt the class load.  The flags sepcified on the methods are ignored.
+	whether or not to attempt the class load.  The flags specified on the methods are ignored.
 	The method flags are only documentation to help map which feature (as expressed on the class) requires
 	the particular method.
 
@@ -423,6 +423,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<virtualmethodref class="java/lang/ClassLoader" name="loadClass" signature="(Ljava/lang/String;)Ljava/lang/Class;"/>
 	<specialmethodref class="java/lang/Thread" name="uncaughtException" signature="(Ljava/lang/Throwable;)V"/>
 	<specialmethodref class="java/lang/Thread" name="&lt;init>" signature="(Ljava/lang/String;Ljava/lang/Object;IZ)V"/>
+	<staticmethodref class="java/lang/ClassLoader" name="findNative" signature="(Ljava/lang/ClassLoader;Ljava/lang/String;)J" versions="17-"/>
 
 	<fieldref class="java/lang/J9VMInternals$ClassInitializationLock" name="theClass" signature="Ljava/lang/Class;"/>
 

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -689,7 +689,11 @@ runJavaThread(J9VMThread *currentThread)
 void JNICALL
 runStaticMethod(J9VMThread *currentThread, U_8 *className, J9NameAndSignature *selector, UDATA argCount, UDATA *arguments)
 {
-	/* Assumes that the called method returns void and that className is a canonical UTF.
+	/* Assumes that className is a canonical UTF.
+	 * The returnValue and returnValue2 are copies of the top two stack slots when the called method returns.
+	 * On 64-bit, long values are stored in the lower-memory slot of the 2 stack slots required for longs,
+	 * so returnValue contains the return value.
+	 *
 	 * Also, the arguments must be in stack shape (ints in the low-memory half of the stack slot on 64-bit)
 	 * and contain no object pointers, as there are GC points in here before the arguments are copied to
 	 * the stack.
@@ -729,6 +733,7 @@ internalRunStaticMethod(J9VMThread *currentThread, J9Method *method, BOOLEAN ret
 	Trc_VM_internalRunStaticMethod_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
 
+	Assert_VM_false(VM_VMHelpers::classRequiresInitialization(currentThread, J9_CLASS_FROM_METHOD(method)));
 	if (buildCallInStackFrame(currentThread, &newELS, returnsObject != 0, false)) {
 		for (UDATA i = 0; i < argCount; ++i) {
 			*--currentThread->sp = arguments[i];


### PR DESCRIPTION
Added an assertion `VM_VMHelpers::classRequiresInitialization`;
Updated comments.

[An internal personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/13599/)

There was no test failure reported due to the issue being addressed. It was discovered during static code reviewing.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>