### PR TITLE
Add missing bounds check to deleteCharAt

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -657,14 +657,16 @@ public synchronized char charAt(int index) {
 }
 
 /**
- * Deletes a range of characters.
+ * Deletes a range of characters starting from offset {@code start} to offset
+ * {@code end - 1}. If {@code end} is beyond the last character, then this
+ * method deletes up to the end of the StringBuffer.
  *
  * @param		start	the offset of the first character
  * @param		end	the offset one past the last character
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
- *				{@code end > length()}
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0}, {@code start > end} or
+ *				{@code start > length()}
  */
 public synchronized StringBuffer delete(int start, int end) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -754,8 +756,8 @@ public synchronized StringBuffer delete(int start, int end) {
 public synchronized StringBuffer deleteCharAt(int location) {
 	int currentLength = lengthInternalUnsynchronized();
 
-	if (currentLength != 0) {
-		return delete (location, location + 1);
+	if ((0 <= location) && (location < currentLength)) {
+		return delete(location, location + 1);
 	} else {
 		throw new StringIndexOutOfBoundsException ();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -656,14 +656,16 @@ public char charAt(int index) {
 }
 
 /**
- * Deletes a range of characters.
+ * Deletes a range of characters starting from offset {@code start} to offset
+ * {@code end - 1}. If {@code end} is beyond the last character, then this
+ * method deletes up to the end of the StringBuilder.
  *
  * @param		start	the offset of the first character
  * @param		end	the offset one past the last character
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
- *				{@code end > length()}
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0}, {@code start > end} or
+ *				{@code start > length()}
  */
 public StringBuilder delete(int start, int end) {
 	int currentLength = lengthInternal();
@@ -753,8 +755,8 @@ public StringBuilder delete(int start, int end) {
 public StringBuilder deleteCharAt(int location) {
 	int currentLength = lengthInternal();
 
-	if (currentLength != 0) {
-		return delete (location, location + 1);
+	if ((0 <= location) && (location < currentLength)) {
+		return delete(location, location + 1);
 	} else {
 		throw new StringIndexOutOfBoundsException ();
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuffer.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuffer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -307,8 +307,22 @@ public class Test_StringBuffer {
 	 */
 	@Test
 	public void test_deleteCharAt() {
-		testBuffer.deleteCharAt(3);
-		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("Thi is a test buffer"));
+		testBuffer.deleteCharAt(0);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("his is a test buffer"));
+		testBuffer.deleteCharAt(2);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("hi is a test buffer"));
+		testBuffer.deleteCharAt(testBuffer.length() - 1);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("hi is a test buffe"));
+		try {
+			testBuffer.deleteCharAt(-1);
+			AssertJUnit.fail("Index less than zero should have failed");
+		} catch (IndexOutOfBoundsException e) {
+		}
+		try {
+			testBuffer.deleteCharAt(testBuffer.length());
+			AssertJUnit.fail("Index >= buffer length should have failed");
+		} catch (IndexOutOfBoundsException e) {
+		}
 	}
 
 	/**

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuilder.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -308,6 +308,29 @@ public class Test_StringBuilder {
 		} catch (IndexOutOfBoundsException e) {
 		}
 		AssertJUnit.assertTrue("Wrong contents 2", testBuffer.toString().equals("more stuff"));
+	}
+
+	/**
+	 * @tests java.lang.StringBuilder#deleteCharAt(int)
+	 */
+	@Test
+	public void test_deleteCharAt() {
+		testBuffer.deleteCharAt(0);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("his is a test buffer"));
+		testBuffer.deleteCharAt(2);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("hi is a test buffer"));
+		testBuffer.deleteCharAt(testBuffer.length() - 1);
+		AssertJUnit.assertTrue("Deleted incorrect char", testBuffer.toString().equals("hi is a test buffe"));
+		try {
+			testBuffer.deleteCharAt(-1);
+			AssertJUnit.fail("Index less than zero should have failed");
+		} catch (IndexOutOfBoundsException e) {
+		}
+		try {
+			testBuffer.deleteCharAt(testBuffer.length());
+			AssertJUnit.fail("Index >= buffer length should have failed");
+		} catch (IndexOutOfBoundsException e) {
+		}
 	}
 
 	/**


### PR DESCRIPTION
For StringBuilder and StringBuffer
Add tests for deleteCharAt with out of bound indices.

Fixes https://github.com/eclipse-openj9/openj9/issues/15897

Tested internally [here](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/28143/) running JCL_Test_SE80