### PR TITLE
Disable LocalSyncCompiles under FullSpeedDebug

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2650,6 +2650,9 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
             }
 
          self()->setOption(TR_FullSpeedDebug);
+#if defined(J9VM_OPT_JITSERVER)
+         compInfo->getPersistentInfo()->setLocalSyncCompiles(false);
+#endif /* defined(J9VM_OPT_JITSERVER) */
          self()->setOption(TR_DisableDirectToJNI);
          //setOption(TR_DisableNoVMAccess);
          //setOption(TR_DisableAsyncCompilation);


### PR DESCRIPTION
The JITServerLocalSyncCompiles option causes remote recompilations to
be scheduled after synchronous JIT compilations. This is incompatible
with FullSpeedDebug, which is supposed to disable recompilations.

Signed-off-by: Christian Despres <despresc@ibm.com>