### PR TITLE
Support for reading/writing a JITServer AOT cache in the background

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -12973,7 +12973,10 @@ TR::CompilationInfo::addOutOfProcessMethodToBeCompiled(JITServer::ServerStream *
       {
       // Initialize the entry with defaults (some, like methodDetails, are bogus)
       TR::IlGeneratorMethodDetails details;
-      entry->initialize(details, NULL, CP_SYNC_NORMAL, NULL);
+      // stream == LOAD_AOTCACHE_REQUEST is a special case of request that performs AOTCache loads from disk
+      // This needs to be served as soon as possible, so we give it a higher priority
+      CompilationPriority priority = (stream == LOAD_AOTCACHE_REQUEST) ? CP_SYNC_BELOW_MAX : CP_SYNC_NORMAL;
+      entry->initialize(details, NULL, priority, NULL);
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
          {
          PORT_ACCESS_FROM_JITCONFIG(_jitConfig);

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -133,6 +133,8 @@ int32_t J9::Options::_sharedROMClassCacheNumPartitions = 16;
 int32_t J9::Options::_reconnectWaitTimeMs = 1000;
 int32_t J9::Options::_highActiveThreadThreshold = -1;
 int32_t J9::Options::_veryHighActiveThreadThreshold = -1;
+int32_t J9::Options::_aotCachePersistenceMinDeltaMethods = 200;
+int32_t J9::Options::_aotCachePersistenceMinPeriodMs = 10000; // ms
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
@@ -688,6 +690,12 @@ TR::OptionTable OMR::Options::_feOptions[] = {
 
    {"activeThreadsThresholdForInterpreterSampling=", "M<nnn>\tSampling does not affect invocation count beyond this threshold",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_activeThreadsThreshold, 0, "F%d", NOT_IN_SUBSET },
+#if defined(J9VM_OPT_JITSERVER)
+   {"aotCachePersistenceMinDeltaMethods=", "M<nnn>\tnumber of extra AOT methods that need to be added to the JITServer AOT cache before considering a save operation",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_aotCachePersistenceMinDeltaMethods, 0, "F%d", NOT_IN_SUBSET },
+   {"aotCachePersistenceMinPeriodMs=", "M<nnn>\tmiminum time between two consecutive JITServer AOT cache save operations (ms)",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_aotCachePersistenceMinPeriodMs, 0, "F%d", NOT_IN_SUBSET },
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"aotMethodCompilesThreshold=", "R<nnn>\tIf this many AOT methods are compiled before exceeding aotMethodThreshold, don't stop AOT compiling",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_aotMethodCompilesThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"aotMethodThreshold=", "R<nnn>\tNumber of methods found in shared cache after which we stop AOTing",

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2103,6 +2103,26 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             {
             disabledShareROMClasses = true;
             }
+
+         // Check if the JITServer AOT cache persistence feature is enabled
+         const char *xxJITServerAOTCachePersistenceOption = "-XX:+JITServerAOTCachePersistence";
+         const char *xxDisableJITServerAOTCachePersistenceOption = "-XX:-JITServerAOTCachePersistence";
+         int32_t xxJITServerAOTCachePersistenceArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerAOTCachePersistenceOption, 0);
+         int32_t xxDisableJITServerAOTCachePersistenceArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerAOTCachePersistenceOption, 0);
+         if (xxJITServerAOTCachePersistenceArgIndex > xxDisableJITServerAOTCachePersistenceArgIndex)
+            {
+            compInfo->getPersistentInfo()->setJITServerUseAOTCachePersistence(true);
+
+            // If enabled, get the name of the directory where the AOT cache files will be stored
+            const char *xxJITServerAOTCacheDirOption = "-XX:JITServerAOTCacheDir=";
+            int32_t xxJITServerAOTCacheDirArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTCacheDirOption, 0);
+            if (xxJITServerAOTCacheDirArgIndex >= 0)
+               {
+               char *directory = NULL;
+               GET_OPTION_VALUE(xxJITServerAOTCacheDirArgIndex, '=', &directory);
+               compInfo->getPersistentInfo()->setJITServerAOTCacheDir(directory);
+               }
+            }
          }
       else // Client mode (possibly)
          {

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -277,6 +277,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _reconnectWaitTimeMs;
    static const uint32_t DEFAULT_JITCLIENT_TIMEOUT = 30000; // ms
    static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
+   static int32_t _aotCachePersistenceMinDeltaMethods;
+   static int32_t _aotCachePersistenceMinPeriodMs;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -165,10 +165,12 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _socketTimeoutMs(0),
          _clientUID(0),
          _JITServerMetricsPort(38500),
-         _JITServerUseAOTCache(false),
          _requireJITServer(false),
          _localSyncCompiles(true),
+         _JITServerUseAOTCache(false),
          _JITServerAOTCacheName("default"),
+         _JITServerUseAOTCachePersistence(false),
+         _JITServerAOTCacheDir(),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -357,6 +359,10 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
    const std::string &getJITServerAOTCacheName() const { return _JITServerAOTCacheName; }
    void setJITServerAOTCacheName(const char *name) { _JITServerAOTCacheName = name; }
+   bool getJITServerUseAOTCachePersistence() const { return _JITServerUseAOTCachePersistence; }
+   void setJITServerUseAOTCachePersistence(bool use) { _JITServerUseAOTCachePersistence = use; }
+   const std::string &getJITServerAOTCacheDir() const { return _JITServerAOTCacheDir; }
+   void setJITServerAOTCacheDir(const char *dir) { _JITServerAOTCacheDir = dir; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -452,6 +458,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    bool        _localSyncCompiles;
    bool        _JITServerUseAOTCache;
    std::string _JITServerAOTCacheName; // Name of the server AOT cache that this client is using
+   bool        _JITServerUseAOTCachePersistence; // Whether to persist the JITServer AOT caches at the server
+   std::string _JITServerAOTCacheDir;  // Directory where the JITServer persistent AOT caches are located
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/env/PersistentCollections.hpp
+++ b/runtime/compiler/env/PersistentCollections.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,10 @@
 #ifndef PERSISTENT_COLLECTIONS_H
 #define PERSISTENT_COLLECTIONS_H
 
-#include <vector>
+#include <list>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "env/PersistentAllocator.hpp"
 #include "env/Region.hpp"
@@ -35,6 +36,11 @@ template<typename T>
 using PersistentVectorAllocator = TR::typed_allocator<T, TR::PersistentAllocator &>;
 template<typename T>
 using PersistentVector = std::vector<T, PersistentVectorAllocator<T>>;
+
+template<typename T>
+using PersistentListAllocator = TR::typed_allocator<T, TR::PersistentAllocator &>;
+template<typename T>
+using PersistentList = std::list<T, PersistentListAllocator<T>>;
 
 template<typename T>
 using PersistentUnorderedSetAllocator = TR::typed_allocator<T, TR::PersistentAllocator &>;

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -74,6 +74,7 @@ struct AOTCacheWellKnownClassesRecord;
 struct AOTCacheAOTHeaderRecord;
 
 #define LOAD_AOTCACHE_REQUEST (JITServer::ServerStream *)0x1
+#define SAVE_AOTCACHE_REQUEST (JITServer::ServerStream *)0x3 // pointers cannot have the last bit set
 
 // Base class for serialization record "wrappers" stored at the server.
 //
@@ -425,8 +426,43 @@ public:
 
    void printStats(FILE *f) const;
 
-   bool writeCache(FILE *f) const;
+   size_t writeCache(FILE *f) const;
    static JITServerAOTCache *readCache(FILE *f, const std::string &name, TR_Memory &trMemory);
+   size_t getNumCachedMethods() const;
+   void setMinNumAOTMethodsToSave(size_t num) { _minNumAOTMethodsToSave = num; }
+
+  /**
+   * @brief  If conditions are right, launch another compilation thread to store this AOT cache to a file.
+   *
+   * This is done if both conditions below are met:
+   * (1) "enough" methods were added to the in-memory AOT cache since the last snapshot
+   * and
+   * (2) "enough" time has passed since the last snapshot
+   *
+   * Until the save operation is complete, the _saveOperationInProgress flag is set
+   * to 'true' to prevent other threads launching other save operations
+   * Internally, this method aquires temporarily the _cachedMethodMonitor,
+   * the monitor protecting the aotCacheMap and the compilation monitor.
+   *
+   * @return true if the save operation was launched, false otherwise
+   */
+   bool triggerAOTCacheStoreToFileIfNeeded();
+   void finalizeSaveOperation(bool success, size_t numMethodsSavedToFile);
+   void excludeCacheFromSavingToFile() { _excludedFromSavingToFile = true; }
+
+   /**
+      @brief Determine if current in-memory AOT cache is "better" than the one on file.
+
+      An in-memory AOT cache is considered "better" than the one on file if it has `numExtraMethods` more AOT methods.
+      Artificially, it is also considered better if one of the following conditions is true:
+      (1) cache on file is incompatible with the in-memory cache
+      (2) file containing the cache cannot be opened or its content cannot be read
+
+      @param cacheFileName The name of the file containing the AOT snapshot to be compared (second term of the comparison)
+      @param numExtraMethods How many more methods need to be in the in-memory cache compared to the AOT snapshot in order to be considered "better"
+      @return true if the in-memory cache is better than the one on file, false otherwise
+   */
+   bool isAOTCacheBetterThanSnapshot(const std::string &cacheFileName, size_t numExtraMethods);
 
 private:
    struct ClassLoaderKey
@@ -561,6 +597,11 @@ private:
    CachedAOTMethod *_cachedMethodTail;
    TR::Monitor *const _cachedMethodMonitor;
 
+   uint64_t _timePrevSaveOperation;   // Millis when this cache was last saved to file
+   size_t _minNumAOTMethodsToSave;    // Minimum number of AOT methods present in the cache before considering a save operation
+   bool _saveOperationInProgress;     // True if an AOTCache save operation is in progress
+   bool _excludedFromSavingToFile;    // True if this cache is excluded from saving to file
+
    // Statistics
    size_t _numCacheBypasses;
    size_t _numCacheHits;
@@ -578,10 +619,40 @@ public:
 
    JITServerAOTCacheMap();
    ~JITServerAOTCacheMap();
+   /**
+      @brief Enqueue the given AOT cache name to be saved saving to file, later-on.
+   */
+   void queueAOTCacheForSavingToFile(const std::string &cacheName);
 
-   JITServerAOTCache *get(const std::string &name, uint64_t clientUID, bool &pending);
+   /**
+      @brief Attempt to save to file the next AOT cache that is queued for saving.
+   */
+   bool saveNextQueuedAOTCacheToFile();
+
+   /**
+      @brief Load from file the next AOT cache that is queued for loading.
+
+      If the load operation succeeds, a new named in-memory cache is created.
+      If the load operation fails, this cache name is excluded from future load operations.
+      Any exceptions thrown by this method are caught and logged.
+      This method acquires the AOTCacheMap monitor.
+   */
    void loadNextQueuedAOTCacheFromFile(J9::J9SegmentProvider &scratchSegmentProvider);
 
+   /**
+      @brief Obtain a pointer to a named AOT cache. If it doesn't exist, attempt to create one.
+
+      If the cache exists, return a pointer to it.
+      If the cache doesn't exist and the persistence feature is disabled, create an empty cache;
+      if the persistence feature is enabled and this cache name is not on the exclusion list,
+      enqueue a special compilation request that will load the cache from file and set "pending" to true
+
+      @param name  Name of the cache to get or create
+      @param clientUID UID of the client that will be using this cache
+      @param pending Output flag indicating that a cache load operation from file is in progress, but not read yet
+      @return Pointer to the named AOT cache, or NULL if the cache could not be created right away (or at all)
+   */
+   JITServerAOTCache *get(const std::string &name, uint64_t clientUID, bool &pending);
    size_t getNumDeserializedMethods() const;
 
    static void setCacheMaxBytes(size_t bytes) { _cacheMaxBytes = bytes; }
@@ -590,19 +661,29 @@ public:
    void printStats(FILE *f) const;
 
 private:
+   static std::string buildCacheFileName(const std::string &cacheDir, const std::string &cacheName);
+
    PersistentUnorderedMap<std::string, JITServerAOTCache *> _map;
-   std::string buildCacheFileName(const std::string &cacheDir, const std::string &cacheName);
+
    // The following set is used to keep track of the caches that are in process of being loaded from file
    // Once a cache is loaded, it is removed from the set and added to the _map
    PersistentUnorderedSet<std::string> _cachesBeingLoaded;
+
    // _cachesToLoadQueue is used to order the caches that need to be loaded from file.
    // A compilation thread dequeues the first name and starts to load the cache from file.
    // When it finishes (either successfully or not), it deletes the name from _cachesBeingLoaded.
    PersistentList<std::string> _cachesToLoadQueue;
+
    // _cachesExcludedFromLoading is used to keep track of the caches that we don't want to load
    // from file, maybe because the load operation already was attempted and failed
    // We could also populate this set from command line options
    PersistentUnorderedSet<std::string> _cachesExcludedFromLoading;
+
+   // _cachesToSaveQueue is used to remember the caches that need to be saved to file
+   // A compilation thread dequeues the first name and tries to save the named cache to a file,
+   // possibly overwriting an existent file
+   PersistentList<std::string> _cachesToSaveQueue;
+
    TR::Monitor *const _monitor;
 
    static size_t _cacheMaxBytes;


### PR DESCRIPTION
This PR implements support for loading an AOT cache from a file and saving an AOT cache to a file. This is done by a compilation thread that works concurrently with other compilation threads that compile methods.
For reading, the sequence of actions is the following:
1. Compilation thread at the server reads compilation request from client and determines whether the client wants to use the AOTCache
2. Server checks its hashmap to see if the named cache already exists. If it exists, it will be used.
3. If desired cache does not exist, server checks if the persistence feature is enabled and whether a file for the desired cache exists.
4. If the AOT cache file exists, the server will memorize the name of the cache in a set, queue a special compilation request (with stream==0) and wake a compilation thread to process it. It will then proceed to compile the requested method, without waiting for the AOT cache to be loaded.
5. If the AOT cache file does not exist (or persistence is disabled), the server will create an empty AOT cache which is going to be populated as methods get compiled.
6. When a compilation thread extracts the special request from the queue, it will proceed to load the AOT cache from disk. The name of the AOT cache is retrieved from the set where it was memorized earlier. If there is a problem during the loading, the name of the cache will be included into a set of cached that are excluded from being loaded in the future.

For writing, the sequence of actions is the following:
1. In `outOfProcessCompilationEnd()`, when a compilation finishes, we check if conditions for saving the AOT cache are met (in method `triggerAOTCacheStoreToFileIfNeeded()`). These conditions are: (A) "enough" methods were added to the in-memory AOT cache since the last snapshot and (B) "enough" time has passed since the last snapshot
2. If we decide to save the cache then, 
(A) we set `_saveOperationInProgress` to prevent other threads doing a concurrent save; 
(B) add the name of the cache to a queue of caches to be saved;
(C) queue a special compilation request with stream==SAVE_AOTCACHE_REQUEST 
(D) notify a sleeping compilation thread
3. Later on, the special compilation request is picked up by a compilation thread in `processEntry()` and we call `aotCacheMap->saveNextQueuedAOTCacheToFile();`
4. The name of the first cache to be saved is dequeued and we find the pointer to the cache
5. Based on the cache name we construct the name of the file where the cache will be saved (e.g. JITServerAOTCache.default.J17)
6. Try to open a possible existing cache file with the same name.
7. If an existing snapshot already exists, read the header and determine if it contains more methods than we have. If it does, we don't perform the save
8. If the existing snapshot is incompatible with our cache or if it contains fewer methods than what we have, we will save our own cache
9. Create a temporary file and write our cache content to it
10. Rename the temporary file to the final cache filename
11. If the rename operation fails or if we cannot create the temporary file we mark this cache so that it we don't attempt other save operations for it
12. Finalize the save operation by remembering the time when it took place and updating the number of methods that we need to have in order to allow for another save operation. Also reset `_saveOperationInProgress` flag

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>
