### PR TITLE
Fix small memory leak at JITServer

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -1061,6 +1061,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          stream->~ServerStream();
          TR::Compiler->persistentGlobalAllocator().deallocate(stream);
          entry._stream = NULL;
+         compInfo->recycleCompilationEntry(&entry);
          }
 
       // Reset the pointer to the cached client session data
@@ -1158,6 +1159,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       stream->~ServerStream();
       TR::Compiler->persistentGlobalAllocator().deallocate(stream);
       entry._stream = NULL;
+      compInfo->recycleCompilationEntry(&entry);
       }
 
    compInfo->printQueue();


### PR DESCRIPTION
Data structures of type TR_MethodToBeCompiled are allocated to hold compilation requests generated by the listener thread of JITServer. Compilation requests are queued by the listener thread and dequeued by compilation threads that work on them. As long as the connection between the client and server is maintained, the same TR_MethodToBeCompiled is reused by queuing back the compilation request. When the client-server connection is severed (maybe because the compilation queue at the client has become empty) the TR_MethodToBeCompiled structure should be placed into a pool, to be reused later. Currently, this is not happening for JITServer and such data structures are leaked.
This PR fixes the problem mentioned above by calling recycleCompilationEntry() at the appropriate places.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>