### PR TITLE
Update Continuation.yield to use onPinned API

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -216,6 +216,8 @@ public class Continuation {
 	 */
 	public static boolean yield(ContinuationScope scope) {
 		/* TODO find matching scope to yield */
+		Thread carrierThread = JLA.currentCarrierThread();
+		Continuation cont = JLA.getContinuation(carrierThread);
 		int rcPinned = isPinnedImpl();
 		if (rcPinned != 0) {
 			Pinned reason = null;
@@ -228,17 +230,19 @@ public class Continuation {
 			} else {
 				throw new AssertionError("Unknown pinned error code: " + rcPinned);
 			}
-			throw new IllegalStateException("Continuation is pinned: " + reason);
+			cont.onPinned(reason);
+		} else {
+			yieldImpl();
+			cont.onContinue();
 		}
-		return yieldImpl();
+		return (rcPinned == 0);
 	}
 
 	protected void onPinned(Pinned reason) {
-		throw new UnsupportedOperationException();
+		throw new IllegalStateException("Continuation is pinned: " + reason);
 	}
 
 	protected void onContinue() {
-		throw new UnsupportedOperationException();
 	}
 
 	public boolean isDone() {


### PR DESCRIPTION
Continuation class implementation expects IllegalStateException when
yielding a pinned Continuation. But VirtualThread class overrides
this behaviour and only returns false without throwing the exception
when yield fails.

- Allow the overriden onPinned method to perform non-throw behaviour
when the Continuation is pinned during yield.
- Update VirtualThread tests on new behaviour.

Rework of #15996 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>