### PR TITLE
macOS: Fix captureCommandLine()

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -739,14 +739,14 @@ done:
 						}
 					}
 
-					captured = storeCommandLine(buffer);
+					captured = storeCommandLine(start);
 				}
 			}
 
 			free(buffer);
 		}
 	}
-#elif defined(WIN32) /* defined(AIXPPC) */
+#elif defined(WIN32) /* defined(OSX) */
 	const wchar_t *commandLine = GetCommandLineW();
 
 	if (NULL != commandLine) {


### PR DESCRIPTION
This commit fixes the captureCommandLine() code for macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>