### PR TITLE
Add isVMInStartupPhase() overload taking compilation object

### DIFF
--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -510,4 +510,10 @@ J9::VMEnv::isVMInStartupPhase(J9JITConfig *jitConfig)
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP;
+   }
+
+bool
+J9::VMEnv::isVMInStartupPhase(TR::Compilation *comp)
+   {
+   return self()->isVMInStartupPhase(comp->fej9()->getJ9JITConfig());
    }

--- a/runtime/compiler/env/J9VMEnv.hpp
+++ b/runtime/compiler/env/J9VMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,6 +116,7 @@ public:
    size_t getInterpreterVTableOffset();
    
    bool isVMInStartupPhase(J9JITConfig *jitConfig);
+   bool isVMInStartupPhase(TR::Compilation *comp);
    };
 
 }


### PR DESCRIPTION
To make `isVMInStartupPhase()` callable in OMR, it will need to be declared in `OMR::VMEnv` in such a way that `J9::VMEnv` overrides it. However, that new declaration and any use sites in OMR will not be able to use the current signature, which requires `J9JITConfig*`.