### PR TITLE
Enable JITServer in CRIU non-portable mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -349,7 +349,11 @@ class CompilationInfoPerThreadBase
              can do a remote compilation, because the server could have died since
              we last checked.
     */
-   bool cannotPerformRemoteComp();
+   bool cannotPerformRemoteComp(
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      J9VMThread *vmThread
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+   );
    /**
       @brief Returns true if heuristics determine that we have the resources to perform
              this compilation locally, rather than offloading it to the remote server.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4868,6 +4868,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*jvmRestoreHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*isCRIUSupportEnabled)(struct J9VMThread *currentThread);
 	BOOLEAN (*isCheckpointAllowed)(struct J9VMThread *currentThread);
+	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);
 	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*runDelayedLockRelatedOperations)(struct J9VMThread *currentThread);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -514,6 +514,18 @@ BOOLEAN
 isCheckpointAllowed(J9VMThread *currentThread);
 
 /**
+ * @brief Queries if non-portable restore mode (specified via
+ * -XX:+CRIURestoreNonPortableMode) is enabled. If so, checkpointing will
+ * not be permitted after the JVM has been restored from a checkpoint
+ * (checkpoint once mode).
+ *
+ * @param currentThread vmthread token
+ * @return TRUE if enabled, FALSE otherwise
+ */
+BOOLEAN
+isNonPortableRestoreMode(J9VMThread *currentThread);
+
+/**
  * @brief JVM hooks to run before performing a JVM checkpoint
  *
  * @param currentThread vmthread token

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -114,6 +114,12 @@ isCheckpointAllowed(J9VMThread *currentThread)
 	return result;
 }
 
+BOOLEAN
+isNonPortableRestoreMode(J9VMThread *currentThread)
+{
+	return currentThread->javaVM->checkpointState.isNonPortableRestoreMode;
+}
+
 /**
  * This adds an internal CRIU hook to trace all heap objects of instanceType and its subclasses if specified.
  *

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -406,6 +406,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jvmRestoreHooks,
 	isCRIUSupportEnabled,
 	isCheckpointAllowed,
+	isNonPortableRestoreMode,
 	runInternalJVMCheckpointHooks,
 	runInternalJVMRestoreHooks,
 	runDelayedLockRelatedOperations,


### PR DESCRIPTION
To make life simpler for end users CRIU mode can also implicitly enable JITServer client mode so that restored processes can seamlessly connect to a JITServer should one be available.

This PR accomplishes two things:

1. Implicitly enables JITServer when CRIU non-portable mode is enabled (and allows disabling via explicit `-XX:-UseJITServer`)
2. Delays remote compilations in non-portable mode until after the process is restored

Neither of the above happens in portable mode. Users can explicitly enable JITServer in portable mode via `-XX:+UseJITServer` if they wish. Delaying compilations until after restore doesn't make sense in portable mode since there is no limit on how many times the process can be checkpointed/restored.

Here's a summary of operations under various combinations of options:

JITServer disabled:

`-XX:+EnableCRIUSupport`
`-XX:+EnableCRIUSupport -XX:-CRIURestoreNonPortableMode`
`-XX:+EnableCRIUSupport -XX:-UseJITServer`
`-XX:+EnableCRIUSupport -XX:-CRIURestoreNonPortableMode -XX:-UseJITServer`
`-XX:+EnableCRIUSupport -XX:+CRIURestoreNonPortableMode -XX:-UseJITServer`

JITServer enabled, remote compilation delayed until after restore:

`-XX:+EnableCRIUSupport -XX:+CRIURestoreNonPortableMode` (JITServer implicitly enabled)
`-XX:+EnableCRIUSupport -XX:+CRIURestoreNonPortableMode -XX:+UseJITServer`

JITServer enabled, remote compilation not delayed:

`-XX:+EnableCRIUSupport -XX:+UseJITServer`
`-XX:+EnableCRIUSupport -XX:-CRIURestoreNonPortableMode -XX:+UseJITServer`