### PR TITLE
Revert "Preserve ymm/zmm registers on x"

### DIFF
--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2022 IBM Corp. and others
+dnl Copyright (c) 2017, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1051,13 +1051,10 @@ START_PROC(jitReferenceArrayCopy)
 	mov PARM_REG(2),_rcx
 	mov PARM_REG(1),_rbp
 	call FASTCALL_SYMBOL(impl_jitReferenceArrayCopy,2)
-	dnl Save return value to check later.
-	dnl We don't check it now because restoring the register clobbers flags.
-	mov dword ptr J9TR_VMThread_floatTemp3[_rbp],eax
+	dnl set ZF if succeed
+	test _rax,_rax
 	RESTORE_C_VOLATILE_REGS
 	SWITCH_TO_JAVA_STACK
-	dnl Set ZF on success.
-	test dword ptr J9TR_VMThread_floatTemp3[_rbp], -1
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	ret
 END_PROC(jitReferenceArrayCopy)

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -393,7 +393,6 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_machineBP", offsetof(J9CInterpreterStackFrame, machineBP)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitGPRs", offsetof(J9CInterpreterStackFrame, jitGPRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitFPRs", offsetof(J9CInterpreterStackFrame, jitFPRs)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_maskRegisters", offsetof(J9CInterpreterStackFrame, maskRegisters)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rax", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rax)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rbx", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rbx)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_rcx", offsetof(J9CInterpreterStackFrame, jitGPRs.jitGPRs.named.rcx)) |
@@ -759,7 +758,6 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELSSize", sizeof(J9VMEntryLocalStorage)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9_EXTENDED_RUNTIME_DEBUG_MODE", J9_EXTENDED_RUNTIME_DEBUG_MODE) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS", J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS", J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES", J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9_INLINE_JNI_MAX_ARG_COUNT", J9_INLINE_JNI_MAX_ARG_COUNT) |
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6134,9 +6134,8 @@ typedef struct J9CInterpreterStackFrame {
 	 *
 	 * Stack must be 16-byte aligned.
 	 */
-	U_8 jitFPRs[6 * 64]; /* zmm0-5 512-bit OR xmm0-7 64-bit */
+	U_8 jitFPRs[6 * 16]; /* xmm0-5 128-bit OR xmm0-7 64-bit */
 	U_8 preservedFPRs[10 * 16]; /* xmm6-15 128-bit */
-	U_8 maskRegisters[8 * 8]; /* k0-k7 */
 	UDATA align[1];
 	/* r15,r14,r13,r12,rdi,rsi,rbx,rbp,return address
 	 * RSP is 16-byte aligned at this point
@@ -6146,8 +6145,7 @@ typedef struct J9CInterpreterStackFrame {
 	 *
 	 * Stack must be 16-byte aligned.
 	 */
-	U_8 jitFPRs[32 * 64]; /* zmm0-31 512-bit OR xmm0-7 64-bit */
-	U_8 maskRegisters[8 * 8]; /* k0-k7 */
+	U_8 jitFPRs[16 * 16]; /* xmm0-15 128-bit OR xmm0-7 64-bit */
 	UDATA align[1];
 	/* r15,r14,r13,r12,rbx,rbp,return address
 	 * RSP is 16-byte aligned at this point
@@ -6160,8 +6158,7 @@ typedef struct J9CInterpreterStackFrame {
 	 */
 	J9JITGPRSpillArea jitGPRs;
 	UDATA align1[2];
-	U_8 jitFPRs[8 * 64]; /* zmm0-7 512-bit */
-	U_8 maskRegisters[8 * 8]; /* k0-k7 */
+	U_8 jitFPRs[8 * 16]; /* xmm0-7 128-bit */
 	UDATA align2[1];
 	/* ebx,edi,esi
 	 * ESP is forcibly 16-byte aligned at this point


### PR DESCRIPTION
This reverts PR #14632. A 10%+ performance
regression (issue #15716) reported on JDK 8
was isolated to #14632. Reverting this PR
should not have any function change, it
was only intended to support the Vector
API JEPs which have not yet been enabled
on x86 in OpenJ9. A previous attempt at
disabling just the extended vector register
preservation did not recoup the performance,
but only completely reverting this PR
restored the regression. This suggests
there is something with the way the helpers
have been restructured that is causing the
performance degradation. This PR will be
reverted while the cause is investigated.