### PR TITLE
Loom: Update JVMTI monitor functions

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1929,3 +1929,24 @@ genericWalkStackFramesHelper(J9VMThread *currentThread, J9VMThread *targetThread
 
 	return rc;
 }
+
+#if JAVA_SPEC_VERSION >= 19
+J9VMContinuation *
+getJ9VMContinuationToWalk(J9VMThread *currentThread, J9VMThread *targetThread, j9object_t threadObject)
+{
+	J9VMContinuation *continuation = NULL;
+	if (IS_VIRTUAL_THREAD(currentThread, threadObject)) {
+		if (NULL == targetThread) {
+			/* An unmounted virtual thread will have a valid J9VMContinuation. */
+			j9object_t contObject = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
+			continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, contObject);
+		}
+	} else {
+		/* J9VMThread->currentContinuation is set to NULL if a virtual thread is not mounted.
+		 * If a virtual thread is mounted, currentContinuation stores the carrier thread details.
+		 */
+		continuation = targetThread->currentContinuation;
+	}
+	return continuation;
+}
+#endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1362,6 +1362,24 @@ findDecompileInfo(J9VMThread *currentThread, J9VMThread *targetThread, UDATA dep
 UDATA
 genericWalkStackFramesHelper(J9VMThread *currentThread, J9VMThread *targetThread, j9object_t threadObject, J9StackWalkState *walkState);
 
+#if JAVA_SPEC_VERSION >= 19
+/**
+ * With the introduction of virtual threads, targetThread may not have threadObject
+ * mounted. If threadObject is not mounted onto the targetThread, then its stack
+ * and other important details will be stored in a J9VMContinuation instance. This
+ * helper determines if threadObject is not mounted, and returns the corresponding
+ * J9VMContinuation for threadObject. If threadObject is mounted onto the targetThread,
+ * then this helper returns NULL.
+ *
+ * @param[in] currentThread current thread.
+ * @param[in] targetThread the J9VMThread where threadObject can be mounted.
+ * @param[in] threadObject the thread object.
+ * @return a J9VMContinuation if threadObject is not mounted; otherwise NULL.
+ */
+J9VMContinuation *
+getJ9VMContinuationToWalk(J9VMThread *currentThread, J9VMThread *targetThread, j9object_t threadObject);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 /* ---------------- jvmtiHook.c ---------------- */
 
 /**


### PR DESCRIPTION
Support for virtual threads added in the following JVMTI functions:
- GetOwnedMonitorInfo
- GetOwnedMonitorStackDepthInfo
- GetCurrentContendedMonitor

Related changes: #15857

GetThreadState and GetThreadInfo allow a NULL input thread. In such
a case, they should look at the current thread's object. Because using
the NULL input thread causes a seg fault. This has been fixed.

Related issue: #15759

Co-authored-by: Gengchen Tuo <gengchen.tuo@ibm.com>
Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>