### PR TITLE
Print full exception details if a jdmpview !-command throws an exception

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/Context.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/Context.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -231,7 +231,7 @@ public class Context
 			} catch (Exception e) {
 				logger.log(Level.FINE, "Problem running command: ", e);
 				defaultOut.println("Problem running command:");
-				defaultOut.println(e.getMessage());
+				e.printStackTrace(defaultOut);
 			}
 
 			defaultOut.flush();


### PR DESCRIPTION
Fixes #15889

```
Problem running command:
java.nio.BufferOverflowException
	at java.nio.HeapByteBuffer.put(HeapByteBuffer.java:194)
	at java.nio.ByteBuffer.put(ByteBuffer.java:867)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.TraceFileHeaderWriter.writeStartupSection(TraceFileHeaderWriter.java:331)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.TraceFileHeaderWriter.writeTraceFileHeader(TraceFileHeaderWriter.java:203)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.TraceFileHeaderWriter.createAndWriteTraceFileHeader(TraceFileHeaderWriter.java:164)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.SnapBaseCommand.createAndWriteTraceFileHeader(SnapBaseCommand.java:177)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.SnapBaseCommand.extractTraceData(SnapBaseCommand.java:88)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.SnapFormatCommand.run(SnapFormatCommand.java:458)
	at com.ibm.j9ddr.tools.ddrinteractive.commands.SnapFormatWrapperCommand.run(SnapFormatWrapperCommand.java:70)
	at com.ibm.j9ddr.tools.ddrinteractive.Context.tryCommand(Context.java:229)
	at com.ibm.j9ddr.tools.ddrinteractive.Context.execute(Context.java:202)
	at com.ibm.j9ddr.tools.ddrinteractive.DDRInteractive.execute(DDRInteractive.java:356)
	at com.ibm.j9ddr.command.CommandReader.processLine(CommandReader.java:78)
	at com.ibm.j9ddr.tools.ddrinteractive.DDRInteractive.processLine(DDRInteractive.java:331)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.ibm.jvm.dtfjview.CombinedContext.executeDDRInteractiveCommand(CombinedContext.java:258)
	at com.ibm.jvm.dtfjview.CombinedContext.execute(CombinedContext.java:169)
	at com.ibm.jvm.dtfjview.Session.execute(Session.java:813)
	at com.ibm.jvm.dtfjview.Session.execute(Session.java:767)
	at DTFJTest.main(DTFJTest.java:15)
```

Signed-off-by: Kevin Grigorenko <kevin.grigorenko@us.ibm.com>