### PR TITLE
Fix caller of getGuaranteedNurseryRange() and use new functions

### DIFF
--- a/runtime/gc_api/GuaranteedNurseryRange.cpp
+++ b/runtime/gc_api/GuaranteedNurseryRange.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,13 +60,8 @@ extern "C" {
 void
 j9mm_get_guaranteed_nursery_range(J9JavaVM* javaVM, void** start, void** end)
 {
-#if defined (J9VM_GC_GENERATIONAL)
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(javaVM->omrVM);
 	extensions->getGuaranteedNurseryRange(start, end);
-#else /* J9VM_GC_GENERATIONAL */
-	*start = NULL;
-	*end = NULL;
-#endif /* J9VM_GC_GENERATIONAL */
 }
 
 }

--- a/runtime/gc_base/GenerationalAccessBarrierComponent.cpp
+++ b/runtime/gc_base/GenerationalAccessBarrierComponent.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,7 +107,7 @@ MM_GenerationalAccessBarrierComponent::postObjectStore(J9VMThread *vmThread, J9O
 					 * The REMEMBERED bit is kept in the object for optimization purposes (only scan objects
 					 * whose REMEMBERED bit is set in an overflow scan) 
 					 */
-					extensions->setRememberedSetOverflowState();
+					extensions->setScavengerRememberedSetOverflowState();
 					reportRememberedSetOverflow(vmThread);
 				}
 			}
@@ -153,7 +153,7 @@ MM_GenerationalAccessBarrierComponent::postBatchObjectStore(J9VMThread *vmThread
 					/* No slot was available from any fragment.  Set the remembered set overflow flag.
 					 * The REMEMBERED bit is kept in the object for optimization purposes (only scan objects
 					 * whose REMEMBERED bit is set in an overflow scan) */
-					extensions->setRememberedSetOverflowState();
+					extensions->setScavengerRememberedSetOverflowState();
 					reportRememberedSetOverflow(vmThread);
 				} else {
 					/* Successfully allocated a slot from the remembered set.  Record the object. */

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -349,7 +349,7 @@ MM_StandardAccessBarrier::recentlyAllocatedObject(J9VMThread *vmThread, J9Object
 				 * The REMEMBERED bit is kept in the object for optimization purposes (only scan objects
 				 * whose REMEMBERED bit is set in an overflow scan)
 				 */
-				extensions->setRememberedSetOverflowState();
+				extensions->setScavengerRememberedSetOverflowState();
 #if defined(J9VM_GC_MODRON_EVENTS)			
 				reportRememberedSetOverflow(vmThread);
 #endif /* J9VM_GC_MODRON_EVENTS */

--- a/runtime/gcchk/gcchk.cpp
+++ b/runtime/gcchk/gcchk.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -478,7 +478,7 @@ hookRememberedSetOverflow(J9HookInterface** hook, UDATA eventNum, void* eventDat
 	GC_CheckCycle *cycle = (GC_CheckCycle *)extensions->checkCycle;
 
 	if (cycle->getMiscFlags() & J9MODRON_GCCHK_REMEMBEREDSET_OVERFLOW) {
-		checkEngine->_rsOverflowState = MM_GCExtensions::getExtensions(event->currentThread)->isRememberedSetInOverflowState();
+		checkEngine->_rsOverflowState = MM_GCExtensions::getExtensions(event->currentThread)->isScavengerRememberedSetInOverflowState();
 	}
 }
 #endif /* J9VM_GC_GENERATIONAL */


### PR DESCRIPTION
getGuaranteedNurseryRange() in GCExtensionsBase is defind always no. There is no need to check J9VM_GC_GENERATIONAL (and technically this is wrong flag any way, OMR_GC_MODRON_SCAVENGER should be checked instead). This function is going to set output parameters to NULL if OMR_GC_MODRON_SCAVENGER is not defined

#depends https://github.com/eclipse/omr/pull/6715

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>