### PR TITLE
(0.33) Remove musl license and update OpenJ9/OMR start copyright date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Product: OpenJ9
 
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 1991, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 
@@ -19,7 +19,6 @@ Subject to the following notices:
 4.      libffi is provided under the libffi license below (section E).
 5.      zlib is provided under the zlib license below (section F).
 6.      CuTest is provided under the CuTest license below (section G).
-7.      musl is provided under the musl license below (section H).
 
 You may distribute this program and materials under either the
 Eclipse Public License 2 or the Apache V2.0 License as long as you pass through
@@ -575,28 +574,6 @@ be misrepresented as being the original software.
 
 3. This notice may not be removed or altered from any source
 distribution.
-
-H. musl
-Copyright (c) 2005-2014 Rich Felker, et al.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 END OF TERMS AND CONDITIONS

--- a/longabout.html
+++ b/longabout.html
@@ -8,7 +8,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
 
-<p><em>March 30, 2022</em></p>
+<p><em>July 21, 2022</em></p>
 <h3>License</h3>
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
@@ -36,7 +36,7 @@ for informational purposes only, and you should look to the Redistributor's lice
 terms and conditions of use.</p>
 
 <h4>Eclipse OMR</h4>
-<p>Copyright (c) 2017, 2022 IBM Corp. and others</p>
+<p>Copyright (c) 1991, 2022 IBM Corp. and others</p>
 <p>
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 <p>
@@ -234,30 +234,5 @@ be misrepresented as being the original software.
 <p>
 3. This notice may not be removed or altered from any source
 distribution.
-<h4>
-musl 1.1.4
-</h4>
-c<p>
-Copyright &copy; 2005-2014 Rich Felker, et al.
-</p><p>
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-</p><p>
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-</p><p>
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</p>
 </body>
 </html>


### PR DESCRIPTION
Use of musl was removed with https://github.com/eclipse-openj9/openj9/pull/3952

The earliest copyright date in OpenJ9/OMR source files is 1991 not 2017.

Cherry pick https://github.com/eclipse-openj9/openj9/pull/15597 for 0.33