### PR TITLE
Implement Access.executeOnCarrierThread()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -523,7 +523,20 @@ final class Access implements JavaLangAccess {
 	}
 
 	public <V> V executeOnCarrierThread(Callable<V> task) throws Exception {
-		throw new UnsupportedOperationException();
+		V result;
+		Thread currentThread = Thread.currentThread();
+		if (currentThread.isVirtual()) {
+			Thread carrierThread = Thread.currentCarrierThread();
+			carrierThread.setCurrentThread(carrierThread);
+			try {
+				result = task.call();
+			} finally {
+				carrierThread.setCurrentThread(currentThread);
+			}
+		} else {
+			result = task.call();
+		}
+		return result;
 	}
 
 	public Continuation getContinuation(Thread thread) {


### PR DESCRIPTION
Set current thread to the carrier thread, run the task, and restore the initial thread afterwards.

Fix internal RTC 147936.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>