### PR TITLE
Avoid compilation failures due to imprecision in memory availability readout

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -264,7 +264,7 @@ int32_t J9::Options::_numCodeCachesToCreateAtStartup = 0; // 0 means no change f
 int32_t J9::Options::_dataCacheQuantumSize = 64;
 int32_t J9::Options::_dataCacheMinQuanta = 2;
 
-int32_t J9::Options::_updateFreeMemoryMinPeriod = 500;  // 500 ms
+int32_t J9::Options::_updateFreeMemoryMinPeriod = 50;  // 50 ms
 
 size_t J9::Options::_scratchSpaceLimitKBWhenLowVirtualMemory = 64*1024; // 64MB; currently, only used on 32 bit Windows
 


### PR DESCRIPTION
In order to avoid out-of-memory scenarios, the JIT reads the amount of
available physical memory before each compilation. To control the overhead
of the memory availability call, there is a caching mechanism that makes sure
that two such calls cannot be closer than 500ms.
When a compilation consumes most of the available memory for the JVM, it may fail,
and this is completely normal. However, many of the subsequent compilations
can also fail, thinking that there is very little memory available. In reality,
the memory expensive compilation that failed already released all its memory to the
OS, and the JIT is getting stale memory availability information from the caching
mechanism.

This PR implements two changes:
1. Bypass the caching mechanism and do a proper memory readout, if the JIT is about to fail a compilation due to insufficient physical memory.
2. Decrease _updateFreeMemoryMinPeriod from 500 ms to 50 ms. This configuration option controls the maximum frequency at which the JIT is allowed to read the amount of available physical memory.
 