### PR TITLE
Fix obsolete link

### DIFF
--- a/cdsadapter/README.md
+++ b/cdsadapter/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,4 +23,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 Documentation
 =============
 
-Since CDS has been transferred to Eclipse OSGI, the Eclipse version cds is under package org.eclipse.osgi.internal.cds, with source code available [here](https://github.com/eclipse/rt.equinox.framework/tree/master/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/cds).
+Since CDS has been transferred to Eclipse OSGI, the Eclipse version cds is under package org.eclipse.osgi.internal.cds, with source code available [here](https://github.com/eclipse-equinox/equinox/tree/master/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/cds).


### PR DESCRIPTION
The Eclipse Equinox project has been moved to the new github repo. Fix
the URL to point to the correct repo.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>