### PR TITLE
Add Continuation direct transition support

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -39,7 +39,7 @@ public class Continuation {
 	private boolean started;
 	private boolean finished;
 
-	private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+	private static JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
 	/**
 	 * Continuation's Pinned reasons
@@ -99,6 +99,9 @@ public class Continuation {
 		this.scope = scope;
 		this.runnable = target;
 		createContinuationImpl();
+		if (JLA == null) {
+			JLA = SharedSecrets.getJavaLangAccess();
+		}
 	}
 
 	public ContinuationScope getScope() {

--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -37,7 +37,7 @@ public class Continuation {
 	private final Runnable runnable;
 	private Continuation parent;
 	private boolean started;
-	private volatile boolean finished;
+	private boolean finished;
 
 	private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
@@ -150,7 +150,12 @@ public class Continuation {
 	}
 
 	private static void execute(Continuation cont) {
-		cont.runnable.run();
+		try {
+			cont.runnable.run();
+		} finally {
+			cont.finished = true;
+			yieldImpl(true);
+		}
 	}
 
 	public final void run() {
@@ -203,7 +208,7 @@ public class Continuation {
 			}
 			throw new IllegalStateException("Continuation is pinned: " + reason);
 		}
-		return yieldImpl();
+		return yieldImpl(false);
 	}
 
 	protected void onPinned(Pinned reason) {
@@ -239,6 +244,6 @@ public class Continuation {
 	/* Continuation Native APIs */
 	private native boolean createContinuationImpl();
 	private native boolean enterImpl();
-	private static native boolean yieldImpl();
+	private static native boolean yieldImpl(boolean isFinished);
 
 }

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2038,6 +2038,16 @@ exit:
 		}
 #endif /* JAVA_SPEC_VERSION > 11 */
 	}
+
+	static VMINLINE UDATA
+	walkContinuationStackFramesWrapper(J9VMThread *vmThread, j9object_t continuationObject, J9StackWalkState *walkState)
+	{
+		UDATA rc = J9_STACKWALK_RC_NONE;
+#if JAVA_SPEC_VERSION >= 19
+		rc = walkContinuationStackFrames(vmThread, continuationObject, walkState);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+		return rc;
+	}
 };
 
 #endif /* VMHELPERS_HPP_ */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4891,6 +4891,68 @@ typedef struct J9InvocationJavaVM {
 	J9NativeLibrary * reserved2_library;
 } J9InvocationJavaVM;
 
+typedef struct J9JITGPRSpillArea {
+#if defined(J9VM_ARCH_S390)
+	U_8 jitGPRs[16 * 8];	/* r0-r15 full 8-byte */
+#elif defined(J9VM_ARCH_POWER) /* J9VM_ARCH_S390 */
+	UDATA jitGPRs[32];	/* r0-r31 */
+	UDATA jitCR;
+	UDATA jitLR;
+#elif defined(J9VM_ARCH_ARM) /* J9VM_ARCH_POWER */
+#if defined(J9VM_ENV_DATA64)
+	/* ARM 64 */
+#error ARM 64 unsupported
+#else /* J9VM_ENV_DATA64 */
+	/* ARM 32 */
+	UDATA jitGPRs[16];	/* r0-r15 */
+#endif /* J9VM_ENV_DATA64 */
+#elif defined(J9VM_ARCH_AARCH64) /* J9VM_ARCH_ARM */
+	UDATA jitGPRs[32]; /* x0-x31 */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_AARCH64 */
+	UDATA jitGPRs[32];	/* x0-x31 */
+#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_RISCV */
+#if defined(J9VM_ENV_DATA64)
+	union {
+		UDATA numbered[16];
+		struct {
+			UDATA rax;
+			UDATA rbx;
+			UDATA rcx;
+			UDATA rdx;
+			UDATA rdi;
+			UDATA rsi;
+			UDATA rbp;
+			UDATA rsp;
+			UDATA r8;
+			UDATA r9;
+			UDATA r10;
+			UDATA r11;
+			UDATA r12;
+			UDATA r13;
+			UDATA r14;
+			UDATA r15;
+		} named;
+	} jitGPRs;
+#else /* J9VM_ENV_DATA64 */
+	union {
+		UDATA numbered[8];
+		struct {
+			UDATA rax;
+			UDATA rbx;
+			UDATA rcx;
+			UDATA rdx;
+			UDATA rdi;
+			UDATA rsi;
+			UDATA rbp;
+			UDATA rsp;
+		} named;
+	} jitGPRs;
+#endif /* J9VM_ENV_DATA64 */
+#else /* J9VM_ARCH_X86 */
+#error Unknown architecture
+#endif /* J9VM_ARCH_X86 */
+} J9JITGPRSpillArea;
+
 #if JAVA_SPEC_VERSION >= 19
 typedef struct J9VMContinuation {
 	UDATA* arg0EA;
@@ -4901,7 +4963,10 @@ typedef struct J9VMContinuation {
 	UDATA* stackOverflowMark;
 	UDATA* stackOverflowMark2;
 	J9JavaStack* stackObject;
-	struct J9VMEntryLocalStorage entryLocalStorage;
+	struct J9JITDecompilationInfo* decompilationStack;
+	UDATA* j2iFrame;
+	struct J9JITGPRSpillArea jitGPRs;
+	struct J9VMEntryLocalStorage* oldEntryLocalStorage;
 } J9VMContinuation;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
@@ -5745,68 +5810,6 @@ typedef struct J9JITWatchedStaticFieldData {
 #if J9_INLINE_JNI_MAX_ARG_COUNT != 32
 #error Math is depending on J9_INLINE_JNI_MAX_ARG_COUNT being 32
 #endif
-
-typedef struct J9JITGPRSpillArea {
-#if defined(J9VM_ARCH_S390)
-	U_8 jitGPRs[16 * 8];	/* r0-r15 full 8-byte */
-#elif defined(J9VM_ARCH_POWER) /* J9VM_ARCH_S390 */
-	UDATA jitGPRs[32];	/* r0-r31 */
-	UDATA jitCR;
-	UDATA jitLR;
-#elif defined(J9VM_ARCH_ARM) /* J9VM_ARCH_POWER */
-#if defined(J9VM_ENV_DATA64)
-	/* ARM 64 */
-#error ARM 64 unsupported
-#else /* J9VM_ENV_DATA64 */
-	/* ARM 32 */
-	UDATA jitGPRs[16];	/* r0-r15 */
-#endif /* J9VM_ENV_DATA64 */
-#elif defined(J9VM_ARCH_AARCH64) /* J9VM_ARCH_ARM */
-	UDATA jitGPRs[32]; /* x0-x31 */
-#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_AARCH64 */
-	UDATA jitGPRs[32];	/* x0-x31 */
-#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_RISCV */
-#if defined(J9VM_ENV_DATA64)
-	union {
-		UDATA numbered[16];
-		struct {
-			UDATA rax;
-			UDATA rbx;
-			UDATA rcx;
-			UDATA rdx;
-			UDATA rdi;
-			UDATA rsi;
-			UDATA rbp;
-			UDATA rsp;
-			UDATA r8;
-			UDATA r9;
-			UDATA r10;
-			UDATA r11;
-			UDATA r12;
-			UDATA r13;
-			UDATA r14;
-			UDATA r15;
-		} named;
-	} jitGPRs;
-#else /* J9VM_ENV_DATA64 */
-	union {
-		UDATA numbered[8];
-		struct {
-			UDATA rax;
-			UDATA rbx;
-			UDATA rcx;
-			UDATA rdx;
-			UDATA rdi;
-			UDATA rsi;
-			UDATA rbp;
-			UDATA rsp;
-		} named;
-	} jitGPRs;
-#endif /* J9VM_ENV_DATA64 */
-#else /* J9VM_ARCH_X86 */
-#error Unknown architecture
-#endif /* J9VM_ARCH_X86 */
-} J9JITGPRSpillArea;
 
 typedef struct J9CInterpreterStackFrame {
 #if defined(J9VM_ARCH_S390)

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4343,6 +4343,16 @@ yieldContinuation(struct J9VMThread *currentThread);
  */
 jint
 isPinnedContinuation(J9VMThread *currentThread);
+
+/**
+ * @brief  Walk the stackframes associated with Continuation object
+ *
+ * @param currentThread
+ * @param continuationObject
+ * @return UDATA
+ */
+UDATA
+walkContinuationStackFrames(J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 /* ---------------- hookableAsync.c ---------------- */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -444,6 +444,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="15-18"/>
 	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="19-"/>
 
+	<!-- Static method references needed to support VirtualThread/Continuation. -->
+	<staticmethodref class="jdk/internal/vm/Continuation" name="execute" signature="(Ljdk/internal/vm/Continuation;)V" versions="19-"/>
 	<!-- Security manager check -->
 	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5154,37 +5154,37 @@ ffi_OOM:
 	enterContinuationImpl(REGISTER_ARGS_LIST)
 	{
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
-		jboolean res = JNI_FALSE;
 
 		j9object_t continuationObject = *(j9object_t*)_sp;
 
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 
-		res = enterContinuation(_currentThread, continuationObject);
-
-		VMStructHasBeenUpdated(REGISTER_ARGS);
-		if (VM_VMHelpers::exceptionPending(_currentThread)) {
-			rc = GOTO_THROW_CURRENT_EXCEPTION;
-			goto done;
+		if (enterContinuation(_currentThread, continuationObject)) {
+			_sendMethod = J9VMJDKINTERNALVMCONTINUATION_EXECUTE_METHOD(_currentThread->javaVM);
+			rc = GOTO_RUN_METHOD;
 		}
 
-		restoreInternalNativeStackFrame(REGISTER_ARGS);
-		returnSingleFromINL(REGISTER_ARGS, res, 1);
-done:
+		VMStructHasBeenUpdated(REGISTER_ARGS);
+
 		return rc;
 	}
 
-	/* jdk.internal.vm.Continuation: private static native boolean yieldImpl(); */
+	/* jdk.internal.vm.Continuation: private static native boolean yieldImpl(boolean isFinished); */
 	VMINLINE VM_BytecodeAction
 	yieldContinuationImpl(REGISTER_ARGS_LIST)
 	{
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
+		UDATA isFinished = *(I_32*)_sp;
+
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 
 		/* store the current Continuation state and swap to carrier thread stack */
 		yieldContinuation(_currentThread);
+		if (isFinished) {
+			/* CleanupContinuation */
+		}
 
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		restoreInternalNativeStackFrame(REGISTER_ARGS);

--- a/runtime/vm/ContinuationHelpers.hpp
+++ b/runtime/vm/ContinuationHelpers.hpp
@@ -67,14 +67,14 @@ public:
 		SWAP_MEMBER(stackOverflowMark, UDATA*, vmThread, continuation);
 		SWAP_MEMBER(stackOverflowMark2, UDATA*, vmThread, continuation);
 		SWAP_MEMBER(stackObject, J9JavaStack*, vmThread, continuation);
-	}
+		SWAP_MEMBER(decompilationStack, J9JITDecompilationInfo*, vmThread, continuation);
+		SWAP_MEMBER(j2iFrame, UDATA*, vmThread, continuation);
 
-	static VMINLINE void
-	popAndStoreELS(J9VMThread *vmThread, J9VMContinuation *continuation)
-	{
-		continuation->entryLocalStorage = *vmThread->entryLocalStorage;
-		continuation->entryLocalStorage.oldEntryLocalStorage = NULL;
-		vmThread->entryLocalStorage = vmThread->entryLocalStorage->oldEntryLocalStorage;
+		/* Swap the JIT GPR registers data referenced by ELS */
+		J9JITGPRSpillArea tempGPRs = continuation->jitGPRs;
+		continuation->jitGPRs = *(J9JITGPRSpillArea*)vmThread->entryLocalStorage->jitGlobalStorageBase;
+		*(J9JITGPRSpillArea*)vmThread->entryLocalStorage->jitGlobalStorageBase = tempGPRs;
+		SWAP_MEMBER(oldEntryLocalStorage, J9VMEntryLocalStorage*, vmThread->entryLocalStorage, continuation);
 	}
 
 };

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -296,7 +296,7 @@ static inlMapping mappings[] = {
 #endif /* JAVA_SPEC_VERSION >= 16 */
 #if JAVA_SPEC_VERSION >= 19
 	{ "Java_jdk_internal_vm_Continuation_enterImpl__", J9_BCLOOP_SEND_TARGET_ENTER_CONTINUATION },
-	{ "Java_jdk_internal_vm_Continuation_yieldImpl__", J9_BCLOOP_SEND_TARGET_YIELD_CONTINUATION },
+	{ "Java_jdk_internal_vm_Continuation_yieldImpl__Z", J9_BCLOOP_SEND_TARGET_YIELD_CONTINUATION },
 	{ "Java_jdk_internal_vm_Continuation_isPinnedImpl__", J9_BCLOOP_SEND_TARGET_ISPINNED_CONTINUATION },
 #endif /* JAVA_SPEC_VERSION >= 19 */
 };


### PR DESCRIPTION
- Cache jitGPR data in J9VMContinuation
- Wrap `Continuation.execute` call to force yield after completion
- Build Callin frame during first enterContinuation call
- added helper to copy Continuation data into J9VMThread structure

Closes: #15464 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>