### PR TITLE
AArch64 macOS: Re-acquire execution permission in compilation threads

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8201,6 +8201,11 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
                                      reloRuntime);
       }
 
+#if defined(OSX) && defined(AARCH64)
+   // Re-acquire execution permission of JIT code cache for this thread
+   // regardless of the previous protection status
+   pthread_jit_write_protect_np(1);
+#endif
 
    vmThread->omrVMThread->vmState = oldState;
    vmThread->jitMethodToBeCompiled = NULL;


### PR DESCRIPTION
This commit adds a call to pthread_jit_write_protect_np(1) at the end of TR::CompilationInfoPerThreadBase::compile() so that the JIT compilation thread always re-acquires the execution permission for JIT code cache.

Fixes: #14621
Fixes: #14635
Fixes: #14717
Fixes: #15315
Fixes: #15352
Fixes: #15518
Fixes: #15868

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>