### PR TITLE
Continuation Scan Update for generational GC or concurrent GC

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -251,6 +251,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9mm_iterate_all_continuation_objects,
 	ownableSynchronizerObjectCreated,
 	continuationObjectCreated,
+	preMountContinuation,
+	postDismountContinuation,
 	j9gc_notifyGCOfClassReplacement,
 	j9gc_get_jit_string_dedup_policy,
 	j9gc_stringHashFn,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -268,6 +268,9 @@ extern J9_CFUNC void* finalizeForcedClassLoaderUnload(J9VMThread *vmThread);
 extern J9_CFUNC UDATA ownableSynchronizerObjectCreated(J9VMThread *vmThread, j9object_t object);
 extern J9_CFUNC UDATA continuationObjectCreated(J9VMThread *vmThread, j9object_t object);
 
+extern J9_CFUNC void preMountContinuation(J9VMThread *vmThread, j9object_t object);
+extern J9_CFUNC void postDismountContinuation(J9VMThread *vmThread, j9object_t object);
+
 extern J9_CFUNC void j9gc_notifyGCOfClassReplacement(J9VMThread *vmThread, J9Class *originalClass, J9Class *replacementClass, UDATA isFastHCR);
 
 /* GuaranteedNurseryRange.cpp */

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -52,6 +52,21 @@
 
 extern "C" {
 
+void
+preMountContinuation(J9VMThread *vmThread, j9object_t object)
+{
+	/* need read barrier to handle concurrent scavenger and gcpolicy:metronome case */
+
+}
+
+void
+postDismountContinuation(J9VMThread *vmThread, j9object_t object)
+{
+	/* Conservatively assume that via mutations of stack slots (which are not subject to access barriers),
+	 * all post-write barriers have been triggered on this Continuation object, since it's been mounted. */
+	vmThread->javaVM->memoryManagerFunctions->J9WriteBarrierBatch(vmThread, object);
+}
+
 UDATA
 j9gc_modron_global_collect(J9VMThread *vmThread)
 {

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -102,6 +102,8 @@ J9HookInterface** j9gc_get_private_hook_interface(J9JavaVM *javaVM);
 UDATA ownableSynchronizerObjectCreated(J9VMThread *vmThread, j9object_t object);
 
 UDATA continuationObjectCreated(J9VMThread *vmThread, j9object_t object);
+void preMountContinuation(J9VMThread *vmThread, j9object_t object);
+void postDismountContinuation(J9VMThread *vmThread, j9object_t object);
 
 /**
  * Called during class redefinition to notify the GC of replaced classes.In certain cases the GC needs to 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4498,6 +4498,8 @@ typedef struct J9MemoryManagerFunctions {
 	jvmtiIterationControl  ( *j9mm_iterate_all_continuation_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;
 	UDATA ( *ownableSynchronizerObjectCreated)(struct J9VMThread *vmThread, j9object_t object) ;
 	UDATA ( *continuationObjectCreated)(struct J9VMThread *vmThread, j9object_t object) ;
+	void ( *preMountContinuation)(struct J9VMThread *vmThread, j9object_t object) ;
+	void ( *postDismountContinuation)(struct J9VMThread *vmThread, j9object_t object) ;
 
 	void  ( *j9gc_notifyGCOfClassReplacement)(struct J9VMThread *vmThread, J9Class *originalClass, J9Class *replacementClass, UDATA isFastHCR) ;
 	I_32  ( *j9gc_get_jit_string_dedup_policy)(struct J9JavaVM *javaVM) ;

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -242,6 +242,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Thread" name="stopCalled" signature="Z"/>
 
 	<!-- Field references for Java 19 Virtual Thread. -->
+	<fieldref class="java/lang/Thread" name="cont" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 	<fieldref class="java/lang/Thread" name="holder" signature="Ljava/lang/Thread$FieldHolder;" versions="19-"/>
 	<fieldref class="java/lang/Thread$FieldHolder" name="daemon" signature="Z" versions="19-"/>
 	<fieldref class="java/lang/Thread$FieldHolder" name="group" signature="Ljava/lang/ThreadGroup;" versions="19-"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5215,6 +5215,9 @@ ffi_OOM:
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 
+		/* Notify GC of Continuation stack swap */
+		_vm->memoryManagerFunctions->preMountContinuation(_currentThread, continuationObject);
+
 		if (enterContinuation(_currentThread, continuationObject)) {
 			_sendMethod = J9VMJDKINTERNALVMCONTINUATION_EXECUTE_METHOD(_currentThread->javaVM);
 			rc = GOTO_RUN_METHOD;
@@ -5236,6 +5239,10 @@ ffi_OOM:
 
 		/* store the current Continuation state and swap to carrier thread stack */
 		yieldContinuation(_currentThread);
+
+		j9object_t continuationObject = J9VMJAVALANGTHREAD_CONT(_currentThread, _currentThread->carrierThreadObject);
+		/* Notify GC of Continuation stack swap */
+		_vm->memoryManagerFunctions->postDismountContinuation(_currentThread, continuationObject);
 
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		restoreInternalNativeStackFrame(REGISTER_ARGS);


### PR DESCRIPTION
For generational GC, local GC would not scan tenured Object, which dose
not contain any nursery reference, so if the continuation Object has
been tenured, next local GC might miss to scan it.

For GenCon and balanced GC, we need general post writebarrier to handle
the case. the barrier will be triggered after yieldContinuation.
this change does not cover concurrent Scavenger and metronome, which is
required read barrier.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>