### PR TITLE
The session/scope fixes on the downcall handler in multithreading

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/DowncallLinker.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/DowncallLinker.java
@@ -43,6 +43,6 @@ public class DowncallLinker {
 	 * @return a method handle bound to the native method
 	 */
 	public static MethodHandle getBoundMethodHandle(MethodType functionMethodType, FunctionDescriptor funcDesc) {
-		return InternalDowncallHandler.getBoundMethodHandle(functionMethodType, funcDesc);
+		return new InternalDowncallHandler(functionMethodType, funcDesc).getBoundMethodHandle();
 	}
 }

--- a/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/jcl/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -45,11 +45,11 @@ public class ProgrammableInvoker {
 	 */
 	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	public static MethodHandle getBoundMethodHandle(MethodType functionMethodType, FunctionDescriptor funcDesc) {
-		return InternalDowncallHandler.getBoundMethodHandle(functionMethodType, funcDesc);
+		return new InternalDowncallHandler(functionMethodType, funcDesc).getBoundMethodHandle();
 	}
 	/*[ELSE] JAVA_SPEC_VERSION >= 17 */
 	public static MethodHandle getBoundMethodHandle(Addressable downcallAddr, MethodType functionMethodType, FunctionDescriptor funcDesc) {
-		return InternalDowncallHandler.getBoundMethodHandle(downcallAddr, functionMethodType, funcDesc);
+		return new InternalDowncallHandler(downcallAddr, functionMethodType, funcDesc).getBoundMethodHandle();
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 }


### PR DESCRIPTION
The changes aim to resolve the issues specific to session/scope
detected in jtreg tests to ensure the session/scopes are kept
alive for the owner thread in the native invocation in the
multithreading environment.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>