### PR TITLE
Reinitialize target process info on restore in nonportable mode

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1855,6 +1855,9 @@ static void jitHookPrepareRestore(J9HookInterface * * hookInterface, UDATA event
       {
       TR::Compiler->target.cpu = TR::CPU::detect(TR::Compiler->omrPortLib);
       jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
+
+      /* Reinitialize the (technically unused) targetProcesssorInfo on x86 to prevent asserts */
+      TR::Compiler->target.cpu.initializeTargetProcessorInfo(true);
       }
 
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);


### PR DESCRIPTION
The TR_X86ProcessorInfo struct is used in a bunch of asserts as sanity 
tests to ensure consistency with the Port Library. In a restore run, in 
non portable mode, the processor description acquired from the port 
library can change; therefore, the TR_X86ProcessorInfo struct also needs 
to be reinitialized.

Depends on https://github.com/eclipse/omr/pull/6695

Fixes https://github.com/eclipse-openj9/openj9/issues/15814