### PR TITLE
Check VFE1 feature instead of flag when generating Math.fma on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2423,7 +2423,7 @@ J9::Z::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGenerator *cg)
 
    if (cg->getSupportsVectorRegisters() &&
          (!node->getOpCode().isFloat() ||
-           cg->comp()->target().cpu.getSupportsVectorFacilityEnhancement1()))
+           cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1)))
       {
       // target = a*b + c
       TR::Register * c = cg->evaluate(node->getThirdChild());


### PR DESCRIPTION
Patch to use VFE1 feature instead of flag when checking if vector FMA is supported.

See discussion at https://github.com/eclipse/omr/pull/6615 as to why this is necessary.