### PR TITLE
JDK20 deprecates java.lang.Thread.stop()

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -156,7 +156,6 @@ jvm_add_exports(jvm
 	_JVM_GetStackTraceDepth@8
 	_JVM_FillInStackTrace@8
 	_JVM_StartThread@8
-	_JVM_StopThread@12
 	_JVM_IsThreadAlive@8
 	_JVM_SuspendThread@8
 	_JVM_ResumeThread@8
@@ -403,7 +402,11 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 	)
 endif()
 
-if(NOT JAVA_SPEC_VERSION LESS 20)
+if(JAVA_SPEC_VERSION LESS 20)
+	jvm_add_exports(jvm
+		_JVM_StopThread@12
+	)
+else()
 	jvm_add_exports(jvm
 		JVM_GetClassFileVersion
 	)

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2311,14 +2311,14 @@ JVM_StartThread(JNIEnv* jniEnv, jobject newThread)
 }
 
 
-
+#if JAVA_SPEC_VERSION < 20
 jobject JNICALL
 JVM_StopThread(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_StopThread() stubbed!");
 	return NULL;
 }
-
+#endif /* JAVA_SPEC_VERSION < 20 */
 
 
 jobject JNICALL

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -166,7 +166,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_GetStackTraceDepth@8"/>
 		<export name="_JVM_FillInStackTrace@8"/>
 		<export name="_JVM_StartThread@8"/>
-		<export name="_JVM_StopThread@12"/>
+		<export name="_JVM_StopThread@12">
+			<exclude-if condition="spec.java20"/>
+		</export>
 		<export name="_JVM_IsThreadAlive@8"/>
 		<export name="_JVM_SuspendThread@8"/>
 		<export name="_JVM_ResumeThread@8"/>

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -238,6 +238,7 @@ Java_java_lang_Thread_suspendImpl(JNIEnv *env, jobject rcv)
 vmAccessReleased: ;
 }
 
+#if JAVA_SPEC_VERSION < 20
 void JNICALL
 Java_java_lang_Thread_stopImpl(JNIEnv *env, jobject rcv, jobject stopThrowable)
 {
@@ -270,6 +271,7 @@ Java_java_lang_Thread_stopImpl(JNIEnv *env, jobject rcv, jobject stopThrowable)
 	}
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
+#endif /* JAVA_SPEC_VERSION < 20 */
 
 void JNICALL
 Java_java_lang_Thread_interruptImpl(JNIEnv *env, jobject rcv)

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -359,7 +359,6 @@ omr_add_exports(jclse
 	Java_java_lang_Thread_setNameImpl
 	Java_java_lang_Thread_setPriorityNoVMAccessImpl
 	Java_java_lang_Thread_startImpl
-	Java_java_lang_Thread_stopImpl
 	Java_java_lang_Thread_suspendImpl
 	Java_java_lang_Thread_yield
 	Java_java_lang_invoke_MethodHandleResolver_getCPClassNameAt
@@ -443,6 +442,12 @@ endif()
 if(JAVA_SPEC_VERSION LESS 19)
 omr_add_exports(jclse
 	Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getProcessIDImpl
+)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 20)
+omr_add_exports(jclse
+	Java_java_lang_Thread_stopImpl
 )
 endif()
 

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -287,7 +287,9 @@
 	<export name="Java_java_lang_Thread_interruptImpl" />
 	<export name="Java_java_lang_Thread_resumeImpl" />
 	<export name="Java_java_lang_Thread_startImpl" />
-	<export name="Java_java_lang_Thread_stopImpl" />
+	<export name="Java_java_lang_Thread_stopImpl">
+		<exclude-if condition="spec.java20" />
+	</export>
 	<export name="Java_java_lang_Thread_suspendImpl" />
 	<export name="Java_java_security_AccessController_getAccSnapshot" />
 	<export name="Java_java_security_AccessController_getCallerPD" />

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1124,8 +1124,12 @@ jobjectArray JNICALL Java_com_ibm_oti_vm_VM_getVMArgsImpl(JNIEnv *env, jobject r
 jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_requestToken(JNIEnv *env, jobject runnable, jlong tokenNumber);
 jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_getTokenBucketLimit(JNIEnv *env, jclass clazz, jlong resourceHandle);
 jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_getTokenBucketInterval(JNIEnv *env, jclass clazz, jlong resourceHandle);
-/* thread.c */
+
+/* thread.cpp */
 void JNICALL Java_java_lang_Thread_yield(JNIEnv *env, jclass threadClass);
+#if JAVA_SPEC_VERSION < 20
+void JNICALL Java_java_lang_Thread_stopImpl(JNIEnv *env, jobject rcv, jobject stopThrowable);
+#endif /* JAVA_SPEC_VERSION < 20 */
 
 /* java_lang_Class.c */
 jboolean JNICALL

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -239,7 +239,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<fieldalias name="interruptLock" signature="Ljava/lang/Object;" versions="19-"/>
 	</fieldref>
 	<fieldref class="java/lang/Thread" name="started" signature="Z"/>
-	<fieldref class="java/lang/Thread" name="stopCalled" signature="Z"/>
+	<fieldref class="java/lang/Thread" name="stopCalled" signature="Z" versions="8-19"/>
 
 	<!-- Field references for Java 19 Virtual Thread. -->
 	<fieldref class="java/lang/Thread" name="cont" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -192,7 +192,8 @@ _X(JVM_SetPrimitiveArrayElement,JNICALL,true,void,JNIEnv *env, jobject array, ji
 _X(JVM_SetProtectionDomain,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
 _X(JVM_SetThreadPriority,JNICALL,true,void,JNIEnv *env, jobject thread, jint priority)
 _X(JVM_StartThread,JNICALL,true,void,JNIEnv *env, jobject newThread)
-_X(JVM_StopThread,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
+_IF([JAVA_SPEC_VERSION < 20],
+	[_X(JVM_StopThread,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)])
 _X(JVM_SuspendThread,JNICALL,true,jobject,jint arg0, jint arg1)
 _IF([JAVA_SPEC_VERSION < 15],
 	[_X(JVM_UnloadLibrary, JNICALL, true, jobject, jint arg0)],

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -2071,7 +2071,6 @@ setFailedToForkThreadException(J9VMThread *currentThread, IDATA retVal, omrthrea
 static UDATA
 javaProtectedThreadProc(J9PortLibrary* portLibrary, void * entryarg)
 {
-	
 	J9VMThread * vmThread = (J9VMThread *) entryarg;
 	J9JavaVM *vm = vmThread->javaVM;
 
@@ -2079,26 +2078,20 @@ javaProtectedThreadProc(J9PortLibrary* portLibrary, void * entryarg)
 
 #if defined(LINUX)
 	omrthread_set_name(vmThread->osThread, (char*)vmThread->omrVMThread->threadName);
-#endif
+#endif /* defined(LINUX) */
 
 	threadAboutToStart(vmThread);
 
 	TRIGGER_J9HOOK_VM_THREAD_STARTED(vm->hookInterface, vmThread, vmThread);
 
-
 	acquireVMAccess(vmThread);
-#ifdef J9VM_OPT_DEPRECATED_METHODS
-	if (!(J9VMJAVALANGTHREAD_STOPCALLED(vmThread,vmThread->threadObject))){
-#endif
-
-		{
-			/* Start running the thread */
-			runJavaThread(vmThread);
-		}
-
-#ifdef J9VM_OPT_DEPRECATED_METHODS
+#if defined(J9VM_OPT_DEPRECATED_METHODS) && (JAVA_SPEC_VERSION < 20)
+	if (!(J9VMJAVALANGTHREAD_STOPCALLED(vmThread, vmThread->threadObject)))
+#endif /* defined(J9VM_OPT_DEPRECATED_METHODS) && (JAVA_SPEC_VERSION < 20) */
+	{
+		/* Start running the thread. */
+		runJavaThread(vmThread);
 	}
-#endif	
 	releaseVMAccess(vmThread);
 
 	/* Perform thread cleanup */


### PR DESCRIPTION
Remove `j.l.Thread.stopImpl()`, and `Thread.stopCalled` for Java 20+.

Depends https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/497

Signed-off-by: Jason Feng <fengj@ca.ibm.com>