### PR TITLE
Enhance assertion to simplify debugging

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2248,7 +2248,7 @@ MM_CopyForwardScheme::updateMarkMapAndCardTableOnCopy(MM_EnvironmentVLHGC *env, 
 				/* do nothing */
 				break;
 			default:
-				Assert_MM_unreachable();
+				Assert_GC_true_with_message4(env, false, "Unexpected Card state %u for Card %p, srcObject %p, dstObject %p\n", *card, card, srcObject, dstObject);
 			}
 		}
 	}


### PR DESCRIPTION
Currently MM_CopyForwardScheme::updateMarkMapAndCardTableOnCopy() throws
assertion unreachable for unexpected Card state. Replacing assertion
unreachable to assertion with message to get extra information and
simplify debugging


Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>