### PR TITLE
Fix JDKNext duplicated Access API definitions

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -518,40 +518,6 @@ final class Access implements JavaLangAccess {
 		return Thread.currentCarrierThread();
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 20]*/
-	/*
-	 * To access package-private methods in ThreadLocal, an
-	 * (implicit) cast from CarrierThreadLocal is required.
-	 */
-	private static <T> ThreadLocal<T> asThreadLocal(CarrierThreadLocal<T> local) {
-		return local;
-	}
-
-	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> local) {
-		return asThreadLocal(local).getCarrierThreadLocal();
-	}
-
-	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> local) {
-		return asThreadLocal(local).isCarrierThreadLocalPresent();
-	}
-
-	public void removeCarrierThreadLocal(CarrierThreadLocal<?> local) {
-		asThreadLocal(local).removeCarrierThreadLocal();
-	}
-
-	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> local, T value) {
-		asThreadLocal(local).setCarrierThreadLocal(value);
-	}
-/*[ELSE] JAVA_SPEC_VERSION >= 20 */
-	public <T> T getCarrierThreadLocal(ThreadLocal<T> local) {
-		return local.getCarrierThreadLocal();
-	}
-
-	public <T> void setCarrierThreadLocal(ThreadLocal<T> local, T value) {
-		local.setCarrierThreadLocal(value);
-	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
-
 	public <V> V executeOnCarrierThread(Callable<V> task) throws Exception {
 		V result;
 		Thread currentThread = Thread.currentThread();
@@ -645,20 +611,28 @@ final class Access implements JavaLangAccess {
 		return StackWalker.newInstance(options, null, contScope, continuation);
 	}
 
+	/*
+	 * To access package-private methods in ThreadLocal, an
+	 * (implicit) cast from CarrierThreadLocal is required.
+	 */
+	private static <T> ThreadLocal<T> asThreadLocal(CarrierThreadLocal<T> local) {
+		return local;
+	}
+
 	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> carrierThreadlocal) {
-		return ((ThreadLocal<?>)carrierThreadlocal).isCarrierThreadLocalPresent();
+		return asThreadLocal(carrierThreadlocal).isCarrierThreadLocalPresent();
 	}
 
 	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal) {
-		return ((ThreadLocal<T>)carrierThreadlocal).getCarrierThreadLocal();
+		return asThreadLocal(carrierThreadlocal).getCarrierThreadLocal();
 	}
 
 	public void removeCarrierThreadLocal(CarrierThreadLocal<?> carrierThreadlocal) {
-		((ThreadLocal<?>)carrierThreadlocal).removeCarrierThreadLocal();
+		asThreadLocal(carrierThreadlocal).removeCarrierThreadLocal();
 	}
 
 	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal, T carrierThreadLocalvalue) {
-		((ThreadLocal<T>)carrierThreadlocal).setCarrierThreadLocal(carrierThreadLocalvalue);
+		asThreadLocal(carrierThreadlocal).setCarrierThreadLocal(carrierThreadLocalvalue);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 


### PR DESCRIPTION
Fix JDKNext duplicated Access API definitions

closes https://github.com/eclipse-openj9/openj9/issues/16162

Signed-off-by: Jason Feng <fengj@ca.ibm.com>