### PR TITLE
Move value type public APIs in Class.java into Access.java

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -645,5 +645,32 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
+/*[IF INLINE-TYPES]*/
+	@Override
+	public boolean isPrimitiveClass(Class<?> c) {
+		return c.isPrimitiveClass();
+	}
+
+	@Override
+	public Class<?> asPrimaryType(Class<?> c) {
+		return c.asPrimaryType();
+	}
+
+	@Override
+	public Class<?> asValueType(Class<?> c) {
+		return c.asValueType();
+	}
+
+	@Override
+	public boolean isPrimaryType(Class<?> c) {
+		return c.isPrimaryType();
+	}
+
+	@Override
+	public boolean isPrimitiveValueType(Class<?> c) {
+		return c.isPrimitiveValueType();
+	}
+/*[ENDIF] INLINE-TYPES */
+
 /*[ENDIF] Sidecar19-SE */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -5665,4 +5665,10 @@ SecurityException {
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	/* ToDo: Real implementation to be added under https://github.com/eclipse-openj9/openj9/issues/15933. */
+	public Set<AccessFlag> accessFlags() {
+		return null;
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2609,7 +2609,7 @@ public native boolean isPrimitive();
  *
  * @return	true if receiver is primitive class type, and false otherwise.
  */
-public native boolean isPrimitiveClass();
+native boolean isPrimitiveClass();
 
 /**
  * Answers true if the receiver represents a value class type. Array classes
@@ -2622,19 +2622,19 @@ public native boolean isValue();
 /**
  * ToDo: add comments for public methods - https://github.com/eclipse-openj9/openj9/issues/13615
  */
-public Class<?> asPrimaryType() {
+Class<?> asPrimaryType() {
 	// ToDo: this is a temporary implementation - https://github.com/eclipse-openj9/openj9/issues/13615
 	return this;
 }
-public Class<?> asValueType() {
+Class<?> asValueType() {
 	// ToDo: this is a temporary implementation - https://github.com/eclipse-openj9/openj9/issues/13615
 	return this;
 }
-public boolean isPrimaryType() {
+boolean isPrimaryType() {
 	// ToDo: this is a temporary implementation - https://github.com/eclipse-openj9/openj9/issues/13615
 	return true;
 }
-public boolean isPrimitiveValueType() {
+boolean isPrimitiveValueType() {
 	// ToDo: this is a temporary implementation - https://github.com/eclipse-openj9/openj9/issues/13615
 	return false;
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corp. and others
+ * Copyright (c) 2020, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.lang.StringBuilder;
+/*[IF INLINE-TYPES]*/
+import jdk.internal.value.PrimitiveClass;
+/*[ENDIF] INLINE-TYPES */
 
 import com.ibm.oti.util.Msg;
 
@@ -177,7 +180,7 @@ final class MethodTypeHelper {
 		if (c.isArray()) {
 		}
 		/*[IF INLINE-TYPES]*/
-		else if (c.isPrimitiveClass()) {
+		else if (PrimitiveClass.isPrimitiveClass(c)) {
 			name = new StringBuilder(name.length() + 2).
 				append('Q').append(name).append(';').toString();
 		}

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2021 IBM Corp. and others
+  Copyright (c) 2017, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${transformerListener}" />
-			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -38,6 +38,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xint \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
 		-groups $(TEST_GROUP) \
@@ -73,6 +74,7 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTestsJIT \
 		-groups $(TEST_GROUP) \
@@ -103,6 +105,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xint \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeUnsafeTests \
 		-groups $(TEST_GROUP) \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import jdk.internal.value.PrimitiveClass;
 import sun.misc.Unsafe;
 import org.testng.Assert;
 import static org.testng.Assert.*;
@@ -3023,14 +3024,14 @@ public class ValueTypeTests {
 	static public void testIdentityObjectOnValueType() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateValueClass("testIdentityObjectOnValueType", fields);
-		assertTrue(valueClass.isPrimitiveClass());
+		assertTrue(PrimitiveClass.isPrimitiveClass(valueClass));
 		assertTrue(valueClass.isValue());
 	}
 
 	@Test(priority=1)
 	static public void testIdentityObjectOnHeavyAbstract() throws Throwable {
 		assertFalse(HeavyAbstractClass.class.isValue());
-		assertFalse(HeavyAbstractClass.class.isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(HeavyAbstractClass.class));
 	}
 	public static abstract class HeavyAbstractClass {
 		/* Abstract class that has fields */
@@ -3077,7 +3078,7 @@ public class ValueTypeTests {
 			superClassName = "java/lang/Object";
 		}
 		Class valueClass = ValueTypeGenerator.generateValueClass(testName, superClassName, fields, extraClassFlags);
-		assertTrue(valueClass.isPrimitiveClass());
+		assertTrue(PrimitiveClass.isPrimitiveClass(valueClass));
 	}
 
 	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
@@ -3150,19 +3151,19 @@ public class ValueTypeTests {
 	static public void testIsPrimitiveClassOnRef() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class refClass = ValueTypeGenerator.generateRefClass("testIsPrimitiveClassOnRef", fields);
-		assertFalse(refClass.isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(refClass));
 	}
 
 	@Test(priority=1)
 	static public void testIsPrimitiveClassOnValueType() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateValueClass("testIsPrimitiveClassOnValueType", fields);
-		assertTrue(valueClass.isPrimitiveClass());
+		assertTrue(PrimitiveClass.isPrimitiveClass(valueClass));
 	}
 
 	@Test(priority=1)
 	static public void testIsPrimitiveClassOnInterface() throws Throwable {
-		assertFalse(TestInterface.class.isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(TestInterface.class));
 	}
 
 	private interface TestInterface {
@@ -3171,21 +3172,21 @@ public class ValueTypeTests {
 
 	@Test(priority=1)
 	static public void testIsPrimitiveClassOnAbstractClass() throws Throwable {
-		assertFalse(HeavyAbstractClass.class.isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(HeavyAbstractClass.class));
 	}
 
 	@Test(priority=1)
 	static public void testIsPrimitiveOnValueArrayClass() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateValueClass("testIsPrimitiveOnValueArrayClass", fields);
-		assertFalse(valueClass.arrayType().isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(valueClass.arrayType()));
 	}
 
 	@Test(priority=1)
 	static public void testIsPrimitiveOnRefArrayClass() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class refClass = ValueTypeGenerator.generateRefClass("testIsPrimitiveOnRefArrayClass", fields);
-		assertFalse(refClass.arrayType().isPrimitiveClass());
+		assertFalse(PrimitiveClass.isPrimitiveClass(refClass.arrayType()));
 	}
 
 	@Test(priority=1)


### PR DESCRIPTION
1. The following 5 methods become non-public in Class.java
isPrimitiveClass()
asPrimaryType()
asValueType()
isPrimaryType()
isPrimitiveValueType()
The public version of these 5 methods are added in Access.java

2. Add stub method Class.accessFlags()

Closes https://github.com/eclipse-openj9/openj9/issues/15929

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>