### PR TITLE
Handle virtual threads in JVMTI GetOSThreadID & InterruptThread

### DIFF
--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -1441,13 +1441,13 @@ done:
 static jvmtiError JNICALL
 jvmtiGetOSThreadID(jvmtiEnv* jvmti_env, ...)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(jvmti_env);
-	jvmtiError rc;
-	J9VMThread * currentThread;
+	J9JavaVM *vm = JAVAVM_FROM_ENV(jvmti_env);
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread = NULL;
 	jlong rv_threadid = 0;
 
-	jthread thread;
-	jlong * threadid_ptr;
+	jthread thread = NULL;
+	jlong *threadid_ptr = NULL;
 	va_list args;
 	va_start(args, jvmti_env);
 	thread = va_arg(args, jthread);
@@ -1464,6 +1464,12 @@ jvmtiGetOSThreadID(jvmtiEnv* jvmti_env, ...)
 
 		ENSURE_PHASE_START_OR_LIVE(jvmti_env);
 		ENSURE_NON_NULL(threadid_ptr);
+
+#if JAVA_SPEC_VERSION >= 19
+		if (NULL != thread) {
+			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_UNSUPPORTED_OPERATION);
+		}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -415,12 +415,17 @@ jvmtiInterruptThread(jvmtiEnv* env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, FALSE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
-			omrthread_interrupt(targetThread->osThread);
+#if JAVA_SPEC_VERSION >= 19
+			if (NULL != targetThread)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+			{
+				omrthread_interrupt(targetThread->osThread);
 #ifdef J9VM_OPT_SIDECAR
-			if (vm->sidecarInterruptFunction != NULL) {
-				vm->sidecarInterruptFunction(targetThread);
+				if (vm->sidecarInterruptFunction != NULL) {
+					vm->sidecarInterruptFunction(targetThread);
+				}
+#endif /* J9VM_OPT_SIDECAR */
 			}
-#endif
 			releaseVMThread(currentThread, targetThread, thread);
 		}
 done:


### PR DESCRIPTION
GetOSThreadID: Throw JVMTI_ERROR_UNSUPPORTED_OPERATION for virtual
threads since this function is OpenJ9 specific, and we can dictate its
implementation.

InterruptThread: If virtual thread is unmounted i.e. targetThread is
NULL, then skip the targetThread->osThread related operations.

Due to the new synchronization for addressing the timing gap, the
virtual thread is pinned regardless whether it is mounted or not.

Fixes: #15763

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>