### PR TITLE
CRIU nanoTimeMonotonicClockDelta calculation adjusted

### DIFF
--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -33,9 +33,11 @@ TraceAssert=Assert_CRIU_mustNotHaveVMAccess noEnv Overhead=1 Level=1 Assert="0 =
 TraceException=Trc_CRIU_getNativeString_getStringSizeFail Overhead=1 Level=1 Template="Failed to get Java string size: mutf8String=%s mutf8StringSize=%zu"
 TraceException=Trc_CRIU_getNativeString_convertFail Overhead=1 Level=1 Template="Failed to convert Java string: mutf8String=%s mutf8StringSize=%zu requiredConvertedStringSize=%zd"
 
-TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump(), checkpointNanoTimeMonotonic = %lld, checkpointNanoUTCTime = %llu"
-TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump(), restoreNanoUTCTime = %llu, checkpointNanoUTCTime = %llu, checkpointRestoreTimeDelta = %lld, restoreNanoTimeMonotonic = %lld, checkpointNanoTimeMonotonic = %lld, nanoTimeMonotonicClockDelta = %lld"
+TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump(), j9time_nano_time() returns %lld, j9time_current_time_nanos() returns %llu"
+TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump(), j9time_nano_time() returns %lld, j9time_current_time_nanos() returns %llu"
 TraceEntry=Trc_CRIU_checkpointJVMImpl_Entry Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
 TraceExit=Trc_CRIU_checkpointJVMImpl_Exit Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_checkIfSafeToCheckpointBlocked Overhead=1 Level=2 Template="Checkpoint blocked because thread=%p is in method=%p marked as not safe to checkpoint"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_syslogOptions Overhead=1 Level=3 Template="Current syslogOptions: %s"
+TraceEvent=Trc_CRIU_checkpoint_nano_times Overhead=1 Level=2 Template="Before checkpoint, checkpointNanoTimeMonotonic = %lld, checkpointNanoUTCTime = %llu"
+TraceEvent=Trc_CRIU_restore_nano_times Overhead=1 Level=2 Template="After restore, restoreNanoUTCTime = %llu, checkpointNanoUTCTime = %llu, checkpointRestoreTimeDelta = %lld, restoreNanoTimeMonotonic = %lld, checkpointNanoTimeMonotonic = %lld, nanoTimeMonotonicClockDelta = %lld"

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -49,7 +49,6 @@ static jvmtiIterationControl objectIteratorCallback(J9JavaVM *vm, J9MM_IterateOb
 BOOLEAN
 jvmCheckpointHooks(J9VMThread *currentThread)
 {
-	J9JavaVM *vm = currentThread->javaVM;
 	BOOLEAN result = TRUE;
 	J9NameAndSignature nas = {0};
 	nas.name = (J9UTF8 *)&runPreCheckpointHooks_name;
@@ -62,12 +61,8 @@ jvmCheckpointHooks(J9VMThread *currentThread)
 
 	if (VM_VMHelpers::exceptionPending(currentThread)) {
 		result = FALSE;
-		goto done;
 	}
 
-	TRIGGER_J9HOOK_VM_PREPARING_FOR_CHECKPOINT(vm->hookInterface, currentThread);
-
-done:
 	return result;
 }
 


### PR DESCRIPTION
Move `checkpointNanoTimeMonotonic=j9time_nano_time()` before `TRIGGER_J9HOOK_VM_PREPARING_FOR_CHECKPOINT` which is closer to the stage JVM paused;
Move `checkpointNanoUTCTime=j9time_current_time_nanos()` as well.
Keep `Trc_CRIU_before_checkpoint()` and `Trc_CRIU_after_checkpoint()` close to `criu_dump()` for time measurement of the pre-checkpoint phase;
Add `Trc_CRIU_checkpoint_nano_times()` and `Trc_CRIU_restore_nano_times()` to record time compensation.

closes https://github.com/eclipse-openj9/openj9/issues/15991

Signed-off-by: Jason Feng <fengj@ca.ibm.com>