### PR TITLE
Stop registering class extend assumptions for HCR guards

### DIFF
--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -541,13 +541,13 @@ TR_CHTable::commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> 
 
    if ((info->getKind() == TR_HCRGuard) || info->mergedWithHCRGuard())
       {
-      guardedClass = info->getThisClass();
+      TR_OpaqueClassBlock *hcrGuardedClass = info->getThisClass();
       ListIterator<TR_VirtualGuardSite> it(&sites);
       for (TR_VirtualGuardSite *site = it.getFirst(); site; site = it.getNext())
          {
          TR_ASSERT(site->getLocation(), "assertion failure");
          TR_PatchNOPedGuardSiteOnClassRedefinition
-            ::make(comp->fe(), comp->trPersistentMemory(), guardedClass, site->getLocation(), site->getDestination(), comp->getMetadataAssumptionList());
+            ::make(comp->fe(), comp->trPersistentMemory(), hcrGuardedClass, site->getLocation(), site->getDestination(), comp->getMetadataAssumptionList());
          comp->setHasClassRedefinitionAssumptions();
          }
       // if it's not real HCR guard then we need to register


### PR DESCRIPTION
Extending the defining class of an inlined method does not invalidate the bodies of methods defined by that class, which remain unchanged until/unless the class is actually redefined.

It's possible for a guard merged with an HCR guard to require a class extend assumption for its (non-HCR) virtual guard semantics. In that case, execution will continue on and create the class extend assumption in exactly the same way as it would without the merged HCR guard.