### PR TITLE
Add default hashcode for value types

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4903,6 +4903,7 @@ typedef struct J9InternalVMFunctions {
 #if JAVA_SPEC_VERSION >= 19
 	UDATA (*walkContinuationStackFrames)(struct J9VMThread *currentThread, j9object_t continuationObject, J9StackWalkState *walkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
+	J9Class* (*findJ9ClassInFlattenedClassCache)(J9FlattenedClassCache *flattenedClassCache, U_8 *className, UDATA classNameLength);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -434,4 +434,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if JAVA_SPEC_VERSION >= 19
 	walkContinuationStackFrames,
 #endif /* JAVA_SPEC_VERSION >= 19 */
+	findJ9ClassInFlattenedClassCache,
 };


### PR DESCRIPTION
ObjectHash.hpp: Change convertObjectToHash to hash value types according to their value rather than their identity

ObjectModel.hpp: Hash objects differently depending on if they are forwarded pointers or not (since, due to ObjectHash changes, convertObjectToHash will now crash if passed a forwarded pointer)

For issue #15768

Signed-off-by: Ehren Julien-Neitzert <ehren.julien-neitzert@ibm.com>