### PR TITLE
Cache J9I2JState in J9VMContinuation during transition

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4997,6 +4997,7 @@ typedef struct J9VMContinuation {
 	struct J9JITDecompilationInfo* decompilationStack;
 	UDATA* j2iFrame;
 	struct J9JITGPRSpillArea jitGPRs;
+	struct J9I2JState i2jState;
 	struct J9VMEntryLocalStorage* oldEntryLocalStorage;
 	struct J9VMThread* carrierThread;
 } J9VMContinuation;

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -203,7 +203,6 @@ isPinnedContinuation(J9VMThread *currentThread)
 void
 copyFieldsFromContinuation(J9VMThread *currentThread, J9VMThread *vmThread, J9VMEntryLocalStorage *els, J9VMContinuation *continuation)
 {
-	vmThread->entryLocalStorage = els;
 	vmThread->javaVM = currentThread->javaVM;
 	vmThread->arg0EA = continuation->arg0EA;
 	vmThread->bytecodes = continuation->bytecodes;
@@ -213,10 +212,12 @@ copyFieldsFromContinuation(J9VMThread *currentThread, J9VMThread *vmThread, J9VM
 	vmThread->stackOverflowMark = continuation->stackOverflowMark;
 	vmThread->stackOverflowMark2 = continuation->stackOverflowMark2;
 	vmThread->stackObject = continuation->stackObject;
-	vmThread->entryLocalStorage->oldEntryLocalStorage = continuation->oldEntryLocalStorage;
-	vmThread->entryLocalStorage->jitGlobalStorageBase = (UDATA*)&continuation->jitGPRs;
 	vmThread->j2iFrame = continuation->j2iFrame;
 	vmThread->decompilationStack = continuation->decompilationStack;
+	els->oldEntryLocalStorage = continuation->oldEntryLocalStorage;
+	els->jitGlobalStorageBase = (UDATA*)&continuation->jitGPRs;
+	els->i2jState = continuation->i2jState;
+	vmThread->entryLocalStorage = els;
 }
 
 UDATA

--- a/runtime/vm/ContinuationHelpers.hpp
+++ b/runtime/vm/ContinuationHelpers.hpp
@@ -70,11 +70,15 @@ public:
 		SWAP_MEMBER(decompilationStack, J9JITDecompilationInfo*, vmThread, continuation);
 		SWAP_MEMBER(j2iFrame, UDATA*, vmThread, continuation);
 
+		J9VMEntryLocalStorage *threadELS = vmThread->entryLocalStorage;
 		/* Swap the JIT GPR registers data referenced by ELS */
 		J9JITGPRSpillArea tempGPRs = continuation->jitGPRs;
-		continuation->jitGPRs = *(J9JITGPRSpillArea*)vmThread->entryLocalStorage->jitGlobalStorageBase;
-		*(J9JITGPRSpillArea*)vmThread->entryLocalStorage->jitGlobalStorageBase = tempGPRs;
-		SWAP_MEMBER(oldEntryLocalStorage, J9VMEntryLocalStorage*, vmThread->entryLocalStorage, continuation);
+		continuation->jitGPRs = *(J9JITGPRSpillArea*)threadELS->jitGlobalStorageBase;
+		*(J9JITGPRSpillArea*)threadELS->jitGlobalStorageBase = tempGPRs;
+		J9I2JState tempI2J = continuation->i2jState;
+		continuation->i2jState = threadELS->i2jState;
+		threadELS->i2jState = tempI2J;
+		SWAP_MEMBER(oldEntryLocalStorage, J9VMEntryLocalStorage*, threadELS, continuation);
 	}
 
 };

--- a/test/functional/Java19andUp/playlist.xml
+++ b/test/functional/Java19andUp/playlist.xml
@@ -24,10 +24,10 @@
 	<test>
 		<testCaseName>Jep425Tests_testVirtualThread</testCaseName>
 		<variations>
-			<variation>--enable-preview -Xint -Xgcpolicy:optthruput</variation>
-			<variation>--enable-preview -Xint -Xgcpolicy:gencon</variation>
-			<variation>--enable-preview -Xint -Xgcpolicy:balanced</variation>
-			<variation>--enable-preview -Xint -Xgcpolicy:optavgpause</variation>
+			<variation>--enable-preview -Xgcpolicy:optthruput</variation>
+			<variation>--enable-preview -Xgcpolicy:gencon</variation>
+			<variation>--enable-preview -Xgcpolicy:balanced</variation>
+			<variation>--enable-preview -Xgcpolicy:optavgpause</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--add-opens java.base/java.lang=ALL-UNNAMED \
@@ -38,7 +38,7 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>bits.64,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^os.zos,^os.sunos,^arch.ppc</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Enable JIT in VirtualThread tests
- Disable testing on PPC due to known test failure
- PPC testing will be re-enabled with https://github.com/eclipse-openj9/openj9/pull/16014

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>