### PR TITLE
x86: Enable VectorAPI at 128-bits

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -376,7 +376,8 @@ class TR_VectorAPIExpansion : public TR::Optimization
          // General check for supported infrastructure
          if (!comp->target().cpu.isPower() &&
                !(comp->target().cpu.isZ() && comp->cg()->getSupportsVectorRegisters()) &&
-               !comp->target().cpu.isARM64())
+               !comp->target().cpu.isARM64() &&
+               !comp->target().cpu.isX86())
             {
             length = TR::NoVectorLength;
             }


### PR DESCRIPTION
Depends on: eclipse-omr/omr#7833

Signed-off-by: BradleyWood <bradley.wood@ibm.com>