### PR TITLE
(0.33) Update SysPropTest to work on AIX with jdk18.0.2

### DIFF
--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -47,10 +47,10 @@ public class SysPropTest
 				isWindows = true;
 			}
 
-			/* On jdk18+ with JEP 400 UTF-8 by default, the non-ascii characters in the testkey property
+			/* On jdk18 with JEP 400 UTF-8 by default, the non-ascii characters in the testkey property
 			 * are converted to UTF8 by the test (not the JVM).
 			 */
-			final byte[] expectedBytes = ((VersionCheck.major() >= 18) && !isWindows) ? inputBytesUtf8 : inputBytes;
+			final byte[] expectedBytes = ((VersionCheck.major() == 18) && !isWindows) ? inputBytesUtf8 : inputBytes;
 
 			if (argEncoding.equals("DEFAULT")) {
 				osEncoding = System.getProperty("os.encoding");
@@ -60,7 +60,7 @@ public class SysPropTest
 			 * sets os.encoding to UTF8. To replicate this behavior, on Windows use the default encoding
 			 * and not the os.encoding.
 			 */
-			if (osEncoding != null && osEncoding.length() != 0 && isWindows == false) {
+			if ((osEncoding != null) && (osEncoding.length() != 0) && !isWindows) {
 				strTestProp = new String(expectedBytes, osEncoding);
 			} else {
 				if ((argEncoding.equals("UTF-8") || argEncoding.equals("ISO-8859-1"))) {

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -28,12 +28,10 @@ import org.openj9.test.util.VersionCheck;
 public class SysPropTest
 {
 	/* TestVa&#187;lue&#161; */
-	static final byte[] inputBytes = { (byte)'T', (byte)'e', (byte)'s', (byte)'t', (byte)'V', (byte)'a', (byte)187, (byte)'l', (byte)'u', (byte)'e', (byte)161};
-	static final byte[] inputBytesUtf8 = { (byte)'T', (byte)'e', (byte)'s', (byte)'t', (byte)'V', (byte)'a', (byte)0xC2, (byte)187, (byte)'l', (byte)'u', (byte)'e', (byte)0xC2, (byte)161};
+	static final byte[] expectedBytes = { (byte)'T', (byte)'e', (byte)'s', (byte)'t', (byte)'V', (byte)'a', (byte)187, (byte)'l', (byte)'u', (byte)'e', (byte)161};
 
 	public static void main(String args[])
 	{
-		boolean isWindows = false;
 		if (args.length == 0) {
 			System.out.println("test failed");
 			return;
@@ -41,16 +39,9 @@ public class SysPropTest
 		String argEncoding = args[0];
 		/* check -Dtestkey=TestVa?lue? */
 		try {
+			boolean isWindows = System.getProperty("os.name").contains("Windows");
 			String osEncoding = "";
 			String strTestProp;
-			if (System.getProperty("os.name").contains("Windows")) {
-				isWindows = true;
-			}
-
-			/* On jdk18 with JEP 400 UTF-8 by default, the non-ascii characters in the testkey property
-			 * are converted to UTF8 by the test (not the JVM).
-			 */
-			final byte[] expectedBytes = ((VersionCheck.major() == 18) && !isWindows) ? inputBytesUtf8 : inputBytes;
 
 			if (argEncoding.equals("DEFAULT")) {
 				osEncoding = System.getProperty("os.encoding");


### PR DESCRIPTION
Cherry pick https://github.com/eclipse-openj9/openj9/pull/15292 and https://github.com/eclipse-openj9/openj9/pull/15588 for 0.33