### PR TITLE
Remove duplicate methods for CarrierThreadLocal in jdk20

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -518,7 +518,7 @@ final class Access implements JavaLangAccess {
 		return Thread.currentCarrierThread();
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 20]*/
+/*[IF JAVA_SPEC_VERSION >= 19]*/
 	/*
 	 * To access package-private methods in ThreadLocal, an
 	 * (implicit) cast from CarrierThreadLocal is required.
@@ -542,7 +542,7 @@ final class Access implements JavaLangAccess {
 	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> local, T value) {
 		asThreadLocal(local).setCarrierThreadLocal(value);
 	}
-/*[ELSE] JAVA_SPEC_VERSION >= 20 */
+/*[ELSE] JAVA_SPEC_VERSION >= 19 */
 	public <T> T getCarrierThreadLocal(ThreadLocal<T> local) {
 		return local.getCarrierThreadLocal();
 	}
@@ -550,7 +550,7 @@ final class Access implements JavaLangAccess {
 	public <T> void setCarrierThreadLocal(ThreadLocal<T> local, T value) {
 		local.setCarrierThreadLocal(value);
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
 	public <V> V executeOnCarrierThread(Callable<V> task) throws Exception {
 		V result;
@@ -643,22 +643,6 @@ final class Access implements JavaLangAccess {
 
 	public StackWalker newStackWalkerInstance(Set<StackWalker.Option> options, ContinuationScope contScope, Continuation continuation) {
 		return StackWalker.newInstance(options, null, contScope, continuation);
-	}
-
-	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> carrierThreadlocal) {
-		return ((ThreadLocal<?>)carrierThreadlocal).isCarrierThreadLocalPresent();
-	}
-
-	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal) {
-		return ((ThreadLocal<T>)carrierThreadlocal).getCarrierThreadLocal();
-	}
-
-	public void removeCarrierThreadLocal(CarrierThreadLocal<?> carrierThreadlocal) {
-		((ThreadLocal<?>)carrierThreadlocal).removeCarrierThreadLocal();
-	}
-
-	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal, T carrierThreadLocalvalue) {
-		((ThreadLocal<T>)carrierThreadlocal).setCarrierThreadLocal(carrierThreadLocalvalue);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/16162

See, for example in https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_mac_OpenJDK/27/console:
```
00:05:22.218  === Output from failing command(s) repeated here ===
00:05:22.218  * For target jdk_modules_java.base__the.java.base_batch:
00:05:22.218  /Users/jenkins/workspace/Build_JDKnext_aarch64_mac_OpenJDK/build/macosx-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:545: error: method isCarrierThreadLocalPresent(CarrierThreadLocal<?>) is already defined in class Access
00:05:22.218  	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> carrierThreadlocal) {
00:05:22.218  	               ^
00:05:22.218  /Users/jenkins/workspace/Build_JDKnext_aarch64_mac_OpenJDK/build/macosx-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:549: error: method <T>getCarrierThreadLocal(CarrierThreadLocal<T>) is already defined in class Access
00:05:22.218  	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal) {
00:05:22.218  	             ^
00:05:22.218    where T is a type-variable:
00:05:22.218      T extends Object declared in method <T>getCarrierThreadLocal(CarrierThreadLocal<T>)
00:05:22.218  /Users/jenkins/workspace/Build_JDKnext_aarch64_mac_OpenJDK/build/macosx-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:553: error: method removeCarrierThreadLocal(CarrierThreadLocal<?>) is already defined in class Access
00:05:22.218  	public void removeCarrierThreadLocal(CarrierThreadLocal<?> carrierThreadlocal) {
00:05:22.218  	            ^
00:05:22.218  /Users/jenkins/workspace/Build_JDKnext_aarch64_mac_OpenJDK/build/macosx-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:557: error: method <T>setCarrierThreadLocal(CarrierThreadLocal<T>,T) is already defined in class Access
00:05:22.218  	public <T> void setCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal, T carrierThreadLocalvalue) {
00:05:22.218  	                ^
00:05:22.218    where T is a type-variable:
00:05:22.218     ... (rest of output omitted)
```