### PR TITLE
Support virtual threads in JVMTI Resume* and Suspend* functions

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -663,6 +663,11 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "inspectorCount", "J", &vm->virtualThreadInspectorCountOffset)) {
 		return 1;
 	}
+
+	/* Stores a non-zero value if the virtual thread is suspended by JVMTI. */
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "isSuspendedByJVMTI", "I", &vm->isSuspendedByJVMTIOffset)) {
+		return 1;
+	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 	vmThread->privateFlags |= J9_PRIVATE_FLAGS_REPORT_ERROR_LOADING_CLASS;

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -375,7 +375,7 @@ Java_java_lang_Thread_getStackTraceImpl(JNIEnv *env, jobject rcv)
 		vthreadInspectorCount -= 1;
 		J9OBJECT_I64_STORE(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset, vthreadInspectorCount);
 
-		if (0 == vthreadInspectorCount) {
+		if (!vm->inspectingLiveVirtualThreadList && (0 == vthreadInspectorCount)) {
 			omrthread_monitor_notify_all(vm->liveVirtualThreadListMutex);
 		}
 		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);

--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -640,3 +640,9 @@ TraceEntry=Trc_JVMTI_jvmtiHookVirtualThreadDestroy_Entry Overhead=1 Level=5 Noen
 TraceExit=Trc_JVMTI_jvmtiHookVirtualThreadDestroy_Exit Overhead=1 Level=5 Noenv Template="HookVirtualThreadDestroy"
 
 TraceAssert=Assert_JVMTI_unreachable noEnv Overhead=1 Level=1 Assert="0"
+
+TraceEntry=Trc_JVMTI_jvmtiResumeAllVirtualThreads_Entry Overhead=1 Level=5 Noenv Template="ResumeAllVirtualThreads env=%p"
+TraceExit=Trc_JVMTI_jvmtiResumeAllVirtualThreads_Exit Overhead=1 Level=5 Noenv Template="ResumeAllVirtualThreads returning %d"
+
+TraceEntry=Trc_JVMTI_jvmtiSuspendAllVirtualThreads_Entry Overhead=1 Level=5 Noenv Template="SuspendAllVirtualThreads env=%p"
+TraceExit=Trc_JVMTI_jvmtiSuspendAllVirtualThreads_Exit Overhead=1 Level=5 Noenv Template="SuspendAllVirtualThreads returning %d"

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -217,7 +217,7 @@ releaseVMThread(J9VMThread *currentThread, J9VMThread *targetThread, jthread thr
 			Assert_JVMTI_true(vthreadInspectorCount > 0);
 			vthreadInspectorCount -= 1;
 			J9OBJECT_I64_STORE(currentThread, threadObject, vm->virtualThreadInspectorCountOffset, vthreadInspectorCount);
-			if (0 == vthreadInspectorCount) {
+			if (!vm->inspectingLiveVirtualThreadList && (0 == vthreadInspectorCount)) {
 				omrthread_monitor_notify_all(vm->liveVirtualThreadListMutex);
 			}
 			omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
@@ -874,6 +874,9 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread)
 			default:
 				Assert_JVMTI_unreachable();
 				rc = JVMTI_ERROR_INTERNAL;
+			}
+			if (0 != J9OBJECT_U32_LOAD(currentThread, vThreadObject, vm->isSuspendedByJVMTIOffset)) {
+				rc |= JVMTI_THREAD_STATE_SUSPENDED;
 			}
 		}
 		releaseVMThread(currentThread, targetThread, thread);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5784,9 +5784,11 @@ typedef struct J9JavaVM {
 	U_64 nextTID;
 	j9object_t *liveVirtualThreadList;
 	omrthread_monitor_t liveVirtualThreadListMutex;
+	volatile BOOLEAN inspectingLiveVirtualThreadList;
 	UDATA virtualThreadLinkNextOffset;
 	UDATA virtualThreadLinkPreviousOffset;
 	UDATA virtualThreadInspectorCountOffset;
+	UDATA isSuspendedByJVMTIOffset;
 	UDATA tlsOffset;
 	j9_tls_finalizer_t tlsFinalizers[J9JVMTI_MAX_TLS_KEYS];
 	omrthread_monitor_t tlsFinalizersMutex;


### PR DESCRIPTION
This PR impacts the following JVMTI functions:

- [Resume|Suspend]Thread
- [Resume|Suspend]ThreadList
- [Resume|Suspend]AllVirtualThreads

The above functions have been either implemented or updated as per the
JVMTI doc:
https://download.java.net/java/early_access/jdk19/docs/specs/jvmti.html

Other changes:
- Added boolean inspectingLiveVirtualThreadList to synchronize between
[Resume|Suspend]AllVirtualThreads, JVM_VirtualThreadMountBegin-End and
JVM_VirtualThreadUnmountBegin-End.
- If a thread is suspended while waiting on the monitor, then the
monitor is released after waking up and before invoking
internalEnterVMFromJNI, where the thread will be halted until resumed.
After resuming, the monitor is acquired again. This helps avoid
deadlocks.
- Added hidden field isSuspendedByJVMTI in VirtualThread to track if the
thread was suspended in JVMTI. If isSuspendedByJVMTI is non-zero, then
J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND is set in carrier J9VMThread's
publicFlags while resetting isSuspendedByJVMTI to zero. During mount,
this suspends the thread if the thread was unmounted while JVMTI
suspended it.

Related: #15760

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>