### PR TITLE
Rename registerPreSnapshotHook to registerPreCheckpointHook

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -477,7 +477,7 @@ public final class CRIUSupport {
 	 *
 	 * TODO: Additional JVM capabilities will be added to prevent certain deadlock scenarios
 	 */
-	public CRIUSupport registerPreSnapshotHook(Runnable hook) {
+	public CRIUSupport registerPreCheckpointHook(Runnable hook) {
 		if (hook != null) {
 			J9InternalCheckpointHookAPI.registerPreCheckpointHook(USER_HOOKS_PRIORITY, "User pre-checkpoint hook", ()->{ //$NON-NLS-1$
 				try {

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
@@ -90,9 +90,9 @@ public class DeadlockTest {
 		t1.start();
 
 		CRIUSupport criuSupport = new CRIUSupport(path);
-		criuSupport.registerPreSnapshotHook(() -> {
+		criuSupport.registerPreCheckpointHook(() -> {
 			synchronized (lock) {
-				System.out.println("Presnapshot hook inside monitor");
+				System.out.println("Precheckpoint hook inside monitor");
 				testResult.testPassed = false;
 			}
 		});
@@ -198,7 +198,7 @@ public class DeadlockTest {
 		Class clazz = unsafe.defineClass(A.class.getName(), bytes, 0, bytes.length, loader, null);
 
 		CRIUSupport criuSupport = new CRIUSupport(path);
-		criuSupport.registerPreSnapshotHook(()->{
+		criuSupport.registerPreCheckpointHook(()->{
 			MethodType type = MethodType.methodType(clazz);
 		});
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
@@ -42,16 +42,16 @@ public class TestDelayedOperations {
 			final Thread currentThread = Thread.currentThread();
 			CRIUTestUtils.showThreadCurrentTime(
 					"currentThread : " + currentThread + " with name : " + currentThread.getName());
-			criu.registerPreSnapshotHook(new Runnable() {
+			criu.registerPreCheckpointHook(new Runnable() {
 				public void run() {
 					CRIUTestUtils.showThreadCurrentTime(
-							"PreSnapshotHook() before threadAwaiting.interrupt() - currentThread : " + currentThread);
+							"PreCheckpointHook() before threadAwaiting.interrupt() - currentThread : " + currentThread);
 					currentThread.interrupt();
 					if (currentThread.isInterrupted()) {
 						System.out.println(
-								"TestDelayedOperations.testDelayedThreadInterrupt(): FAILED at PreSnapshotHook()");
+								"TestDelayedOperations.testDelayedThreadInterrupt(): FAILED at PreCheckpointHook()");
 					}
-					CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() after threadAwaiting.interrupt()");
+					CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() after threadAwaiting.interrupt()");
 				}
 			});
 			criu.registerPostRestoreHook(new Runnable() {

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
@@ -44,13 +44,13 @@ public class TestSingleThreadModeCheckpointException {
 				CRIUTestUtils.deleteCheckpointDirectory(imagePath);
 				CRIUTestUtils.createCheckpointDirectory(imagePath);
 				CRIUSupport criu = new CRIUSupport(imagePath);
-				criu.registerPreSnapshotHook(new Runnable() {
+				criu.registerPreCheckpointHook(new Runnable() {
 					public void run() {
-						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() before synchronized on " + lock);
+						CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() before synchronized on " + lock);
 						synchronized (lock) {
-							CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() within synchronized on " + lock);
+							CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() within synchronized on " + lock);
 						}
-						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() after synchronized on " + lock);
+						CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() after synchronized on " + lock);
 					}
 				});
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
@@ -46,11 +46,11 @@ public class TestSingleThreadModeRestoreException {
 				CRIUSupport criu = new CRIUSupport(imagePath);
 				criu.registerPostRestoreHook(new Runnable() {
 					public void run() {
-						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() before synchronized on " + lock);
+						CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() before synchronized on " + lock);
 						synchronized (lock) {
-							CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() within synchronized on " + lock);
+							CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() within synchronized on " + lock);
 						}
-						CRIUTestUtils.showThreadCurrentTime("PreSnapshotHook() after synchronized on " + lock);
+						CRIUTestUtils.showThreadCurrentTime("PreCheckpointHook() after synchronized on " + lock);
 					}
 				});
 


### PR DESCRIPTION
Rename registerPreSnapshotHook to registerPreCheckpointHook

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>