### PR TITLE
Add BCT_JavaMajorVersionUnshifted()

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1284,7 +1284,7 @@ ROMClassBuilder::computeExtraModifiers(ClassFileOracle *classFileOracle, ROMClas
 		}
 	}
 
-	if (classFileOracle->getMajorVersion() >= (BCT_JavaMajorVersionShifted(6) >> BCT_MajorClassFileVersionMaskShift)) {
+	if (classFileOracle->getMajorVersion() >= BCT_JavaMajorVersionUnshifted(6)) {
 		/* Expect verify data for Java 6 and later versions */
 		modifiers |= J9AccClassHasVerifyData;
 	} else {

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -551,8 +551,8 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
 	{
-		/* majorVer is introduced to workaround JDK8 zOS 64bit compiler issue. */
-		U_32 majorVer = BCT_JavaMajorVersionShifted(JAVA_SPEC_VERSION);
+		/* Using local variable majorVer avoids a z/OS 64-bit compiler issue. */
+		U_32 majorVer = BCT_JavaMaxMajorVersionShifted;
 		translationFlags |= majorVer;
 	}
 #endif

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -427,7 +427,7 @@ JVM_GetClassFileVersion(JNIEnv *env, jclass cls)
 		J9ROMClass *romClass = clazz->romClass;
 
 		if (J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass)) {
-			version = BCT_JavaMajorVersionShifted(JAVA_SPEC_VERSION) >> BCT_MajorClassFileVersionMaskShift;
+			version = BCT_JavaMaxMajorVersionUnshifted;
 		} else {
 			version = (jint)((romClass->minorVersion << 16) + romClass->majorVersion);
 		}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2071,9 +2071,10 @@ typedef struct J9BCTranslationData {
 #define BCT_MajorClassFileVersionMaskShift  24
 
 /* A given Java feature version uses class-file format (version) + 44. */
-#define BCT_JavaMajorVersionShifted(java_version)  ((44 + (U_32)(java_version)) << BCT_MajorClassFileVersionMaskShift)
-/* When adding support for a new Java feature version, update this appropriately. */
-#define BCT_JavaMaxMajorVersionShifted  BCT_JavaMajorVersionShifted(19)
+#define BCT_JavaMajorVersionUnshifted(java_version)  (44 + (U_32)(java_version))
+#define BCT_JavaMajorVersionShifted(java_version)  (BCT_JavaMajorVersionUnshifted(java_version) << BCT_MajorClassFileVersionMaskShift)
+#define BCT_JavaMaxMajorVersionUnshifted  BCT_JavaMajorVersionUnshifted(JAVA_SPEC_VERSION)
+#define BCT_JavaMaxMajorVersionShifted  BCT_JavaMajorVersionShifted(JAVA_SPEC_VERSION)
 
 typedef struct J9RAMClassFreeListBlock {
 	UDATA size;


### PR DESCRIPTION
Simplify code by reducing use of the pattern `(versionShifted >> BCT_MajorClassFileVersionMaskShift)`.