### PR TITLE
Add JITServer AOT cache persistence

### DIFF
--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -207,6 +207,7 @@ CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassCh
                                  TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
                                  const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
                                  const void *code, size_t codeSize, const void *data, size_t dataSize) :
+   _nextRecord(NULL),
    _data(definingClassChainRecord->data().id(), index, optLevel,
          aotHeaderRecord->data().id(), records.size(), code, codeSize, data, dataSize),
    _definingClassChainRecord(definingClassChainRecord)
@@ -346,24 +347,38 @@ freeMapValues(const PersistentUnorderedMap<K, V *, H> &map)
 JITServerAOTCache::JITServerAOTCache(const std::string &name) :
    _name(name),
    _classLoaderMap(decltype(_classLoaderMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classLoaderHead(NULL),
+   _classLoaderTail(NULL),
    _nextClassLoaderId(1),// ID 0 is invalid
    _classLoaderMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassLoaderMonitor")),
    _classMap(decltype(_classMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classHead(NULL),
+   _classTail(NULL),
    _nextClassId(1),// ID 0 is invalid
    _classMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassMonitor")),
    _methodMap(decltype(_methodMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _methodHead(NULL),
+   _methodTail(NULL),
    _nextMethodId(1),// ID 0 is invalid
    _methodMonitor(TR::Monitor::create("JIT-JITServerAOTCacheMethodMonitor")),
    _classChainMap(decltype(_classChainMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classChainHead(NULL),
+   _classChainTail(NULL),
    _nextClassChainId(1),// ID 0 is invalid
    _classChainMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassChainMonitor")),
    _wellKnownClassesMap(decltype(_wellKnownClassesMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _wellKnownClassesHead(NULL),
+   _wellKnownClassesTail(NULL),
    _nextWellKnownClassesId(1),// ID 0 is invalid
    _wellKnownClassesMonitor(TR::Monitor::create("JIT-JITServerAOTCacheWellKnownClassesMonitor")),
    _aotHeaderMap(decltype(_aotHeaderMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _aotHeaderHead(NULL),
+   _aotHeaderTail(NULL),
    _nextAOTHeaderId(1),// ID 0 is invalid
    _aotHeaderMonitor(TR::Monitor::create("JIT-JITServerAOTCacheAOTHeaderMonitor")),
    _cachedMethodMap(decltype(_cachedMethodMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _cachedMethodHead(NULL),
+   _cachedMethodTail(NULL),
    _cachedMethodMonitor(TR::Monitor::create("JIT-JITServerAOTCacheCachedMethodMonitor")),
    _numCacheBypasses(0), _numCacheHits(0), _numCacheMisses(0),
    _numDeserializedMethods(0), _numDeserializationFailures(0)

--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -317,8 +317,12 @@ JITServerAOTCache::AOTHeaderKey::Hash::operator()(const AOTHeaderKey &k) const n
 
 // Insert the value (which must be allocated with AOTCacheRecord::allocate())
 // with the key into the map, avoiding memory leaks in case of exceptions.
+// Also insert it into the linked list traversal of the map defined by the
+// given head and tail.
 template<typename K, typename V, typename H> static void
 addToMap(PersistentUnorderedMap<K, V *, H> &map,
+         V *&traversalHead,
+         V *&traversalTail,
          const typename PersistentUnorderedMap<K, V *, H>::const_iterator &it,
          const K &key, V *value)
    {
@@ -331,6 +335,19 @@ addToMap(PersistentUnorderedMap<K, V *, H> &map,
       AOTCacheRecord::free(value);
       throw;
       }
+
+   // Normally we would need a write barrier here to ensure that the record was fully written to memory before
+   // adding it to this traversal. However, since we save the number of records to be written in writeRecordList,
+   // we will never encounter such a partial record in the serializer, and so the write barrier is unnecessary.
+   if (traversalTail == NULL)
+      {
+      traversalHead = value;
+      }
+   else
+      {
+      traversalTail->setNextRecord(value);
+      }
+   traversalTail = value;
    }
 
 // Free all the values (which must be allocated with AOTCacheRecord::allocate()) in the map.
@@ -433,7 +450,7 @@ JITServerAOTCache::getClassLoaderRecord(const uint8_t *name, size_t nameLength)
       }
 
    auto record = AOTCacheClassLoaderRecord::create(_nextClassLoaderId, name, nameLength);
-   addToMap(_classLoaderMap, it, { record->data().name(), record->data().nameLength() }, record);
+   addToMap(_classLoaderMap, _classLoaderHead, _classLoaderTail, it, { record->data().name(), record->data().nameLength() }, record);
    ++_nextClassLoaderId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -466,7 +483,7 @@ JITServerAOTCache::getClassRecord(const AOTCacheClassLoaderRecord *classLoaderRe
       }
 
    auto record = AOTCacheClassRecord::create(_nextClassId, classLoaderRecord, hash, romClass);
-   addToMap(_classMap, it, { classLoaderRecord, &record->data().hash() }, record);
+   addToMap(_classMap, _classHead, _classTail, it, { classLoaderRecord, &record->data().hash() }, record);
    ++_nextClassId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -499,7 +516,7 @@ JITServerAOTCache::getMethodRecord(const AOTCacheClassRecord *definingClassRecor
       }
 
    auto record = AOTCacheMethodRecord::create(_nextMethodId, definingClassRecord, index);
-   addToMap(_methodMap, it, key, record);
+   addToMap(_methodMap, _methodHead, _methodTail, it, key, record);
    ++_nextMethodId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -529,7 +546,7 @@ JITServerAOTCache::getClassChainRecord(const AOTCacheClassRecord *const *classRe
       }
 
    auto record = AOTCacheClassChainRecord::create(_nextClassChainId, classRecords, length);
-   addToMap(_classChainMap, it, { record->records(), length }, record);
+   addToMap(_classChainMap, _classChainHead, _classChainTail, it, { record->records(), length }, record);
    ++_nextClassChainId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -560,7 +577,7 @@ JITServerAOTCache::getWellKnownClassesRecord(const AOTCacheClassChainRecord *con
       }
 
    auto record = AOTCacheWellKnownClassesRecord::create(_nextWellKnownClassesId, chainRecords, length, includedClasses);
-   addToMap(_wellKnownClassesMap, it, { record->records(), length, includedClasses }, record);
+   addToMap(_wellKnownClassesMap, _wellKnownClassesHead, _wellKnownClassesTail, it, { record->records(), length, includedClasses }, record);
    ++_nextWellKnownClassesId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -594,7 +611,7 @@ JITServerAOTCache::getAOTHeaderRecord(const TR_AOTHeader *header, uint64_t clien
       }
 
    auto record = AOTCacheAOTHeaderRecord::create(_nextAOTHeaderId, header);
-   addToMap(_aotHeaderMap, it, { record->data().header() }, record);
+   addToMap(_aotHeaderMap, _aotHeaderHead, _aotHeaderTail, it, { record->data().header() }, record);
    ++_nextAOTHeaderId;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -646,7 +663,7 @@ JITServerAOTCache::storeMethod(const AOTCacheClassChainRecord *definingClassChai
 
    auto method = CachedAOTMethod::create(definingClassChainRecord, index, optLevel, aotHeaderRecord,
                                          records, code, codeSize, data, dataSize);
-   addToMap(_cachedMethodMap, it, key, method);
+   addToMap(_cachedMethodMap, _cachedMethodHead, _cachedMethodTail, it, key, method);
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -29,8 +29,41 @@
 #include "env/PersistentCollections.hpp"
 #include "runtime/JITServerAOTSerializationRecords.hpp"
 
+static const uint32_t JITSERVER_AOTCACHE_VERSION = 0;
+static const char JITSERVER_AOTCACHE_EYECATCHER[] = "AOTCACHE";
+// the eye-catcher is not null-terminated in the snapshot files
+static const size_t JITSERVER_AOTCACHE_EYECATCHER_LENGTH = sizeof(JITSERVER_AOTCACHE_EYECATCHER) - 1;
+
 namespace TR { class Monitor; }
 
+// Information relevant to the compatibility of a cache snapshot with the server.
+struct JITServerAOTCacheVersion
+   {
+   char _eyeCatcher[JITSERVER_AOTCACHE_EYECATCHER_LENGTH];
+   uint32_t _snapshotVersion;
+   uint32_t _padding; // explicit padding, currently unused
+   uint64_t _jitserverVersion;
+   };
+
+// The header information for an AOT cache snapshot.
+struct JITServerAOTCacheHeader
+   {
+   JITServerAOTCacheVersion _version;
+   uint64_t _serverUID;
+   size_t _numClassLoaderRecords;
+   size_t _numClassRecords;
+   size_t _numMethodRecords;
+   size_t _numClassChainRecords;
+   size_t _numWellKnownClassesRecords;
+   size_t _numAOTHeaderRecords;
+   size_t _numCachedAOTMethods;
+   size_t _nextClassLoaderId;
+   size_t _nextClassId;
+   size_t _nextMethodId;
+   size_t _nextClassChainId;
+   size_t _nextWellKnownClassesId;
+   size_t _nextAOTHeaderId;
+   };
 
 // Base class for serialization record "wrappers" stored at the server.
 //
@@ -451,6 +484,5 @@ private:
    static size_t _cacheMaxBytes;
    static bool _cacheIsFull;
    };
-
 
 #endif /* defined(JITSERVER_AOTCACHE_H) */

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,6 +64,7 @@ public:
    //NOTE: 0 signifies an invalid record ID
    uintptr_t id() const { return getId(_idAndType); }
    AOTSerializationRecordType type() const { return getType(_idAndType); }
+   bool isValid(AOTSerializationRecordType type) const;
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
 
    static const AOTSerializationRecord *get(const std::string &str)
@@ -110,11 +111,13 @@ struct ClassLoaderSerializationRecord : public AOTSerializationRecord
 public:
    size_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::ClassLoader); }
 
 private:
    friend class AOTCacheClassLoaderRecord;
 
    ClassLoaderSerializationRecord(uintptr_t id, const uint8_t *name, size_t nameLength);
+   ClassLoaderSerializationRecord();
 
    static size_t size(size_t nameLength)
       {
@@ -135,12 +138,14 @@ public:
    uint32_t romClassSize() const { return _romClassSize; }
    size_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::Class); }
 
 private:
    friend class AOTCacheClassRecord;
 
    ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
                             const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+   ClassSerializationRecord();
 
    static size_t size(size_t nameLength)
       {
@@ -162,11 +167,13 @@ struct MethodSerializationRecord : public AOTSerializationRecord
 public:
    uintptr_t definingClassId() const { return _definingClassId; }
    uint32_t index() const { return _index; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::Method); }
 
 private:
    friend class AOTCacheMethodRecord;
 
    MethodSerializationRecord(uintptr_t id, uintptr_t definingClassId, uint32_t index);
+   MethodSerializationRecord();
 
    const uintptr_t _definingClassId;
    // Index in the array of methods of the defining class
@@ -195,11 +202,13 @@ struct ClassChainSerializationRecord : public AOTSerializationRecord
    {
 public:
    const IdList &list() const { return _list; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::ClassChain); }
 
 private:
    template<class D, class R, typename... Args> friend class AOTCacheListRecord;
 
    ClassChainSerializationRecord(uintptr_t id, size_t length);
+   ClassChainSerializationRecord();
 
    IdList &list() { return _list; }
 
@@ -218,11 +227,13 @@ struct WellKnownClassesSerializationRecord : public AOTSerializationRecord
 public:
    uintptr_t includedClasses() const { return _includedClasses; }
    const IdList &list() const { return _list; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::WellKnownClasses); }
 
 private:
    template<class D, class R, typename... Args> friend class AOTCacheListRecord;
 
    WellKnownClassesSerializationRecord(uintptr_t id, size_t length, uintptr_t includedClasses);
+   WellKnownClassesSerializationRecord();
 
    IdList &list() { return _list; }
 
@@ -242,11 +253,13 @@ struct AOTHeaderSerializationRecord : public AOTSerializationRecord
    {
 public:
    const TR_AOTHeader *header() const { return &_header; }
+   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::AOTHeader); }
 
 private:
    friend class AOTCacheAOTHeaderRecord;
 
    AOTHeaderSerializationRecord(uintptr_t id, const TR_AOTHeader *header);
+   AOTHeaderSerializationRecord();
 
    const TR_AOTHeader _header;
    };
@@ -294,6 +307,7 @@ public:
    const uint8_t *data() const { return code() + _codeSize; }
    uint8_t *data() { return (uint8_t *)(code() + _codeSize); }
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
+   bool isValid() const;
 
    static SerializedAOTMethod *get(std::string &str)
       {
@@ -308,6 +322,7 @@ private:
    SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
                        TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
                        const void *code, size_t codeSize, const void *data, size_t dataSize);
+   SerializedAOTMethod();
 
    static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
       {


### PR DESCRIPTION
The current JITServer AOT cache lacks any persistence mechanism. These changes add two functions

```c++
class JITServerAOTCache
   {
   ...
   bool writeCache(FILE *f) const;
   static JITServerAOTCache *readCache(FILE *f, const std::string &name, TR_Memory &trMemory);
   }
```

to the public cache interface that will read or write an entire cache to or from a particular file stream. A cache file header and versioning mechanism has also been introduced.

The added intrusive linked list traversals of the AOT cache maps allow cache serialization to be performed concurrently with other cache record storage and retrieval.