### PR TITLE
Check for vector support on Z in supportedForPlatform

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#include "codegen/CodeGenerator.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/VerboseLog.hpp"
 #include "env/VMAccessCriticalSection.hpp"

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include "optimizer/Optimization.hpp"
 #include "optimizer/OptimizationManager.hpp"
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "il/SymbolReference.hpp"
 #include "infra/Assert.hpp"
@@ -264,7 +265,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    static TR::VectorLength supportedOnPlatform(TR::Compilation *comp, vec_sz_t vectorLength)
          {
          // General check for supported infrastructure
-         if (!comp->target().cpu.isPower() && !comp->target().cpu.isZ() && !comp->target().cpu.isARM64())
+         if (!comp->target().cpu.isPower() &&
+               !(comp->target().cpu.isZ() && comp->cg()->getSupportsVectorRegisters()) &&
+               !comp->target().cpu.isARM64())
             return TR::NoVectorLength;
 
          if (vectorLength != 128)


### PR DESCRIPTION
While generating the vector opcodes for loading and storing in vector
api expansion, we need to check if the vector supports is available on
Z. This commit adds that check in to supportedOnPlatform query.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>