### PR TITLE
Update jvmtiGetStackTrace to support virtual thread

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -172,6 +172,11 @@ getVMThread(J9VMThread *currentThread, jthread thread, J9VMThread **vmThreadPtr,
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	omrthread_monitor_exit(vm->vmThreadListMutex);
+
+#if JAVA_SPEC_VERSION >= 19
+	Assert_JVMTI_true((NULL != targetThread) || isVirtualThread);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 	return JVMTI_ERROR_NONE;
 }
 


### PR DESCRIPTION
Refactors vm->internalVMFunctions to vmFuncs
Adds a continuation object parameter to jvmtiInternalGetStackTrace.
If targetThread is not null, the targetThread will be used, otherwise
check if continuation object is not null and use that.

In jvmtiGetStackTrace, adds a check for virtual thread, call
jvmtiInternalGetStackTrace with the corresponding arguments depending
on whether the thread is virtual or not.

Adds an assertion to getVMThread to ensure that targetThread will be
NULL for a virtual thread so the extra call to IS_VIRTUAL_THREAD can be
avoided.

Updates jvmtiGetFrameCount and jvmtiGetFrameLocation to remove the
unnecessary IS_VIRTUAL_THREAD call.

Updates the coding style of surrounding code

Issues: https://github.com/eclipse-openj9/openj9/issues/15759 https://github.com/eclipse-openj9/openj9/issues/15183

Signed-off-by: Gengchen Tuo <gengchen.tuo@ibm.com>