### PR TITLE
Fix build errors in jdk20

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,5 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
-/*******************************************************************************
+/*
  * Copyright (c) 2007, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
@@ -19,7 +19,7 @@
  * [2] http://openjdk.java.net/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
- *******************************************************************************/
+ */
 package java.lang;
 
 import java.lang.annotation.Annotation;
@@ -69,6 +69,9 @@ import jdk.internal.vm.ContinuationScope;
 import jdk.internal.vm.StackableScope;
 import jdk.internal.vm.ThreadContainer;
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+import jdk.internal.misc.CarrierThreadLocal;
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 /*[ELSE] Sidecar19-SE */
 import sun.misc.JavaLangAccess;
 import sun.reflect.ConstantPool;
@@ -514,6 +517,31 @@ final class Access implements JavaLangAccess {
 		return Thread.currentCarrierThread();
 	}
 
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	/*
+	 * To access package-private methods in ThreadLocal, an
+	 * (implicit) cast from CarrierThreadLocal is required.
+	 */
+	private static <T> ThreadLocal<T> asThreadLocal(CarrierThreadLocal<T> local) {
+		return local;
+	}
+
+	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> local) {
+		return asThreadLocal(local).getCarrierThreadLocal();
+	}
+
+	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> local) {
+		return asThreadLocal(local).isCarrierThreadLocalPresent();
+	}
+
+	public void removeCarrierThreadLocal(CarrierThreadLocal<?> local) {
+		asThreadLocal(local).removeCarrierThreadLocal();
+	}
+
+	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> local, T value) {
+		asThreadLocal(local).setCarrierThreadLocal(value);
+	}
+/*[ELSE] JAVA_SPEC_VERSION >= 20 */
 	public <T> T getCarrierThreadLocal(ThreadLocal<T> local) {
 		return local.getCarrierThreadLocal();
 	}
@@ -521,6 +549,7 @@ final class Access implements JavaLangAccess {
 	public <T> void setCarrierThreadLocal(ThreadLocal<T> local, T value) {
 		local.setCarrierThreadLocal(value);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
 	public <V> V executeOnCarrierThread(Callable<V> task) throws Exception {
 		V result;

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -404,6 +404,12 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 20)
+	jvm_add_exports(jvm
+		JVM_GetClassFileVersion
+	)
+endif()
+
 if(J9VM_OPT_JITSERVER)
 	jvm_add_exports(jvm
 		JITServer_CreateServer

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -405,4 +405,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_VirtualThreadUnmountEnd"/>
 	</exports>
 
+	<exports group="jdk20">
+		<!-- Additions for Java 20 (General) -->
+		<export name="JVM_GetClassFileVersion"/>
+	</exports>
+
 </exportlists>

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -76,6 +76,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk19">
 				<include-if condition="spec.java19"/>
 			</group>
+			<group name="jdk20">
+				<include-if condition="spec.java20"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -398,3 +398,5 @@ _IF([JAVA_SPEC_VERSION >= 19],
 	[_X(JVM_VirtualThreadUnmountBegin, JNICALL, false, void, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 19],
 	[_X(JVM_VirtualThreadUnmountEnd, JNICALL, false, void, JNIEnv *env)])
+_IF([JAVA_SPEC_VERSION >= 20],
+	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])


### PR DESCRIPTION
See https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/313 which says:
```
01:58:11  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_OpenJDK/build/linux-x86_64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:66: error: Access is not abstract and does not override abstract method isCarrierThreadLocalPresent(CarrierThreadLocal<?>) in JavaLangAccess
01:58:11  final class Access implements JavaLangAccess {
01:58:11        ^
```
Also required is a new JVM function: `JNIEXPORT jint JNICALL JVM_GetClassFileVersion(JNIEnv *, jclass)`.