### PR TITLE
Support JNI_VERSION_20 for jdk20+

### DIFF
--- a/runtime/include/jni.h.m4
+++ b/runtime/include/jni.h.m4
@@ -53,9 +53,10 @@ extern "C" {
 #define JNI_VERSION_1_4 0x00010004
 #define JNI_VERSION_1_6 0x00010006
 #define JNI_VERSION_1_8 0x00010008
-ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, `#define JNI_VERSION_9   0x00090000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >=  9), 1, `#define JNI_VERSION_9   0x00090000', `dnl')
 ifelse(eval(JAVA_SPEC_VERSION >= 10), 1, `#define JNI_VERSION_10  0x000A0000', `dnl')
 ifelse(eval(JAVA_SPEC_VERSION >= 19), 1, `#define JNI_VERSION_19  0x00130000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 20), 1, `#define JNI_VERSION_20  0x00140000', `dnl')
 
 #define JVMEXT_VERSION_1_1 0x7E010001
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1673,6 +1673,9 @@ JVM_IsSupportedJNIVersion(jint version)
 #if JAVA_SPEC_VERSION >= 19
 	case JNI_VERSION_19:
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if JAVA_SPEC_VERSION >= 20
+	case JNI_VERSION_20:
+#endif /* JAVA_SPEC_VERSION >= 20 */
 		return JNI_TRUE;
 
 	default:

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2540,6 +2540,9 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 19
 	case JNI_VERSION_19:
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if JAVA_SPEC_VERSION >= 20
+	case JNI_VERSION_20:
+#endif /* JAVA_SPEC_VERSION >= 20 */
 		return JNI_OK;
 	}
 

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -932,6 +932,9 @@ JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 19
 		case JNI_VERSION_19:
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if JAVA_SPEC_VERSION >= 20
+		case JNI_VERSION_20:
+#endif /* JAVA_SPEC_VERSION >= 20 */
 			return JNI_OK;
 		default:
 			break;

--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -130,8 +130,9 @@ jint JNICALL J9_CreateJavaVM(JavaVM ** p_vm, void ** p_env, J9CreateJavaVMParams
 	omrthread_monitor_t globalMonitor;
 #endif
 
-	if (!jniVersionIsValid(version) || version == JNI_VERSION_1_1)
-		return JNI_EVERSION;			/* unknown arg style, exit. */
+	if ((JNI_VERSION_1_1 == version) || !jniVersionIsValid(version)) {
+		return JNI_EVERSION; /* unknown arg style, exit. */
+	}
 
 #ifndef J9VM_OPT_MULTI_VM
 	if (*pvmList)

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -430,7 +430,9 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-#if JAVA_SPEC_VERSION >= 19
+#if JAVA_SPEC_VERSION >= 20
+	return JNI_VERSION_20;
+#elif JAVA_SPEC_VERSION >= 19
 	return JNI_VERSION_19;
 #elif JAVA_SPEC_VERSION >= 10
 	return JNI_VERSION_10;

--- a/runtime/vm/jvminitcommon.c
+++ b/runtime/vm/jvminitcommon.c
@@ -149,6 +149,9 @@ jniVersionIsValid(UDATA jniVersion)
 #if JAVA_SPEC_VERSION >= 19
 	case JNI_VERSION_19:
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if JAVA_SPEC_VERSION >= 20
+	case JNI_VERSION_20:
+#endif /* JAVA_SPEC_VERSION >= 20 */
 		return JNI_TRUE;
 	default:
 		return JNI_FALSE;


### PR DESCRIPTION
`JNI_VERSION_20` was added in https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/5c4d9ed098d8a7d8faf6f2e2d60f2808367a5043.