### PR TITLE
Add AVX2 to supported feature tests

### DIFF
--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -341,6 +341,7 @@ J9::X86::CPU::supports_feature_test(uint32_t feature)
       case OMR_FEATURE_X86_TM:
          return TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor() == ans;
       case OMR_FEATURE_X86_AVX:
+      case OMR_FEATURE_X86_AVX2:
       case OMR_FEATURE_X86_AVX512F:
       case OMR_FEATURE_X86_AVX512VL:
       case OMR_FEATURE_X86_AVX512BW:


### PR DESCRIPTION
Depends eclipse/omr#6617

Signed-off-by: BradleyWood <bradley.wood@ibm.com>