### PR TITLE
Virtual threads support for jvmtiGetFrameCount

### DIFF
--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -461,6 +461,7 @@ TraceAssert=Assert_JVMTI_false noEnv Overhead=1 Level=1 Assert="!(P1)"
 TraceAssert=Assert_JVMTI_notNull noEnv Overhead=1 Level=1 Assert="(P1) != NULL"
 TraceAssert=Assert_JVMTI_mustHaveVMAccess noEnv overhead=1 Level=1 Assert="(P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS"
 TraceAssert=Assert_JVMTI_mustNotHaveVMAccess noEnv overhead=1 Level=1 Assert="0 == ((P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)"
+TraceAssert=Assert_JVMTI_unreachable noEnv Overhead=1 Level=1 Assert="0"
 
 TraceEntry=Trc_JVMTI_jvmtiHookResourceExhausted_Entry Overhead=1 Level=1 Noenv Template="ResourceExhaustedEvent"
 TraceExit=Trc_JVMTI_jvmtiHookResourceExhausted_Exit Overhead=1 Level=1 Noenv Template="ResourceExhaustedEvent"

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4900,6 +4900,9 @@ typedef struct J9InternalVMFunctions {
 	U_8 * (JNICALL *native2InterpJavaUpcallStruct)(struct J9UpcallMetaData *data, void *argsListPointer);
 */
 #endif /* JAVA_SPEC_VERSION >= 16 */
+#if JAVA_SPEC_VERSION >= 19
+	UDATA (*walkContinuationStackFrames)(struct J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -255,6 +255,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<fieldref class="java/lang/VirtualThread" name="state" signature="I" versions="19-"/>
 	<fieldref class="java/lang/VirtualThread" name="carrierThread" signature="Ljava/lang/Thread;" versions="19-"/>
+	<fieldref class="java/lang/VirtualThread" name="cont" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 
 	<fieldref class="java/lang/Throwable" name="cause" signature="Ljava/lang/Throwable;"/>
 	<fieldref class="java/lang/Throwable" name="detailMessage" signature="Ljava/lang/String;"/>

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -432,4 +432,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	native2InterpJavaUpcallStruct,
 */
 #endif /* JAVA_SPEC_VERSION >= 16 */
+#if JAVA_SPEC_VERSION >= 19
+	walkContinuationStackFrames,
+#endif /* JAVA_SPEC_VERSION >= 19 */
 };


### PR DESCRIPTION
Adds `walkContinuationStackFrames` to internal functions so jvmti code can use it.
Adds a check for whether it's a virtual thread and not yielded or terminated.
If it is, use `walkContinuationStackFrames` to walk the continuation object.
Issue: https://github.com/eclipse-openj9/openj9/issues/15183 https://github.com/eclipse-openj9/openj9/issues/15759