### PR TITLE
Deleted an unnecessary assert

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2109,7 +2109,6 @@ bool TR::CompilationInfo::shouldAbortCompilation(TR_MethodToBeCompiled *entry, T
 
    if (entry->_unloadedMethod) // method was unloaded while we were trying to compile it
       {
-      TR_ASSERT(entry->_compErrCode == compilationInterrupted, "Received error code %u, expect compilationInterrupted when the method was unloaded", entry->_compErrCode);
       entry->_compErrCode = compilationNotNeeded; // change error code
       return true;
       }


### PR DESCRIPTION
Assert from Issue:#15481
This assert should be eliminated because it is unnecessary.
When a compilation fails with an error code, a redefinition may happen right away, marking the compilation entry as unloaded, even though the compilation has failed.
So it's totally possible to have the entry marked as unloaded and the error code be something else than compilationInterrupted.
It's quite normal to get into shouldAbortCompilation with a different error code, thus this assert is invalid and can be deleted.

Signed-off-by: Manasha Vetrivelu <manasha.vetrivelu@ibm.com>