### PR TITLE
(0.35) Update openssl to version 1.1.1r

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -134,7 +134,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1q'
+  extra_getsource_options: '--openssl-version=1.1.1r'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling
@@ -391,7 +391,6 @@ x86-32_windows:
 #========================================#
 x86-64_mac:
   extends: ['boot_jdk_default', 'debuginfo', 'openssl', 'openssl_bundle']
-  extra_getsource_options: '--openssl-version=1.1.1p'
   boot_jdk:
     arch: 'x64'
     os: 'mac'
@@ -414,7 +413,6 @@ x86-64_mac:
 #========================================#
 aarch64_mac:
   extends: ['boot_jdk_default', 'openssl', 'openssl_bundle']
-  extra_getsource_options: '--openssl-version=1.1.1p'
   boot_jdk:
     arch: 'aarch64'
     os: 'mac'


### PR DESCRIPTION
Cherry pick of https://github.com/eclipse-openj9/openj9/pull/16086 for the 0.35 release.