### PR TITLE
Fix issues in recent PRs

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -2649,12 +2649,12 @@ jvmtiGetConstantPool_addReference(jvmtiGcp_translation *translation, UDATA cpInd
 static jvmtiError
 jvmtiGetConstantPool_addMethodHandle(jvmtiGcp_translation *translation, UDATA cpIndex, U_8 cpType, J9ROMMethodHandleRef *ref, U_32 *sunCpIndex)
 {
-	jvmtiGcp_translationEntry entry;
-	jvmtiGcp_translationEntry *htEntry;
-	U_8 fieldOrMethodCpType;
+	jvmtiGcp_translationEntry entry = {0};
+	jvmtiGcp_translationEntry *htEntry = NULL;
+	U_8 fieldOrMethodCpType = 0;
 
 	/* Add the Reference item to the hashtable, use our CP index as key */
-	entry.key = (void *) cpIndex;
+	entry.key = (void *)cpIndex;
 	entry.cpType = cpType;
 	entry.sunCpIndex = *sunCpIndex;
 	entry.type.methodHandle.methodOrFieldRefIndex = (*sunCpIndex) + 1;
@@ -2674,27 +2674,27 @@ jvmtiGetConstantPool_addMethodHandle(jvmtiGcp_translation *translation, UDATA cp
 	case MH_REF_PUTSTATIC:
 		fieldOrMethodCpType = CFR_CONSTANT_Fieldref;
 		break;
-
 	case MH_REF_INVOKEVIRTUAL:
 	case MH_REF_INVOKESTATIC:
 	case MH_REF_INVOKESPECIAL:
 	case MH_REF_NEWINVOKESPECIAL:
 		fieldOrMethodCpType = CFR_CONSTANT_Methodref;
 		break;
-
 	case MH_REF_INVOKEINTERFACE:
 		fieldOrMethodCpType = CFR_CONSTANT_InterfaceMethodref;
 		break;
 	default:
-		Assert_JVMTI_true(0);
+		Assert_JVMTI_unreachable();
 		return JVMTI_ERROR_INTERNAL;
 	}
 
 	/* Ensure the field/method ref is also added */
-	return jvmtiGetConstantPool_addReference(translation, ref->methodOrFieldRefIndex,
-						fieldOrMethodCpType,
-						(J9ROMFieldRef *) &translation->romConstantPool[ref->methodOrFieldRefIndex],
-						sunCpIndex);
+	return jvmtiGetConstantPool_addReference(
+				translation,
+				ref->methodOrFieldRefIndex,
+				fieldOrMethodCpType,
+				(J9ROMFieldRef *)&translation->romConstantPool[ref->methodOrFieldRefIndex],
+				sunCpIndex);
 }
 
 

--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -291,17 +291,17 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 	jthread thread,
 	jint* count_ptr)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
-	J9VMThread * currentThread;
+	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread = NULL;
 	jint rv_count = 0;
-	J9InternalVMFunctions* vmFuncs = vm->internalVMFunctions;
 
 	Trc_JVMTI_jvmtiGetFrameCount_Entry(env);
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
 		J9VMThread *targetThread = NULL;
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 


### PR DESCRIPTION
- Define vmFuncs only within the scope of its usage.
- Initialize local variables.
- Fix formatting.
- Use Assert_JVMTI_unreachable instead of Assert_JVMTI_true.

Related: #15788, #15813

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>