### PR TITLE
Prefer local compilations in more cases

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6538,7 +6538,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
 
             if (plan)
                {
-               TR_MethodToBeCompiled *entryRemoteCompReq = addMethodToBeCompiled(details, currOldStartPC, compPriority, isAsync,
+               TR_MethodToBeCompiled *entryRemoteCompReq = addMethodToBeCompiled(details, startPC, compPriority, isAsync,
                                                                                  plan, &queuedForRemote, mthInSharedCache);
 
                if (entryRemoteCompReq)
@@ -7170,6 +7170,13 @@ TR::CompilationInfoPerThreadBase::cannotPerformRemoteComp(
 bool
 TR::CompilationInfoPerThreadBase::preferLocalComp(const TR_MethodToBeCompiled *entry)
    {
+   if (_compInfo.getPersistentInfo()->isLocalSyncCompiles() &&
+       (entry->_optimizationPlan->getOptLevel() <= cold) &&
+       !entry->_async)
+      {
+      return true;
+      }
+
    // As a heuristic, cold compilations could be performed locally because
    // they are supposed to be cheap with respect to memory and CPU, but
    // only if we think we have enough resources


### PR DESCRIPTION
We now prefer to compile locally when local sync compilation
is enabled and the method in question is cold and synchronous.

A function was also passed the incorrect pc when adding a remote
compilation request. This was also fixed.

Signed-off-by: Christian Despres <despresc@ibm.com>