### PR TITLE
Loom: GC Thread scanning

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -536,7 +536,19 @@ MM_RootScanner::scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, v
 		doVMThreadSlot(slot, &vmThreadIterator);
 	}
 
-	GC_VMThreadStackSlotIterator::scanSlots((J9VMThread *)env->getOmrVMThread()->_language_vmthread, walkThread, localData, stackSlotIterator, isStackFrameClassWalkNeeded(), _trackVisibleStackFrameDepth);
+	J9VMThread *currentThread = (J9VMThread *)env->getOmrVMThread()->_language_vmthread;
+	/* In a case this thread is a carrier thread, and a virtual thread is mounted, we will scan virtual thread's stack.
+	 * If virtual thread is not mounted, or this is just a regular thread, this will scan its own stack. */
+	GC_VMThreadStackSlotIterator::scanSlots(currentThread, walkThread, localData, stackSlotIterator, isStackFrameClassWalkNeeded(), _trackVisibleStackFrameDepth);
+
+#if JAVA_SPEC_VERSION >= 19
+	if (NULL != walkThread->currentContinuation)
+	{
+		/* At this point we know that a virtual thread is mounted. We previously scanned its stack,
+		 * and now we will scan carrier's stack, that continuation struct is currently pointing to. */
+		GC_VMThreadStackSlotIterator::scanSlots(currentThread, walkThread->currentContinuation, localData, stackSlotIterator, isStackFrameClassWalkNeeded(), _trackVisibleStackFrameDepth);
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	return false;
 }
 

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -152,7 +152,14 @@ MM_ConcurrentMarkingDelegate::scanThreadRoots(MM_EnvironmentBase *env)
 	markSchemeStackIteratorData localData;
 	localData.markingScheme = _markingScheme;
 	localData.env = env;
+	/* In a case this thread is a carrier thread, and a virtual thread is mounted, we will scan virtual thread's stack. */
 	GC_VMThreadStackSlotIterator::scanSlots(vmThread, vmThread, (void *)&localData, concurrentStackSlotIterator, true, false);
+
+#if JAVA_SPEC_VERSION >= 19
+	if (NULL != vmThread->currentContinuation) {
+		GC_VMThreadStackSlotIterator::scanSlots(vmThread, vmThread->currentContinuation, (void *)&localData, concurrentStackSlotIterator, true, false);
+	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 	return true;
 }

--- a/runtime/gc_structs/VMThreadStackSlotIterator.hpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.hpp
@@ -43,6 +43,14 @@ typedef void J9MODRON_OSLOTITERATOR(J9JavaVM *javaVM, J9Object **objectIndirect,
  */
 class GC_VMThreadStackSlotIterator
 {
+private:
+	static void initializeStackWalkState(
+			J9StackWalkState *stackWalkState,
+			J9VMThread *vmThread,
+			void *userData,
+			J9MODRON_OSLOTITERATOR *oSlotIterator,
+			bool includeStackFrameClassReferences,
+			bool trackVisibleFrameDepth);
 public:
 	static void scanSlots(
 			J9VMThread *vmThread,
@@ -59,6 +67,16 @@ public:
 			J9MODRON_OSLOTITERATOR *oSlotIterator,
 			bool includeStackFrameClassReferences,
 			bool trackVisibleFrameDepth);
+
+#if JAVA_SPEC_VERSION >= 19
+	static void scanSlots(
+			J9VMThread *vmThread,
+			J9VMContinuation *continuation,
+			void *userData,
+			J9MODRON_OSLOTITERATOR *oSlotIterator,
+			bool includeStackFrameClassReferences,
+			bool trackVisibleFrameDepth);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 };
 
 #endif /* VMTHREADSTACKSLOTITERATOR_HPP_ */


### PR DESCRIPTION
Threads should be scanned as they normally would. If a thread is mounted
with a VirtualThread, then the virtual thread stack will be scanned, the
carrier thread stack will be stored in a continuation instance.

currentContinuation field of the J9vmThread point to either NULL or the
continuation with carrier thread stack(mounting with a VirtualThread
case). scanning currentContinuation if needed.

#depends: https://github.com/eclipse-openj9/openj9/pull/15603
#fix: https://github.com/eclipse-openj9/openj9/issues/15179
Signed-off-by: Lin Hu <linhu@ca.ibm.com>