### PR TITLE
Abstract JIT GPR spill area

### DIFF
--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -364,8 +364,8 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitVRs", offsetof(J9CInterpreterStackFrame, jitVRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_preservedVRs", offsetof(J9CInterpreterStackFrame, preservedVRs)) |
 #endif /* J9VM_ENV_DATA64 */
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitCR", offsetof(J9CInterpreterStackFrame, jitCR)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitLR", offsetof(J9CInterpreterStackFrame, jitLR)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitCR", offsetof(J9CInterpreterStackFrame, jitGPRs.jitCR)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitLR", offsetof(J9CInterpreterStackFrame, jitGPRs.jitLR)) |
 #if !defined(LINUX) || defined(J9VM_ENV_DATA64)
 			/* Everyone but Linux PPC 32 */
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_currentTOC", offsetof(J9CInterpreterStackFrame, currentTOC)) |
@@ -394,23 +394,23 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitGPRs", offsetof(J9CInterpreterStackFrame, jitGPRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitFPRs", offsetof(J9CInterpreterStackFrame, jitFPRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_maskRegisters", offsetof(J9CInterpreterStackFrame, maskRegisters)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rax", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rax)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rbx", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rbx)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rcx", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rcx)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rdx", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rdx)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rdi", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rdi)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rsi", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rsi)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rbp", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rbp)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rsp", offsetof(J9CInterpreterStackFrame, jitGPRs.named.rsp)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rax", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rax)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rbx", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rbx)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rcx", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rcx)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rdx", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rdx)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rdi", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rdi)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rsi", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rsi)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rbp", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rbp)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rsp", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rsp)) |
 #if defined(J9VM_ENV_DATA64)
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r8", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r8)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r9", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r9)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r10", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r10)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r11", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r11)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r12", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r12)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r13", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r13)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r14", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r14)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r15", offsetof(J9CInterpreterStackFrame, jitGPRs.named.r15)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r8", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r8)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r9", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r9)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r10", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r10)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r11", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r11)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r12", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r12)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r13", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r13)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r14", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r14)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_r15", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.r15)) |
 #if defined(WIN32)
 			/* Windows x86-64 */
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_preservedFPRs", offsetof(J9CInterpreterStackFrame, preservedFPRs)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5739,6 +5739,68 @@ typedef struct J9JITWatchedStaticFieldData {
 #error Math is depending on J9_INLINE_JNI_MAX_ARG_COUNT being 32
 #endif
 
+typedef struct J9JITGPRSpillArea {
+#if defined(J9VM_ARCH_S390)
+	U_8 jitGPRs[16 * 8];	/* r0-r15 full 8-byte */
+#elif defined(J9VM_ARCH_POWER) /* J9VM_ARCH_S390 */
+	UDATA jitGPRs[32];	/* r0-r31 */
+	UDATA jitCR;
+	UDATA jitLR;
+#elif defined(J9VM_ARCH_ARM) /* J9VM_ARCH_POWER */
+#if defined(J9VM_ENV_DATA64)
+	/* ARM 64 */
+#error ARM 64 unsupported
+#else /* J9VM_ENV_DATA64 */
+	/* ARM 32 */
+	UDATA jitGPRs[16];	/* r0-r15 */
+#endif /* J9VM_ENV_DATA64 */
+#elif defined(J9VM_ARCH_AARCH64) /* J9VM_ARCH_ARM */
+	UDATA jitGPRs[32]; /* x0-x31 */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_AARCH64 */
+	UDATA jitGPRs[32];	/* x0-x31 */
+#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_RISCV */
+#if defined(J9VM_ENV_DATA64)
+	union {
+		UDATA numbered[16];
+		struct {
+			UDATA rax;
+			UDATA rbx;
+			UDATA rcx;
+			UDATA rdx;
+			UDATA rdi;
+			UDATA rsi;
+			UDATA rbp;
+			UDATA rsp;
+			UDATA r8;
+			UDATA r9;
+			UDATA r10;
+			UDATA r11;
+			UDATA r12;
+			UDATA r13;
+			UDATA r14;
+			UDATA r15;
+		} named;
+	} jitGPRs;
+#else /* J9VM_ENV_DATA64 */
+	union {
+		UDATA numbered[8];
+		struct {
+			UDATA rax;
+			UDATA rbx;
+			UDATA rcx;
+			UDATA rdx;
+			UDATA rdi;
+			UDATA rsi;
+			UDATA rbp;
+			UDATA rsp;
+		} named;
+	} jitGPRs;
+#endif /* J9VM_ENV_DATA64 */
+#else /* J9VM_ARCH_X86 */
+#error Unknown architecture
+#endif /* J9VM_ARCH_X86 */
+} J9JITGPRSpillArea;
+
 typedef struct J9CInterpreterStackFrame {
 #if defined(J9VM_ARCH_S390)
 #if defined(J9ZOS390)
@@ -5780,7 +5842,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	U_8 preservedFPRs[8 * 8]; /* fp8-fp15 - callee saves in own frame */
 #endif /* J9ZOS390 */
-	U_8 jitGPRs[16 * 8]; /* r0-r15 full 8-byte */
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[16 * 8]; /* f0-f15 */
 	U_8 jitVRs[32 * 16]; /* v0-v31 */
 #elif defined(J9VM_ARCH_POWER) /* J9VM_ARCH_S390 */
@@ -5796,9 +5858,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA reserved;
 	UDATA currentTOC; /* callee saves incoming TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
-	UDATA jitGPRs[32]; /* r0-r31 */
-	UDATA jitCR;
-	UDATA jitLR;
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 #if defined(J9VM_ENV_DATA64)
 	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
@@ -5822,9 +5882,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA preservedLR; /* callee saves in caller frame */
 	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
-	UDATA jitGPRs[32]; /* r0-r31 */
-	UDATA jitCR;
-	UDATA jitLR;
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
 	UDATA align[6];
@@ -5843,9 +5901,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA reserved;
 	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
-	UDATA jitGPRs[32]; /* r0-r31 */
-	UDATA jitCR;
-	UDATA jitLR;
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
 	UDATA align[4];
@@ -5865,9 +5921,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA backChain; /* caller SP */
 	UDATA preservedLR; /* callee saves in caller frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
-	UDATA jitGPRs[32]; /* r0-r31 */
-	UDATA jitCR;
-	UDATA jitLR;
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA preservedCR; /* callee saves in own frame */
 	UDATA preservedGPRs[19]; /* r13-r31 */
@@ -5883,48 +5937,28 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA preservedGPRs[9]; /* r4-r11 and r14 */
 	UDATA align[1];
 	U_8 preservedFPRs[8 * 8]; /* fpr8-15 */
-	UDATA jitGPRs[16]; /* r0-r15 */
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[16 * 8]; /* fpr0-15 */
 #endif /* J9VM_ENV_DATA64 */
 #elif defined(J9VM_ARCH_AARCH64) /* J9VM_ARCH_ARM */
 	UDATA preservedGPRs[12]; /* x19-x30 */
 	U_8 preservedFPRs[8 * 8]; /* v8-15 */
-	UDATA jitGPRs[32]; /* x0-x31 */
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 16]; /* v0-v31 */
-#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_ARM */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_AARCH64 */
 	UDATA preservedGPRs[13];   /* x8, x9 and x18-x27 and ra */
 	U_8 preservedFPRs[12 * 8]; /* f8, f9 and f18-f27 */
-	UDATA jitGPRs[32];         /* x0-x31 */
+	J9JITGPRSpillArea jitGPRs;
 	U_8 jitFPRs[32 * 8];       /* f0-f31 */
 	U_8 padding[8]; /* padding to 16-byte boundary */
-#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_AARCH64 */
+#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_RISCV */
 #if defined(J9VM_ENV_DATA64) && defined(WIN32)
 	UDATA arguments[4]; /* outgoing arguments shadow */
 #endif /*J9VM_ENV_DATA64 && WIN32*/
 	UDATA vmStruct;
 	UDATA machineBP;
 #if defined(J9VM_ENV_DATA64)
-	union {
-		UDATA numbered[16];
-		struct {
-			UDATA rax;
-			UDATA rbx;
-			UDATA rcx;
-			UDATA rdx;
-			UDATA rdi;
-			UDATA rsi;
-			UDATA rbp;
-			UDATA rsp;
-			UDATA r8;
-			UDATA r9;
-			UDATA r10;
-			UDATA r11;
-			UDATA r12;
-			UDATA r13;
-			UDATA r14;
-			UDATA r15;
-		} named;
-	} jitGPRs;
+	J9JITGPRSpillArea jitGPRs;
 #if defined(WIN32)
 	/* Windows x86-64
 	 *
@@ -5954,19 +5988,7 @@ typedef struct J9CInterpreterStackFrame {
 	 *
 	 * Stack is forcibly aligned to 16 after pushing EBP
 	 */
-	union {
-		UDATA numbered[8];
-		struct {
-			UDATA rax;
-			UDATA rbx;
-			UDATA rcx;
-			UDATA rdx;
-			UDATA rdi;
-			UDATA rsi;
-			UDATA rbp;
-			UDATA rsp;
-		} named;
-	} jitGPRs;
+	J9JITGPRSpillArea jitGPRs;
 	UDATA align1[2];
 	U_8 jitFPRs[8 * 64]; /* zmm0-7 512-bit */
 	U_8 maskRegisters[8 * 8]; /* k0-k7 */


### PR DESCRIPTION
Move inline JIT GPR spill area declaration from J9CInterpreterStackFrame
into new struct J9JITGPRSpillArea.

Related: #15464

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>