### PR TITLE
Revert "Avoid to cache scavenger too early in StandardAccessBarrier"

### DIFF
--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -38,6 +38,7 @@
 #include "HeapRegionIterator.hpp"
 #include "HeapRegionManager.hpp"
 #include "GlobalCollector.hpp"
+#include "ObjectAccessBarrier.hpp"
 #include "ObjectAllocationInterface.hpp"
 #include "ObjectModel.hpp"
 #include "OwnableSynchronizerObjectBuffer.hpp"

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -143,10 +143,6 @@ MM_ScavengerDelegate::initialize(MM_EnvironmentBase *env)
 		_flushCachesAsyncCallbackKey = _javaVM->internalVMFunctions->J9RegisterAsyncEvent(_javaVM, concurrentScavengerAsyncCallbackHandlerDelegate, NULL);
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
-#if defined(J9VM_GC_GENERATIONAL)
-	MM_StandardAccessBarrier *stdBarrier = (MM_StandardAccessBarrier *)_extensions->accessBarrier;
-	stdBarrier->setScavenger(_extensions->scavenger);
-#endif /* J9VM_GC_GENERATIONAL */
 
 	return true;
 }

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -80,6 +80,7 @@ MM_StandardAccessBarrier::initialize(MM_EnvironmentBase *env)
 	if (!_generationalAccessBarrierComponent.initialize(env)) {
 		return false;
 	}
+	_scavenger = MM_GCExtensions::getExtensions(env)->scavenger;
 #endif /* J9VM_GC_GENERATIONAL */
 	
 	return MM_ObjectAccessBarrier::initialize(env);

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -49,7 +49,7 @@ class MM_StandardAccessBarrier : public MM_ObjectAccessBarrier
 private:
 #if defined(J9VM_GC_GENERATIONAL)
 	MM_GenerationalAccessBarrierComponent _generationalAccessBarrierComponent;	/**< Generational Component of Access Barrier */
-	MM_Scavenger *_scavenger;	/**< caching MM_GCExtensions::scavenger,  initialization is postponed in MM_ScavengerDelegate::initialize(), due to StandardAccessBarrier is initialized earlier than scavenger is setup. */
+	MM_Scavenger *_scavenger;	/**< caching MM_GCExtensions::scavenger */
 #endif /* J9VM_GC_GENERATIONAL */
 	MM_MarkingScheme *_markingScheme;	/**< caching MM_MarkingScheme instance */
 
@@ -79,9 +79,6 @@ public:
 		_typeId = __FUNCTION__;
 	}
 
-#if defined(J9VM_GC_GENERATIONAL)
-	void setScavenger(MM_Scavenger *scavenger) { _scavenger = scavenger; }
-#endif /* J9VM_GC_GENERATIONAL */
 	virtual J9Object* asConstantPoolObject(J9VMThread *vmThread, J9Object* toConvert, UDATA allocationFlags);
 
 	virtual void rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object);


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#16137

Needs an OMR change for this fix to work properly. Reverting till OMR change is in.