### PR TITLE
Load default value instance if the class is initialized

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -241,6 +241,10 @@ static const char* getNameForMethodRelocation (int type)
             return "TR_SpecialRamMethodConst";
          case TR_VirtualRamMethodConst:
             return "TR_VirtualRamMethodConst";
+         case TR_ClassAddress:
+            return "TR_ClassAddress";
+         case TR_StaticDefaultValueInstance:
+            return "TR_StaticDefaultValueInstance";
          default:
             TR_ASSERT(0, "We already cleared one switch, hard to imagine why we would have a different type here");
             break;
@@ -381,6 +385,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
       case TR_StaticRamMethodConst:
       case TR_SpecialRamMethodConst:
       case TR_VirtualRamMethodConst:
+      case TR_StaticDefaultValueInstance:
       case TR_ClassAddress:
          {
          TR_RelocationRecordConstantPoolWithIndex *cpiRecord = reinterpret_cast<TR_RelocationRecordConstantPoolWithIndex *>(reloRecord);
@@ -1464,6 +1469,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
          }
          break;
 
+      case TR_StaticDefaultValueInstance:
       case TR_ClassAddress:
          {
          TR_RelocationRecordConstantPoolWithIndex *cpiRecord = reinterpret_cast<TR_RelocationRecordConstantPoolWithIndex *>(reloRecord);
@@ -1471,7 +1477,8 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
          self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
          if (isVerbose)
             {
-            traceMsg(self()->comp(), "\n Address Relocation (TR_ClassAddress): inlinedIndex = %d, constantPool = %p, CPI = %d, flags = %x",
+            traceMsg(self()->comp(), "\n Address Relocation (%s): inlinedIndex = %d, constantPool = %p, CPI = %d, flags = 0x%x",
+                                     getNameForMethodRelocation(kind),
                                      cpiRecord->inlinedSiteIndex(reloTarget),
                                      cpiRecord->constantPool(reloTarget),
                                      cpiRecord->cpIndex(reloTarget),

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -82,6 +82,7 @@ J9::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation 
      _currentThreadDebugEventDataSymbol(0),
      _currentThreadDebugEventDataSymbolRefs(c->trMemory()),
      _constantPoolAddressSymbolRefs(c->trMemory()),
+     _defaultValueAddressSlotSymbolRefs(c->trMemory()),
      _resolvedFieldShadows(
         std::less<ResolvedFieldShadowKey>(),
         getTypedAllocator<ResolvedFieldShadowsEntry>(c->allocator())),
@@ -926,6 +927,38 @@ J9::SymbolReferenceTable::findOrFabricateFlattenedArrayElementFieldShadowSymbol(
    initShadowSymbol(NULL, symRef, isResolved, type, flattenedFieldOffset, isUnresolvedInCP);
 
    _flattenedArrayElementFieldShadows.insert(std::make_pair(key, symRef));
+   return symRef;
+   }
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateDefaultValueSymbolRef(void *defaultValueSlotAddress, int32_t cpIndex)
+   {
+   ListIterator<TR::SymbolReference> i(&_defaultValueAddressSlotSymbolRefs);
+   TR::SymbolReference *symRef;
+   for (symRef = i.getFirst(); symRef; symRef = i.getNext())
+      {
+      if (symRef->getSymbol()->getStaticSymbol()->getStaticAddress() == defaultValueSlotAddress)
+         {
+         return symRef;
+         }
+      }
+
+   TR::StaticSymbol *sym = TR::StaticSymbol::create(trHeapMemory(), TR::Address);
+
+   sym->setStaticAddress(defaultValueSlotAddress);
+
+   sym->setNotDataAddress();
+   sym->setStaticDefaultValueInstance();
+
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym);
+
+   symRef->setCPIndex(cpIndex);
+   symRef->setOwningMethodIndex(comp()->getMethodSymbol()->getResolvedMethodIndex());
+
+   // TODO: Is this required?
+   aliasBuilder.addressStaticSymRefs().set(symRef->getReferenceNumber());
+
+   _defaultValueAddressSlotSymbolRefs.add(symRef);
    return symRef;
    }
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -221,6 +221,11 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     */
    TR::SymbolReference * findOrFabricateFlattenedArrayElementFieldShadowSymbol(TR_OpaqueClassBlock *arrayComponentClass, TR::DataType type, uint32_t fieldOffset, bool isPrivate, const char *fieldName, const char *fieldSignature);
 
+   /** \brief
+    *     Returns a symbol reference for default value instance of value class.
+    */
+   TR::SymbolReference * findOrCreateDefaultValueSymbolRef(void *defaultValueSlotAddress, int32_t cpIndex);
+
    TR::SymbolReference * findOrCreateObjectNewInstanceImplSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateDLTBlockSymbolRef();
    TR::SymbolReference * findDLTBlockSymbolRef();
@@ -456,6 +461,7 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::Symbol                           *_currentThreadDebugEventDataSymbol;
    List<TR::SymbolReference>            _currentThreadDebugEventDataSymbolRefs;
    List<TR::SymbolReference>            _constantPoolAddressSymbolRefs;
+   List<TR::SymbolReference>            _defaultValueAddressSlotSymbolRefs;
 
    private:
 

--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -337,6 +337,10 @@ SymbolReference::getTypeSignature(int32_t & len, TR_AllocationKind allocKind, bo
             {
             len = 1;
             return dataTypeToSig[_symbol->getDataType()];
+            }
+         if (_symbol->isStaticDefaultValueInstance())
+            {
+            return 0;
             }
 
          persistentClassInfo =

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1918,5 +1918,16 @@ class TR_RelocationRecordValidateJ2IThunkFromMethod : public TR_RelocationRecord
       uint16_t methodID(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordStaticDefaultValueInstance : public TR_RelocationRecordClassAddress
+   {
+   public:
+      TR_RelocationRecordStaticDefaultValueInstance() {}
+      TR_RelocationRecordStaticDefaultValueInstance(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordClassAddress(reloRuntime, record) {}
+
+      virtual char *name();
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
 #endif   // RELOCATION_RECORD_INCL
 

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -202,7 +202,9 @@ struct TR_RelocationError
       directJNICallRelocationFailure                   = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
       ramMethodConstRelocationFailure                  = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
 
-      maxRelocationError                               = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
+      staticDefaultValueInstanceRelocationFailure      = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+
+      maxRelocationError                               = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
       };
 
    static uint32_t decode(TR_RelocationErrorCode errorCode) { return static_cast<uint32_t>(errorCode >> RELO_ERRORCODE_SHIFT); }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2126,6 +2126,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_ClassAddress:
       case TR_MethodObject:
       //case TR_DataAddress:
+      case TR_StaticDefaultValueInstance:
 #endif
 #if defined(TR_HOST_32BIT) && defined(TR_HOST_POWER)
       case TR_ArrayCopyHelper:


### PR DESCRIPTION
ILGen:
- aconst_init: Load the default value instance if the class is initialized. This enhancement can be disabled
by setting env variable `TR_DisableLoadStaticDefaultValueInstance`.

SymRef:
- Create symbol reference for default value instance of value class.

AOT (X86):
- Add new relocation record `TR_RelocationRecordStaticDefaultValueInstance`
to materialize the default value instance slot address on AOT load.

**Depends on** 
- [x] https://github.com/eclipse/omr/pull/6641

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>