### PR TITLE
Give a name to the default JITServer AOT cache

### DIFF
--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -168,7 +168,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerUseAOTCache(false),
          _requireJITServer(false),
          _localSyncCompiles(true),
-         _JITServerAOTCacheName(),
+         _JITServerAOTCacheName("default"),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}


### PR DESCRIPTION
The default name of the AOT cache that a client will request from a JITServer instance is now "default". Formerly it was nameless (the empty string).

Fixes: #16107
Signed-off-by: Christian Despres <despresc@ibm.com>