### PR TITLE
Fix JDK19 java.lang.ref.Reference signature

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -1,8 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-package java.lang.ref;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +20,8 @@ package java.lang.ref;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- 
+package java.lang.ref;
+
 /**
  * PhantomReference objects are used to detect referents which 
  * are no longer visible and are eligible to have their storage
@@ -32,7 +31,11 @@ package java.lang.ref;
  * @version		initial
  * @since		JDK1.2
  */	
-public class PhantomReference<T> extends java.lang.ref.Reference<T> {
+public
+/*[IF JAVA_SPEC_VERSION >= 19]*/
+non-sealed
+/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+class PhantomReference<T> extends Reference<T> {
 
 /**
  * Return the referent of the reference object.  Phantom reference 

--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -49,7 +49,11 @@ import sun.misc.SharedSecrets;
  * @version		initial
  * @since		1.2
  */
-public abstract class Reference<T> extends Object {
+/*[IF JAVA_SPEC_VERSION < 19]*/
+public abstract	class Reference<T> extends Object {
+/*[ELSE] JAVA_SPEC_VERSION < 19
+public abstract sealed class Reference<T> extends Object permits PhantomReference, SoftReference, WeakReference, FinalReference {
+/*[ENDIF] JAVA_SPEC_VERSION < 19 */
 	private static final int STATE_INITIAL = 0;
 	private static final int STATE_CLEARED = 1;
 	private static final int STATE_ENQUEUED = 2;

--- a/jcl/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -1,8 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-package java.lang.ref;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +20,8 @@ package java.lang.ref;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- 
+package java.lang.ref;
+
 /**
  * SoftReference objects are used to detect referents which
  * are no longer visible and who's memory is to be reclaimed.
@@ -31,7 +30,11 @@ package java.lang.ref;
  * @version		initial
  * @since		1.2
  */	
-public class SoftReference<T> extends java.lang.ref.Reference<T> {
+public
+/*[IF JAVA_SPEC_VERSION >= 19]*/
+non-sealed
+/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+class SoftReference<T> extends Reference<T> {
 	/*[PR 124242] SoftReference.get() should reset age */
 	private volatile int age;
 

--- a/jcl/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -1,8 +1,6 @@
-/*[INCLUDE-IF Sidecar16]*/
-package java.lang.ref;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +20,8 @@ package java.lang.ref;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- 
+package java.lang.ref;
+
 /**
  * WeakReference objects are used to detect referents which
  * are no longer visible.
@@ -31,7 +30,11 @@ package java.lang.ref;
  * @version		initial
  * @since		1.2
  */	
-public class WeakReference<T> extends java.lang.ref.Reference<T> {
+public
+/*[IF JAVA_SPEC_VERSION >= 19]*/
+non-sealed
+/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+class WeakReference<T> extends Reference<T> {
 
 /**
  * Constructs a new instance of this class.


### PR DESCRIPTION
Added `sealed` and `permits PhantomReference, SoftReference, WeakReference, FinalReference`.
Updated `PhantomReference`, `SoftReference`, and `WeakReference` accordingly.

Fix [internal workitem](https://jazz103.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/147612)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>