### PR TITLE
Control vector register preservation in JIT

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1518,7 +1518,27 @@ onLoadInternal(
       {
       javaVM->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
       }
+#elif defined(J9HAMMER)
+   bool hasAVX = TR::Compiler->target.cpu.supportsAVX();
+   bool hasAVX512 = TR::Compiler->target.cpu.supportsFeature(OMR_FEATURE_X86_AVX512F);
+   bool hasAVX512bw = TR::Compiler->target.cpu.supportsFeature(OMR_FEATURE_X86_AVX512BW);
+   static char *useExtendedRegisters = feGetEnv("TR_UseExtendedVectorRegisters");
+
+   if (hasAVX512 && hasAVX512bw && useExtendedRegisters)
+      {
+      javaVM->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
+      javaVM->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
+      }
+   else if (hasAVX512 && useExtendedRegisters)
+      {
+      javaVM->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
+      }
+   else if (hasAVX)
+      {
+      javaVM->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
+      }
 #endif
+
 
    // Address the case where the number of compilation threads is higher than the
    // maximum number of code caches

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1062,20 +1062,6 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	}
 #endif /* J9VM_OPT_JITSERVER */
 
-#if defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17)
-	J9ProcessorDesc desc;
-	j9sysinfo_get_processor_description(&desc);
-
-	if (j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX512F) && j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX512BW)) {
-		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
-		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
-	} else if (j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX512F)) {
-		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
-	} else if (j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX)) {
-		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
-	}
-#endif /* defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) */
-
 	initArgs.j2seVersion = createParams->j2seVersion;
 	initArgs.j2seRootDirectory = createParams->j2seRootDirectory;
 	initArgs.j9libvmDirectory = createParams->j9libvmDirectory;


### PR DESCRIPTION
This change moves the logic to enable vector register
preservation from the VM to the JIT. We also guard
the enablement of the extended vector registers with
with an environment variable.

Signed-off-by: BradleyWood <bradley.wood@ibm.com>