### PR TITLE
Fix stackwalk related jvmti functions

### DIFF
--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -319,7 +319,8 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 			if (NULL == targetThread) {
 				j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 				j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
-				vmFuncs->walkContinuationStackFrames(currentThread, contObject, &walkState);
+				J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, contObject);
+				vmFuncs->walkContinuationStackFrames(currentThread, continuation, &walkState);
 			} else
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
@@ -448,7 +449,8 @@ jvmtiGetFrameLocation(jvmtiEnv *env,
 			if (NULL == targetThread) {
 				j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 				j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
-				vmFuncs->walkContinuationStackFrames(currentThread, contObject, &walkState);
+				J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, contObject);
+				vmFuncs->walkContinuationStackFrames(currentThread, continuation, &walkState);
 			} else
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
@@ -658,7 +660,8 @@ jvmtiInternalGetStackTrace(
 	}
 #if JAVA_SPEC_VERSION >= 19
 	else if (NULL != continuationObject) {
-		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuationObject, &walkState);
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
+		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuation, &walkState);
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	if (start_depth == 0) {
@@ -687,7 +690,8 @@ jvmtiInternalGetStackTrace(
 	}
 #if JAVA_SPEC_VERSION >= 19
 	else if (NULL != continuationObject) {
-		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuationObject, &walkState);
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
+		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuation, &walkState);
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	if (NULL == walkState.userData1) {

--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -26,10 +26,7 @@
 static UDATA popFrameCheckIterator (J9VMThread * currentThread, J9StackWalkState * walkState);
 static UDATA jvmtiInternalGetStackTraceIterator (J9VMThread * currentThread, J9StackWalkState * walkState);
 static jvmtiError jvmtiInternalGetStackTrace(
-	jvmtiEnv *env, J9VMThread *currentThread, J9VMThread *targetThread,
-#if JAVA_SPEC_VERSION >= 19
-	j9object_t continuationObject,
-#endif /* JAVA_SPEC_VERSION >= 19 */
+	jvmtiEnv *env, J9VMThread *currentThread, J9VMThread *targetThread, j9object_t threadObject,
 	jint start_depth, UDATA max_frame_count, jvmtiFrameInfo *frame_buffer, jint *count_ptr);
 
 
@@ -63,23 +60,18 @@ jvmtiGetStackTrace(jvmtiEnv* env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
+			j9object_t threadObject = (NULL == thread) ? currentThread->threadObject : J9_JNI_UNWRAP_REFERENCE(thread);
 #if JAVA_SPEC_VERSION >= 19
-			if (NULL == targetThread) {
-				j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
-				j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
-				rc = jvmtiInternalGetStackTrace(env, currentThread, NULL, contObject, start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
-			} else
+			if (NULL != targetThread)
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
 				vmFuncs->haltThreadForInspection(currentThread, targetThread);
-
-				rc = jvmtiInternalGetStackTrace(
-					env, currentThread, targetThread,
+			}
+			rc = jvmtiInternalGetStackTrace(env, currentThread, targetThread, threadObject, start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
 #if JAVA_SPEC_VERSION >= 19
-					NULL,
+			if (NULL != targetThread)
 #endif /* JAVA_SPEC_VERSION >= 19 */
-					start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
-
+			{
 				vmFuncs->resumeThreadForInspection(currentThread, targetThread);
 			}
 			releaseVMThread(currentThread, targetThread, thread);
@@ -146,7 +138,9 @@ jvmtiGetAllStackTraces(jvmtiEnv* env,
 						currentThread,
 						targetThread,
 #if JAVA_SPEC_VERSION >= 19
-						NULL,
+						targetThread->carrierThreadObject,
+#else /* JAVA_SPEC_VERSION >= 19 */
+						targetThread->threadObject,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 						0,
 						(UDATA) max_frame_count,
@@ -247,9 +241,7 @@ jvmtiGetThreadListStackTraces(jvmtiEnv* env,
 						env,
 						currentThread,
 						targetThread,
-#if JAVA_SPEC_VERSION >= 19
-						NULL,
-#endif /* JAVA_SPEC_VERSION >= 19 */
+						threadObject,
 						0,
 						(UDATA) max_frame_count,
 						(void *) currentFrameInfo,
@@ -311,22 +303,22 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
+			j9object_t threadObject = (NULL == thread) ? currentThread->threadObject : J9_JNI_UNWRAP_REFERENCE(thread);
 			J9StackWalkState walkState;
 			walkState.flags = J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
 			walkState.skipCount = 0;
 
 #if JAVA_SPEC_VERSION >= 19
-			if (NULL == targetThread) {
-				j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
-				j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
-				J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, contObject);
-				vmFuncs->walkContinuationStackFrames(currentThread, continuation, &walkState);
-			} else
+			if (NULL != targetThread)
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
 				vmFuncs->haltThreadForInspection(currentThread, targetThread);
-				walkState.walkThread = targetThread;
-				vm->walkStackFrames(currentThread, &walkState);
+			}
+			genericWalkStackFramesHelper(currentThread, targetThread, threadObject, &walkState);
+#if JAVA_SPEC_VERSION >= 19
+			if (NULL != targetThread)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+			{
 				vmFuncs->resumeThreadForInspection(currentThread, targetThread);
 			}
 
@@ -440,25 +432,26 @@ jvmtiGetFrameLocation(jvmtiEnv *env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
+			j9object_t threadObject = (NULL == thread) ? currentThread->threadObject : J9_JNI_UNWRAP_REFERENCE(thread);
 			J9StackWalkState walkState = {0};
 			walkState.flags = J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY | J9_STACKWALK_COUNT_SPECIFIED | J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET;
 			walkState.skipCount = (UDATA) depth;
 			walkState.maxFrames = 1;
 
 #if JAVA_SPEC_VERSION >= 19
-			if (NULL == targetThread) {
-				j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
-				j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
-				J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, contObject);
-				vmFuncs->walkContinuationStackFrames(currentThread, continuation, &walkState);
-			} else
+			if (NULL != targetThread)
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
 				vmFuncs->haltThreadForInspection(currentThread, targetThread);
-				walkState.walkThread = targetThread;
-				vm->walkStackFrames(currentThread, &walkState);
+			}
+			genericWalkStackFramesHelper(currentThread, targetThread, threadObject, &walkState);
+#if JAVA_SPEC_VERSION >= 19
+			if (NULL != targetThread)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+			{
 				vmFuncs->resumeThreadForInspection(currentThread, targetThread);
 			}
+
 			if (1 == walkState.framesWalked) {
 				jmethodID methodID = getCurrentMethodID(currentThread, walkState.method);
 
@@ -641,29 +634,18 @@ jvmtiInternalGetStackTrace(
 	jvmtiEnv *env,
 	J9VMThread *currentThread,
 	J9VMThread *targetThread,
-#if JAVA_SPEC_VERSION >= 19
-	j9object_t continuationObject,
-#endif /* JAVA_SPEC_VERSION >= 19 */
+	j9object_t threadObject,
 	jint start_depth,
 	UDATA max_frame_count,
 	jvmtiFrameInfo *frame_buffer,
-	jint *count_ptr
-) {
-	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
+	jint *count_ptr)
+{
 	J9StackWalkState walkState = {0};
 
 	walkState.flags = J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
 	walkState.skipCount = 0;
-	if (NULL != targetThread) {
-		walkState.walkThread = targetThread;
-		vm->walkStackFrames(currentThread, &walkState);
-	}
-#if JAVA_SPEC_VERSION >= 19
-	else if (NULL != continuationObject) {
-		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
-		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuation, &walkState);
-	}
-#endif /* JAVA_SPEC_VERSION >= 19 */
+
+	genericWalkStackFramesHelper(currentThread, targetThread, threadObject, &walkState);
 	if (start_depth == 0) {
 		/* This violates the spec, but matches JDK behaviour - allows querying an empty stack with start_depth == 0 */
 		walkState.skipCount = 0;
@@ -685,15 +667,7 @@ jvmtiInternalGetStackTrace(
 	walkState.userData1 = frame_buffer;
 	walkState.frameWalkFunction = jvmtiInternalGetStackTraceIterator;
 
-	if (NULL != targetThread) {
-		vm->walkStackFrames(currentThread, &walkState);
-	}
-#if JAVA_SPEC_VERSION >= 19
-	else if (NULL != continuationObject) {
-		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
-		vm->internalVMFunctions->walkContinuationStackFrames(currentThread, continuation, &walkState);
-	}
-#endif /* JAVA_SPEC_VERSION >= 19 */
+	genericWalkStackFramesHelper(currentThread, targetThread, threadObject, &walkState);
 	if (NULL == walkState.userData1) {
 		return JVMTI_ERROR_OUT_OF_MEMORY;
 	}

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1341,6 +1341,17 @@ suspendAgentBreakpoint(J9VMThread * currentThread, J9JVMTIAgentBreakpoint * agen
 UDATA
 findDecompileInfo(J9VMThread *currentThread, J9VMThread *targetThread, UDATA depth, J9StackWalkState *walkState);
 
+/**
+ * A helper to walk a platform thread or virtual thread
+ * @param[in] currentThread current thread
+ * @param[in] targetThread the thread to walk
+ * @param[in] threadObject the thread to walk
+ * @param[in] walkState a stack walk state
+ * @return 0 on success and non-zero on failure
+ */
+UDATA
+genericWalkStackFramesHelper(J9VMThread *currentThread, J9VMThread *targetThread, j9object_t threadObject, J9StackWalkState *walkState);
+
 /* ---------------- jvmtiHook.c ---------------- */
 
 /**

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2046,7 +2046,8 @@ exit:
 	{
 		UDATA rc = J9_STACKWALK_RC_NONE;
 #if JAVA_SPEC_VERSION >= 19
-		rc = vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuationObject, walkState);
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, continuationObject);
+		rc = vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuation, walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		return rc;
 	}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -326,6 +326,9 @@ struct J9UpcallSigType;
 struct J9UpcallMetaData;
 struct J9UpcallNativeSignature;
 #endif /* JAVA_SPEC_VERSION >= 16 */
+#if JAVA_SPEC_VERSION >= 19
+struct J9VMContinuation;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 /* @ddr_namespace: map_to_type=J9CfrError */
 
@@ -4901,7 +4904,7 @@ typedef struct J9InternalVMFunctions {
 	U_8 * (JNICALL *native2InterpJavaUpcallStruct)(struct J9UpcallMetaData *data, void *argsListPointer);
 #endif /* JAVA_SPEC_VERSION >= 16 */
 #if JAVA_SPEC_VERSION >= 19
-	UDATA (*walkContinuationStackFrames)(struct J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState);
+	UDATA (*walkContinuationStackFrames)(struct J9VMThread *currentThread, struct J9VMContinuation *continuation, J9StackWalkState *walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9InternalVMFunctions;
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4352,7 +4352,7 @@ isPinnedContinuation(J9VMThread *currentThread);
  * @return UDATA
  */
 UDATA
-walkContinuationStackFrames(J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState);
+walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continuation, J9StackWalkState *walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 /* ---------------- hookableAsync.c ---------------- */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4345,11 +4345,11 @@ jint
 isPinnedContinuation(J9VMThread *currentThread);
 
 /**
- * @brief  Walk the stackframes associated with Continuation object
+ * @brief Walk the stackframes associated with a continuation
  *
- * @param currentThread
- * @param continuationObject
- * @return UDATA
+ * @param currentThread current thread
+ * @param continuation the continuation to be walked
+ * @return 0 on success and non-zero on failure
  */
 UDATA
 walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continuation, J9StackWalkState *walkState);

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -169,12 +169,11 @@ isPinnedContinuation(J9VMThread *currentThread)
 }
 
 UDATA
-walkContinuationStackFrames(J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState)
+walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continuation, J9StackWalkState *walkState)
 {
 	Assert_VM_notNull(currentThread);
 
 	UDATA rc = J9_STACKWALK_RC_NONE;
-	J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
 
 	if (NULL != continuation) {
 		J9VMThread stackThread = {0};


### PR DESCRIPTION
In some cases the J9VMContinuation cannot be accessed through a j9object so we change the parameter of walkContinuationStackFrames to accept a J9VMContinuation pointer directly.

Adds declaration of J9VMContinuation to the top.

In the old implementation, if a carrier thread has a virtual thread mounted after getVMThread being called, the virtual thread will be walked. We fix this by adding a check for currentContinuation of the carrier thread. If the currentContinuation is not null, the info of the carrier thread has been swapped to the currentContinuation, so the
currentContinuation will be walked instead.

To facilitate other stackwalk-related functions, a generic stackwalk helper is added to walk a platform thread or a virtual thread. A virtual can be mounted or unmounted, if it's mounted, the carrier thread is walked, otherwise the continuation object is walked. For a platform thread, if the currentContinuation is not null, the currentContinuation will be walked, otherwise the thread is walked.

Signed-off-by: Gengchen Tuo <gengchen.tuo@ibm.com>