### PR TITLE
Inline superClassTest for transformed checkCast nodes when castClass is runtime variable

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -1345,8 +1345,7 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
       sequences[i++] = ClassEqualityTest;
       sequences[i++] = CastClassCacheTest;
       // On Z, We were having support for Super Class Test for dynamic Cast Class so adding it here. It can be guarded if Power/X do not need it.
-      if (cg->supportsInliningOfIsInstance() &&
-         instanceOfOrCheckCastNode->getOpCodeValue() == TR::instanceof &&
+      if ( (cg->supportsInliningOfIsInstance() || instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcast) &&
          instanceOfOrCheckCastNode->getSecondChild()->getOpCodeValue() != TR::loadaddr)
          sequences[i++] = SuperClassTest;
       if (createDynamicCacheTests)

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -1292,7 +1292,7 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
 
    // By default maxOnsiteCacheSlotForInstanceOf is set to 0 which means cache is disable.
    // To enable test pass JIT option maxOnsiteCacheSlotForInstanceOf=<number_of_slots>
-   bool createDynamicCacheTests = cg->comp()->getOptions()->getMaxOnsiteCacheSlotForInstanceOf() > 0;
+   bool createDynamicCacheTests = cg->comp()->getOptions()->getMaxOnsiteCacheSlotForInstanceOf() > 0 && isInstanceOf;
 
 
    uint32_t i = 0;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3655,8 +3655,8 @@ bool genInstanceOfOrCheckcastSuperClassTest(TR::Node *node, TR::CodeGenerator *c
       {
       TR::Register *scratchRegister1 = srm->findOrCreateScratchRegister();
       //TR::Register *scratchRegister1 = scratch1Reg;
-      TR_ASSERT((node->getOpCodeValue() == TR::instanceof &&
-            node->getSecondChild()->getOpCodeValue() != TR::loadaddr), "genTestIsSuper: castClassDepth == -1 is only supported for transformed isInstance calls.");
+      TR_ASSERT(node->getSecondChild()->getOpCodeValue() != TR::loadaddr,
+            "genTestIsSuper: castClassDepth == -1 is not supported for a loadaddr castClass.");
       cursor = generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchRegister1,
             generateS390MemoryReference(castClassReg, offsetof(J9Class, romClass), cg), cursor);
       cursor = generateRXInstruction(cg, TR::InstOpCode::L, node, scratchRegister1,

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3912,7 +3912,7 @@ J9::Z::TreeEvaluator::checkcastEvaluator(TR::Node * node, TR::CodeGenerator * cg
             TR_ASSERT(numSequencesRemaining == 2, "SuperClassTest should always be followed by a GoToFalse and must always be the second last test generated");
             if (comp->getOption(TR_TraceCG))
                traceMsg(comp, "%s: Emitting Super Class Test, Cast Class Depth=%d\n", node->getOpCode().getName(),castClassDepth);
-            dynamicCastClass = genInstanceOfOrCheckcastSuperClassTest(node, cg, objClassReg, castClassReg, castClassDepth, callLabel, NULL, srm);
+            dynamicCastClass = genInstanceOfOrCheckcastSuperClassTest(node, cg, objClassReg, castClassReg, castClassDepth, callLabel, callLabel, srm);
             /* outlinedSlowPath will be non-NULL if we have a higher probability of ClassEqualityTest succeeding.
                * In such cases we will do rest of the tests in OOL section, and as such we need to skip the helper call
                * if the result of SuperClassTest is true and branch to resultLabel which will branch back to the doneLabel from OOL code.


### PR DESCRIPTION
The case of castClass being a runtime variable was only for `instanceOf` nodes until #15079 (transforms Class.cast calls to checkCast nodes), for this new case we can inline superClassTest to improve performance. This part of common code is used by Z, P and AARCH64. 

This PR allows `checkCast` nodes in the case of variable castClass to inline superClassTest. 
It also adds array and interface checks for castClass before the superClassTest, if so skip superClassTest, for P and AARCH64. It's already implemented in Z.

Description issue: #15535

- ~Finish/check AARCH64 code (using/not-using `tbz/tbnz`, immediate `immr:imms`)~
- ~P handle unknown classDepth for superClassTest~
- ~Testing and benchmark performance~
