### PR TITLE
Update JDK version for Valhalla

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -3011,8 +3011,8 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 	}
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	/* Currently value type is built on JDK19, so compare with JDK19 for now. Eventually it may need to compare to JDK20. */
-	if ((flags & BCT_MajorClassFileVersionMask) < BCT_JavaMajorVersionShifted(19)) {
+	/* Currently value type is built on JDK20, so compare with JDK20 for now. Eventually it may need to compare to JDK21. */
+	if ((flags & BCT_MajorClassFileVersionMask) < BCT_JavaMajorVersionShifted(20)) {
 		classfile->accessFlags &= ~(CFR_ACC_VALUE_TYPE | CFR_ACC_PRIMITIVE_VALUE_TYPE | CFR_ACC_IDENTITY);
 	}
 	if (J9_ARE_ALL_BITS_SET(classfile->accessFlags, CFR_ACC_PRIMITIVE_VALUE_TYPE)) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -196,11 +196,11 @@ public class ValueTypeGenerator extends ClassLoader {
 		String[] fields = config.getFields();
 		int extraClassFlags = config.getExtraClassFlags();
 		/**
-		 * Currently value type is built on JDK19, so use java file major version 63 for now.
-		 * If moved to JDK20, this needs to be incremented to 64. The check in j9bcutil_readClassFileBytes()
-		 * against BCT_JavaMajorVersionShifted(19) needs to be updated as well.
+		 * Currently value type is built on JDK20, so use java file major version 64 for now.
+		 * If moved to JDK21, this needs to be incremented to 65. The check in j9bcutil_readClassFileBytes()
+		 * against BCT_JavaMajorVersionShifted(20) needs to be updated as well.
 		 */
-		int classFileVersion = 63;
+		int classFileVersion = 64;
 
 		String nestHost = config.getNestHost();
 


### PR DESCRIPTION
1. Valhalla is built on JDKNext which is Java 20 now. Update the code to check against Java 20.
2. Update the test code to generate Java 20 classes.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>