### PR TITLE
Remove include X86Evaluator.hpp

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -74,7 +74,6 @@
 #include "x/codegen/MonitorSnippet.hpp"
 #include "x/codegen/OutlinedInstructions.hpp"
 #include "x/codegen/HelperCallSnippet.hpp"
-#include "x/codegen/X86Evaluator.hpp"
 #include "env/CompilerEnv.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "codegen/J9WatchedStaticFieldSnippet.hpp"


### PR DESCRIPTION
`X86Evaluator.hpp` is removed in eclipse/omr#6718

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>