### PR TITLE
Prevent endless loop in native stack walk

### DIFF
--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -93,6 +93,7 @@ static void dropToCurrentFrame (J9StackWalkState * walkState);
 
 UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 {
+	long loop_count = 0;
 	UDATA rc = (walkState->walkThread->privateFlags & J9_PRIVATE_FLAGS_STACK_CORRUPT) ? J9_STACKWALK_RC_STACK_CORRUPT : J9_STACKWALK_RC_NONE;
 	J9Method * nextLiterals;
 	UDATA * nextA0;
@@ -256,7 +257,13 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 	}
 #endif 
 
+	loop_count = 0;
 	while(1) {
+		loop_count = loop_count + 1;
+		if (loop_count > 4096) {
+			rc = J9_STACKWALK_RC_STACK_CORRUPT;
+			goto terminationPoint;
+		}
 		J9SFStackFrame * fixedStackFrame;
 
 		walkState->constantPool = NULL;


### PR DESCRIPTION
When using ASGCT call to obtain stacktraces it can happen that the stack walking code gets into endless loop hanging the profiled application.

This is an attempt to detect such endless loop and just bail out  with 'corrupted flag' in the return code.

I was not able to find where and whether there is max stack value in number of frames defined so I am using a hard coded value in this draft. Also, I am not sure the 'corrupted stack' RC is the correct one but it is working fine, preventing endless loop and not crashing the app.