### PR TITLE
Limit JITServer AOT cache memory usage

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -71,7 +71,8 @@ J9::AheadOfTimeCompile::addClassSerializationRecord(TR_OpaqueClassBlock *ramClas
    TR::Compilation *comp = self()->comp();
    if (comp->isAOTCacheStore())
       {
-      const AOTCacheClassRecord *record = comp->getClientData()->getClassRecord((J9Class *)ramClass, comp->getStream());
+      bool missingLoaderInfo = false;
+      const AOTCacheClassRecord *record = comp->getClientData()->getClassRecord((J9Class *)ramClass, comp->getStream(), missingLoaderInfo);
       self()->addSerializationRecord(record, romClassOffsetAddr);
       }
    }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1155,6 +1155,7 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    const char *xxDisableRequireJITServerOption = "-XX:-RequireJITServer";
    const char *xxJITServerLogConnections = "-XX:+JITServerLogConnections";
    const char *xxDisableJITServerLogConnections = "-XX:-JITServerLogConnections";
+   const char *xxJITServerAOTmxOption = "-XX:JITServerAOTmx=";
 
    int32_t xxJITServerPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerPortOption, 0);
    int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
@@ -1167,6 +1168,7 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    int32_t xxDisableRequireJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableRequireJITServerOption, 0);
    int32_t xxJITServerLogConnectionsArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLogConnections, 0);
    int32_t xxDisableJITServerLogConnectionsArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLogConnections, 0);
+   int32_t xxJITServerAOTmxArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTmxOption, 0);
 
    if (xxJITServerPortArgIndex >= 0)
       {
@@ -1233,6 +1235,15 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    if (xxJITServerLogConnectionsArgIndex > xxDisableJITServerLogConnectionsArgIndex)
       {
       TR::Options::setVerboseOption(TR_VerboseJITServerConns);
+      }
+
+   if (xxJITServerAOTmxArgIndex >= 0)
+      {
+      uint32_t aotMaxBytes = 0;
+      if (GET_MEMORY_VALUE(xxJITServerAOTmxArgIndex, xxJITServerAOTmxOption, aotMaxBytes) == OPTION_OK)
+         {
+         JITServerAOTCacheMap::setCacheMaxBytes(aotMaxBytes);
+         }
       }
 
    return true;

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1425,7 +1425,8 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
          {
          JITServerHelpers::cacheRemoteROMClassBatch(clientData, uncachedRAMClasses, uncachedClassInfos);
          // This call will cache both the class chain and the AOT cache record in the client session
-         record = clientData->getClassChainRecord(clazz, classChain, ramClassChain, _stream);
+         bool missingLoaderInfo = false;
+         record = clientData->getClassChainRecord(clazz, classChain, ramClassChain, _stream, missingLoaderInfo);
          if (classChainRecord)
             *classChainRecord = record;
          }

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -252,7 +252,8 @@ public:
    const std::string &name() const { return _name; }
 
    // Each get{Type}Record() method returns the record for given parameters (which fully identify
-   // the unique record), by either looking up the existing record or creating a new one.
+   // the unique record), by either looking up the existing record or creating a new one if there is sufficient
+   // space.
    const AOTCacheClassLoaderRecord *getClassLoaderRecord(const uint8_t *name, size_t nameLength);
    const AOTCacheClassRecord *getClassRecord(const AOTCacheClassLoaderRecord *loaderRecord, const J9ROMClass *romClass);
    const AOTCacheMethodRecord *getMethodRecord(const AOTCacheClassRecord *definingClassRecord,
@@ -406,11 +407,17 @@ public:
 
    size_t getNumDeserializedMethods() const;
 
+   static void setCacheMaxBytes(size_t bytes) { _cacheMaxBytes = bytes; }
+   static bool cacheHasSpace();
+
    void printStats(FILE *f) const;
 
 private:
    PersistentUnorderedMap<std::string, JITServerAOTCache *> _map;
    TR::Monitor *const _monitor;
+
+   static size_t _cacheMaxBytes;
+   static bool _cacheIsFull;
    };
 
 


### PR DESCRIPTION
The record creation methods of the JITServer AOT cache now check that
total record allocations do not exceed a configurable maximum before
creating new records. This should be correlated with the total
JITServer AOT cache memory usage, and so provide a bound on that value.

Fixes: https://github.com/eclipse-openj9/openj9/issues/15480

Signed-off-by: Christian Despres <despresc@ibm.com>