### PR TITLE
Intermediate SATB Access Barrier Changes

### DIFF
--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -34,6 +34,7 @@
 #include "VMAccess.hpp"
 #include "VMInterface.hpp"
 #include "VMThreadListIterator.hpp"
+#include "StandardAccessBarrier.hpp"
 
 /**
  * Concurrents stack slot iterator.
@@ -464,6 +465,13 @@ MM_ConcurrentMarkingDelegate::acquireExclusiveVMAccessAndSignalThreadsToActivate
 		vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
 		vmThread->javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
 	}
+}
+
+void
+MM_ConcurrentMarkingDelegate::rememberObjectToRescan(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
+{
+	MM_StandardAccessBarrier *barrier = (MM_StandardAccessBarrier *)(MM_GCExtensions::getExtensions(env)->accessBarrier);
+	barrier->rememberObjectToRescan(env, objectPtr);
 }
 
 #endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
@@ -357,6 +357,8 @@ public:
 
 	bool setupClassScanning(MM_EnvironmentBase *env);
 
+	void rememberObjectToRescan(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
+
 	/**
 	 * Constructor.
 	 */

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -158,15 +158,15 @@ typedef struct J9IndexableObject* mm_j9array_t;
 	(void)0)
 #define J9OBJECT__PRE_OBJECT_STORE_ADDRESS(vmThread, object, address, value) \
 	(\
-	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS <= J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType) && \
-	(J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType <= OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK)) ? \
+	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS == J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType) || \
+	(OMR_GC_WRITE_BARRIER_TYPE_SATB == J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType)) ? \
 	J9VMTHREAD_JAVAVM((vmThread))->memoryManagerFunctions->J9WriteBarrierPre((vmThread), (j9object_t)(object), (fj9object_t*)(address), (j9object_t)(value)) : \
 	(void)0 \
 	)
 #define J9OBJECT__PRE_OBJECT_STORE_ADDRESS_VM(javaVM, object, address, value) \
 	(\
-	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS <= javaVM->gcWriteBarrierType) && \
-	(javaVM->gcWriteBarrierType <= OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK)) ? \
+	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS == javaVM->gcWriteBarrierType) || \
+	(OMR_GC_WRITE_BARRIER_TYPE_SATB == javaVM->gcWriteBarrierType)) ? \
 	javaVM->memoryManagerFunctions->J9WriteBarrierPre(J9JAVAVM_VMTHREAD(javaVM), (j9object_t)(object), (fj9object_t*)(address), (j9object_t)(value)) : \
 	(void)0 \
 	)
@@ -186,15 +186,15 @@ typedef struct J9IndexableObject* mm_j9array_t;
 	)
 #define J9STATIC__PRE_OBJECT_STORE(vmThread, clazz, address, value) \
 	(\
-	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS <= J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType) && \
-	(J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType <= OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK)) ? \
+	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS == J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType) || \
+	(OMR_GC_WRITE_BARRIER_TYPE_SATB == J9VMTHREAD_JAVAVM((vmThread))->gcWriteBarrierType)) ? \
 	J9VMTHREAD_JAVAVM((vmThread))->memoryManagerFunctions->J9WriteBarrierPreClass((vmThread), J9VM_J9CLASS_TO_HEAPCLASS((clazz)), (j9object_t*)(address), (j9object_t)(value)) : \
 	(void)0 \
 	)
 #define J9STATIC__PRE_OBJECT_STORE_VM(javaVM, clazz, address, value) \
 	(\
-	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS <= javaVM->gcWriteBarrierType) && \
-	(javaVM->gcWriteBarrierType <= OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK)) ? \
+	((OMR_GC_WRITE_BARRIER_TYPE_ALWAYS == javaVM->gcWriteBarrierType) || \
+	(OMR_GC_WRITE_BARRIER_TYPE_SATB == javaVM->gcWriteBarrierType)) ? \
 	javaVM->memoryManagerFunctions->J9WriteBarrierPreClass(J9JAVAVM_VMTHREAD(javaVM), J9VM_J9CLASS_TO_HEAPCLASS((clazz)), (j9object_t*)(address), (j9object_t)(value)) : \
 	(void)0 \
 	)


### PR DESCRIPTION
- Introduced concurrent mark delegate “rememberObjectToRescan”, used by global collector to invoke SATB barrier _(upon local collector mutation to tenure space)_
- PRE_STORE* guard condition changed to explicitly check barrier types rather than range check. These changes are required to coordinate OMR GC const changes being made.This will be reverted back to a range check by https://github.com/eclipse-openj9/openj9/pull/15777 after https://github.com/eclipse/omr/pull/6675 is merged.  

Barrier type const order is being changed from:
```
OMR_GC_WRITE_BARRIER_TYPE_ALWAYS 0x6
OMR_GC_WRITE_BARRIER_TYPE_SATB 0x7
OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK 0x8
```
to:
```
OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK 0x6
OMR_GC_WRITE_BARRIER_TYPE_ALWAYS 0x7
OMR_GC_WRITE_BARRIER_TYPE_SATB 0x8
```

Current PRE_STORE* guard checks will be invalid with the reorder:
```
OMR_GC_WRITE_BARRIER_TYPE_OLDCHECK <= gcWriteBarrierType <= OMR_GC_WRITE_BARRIER_TYPE_ALWAYS.
```

With the changes being made, we exclude `OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK` from the PRE_STORE*, however this is not an issue.

Signed-off-by: Salman Rana <salman.rana@ibm.com>