### PR TITLE
  Ignore VirtualThreads in jvmtiGetAllThreads and Thread.getThreads 

### DIFF
--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -462,7 +462,14 @@ Java_java_lang_Thread_getThreads(JNIEnv *env, jclass clazz)
 		UDATA threadCount = 0;
 
 		do {
+#if JAVA_SPEC_VERSION >= 19
+			/* carrierThreadObject should always point to a platform thread.
+			 * Thus, all virtual threads should be excluded.
+			 */
+			j9object_t threadObject = targetThread->carrierThreadObject;
+#else /* JAVA_SPEC_VERSION >= 19 */
 			j9object_t threadObject = targetThread->threadObject;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 			/* Only count live threads */
 			if (NULL != threadObject) {

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -161,13 +161,19 @@ jvmtiGetAllThreads(jvmtiEnv* env,
 
 			targetThread = vm->mainThread;
 			do {
+#if JAVA_SPEC_VERSION >= 19
+				/* carrierThreadObject should always point to a platform thread.
+				 * Thus, all virtual threads should be excluded.
+				 */
+				j9object_t threadObject = targetThread->carrierThreadObject;
+#else /* JAVA_SPEC_VERSION >= 19 */
 				j9object_t threadObject = targetThread->threadObject;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 				/* Only count live threads */
-
 				if (threadObject != NULL) {
 					if (J9VMJAVALANGTHREAD_STARTED(currentThread, threadObject) && (J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject) != NULL)) {
-						*currentThreadPtr++ = (jthread) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t) threadObject);
+						*currentThreadPtr++ = (jthread)vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, (j9object_t)threadObject);
 						++threadCount;
 					}
 				}


### PR DESCRIPTION
This change impacts the following methods in JDK19+:
- `private static native Thread[] getThreads()`
- `jvmtiGetAllThreads`

Virtual threads are ignored by looking at `J9VMThread->carrierThreadObject`
instead of `J9VMThread->threadObject`.

Related: #15183

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>