### PR TITLE
Jenkins: Add option to prefix Artifactory build names

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -678,7 +678,7 @@ def upload_artifactory_core(geo, uploadSpec) {
     // Do not upload buildInfo if Server is behind a VPN as the Controller will not be able to talk to it.
     pipelineFunctions.retry_and_delay({
         server.upload spec: uploadSpec, buildInfo: buildInfo;
-        if ("${ARTIFACTORY_CONFIG[geo]['vpn']}" == "false") { server.publishBuildInfo buildInfo } },
+        server.publishBuildInfo buildInfo},
         3, 300)
 
     ARTIFACTORY_CONFIG[geo]['url'] = server.getUrl()

--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -673,6 +673,10 @@ def upload_artifactory_core(geo, uploadSpec) {
     // Add BUILD_IDENTIFIER to the buildInfo. The UploadSpec adds it to the Artifact info
     buildInfo.env.filter.addInclude("BUILD_IDENTIFIER")
     buildInfo.env.capture = true
+    if (ARTIFACTORY_CONFIG[geo]['buildNamePrefix'] != '') {
+        buildInfo.name = ARTIFACTORY_CONFIG[geo]['buildNamePrefix'] + '/' + JOB_NAME
+    }
+    println "buildInfo.name:$buildInfo.name"
 
     //Retry uploading to Artifactory if errors occur
     // Do not upload buildInfo if Server is behind a VPN as the Controller will not be able to talk to it.

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -861,6 +861,7 @@ def set_basic_artifactory_config(id="Nightly") {
             ARTIFACTORY_CONFIG[geo]['daysToKeepArtifacts'] = get_value(VARIABLES.artifactory.daysToKeepArtifacts, geo).toInteger()
             ARTIFACTORY_CONFIG[geo]['manualCleanup'] = get_value(VARIABLES.artifactory.manualCleanup, geo)
             ARTIFACTORY_CONFIG[geo]['vpn'] = get_value(VARIABLES.artifactory.vpn, geo)
+            ARTIFACTORY_CONFIG[geo]['buildNamePrefix'] = get_value(VARIABLES.artifactory.buildNamePrefix, geo)
         }
 
         /*

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -71,6 +71,9 @@ artifactory:
     default: 'ci-openj9'
   uploadDir:
     default: "${repo}/${JOB_NAME}/${BUILD_ID}"
+  buildNamePrefix:
+    osu: ''
+    unb: ''
   daysToKeepArtifacts:
     osu: 40
     unb: 30


### PR DESCRIPTION
The internal Artifactory server is forcing
the use a buildName prefix. This adds the option
to have a buildName prefix. However, we don't need
this at the OpenJ9 Jenkins farm so defaults.yml
sets the option to empty string.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>