### PR TITLE
Allow for incompatible caches in JVMTI shared cache management test

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/sharedCacheAPI/sca001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/sharedCacheAPI/sca001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,9 +147,16 @@ validateSharedCacheInfoVersion5(jvmtiEnv *jvmti, jvmtiSharedCacheInfo *cache_inf
 		return JNI_EINVAL;
 	}
 	
-	if (0 != cache_info->layer) {
-		error(env, JVMTI_ERROR_INVALID_TYPESTATE, "Field layer of jvmtiSharedCacheInfo is wrong when passing COM_IBM_ITERATE_SHARED_CACHES_VERSION_5 to iterateSharedCacheFunction \n");
-		return JNI_EINVAL;
+	if (cache_info->isCompatible) {
+		if (0 != cache_info->layer) {
+			error(env, JVMTI_ERROR_INVALID_TYPESTATE, "Field layer of jvmtiSharedCacheInfo is wrong for compatible cache when passing COM_IBM_ITERATE_SHARED_CACHES_VERSION_5 to iterateSharedCacheFunction \n");
+			return JNI_EINVAL;
+		}
+	} else {
+		if ((0 != cache_info->layer) && (-1 != cache_info->layer)) {
+			error(env, JVMTI_ERROR_INVALID_TYPESTATE, "Field layer of jvmtiSharedCacheInfo is wrong for incompatible cache when passing COM_IBM_ITERATE_SHARED_CACHES_VERSION_5 to iterateSharedCacheFunction \n");
+			return JNI_EINVAL;
+		}
 	}
 
 	cacheCountVersion5 ++;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/15649

Tested via https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1211