### PR TITLE
Remove uses of unsupported freetype configure options

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -619,8 +619,6 @@ When you have all the source files that you need, run the configure script, whic
 bash configure --with-boot-jdk=<path_to_boot_JDK11>
 ```
 
-:pencil: Modify the path for the macOS boot JDK that you installed in step 1. If `configure` is unable to detect Freetype, add the option `--with-freetype=<path to freetype>`, where `<path to freetype>` is typically `/usr/local/Cellar/freetype/2.9.1/`.
-
 :pencil: Configuring and building is not specific to OpenJ9 but uses the OpenJDK build infrastructure with OpenJ9 added.
 Many other configuration options are available, including options to increase the verbosity of the build output to include command lines (`LOG=cmdlines`), more info or debug information.
 For more information see [OpenJDK build troubleshooting](https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk11u/master/doc/building.html#troubleshooting).

--- a/doc/build-instructions/Build_Instructions_V17.md
+++ b/doc/build-instructions/Build_Instructions_V17.md
@@ -614,8 +614,6 @@ When you have all the source files that you need, run the configure script, whic
 bash configure --with-boot-jdk=<path_to_boot_JDK17>
 ```
 
-:pencil: Modify the path for the macOS boot JDK that you installed in step 1. If `configure` is unable to detect Freetype, add the option `--with-freetype=<path to freetype>`, where `<path to freetype>` is typically `/usr/local/Cellar/freetype/2.9.1/`.
-
 :pencil: Configuring and building is not specific to OpenJ9 but uses the OpenJDK build infrastructure with OpenJ9 added.
 Many other configuration options are available, including options to increase the verbosity of the build output to include command lines (`LOG=cmdlines`), more info or debug information.
 For more information see [OpenJDK build troubleshooting](https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk17u/master/doc/building.html#troubleshooting).

--- a/doc/build-instructions/Build_Instructions_V18.md
+++ b/doc/build-instructions/Build_Instructions_V18.md
@@ -614,8 +614,6 @@ When you have all the source files that you need, run the configure script, whic
 bash configure --with-boot-jdk=<path_to_boot_JDK17>
 ```
 
-:pencil: Modify the path for the macOS boot JDK that you installed in step 1. If `configure` is unable to detect Freetype, add the option `--with-freetype=<path to freetype>`, where `<path to freetype>` is typically `/usr/local/Cellar/freetype/2.9.1/`.
-
 :pencil: Configuring and building is not specific to OpenJ9 but uses the OpenJDK build infrastructure with OpenJ9 added.
 Many other configuration options are available, including options to increase the verbosity of the build output to include command lines (`LOG=cmdlines`), more info or debug information.
 For more information see [OpenJDK build troubleshooting](https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk18u/master/doc/building.html#troubleshooting).

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -479,7 +479,7 @@ bash configure --disable-ccache \
 ```
 bash configure --disable-ccache \
                --with-boot-jdk=/cygdrive/c/<path_to_jdk8> \
-               --with-freetype-src=/cygdrive/c/temp/freetype
+               --with-freetype-src=/cygdrive/c/temp/freetype \
                --with-target-bits=32
 ```
 Note: If you have multiple versions of Visual Studio installed, you can enforce a specific version to be used by setting `--with-toolchain-version`, i.e., by including `--with-toolchain-version=2013` option in the configure command.


### PR DESCRIPTION
* add missing line-continuation for jdk8
* remove advice to use `--with-freetype=<path>` with jdk11+ to avoid this error
> configure: error: 'valid values for --with-freetype are 'system' and 'bundled'

