### PR TITLE
Check VFT bounds in TR_J9VMBase::getVFTEntry()

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -263,7 +263,9 @@ public:
     *
     * @param clazz The RAM class pointer to read from
     * @param offset An offset into the virtual function table (VFT) of clazz
-    * @return The entry point of the method at the given offset
+    * @return The method at the given offset, or (depending on offset) its
+    * entry point, or 0 if offset is out of bounds or the result is otherwise
+    * unavailable.
     */
    intptr_t getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset);
    uint8_t *getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6195,6 +6195,26 @@ TR_J9VMBase::isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz)
 intptr_t
 TR_J9VMBase::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
    {
+   if (isInterfaceClass(clazz))
+      return 0; // no VFT
+
+   // Handle only positive offsets (i.e. in the interpreter side of the VFT)
+   // for now, since the only use of getVFTEntry() is to analyze guards with
+   // method tests in VP, and those use a positive offset to find the J9Method.
+   int32_t fixedPartOfOffset = sizeof (J9Class) + sizeof(J9VTableHeader);
+   if (offset < fixedPartOfOffset)
+      return 0;
+
+   // offset - fixedPartOfOffset is non-negative and fits into 32 bits because
+   // offset >= fixedPartOfOffset. Dividing will only reduce the value.
+   uint32_t index =
+      static_cast<uint32_t>(offset - fixedPartOfOffset) / sizeof(uintptr_t);
+
+   J9Class *j9class = reinterpret_cast<J9Class*>(clazz);
+   J9VTableHeader *vftHeader = reinterpret_cast<J9VTableHeader*>(j9class + 1);
+   if (index >= vftHeader->size)
+      return 0;
+
    return *(intptr_t*) (((uint8_t *)clazz) + offset);
    }
 


### PR DESCRIPTION
Also check for interfaces, which don't have a VFT at all.