### PR TITLE
Fix node reference counts in VectorAPIExpansion

### DIFF
--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,6 +123,9 @@ J9::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFacto
          break;
       case OMR::handleRecompilationOps:
          _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
+         break;
+      case OMR::vectorAPIExpansion:
+         _flags.set(verifyTrees);
          break;
       default:
          // do nothing

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1193,6 +1193,7 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
       if (elementType == TR::Int8 || elementType == TR::Int16)
          {
          TR::Node *newLoadNode = node->duplicateTree(false);
+         aladdNode->decReferenceCount(); // since aladd has one extra count due to duplication
          TR::Node::recreate(node, elementType == TR::Int8 ? TR::b2i : TR::s2i);
          node->setAndIncChild(0, newLoadNode);
          }
@@ -1518,7 +1519,7 @@ TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExp
    if (mode == doScalarization)
       {
       // modify original node in place
-      node->setAndIncChild(0, newNode->getChild(0));
+      node->setChild(0, newNode->getChild(0));
       node->setNumChildren(1);
 
       int32_t numLanes = vectorLength/8/elementSize;


### PR DESCRIPTION
- fix two node reference count issues
- run verifyTrees every time the optimization runs