### PR TITLE
Add ability to merge -Xjit/-Xaot opts

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -126,8 +126,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
          FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XsamplingExpirationTime", 0);
          FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XcompilationThreads", 0);
          FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XaggressivenessLevel", 0);
-         argIndexXjit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, "-Xjit", 0);
-         argIndexXaot = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, "-Xaot", 0);
+         argIndexXjit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, VMOPT_XJIT, 0);
+         argIndexXaot = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, VMOPT_XAOT, 0);
          argIndexXnojit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, "-Xnojit", 0);
 
          argIndexRIEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:+RuntimeInstrumentation", 0);
@@ -251,8 +251,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                /*
                 * Note that the option prefix we need to match includes the colon.
                 */
-               argIndexXjit = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, "-Xjit:", 0);
-               argIndexXaot = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, "-Xaot:", 0);
+               argIndexXjit = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, VMOPT_XJIT_COLON, 0);
+               argIndexXaot = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, VMOPT_XAOT_COLON, 0);
 
                /* do initializations for -Xjit options */
                if (isJIT && argIndexXjit >= 0)


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/issues/12503

Opening this PR for discussion. I figure something like this is a good first step towards allowing multiple -Xjit options by default.

I've introduced the VM option `-XX:MergeJitOptions` to control whether or not to merge the JIT/AOT options (merging is disabled by default). As the code stands, I allow multiple empty `-Xjit:`/`-Xaot:` as long as there's at least one that isn't empty. 

Here are some of the results; I put a printf in the options processing code to demonstrate the options that the JIT will parse:

No Options:
```
 ./jdk11/bin/java -Xshareclasses:none -version

xjitCommandLineOptions=
xaotCommandLineOptions=
...
```
```
$ ./jdk11/bin/java -XX:MergeJitOptions -Xshareclasses:none -version

xjitCommandLineOptions=
xaotCommandLineOptions=
...
```

One JIT option:
```
$ ./jdk11/bin/java -Xshareclasses:none  -Xjit:version -version

xjitCommandLineOptions=version
xaotCommandLineOptions=
...
```
```
$ ./jdk11/bin/java  -XX:MergeJitOptions -Xshareclasses:none  -Xjit:version -version

xjitCommandLineOptions=version
xaotCommandLineOptions=
...
```
Multiple JIT options:
```
$ ./jdk11/bin/java -Xshareclasses:none '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -version

xjitCommandLineOptions=version
xaotCommandLineOptions=
...
```
```
$ ./jdk11/bin/java -Xshareclasses:none -XX:MergeJitOptions  '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -version

xjitCommandLineOptions=verbose={compilePerformance},vlog=vlog,version
xaotCommandLineOptions=
...
```
Empty `-Xjit:`:
```
$ ./jdk11/bin/java  -Xshareclasses:none  -Xjit: -version
JVMJ9VM015W Initialization error for library j9jit29(11): no arguments for -Xjit:
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
```
$ ./jdk11/bin/java  -XX:MergeJitOptions -Xshareclasses:none  -Xjit: -version
JVMJ9VM015W Initialization error for library j9jit29(11): no arguments for -Xjit:
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
Empty `-Xjit:` at start:
```
$ ./jdk11/bin/java -Xshareclasses:none -Xjit: '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -version

xjitCommandLineOptions=version
xaotCommandLineOptions=
...
```
```
$ ./jdk11/bin/java -Xshareclasses:none -XX:MergeJitOptions  -Xjit: '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -version

xjitCommandLineOptions=verbose={compilePerformance},vlog=vlog,version
xaotCommandLineOptions=
...
```
Empty -`Xjit:` at end:
```
$ ./jdk11/bin/java -Xshareclasses:none '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -Xjit: -version
JVMJ9VM015W Initialization error for library j9jit29(11): no arguments for -Xjit:
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
```
$ ./jdk11/bin/java -Xshareclasses:none  -XX:MergeJitOptions  '-Xjit:verbose={compilePerformance},vlog=vlog' -Xjit:version -Xjit: -version

xjitCommandLineOptions=verbose={compilePerformance},vlog=vlog,version
xaotCommandLineOptions=
...
```