### PR TITLE
Loom: GC Scan Continuation Object

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -87,7 +87,8 @@ J9::ClassEnv::isClassSpecialForStackAllocation(TR_OpaqueClassBlock * clazz)
    const UDATA mask = (J9AccClassReferenceWeak |
                        J9AccClassReferenceSoft |
                        J9AccClassFinalizeNeeded |
-                       J9AccClassOwnableSynchronizer);
+                       J9AccClassOwnableSynchronizer |
+                       J9AccClassContinuation );
 
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1588,7 +1588,7 @@ UDATA TR_J9VMBase::constClassFlagsPublic()      {return J9AccPublic;}
 
 int32_t TR_J9VMBase::getFlagValueForPrimitiveTypeCheck()        {return J9AccClassInternalPrimitiveType;}
 int32_t TR_J9VMBase::getFlagValueForArrayCheck()                {return J9AccClassArray;}
-int32_t TR_J9VMBase::getFlagValueForFinalizerCheck()            {return J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer;}
+int32_t TR_J9VMBase::getFlagValueForFinalizerCheck()            {return J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation;}
 
 
 UDATA TR_J9VMBase::getGCForwardingPointerOffset()               {
@@ -6497,6 +6497,13 @@ TR_J9VMBase::isOwnableSyncClass(TR_OpaqueClassBlock *clazz)
    return ((J9CLASS_FLAGS(j9class) & J9AccClassOwnableSynchronizer) != 0);
    }
 
+bool
+TR_J9VMBase::isContinuationClass(TR_OpaqueClassBlock *clazz)
+   {
+   J9Class* j9class = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+   return ((J9CLASS_FLAGS(j9class) & J9AccClassContinuation) != 0);
+   }
+
 const char *
 TR_J9VMBase::getByteCodeName(uint8_t opcode)
    {
@@ -6831,7 +6838,7 @@ TR_J9VM::isPublicClass(TR_OpaqueClassBlock * clazz)
 bool
 TR_J9VMBase::hasFinalizer(TR_OpaqueClassBlock * classPointer)
    {
-   return (J9CLASS_FLAGS(TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer)) & (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer)) != 0;
+   return (J9CLASS_FLAGS(TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer)) & (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)) != 0;
    }
 
 uintptr_t

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1289,6 +1289,8 @@ public:
    virtual bool isOwnableSyncClass(TR_OpaqueClassBlock *clazz);
    const char *getJ9MonitorName(J9ThreadMonitor* monitor);
 
+   virtual bool  isContinuationClass(TR_OpaqueClassBlock *clazz);
+
    virtual TR_J9SharedCache *sharedCache() { return _sharedCache; }
    virtual void              freeSharedCache();
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1397,7 +1397,7 @@ TR_J9ServerVM::hasFinalizer(TR_OpaqueClassBlock *clazz)
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
 
-   return ((classDepthAndFlags & (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer)) != 0);
+   return ((classDepthAndFlags & (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)) != 0);
    }
 
 uintptr_t
@@ -1588,6 +1588,16 @@ TR_J9ServerVM::isOwnableSyncClass(TR_OpaqueClassBlock *clazz)
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
 
    return ((classDepthAndFlags & J9AccClassOwnableSynchronizer) != 0);
+   }
+
+bool
+TR_J9ServerVM::isContinuationClass(TR_OpaqueClassBlock *clazz)
+   {
+   uintptr_t classDepthAndFlags = 0;
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
+
+   return ((classDepthAndFlags & J9AccClassContinuation) != 0);
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -171,6 +171,7 @@ public:
    virtual void revertToInterpreted(TR_OpaqueMethodBlock *method) override;
    virtual void * getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *clazz) override;
    virtual bool isOwnableSyncClass(TR_OpaqueClassBlock *clazz) override;
+   virtual bool isContinuationClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getClassFromMethodBlock(TR_OpaqueMethodBlock *method) override;
    virtual U_8 * fetchMethodExtendedFlagsPointer(J9Method *method) override;
    virtual void * getStaticHookAddress(int32_t event) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -97,7 +97,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 40;
+   static const uint16_t MINOR_NUMBER = 41;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/gc_api/HeapIteratorAPI.cpp
+++ b/runtime/gc_api/HeapIteratorAPI.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -402,12 +402,12 @@ j9mm_iterate_object_slots(
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 	case GC_ObjectModel::SCAN_CLASS_OBJECT:
 	case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 	case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 		returnCode = iterateMixedObjectSlots(javaVM, objectPtr, object, flags, func, userData);
 		break;
-
 	case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
 		returnCode = iterateArrayObjectSlots(javaVM, objectPtr, object, flags, func, userData);
 		if (JVMTI_ITERATION_CONTINUE == returnCode) {

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -60,6 +60,7 @@ protected:
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	UDATA _referenceLinkOffset; /** Offset within java/lang/ref/Reference of the reference link field */
 	UDATA _ownableSynchronizerLinkOffset; /** Offset within java/util/concurrent/locks/AbstractOwnableSynchronizer of the ownable synchronizer link field */
+	UDATA _continuationLinkOffset; /** Offset within java/lang/VirtualThread$VThreadContinuation (jdk/internal/vm/Continuation) of the continuation link field */
 public:
 
 	/* member function */
@@ -491,6 +492,26 @@ public:
 	}
 
 	/**
+	 * Set the continuationLink link field of the specified reference object to value.
+	 * @param object the object to modify
+	 * @param value the value to store into the object's reference link field
+	 */
+	void setContinuationLink(j9object_t object, j9object_t value);
+
+	/**
+	 * Fetch the continuationLink link field of the specified reference object.
+	 * @param object the object to read
+	 * @return the value stored in the object's reference link field
+	 */
+	j9object_t getContinuationLink(j9object_t object)
+	{
+		UDATA linkOffset = _continuationLinkOffset;
+		fj9object_t *continuationLink = (fj9object_t*)((UDATA)object + linkOffset);
+		GC_SlotObject slot(_extensions->getOmrVM(), continuationLink);
+		return slot.readReferenceFromSlot();
+	}
+
+	/**
 	 * Implementation of the JNI GetPrimitiveArrayCritical API.
 	 * See the JNI spec for full details.
 	 *
@@ -592,6 +613,7 @@ public:
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		, _referenceLinkOffset(UDATA_MAX)
 		, _ownableSynchronizerLinkOffset(UDATA_MAX)
+		, _continuationLinkOffset(UDATA_MAX)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -351,6 +351,7 @@ MM_ReferenceChainWalker::scanObject(J9Object *objectPtr)
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 	case GC_ObjectModel::SCAN_CLASS_OBJECT:
 	case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		scanMixedObject(objectPtr);

--- a/runtime/gc_glue_java/CMakeLists.txt
+++ b/runtime/gc_glue_java/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@ set(j9vm_gc_glue_sources
 	${CMAKE_CURRENT_SOURCE_DIR}/ConcurrentSafepointCallbackJava.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/EnvironmentDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/GlobalCollectorDelegate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/HeapWalkerDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/JNICriticalRegion.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingSchemeRootClearer.cpp

--- a/runtime/gc_glue_java/CompactDelegate.cpp
+++ b/runtime/gc_glue_java/CompactDelegate.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,6 +82,7 @@ MM_CompactDelegate::verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap)
 			case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 			case GC_ObjectModel::SCAN_MIXED_OBJECT:
 			case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+			case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 			case GC_ObjectModel::SCAN_CLASS_OBJECT:
 			case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 			case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,7 @@ private:
 	MM_CompactScheme *_compactScheme;
 public:
 
+	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t fromObject, omrobjectptr_t *slot);
 	/**
 	 * Perform fixup for a single object
 	 * @param env[in] the current thread
@@ -73,6 +74,7 @@ private:
 	 */
 	void fixupFlattenedArrayObject(omrobjectptr_t objectPtr);
 
+	void fixupContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	/**
 	 * Called whenever a ownable synchronizer object is fixed up during compact. Places the object on the thread-specific buffer of gc work thread.
 	 * @param env -- current thread environment
@@ -80,5 +82,11 @@ private:
 	 */
 	MMINLINE void addOwnableSynchronizerObjectInList(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 };
+
+typedef struct StackIteratorData4CompactSchemeFixupObject {
+	MM_CompactSchemeFixupObject *compactSchemeFixupObject;
+	MM_EnvironmentBase *env;
+	J9Object *fromObject;
+} StackIteratorData4CompactSchemeFixupObject;
 
 #endif /* COMPACTSCHEMEOBJECTFIXUP_HPP_ */

--- a/runtime/gc_glue_java/HeapWalkerDelegate.hpp
+++ b/runtime/gc_glue_java/HeapWalkerDelegate.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(HEAPWALKERDELEGATE_HPP_)
+#define HEAPWALKERDELEGATE_HPP_
+
+#include "EnvironmentBase.hpp"
+#include "GCExtensionsBase.hpp"
+
+class MM_HeapWalker;
+typedef void (*MM_HeapWalkerSlotFunc)(OMR_VM *, omrobjectptr_t *, void *, uint32_t);
+
+/**
+ * Provides language-specific support for heap walking.
+ */
+class MM_HeapWalkerDelegate
+{
+	/*
+	 * Data members
+	 */
+private:
+
+protected:
+	GC_ObjectModel *_objectModel;
+	MM_HeapWalker *_heapWalker;
+
+public:
+
+	/*
+	 * Function members
+	 */
+private:
+	void doContinuationObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData);
+protected:
+
+public:
+	/**
+	 * Initialize the delegate.
+	 *
+	 * @param env environment for calling thread
+	 * @param heapWalker the MM_HeapWalker that the delegate is bound to
+	 * @return true if delegate initialized successfully
+	 */
+	MMINLINE bool
+	initialize(MM_EnvironmentBase *env, MM_HeapWalker *heapWalker)
+	{
+		_objectModel = &(env->getExtensions()->objectModel);
+		_heapWalker = heapWalker;
+		return true;
+	}
+
+	/**
+	 * This method is used to do language specific treatment for the Object found during heap walking
+	 *
+	 * This method is informational, no specific action is required.
+	 *
+	 * @param omrVMThread the calling thread
+	 * @param objectPtr heap object ptr
+	 */
+	void objectSlotsDo(OMR_VMThread *omrVMThread, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData);
+
+	/**
+	 * Constructor.
+	 */
+	MMINLINE MM_HeapWalkerDelegate()
+		: _objectModel(NULL)
+		, _heapWalker(NULL)
+	{ }
+};
+
+typedef struct StackIteratorData4HeapWalker {
+	MM_HeapWalker *heapWalker;
+	MM_EnvironmentBase *env;
+	omrobjectptr_t fromObject;
+	MM_HeapWalkerSlotFunc function;
+	void *userData;
+} StackIteratorData4HeapWalker;
+
+#endif /* HEAPWALKERDELEGATE_HPP_ */

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@
 #include "RealtimeMarkingScheme.hpp"
 #include "ReferenceObjectBuffer.hpp"
 #include "Scheduler.hpp"
+#include "StackSlotValidator.hpp"
 
 class MM_HeapRegionDescriptorRealtime;
 class MM_RealtimeMarkingSchemeRootMarker;
@@ -172,6 +173,9 @@ public:
 	void checkReferenceBuffer(MM_EnvironmentRealtime *env);
 	void setUnmarkedImpliesCleared();
 	void unsetUnmarkedImpliesCleared();
+
+	UDATA scanContinuationObject(MM_EnvironmentRealtime *env, J9Object *objectPtr);
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	MMINLINE void
 	markClassOfObject(MM_EnvironmentRealtime *env, J9Object *objectPtr)
@@ -217,6 +221,9 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 			pointersScanned = scanMixedObject(env, objectPtr);
+			break;
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
+			pointersScanned = scanContinuationObject(env, objectPtr);
 			break;
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
 			pointersScanned = scanPointerArrayObject(env, (J9IndexableObject *)objectPtr);
@@ -553,6 +560,12 @@ private:
 	friend class MM_RealtimeGC;
 	friend class MM_RealtimeMarkingSchemeRootClearer;
 };
+
+typedef struct StackIteratorData4RealtimeMarkingScheme {
+	MM_RealtimeMarkingScheme *realtimeMarkingScheme;
+	MM_EnvironmentRealtime *env;
+	J9Object *fromObject;
+} StackIteratorData4RealtimeMarkingScheme;
 
 #endif /* defined(J9VM_GC_REALTIME) */
 

--- a/runtime/gc_glue_java/ObjectIterator.hpp
+++ b/runtime/gc_glue_java/ObjectIterator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corp. and others
+ * Copyright (c) 2014, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,6 +71,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 			return _mixedObjectIterator.initialize(_omrVM, objectPtr);
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
@@ -98,6 +99,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 			return _mixedObjectIterator.nextSlot();
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
@@ -126,6 +128,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 			return _mixedObjectIterator.restore(objectIteratorState);
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
@@ -153,6 +156,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 			return _mixedObjectIterator.save(objectIteratorState);
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@
 
 #include "j9.h"
 #include "omrcfg.h"
+#include "omrgcconsts.h"
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 
@@ -114,6 +115,7 @@ private:
 	 * prevents scavenging. Percolate collect instead.
 	 */
 	bool private_shouldPercolateGarbageCollect_activeJNICriticalRegions(MM_EnvironmentBase *envBase);
+	bool doContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, MM_ScavengeScanReason reason);
 
 protected:
 public:
@@ -124,6 +126,8 @@ public:
 	void mainThreadGarbageCollect_scavengeComplete(MM_EnvironmentBase *envBase);
 	void mainThreadGarbageCollect_scavengeSuccess(MM_EnvironmentBase *envBase);
 	bool internalGarbageCollect_shouldPercolateGarbageCollect(MM_EnvironmentBase *envBase, PercolateReason *reason, U_32 *gcCode);
+	GC_ObjectScanner *getObjectScanner(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, void *allocSpace, uintptr_t flags, MM_ScavengeScanReason reason, bool *shouldRemember);
+	/* TODO:it is old API just for cross dependency , need to remove at second stage merge */
 	GC_ObjectScanner *getObjectScanner(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, void *allocSpace, uintptr_t flags);
 	void flushReferenceObjects(MM_EnvironmentStandard *env);
 	bool hasIndirectReferentsInNewSpace(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
@@ -169,6 +173,7 @@ public:
 	void poisonSlots(MM_EnvironmentBase *env);
 	void healSlots(MM_EnvironmentBase *env);
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
+	void doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember);
 
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);
@@ -177,4 +182,11 @@ public:
 };
 
 #endif /* OMR_GC_MODRON_SCAVENGER */
+typedef struct StackIteratorData4Scavenge {
+	MM_ScavengerDelegate *scavengerDelegate;
+	MM_EnvironmentStandard *env;
+	MM_ScavengeScanReason reason;
+	bool *shouldRemember;
+} StackIteratorData4Scavenge;
+
 #endif /* SCAVENGERDELEGATEJAVA_HPP_ */

--- a/runtime/gc_include/HeapIteratorAPI.h
+++ b/runtime/gc_include/HeapIteratorAPI.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,8 @@ extern "C" {
 #define SCAN_REMEBERED_SET 0x08000
 #define SCAN_JVMTI_OBJECT_TAG_TABLE	0x10000
 #define SCAN_OWNABLE_SYNCHRONIZER 0x20000
-#define SCAN_ALL 0x3FFFF
+#define SCAN_CONTINUATION 0x40000
+#define SCAN_ALL 0x7FFFF
 
 #define HEAP_ROOT_SLOT_DESCRIPTOR_OBJECT 0
 #define HEAP_ROOT_SLOT_DESCRIPTOR_CLASS 1

--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,6 +130,7 @@ typedef jvmtiIterationControl J9MODRON_REFERENCE_CHAIN_WALKER_CALLBACK(J9Object 
 #define J9GC_ROOT_TYPE_STACK_SLOT 20
 #define J9GC_ROOT_TYPE_JVMTI_TAG_REF 21
 #define J9GC_ROOT_TYPE_OWNABLE_SYNCHRONIZER_OBJECT 22
+#define J9GC_ROOT_TYPE_CONTINUATION_OBJECT 23
 
 #define J9GC_REFERENCE_TYPE_UNKNOWN -1 /**< reference to an object that fell through a default state in an iterator */
 #define J9GC_REFERENCE_TYPE_FIELD -2	/**< field reference to an object */

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -251,6 +251,7 @@ MM_RealtimeAccessBarrier::validateWriteBarrier(J9VMThread *vmThread, J9Object *d
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 	case GC_ObjectModel::SCAN_CLASS_OBJECT:
 	case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 	case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:

--- a/runtime/gc_structs/VMThreadStackSlotIterator.hpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,14 @@ public:
 	static void scanSlots(
 			J9VMThread *vmThread,
 			J9VMThread *walkThread,
+			void *userData,
+			J9MODRON_OSLOTITERATOR *oSlotIterator,
+			bool includeStackFrameClassReferences,
+			bool trackVisibleFrameDepth);
+
+	static void scanSlots(
+			J9VMThread *vmThread,
+			j9object_t continuationObjectPtr,
 			void *userData,
 			J9MODRON_OSLOTITERATOR *oSlotIterator,
 			bool includeStackFrameClassReferences,

--- a/runtime/gc_trace_vlhgc/TgcInterRegionReferences.cpp
+++ b/runtime/gc_trace_vlhgc/TgcInterRegionReferences.cpp
@@ -104,6 +104,7 @@ tgcHookReportInterRegionReferenceCounting(J9HookInterface** hookInterface, UDATA
 				case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 				case GC_ObjectModel::SCAN_MIXED_OBJECT:
 				case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
+				case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 				case GC_ObjectModel::SCAN_CLASS_OBJECT:
 				case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 				{

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -301,6 +301,8 @@ private:
 	 */
 	MMINLINE void scanOwnableSynchronizerObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 
+
+	MMINLINE void scanContinuationObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 	/**
 	 * Called whenever a ownable synchronizer object is scaned during CopyForwardScheme. Places the object on the thread-specific buffer of gc work thread.
 	 * @param env -- current thread environment
@@ -1124,6 +1126,7 @@ public:
 	}
 
 	void abandonTLHRemainders(MM_EnvironmentVLHGC *env);
+	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 
 	friend class MM_CopyForwardGMPCardCleaner;
 	friend class MM_CopyForwardNoGMPCardCleaner;
@@ -1132,5 +1135,11 @@ public:
 	friend class MM_CopyForwardSchemeRootClearer;
 	friend class MM_CopyForwardSchemeAbortScanner;
 };
+
+typedef struct StackIteratorData4CopyForward {
+	MM_CopyForwardScheme *copyForwardScheme;
+	MM_EnvironmentVLHGC *env;
+	J9Object *fromObject;
+} StackIteratorData4CopyForward;
 
 #endif /* COPYFORWARDSCHEME_HPP_ */

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,6 +83,7 @@ private:
 	 */
 	bool scrubMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr);
 
+	bool scrubContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr);
 	/**
 	 * Scrub a SCAN_POINTER_ARRAY_OBJECT.
 	 * @param env[in] the current thread
@@ -104,16 +105,6 @@ private:
 	 */
 	bool scrubClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object *classLoaderObject);
 
-	/**
-	 * Given the specified reference from fromObject to toObject, determine if the card can
-	 * be scrubbed (marked clean).
-	 * @param env[in] the current thread
-	 * @param fromObject[in] the object being scanned
-	 * @param toObject[in] an object referenced from fromObject
-	 * @return true if the card may be scrubbed, false if cleaning is required
-	 */
-	bool mayScrubReference(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object* toObject);
-	
 	/**
 	 * Scans the marked objects in the [lowAddress..highAddress) range to determine if these objects need to be scanned during
 	 * card cleaning. The receiver uses its _markMap to determine which objects in the range are marked.
@@ -180,6 +171,16 @@ public:
 	 */
 	UDATA getScrubbedObjects() { return _statistics._scrubbedObjects; }
 
+	/**
+	 * Given the specified reference from fromObject to toObject, determine if the card can
+	 * be scrubbed (marked clean).
+	 * @param env[in] the current thread
+	 * @param fromObject[in] the object being scanned
+	 * @param toObject[in] an object referenced from fromObject
+	 * @return true if the card may be scrubbed, false if cleaning is required
+	 */
+	bool mayScrubReference(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object* toObject);
+
 };
 
 class MM_ParallelScrubCardTableTask : public MM_ParallelTask
@@ -224,5 +225,11 @@ public:
 	};
 };
 
+typedef struct StackIteratorData4GlobalMarkCardScrubber {
+	MM_GlobalMarkCardScrubber *globalMarkCardScrubber;
+	MM_EnvironmentVLHGC *env;
+	J9Object *fromObject;
+	bool *doScrub;
+} StackIteratorData4GlobalMarkCardScrubber;
 
 #endif /* GLOBALMARKCARDSCRUBBER_HPP_ */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -313,6 +313,8 @@ private:
 	 */
 	void scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 	
+	void scanContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
+
 	/**
 	 * Scan the specified instance of java.lang.Class.
 	 * 1. Scan the object itself, as in scanMixedObject()
@@ -504,6 +506,7 @@ public:
 	 */
 	void flushBuffers(MM_EnvironmentVLHGC *env);
 	
+	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 	/**
 	 * Create a GlobalMarkingScheme object.
 	 */
@@ -530,5 +533,11 @@ public:
 	friend class MM_GlobalMarkingSchemeRootMarker;
 	friend class MM_GlobalMarkingSchemeRootClearer;
 };
+
+typedef struct StackIteratorData4GlobalMarkingScheme {
+	MM_GlobalMarkingScheme *globalMarkingScheme;
+	MM_EnvironmentVLHGC *env;
+	J9Object *fromObject;
+} StackIteratorData4GlobalMarkingScheme;
 
 #endif /* GLOBALMARKINGSCHEME_HPP_ */

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1750,6 +1750,7 @@ MM_IncrementalGenerationalGC::verifyMarkMapClosure(MM_EnvironmentVLHGC *env, MM_
 				case GC_ObjectModel::SCAN_MIXED_OBJECT:
 				case GC_ObjectModel::SCAN_CLASS_OBJECT:
 				case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
+				case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
 				{
 					Assert_MM_true(_extensions->classLoaderRememberedSet->isInstanceRemembered(env, object));
 					

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -201,6 +201,7 @@ private:
 	MMINLINE void preObjectMove(MM_EnvironmentVLHGC* env, J9Object *objectPtr, UDATA *objectSizeAfterMove);
 	MMINLINE void postObjectMove(MM_EnvironmentVLHGC* env, J9Object *newLocation, J9Object *objectPtr);
 	void fixupMixedObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
+	void fixupContinuationObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
 	void fixupClassObject(MM_EnvironmentVLHGC* env, J9Object *classObject, J9MM_FixupCache *cache);
 	void fixupClassLoaderObject(MM_EnvironmentVLHGC* env, J9Object *classLoaderObject, J9MM_FixupCache *cache);
 	void fixupPointerArrayObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
@@ -596,12 +597,19 @@ public:
 	 * @param workStackBaseHighPriority[in/out] The "high priority" work stack base.  This reference parameter will be updated before the function returns is region is high priority
 	 */
 	void pushRegionOntoWorkStack(MM_HeapRegionDescriptorVLHGC **workStackBase, MM_HeapRegionDescriptorVLHGC **workStackBaseHighPriority, MM_HeapRegionDescriptorVLHGC *region);
+	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slot);
 
 	friend class MM_WriteOnceCompactFixupRoots;
 	friend class MM_ParallelWriteOnceCompactTask;
 };
 
 #endif /* J9VM_GC_MODRON_COMPACTION */
+
+typedef struct StackIteratorData4WriteOnceCompactor {
+	MM_WriteOnceCompactor *writeOnceCompactor;
+	MM_EnvironmentVLHGC *env;
+	J9Object *fromObject;
+} StackIteratorData4WriteOnceCompactor;
 
 #endif /* COMPACTSCHEMEVLHGC_HPP_ */
 

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1115,6 +1115,7 @@ mapEventType(J9JVMTIHeapData * data, IDATA type, jint index, j9object_t referrer
 		case J9GC_ROOT_TYPE_STRING_TABLE:
 		case J9GC_ROOT_TYPE_REMEMBERED_SET:
 		case J9GC_ROOT_TYPE_OWNABLE_SYNCHRONIZER_OBJECT:
+		case J9GC_ROOT_TYPE_CONTINUATION_OBJECT:
 			event->type = J9JVMTI_HEAP_EVENT_NONE_NOFOLLOW;
 			event->refKind = JVMTI_HEAP_REFERENCE_OTHER;
 			break;

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -328,6 +328,7 @@ mapEventType(J9VMThread *vmThread, J9JVMTIObjectIteratorData * data, IDATA type,
 		case J9GC_ROOT_TYPE_STRING_TABLE:
 		case J9GC_ROOT_TYPE_REMEMBERED_SET:
 		case J9GC_ROOT_TYPE_OWNABLE_SYNCHRONIZER_OBJECT:
+		case J9GC_ROOT_TYPE_CONTINUATION_OBJECT:
 			event.type = J9JVMTI_HEAP_EVENT_NONE_NOFOLLOW;
 			event.rootKind = JVMTI_HEAP_ROOT_OTHER;
 			break;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2046,9 +2046,20 @@ exit:
 	{
 		UDATA rc = J9_STACKWALK_RC_NONE;
 #if JAVA_SPEC_VERSION >= 19
-		rc = walkContinuationStackFrames(vmThread, continuationObject, walkState);
+		rc = vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuationObject, walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		return rc;
+	}
+
+	static VMINLINE bool
+	needScanStacksForContinuation(J9VMThread *vmThread, j9object_t continuationObject) {
+		bool needScan = false;
+#if JAVA_SPEC_VERSION >= 19
+		jboolean started = J9VMJDKINTERNALVMCONTINUATION_STARTED(vmThread, continuationObject);
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, continuationObject);
+		needScan = started && (NULL != continuation);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+		return needScan;
 	}
 };
 

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -65,8 +65,9 @@
 #define J9AccClassInternalPrimitiveType 0x20000
 #define J9AccClassIsContended 0x1000000
 #define J9AccClassOwnableSynchronizer 0x200000
-#define J9AccClassUnused200 0x200
+#define J9AccClassContinuation 0x1000000
 #define J9AccClassUnused400 0x400
+#define J9AccClassUnused200 0x200
 #define J9AccClassRAMArray 0x10000
 #define J9AccClassRAMShapeShift 0x10
 #define J9AccClassReferenceMask 0x30000000
@@ -132,7 +133,7 @@
 #define J9StaticFieldRefPutResolved 0x10
 #define J9StaticFieldRefFinal 0x20
 #define J9StaticFieldRefFlagBits 0x3F
-#define J9_JAVA_CLASS_FINALIZER_CHECK_MASK (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer)
+#define J9_JAVA_CLASS_FINALIZER_CHECK_MASK (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)
 #define J9_JAVA_MODIFIERS_SPECIAL_OBJECT (J9AccClassFinalizeNeeded | J9AccClassReferenceMask)
 
 #endif /*J9JAVAACCESSFLAGS_H */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3115,7 +3115,7 @@ fail:
 			 *            + AccClassHasJDBCNatives (set during native method binding, not inherited)
 			 *           + AccClassGCSpecial (set during internal class load hook and inherited)
 			 *
-			 *         + AccClassIsContended (from romClass->extraModifiers and inherited)
+			 *         + AccClassContinuation (set during internal class load hook and inherited)
 			 *        + AccClassHasFinalFields (from romClass->extraModifiers and inherited)
 			 *       + AccClassHotSwappedOut (not set during creation, not inherited)
 			 *      + AccClassDying (not set during creation, inherited but that can't actually occur)
@@ -3192,7 +3192,7 @@ fail:
 
 				/* fill in class depth */
 				tempClassDepthAndFlags |= superclass->classDepthAndFlags;
-				tempClassDepthAndFlags &= ~(J9AccClassHotSwappedOut | J9AccClassHasBeenOverridden | J9AccClassHasJDBCNatives | J9AccClassRAMArray | (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift));
+				tempClassDepthAndFlags &= ~(J9AccClassHotSwappedOut | J9AccClassHasBeenOverridden | J9AccClassHasJDBCNatives | J9AccClassIsContended | J9AccClassRAMArray | (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift));
 				tempClassDepthAndFlags++;
 
 #if defined(J9VM_GC_FINALIZATION)

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 #include "j9protos.h"
-
+#include "vm_api.h"
 #if defined(J9VM_OPT_VM_LOCAL_STORAGE)
 
 #include "j9vmls.h"


### PR DESCRIPTION
Identify if the Object is an instance of Continuation, if it is, scan
the Java stacks in related J9vmContinuation.

	- add ContinuationLink as a hiddenInstanceField of Continuation
          instance for the global linklist
	- openjdk using sub class "java/lang/VirtualThread$VThreadContinuation"
	 instead of "jdk/internal/vm/Continuation" for creating instance of
         Continuation.
	- new HeapWalkerDelegate to handle special treatment for Continuation
	Instance.
	- new Scan Type GC_ObjectModel::SCAN_CONTINUATION_OBJECT
	- new J9AccClassContinuation bit (0x1000000, bit in classDepthAndFlags)
	for identifying Continuation Instance, reset AccClassIsContended bit
	(copy from romClass->extraModifiers, but not been used at all).
	- scan/special treatment the Java stack related Continuation Instance
		CompactSchemeFixupObject
		CopyForwardScheme
		GlobalCollectorDelegate
		GlobalMarkCardScrbber
		HeapWalkerDelegate
		MarkingDelegate
		MetronomeDelegate
		RealtimeMarkingScheme
		ScavengerDelegate

	- ToDo List, below the items might also need some change to match
	 continuation, but not directly block the loom basic features.
		HeapIteratorAPI::j9mm_iterate_object_slots()
		MM_ReferenceChainWalker::scanObject()
		MM_CompactDelegate::verifyHeap()
		MM_RealtimeAccessBarrier::validateWriteBarrier()
	 	tgcHookReportInterRegionReferenceCounting()
		MM_CopyForwardScheme::verifyObject()
		MM_IncrementalGenerationalGC::verifyMarkMapClosure()
		MM_WriteOnceCompactor::verifyHeap()
		jvmtiHeap.mapEventType()
		DDR
		GCCheck
       - need to handle/avoid mount/unmount continuation during concurrent GCs

#depends on https://github.com/eclipse/omr/pull/6575, https://github.com/eclipse-openj9/openj9/pull/15434, https://github.com/eclipse-openj9/openj9/pull/15678/
#fix: https://github.com/eclipse-openj9/openj9/issues/15178

Signed-off-by: Lin Hu <linhu@ca.ibm.com>