### PR TITLE
Change how TR_IPBCDataCallGraph entries are persisted into SCC

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1342,6 +1342,17 @@ TR_J9SharedCache::getClassChainOffsetIdentifyingLoaderNoFail(TR_OpaqueClassBlock
    }
 #endif // defined(J9VM_OPT_JITSERVER)
 
+uintptr_t
+TR_J9SharedCache::getClassChainOffsetIdentifyingLoaderNoThrow(TR_OpaqueClassBlock *clazz)
+   {
+   void *loaderForClazz = _fe->getClassLoader(clazz);
+   void *classChainIdentifyingLoaderForClazz = persistentClassLoaderTable()->lookupClassChainAssociatedWithClassLoader(loaderForClazz);
+   uintptr_t classChainOffsetInSharedCache;
+   if (!isPointerInSharedCache(classChainIdentifyingLoaderForClazz, &classChainOffsetInSharedCache))
+      return 0;
+   return classChainOffsetInSharedCache;
+   }
+
 const void *
 TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor)
    {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -93,7 +93,7 @@ public:
    TR_ALLOC_SPECIALIZED(TR_Memory::SharedCache)
 
    TR_J9SharedCache(TR_J9VMBase *fe);
-
+   TR_J9VMBase *fe() { return _fe; }
    virtual bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL);
    virtual bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL);
    virtual uint16_t getAllEnabledHints(J9Method *method);
@@ -310,6 +310,8 @@ public:
    uintptr_t getClassChainOffsetIdentifyingLoaderNoFail(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+   uintptr_t getClassChainOffsetIdentifyingLoaderNoThrow(TR_OpaqueClassBlock *clazz);
+
    virtual const void *storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor);
 
    enum TR_J9SharedCacheDisabledReason
@@ -375,7 +377,6 @@ private:
 
    J9JITConfig *jitConfig() { return _jitConfig; }
    J9JavaVM *javaVM() { return _javaVM; }
-   TR_J9VMBase *fe() { return _fe; }
    J9SharedClassConfig *sharedCacheConfig() { return _sharedCacheConfig; }
 
    TR_AOTStats *aotStats() { return _aotStats; }


### PR DESCRIPTION
Before this change, each `TR_IPBCDataCallGraph` entry that is persisted can contain
up to 3 ROMClasses and their associates sampling frequencies. When loading from
SCC we need to convert from a ROMClass to a RAMClass. This is done with the
help of the `matchRAMclassFromROMclass()` frontend method, which first tries
the classloader of the method being compiled and then the bootstrap classloader.
If none of these attempts is successfull, we store NULL into the IProfiler entry
which is created from the SCC entry.

In this commit we change the mechanism to convert from a ROMClass to a RAMClass,
to match the mechanism that is used in AOT relocation records. Specifically, the
new code is using the mechanism that associates a classloader with the first class
that is loaded by that class loader (see ClassLoaderTable.cpp).
Thus, the IProfiler entry stored in SCC needs to contain two values now:
(1) The classchain for the class that is being traked and
(2) The classchain for the first class loaded by the classloader that loaded the class
being tracked.
Since in the new implementation we store more information, we will only track one
target class instead of 3.

This change is improving the throughput of some applications that rely on IProfiler
information stored in SCC.

Depends on https://github.com/eclipse/omr/pull/6638

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>