### PR TITLE
Fix EA so that it does not assume monExit will always execute an lwsync

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -341,7 +341,7 @@ class FlushCandidate : public TR_Link<FlushCandidate>
    {
    public:
    FlushCandidate(TR::TreeTop *flushNode, TR::Node *node, int32_t blockNum, Candidate *candidate = 0)
-     : _flushNode(flushNode), _node(node), _blockNum(blockNum), _candidate(candidate), _isKnownToLackCandidate(false)
+     : _flushNode(flushNode), _node(node), _blockNum(blockNum), _candidate(candidate), _isKnownToLackCandidate(false), _optimallyPlaced(false)
      {
      }
 
@@ -380,12 +380,33 @@ class FlushCandidate : public TR_Link<FlushCandidate>
     */
    void setIsKnownToLackCandidate(bool setting) {_isKnownToLackCandidate = setting;}
 
+    /**
+    * \brief Indicates whether this \c FlushCandidate is known to be
+    * optimally placed above a volatile access node and therefor should
+    * not be be considered for further optimization.
+    *
+    * \return \c true if this \c FlushCandidate is known be already optimally placed;
+    * \c false if this \c FlushCandidate can be considered for further optimization,
+    * or if it has not yet been determined whether it is optimally placed.
+    */
+   bool isOptimallyPlaced() { return _optimallyPlaced;}
+
+   /**
+    * \brief Sets the status of this \c FlushCandidate, indicating whether
+    * it is known to be optimally placed above a volatile access node.
+    *
+    * \param setting The updated status indicating whether this \c FlushCandidate
+    * is known to be optimally placed.
+    */
+   void setOptimallyPlaced(bool setting) {_optimallyPlaced = setting;}
+
    private:
    TR::Node *_node;
    TR::TreeTop *_flushNode;
    int32_t _blockNum;
    Candidate *_candidate;
    bool _isKnownToLackCandidate;
+   bool _optimallyPlaced;
    };
 
 
@@ -782,7 +803,7 @@ class TR_LocalFlushElimination
    TR_LocalFlushElimination(TR_EscapeAnalysis *, int32_t numAllocations);
 
    virtual int32_t perform();
-   bool examineNode(TR::Node *, TR::NodeChecklist& visited);
+   bool examineNode(TR::Node *, TR::TreeTop *, TR::NodeChecklist& visited);
 
    TR::Optimizer *        optimizer()                     { return _escapeAnalysis->optimizer(); }
    TR::Compilation *        comp()                          { return _escapeAnalysis->comp(); }

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -60,6 +60,7 @@
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
 #include "infra/Annotations.hpp"
+#include "infra/ILWalk.hpp"
 #include "infra/Bit.hpp"
 #include "optimizer/VectorAPIExpansion.hpp"
 #include "p/codegen/ForceRecompilationSnippet.hpp"
@@ -3363,7 +3364,31 @@ TR::Register *J9::Power::TreeEvaluator::flushEvaluator(TR::Node *node, TR::CodeG
    if (opCode == TR::allocationFence)
       {
       if (!node->canOmitSync())
-         generateInstruction(cg, TR::InstOpCode::lwsync, node);
+         {
+         // If the following node will issue an lwsync then skip emitting one now. EscapeAnalysis can purposefully place
+         // an AllocationFence before a monexit or volatile access so that the codegen can optimize the memory flush
+         TR::TreeTop *tt = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();
+         TR::Node *node = tt->getNode();
+         TR::Node *child = (node->getNumChildren() >= 1) ? node->getFirstChild() : NULL;
+         if (!child || (node->getOpCodeValue() != TR::monexit && child->getOpCodeValue() != TR::monexit))
+            {
+            // Iterate the next tree to see if there is a resolved volatile load/store node that has yet to be evaluated
+            // An unresolved volatile might not actually be a volatile access, and therefore can not replace the AllocationFence
+            // An node that is already evaluated will not actually emit an 'lwsync' so it can not replace the AllocationFence
+            bool volatileAccessFound = false;
+            for (TR::PreorderNodeIterator it(tt, cg->comp()); it.currentTree() == tt; ++it)
+               {
+               node = it.currentNode();
+               if (node->getOpCode().hasSymbolReference() && !node->hasUnresolvedSymbolReference() && node->getSymbolReference()->getSymbol()->isVolatile() && !node->getRegister())
+                  {
+                  volatileAccessFound = true;
+                  break;
+                  }
+               }
+            if (!volatileAccessFound)
+               generateInstruction(cg, TR::InstOpCode::lwsync, node);
+            }
+         }
       }
    else
       {
@@ -4840,6 +4865,14 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
    TR::Compilation *comp = cg->comp();
    TR_YesNoMaybe isMonitorValueBasedOrValueType = cg->isMonitorValueBasedOrValueType(node);
+   bool unconditionalSync = false;
+
+   // WARNING:
+   // If there is an AllocationFence directly above this monExit we will not have emitted an
+   // lwsync for the fence and now must ensure that an lwsync is always executed for this monexit.
+   // When unconditionalSync is true, all paths through this method must emit an unconditional 'lwsync'!
+   if (cg->getCurrentEvaluationTreeTop()->getPrevTreeTop()->getNode()->getOpCodeValue() == TR::allocationFence)
+      unconditionalSync = true;
 
    if (comp->getOption(TR_FullSpeedDebug) ||
          (isMonitorValueBasedOrValueType == TR_yes) ||
@@ -4849,6 +4882,8 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
       TR::Node::recreate(node, TR::call);
       TR::Register *targetRegister = directCallEvaluator(node, cg);
       TR::Node::recreate(node, opCode);
+      if (comp->target().isSMP() && unconditionalSync == true)
+         generateInstruction(cg, TR::InstOpCode::lwsync, node);
       return targetRegister;
       }
 
@@ -5009,7 +5044,11 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
          TR::TreeEvaluator::evaluateLockForReservation(node, &reserveLocking, &normalLockWithReservationPreserving, cg);
 
       if (reserveLocking)
+         {
+         if (comp->target().isSMP() && unconditionalSync == true)
+            generateInstruction(cg, TR::InstOpCode::lwsync, node);
          return reservationLockExit(node, lwOffset, cg, conditions, baseReg, monitorReg, threadReg, tempReg, condReg, callLabel);
+         }
       }
 
    int32_t lockSize;
@@ -5058,8 +5097,9 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
        *    ld/lwz monitorReg, lwOffset(baseReg)
        *    li     tempReg, 0
        *    cmpl   cr0, monitorReg, metaReg
+       *    lwsync <if unconditionalSync>
        *    bne    decrementCheckLabel
-       *    lwsync
+       *    lwsync <if !unconditionalSync>
        *    st     tempReg, lwOffset(baseReg)
        *    b      doneLabel
        *
@@ -5089,11 +5129,13 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
       generateTrg1MemInstruction(cg, loadOpCode, node, monitorReg, TR::MemoryReference::createWithDisplacement(cg, baseReg, lwOffset, lockSize));
       generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, 0);
       generateTrg1Src2Instruction(cg, compareLogicalOpCode, node, condReg, monitorReg, metaReg);
+      if (comp->target().isSMP() && unconditionalSync == true)
+         generateInstruction(cg, TR::InstOpCode::lwsync, node);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, decrementCheckLabel, condReg);
 
       // exiting from read monitors still needs lwsync
       // (ensures loads have completed before releasing lock)
-      if (comp->target().isSMP())
+      if (comp->target().isSMP() && unconditionalSync == false)
          generateInstruction(cg, TR::InstOpCode::lwsync, node);
 
       generateMemSrc1Instruction(cg, storeOpCode, node, TR::MemoryReference::createWithDisplacement(cg, baseReg, lwOffset, lockSize), tempReg);


### PR DESCRIPTION
With Lock Reservation and Nested Locks it's possible for a monExit to skip executing a lwsync(ppc). Yet EA disables AllocationFence nodes when it encounters a monExit or a synchronized call before the object which the AllocationFence is guarding escapes. This allows for cases where no lwsync is executed before references to the object is stored to the heap which might result in a crash when other threads attempt to read the object contents on weak memory coherency CPUs (PPC & AArch64).

Optimizer Changes:
This fix changes EA so that it will insert new AllocationFence nodes before monExit or volatile-access nodes that EA has decided can replace the original AllocationFence. The code generator can then optimize the generation of lwsync instructions so that only one lwsync is executed and also insure that the one lwsync is unconditionally executed.

EA now keeps track of one TreeTop for each block where a monExit or volatile-access node exists. It prefers trees with volatile-access nodes over monExit nodes because volatile-access nodes always unconditionally execute sync instructions where monExit nodes can skip sync instruction in some cases.

It also removes the code that attempts to disable AllocationFence nodes when a synchronized call proceeds the escape of an object. There is no way to be sure that the unlock at the end of a synchronized call will actually execute an lwsync (due to lock reservation or nested locks). Therefore this code is unsafe and will be removed.

This change also fixes an issue where local flush elimination was not limiting it's actions to flush nodes that were in the same block as the allocation under consideration.

Lastly, the fix insures that AllocationFence nodes that have been disassociated with a single specific allocation (and is therefore serving as the fence for more then one allocation) is not considered as a candidate for removal later on in the same EA pass. This was possible when an earlier action in the EA pass had disassociated the fence before an attempt to find a replacement sync node for the AllocationFence was even attempted.

Code Generator Changes:
The PPC code generator was modified so that it would skip generating an lwsync for AllocationFence nodes when the next tree contains a monExit or a volatile-access node. In addition, when generating a monExit where the previous tree contains an AllocationFence, the lwsync will be generated in a location where it's unconditionally executed. These changes provide a generic "peephole" like optimization that the EA changes described above takes advantage of when it places AllocationFence nodes.

The AArch64 code generator will need to implement similar changes in order to optimize the number of sync instruction that are executed.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>