### PR TITLE
(v0.35.0) Readd getConstantPool() method to Class.java

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -5239,6 +5239,10 @@ Object setMethodHandleCache(Object cache) {
 	return result;
 }
 
+ConstantPool getConstantPool() {
+	return SharedSecrets.getJavaLangAccess().getConstantPool(this);
+}
+
 ConstantPool getConstantPool(Object internalCP) {
 	return VM.getVMLangAccess().getConstantPool(internalCP);
 }


### PR DESCRIPTION
Method needed for compatibility reasons.

Port of https://github.com/eclipse-openj9/openj9/pull/15891

fyi @pshipton 