### PR TITLE
Fix UMA build errors

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -324,7 +324,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_AddModulePackage"/>
 		<export name="JVM_AddModuleExportsToAllUnnamed"/>
 		<export name="JVM_SetBootLoaderUnnamedModule"/>
-		<export name="JVM_GetModuleByPackageName"/>
 
 		<!-- Additions for Java 9 RAW -->
 		<export name="JVM_GetSimpleBinaryName"/>

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -88,6 +88,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</include>
 			<include path="$(OMR_DIR)/gc/include" type="relativepath"/>
 			<include path="j9gcgluejava"/>
+			<include path="j9gcinclude"/>
 		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>

--- a/runtime/jcl/uma/java_lang_invoke_MethodHandleNatives_exports.xml
+++ b/runtime/jcl/uma/java_lang_invoke_MethodHandleNatives_exports.xml
@@ -1,22 +1,22 @@
-<!-- 
-	Copyright (c) 2021, 2022 IBM Corp. and others
-	
-	This program and the accompanying materials are made available under
-	the terms of the Eclipse Public License 2.0 which accompanies this
-	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-	or the Apache License, Version 2.0 which accompanies this distribution and
-	is available at https://www.apache.org/licenses/LICENSE-2.0.
-	
-	This Source Code may also be made available under the following
-	Secondary Licenses when the conditions for such availability set
-	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-	General Public License, version 2 with the GNU Classpath
-	Exception [1] and GNU General Public License, version 2 with the
-	OpenJDK Assembly Exception [2].
-	
-	[1] https://www.gnu.org/software/classpath/license.html
-	[2] http://openjdk.java.net/legal/assembly-exception.html
-	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+<!--
+Copyright (c) 2021, 2022 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="java_lang_invoke_MethodHandleNatives">
 	<export name="Java_java_lang_invoke_MethodHandleNatives_init" />
@@ -38,6 +38,6 @@
 	<export name="Java_java_lang_invoke_MethodHandleNatives_getNamedCon" />
 	<export name="Java_java_lang_invoke_MethodHandleNatives_registerNatives" />
 	<export name="Java_java_lang_invoke_MethodHandleNatives_getConstant">
-		<include-if condition="spec.java8"/>
+		<exclude-if condition="spec.java9"/>
 	</export>
 </exports>

--- a/runtime/jcl/uma/se19_exports.xml
+++ b/runtime/jcl/uma/se19_exports.xml
@@ -27,13 +27,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_java_lang_Thread_getThreads" />
 	<export name="Java_java_lang_Thread_setExtentLocalCache" />
 	<export name="Java_java_lang_Thread_registerNatives" />
-	<export name="Java_java_lang_VirtualThread_notifyJvmtiMountBegin" />
-	<export name="Java_java_lang_VirtualThread_notifyJvmtiMountEnd" />
-	<export name="Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin" />
-	<export name="Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd" />
-	<export name="Java_java_lang_VirtualThread_registerNatives" />
 	<export name="Java_jdk_internal_vm_Continuation_createContinuationImpl" />
 	<export name="Java_jdk_internal_vm_Continuation_pin" />
 	<export name="Java_jdk_internal_vm_Continuation_unpin" />
-	<export name="Java_jdk_internal_vm_Continuation_isPinnedImpl" />
 </exports>


### PR DESCRIPTION
Fix compile error due to new `#include "VMHelpers.hpp"` in jcl code.

Remove obsolete exports that cause link errors:
```
  JVM_GetModuleByPackageName
  Java_java_lang_invoke_MethodHandleNatives_getConstant
  Java_java_lang_VirtualThread_notifyJvmtiMountBegin
  Java_java_lang_VirtualThread_notifyJvmtiMountEnd
  Java_java_lang_VirtualThread_notifyJvmtiUnmountBegin
  Java_java_lang_VirtualThread_notifyJvmtiUnmountEnd
  Java_java_lang_VirtualThread_registerNatives
  Java_jdk_internal_vm_Continuation_isPinnedImpl
```