### PR TITLE
Correct signature of JVM_VirtualThread functions

### DIFF
--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -236,25 +236,25 @@ JVM_IsPreviewEnabled(void)
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadMountBegin(JNIEnv *env)
+JVM_VirtualThreadMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 {
 	assert(!"JVM_VirtualThreadMountBegin unimplemented");
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadMountEnd(JNIEnv *env)
+JVM_VirtualThreadMountEnd(JNIEnv *env, jobject thread, jboolean firstMount)
 {
 	assert(!"JVM_VirtualThreadMountEnd unimplemented");
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadUnmountBegin(JNIEnv *env)
+JVM_VirtualThreadUnmountBegin(JNIEnv *env, jobject thread, jboolean lastUnmount)
 {
 	assert(!"JVM_VirtualThreadUnmountBegin unimplemented");
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadUnmountEnd(JNIEnv *env)
+JVM_VirtualThreadUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
 {
 	assert(!"JVM_VirtualThreadUnmountEnd unimplemented");
 }

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -391,12 +391,12 @@ _IF([JAVA_SPEC_VERSION >= 19],
 _IF([JAVA_SPEC_VERSION >= 19],
 	[_X(JVM_IsPreviewEnabled, JNICALL, false, void, void)])
 _IF([JAVA_SPEC_VERSION >= 19],
-	[_X(JVM_VirtualThreadMountBegin, JNICALL, false, void, JNIEnv *env)])
+	[_X(JVM_VirtualThreadMountBegin, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean first_mount)])
 _IF([JAVA_SPEC_VERSION >= 19],
-	[_X(JVM_VirtualThreadMountEnd, JNICALL, false, void, JNIEnv *env)])
+	[_X(JVM_VirtualThreadMountEnd, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean first_mount)])
 _IF([JAVA_SPEC_VERSION >= 19],
-	[_X(JVM_VirtualThreadUnmountBegin, JNICALL, false, void, JNIEnv *env)])
+	[_X(JVM_VirtualThreadUnmountBegin, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean last_unmount)])
 _IF([JAVA_SPEC_VERSION >= 19],
-	[_X(JVM_VirtualThreadUnmountEnd, JNICALL, false, void, JNIEnv *env)])
+	[_X(JVM_VirtualThreadUnmountEnd, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean last_unmount)])
 _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])


### PR DESCRIPTION
They all expect three parameters (not just one); see [jvm.h](https://github.com/ibmruntimes/openj9-openjdk-jdk19/blob/openj9/src/hotspot/share/include/jvm.h#L1150-L1160).