### PR TITLE
(0.35) Add java.specification.maintenance.version=4 jdk8 system property

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -627,6 +627,13 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 #endif /* JAVA_SPEC_VERSION < 12 */
+
+#if JAVA_SPEC_VERSION == 8
+	rc = addSystemProperty(vm, "java.specification.maintenance.version", "4", 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+#endif /* JAVA_SPEC_VERSION == 8 */
 
 	rc = addSystemProperty(vm, "java.vm.vendor", JAVA_VM_VENDOR, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {


### PR DESCRIPTION
As per the jdk8 JSR 337 Maintenance Release 4 spec
https://jcp.org/aboutJava/communityprocess/maintenance/jsr337/jsr337-mr4-changes.html

See also OpenJDK 8285497
https://github.com/ibmruntimes/openj9-openjdk-jdk8/commit/df84c26757ec70ef67fd94d1cfacd77f1b4c302f

Cherry pick https://github.com/eclipse-openj9/openj9/pull/15828 for 0.35