### PR TITLE
Fix cmdLineTester_criu_keepCheckpoint

### DIFF
--- a/test/functional/cmdLineTests/criu/criuScript.sh
+++ b/test/functional/cmdLineTests/criu/criuScript.sh
@@ -32,9 +32,9 @@ echo "start running script";
 # $6 is the NUM_CHECKPOINT
 # $7 is the KEEP_CHECKPOINT
 
-$2 -XX:+EnableCRIUSupport $3 -cp "$1/criu.jar" $4 $5 "$6" >testOutput 2>&1;
+$2 -XX:+EnableCRIUSupport $3 -cp "$1/criu.jar" $4 $5 $6 >testOutput 2>&1;
 
-if [ "$6" != true ]; then
+if [ "$7" != true ]; then
     NUM_CHECKPOINT=$6
     for ((i=0; i<$NUM_CHECKPOINT; i++)); do
         sleep 2;
@@ -46,5 +46,6 @@ cat testOutput;
 
 if  [ "$7" != true ]; then
     rm -rf testOutput
+    echo "Removed testOutput file"
 fi
 echo "finished script";

--- a/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
@@ -28,11 +28,12 @@
   <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
 
   <test id="Create Criu Checkpoint Image without Restore">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 1 true</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 1 1 true</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Removed testOutput file</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">ERR</output>
   </test>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSimpleTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUSimpleTest.java
@@ -29,7 +29,7 @@ public class CRIUSimpleTest {
 
 	public static void main(String args[]) {
 		try {
-			int num_checkpoints=Integer.parseInt(args[0]);
+			int num_checkpoints=Integer.parseInt(args[1]);
 			checkpoints(num_checkpoints);
 		} catch (NumberFormatException e) {
 			System.out.println("Input is not a valid integer");


### PR DESCRIPTION
- Fix cmdLineTester_criu_keepCheckpoint input arguments
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/14486

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>