### PR TITLE
Disallow nop guards for interface call sites

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2847,7 +2847,7 @@ TR_MultipleCallTargetInliner::eliminateTailRecursion(
       backEdge = TR::CFGEdge::createEdge(gotoBlock,  branchDestination, trMemory());
       callerCFG->addEdge(backEdge);
       callerCFG->removeEdge(origEdge);
-      if (guard->_kind == TR_ProfiledGuard)
+      if (guard->_kind == TR_ProfiledGuard && !guard->_forceTakenSideCold)
          {
          if (block->getFrequency() < 0)
             block2->setFrequency(block->getFrequency());
@@ -6784,7 +6784,11 @@ TR_J9InlinerPolicy::suitableForRemat(TR::Compilation *comp, TR::Node *callNode, 
 
    bool suitableForRemat = true;
    TR_AddressInfo *valueInfo = static_cast<TR_AddressInfo*>(TR_ValueProfileInfoManager::getProfiledValueInfo(callNode, comp, AddressInfo));
-   if (guard->isHighProbablityProfiledGuard())
+   if (guard->_forceTakenSideCold)
+      {
+      // remat ok
+      }
+   else if (guard->isHighProbablityProfiledGuard())
       {
       if (comp->getMethodHotness() <= warm && comp->getPersistentInfo()->getJitState() == STARTUP_STATE)
          {

--- a/runtime/compiler/optimizer/J9CallGraph.hpp
+++ b/runtime/compiler/optimizer/J9CallGraph.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,6 +87,7 @@ class TR_J9InterfaceCallSite : public TR_ProfileableCallSite
    public:
       TR_CALLSITE_TR_ALLOC_AND_INHERIT_EMPTY_CONSTRUCTOR(TR_J9InterfaceCallSite, TR_ProfileableCallSite)
       virtual bool findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner);
+      bool findCallSiteTargetImpl (TR_CallStack *callStack, TR_InlinerBase* inliner);
       virtual TR_OpaqueClassBlock* getClassFromMethod ();
 		virtual const char*  name () { return "TR_J9InterfaceCallSite"; }
    protected:

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -824,26 +824,134 @@ bool TR_J9InterfaceCallSite::findCallSiteTargetImpl(TR_CallStack *callStack, TR_
    if (calleeResolvedMethod && !calleeResolvedMethod->virtualMethodIsOverridden())
       {
       TR_VirtualGuardKind kind = TR_ProfiledGuard;
+      TR_VirtualGuardTestType testType = TR_DummyTest;
+      TR_OpaqueClassBlock *thisClass = _receiverClass;
       if (_receiverClass != NULL
           && !TR::Compiler->cls.isInterfaceClass(comp(), _receiverClass))
          {
          kind = TR_InterfaceGuard;
+         testType = TR_MethodTest;
          }
       else
          {
-         // Profiled guard with method test must test for a method defined by a
-         // class that implements the expected interface. See the comment in
-         // TR_J9InterfaceCallSite::findCallSiteTarget().
+         // Whether to try to choose VFT test based on a non-extended defClass
+         // or based on profiling. This does not affect the final defClass
+         // heuristic because in that case we can be certain that the class
+         // won't be extended later.
+         bool useVftTestHeuristics = true;
+         TR::PersistentInfo *persistInfo = comp()->getPersistentInfo();
+         if (persistInfo->getJitState() == STARTUP_STATE)
+            {
+            const static bool useVftTestHeuristicsDuringStartup =
+               feGetEnv("TR_useInterfaceVftTestHeuristicsDuringStartup") != NULL;
+
+            useVftTestHeuristics = useVftTestHeuristicsDuringStartup;
+            }
+
+         // Profiled guards must guarantee that passing receivers are instances
+         // of some class that implements the expected interface. See the
+         // comment in TR_J9InterfaceCallSite::findCallSiteTarget().
+         //
+         // The choice of VFT test vs. method test is irrelevant here, as
+         // either one would accept instances of defClass. However, a VFT test
+         // obtained by consulting the profiled receiver types would work.
+         //
          TR_OpaqueClassBlock *defClass = calleeResolvedMethod->containingClass();
+         thisClass = defClass;
          TR_OpaqueClassBlock *iface = getClassFromMethod();
          if (fe()->isInstanceOf(defClass, iface, true, true, true) != TR_yes)
+            {
             calleeResolvedMethod = NULL; // hope to get a VFT test from profiling
+            }
+         // Heuristically choose between VFT test and method test. VFT test
+         // is cheaper, but method test can potentially allow the inlined
+         // body to be run for more receivers.
+         else if (TR::Compiler->cls.isClassFinal(comp(), defClass))
+            {
+            testType = TR_VftTest; // method test will never help
+            }
+         else if (useVftTestHeuristics && !fe()->classHasBeenExtended(defClass))
+            {
+            // Hope that defClass won't be extended in the future, or if it is,
+            // that its subtypes will override the inlined method anyway.
+            testType = TR_VftTest;
+            }
+         else
+            {
+            // There's already at least one subclass inheriting the single
+            // implementation. Choose method test because it covers the
+            // defining class and (so far) all of its subclasses. (If there
+            // were a subclass with its own override, then calleeResolvedMethod
+            // would be overridden.)
+            testType = TR_MethodTest;
+
+            // Still consult the profiling though, since it might reveal that
+            // one type is overwhelmingly frequent at this call site. In that
+            // case, change back to VFT test.
+            TR_ValueProfileInfoManager *profMgr =
+               TR_ValueProfileInfoManager::get(comp());
+
+            TR_AddressInfo *valueInfo = NULL;
+            if (profMgr != NULL)
+               {
+               valueInfo = static_cast<TR_AddressInfo*>(
+                  profMgr->getValueInfo(_bcInfo, comp(), AddressInfo));
+               }
+
+            if (useVftTestHeuristics
+                && valueInfo != NULL
+                && !comp()->getOption(TR_DisableProfiledInlining))
+               {
+               TR_ScratchList<TR_ExtraAddressInfo> byFreqDesc(comp()->trMemory());
+               valueInfo->getSortedList(comp(), &byFreqDesc);
+               ListIterator<TR_ExtraAddressInfo> it(&byFreqDesc);
+               uint32_t remainingTotalFreq = valueInfo->getTotalFrequency();
+               TR_OpaqueClassBlock *topProfiledClass = NULL;
+               uint32_t topProfiledFreq = 0;
+               TR_ExtraAddressInfo *cur = it.getFirst();
+               for (; cur != NULL; cur = it.getNext())
+                  {
+                  auto *curClass =
+                     reinterpret_cast<TR_OpaqueClassBlock*>(cur->_value);
+
+                  if (persistInfo->isObsoleteClass(curClass, comp()->fe())
+                      || fe()->isInstanceOf(curClass, iface, true, true, true) != TR_yes)
+                     {
+                     remainingTotalFreq -= cur->_frequency;
+                     }
+                  else if (topProfiledClass == NULL)
+                     {
+                     topProfiledClass = curClass;
+                     topProfiledFreq = cur->_frequency;
+                     }
+                  }
+
+               if (topProfiledClass != NULL
+                   && remainingTotalFreq >= 32
+                   && topProfiledFreq == remainingTotalFreq)
+                  {
+                  testType = TR_VftTest;
+                  thisClass = topProfiledClass;
+                  }
+               }
+            }
          }
 
       if (calleeResolvedMethod != NULL)
          {
-         TR_VirtualGuardSelection * guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(kind, TR_MethodTest);
-         addTarget(comp()->trMemory(),inliner,guard,calleeResolvedMethod,_receiverClass,heapAlloc);
+         TR_ASSERT_FATAL(testType != TR_DummyTest, "failed to select a guard test type");
+         TR_VirtualGuardSelection *guard =
+            new (comp()->trHeapMemory()) TR_VirtualGuardSelection(
+               kind, testType, thisClass);
+
+         addTarget(
+            comp()->trMemory(),
+            inliner,
+            guard,
+            calleeResolvedMethod,
+            thisClass,
+            heapAlloc);
+
          heuristicTrace(inliner->tracer(),"Call is an Interface with a Single Implementer guard %p\n", guard);
          return true;
          }

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -753,7 +753,7 @@ bool TR_J9InterfaceCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inl
          TR_OpaqueClassBlock *passClass = NULL;
          TR_ResolvedMethod *callee = tgt->_calleeMethod;
          if (tgt->_guard->_type == TR_VftTest)
-            passClass = tgt->_guard->_thisClass;
+            passClass = tgt->_receiverClass;
          else
             passClass = callee->containingClass();
 

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -944,6 +944,20 @@ bool TR_J9InterfaceCallSite::findCallSiteTargetImpl(TR_CallStack *callStack, TR_
             new (comp()->trHeapMemory()) TR_VirtualGuardSelection(
                kind, testType, thisClass);
 
+         if (kind == TR_ProfiledGuard)
+            {
+            // Almost all bytecode would pass type checking even including
+            // interface types. So even though this can't be a nop guard
+            // (because verification doesn't check interface types), treat it
+            // as much like a nop guard as possible. In particular, this will
+            // ensure that the block containing the cold call is actually
+            // marked cold, and ensure that priv. arg remat is allowed.
+            guard->_forceTakenSideCold = true;
+
+            // It is still a high-probability profiled guard...
+            guard->setIsHighProbablityProfiledGuard();
+            }
+
          addTarget(
             comp()->trMemory(),
             inliner,

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -840,7 +840,7 @@ bool TR_J9InterfaceCallSite::findCallSiteTargetImpl(TR_CallStack *callStack, TR_
          // won't be extended later.
          bool useVftTestHeuristics = true;
          TR::PersistentInfo *persistInfo = comp()->getPersistentInfo();
-         if (persistInfo->getJitState() == STARTUP_STATE)
+         if (TR::Compiler->vm.isVMInStartupPhase(comp()->fej9()->getJ9JITConfig()))
             {
             const static bool useVftTestHeuristicsDuringStartup =
                feGetEnv("TR_useInterfaceVftTestHeuristicsDuringStartup") != NULL;


### PR DESCRIPTION
...unless inliner has already proved that the receiver is an instance of a particular class that implements the expected interface. (However, it appears that it is currently difficult or maybe impossible to get such a bound despite `tryToRefineReceiverClassBasedOnResolvedTypeArgInfo()`).

A passing `vgnop`-based interface guard can guarantee the receiver type is as expected by the inlined body, but only if we already know before the guard that the receiver implements the expected interface. Here, an interface type bound is insufficient to know that, because bytecode verification does not guarantee any particular receiver type at `invokeinterface`.

As such, in the absence of a class (i.e. non-interface) type bound on the receiver, all targets must use profiled guard. Additionally, the profiled guard must ensure on the hot side that the receiver is an instance of the interface expected at this call site.

There was one circumstance where it was possible to generate a profiled guard with method test for a method defined by a class that does not implement the interface. Inliner now uses a VFT test instead in this situation. Only hot compilations performed during startup are affected.

It was also possible to generate an interface (nop) guard for a single implementer method defined by a class that does not implement the interface. Since this must now be a profiled guard, inliner will only accept single implementers defined by classes that do implement the interface. Others will be rejected in the hope that it will be possible to generate a VFT test based on profiling.

Without these precautions, it would be possible for the JIT to inline a single implementing method with a nop guard, and for execution to flow into the inlined body with a receiver that is not an instance of the class expected by the inlined code. The inlined code could then access fields of the receiver as though it were of the expected type.

-----

This series has a few additional changes mainly to reduce the performance impact of all of the additional profiled guards:
- Correct interface call site assertion
- Heuristically consider VFT test for interface call profiled guards
- Be more confident about single interface implementer profiled guards
- Base interface inlining determination directly on VM startup phase