### PR TITLE
(0.33.1) Disable AVX register preservation on x86

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1057,7 +1057,12 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	}
 #endif /* J9VM_OPT_JITSERVER */
 
-#if defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17)
+
+/*
+ * Disable AVX+ vector register preservation on x86 due to a large performance regression.
+ * Issue: #15716
+ */
+#if defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) && 0
 	J9ProcessorDesc desc;
 	j9sysinfo_get_processor_description(&desc);
 
@@ -1069,7 +1074,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	} else if (j9sysinfo_processor_has_feature(&desc, J9PORT_X86_FEATURE_AVX)) {
 		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
 	}
-#endif /* defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) */
+#endif /* defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) && 0 */
 
 	initArgs.j2seVersion = createParams->j2seVersion;
 	initArgs.j2seRootDirectory = createParams->j2seRootDirectory;


### PR DESCRIPTION
Cherry pick https://github.com/eclipse-openj9/openj9/pull/15722 for the 0.33.1 release.