### PR TITLE
Add support for VirtualThread getStackTrace

### DIFF
--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -127,6 +127,57 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 	return result;
 }
 
+#if JAVA_SPEC_VERSION >= 19
+jobject JNICALL
+Java_java_lang_StackWalker_walkContinuationImpl(JNIEnv *env, jclass clazz, jint flags, jobject function, jobject cont)
+{
+	J9VMThread *vmThread = (J9VMThread *) env;
+	J9JavaVM *vm = vmThread->javaVM;
+
+	J9StackWalkState walkState = {0};
+	J9VMThread stackThread = {0};
+	J9VMEntryLocalStorage els = {0};
+
+	enterVMFromJNI(vmThread);
+	j9object_t continuationObject = J9_JNI_UNWRAP_REFERENCE(cont);
+	J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, continuationObject);
+	vm->internalVMFunctions->copyFieldsFromContinuation(vmThread, &stackThread, &els, continuation);
+	exitVMToJNI(vmThread);
+
+	walkState.walkThread = &stackThread;
+	walkState.flags = J9_STACKWALK_ITERATE_FRAMES | J9_STACKWALK_WALK_TRANSLATE_PC
+			|  J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
+	/* If -XX:+ShowHiddenFrames and StackWalker.SHOW_HIDDEN_FRAMES option has not been set, skip hidden method frames */
+	if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)
+	&& J9_ARE_NO_BITS_SET((UDATA)flags, SHOW_HIDDEN_FRAMES)
+	) {
+		walkState.flags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
+	}
+	walkState.frameWalkFunction = stackFrameFilter;
+
+	/* walking unmounted Continuation will not require skipping StackWalker methods */
+	walkState.userData2 = NULL;
+	UDATA walkStateResult = vm->walkStackFrames(vmThread, &walkState);
+	Assert_JCL_true(walkStateResult == J9_STACKWALK_RC_NONE);
+	walkState.flags |= J9_STACKWALK_RESUME;
+	walkState.userData1 = (void *)(UDATA)flags;
+	if (J9SF_FRAME_TYPE_END_OF_STACK != walkState.pc) {
+		/* indicate the we have the topmost client method's frame */
+		walkState.userData1 = (void *)((UDATA) walkState.userData1 | FRAME_VALID);
+	}
+
+	jmethodID walkImplMID = JCL_CACHE_GET(env, MID_java_lang_StackWalker_walkImpl);
+	if (NULL == walkImplMID) {
+		walkImplMID = env->GetStaticMethodID( clazz, "walkImpl", "(Ljava/util/function/Function;J)Ljava/lang/Object;");
+		Assert_JCL_notNull (walkImplMID);
+		JCL_CACHE_SET(env, MID_java_lang_StackWalker_walkImpl, walkImplMID);
+	}
+	jobject result = env->CallStaticObjectMethod(clazz, walkImplMID, function, (jlong)(UDATA)&walkState);
+
+	return result;
+}
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 jobject JNICALL
 Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 {

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -111,11 +111,11 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 		walkState->userData1 = (void *)((UDATA) walkState->userData1 | FRAME_VALID);
 	}
 
-	jmethodID walkImplMID = JCL_CACHE_GET(env, MID_java_lang_StackWalker_walkWrapperImpl);
+	jmethodID walkImplMID = JCL_CACHE_GET(env, MID_java_lang_StackWalker_walkImpl);
 	if (NULL == walkImplMID) {
 		walkImplMID = env->GetStaticMethodID( clazz, "walkImpl", "(Ljava/util/function/Function;J)Ljava/lang/Object;");
 		Assert_JCL_notNull (walkImplMID);
-		JCL_CACHE_SET(env, MID_java_lang_StackWalker_walkWrapperImpl, walkImplMID);
+		JCL_CACHE_SET(env, MID_java_lang_StackWalker_walkImpl, walkImplMID);
 	}
 	jobject result = env->CallStaticObjectMethod(clazz, walkImplMID, function, (jlong)(UDATA)walkState);
 

--- a/runtime/jcl/common/jclglob.h
+++ b/runtime/jcl/common/jclglob.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,7 +98,7 @@ typedef struct JniIDCache {
 
 	jmethodID MID_com_ibm_lang_management_internal_ExtendedGarbageCollectorMXBeanImpl_buildGcInfo;
 
-	jmethodID MID_java_lang_StackWalker_walkWrapperImpl;
+	jmethodID MID_java_lang_StackWalker_walkImpl;
 
 } JniIDCache;
 

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -670,6 +670,7 @@ endif()
 # java 19+
 if(NOT JAVA_SPEC_VERSION LESS 19)
 	omr_add_exports(jclse
+		Java_java_lang_StackWalker_walkContinuationImpl
 		Java_java_lang_Thread_currentCarrierThread
 		Java_java_lang_Thread_dumpThreads
 		Java_java_lang_Thread_extentLocalCache

--- a/runtime/jcl/uma/se19_exports.xml
+++ b/runtime/jcl/uma/se19_exports.xml
@@ -20,6 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="se19">
+	<export name="Java_java_lang_StackWalker_walkContinuationImpl" />
 	<export name="Java_java_lang_Thread_currentCarrierThread" />
 	<export name="Java_java_lang_Thread_dumpThreads" />
 	<export name="Java_java_lang_Thread_extentLocalCache" />

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4353,10 +4353,10 @@ jint
 isPinnedContinuation(J9VMThread *currentThread);
 
 /**
- * @brief Walk the stackframes associated with Continuation object.
+ * @brief Copy data from Continuation struct to vmThread.
  *
  * @param currentThread
- * @params allocated J9VMThread pointer
+ * @param allocated J9VMThread pointer
  * @param allocated J9VMEntryLocalStorage pointer
  * @param continuation struct
  */


### PR DESCRIPTION
- Add copyFieldsFromContinuation helper in VMHelpers.hpp
- Add locking mechanism on Continuation execution
- Fix Thread.getStackTraceImpl to support VirtualThread

Closes: #15758

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>