### PR TITLE
Fix virtual thread test setup for jdk 20

### DIFF
--- a/test/functional/Java19andUp/build.xml
+++ b/test/functional/Java19andUp/build.xml
@@ -49,22 +49,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<if>
-			<equals arg1="${JDK_VERSION}" arg2="19"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${TestUtilities}" />
-					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar" />
-						<pathelement location="${build}" />
-					</classpath>
-				</javac>
-			</then>
-		</if>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/jcommander.jar" />
+				<pathelement location="${LIB_DIR}/asm.jar" />
+				<pathelement location="${build}" />
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">


### PR DESCRIPTION
Run the test (and with --enable-preview) for all java versions, not just
java 19.

Signed-off-by: Eric Yang <eric.yang@ibm.com>