### PR TITLE
Enable VirtualThread natives by default

### DIFF
--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -620,6 +620,10 @@ Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd(JNIEnv *env, jobject thread, 
 void JNICALL
 Java_java_lang_VirtualThread_registerNatives(JNIEnv *env, jclass clazz)
 {
+	jfieldID notifyJvmtiEvents = env->GetStaticFieldID(clazz, "notifyJvmtiEvents", "Z");
+
+	Assert_JCL_notNull(notifyJvmtiEvents);
+	env->SetStaticBooleanField(clazz, notifyJvmtiEvents, JNI_TRUE);
 }
 #endif /* JAVA_SPEC_VERSION >= 19 */
 


### PR DESCRIPTION
The VirtualThread natives are needed to keep a list of every live virtual
thread for JVM TI. Since JVM TI agents can be attached at any time, enable
these natives by default.

Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>