### PR TITLE
Fix JVMTI methods

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -258,7 +258,7 @@ JVM_VirtualThreadMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 	f_monitorEnter(vm->liveVirtualThreadListMutex);
 	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 
-	assert(IS_VIRTUAL_THREAD(currentThread, threadObj));
+	assert(IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObj));
 
 	while (0 != J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset)) {
 		/* Thread is being inspected or unmounted, wait. */

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -335,7 +335,7 @@ Java_java_lang_Thread_getStackTraceImpl(JNIEnv *env, jobject rcv)
 
 #if JAVA_SPEC_VERSION >= 19
 	BOOLEAN releaseInspector = FALSE;
-	if (IS_VIRTUAL_THREAD(currentThread, receiverObject)) {
+	if (IS_JAVA_LANG_VIRTUALTHREAD(currentThread, receiverObject)) {
 		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
 		j9object_t carrierThread = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(currentThread, receiverObject);
 		I_64 vthreadInspectorCount = J9OBJECT_I64_LOAD(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset);

--- a/runtime/jvmti/jvmtiForceEarlyReturn.c
+++ b/runtime/jvmti/jvmtiForceEarlyReturn.c
@@ -144,18 +144,10 @@ jvmtiForceEarlyReturn(jvmtiEnv* env,
 
 		ENSURE_PHASE_LIVE(env);
 		ENSURE_CAPABILITY(env, can_force_early_return);
-		
-		/* Check if the jthread is really a j.l.Thread. a NULL jthread indicates that
-		 * the user wants to use the current thread hence defer the assignment to getVMThread */
-		
-		if (NULL != thread) {
-			ENSURE_JTHREAD(currentThread, thread);
-#if JAVA_SPEC_VERSION >= 19
-			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_OPAQUE_FRAME);
-#endif /* JAVA_SPEC_VERSION >= 19 */
-		}
 
-		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
+		rc = getVMThread(
+				currentThread, thread, &targetThread, JVMTI_ERROR_OPAQUE_FRAME,
+				J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD | J9JVMTI_GETVMTHREAD_ERROR_ON_VIRTUALTHREAD);
 		if (rc == JVMTI_ERROR_NONE) {
 			/* Does this thread need to be suspended at an event? */
 			vm->internalVMFunctions->haltThreadForInspection(currentThread, targetThread);

--- a/runtime/jvmti/jvmtiLocalVariable.c
+++ b/runtime/jvmti/jvmtiLocalVariable.c
@@ -311,7 +311,9 @@ jvmtiGetOrSetLocal(jvmtiEnv *env,
 		J9VMThread *targetThread = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
+		rc = getVMThread(
+				currentThread, thread, &targetThread, JVMTI_ERROR_NONE,
+				J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD);
 		if (rc == JVMTI_ERROR_NONE) {
 			J9StackWalkState walkState = {0};
 			BOOLEAN objectFetched = FALSE;

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -302,7 +302,10 @@ getThreadGroupChildrenImpl(J9JavaVM *vm, J9VMThread *currentThread, jobject grou
 			j9object_t thread = J9JAVAARRAYOFOBJECT_LOAD(currentThread, childrenThreads, i);
 			J9VMThread *targetThread = NULL;
 
-			if (JVMTI_ERROR_NONE == getVMThread(currentThread, (jthread)&thread, &targetThread, FALSE, TRUE)) {
+			rc = getVMThread(
+					currentThread, (jthread)&thread, &targetThread, JVMTI_ERROR_NONE,
+					J9JVMTI_GETVMTHREAD_ERROR_ON_NULL_JTHREAD | J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD);
+			if (JVMTI_ERROR_NONE == rc) {
 				threads[numLiveThreads++] = (jthread)vmFuncs->j9jni_createLocalRef((JNIEnv *)currentThread, thread);
 				releaseVMThread(currentThread, targetThread, (jthread)&thread);
 			}

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -146,10 +146,14 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 			ENSURE_NON_NULL(nanos_ptr);
 			rv_nanos = (jlong)omrthread_get_cpu_time(omrthread_self());
 		} else {
+			rc = getVMThread(
+					currentThread, thread, &targetThread,
 #if JAVA_SPEC_VERSION >= 19
-			ENSURE_JTHREAD_NOT_VIRTUAL(currentThread, thread, JVMTI_ERROR_UNSUPPORTED_OPERATION);
+					JVMTI_ERROR_UNSUPPORTED_OPERATION,
+#else /* JAVA_SPEC_VERSION >= 19 */
+					JVMTI_ERROR_NONE,
 #endif /* JAVA_SPEC_VERSION >= 19 */
-			rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
+					J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD | J9JVMTI_GETVMTHREAD_ERROR_ON_VIRTUALTHREAD);
 			if (rc == JVMTI_ERROR_NONE) {
 				if (nanos_ptr == NULL) {
 					rc = JVMTI_ERROR_NULL_POINTER;

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1205,16 +1205,17 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 /**
- * @brief
- * @param currentThread
- * @param thread
- * @param vmThreadPtr
- * @param allowNull
- * @param mustBeAlive
- * @return jvmtiError
+ * @brief Get the J9VMThread for the input jthread instance.
+ *
+ * @param[in] currentThread the current thread.
+ * @param[in] thread the input jthread instance.
+ * @param[out] vmThreadPtr stores the corresponding J9VMThread for the input thread parameter.
+ * @param[in] vThreadError error to be thrown if virtual threads are excluded.
+ * @param[in] flags specifies the control logic for error checking.
+ * @return JVMTI_ERROR_NONE (0) on success; otherwise a non-zero error value on failure.
  */
 jvmtiError
-getVMThread(J9VMThread * currentThread, jthread thread, J9VMThread ** vmThreadPtr, UDATA allowNull, UDATA mustBeAlive);
+getVMThread(J9VMThread *currentThread, jthread thread, J9VMThread **vmThreadPtr, jvmtiError vThreadError, UDATA flags);
 
 
 /**
@@ -2723,7 +2724,7 @@ jvmtiIsModifiableModule(jvmtiEnv* env,
 * @return jvmtiError
 */
 jvmtiError
-suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, BOOLEAN *currentThreadSuspended);
+suspendThread(J9VMThread *currentThread, jthread thread, BOOLEAN allowNull, BOOLEAN *currentThreadSuspended);
 
 /* ---------------- heapify.cpp ---------------- */
 /**

--- a/runtime/jvmti/suspendhelper.cpp
+++ b/runtime/jvmti/suspendhelper.cpp
@@ -27,13 +27,17 @@
 extern "C" {
 
 jvmtiError
-suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, BOOLEAN *currentThreadSuspended)
+suspendThread(J9VMThread *currentThread, jthread thread, BOOLEAN allowNull, BOOLEAN *currentThreadSuspended)
 {
 	J9VMThread *targetThread = NULL;
 	jvmtiError rc = JVMTI_ERROR_NONE;
+	UDATA flags = J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD;
 
 	*currentThreadSuspended = FALSE;
-	rc = getVMThread(currentThread, thread, &targetThread, allowNull, TRUE);
+	if (!allowNull) {
+		flags |= J9JVMTI_GETVMTHREAD_ERROR_ON_NULL_JTHREAD;
+	}
+	rc = getVMThread(currentThread, thread, &targetThread, JVMTI_ERROR_NONE, flags);
 	if (rc == JVMTI_ERROR_NONE) {
 		if (targetThread->publicFlags & J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND) {
 			rc = JVMTI_ERROR_THREAD_SUSPENDED;

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -356,8 +356,11 @@ static const struct { \
 #define J9_IS_HIDDEN_METHOD(method) \
 	((NULL != (method)) && (J9ROMCLASS_IS_ANON_OR_HIDDEN(J9_CLASS_FROM_METHOD((method))->romClass) || J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD((method))->modifiers, J9AccMethodFrameIteratorSkip)))
 
-#define IS_VIRTUAL_THREAD(vmThread, object) \
+#define IS_JAVA_LANG_VIRTUALTHREAD(vmThread, object) \
 	isSameOrSuperClassOf(J9VMJAVALANGBASEVIRTUALTHREAD((vmThread)->javaVM), J9OBJECT_CLAZZ(vmThread, object))
+
+#define IS_JAVA_LANG_THREAD(vmThread, object) \
+	isSameOrSuperClassOf(J9VMJAVALANGTHREAD_OR_NULL((vmThread)->javaVM), J9OBJECT_CLAZZ(vmThread, object))
 
 #if defined(OPENJ9_BUILD)
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -61,6 +61,9 @@ typedef enum {
 
 #define J9JVMTI_UDATA_BITS (sizeof(UDATA) * 8)
 
+#define J9JVMTI_GETVMTHREAD_ERROR_ON_NULL_JTHREAD 0x1
+#define J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD 0x2
+#define J9JVMTI_GETVMTHREAD_ERROR_ON_VIRTUALTHREAD 0x4
 
 typedef struct {
 	J9NativeLibrary nativeLib;
@@ -454,13 +457,12 @@ typedef struct jvmtiGcp_translation {
 
 #define ENSURE_JOBJECT_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_OBJECT)
 #define ENSURE_JCLASS_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_CLASS)
-#define ENSURE_JTHREAD_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_THREAD)
 #define ENSURE_JTHREADGROUP_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_THREAD_GROUP)
 #define ENSURE_JOBJECT_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_OBJECT)
 
 #define ENSURE_JTHREAD(vmThread, jthrd) \
     do { \
-        if (!isSameOrSuperClassOf(J9VMJAVALANGTHREAD_OR_NULL((vmThread->javaVM)), J9OBJECT_CLAZZ((vmThread), *((j9object_t *) (jthrd))))) { \
+        if (!IS_JAVA_LANG_THREAD((vmThread), J9_JNI_UNWRAP_REFERENCE(jthrd))) { \
             JVMTI_ERROR(JVMTI_ERROR_INVALID_THREAD); \
         } \
     } while(0)
@@ -489,14 +491,14 @@ typedef struct jvmtiGcp_translation {
 #if JAVA_SPEC_VERSION >= 19
 #define ENSURE_JTHREAD_NOT_VIRTUAL(vmThread, jthrd, error) \
 	do { \
-		if (IS_VIRTUAL_THREAD((vmThread), J9_JNI_UNWRAP_REFERENCE(jthrd))) { \
+		if (IS_JAVA_LANG_VIRTUALTHREAD((vmThread), J9_JNI_UNWRAP_REFERENCE(jthrd))) { \
 			JVMTI_ERROR(error); \
 		} \
 	} while(0)
 
 #define ENSURE_JTHREADOBJECT_NOT_VIRTUAL(vmThread, jthrdObject, error) \
 	do { \
-		if (IS_VIRTUAL_THREAD((vmThread), (jthrdObject))) { \
+		if (IS_JAVA_LANG_VIRTUALTHREAD((vmThread), (jthrdObject))) { \
 			JVMTI_ERROR(error); \
 		} \
 	} while(0)
@@ -515,7 +517,6 @@ typedef struct jvmtiGcp_translation {
 #define ENSURE_JFIELDID_NON_NULL(var)
 #define ENSURE_JOBJECT_NON_NULL(var)
 #define ENSURE_JCLASS_NON_NULL(var)
-#define ENSURE_JTHREAD_NON_NULL(var)
 #define ENSURE_JTHREADGROUP_NON_NULL(var)
 #define ENSURE_VALID_HEAP_OBJECT_FILTER(var)
 #define ENSURE_MONITOR_NON_NULL(var)

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -2492,7 +2492,7 @@ isVirtualThread(JNIEnv *env, jobject obj)
 	if (NULL != obj) {
 		VM_VMAccess::inlineEnterVMFromJNI(vmThread);
 		j9object_t object = J9_JNI_UNWRAP_REFERENCE(obj);
-		if ((NULL != object) && IS_VIRTUAL_THREAD(vmThread, object)) {
+		if ((NULL != object) && IS_JAVA_LANG_VIRTUALTHREAD(vmThread, object)) {
 			result = JNI_TRUE;
 		}
 		VM_VMAccess::inlineExitVMToJNI(vmThread);


### PR DESCRIPTION
- Return JVMTI_ERROR_INVALID_THREAD if the input thread parameter is
not a thread object.
- Consolidate j.l.Thread and j.l.VirtualThread error-checking within
getVMThread. This avoids repeated NULL checking and potentially
fetching the current thread.
- Convert getVMThread's boolean input parameters to a bit field.
- More verbose naming used to avoid ambiguity: IS_JAVA_LANG_THREAD
and IS_JAVA_LANG_VIRTUALTHREAD.

Fixes: #15986

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>