### PR TITLE
Remove unwanted addition to superset-constants.dat

### DIFF
--- a/debugtools/DDR_VM/data/superset-constants.dat
+++ b/debugtools/DDR_VM/data/superset-constants.dat
@@ -18,6 +18,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
+# This file lists constants that have always been available. It is safe to use them
+# in hand-written DDR_VM Java source code. If a constant ceases to be defined in any
+# source file, it should be removed from this file. As new constants are defined that
+# need to be used in DDR_VM code, they should be added to CompatibilityConstants29.dat,
+# and DDR_VM code should be written in anticipation of system dump files that predate
+# their existence.
+
 S|AgentType|AgentTypePointer|
 C|FILE_LOGGING
 C|HOOK
@@ -4661,7 +4668,6 @@ S|MM_RealtimeMarkingScheme|MM_RealtimeMarkingSchemePointer|MM_SegregatedMarkingS
 C|OWNABLE_SYNCHRONIZER_OBJECT_YIELD_CHECK_INTERVAL
 C|REFERENCE_OBJECT_YIELD_CHECK_INTERVAL
 C|UNFINALIZED_OBJECT_YIELD_CHECK_INTERVAL
-C|CONTINUATION_OBJECT_YIELD_CHECK_INTERVAL
 S|MM_ReclaimDelegate|MM_ReclaimDelegatePointer|MM_BaseNonVirtual
 C|MAX_SORTED_REGIONS
 S|MM_RegionBasedOverflowVLHGC|MM_RegionBasedOverflowVLHGCPointer|MM_WorkPacketOverflow


### PR DESCRIPTION
Document how additions and removals of constants should be handled.

See also https://github.com/eclipse-openj9/openj9/pull/15611/files#r970106417.