### PR TITLE
JDK19+ j9classshape outputs eetop instead of threadRef

### DIFF
--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -31,6 +31,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="build" location="./bin" />
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
 	<property name="LIB" value="junit4,asm_all,testng" />
@@ -54,6 +55,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" />
 					<classpath>
 						<pathelement location="${LIB_DIR}/junit4.jar" />
 						<pathelement location="${LIB_DIR}/testng.jar" />
@@ -66,6 +68,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" />
 					<classpath>
 						<pathelement location="${LIB_DIR}/junit4.jar" />
 						<pathelement location="${LIB_DIR}/testng.jar" />

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -21,6 +21,8 @@
  *******************************************************************************/
 package j9vm.test.ddrext;
 
+import org.openj9.test.util.VersionCheck;
+
 public class Constants {
 
 	public static final String HEXADDRESS_HEADER = "0x";
@@ -292,7 +294,7 @@ public class Constants {
 	public static final String J9CLASSSHAPE_CMD = "j9classshape";
 	public static final String J9CLASSSHAPE_TEST_CLASS = "j9vm/test/corehelper/SimpleThread$DumperThread";
 	public static final String J9CLASS_TEST_SUCCESS_KEY = "j9vm/test/corehelper/SimpleThread\\$DumperThread";
-	public static final String J9CLASSSHAPE_SUCCESS_KEY = "threadRef,"+J9CLASS_TEST_SUCCESS_KEY;
+	public static final String J9CLASSSHAPE_SUCCESS_KEY = (VersionCheck.major() >= 19 ? "eetop," : "threadRef,") + J9CLASS_TEST_SUCCESS_KEY;
 
 	public static final String J9VTABLES_CMD = "j9vtables";
 	public static final String J9VTABLES_SUCCESS_KEY = "j9class,j9method,"+J9CLASS_TEST_SUCCESS_KEY;


### PR DESCRIPTION
`JDK19+` adopts OpenJDK `java.lang.Thread`, `!j9classshape` output contains `eetop` while the output from earlier Java levels are `threadRef`.

Verified at a local run.

closes https://github.com/eclipse-openj9/openj9/issues/15252

Signed-off-by: Jason Feng <fengj@ca.ibm.com>