### PR TITLE
Fix warnings in jdknext classified as "lossy-conversions"

### DIFF
--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corp. and others
+ * Copyright (c) 2013, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2574,7 +2574,7 @@ public final class DecimalData
 
         // take care of the sign nibble and the right most digit
         byteArray[offset + length - 1] = (byte) ((buffer[numDigitsLeft] - '0') << 4);
-        byteArray[offset + length - 1] |= ((value.signum() == -1) ? 0x0D : 0x0C);
+        byteArray[offset + length - 1] |= (byte) ((value.signum() == -1) ? 0x0D : 0x0C);
 
         // compact 2 digits into each byte
         for (int i = numDigitsLeft - 1; i >= endPosition

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/PackedDecimal.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/PackedDecimal.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corp. and others
+ * Copyright (c) 2013, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -842,14 +842,14 @@ public final class PackedDecimal {
         int charStart = neg ? 1 : 0;
         int charEnd = chars.length - 1;
 
-        pd[end--] = (byte) ((neg ? 0x0D : 0x0C) | (chars[charEnd--] - '0' << 4));
+        pd[end--] = (byte) ((neg ? 0x0D : 0x0C) | ((chars[charEnd--] - '0') << 4));
 
         while (end >= offset) {
             byte b = 0;
             if (charEnd >= charStart) {
                 b = (byte) (chars[charEnd--] - '0');
                 if (charEnd >= charStart) {
-                    b |= chars[charEnd--] - '0' << 4;
+                    b |= (byte) ((chars[charEnd--] - '0') << 4);
                 }
             }
             pd[end--] = b;


### PR DESCRIPTION
The new warning was added in https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/e90c809e0e89115a0ce8c03ff874c428058d560e.