### PR TITLE
Add zOS UpcallThunkGen function stubs

### DIFF
--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -335,7 +335,10 @@ elseif(OMR_ARCH_S390)
 		endif()
 	elseif(OMR_OS_ZOS)
 		if(OMR_ENV_DATA64)
-			target_sources(j9vm PRIVATE mz64/unsafeHelper.s)
+			target_sources(j9vm PRIVATE
+				mz64/unsafeHelper.s
+				mz64/UpcallThunkGen.cpp
+			)
 		else()
 			target_sources(j9vm PRIVATE
 				mz31/unsafeHelper.s

--- a/runtime/vm/mz64/UpcallThunkGen.cpp
+++ b/runtime/vm/mz64/UpcallThunkGen.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+
+/**
+ * @file: UpCallThunkGen.cpp
+ * @brief: Service routines dealing with platform-ABI specifics for upcall
+ *
+ * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
+ * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
+ */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+
+/**
+ * @brief Generate the appropriate thunk/adaptor for a given J9UpcallMetaData
+ *
+ * @param metaData[in/out] a pointer to the given J9UpcallMetaData
+ * @return the address for this future upcall function handle, either the thunk or the thunk-descriptor
+ *
+ * Details:
+ *   On AIX, the caller frame always has the parameter area. Unless thunk needs to distribute
+ *   result back to the hidden parameter, there is no need to create a new frame. And, if a new
+ *   frame is needed, the minimum frame size can be used (112 bytes).
+ *
+ *   A thunk or adaptor is mainly composed of 4 parts of instructions to be counted separately:
+ *   1) the eventual call to the upcallCommonDispatcher (fixed number of instructions)
+ *   2) if needed, instructions to build a stack frame
+ *   3) pushing in-register arguments back to the stack, in caller frame
+ *   4) if needed, instructions to distribute  the java result back to the native side appropriately
+ *
+ *     1) and 3) are mandatory, while 2) and 4) depend on the particular signature under consideration.
+ *     mainly 4) implies needing 2), since this adaptor expects a return from java side before
+ *     returning to the native caller.
+ */
+void *
+createUpcallThunk(J9UpcallMetaData *metaData)
+{
+	/* Return the thunk descriptor. */
+	return (void *)(&(metaData->functionPtr));
+}
+
+/**
+ * @brief Calculate the requested argument in-stack memory address to return
+ *
+ * @param nativeSig[in] a pointer to the J9UpcallNativeSignature
+ * @param argListPtr[in] a pointer to the argument list prepared by the thunk
+ * @param argIdx[in] the requested argument index
+ * @return address in argument list for the requested argument
+ *
+ * Details:
+ *   A quick walk-through of the argument list ahead of the requested one
+ *   Calculating its address based on argListPtr
+ */
+void *
+getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
+{
+	return (void *)((char *)argListPtr);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */


### PR DESCRIPTION
Add empty stub function implementations for upcall thunk generation support to allow OpenJ9 to build on z/OS with spec version >= 16.

Actual implementation of the upcall thunks to be implemented in the future.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>