### PR TITLE
Cleaning for Concurrent Scavenger initialization

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -193,7 +193,7 @@ public:
 	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
 	UDATA minimumFreeSizeForSurvivor; /**< minimum free size can be reused by collector as survivor, for balanced GC only */
 	UDATA freeSizeThresholdForSurvivor; /**< if average freeSize(freeSize/freeCount) of the region is smaller than the Threshold, the region would not be reused by collector as survivor, for balanced GC only */
-	bool  recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
+	bool recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
 
 protected:
 private:

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -973,7 +973,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 		if(try_scan(&scan_start, "softwareRangeCheckReadBarrier")) {
-			extensions->softwareRangeCheckReadBarrier = true;
+			extensions->softwareRangeCheckReadBarrierForced = true;
 			continue;
 		}
 


### PR DESCRIPTION
- Concurrent Scavenger can be run at any platform where it is enabled,
there is no extra check required
- There is no need to enforce usage Software Range Check Barruer on
platforms where HW is not available
- add extensions->softwareRangeCheckReadBarrierForced to indicate
-XXgc:softwareRangeCheckReadBarrier is requested explicitly, stop use
extensions->softwareRangeCheckReadBarrier for this purpose


Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>