### PR TITLE
Testing for 64-bit dump should ignore DDRInteractiveCommandException

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/DDRExtTesterBase.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/DDRExtTesterBase.java
@@ -461,14 +461,14 @@ public class DDRExtTesterBase extends TestCase {
 		coveredStructures.clear();
 	}
 
-	/* Check whether core is generated on 64 bit platform or not.
-	 * Run setvm with the address that can exist only on 64 bit platform
+	/* Check whether core is generated on a 64-bit platform or not.
+	 * Run setvm with an address that can exist only on a 64-bit platform.
 	 */
 	public boolean is64BitPlatform() {
 		String setVMOutput = exec(Constants.SETVM_CMD, new String[] { CommandUtils.UDATA_MAX_64BIT.toString() });
 		boolean is64BitPlatform = true;
-		/* If it is 32-bit platform, then it will complain about address being too large. */
-		if (validate(setVMOutput, "is larger than the max available memory address: 0xFFFFFFFF", null)) {
+		/* If it is a 32-bit platform, then it will complain about address being too large. */
+		if (validate(setVMOutput, "is larger than the max available memory address: 0xFFFFFFFF", 1)) {
 			is64BitPlatform = false;
 		}
 		return is64BitPlatform;


### PR DESCRIPTION
The stack trace added in #15890 necessitates a change to how tests distinguish between 32-bit and 64-bit dumps.

Fixes: #15915.