### PR TITLE
CRIU delay Thread.interrupt() in single thread mode

### DIFF
--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -691,3 +691,5 @@ TraceEntry=Trc_JCL_com_ibm_oti_shared_SharedClassStatistics_cachePathImpl_Entry 
 TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassStatistics_cachePathImpl_Exit Overhead=1 Level=2 Template="JCL: SharedClassStatistics cacheNameImpl: Exiting with result %p (%s)"
 TraceEntry=Trc_JCL_com_ibm_oti_shared_SharedClassStatistics_numberAttachedImpl_Entry Overhead=1 Level=2 Template="JCL: SharedClassStatistics numberAttachedImpl: Entering"
 TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassStatistics_numberAttachedImpl_Exit Overhead=1 Level=2 Template="JCL: SharedClassStatistics numberAttachedImpl: Exiting with result %lld"
+
+TraceEvent=Trc_JCL_Thread_interruptImpl Overhead=1 Level=3 Template="Thread.interrupt() on receiverObject=%p"

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4089,6 +4089,7 @@ typedef struct J9DelayedLockingOpertionsRecord {
 
 #define J9_SINGLE_THREAD_MODE_OP_NOTIFY 0x1
 #define J9_SINGLE_THREAD_MODE_OP_NOTIFY_ALL 0x2
+#define J9_SINGLE_THREAD_MODE_OP_INTERRUPT 0x3
 
 typedef struct J9CRIUCheckpointState {
 	BOOLEAN isCheckPointEnabled;
@@ -4871,6 +4872,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*runDelayedLockRelatedOperations)(struct J9VMThread *currentThread);
+	BOOLEAN (*delayedLockingOperation)(struct J9VMThread *currentThread, j9object_t instance, UDATA operation);
 	void (*setCRIUSingleThreadModeJVMCRIUException)(struct J9VMThread *vmThread, U_32 moduleName, U_32 messageNumber);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	j9object_t (*getClassNameString)(struct J9VMThread *currentThread, j9object_t classObject, jboolean internAndAssign);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -565,6 +565,18 @@ runInternalJVMRestoreHooks(J9VMThread *currentThread);
  */
 BOOLEAN
 runDelayedLockRelatedOperations(J9VMThread *currentThread);
+
+/**
+ * @brief This function delays the identity operations during the Java checkpoint and restore hooks.
+ *
+ * @param currentThread thread token
+ * @param instance the identity object
+ * @param operation the operation specified for the instance
+ *
+ * @return BOOLEAN TRUE if no error, otherwise FALSE
+ */
+BOOLEAN
+delayedLockingOperation(J9VMThread *currentThread, j9object_t instance, UDATA operation);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /* ---------------- classloadersearch.c ---------------- */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -409,6 +409,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	runInternalJVMCheckpointHooks,
 	runInternalJVMRestoreHooks,
 	runDelayedLockRelatedOperations,
+	delayedLockingOperation,
 	setCRIUSingleThreadModeJVMCRIUException,
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	getClassNameString,

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -901,3 +901,5 @@ TraceEvent=Trc_VM_criu_delayedLockingOperation_delayOperation Overhead=1 Level=3
 
 TraceEntry=Trc_VM_JNI_isVirtualThread_Entry Overhead=1 Level=4 Template="JNI IsVirtualThread(obj=%p)"
 TraceExit=Trc_VM_JNI_isVirtualThread_Exit Overhead=1 Level=4 Template="JNI IsVirtualThread -- rc = %d"
+
+TraceEvent=Trc_VM_criu_runDelayedLockRelatedOperations_runDelayedInterrupt Overhead=1 Level=3 Template="Checkpoint thread calling delayed Thread.interrupt() op=%zu on instance=%p"

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -30,6 +30,7 @@
   <variable name="MAINCLASS_SINGLETHREADMODE_CHECKPOINT" value="org.openj9.criu.TestSingleThreadModeCheckpointException" />
   <variable name="MAINCLASS_SINGLETHREADMODE_RESTORE" value="org.openj9.criu.TestSingleThreadModeRestoreException" />
   <variable name="MAINCLASS_DEADLOCK_TEST" value="org.openj9.criu.DeadlockTest" />
+  <variable name="MAINCLASS_DELAYEDOPERATIONS" value="org.openj9.criu.TestDelayedOperations" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
@@ -162,5 +163,16 @@
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">ERR</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
+  </test>
+
+  <test id="Create and Restore Criu Checkpoint Image once - TestDelayedOperations">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_DELAYEDOPERATIONS$ 1 1 false</command>
+    <output type="success" caseSensitive="yes" regex="no">TestDelayedOperations.testDelayedThreadInterrupt(): PASSED</output>
+    <output type="required" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="failure" caseSensitive="no" regex="no">TestDelayedOperations.testDelayedThreadInterrupt(): FAILED</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">ERR</output>
   </test>
 </suite>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -27,16 +27,16 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
-import org.eclipse.openj9.criu.*;
+import org.eclipse.openj9.criu.CRIUSupport;
+import org.eclipse.openj9.criu.RestoreException;
 
 public class CRIUTestUtils {
 	public static void deleteCheckpointDirectory(Path path) {
 		try {
 			if (path.toFile().exists()) {
-				Files.walk(path)
-				.map(Path::toFile)
-				.forEach(File::delete);
+				Files.walk(path).map(Path::toFile).forEach(File::delete);
 
 				Files.deleteIfExists(path);
 			}
@@ -70,10 +70,7 @@ public class CRIUTestUtils {
 				if (criu == null) {
 					criu = new CRIUSupport(path);
 				}
-				criu.setLeaveRunning(false)
-				.setShellJob(true)
-				.setFileLocks(true)
-				.checkpointJVM();
+				criu.setLeaveRunning(false).setShellJob(true).setFileLocks(true).checkpointJVM();
 			} catch (RestoreException e) {
 				e.printStackTrace();
 			}
@@ -83,5 +80,11 @@ public class CRIUTestUtils {
 		} else {
 			System.err.println("CRIU is not enabled");
 		}
+	}
+
+	public static void showThreadCurrentTime(String logStr) {
+		System.out.println(logStr + ", current thread name: " + Thread.currentThread().getName() + ", " + new Date()
+				+ ", System.currentTimeMillis(): " + System.currentTimeMillis() + ", System.nanoTime(): "
+				+ System.nanoTime());
 	}
 }

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.openj9.criu.CRIUSupport;
+import org.eclipse.openj9.criu.JVMCheckpointException;
+
+public class TestDelayedOperations {
+
+	public static void main(String[] args) {
+		new TestDelayedOperations().testDelayedThreadInterrupt();
+	}
+
+	private void testDelayedThreadInterrupt() {
+
+		final Thread threadAwaiting = new Thread(() -> {
+			Path imagePath = Paths.get("cpData");
+			CRIUTestUtils.deleteCheckpointDirectory(imagePath);
+			CRIUTestUtils.createCheckpointDirectory(imagePath);
+			CRIUSupport criu = new CRIUSupport(imagePath);
+			final Thread currentThread = Thread.currentThread();
+			CRIUTestUtils.showThreadCurrentTime(
+					"currentThread : " + currentThread + " with name : " + currentThread.getName());
+			criu.registerPreSnapshotHook(new Runnable() {
+				public void run() {
+					CRIUTestUtils.showThreadCurrentTime(
+							"PreSnapshotHook() before threadAwaiting.interrupt() - currentThread : " + currentThread);
+					currentThread.interrupt();
+					if (currentThread.isInterrupted()) {
+						System.out.println(
+								"TestDelayedOperations.testDelayedThreadInterrupt(): FAILED at PreSnapshotHook()");
+					}
+					CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() after threadAwaiting.interrupt()");
+				}
+			});
+			criu.registerPostRestoreHook(new Runnable() {
+				public void run() {
+					CRIUTestUtils.showThreadCurrentTime(
+							"PostSnapshotHook() before threadAwaiting.interrupt() - currentThread : " + currentThread);
+					currentThread.interrupt();
+					if (currentThread.isInterrupted()) {
+						System.out.println(
+								"TestDelayedOperations.testDelayedThreadInterrupt(): FAILED at PostSnapshotHook()");
+					}
+					CRIUTestUtils.showThreadCurrentTime("PostSnapshotHook() after threadAwaiting.interrupt()");
+				}
+			});
+
+			System.out.println("Pre-checkpoint - currentThread : " + currentThread);
+			CRIUTestUtils.checkPointJVM(criu, imagePath, false);
+			try {
+				Thread.sleep(2000);
+				System.out.println("TestDelayedOperations.testDelayedThreadInterrupt(): FAILED - not interrrupted");
+			} catch (InterruptedException e) {
+				System.out.println("TestDelayedOperations.testDelayedThreadInterrupt(): PASSED.");
+			}
+		});
+		threadAwaiting.start();
+		try {
+			threadAwaiting.join();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Added `J9_SINGLE_THREAD_MODE_OP_INTERRUPT`;
Saved Thread instances to `delayedLockingOperationsRoot` queue;
`CRIUHelpers` refactoring ;
Added tests.

closes https://github.com/eclipse-openj9/openj9/issues/15538

Signed-off-by: Jason Feng <fengj@ca.ibm.com>