### PR TITLE
zTPF: Update gc glue configure to use tpf-as

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corp. and others
+# Copyright (c) 2016, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,9 @@ ifeq (default,$(origin CC))
 endif
 ifeq (default,$(origin CXX))
 	CXX=tpf-g++
+endif
+ifeq (default,$(origin AS))
+	AS=tpf-as
 endif
 
 CONFIGURE_ARGS += --host=s390x-ibm-tpf


### PR DESCRIPTION
This update should only affect z/TPF platforms builds.

As part of an exercise to run a z/TPF openJ9 cross-compiled build on a
different version of Linux a binutils error was encountered because
runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
was referencing the default installed assembler from the binutils.
However, the native binutils isn't compatible with the binutils that was
used to build the z/TPF cross-compiler.

The fix was to redirect the default glue configuration to use tpf-as
from the cross-compiler binutils installation instead of the native 
assembler installed with the different version of the Linux binutils. 



[no ci]