### PR TITLE
Ensure lock contentions for CRIU single thread mode tests

### DIFF
--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
 import org.eclipse.openj9.criu.*;
 
@@ -34,9 +35,7 @@ public class CRIUTestUtils {
 	public static void deleteCheckpointDirectory(Path path) {
 		try {
 			if (path.toFile().exists()) {
-				Files.walk(path)
-				.map(Path::toFile)
-				.forEach(File::delete);
+				Files.walk(path).map(Path::toFile).forEach(File::delete);
 
 				Files.deleteIfExists(path);
 			}
@@ -70,10 +69,7 @@ public class CRIUTestUtils {
 				if (criu == null) {
 					criu = new CRIUSupport(path);
 				}
-				criu.setLeaveRunning(false)
-				.setShellJob(true)
-				.setFileLocks(true)
-				.checkpointJVM();
+				criu.setLeaveRunning(false).setShellJob(true).setFileLocks(true).checkpointJVM();
 			} catch (RestoreException e) {
 				e.printStackTrace();
 			}
@@ -83,5 +79,11 @@ public class CRIUTestUtils {
 		} else {
 			System.err.println("CRIU is not enabled");
 		}
+	}
+
+	public static void showThreadCurrentTime(String logStr) {
+		System.out.println(logStr + ", current thread name: " + Thread.currentThread().getName() + ", " + new Date()
+				+ ", System.currentTimeMillis(): " + System.currentTimeMillis() + ", System.nanoTime(): "
+				+ System.nanoTime());
 	}
 }

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
@@ -30,73 +30,60 @@ import java.nio.file.Paths;
 
 public class TestSingleThreadModeCheckpointException {
 
-	private final static Path imagePath = Paths.get("cpData");
 	private static final Object lock = new Object();
 
 	public static void main(String[] args) {
 		new TestSingleThreadModeCheckpointException().testSingleThreadModeCheckpointException();
 	}
 
-	private void log(String msg) {
-		System.out.println(msg + ": " + this + " name: " + Thread.currentThread().getName());
-	}
-
-	Thread newThreadOwnMonitor() {
+	Thread doCheckpoint() {
 		Thread t = new Thread(new Runnable() {
 			public void run() {
-				log("newThreadOwnMonitor() before synchronized on " + lock);
-				synchronized (lock) {
-					for (;;) {
-						try {
-							log("newThreadOwnMonitor() before Thread.sleep()");
-							Thread.sleep(1000);
-							log("newThreadOwnMonitor() after Thread.sleep()");
-						} catch (InterruptedException e) {
-							log("newThreadOwnMonitor() interrupted");
-							break;
+				boolean result = false;
+				Path imagePath = Paths.get("cpData");
+				CRIUTestUtils.deleteCheckpointDirectory(imagePath);
+				CRIUTestUtils.createCheckpointDirectory(imagePath);
+				CRIUSupport criu = new CRIUSupport(imagePath);
+				criu.registerPreSnapshotHook(new Runnable() {
+					public void run() {
+						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() before synchronized on " + lock);
+						synchronized (lock) {
+							CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() within synchronized on " + lock);
 						}
+						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() after synchronized on " + lock);
 					}
+				});
+
+				try {
+					System.out.println("Pre-checkpoint");
+					CRIUTestUtils.checkPointJVM(criu, imagePath, false);
+				} catch (JVMCheckpointException jvmce) {
+					result = true;
 				}
-				log("newThreadOwnMonitor() after synchronized on " + lock);
+				if (result) {
+					System.out.println("TestSingleThreadModeCheckpointException: PASSED.");
+				} else {
+					System.out.println("TestSingleThreadModeCheckpointException: FAILED.");
+				}
 			}
 		});
 		return t;
 	}
 
 	void testSingleThreadModeCheckpointException() {
-		boolean result = false;
-		Thread tom = newThreadOwnMonitor();
-		tom.start();
-
-		CRIUTestUtils.deleteCheckpointDirectory(imagePath);
-		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criu = new CRIUSupport(imagePath);
-		criu.registerPreSnapshotHook(new Runnable() {
-			public void run() {
-				log("PreSnapshotHook() before synchronized on " + lock);
-				synchronized (lock) {
-					log("PreSnapshotHook() within synchronized on " + lock);
-				}
-				log("PreSnapshotHook() after synchronized on " + lock);
+		CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeCheckpointException() before synchronized on " + lock);
+		synchronized (lock) {
+			try {
+				// ensure the lock already taken before performing a checkpoint
+				CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeCheckpointException() before doCheckpoint()");
+				Thread tpc = doCheckpoint();
+				tpc.start();
+				// set timeout 10s
+				tpc.join(10000);
+				CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeCheckpointException() after doCheckpoint()");
+			} catch (InterruptedException e) {
 			}
-		});
-
-		try {
-			System.out.println("Pre-checkpoint");
-			CRIUTestUtils.checkPointJVM(criu, imagePath, false);
-		} catch (JVMCheckpointException jvmce) {
-			result = true;
 		}
-		if (result) {
-			System.out.println("TestSingleThreadModeCheckpointException: PASSED.");
-		} else {
-			System.out.println("TestSingleThreadModeCheckpointException: FAILED.");
-		}
-
-		tom.interrupt();
-		try {
-			tom.join();
-		} catch (InterruptedException e) {
-		}
+		CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeCheckpointException() after synchronized on " + lock);
 	}
 }


### PR DESCRIPTION
Start a thread to perform checkpoint after the lock already taken to ensure the lock contention, and verify if `JVMCheckpointException`/`RestoreException` are thrown as expected.

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/127#issuecomment-1192538998

Signed-off-by: Jason Feng <fengj@ca.ibm.com>