### PR TITLE
JDK20 deprecates java.lang.Thread.suspend() & resume()

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -157,8 +157,6 @@ jvm_add_exports(jvm
 	_JVM_FillInStackTrace@8
 	_JVM_StartThread@8
 	_JVM_IsThreadAlive@8
-	_JVM_SuspendThread@8
-	_JVM_ResumeThread@8
 	_JVM_SetThreadPriority@12
 	_JVM_Yield@8
 	_JVM_CurrentThread@8
@@ -404,7 +402,9 @@ endif()
 
 if(JAVA_SPEC_VERSION LESS 20)
 	jvm_add_exports(jvm
+		_JVM_ResumeThread@8
 		_JVM_StopThread@12
+		_JVM_SuspendThread@8
 	)
 else()
 	jvm_add_exports(jvm

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1825,17 +1825,6 @@ JVM_ResolveClass(jint arg0, jint arg1)
 	return NULL;
 }
 
-
-
-jobject JNICALL
-JVM_ResumeThread(jint arg0, jint arg1)
-{
-	assert(!"JVM_ResumeThread() stubbed!");
-	return NULL;
-}
-
-
-
 /**
  * Set the val to the array at the index.
  * This function may lock, gc or throw exception.
@@ -2310,16 +2299,20 @@ JVM_StartThread(JNIEnv* jniEnv, jobject newThread)
 	return;
 }
 
-
 #if JAVA_SPEC_VERSION < 20
+jobject JNICALL
+JVM_ResumeThread(jint arg0, jint arg1)
+{
+	assert(!"JVM_ResumeThread() stubbed!");
+	return NULL;
+}
+
 jobject JNICALL
 JVM_StopThread(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_StopThread() stubbed!");
 	return NULL;
 }
-#endif /* JAVA_SPEC_VERSION < 20 */
-
 
 jobject JNICALL
 JVM_SuspendThread(jint arg0, jint arg1)
@@ -2327,7 +2320,7 @@ JVM_SuspendThread(jint arg0, jint arg1)
 	assert(!"JVM_SuspendThread() stubbed!");
 	return NULL;
 }
-
+#endif /* JAVA_SPEC_VERSION < 20 */
 
 /* NOTE this is required by JDK15+ jdk.internal.loader.NativeLibraries.unload().
  */

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -170,8 +170,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<exclude-if condition="spec.java20"/>
 		</export>
 		<export name="_JVM_IsThreadAlive@8"/>
-		<export name="_JVM_SuspendThread@8"/>
-		<export name="_JVM_ResumeThread@8"/>
+		<export name="_JVM_SuspendThread@8">
+			<exclude-if condition="spec.java20"/>
+		</export>
+		<export name="_JVM_ResumeThread@8">
+			<exclude-if condition="spec.java20"/>
+		</export>
 		<export name="_JVM_SetThreadPriority@12"/>
 		<export name="_JVM_Yield@8"/>
 		<export name="_JVM_CurrentThread@8"/>

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -183,6 +183,7 @@ Java_java_lang_Thread_yield(JNIEnv *env, jclass threadClass)
 	omrthread_yield();
 }
 
+#if JAVA_SPEC_VERSION < 20
 void JNICALL
 Java_java_lang_Thread_resumeImpl(JNIEnv *env, jobject rcv)
 {
@@ -238,7 +239,6 @@ Java_java_lang_Thread_suspendImpl(JNIEnv *env, jobject rcv)
 vmAccessReleased: ;
 }
 
-#if JAVA_SPEC_VERSION < 20
 void JNICALL
 Java_java_lang_Thread_stopImpl(JNIEnv *env, jobject rcv, jobject stopThrowable)
 {

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -355,11 +355,9 @@ omr_add_exports(jclse
 	Java_java_lang_Thread_getStateImpl
 	Java_java_lang_Thread_holdsLock
 	Java_java_lang_Thread_interruptImpl
-	Java_java_lang_Thread_resumeImpl
 	Java_java_lang_Thread_setNameImpl
 	Java_java_lang_Thread_setPriorityNoVMAccessImpl
 	Java_java_lang_Thread_startImpl
-	Java_java_lang_Thread_suspendImpl
 	Java_java_lang_Thread_yield
 	Java_java_lang_invoke_MethodHandleResolver_getCPClassNameAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPMethodHandleAt
@@ -447,7 +445,9 @@ endif()
 
 if(JAVA_SPEC_VERSION LESS 20)
 omr_add_exports(jclse
+	Java_java_lang_Thread_resumeImpl
 	Java_java_lang_Thread_stopImpl
+	Java_java_lang_Thread_suspendImpl
 )
 endif()
 

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -285,12 +285,16 @@
 	<export name="Java_java_lang_Thread_getStackTraceImpl" />
 	<export name="Java_java_lang_Thread_holdsLock" />
 	<export name="Java_java_lang_Thread_interruptImpl" />
-	<export name="Java_java_lang_Thread_resumeImpl" />
+	<export name="Java_java_lang_Thread_resumeImpl">
+		<exclude-if condition="spec.java20" />
+	</export>
 	<export name="Java_java_lang_Thread_startImpl" />
 	<export name="Java_java_lang_Thread_stopImpl">
 		<exclude-if condition="spec.java20" />
 	</export>
-	<export name="Java_java_lang_Thread_suspendImpl" />
+	<export name="Java_java_lang_Thread_suspendImpl">
+		<exclude-if condition="spec.java20" />
+	</export>
 	<export name="Java_java_security_AccessController_getAccSnapshot" />
 	<export name="Java_java_security_AccessController_getCallerPD" />
 	<export name="JCL_OnLoad" />

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1128,7 +1128,9 @@ jlong JNICALL Java_javax_rcm_CPUThrottlingRunnable_getTokenBucketInterval(JNIEnv
 /* thread.cpp */
 void JNICALL Java_java_lang_Thread_yield(JNIEnv *env, jclass threadClass);
 #if JAVA_SPEC_VERSION < 20
+void JNICALL Java_java_lang_Thread_resumeImpl(JNIEnv *env, jobject rcv);
 void JNICALL Java_java_lang_Thread_stopImpl(JNIEnv *env, jobject rcv, jobject stopThrowable);
+void JNICALL Java_java_lang_Thread_suspendImpl(JNIEnv *env, jobject rcv);
 #endif /* JAVA_SPEC_VERSION < 20 */
 
 /* java_lang_Class.c */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -185,7 +185,8 @@ _X(JVM_IsThreadAlive,JNICALL,true,jboolean,JNIEnv *env, jobject targetThread)
 _X(JVM_NewArray,JNICALL,true,jobject,JNIEnv *env, jclass componentType, jint dimension)
 _X(JVM_NewMultiArray,JNICALL,true,jobject,JNIEnv *env, jclass eltClass, jintArray dim)
 _X(JVM_ResolveClass,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_ResumeThread,JNICALL,true,jobject,jint arg0, jint arg1)
+_IF([JAVA_SPEC_VERSION < 20],
+	[_X(JVM_ResumeThread,JNICALL,true,jobject,jint arg0, jint arg1)])
 _X(JVM_SetArrayElement,JNICALL,true,void,JNIEnv *env, jobject array, jint index, jobject value)
 _X(JVM_SetClassSigners,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
 _X(JVM_SetPrimitiveArrayElement,JNICALL,true,void,JNIEnv *env, jobject array, jint index, jvalue value, unsigned char vCode)
@@ -194,7 +195,8 @@ _X(JVM_SetThreadPriority,JNICALL,true,void,JNIEnv *env, jobject thread, jint pri
 _X(JVM_StartThread,JNICALL,true,void,JNIEnv *env, jobject newThread)
 _IF([JAVA_SPEC_VERSION < 20],
 	[_X(JVM_StopThread,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)])
-_X(JVM_SuspendThread,JNICALL,true,jobject,jint arg0, jint arg1)
+_IF([JAVA_SPEC_VERSION < 20],
+	[_X(JVM_SuspendThread,JNICALL,true,jobject,jint arg0, jint arg1)])
 _IF([JAVA_SPEC_VERSION < 15],
 	[_X(JVM_UnloadLibrary, JNICALL, true, jobject, jint arg0)],
 	[_X(JVM_UnloadLibrary, JNICALL, true, void, void *handle)])


### PR DESCRIPTION
Removed `j.l.Thread.suspendImpl()`, `resumeImpl()`, `JVM_ResumeThread()`, and `JVM_SuspendThread()` for `JDK20+`.

Depends https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/499

Signed-off-by: Jason Feng <fengj@ca.ibm.com>