### PR TITLE
Update jvmtiGetThreadInfo for Loom

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5766,6 +5766,8 @@ typedef struct J9JavaVM {
 	UDATA virtualThreadLinkNextOffset;
 	UDATA virtualThreadLinkPreviousOffset;
 	UDATA virtualThreadInspectorCountOffset;
+	jclass jlThreadConstants;
+	jfieldID vthreadGroupID;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9JavaVM;
 


### PR DESCRIPTION
For virtual threads,
- Name is obtained from the thread object
- Priority is always JVMTI_THREAD_NORM_PRIORITY
- isDaemon is always JNI_TRUE
- Threadgroup is always java/lang/Thread$Constants.VTHREAD_GROUP if alive
- Context class loader is obtained the same way as from a platform thread

Fixes: #15761
Issue: #15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>