### PR TITLE
Include libraries and symbolic links based on SONAMEs

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
@@ -817,7 +817,10 @@ public class NewElfDump extends CoreReaderSupport {
 		private short _programHeaderCount = 0;
 		private short _sectionHeaderEntrySize = 0;
 		private short _sectionHeaderCount = 0;
-		// The set of ELF objects mentioned in FILE notes.
+		/*
+		 * The set of ELF objects mentioned in FILE notes,
+		 * as well as paths of symbolic links based on SONAMEs.
+		 */
 		final Set<String> _allElfFileNames = new HashSet<>();
 		// Maps to a set of paths of loaded shared libraries for a particular 'soname'.
 		final Map<String, Set<String>> _librariesBySOName = new HashMap<>();
@@ -1059,8 +1062,12 @@ public class NewElfDump extends CoreReaderSupport {
 
 						if (isSameFile(file, sofile)) {
 							Set<String> paths = _librariesBySOName.computeIfAbsent(soname, key -> new HashSet<>());
+							String sopath = sofile.getAbsolutePath();
 
-							paths.add(sofile.getAbsolutePath());
+							paths.add(sopath);
+
+							/* Add the SONAME-based path: it may be different than fileName added above. */
+							_allElfFileNames.add(sopath);
 						}
 					}
 


### PR DESCRIPTION
Fixes: #16079.
Using the example in https://github.com/eclipse-openj9/openj9/issues/16079#issuecomment-1279202325, this latest change will include both these files:
```
/lib/x86_64-linux-gnu/libpthread.so.0
/lib/x86_64-linux-gnu/libpthread-2.27.so
```