### PR TITLE
Add CRIURestoreNonPortableMode test for criu_keepCheckpoint

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
@@ -28,7 +28,7 @@
   <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
 
   <test id="Create Criu Checkpoint Image without Restore">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 1 1 true</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 true</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">Post-checkpoint</output>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -60,6 +60,9 @@
 			<variation>-Xjit</variation>
 			<variation>-Xint</variation>
 			<variation>-Xjit:count=0</variation>
+			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 		</variations>
 		<command>
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \


### PR DESCRIPTION
- Add CRIURestoreNonPortableMode test for criu_keepCheckpoint
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/15814 https://github.com/adoptium/aqa-tests/pull/3951

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>