### PR TITLE
(0.35) Add standalone JIT option -XX:[+|-]PerfTool

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -79,6 +79,9 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
    IDATA argIndexRIEnabled = 0;
    IDATA argIndexRIDisabled = 0;
 
+   IDATA argIndexPerfEnabled = 0;
+   IDATA argIndexPerfDisabled = 0;
+
    static bool isJIT = false;
    static bool isAOT = false;
 
@@ -134,6 +137,13 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
          // Determine if user disabled Runtime Instrumentation
          if (argIndexRIEnabled >= 0 || argIndexRIDisabled >= 0)
             TR::Options::_hwProfilerEnabled = (argIndexRIDisabled > argIndexRIEnabled) ? TR_no : TR_yes;
+
+         argIndexPerfEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:+PerfTool", 0);
+         argIndexPerfDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:-PerfTool", 0);
+
+         // Determine if user disabled PerfTool
+         if (argIndexPerfEnabled >= 0 || argIndexPerfDisabled >= 0)
+            TR::Options::_perfToolEnabled = (argIndexPerfDisabled > argIndexPerfEnabled) ? TR_no : TR_yes;
 
          TR::Options::_doNotProcessEnvVars = (FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:doNotProcessJitEnvVars", 0) >= 0);
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -215,6 +215,7 @@ int32_t J9::Options::_weightOfAOTLoad = 1; // must be between 0 and 256
 int32_t J9::Options::_weightOfJSR292 = 12; // must be between 0 and 256
 
 TR_YesNoMaybe J9::Options::_hwProfilerEnabled = TR_maybe;
+TR_YesNoMaybe J9::Options::_perfToolEnabled = TR_no;
 int32_t J9::Options::_hwprofilerNumOutstandingBuffers = 256; // 1MB / 4KB buffers
 
 // These numbers are cast into floats divided by 10000

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -301,6 +301,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _hwprofilerNumOutstandingBuffers;
 
    static TR_YesNoMaybe _hwProfilerEnabled;
+   static TR_YesNoMaybe _perfToolEnabled;
    static uint32_t _hwprofilerHotOptLevelThreshold;
    static uint32_t _hwprofilerScorchingOptLevelThreshold;
    static uint32_t _hwprofilerWarmOptLevelThreshold;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1318,6 +1318,10 @@ onLoadInternal(
       return -1;
       }
 
+   // Enable perfTool
+   if (TR::Options::_perfToolEnabled == TR_yes)
+      TR::Options::getCmdLineOptions()->setOption(TR_PerfTool);
+
    // Now that the options have been processed we can initialize the RuntimeAssumptionTables
    // If we cannot allocate various runtime assumption hash tables, fail the JVM
 


### PR DESCRIPTION
When specifying multiple JIT options, currently only the last JIT option will be in effect. Added a standalone alternative for -Xjit:perfTool in -XX:+PerfTool to avoid clobbering pre-existing JIT command line options.

New Options
-XX:+PerfTool Enables Perf Tool
-XX:-PerfTool Disables Perf Tool

Cherry pick #15823 for 0.35