### PR TITLE
Add Exception message to Xdump stack agent output

### DIFF
--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2021 IBM Corp. and others
+# Copyright (c) 2000, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -598,4 +598,18 @@ J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.system_action=The JVM continues.
 J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.user_response=Diagnostic information, provide this information to your service representative.
 J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.link=
 
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME=Processing dump event \"%1$s\", detail \"%3$.*2$s\", exception \"%5$.*4$s\" at %6$s - please wait.
+# START NON-TRANSLATABLE
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.explanation=A dump event has occurred and is being handled.
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.system_action=The JVM generates dumps as configured for the event by the -Xdump option.
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.user_response=No response is required.
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_1=throw
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_2=9
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_3=#00000000
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_4=12
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_5=No such file
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_6=20220919.114434
+J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.link=dita:///diag/tools/dump_agents.dita
 # END NON-TRANSLATABLE


### PR DESCRIPTION
When Xdump:stack is used to dump stack trace filtered on an exception, this change along with the primary exception message, displays additional detail about the exception if any. This is similar to how javacore displays additional detail about an exception in 1TISIGINFO tag.

Fixes: #8435
Signed-off-by: Kabir Islam <kaislam1@in.ibm.com>