### PR TITLE
Fix JIT System.nanoTime() in checkpoint mode

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9351,6 +9351,15 @@ TR_J9VMBase::inSnapshotMode()
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
    }
 
+bool
+TR_J9VMBase::isSnapshotModeEnabled()
+   {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   return getJ9JITConfig()->javaVM->internalVMFunctions->isCRIUSupportEnabled(vmThread());
+#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
+   return false;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+   }
 
 // Native method bodies
 //

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1345,7 +1345,22 @@ public:
    virtual bool isStringCompressionEnabledVM();
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);
 
+   /**
+    * \brief Answers whether snapshots (checkpoints) that will include this compiled body
+    * (if/when it is successfully compiled) can be taken.
+    *
+    * \return True if snapshots can be taken, false if no snapshots that will include this
+    * body are allowed.
+    */
    bool inSnapshotMode();
+
+   /**
+    * \brief Answers whether checkpoint and restore mode is enabled (but not necessarily
+    * whether snapshots can be taken or if any restores have already occurred).
+    *
+    * \return True if checkpoint and restore mode is enabled, false otherwise.
+    */
+   bool isSnapshotModeEnabled();
 
 protected:
 

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -326,22 +326,20 @@ J9::Simplifier::simplifyiCallMethods(TR::Node * node, TR::Block * block)
 TR::Node *
 J9::Simplifier::simplifylCallMethods(TR::Node * node, TR::Block * block)
    {
-   if (comp()->cg()->getSupportsCurrentTimeMaxPrecision())
+   TR::MethodSymbol * methodSymbol = node->getSymbol()->getMethodSymbol();
+   if (methodSymbol)
       {
-      TR::MethodSymbol * methodSymbol = node->getSymbol()->getMethodSymbol();
-      if (methodSymbol)
+      if ((methodSymbol->getRecognizedMethod() == TR::java_lang_System_currentTimeMillis) &&
+          comp()->cg()->getSupportsMaxPrecisionMilliTime() &&
+          (methodSymbol->isJNI() || methodSymbol->isVMInternalNative() || methodSymbol->isJITInternalNative()))
          {
-         if (comp()->cg()->getSupportsMaxPrecisionMilliTime() &&
-             (methodSymbol->getRecognizedMethod() == TR::java_lang_System_currentTimeMillis) &&
-             (methodSymbol->isJNI() || methodSymbol->isVMInternalNative() || methodSymbol->isJITInternalNative()))
-            {
-            node = convertCurrentTimeMillis(node, block);
-            }
-         else if (methodSymbol->getRecognizedMethod() == TR::java_lang_System_nanoTime &&
+         node = convertCurrentTimeMillis(node, block);
+         }
+      else if ((methodSymbol->getRecognizedMethod() == TR::java_lang_System_nanoTime) &&
+               comp()->cg()->getSupportsCurrentTimeMaxPrecision() &&
                (methodSymbol->isJNI() || methodSymbol->isVMInternalNative() || methodSymbol->isJITInternalNative()))
-            {
-            node = convertNanoTime(node, block);
-            }
+         {
+         node = convertNanoTime(node, block);
          }
       }
    else

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9240,6 +9240,17 @@ inlineNanoTime(
       // result = reg + result
       generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, result, generateX86MemoryReference(reg, result, 0, cg), cg);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      if (fej9->isSnapshotModeEnabled())
+         {
+         // result = result - nanoTimeMonotonicClockDelta
+         TR::Register *vmThreadReg = cg->getVMThreadRegister();
+         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg, generateX86MemoryReference(reg, offsetof(J9JavaVM, portLibrary), cg), cg);
+         generateRegMemInstruction(TR::InstOpCode::SUB8RegMem, node, result, generateX86MemoryReference(reg, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
+         }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
       cg->stopUsingRegister(reg);
 
       // Store the result to memory if necessary
@@ -9354,9 +9365,23 @@ inlineNanoTime(
       generateRegRegInstruction(TR::InstOpCode::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
 
 
-      // add the two parts then store it back
+      // add the two parts
       generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, eaxReal, reglow, cg);
       generateRegImmInstruction(TR::InstOpCode::ADC4RegImm4, node, edxReal, 0x0, cg);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      if (fej9->isSnapshotModeEnabled())
+         {
+         // subtract nanoTimeMonotonicClockDelta from the result
+         TR::Register *vmThreadReg = cg->getVMThreadRegister();
+         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow, generateX86MemoryReference(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
+         generateRegMemInstruction(TR::InstOpCode::SUB4RegMem, node, eaxReal, generateX86MemoryReference(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
+         generateRegMemInstruction(TR::InstOpCode::SBB4RegMem, node, edxReal, generateX86MemoryReference(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta) + 4, cg), cg);
+         }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
+      // store it back
       generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(resultAddress, 0, cg), eaxReal, cg);
       generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(resultAddress, 4, cg), edxReal, cg);
 

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -165,9 +165,6 @@ J9::Z::CodeGenerator::initialize()
    if (!disableMonitorCacheLookup)
       comp->setOption(TR_EnableMonitorCacheLookup);
 
-   // Enable high-resolution timer
-   cg->setSupportsCurrentTimeMaxPrecision();
-
    // Defect 109299 : PMR 14649,999,760 / CritSit AV8426
    // Turn off use of hardware clock on zLinux for calculating currentTimeMillis() as user can adjust time on their system.
    //
@@ -176,6 +173,12 @@ J9::Z::CodeGenerator::initialize()
    // (see the java/lang/System.nanoTime() spec for details).
    if (comp->target().isZOS())
       cg->setSupportsMaxPrecisionMilliTime();
+
+   // Enable high-resolution timer for System.nanoTime() unless we need to support checkpointing (i.e. snapshot mode), which requires
+   // that we adjust nanoTime() after restoring checkpoints. This adjustment is currently not implemented for the high res timer, hence
+   // we need to stick to the Java nanoTime() implementation.
+   if (!fej9->isSnapshotModeEnabled())
+      cg->setSupportsCurrentTimeMaxPrecision();
 
    // Support BigDecimal Long Lookaside versioning optimizations.
    if (!comp->getOption(TR_DisableBDLLVersioning))
@@ -4095,4 +4098,3 @@ J9::Z::CodeGenerator::supportsTrapsInTMRegion()
    {
    return self()->comp()->target().isZOS();
    }
-

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -64,6 +64,17 @@
     <output type="required" caseSensitive="yes" regex="no">Error</output>
   </test>
 
+  <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJit">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJit" 3 3 false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: System.nanoTime() after CRIU restore:</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
   <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayBeforeCheckpointDone" 3 3 false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -64,8 +64,19 @@
     <output type="required" caseSensitive="yes" regex="no">Error</output>
   </test>
 
-  <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJit">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJit" 3 3 false</command>
+  <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJitPreCheckpointCompile">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPreCheckpointCompile" 3 3 false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
+    <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: System.nanoTime() after CRIU restore:</output>
+    <output type="required" caseSensitive="yes" regex="no">Error</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJitPostCheckpointCompile">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPostCheckpointCompile" 3 3 false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
     <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -85,6 +85,7 @@
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 		</variations>
 		<command>
+			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J}$(Q) \
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
 			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -85,7 +85,7 @@
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 		</variations>
 		<command>
-			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J}$(Q) \
+			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
 			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -48,6 +48,8 @@ public class TimeChangeTest {
 			TimeChangeTest tct = new TimeChangeTest();
 			if ("testSystemNanoTime".equalsIgnoreCase(testName)) {
 				tct.testSystemNanoTime();
+			} else if ("testSystemNanoTimeJit".equalsIgnoreCase(testName)) {
+				tct.testSystemNanoTimeJit();
 			} else {
 				tct.test(testName);
 			}
@@ -94,6 +96,47 @@ public class TimeChangeTest {
 			System.out.println("FAILED: System.nanoTime() after CRIU restore: " + afterRestore
 					+ ", the elapse time is: " + elapsedTime + " ns, w/ MAX_TARDINESS_NS : " + MAX_TARDINESS_NS);
 		}
+	}
+
+	public void testSystemNanoTimeJit() {
+		testSystemNanoTimeJitWarmupPhase();
+		testSystemNanoTimeJitTestPhase();
+	}
+
+	private static void testSystemNanoTimeJitWarmupPhase() {
+		for (int i = 0; i < 100000; i++) {
+			nanoTimeJit();
+		}
+	}
+
+	private void testSystemNanoTimeJitTestPhase() {
+		final long beforeCheckpoint = nanoTimeInt();
+		System.out.println("System.nanoTime() before CRIU checkpoint: " + beforeCheckpoint);
+		CRIUTestUtils.checkPointJVM(imagePath, false);
+		final long afterRestoreJit = nanoTimeJit();
+		final long afterRestoreInt = nanoTimeInt();
+		if (afterRestoreJit <= afterRestoreInt) {
+			System.out.println("PASSED: System.nanoTime() after CRIU restore: interpreter nanotime = " + afterRestoreInt + ", JIT nanotime = " + afterRestoreJit);
+		} else {
+			System.out.println("FAILED: System.nanoTime() after CRIU restore: interpreter nanotime = " + afterRestoreInt + ", JIT nanotime = " + afterRestoreJit);
+		}
+	}
+
+	/*
+	 * In order to test the JIT handling of System.nanoTime() these two methods,
+	 * nanoTimeInt() and nanoTimeJit(), need special treatment.
+	 * 1) nanoTimeInt() must not be compiled or inlined to ensure that when called it
+	 * will invoke the non-JIT implementation of System.nanoTime().
+	 * 2) nanoTimeJit() must not be inlined so that it can be warmed up effectively.
+	 * The above is currently accomplished via Xjit exclude= and dontInline= options
+	 * when the test is executed.
+	 */
+	private static long nanoTimeInt() {
+		return System.nanoTime();
+	}
+
+	private static long nanoTimeJit() {
+		return System.nanoTime();
 	}
 
 	private final TimerTask taskMillisDelayBeforeCheckpointDone = new TimerTask() {

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -48,8 +48,10 @@ public class TimeChangeTest {
 			TimeChangeTest tct = new TimeChangeTest();
 			if ("testSystemNanoTime".equalsIgnoreCase(testName)) {
 				tct.testSystemNanoTime();
-			} else if ("testSystemNanoTimeJit".equalsIgnoreCase(testName)) {
-				tct.testSystemNanoTimeJit();
+			} else if ("testSystemNanoTimeJitPreCheckpointCompile".equalsIgnoreCase(testName)) {
+				tct.testSystemNanoTimeJitPreCheckpointCompile();
+			} else if ("testSystemNanoTimeJitPostCheckpointCompile".equalsIgnoreCase(testName)) {
+				tct.testSystemNanoTimeJitPostCheckpointCompile();
 			} else {
 				tct.test(testName);
 			}
@@ -98,9 +100,18 @@ public class TimeChangeTest {
 		}
 	}
 
-	public void testSystemNanoTimeJit() {
+	public void testSystemNanoTimeJitPreCheckpointCompile() {
+		testSystemNanoTimeJitTestPreCheckpointPhase();
 		testSystemNanoTimeJitWarmupPhase();
-		testSystemNanoTimeJitTestPhase();
+		CRIUTestUtils.checkPointJVM(imagePath, false);
+		testSystemNanoTimeJitTestPostCheckpointPhase();
+	}
+
+	public void testSystemNanoTimeJitPostCheckpointCompile() {
+		testSystemNanoTimeJitTestPreCheckpointPhase();
+		CRIUTestUtils.checkPointJVM(imagePath, false);
+		testSystemNanoTimeJitWarmupPhase();
+		testSystemNanoTimeJitTestPostCheckpointPhase();
 	}
 
 	private static void testSystemNanoTimeJitWarmupPhase() {
@@ -109,10 +120,12 @@ public class TimeChangeTest {
 		}
 	}
 
-	private void testSystemNanoTimeJitTestPhase() {
+	private void testSystemNanoTimeJitTestPreCheckpointPhase() {
 		final long beforeCheckpoint = nanoTimeInt();
 		System.out.println("System.nanoTime() before CRIU checkpoint: " + beforeCheckpoint);
-		CRIUTestUtils.checkPointJVM(imagePath, false);
+	}
+
+	private void testSystemNanoTimeJitTestPostCheckpointPhase() {
 		final long afterRestoreJit = nanoTimeJit();
 		final long afterRestoreInt = nanoTimeInt();
 		if (afterRestoreJit <= afterRestoreInt) {


### PR DESCRIPTION
The attached patches

1. Fix the x86 codegen's `System.nanoTime()` implementation to do the right thing in checkpoint mode
2. Disable the Z codegen's implementation in checkpoint mode until it can be fixed to do the right thing
3. Add a test case to check that JIT compiled code containing calls to `System.nanoTime()` behaves as expected in checkpoint mode

Fixes #15513