### PR TITLE
Handle mounted CarrierThread in Thread.getStackTrace

### DIFF
--- a/runtime/jcl/common/getstacktrace.c
+++ b/runtime/jcl/common/getstacktrace.c
@@ -32,26 +32,45 @@
 #include "ut_j9jcl.h"
 #include "vmaccess.h"
 
-
-
+/**
+ * Creates a throwable object containing the stacktrace of threadObject.
+ * @param[in] currentThread
+ * @param[in] targetThread the J9VMThread that threadObject is running on.
+ * @param[in] skipCount number of frames to skip during stackwalk (ignored if walking continuation stack).
+ * @param[in] threadObject the target thread object to retrieve stacktrace on.
+ * @return throwable object
+ */
 j9object_t
-getStackTraceForThread(J9VMThread *currentThread, J9VMThread *targetThread, UDATA skipCount)
+getStackTraceForThread(J9VMThread *currentThread, J9VMThread *targetThread, UDATA skipCount, j9object_t threadObject)
 {
 	J9JavaVM * vm = currentThread->javaVM;
 	J9InternalVMFunctions * vmfns = vm->internalVMFunctions;
 	j9object_t throwable = NULL;
-	J9StackWalkState walkState;
-	UDATA rc;
-
+	J9StackWalkState walkState = {0};
+	UDATA rc = J9_STACKWALK_RC_NONE;
+#if JAVA_SPEC_VERSION >= 19
+	J9VMContinuation *continuation = targetThread->currentContinuation;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	/* Halt the target thread */
 	vmfns->haltThreadForInspection(currentThread, targetThread);
 
 	/* walk stack and cache PCs */
-	walkState.walkThread = targetThread;
 	walkState.flags = J9_STACKWALK_CACHE_PCS | J9_STACKWALK_WALK_TRANSLATE_PC | J9_STACKWALK_SKIP_INLINES | J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
-	walkState.skipCount = skipCount;
-	rc = vm->walkStackFrames(currentThread, &walkState);
-
+#if JAVA_SPEC_VERSION >= 19
+	if ((NULL != continuation) && (threadObject != targetThread->threadObject)) {
+		/* If targetThread has a continuation mounted and its current threadObject doesn't match the
+		 * target threadObject, then the carrier thread's stacktrace is retrieved through the cached
+		 * state in the continuation.
+		 */
+		walkState.skipCount = 0;
+		rc = vmfns->walkContinuationStackFrames(currentThread, continuation, &walkState);
+	} else
+#endif /* JAVA_SPEC_VERSION >= 19 */
+	{
+		walkState.walkThread = targetThread;
+		walkState.skipCount = skipCount;
+		rc = vm->walkStackFrames(currentThread, &walkState);
+	}
 	/* Now that the stack trace has been copied, resume the thread */
 	vmfns->resumeThreadForInspection(currentThread, targetThread);
 
@@ -71,7 +90,7 @@ fail:
 }
 
 j9object_t
-createStackTraceThrowable(J9VMThread *currentThread,  const UDATA *frames, UDATA maxFrames)
+createStackTraceThrowable(J9VMThread *currentThread, const UDATA *frames, UDATA maxFrames)
 {
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmfns = vm->internalVMFunctions;

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -755,7 +755,7 @@ jint JNICALL JCL_OnLoad (JavaVM * vm, void *reserved);
 extern J9_CFUNC j9object_t
 createStackTraceThrowable (J9VMThread *currentThread,  const UDATA *frames, UDATA maxFrames);
 extern J9_CFUNC j9object_t
-getStackTraceForThread (J9VMThread * vmThread, J9VMThread *targetThread, UDATA skipCount);
+getStackTraceForThread (J9VMThread *vmThread, J9VMThread *targetThread, UDATA skipCount, j9object_t threadObject);
 
 /* J9SourceJclStandardInit*/
 jint JCL_OnUnload (J9JavaVM* vm, void* reserved);


### PR DESCRIPTION
For threads with continuation mounted, check if the caller expects
the stacktrace from the virtual thread or carrier thread.

Fix: #15247 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>