### PR TITLE
Fix Continuation collection issue

### DIFF
--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -234,18 +234,17 @@ MM_ScavengerRootClearer::scavengeContinuationObjects(MM_EnvironmentStandard *env
 					if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 						omrobjectptr_t object = list->getPriorList();
 						while (NULL != object) {
-							omrobjectptr_t next = NULL;
+							omrobjectptr_t next = _extensions->accessBarrier->getContinuationLink(object);
 							gcEnv->_scavengerJavaStats._continuationCandidates += 1;
 
 							MM_ForwardedHeader forwardedHeader(object, compressed);
 							if (!forwardedHeader.isForwardedPointer()) {
-								Assert_MM_true(_scavenger->isObjectInEvacuateMemory(object));
+								Assert_GC_true_with_message2(env, _scavenger->isObjectInEvacuateMemory(object), "Continuation object  %p should be a dead object, forwardedHeader=%p\n", object, forwardedHeader);
 								gcEnv->_scavengerJavaStats._continuationCleared += 1;
 								VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), object);
 							} else {
 								omrobjectptr_t forwardedPtr = forwardedHeader.getForwardedObject();
-								Assert_MM_true(NULL != forwardedPtr);
-								next = _extensions->accessBarrier->getContinuationLink(forwardedPtr);
+								Assert_GC_true_with_message(env, NULL != forwardedPtr, "Continuation object  %p should be forwarded\n", object);
 								gcEnv->_continuationObjectBuffer->add(env, forwardedPtr);
 							}
 							object = next;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3524,7 +3524,6 @@ MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 				J9Object *pointer = region->getContinuationObjectList()->getPriorList();
 
 				while (NULL != pointer) {
-					//bool finalizable = false;
 					env->_copyForwardStats._continuationCandidates += 1;
 					Assert_MM_true(region->isAddressInRegion(pointer));
 
@@ -3540,9 +3539,9 @@ MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 						}
 					}
 
-					J9Object* next = _extensions->accessBarrier->getContinuationLink(forwardedPtr);
+					J9Object* next = _extensions->accessBarrier->getContinuationLink(pointer);
 					if (NULL == forwardedPtr) {
-						/* object was not previously marked -- it is now finalizable so push it to the local buffer */
+						/* object was not previously marked, clean up */
 						env->_copyForwardStats._continuationCleared += 1;
 						VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), pointer);
 					} else {


### PR DESCRIPTION
Retrieve next continuation Link from old Object instead of forwarded Object in case old Object is dead.

fix: https://github.com/eclipse-openj9/openj9/pull/16069#issuecomment-1271956260
Signed-off-by: Lin Hu <linhu@ca.ibm.com>