### PR TITLE
Add class for OSR redefinition when removing a merged HCR guard

### DIFF
--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -405,8 +405,13 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR
 
             TR::DebugCounter::prependDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "hcrGuardRemoval/success"), cursor->getExit());
             }
-         else if (guardInfo->mergedWithHCRGuard())
+         else if (guardInfo->mergedWithHCRGuard()
+            && performTransformation(
+                  comp(),
+                  "O^O HCR GUARD REMOVAL: removing HCR guard merged into node n%un\n",
+                  node->getGlobalIndex()))
             {
+            comp()->addClassForOSRRedefinition(guardInfo->getThisClass());
             guardInfo->setMergedWithHCRGuard(false);
             if (TR_FearPointAnalysis::virtualGuardsKillFear())
                guardInfo->setMergedWithOSRGuard();


### PR DESCRIPTION
Previously, if an HCR guard was merged into another virtual guard, it could be removed without taking into account the class whose redefinition it guards against. If no other removed HCR guard was sensitive to redefinition of the same class, then no redefinition assumption would be made for that class. If that class were later redefined, the JIT would fail to patch OSR guards within the method.

Additionally, use `performTransformation()` to make the removal optional like it is in the non-merged case above.