### PR TITLE
Stop sharing TR_VirtualGuard between multiple guards with the same BCI

### DIFF
--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -273,7 +273,7 @@ bool TR_CHTable::commit(TR::Compilation *comp)
    if (canSkipCommit(comp))
       return true;
 
-   TR::list<TR_VirtualGuard*> &vguards = comp->getVirtualGuards();
+   const TR::Compilation::GuardSet &vguards = comp->getVirtualGuards();
    TR::list<TR_VirtualGuardSite*> *sideEffectPatchSites = comp->getSideEffectGuardPatchSites();
 
    cleanupNewlyExtendedInfo(comp);
@@ -423,7 +423,8 @@ bool TR_CHTable::commit(TR::Compilation *comp)
    }
 
 void
-TR_CHTable::commitOSRVirtualGuards(TR::Compilation *comp, TR::list<TR_VirtualGuard*> &vguards)
+TR_CHTable::commitOSRVirtualGuards(
+   TR::Compilation *comp, const TR::Compilation::GuardSet &vguards)
    {
    // Count patch sites with OSR assumptions
    int osrSites = 0;
@@ -806,7 +807,7 @@ TR_CHTable::computeDataForCHTableCommit(TR::Compilation *comp)
    cleanupNewlyExtendedInfo(comp);
 
    // collect virtual guard info
-   TR::list<TR_VirtualGuard*> &vguards = comp->getVirtualGuards();
+   const TR::Compilation::GuardSet &vguards = comp->getVirtualGuards();
    std::vector<VirtualGuardForCHTable> serialVGuards;
    serialVGuards.reserve(vguards.size());
 

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -418,7 +418,8 @@ class TR_CHTable
 
    void commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> &sites,
                            TR_PersistentCHTable *table, TR::Compilation *comp);
-   void commitOSRVirtualGuards(TR::Compilation *comp, TR::list<TR_VirtualGuard*> &vguards);
+   void commitOSRVirtualGuards(
+      TR::Compilation *comp, const TR::Compilation::GuardSet &vguards);
 #if defined(J9VM_OPT_JITSERVER)
    CHTableCommitData computeDataForCHTableCommit(TR::Compilation *comp);
 #endif

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -6648,10 +6648,6 @@ TR_J9InnerPreexistenceInfo::perform(TR::Compilation *comp, TR::Node *guardNode, 
          ((TR_J9InnerPreexistenceInfo *)point->_callStack->_innerPrexInfo)->addInnerAssumption(a);
          disableTailRecursion = true;
 
-         // Tell compilation that this guard is to be removed
-         //
-         comp->removeVirtualGuard(virtualGuard);
-
          // "Remove" the guard node
          //
          TR_ASSERT(guardNode->getOpCodeValue() == TR::ificmpne ||
@@ -6660,7 +6656,7 @@ TR_J9InnerPreexistenceInfo::perform(TR::Compilation *comp, TR::Node *guardNode, 
                 "Wrong kind of if discovered for a virtual guard");
          guardNode->getFirstChild()->recursivelyDecReferenceCount();
          guardNode->setAndIncChild(0, guardNode->getSecondChild());
-         guardNode->resetIsTheVirtualGuardForAGuardedInlinedCall();
+         guardNode->setVirtualGuardInfo(NULL, comp);
 
          // FIXME:
          //printf("---$$$--- inner prex in %s\n", comp->signature());

--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -44,7 +44,7 @@ static bool generatesFear(TR::Compilation *comp, TR_FearPointAnalysis &fearAnaly
 
 static bool hasHCRGuard(TR::Compilation *comp)
    {
-   TR::list<TR_VirtualGuard*> &virtualGuards = comp->getVirtualGuards();
+   const TR::Compilation::GuardSet &virtualGuards = comp->getVirtualGuards();
    for (auto itr = virtualGuards.begin(), end = virtualGuards.end(); itr != end; ++itr)
       {
       if ((*itr)->getKind() == TR_HCRGuard || (*itr)->mergedWithHCRGuard())
@@ -354,7 +354,6 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR
              && performTransformation(comp(), "O^O HCR GUARD REMOVAL: removing HCRGuard node n%dn\n", node->getGlobalIndex()))
             {
             comp()->addClassForOSRRedefinition(guardInfo->getThisClass());
-            comp()->removeVirtualGuard(guardInfo);
 
             // When removing the HCR branch, first remove the successor edges from the existing HCR block
             // This allows the branch removal operation to skip expensive checks when structure has been modified

--- a/runtime/compiler/optimizer/OSRGuardRemoval.cpp
+++ b/runtime/compiler/optimizer/OSRGuardRemoval.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,7 +113,6 @@ int32_t TR_OSRGuardRemoval::perform()
             }
 
          TR_VirtualGuard *guardInfo = comp()->findVirtualGuardInfo(node);
-         comp()->removeVirtualGuard(guardInfo);
          block->removeBranch(comp());
 
          TR::DebugCounter::prependDebugCounter(


### PR DESCRIPTION
These are a few adjustments to remain compatible with OMR after the corresponding OMR commit.