### PR TITLE
Block Virtual Threads for JVMTI Inspection

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -644,11 +644,18 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 #if JAVA_SPEC_VERSION >= 19
-	/* These fields point to the next and previous VirtualThreads in the liveVirtualThreadList. */
+	/* Points to the next VirtualThread in the liveVirtualThreadList. */
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkNext", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkNextOffset)) {
 		return 1;
 	}
+
+	/* Points to the previous VirtualThread in the liveVirtualThreadList. */
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkPrevious", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkPreviousOffset)) {
+		return 1;
+	}
+
+	/* Counter to track if the virtual thread is being inspected by JVMTI. */
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "inspectorCount", "J", &vm->virtualThreadInspectorCountOffset)) {
 		return 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -527,17 +527,18 @@ Java_java_lang_Thread_registerNatives(JNIEnv *env, jclass clazz)
 void JNICALL
 Java_java_lang_VirtualThread_notifyJvmtiMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 {
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
+	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+
 	if (firstMount) {
-		J9VMThread *currentThread = (J9VMThread *)env;
-		J9JavaVM *vm = currentThread->javaVM;
-		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-		J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
-
-		vmFuncs->internalEnterVMFromJNI(currentThread);
-
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
 		if (NULL == vm->liveVirtualThreadList) {
 			J9Class *virtualThreadClass = J9OBJECT_CLAZZ(currentThread, J9_JNI_UNWRAP_REFERENCE(thread));
+			J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
 
 			/* Allocate empty virtual thread and create a global reference to it as root for the linked list.
 			 * This prevents the root reference from becoming stale if the GC moves the object.
@@ -562,7 +563,6 @@ Java_java_lang_VirtualThread_notifyJvmtiMountBegin(JNIEnv *env, jobject thread, 
 
 		if (NULL != vm->liveVirtualThreadList) {
 			j9object_t root = *(vm->liveVirtualThreadList);
-			j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 			j9object_t rootPrev = J9OBJECT_OBJECT_LOAD(currentThread, root, vm->virtualThreadLinkPreviousOffset);
 
 			/* Add thread to the end of the list. */
@@ -571,10 +571,19 @@ Java_java_lang_VirtualThread_notifyJvmtiMountBegin(JNIEnv *env, jobject thread, 
 			J9OBJECT_OBJECT_STORE(currentThread, rootPrev, vm->virtualThreadLinkNextOffset, threadObj);
 			J9OBJECT_OBJECT_STORE(currentThread, root, vm->virtualThreadLinkPreviousOffset, threadObj);
 		}
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
-
-		vmFuncs->internalExitVMToJNI(currentThread);
+	} else {
+		/* If this virtual thread is being inspected, do not allow a yielded thread to mount. */
+		while (0 != J9OBJECT_U64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset)) {
+			VM_VMHelpers::pushObjectInSpecialFrame(currentThread, threadObj);
+			vmFuncs->internalExitVMToJNI(currentThread);
+			omrthread_monitor_wait(vm->liveVirtualThreadListMutex);
+			vmFuncs->internalEnterVMFromJNI(currentThread);
+			threadObj = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
+		}
 	}
+
+	omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 /* private native void notifyJvmtiMountEnd(boolean firstMount); */
@@ -587,22 +596,25 @@ Java_java_lang_VirtualThread_notifyJvmtiMountEnd(JNIEnv *env, jobject thread, jb
 void JNICALL
 Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin(JNIEnv *env, jobject thread, jboolean lastUnmount)
 {
-}
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
-/* private native void notifyJvmtiUnmountEnd(boolean lastUnmount); */
-void JNICALL
-Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
-{
-	if (lastUnmount) {
-		J9VMThread *currentThread = (J9VMThread *)env;
-		J9JavaVM *vm = currentThread->javaVM;
-		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	vmFuncs->internalEnterVMFromJNI(currentThread);
 
+	omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
+	/* If this virtual thread is being inspected, do not allow it to unmount. */
+	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+	while (0 != J9OBJECT_U64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset)) {
+		VM_VMHelpers::pushObjectInSpecialFrame(currentThread, threadObj);
+		vmFuncs->internalExitVMToJNI(currentThread);
+		omrthread_monitor_wait(vm->liveVirtualThreadListMutex);
 		vmFuncs->internalEnterVMFromJNI(currentThread);
+		threadObj = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
+	}
 
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
+	if (lastUnmount) {
 		if (NULL != vm->liveVirtualThreadList) {
-			j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 			j9object_t threadPrev = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset);
 			j9object_t threadNext = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkNextOffset);
 
@@ -610,10 +622,16 @@ Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd(JNIEnv *env, jobject thread, 
 			J9OBJECT_OBJECT_STORE(currentThread, threadPrev, vm->virtualThreadLinkNextOffset, threadNext);
 			J9OBJECT_OBJECT_STORE(currentThread, threadNext, vm->virtualThreadLinkPreviousOffset, threadPrev);
 		}
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
-
-		vmFuncs->internalExitVMToJNI(currentThread);
 	}
+
+	omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+	vmFuncs->internalExitVMToJNI(currentThread);
+}
+
+/* private native void notifyJvmtiUnmountEnd(boolean lastUnmount); */
+void JNICALL
+Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
+{
 }
 
 /* private static native void registerNatives(); */

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -1458,7 +1458,7 @@ jvmtiGetOSThreadID(jvmtiEnv* jvmti_env, ...)
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -1468,7 +1468,7 @@ jvmtiGetOSThreadID(jvmtiEnv* jvmti_env, ...)
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
 			rv_threadid = (jlong) omrthread_get_osId(targetThread->osThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -1508,7 +1508,7 @@ jvmtiGetStackTraceExtended(jvmtiEnv* env, ...)
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -1525,7 +1525,7 @@ jvmtiGetStackTraceExtended(jvmtiEnv* env, ...)
 			rc = jvmtiInternalGetStackTraceExtended(env, type, currentThread, targetThread, start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -3444,7 +3444,7 @@ jvmtiGetJ9vmThread(jvmtiEnv *env, ...)
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -3455,7 +3455,7 @@ jvmtiGetJ9vmThread(jvmtiEnv *env, ...)
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
 			rv_vmThread = targetThread;
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);

--- a/runtime/jvmti/jvmtiForceEarlyReturn.c
+++ b/runtime/jvmti/jvmtiForceEarlyReturn.c
@@ -138,7 +138,7 @@ jvmtiForceEarlyReturn(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -238,7 +238,7 @@ jvmtiForceEarlyReturn(jvmtiEnv* env,
 			}
 resume:
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);

--- a/runtime/jvmti/jvmtiHelpers.h
+++ b/runtime/jvmti/jvmtiHelpers.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,12 @@
 #include "ut_j9jvmti.h"
 #include "omrlinkedlist.h"
 #include "jvmti_internal.h"
+
+#if JAVA_SPEC_VERSION >= 19
+/* See VirtualThreadTests.test_verifyJVMTIMacros for validation of below macro values. */
+#define JVMTI_VTHREAD_STATE_NEW 0
+#define JVMTI_VTHREAD_STATE_TERMINATED 99
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 #endif			/* jvmtiHelpers_h */
 

--- a/runtime/jvmti/jvmtiLocalVariable.c
+++ b/runtime/jvmti/jvmtiLocalVariable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -309,7 +309,7 @@ jvmtiGetOrSetLocal(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
@@ -425,7 +425,7 @@ jvmtiGetOrSetLocal(jvmtiEnv* env,
 				
 				*((jobject *) value_ptr) = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, obj);
 			}
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}

--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -45,7 +45,7 @@ jvmtiGetStackTrace(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -62,7 +62,7 @@ jvmtiGetStackTrace(jvmtiEnv* env,
 			rc = jvmtiInternalGetStackTrace(env, currentThread, targetThread, start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -272,7 +272,7 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -293,7 +293,7 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 			rv_count = (jint) walkState.framesWalked;
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -326,7 +326,7 @@ jvmtiPopFrame(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -361,7 +361,7 @@ jvmtiPopFrame(jvmtiEnv* env,
 				}
 			}
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -388,7 +388,7 @@ jvmtiGetFrameLocation(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -424,7 +424,7 @@ jvmtiGetFrameLocation(jvmtiEnv* env,
 			}
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -453,7 +453,7 @@ jvmtiNotifyFramePop(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * targetThread;
+		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -491,7 +491,7 @@ jvmtiNotifyFramePop(jvmtiEnv* env,
 			}
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
-			releaseVMThread(currentThread, targetThread);
+			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -304,7 +304,7 @@ getThreadGroupChildrenImpl(J9JavaVM *vm, J9VMThread *currentThread, jobject grou
 
 			if (JVMTI_ERROR_NONE == getVMThread(currentThread, (jthread)&thread, &targetThread, FALSE, TRUE)) {
 				threads[numLiveThreads++] = (jthread)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, thread);
-				releaseVMThread(currentThread, targetThread);
+				releaseVMThread(currentThread, targetThread, NULL);
 			}
 		}
 

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -156,7 +156,7 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 				} else {
 					rv_nanos = (jlong)omrthread_get_cpu_time(targetThread->osThread);
 				}
-				releaseVMThread(currentThread, targetThread);
+				releaseVMThread(currentThread, targetThread, NULL);
 			}
 		}
 done:

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1124,14 +1124,14 @@ getThreadState(J9VMThread *currentThread, j9object_t threadObject);
 
 
 /**
-* @brief
-* @param currentThread
-* @param thread
-* @param vmThreadPtr
-* @param allowNull
-* @param mustBeAlive
-* @return jvmtiError
-*/
+ * @brief
+ * @param currentThread
+ * @param thread
+ * @param vmThreadPtr
+ * @param allowNull
+ * @param mustBeAlive
+ * @return jvmtiError
+ */
 jvmtiError
 getVMThread(J9VMThread * currentThread, jthread thread, J9VMThread ** vmThreadPtr, UDATA allowNull, UDATA mustBeAlive);
 
@@ -1203,13 +1203,14 @@ queueCompileEvent(J9JVMTIData * jvmtiData, jmethodID methodID, void * startPC, U
 
 
 /**
-* @brief
-* @param currentThread
-* @param targetThread
-* @return void
-*/
+ * @brief
+ * @param currentThread
+ * @param targetThread
+ * @param thread
+ * @return void
+ */
 void
-releaseVMThread(J9VMThread * currentThread, J9VMThread * targetThread);
+releaseVMThread(J9VMThread *currentThread, J9VMThread *targetThread, jthread thread);
 
 
 /**

--- a/runtime/jvmti/suspendhelper.cpp
+++ b/runtime/jvmti/suspendhelper.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,8 +29,8 @@ extern "C" {
 jvmtiError
 suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, UDATA *currentThreadSuspended)
 {
-	J9VMThread * targetThread;
-	jvmtiError rc;
+	J9VMThread *targetThread = NULL;
+	jvmtiError rc = JVMTI_ERROR_NONE;
 
 	*currentThreadSuspended = FALSE;
 	rc = getVMThread(currentThread, thread, &targetThread, allowNull, TRUE);
@@ -59,7 +59,7 @@ suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, UDATA 
 				Trc_JVMTI_threadSuspended(targetThread);
 			}
 		}
-		releaseVMThread(currentThread, targetThread);
+		releaseVMThread(currentThread, targetThread, thread);
 	}
 
 	return rc;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5765,6 +5765,7 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t liveVirtualThreadListMutex;
 	UDATA virtualThreadLinkNextOffset;
 	UDATA virtualThreadLinkPreviousOffset;
+	UDATA virtualThreadInspectorCountOffset;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9JavaVM;
 

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -51,6 +51,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<classref name="java/lang/Thread"/>
 	<classref name="java/lang/Thread$FieldHolder" versions="19-"/>
 	<classref name="java/lang/BaseVirtualThread" versions="19-"/>
+	<classref name="java/lang/VirtualThread" versions="19-"/>
 	<classref name="java/lang/ArithmeticException"/>
 	<classref name="java/lang/ThreadGroup"/>
 	<classref name="java/lang/InterruptedException"/>
@@ -251,6 +252,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Thread" name="priority" signature="I" versions="8-18"/>
 	<fieldref class="java/lang/Thread" name="isDaemon" signature="Z" versions="8-18"/>
 	<fieldref class="java/lang/Thread" name="group" signature="Ljava/lang/ThreadGroup;" versions="8-18"/>
+
+	<fieldref class="java/lang/VirtualThread" name="state" signature="I" versions="19-"/>
+	<fieldref class="java/lang/VirtualThread" name="carrierThread" signature="Ljava/lang/Thread;" versions="19-"/>
 
 	<fieldref class="java/lang/Throwable" name="cause" signature="Ljava/lang/Throwable;"/>
 	<fieldref class="java/lang/Throwable" name="detailMessage" signature="Ljava/lang/String;"/>

--- a/test/functional/Java19andUp/playlist.xml
+++ b/test/functional/Java19andUp/playlist.xml
@@ -27,8 +27,10 @@
 			<variation>--enable-preview -Xint -Xgcpolicy:nogc</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+			--add-opens java.base/java.lang=ALL-UNNAMED \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_190.xml$(Q) -testnames Jep425Tests_testVirtualThread \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_190.xml$(Q) \
+			-testnames Jep425Tests_testVirtualThread \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)

--- a/test/functional/Java19andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
@@ -27,6 +27,7 @@ import org.testng.AssertJUnit;
 import static org.testng.Assert.fail;
 
 import java.lang.Thread;
+import java.lang.reflect.*;
 import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -135,6 +136,36 @@ public class VirtualThreadTests {
 
 			t.start();
 			t.join();
+		} catch (Exception e) {
+			Assert.fail("Unexpected exception occured : " + e.getMessage() , e);
+		}
+	}
+
+	private static int readVirtualThreadStates(Class vthreadCls, String fieldName) throws Exception {
+		Field vthreadState = vthreadCls.getDeclaredField(fieldName);
+		vthreadState.setAccessible(true);
+		return vthreadState.getInt(null);
+	}
+
+	@Test
+	public void test_verifyJVMTIMacros() {
+		final int JVMTI_VTHREAD_STATE_NEW = 0;
+		final int JVMTI_VTHREAD_STATE_TERMINATED = 99;
+
+		int value = 0;
+
+		try {
+			Class<?> vthreadCls = Class.forName("java.lang.VirtualThread");
+
+			value = readVirtualThreadStates(vthreadCls, "NEW");
+			if (JVMTI_VTHREAD_STATE_NEW != value) {
+				Assert.fail("JVMTI_VTHREAD_STATE_NEW (" + JVMTI_VTHREAD_STATE_NEW + ") does not match VirtualThread.NEW (" + value + ")");
+			}
+
+			value = readVirtualThreadStates(vthreadCls, "TERMINATED");
+			if (JVMTI_VTHREAD_STATE_TERMINATED != value) {
+				Assert.fail("JVMTI_VTHREAD_STATE_TERMINATED (" + JVMTI_VTHREAD_STATE_TERMINATED + ") does not match VirtualThread.TERMINATED (" + value + ")");
+			}
 		} catch (Exception e) {
 			Assert.fail("Unexpected exception occured : " + e.getMessage() , e);
 		}


### PR DESCRIPTION
- Return the corresponding `J9VMThread` for a virtual thread from
  `getVMThread`.
- Prevent the virtual thread from unmounting using the `inspectorCount`
  approach.
- The virtual thread is stopped just before `J9VMThread->threadObject` is set
  from the virtual thread to the carrier thread.
- This also prevents a virtual thread from freeing its native resources while
  it is being inspected.
- For a virtual thread, even the underlying `J9VMThread` is prevented from
  freeing its native resources using the `inspectorCount` approach.
- `isSameOrSuperClassOf` is unable to handle `NULL` from the `*_OR_NULL` 
   version. Instead, use `J9VMJAVALANGBASEVIRTUALTHREAD` in
  `IS_VIRTUAL_THREAD`.
- Moved code from `notifyJvmtiUnmountEnd` to `notifyJvmtiUnmountBegin` for blocking
before `unmount`. Also, `VirtualThread.carrierThread` is set to NULL in `unmount`.
So, removing the VirtualThread from the linked list before the last `unmount`
in `notifyJvmtiUnmountBegin` seems correct.
- Block mount after yield if a virtual thread is being inspected.
- In `getVMThread`:
  - `targetThread` will be NULL for a yielded virtual thread.
  - `JVMTI_ERROR_NONE` will be returned for a yielded virtual thread.
  - `virtualThreadInspectorCount` will be incremented for a yielded
     virtual thread.
- Reload references after the wait since they can become outdated if a GC
  occurs during the wait.
- Release VM access before the wait and re-acquire VM access after the wait.
- Decrement `virtualThreadInspectorCount` for yielded virtual threads i.e.
  `(targetThread == NULL)`.

Related: #15183. This impacts all JVMTI functions that rely on `getVMThread` and
`releaseVMThread`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>