### PR TITLE
Jenkins: Always publish buildInfo to Artifactory

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -678,7 +678,7 @@ def upload_artifactory_core(geo, uploadSpec) {
     // Do not upload buildInfo if Server is behind a VPN as the Controller will not be able to talk to it.
     pipelineFunctions.retry_and_delay({
         server.upload spec: uploadSpec, buildInfo: buildInfo;
-        if ("${ARTIFACTORY_CONFIG[geo]['vpn']}" == "false") { server.publishBuildInfo buildInfo } },
+        server.publishBuildInfo buildInfo},
         3, 300)
 
     ARTIFACTORY_CONFIG[geo]['url'] = server.getUrl()


### PR DESCRIPTION
In the orignal change to add support for multiple
Artifactory servers, including servers behind a VPN
(https://github.com/eclipse-openj9/openj9/pull/8817), I made a note that buildInfo cannot be published
to VPN'd servers because while the artifacts are pushed
from the node, the buildInfo is pushed from the Controller
and therefore would fail to push if the Controller could
not see the Artifactory server behind the VPN. Since that
change, we've move the UNB VPN connection directly onto our
Controller node, this means we can now publish buildInfo to
the UNB server. This essentially means that as of today, we
can push buildInfo to all servers.

Note we still need the Artifactory vpn config info for other
parts of the code.

Also note that the if condition  written prior to
this change was incorrect so we actually have never published
buildInfo since 8817 went in.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>