### PR TITLE
Add more remote recompilation guards

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7609,7 +7609,9 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
              (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITServerHeuristics) ||
              _compInfo.getPersistentInfo()->isLocalSyncCompiles()) &&
              !TR::Options::getCmdLineOptions()->getOption(TR_DisableUpgradingColdCompilations) &&
-             TR::Options::getCmdLineOptions()->allowRecompilation())
+             TR::Options::getCmdLineOptions()->allowRecompilation() &&
+             !details.isMethodInProgress() &&
+             !TR::Options::getCmdLineOptions()->getOption(TR_MimicInterpreterFrameShape))
             {
             doLocalCompilation = true;
             entry->_origOptLevel = entry->_optimizationPlan->getOptLevel();


### PR DESCRIPTION
Local synchronous compilation followed by remote recompilation
(LocalSyncCompiles) should not be attempted when the relevant method
is a DLT compilation, or when MimicInterpreterFrameShape has been set.

Signed-off-by: Christian Despres <despresc@ibm.com>