### PR TITLE
CRIU skips j9sysinfo_get_username/getpwuid to avoid checkpoint failure

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -393,6 +393,11 @@ typedef struct J9PortLibrary {
 	 * Only supports one Checkpoint, could be restored multiple times.
 	 */
 	int64_t nanoTimeMonotonicClockDelta;
+	/* Invoking j9sysinfo_get_username()/getpwuid() with SSSD enabled can cause checkpoint failure.
+	 * It is safe to call those methods if checkpoint is disallowed after a final restore.
+	 * https://github.com/eclipse-openj9/openj9/issues/15800
+	 */
+	BOOLEAN finalRestore;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9PortLibrary;
 

--- a/runtime/port/common/j9prt.tdf
+++ b/runtime/port/common/j9prt.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2015, 2021 IBM Corp. and others
+// Copyright (c) 2015, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2136,3 +2136,8 @@ TraceException=Trc_PRT_j9shmem_getDir_tryHomeDirFailed_cannotStat Group=j9shmem 
 TraceExit=Trc_PRT_shared_createDir_Exit8 Group=j9shmem Overhead=1 Level=1 NoEnv Template="j9shmem_createDir file_attr reported isDir, directory exists, cacheDirPerm is not present and it is not the default directory"
 
 TraceExit=Trc_PRT_shmem_j9shmem_stat_Exit2_V2 Group=j9shmem Overhead=1 Level=1 NoEnv Template="j9shmem_stat exit - contents of controlFile %s is corrupted, error code is %u"
+
+TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getUserNameTooLong Group=j9shmem Overhead=1 Level=1 NoEnv Template="cleanSharedMemorySegments: The length of the user name is %zd, it should be greater than 0 and less than %d."
+TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getUserName_Failed Group=j9shmem Overhead=1 Level=1 NoEnv Template="cleanSharedMemorySegments: omrsysinfo_get_username failed"
+TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getEnvUserNameTooLong Group=j9shmem Overhead=1 Level=1 NoEnv Template="cleanSharedMemorySegments: The length of the environment variable USER is %zd, it should be greater than 0 and less than %d."
+TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getEnvUserName_Failed Group=j9shmem Overhead=1 Level=1 NoEnv Template="cleanSharedMemorySegments: omrsysinfo_get_env failed"

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -84,6 +84,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 
 	if (vm->checkpointState.isNonPortableRestoreMode) {
 		vm->checkpointState.isCheckPointAllowed = FALSE;
+		vm->portLibrary->finalRestore = TRUE;
 	}
 
 	TRIGGER_J9HOOK_VM_PREPARING_FOR_RESTORE(vm->hookInterface, currentThread);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3752,6 +3752,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		if (enableCRIU > disableCRIU) {
 			vm->checkpointState.isCheckPointEnabled = TRUE;
 			vm->checkpointState.isCheckPointAllowed = TRUE;
+			vm->portLibrary->finalRestore = FALSE;
 		}
 	}
 


### PR DESCRIPTION
CRIU skips `j9sysinfo_get_username()`/`getpwuid()` to avoid checkpoint failure

When `SSSD` is enabled, `j9sysinfo_get_username()`/`getpwuid()` can cause checkpoint failure, these methods will be skipped if a checkpoint can be taken, `j9sysinfo_get_env()` is used instead;
Added `J9PortLibrary.isSafeSSSDMethod` which is equivalent to `!isCheckpointAllowed()`;
Removed obsoleted defines `ARM_EMULATED`, `CHORUS` & `J9PWENT`; 
Refactoring variable initialization, code format around code affected.

[Internal personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/14268/)
Verified manually OpenLiberty checkpoint at `RHEL8` w/ `SSSD` enabled.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>