### PR TITLE
Return JVMTI_ERROR_OPAQUE_FRAME from ForceEarlyReturn* and PopFrame

### DIFF
--- a/runtime/jvmti/jvmtiForceEarlyReturn.c
+++ b/runtime/jvmti/jvmtiForceEarlyReturn.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,11 +32,11 @@ jvmtiForceEarlyReturnObject(jvmtiEnv* env,
 {
 	jvmtiError rc;
 
-	Trc_JVMTI_jvmtiForceEarlyReturnVoid_Entry(env);
+	Trc_JVMTI_jvmtiForceEarlyReturnObject_Entry(env);
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_JOBJECT, value);
 
-	return rc; 
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnObject);
 }
 
 
@@ -47,11 +47,11 @@ jvmtiForceEarlyReturnInt(jvmtiEnv* env,
 {
 	jvmtiError rc;
 
-	Trc_JVMTI_jvmtiForceEarlyReturnVoid_Entry(env);
+	Trc_JVMTI_jvmtiForceEarlyReturnInt_Entry(env);
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_JINT, &value);
 
-	return rc; 
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnInt);
 }
 
 
@@ -62,11 +62,11 @@ jvmtiForceEarlyReturnLong(jvmtiEnv* env,
 {
 	jvmtiError rc;
 
-	Trc_JVMTI_jvmtiForceEarlyReturnVoid_Entry(env);
+	Trc_JVMTI_jvmtiForceEarlyReturnLong_Entry(env);
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_JLONG, &value);
 
-	return rc; 
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnLong);
 }
 
 
@@ -77,11 +77,11 @@ jvmtiForceEarlyReturnFloat(jvmtiEnv* env,
 {
 	jvmtiError rc;
 
-	Trc_JVMTI_jvmtiForceEarlyReturnVoid_Entry(env);
+	Trc_JVMTI_jvmtiForceEarlyReturnFloat_Entry(env);
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_JFLOAT, &value);
 
-	return rc; 
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnFloat);
 }
 
 
@@ -92,11 +92,11 @@ jvmtiForceEarlyReturnDouble(jvmtiEnv* env,
 {
 	jvmtiError rc;
 
-	Trc_JVMTI_jvmtiForceEarlyReturnVoid_Entry(env);
+	Trc_JVMTI_jvmtiForceEarlyReturnDouble_Entry(env);
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_JDOUBLE, &value);
 
-	return rc; 
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnDouble);
 }
 
 
@@ -110,7 +110,7 @@ jvmtiForceEarlyReturnVoid(jvmtiEnv* env,
 
 	rc = jvmtiForceEarlyReturn(env, thread, JVMTI_TYPE_CVOID, NULL);
 
-	return rc;
+	TRACE_JVMTI_RETURN(jvmtiForceEarlyReturnVoid);
 }
 
 
@@ -148,8 +148,11 @@ jvmtiForceEarlyReturn(jvmtiEnv* env,
 		/* Check if the jthread is really a j.l.Thread. a NULL jthread indicates that
 		 * the user wants to use the current thread hence defer the assignment to getVMThread */
 		
-		if (thread) {
+		if (NULL != thread) {
 			ENSURE_JTHREAD(currentThread, thread);
+#if JAVA_SPEC_VERSION >= 19
+			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_OPAQUE_FRAME);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		}
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
@@ -241,5 +244,5 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
-	TRACE_JVMTI_RETURN(jvmtiPopFrame);
+	return rc;
 }

--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -332,6 +332,12 @@ jvmtiPopFrame(jvmtiEnv* env,
 
 		ENSURE_PHASE_LIVE(env);
 		ENSURE_CAPABILITY(env, can_pop_frame);
+
+#if JAVA_SPEC_VERSION >= 19
+		if (NULL != thread) {
+			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_OPAQUE_FRAME);
+		}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 		rc = getVMThread(currentThread, thread, &targetThread, FALSE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -372,7 +372,7 @@ jvmtiStopThread(jvmtiEnv* env,
 
 		ENSURE_JTHREAD_NON_NULL(thread);
 #if JAVA_SPEC_VERSION >= 19
-		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread);
+		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_UNSUPPORTED_OPERATION);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 		rc = getVMThread(currentThread, thread, &targetThread, FALSE, TRUE);
@@ -817,7 +817,7 @@ jvmtiRunAgentThread(jvmtiEnv* env,
 
 		ENSURE_JTHREAD_NON_NULL(thread);
 #if JAVA_SPEC_VERSION >= 19
-		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread);
+		ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_UNSUPPORTED_OPERATION);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		/* Perhaps verify that thread has not already been started? */
 		ENSURE_NON_NULL(proc);

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -76,7 +76,10 @@ jvmtiGetCurrentThreadCpuTime(jvmtiEnv* env,
 	if (JVMTI_ERROR_NONE != rc) {
 		goto done;
 	}
-	ENSURE_JTHREADOBJECT_NOT_VIRTUAL(currentThread, currentThread->threadObject);
+	ENSURE_JTHREADOBJECT_NOT_VIRTUAL(
+		currentThread,
+		currentThread->threadObject,
+		JVMTI_ERROR_UNSUPPORTED_OPERATION);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 	rv_nanos = (jlong)omrthread_get_self_cpu_time(omrthread_self());
@@ -144,7 +147,7 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 			rv_nanos = (jlong)omrthread_get_cpu_time(omrthread_self());
 		} else {
 #if JAVA_SPEC_VERSION >= 19
-			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread);
+			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_UNSUPPORTED_OPERATION);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 			if (rc == JVMTI_ERROR_NONE) {

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -357,7 +357,7 @@ static const struct { \
 	((NULL != (method)) && (J9ROMCLASS_IS_ANON_OR_HIDDEN(J9_CLASS_FROM_METHOD((method))->romClass) || J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD((method))->modifiers, J9AccMethodFrameIteratorSkip)))
 
 #define IS_VIRTUAL_THREAD(vmThread, object) \
-	isSameOrSuperClassOf(J9VMJAVALANGBASEVIRTUALTHREAD_OR_NULL(((vmThread)->javaVM)), J9OBJECT_CLAZZ((vmThread), (object)))
+	isSameOrSuperClassOf(J9VMJAVALANGBASEVIRTUALTHREAD((vmThread)->javaVM), J9OBJECT_CLAZZ(vmThread, object))
 
 #if defined(OPENJ9_BUILD)
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -483,17 +483,17 @@ typedef struct jvmtiGcp_translation {
 	} while(0)
 
 #if JAVA_SPEC_VERSION >= 19
-#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd) \
+#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd, error) \
 	do { \
 		if (IS_VIRTUAL_THREAD((vmThread), J9_JNI_UNWRAP_REFERENCE(jthrd))) { \
-			JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_OPERATION); \
+			JVMTI_ERROR(error); \
 		} \
 	} while(0)
 
-#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject) \
+#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject, error) \
 	do { \
 		if (IS_VIRTUAL_THREAD((vmThread), (jthrdObject))) { \
-			JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_OPERATION); \
+			JVMTI_ERROR(error); \
 		} \
 	} while(0)
 #endif /* JAVA_SPEC_VERSION >= 19 */
@@ -516,8 +516,8 @@ typedef struct jvmtiGcp_translation {
 #define ENSURE_VALID_HEAP_OBJECT_FILTER(var)
 #define ENSURE_MONITOR_NON_NULL(var)
 #if JAVA_SPEC_VERSION >= 19
-#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd)
-#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject)
+#define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd, error)
+#define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject, error)
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 #endif


### PR DESCRIPTION
If the thread is a virtual thread, `ForceEarlyReturn*` and `PopFrame` JVMTI
functions should return `JVMTI_ERROR_OPAQUE_FRAME`.

Also, fixed the `entry/exit` tracepoints for `ForceEarlyReturn*` JVMTI functions.

`isSameOrSuperClassOf` is unable to handle `NULL` from the `*_OR_NULL` version.
Instead, use `J9VMJAVALANGBASEVIRTUALTHREAD` in `IS_VIRTUAL_THREAD`.

Ref: https://download.java.net/java/early_access/jdk19/docs/specs/jvmti.html

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>