### PR TITLE
Update CRIU to v3.17 for OpenJ9 Ubuntu dockerfile

### DIFF
--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -89,7 +89,7 @@ parse_options() {
         action=build
         ;;
       --criu)
-        criu=3.16.1
+        criu=3.17.1
         ;;
       --cuda)
         cuda=9.0


### PR DESCRIPTION
Update CRIU version from 3.16 to 3.17.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>