### PR TITLE
Check whether array index variable is an induction variable

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -7162,7 +7162,15 @@ TR_CISCTransformer::analyzeOneArrayIndex(TR_CISCNode *arrayindex, TR::SymbolRefe
          }
       if (!ret) return false;
       }
-   else if (t->getOpcode() != TR_variable)
+   else if (t->getOpcode() == TR_variable)
+      {
+      TR::SymbolReference *symref = t->getHeadOfTrNodeInfo()->_node->getSymbolReference();
+      if (symref != inductionVariableSymRef)
+         {
+         return false;
+         }
+      }
+   else
       {
       return false;
       }


### PR DESCRIPTION
In examining an array index for Idiom Recognition, `analyzeOneArrayIndex` checks whether the variable operand in a 'var + const' or 'const + var' expression is an induction variable.  On the other hand, if the expression is a simple variable, the analysis assumes the variable reference is acceptable.  However, it can happen that the variable used as the array index is not an induction variable which can result in an incorrect transformation.

Fixed this by adding a check that an array index that is a variable is also an induction variable.

Fixes #15474

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>