### PR TITLE
Get defined argument from the bottom of the vmInitArgs->options array

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4691,7 +4691,7 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *getAnnotationsFromAnnotationInfo)(struct J9AnnotationInfo *annInfo, UDATA annotationType, char *memberName, U_32 memberNameLength, char *memberSignature, U_32 memberSignatureLength, struct J9AnnotationInfoEntry **annotations) ;
 	struct J9AnnotationInfoEntry*  ( *getAnnotationFromAnnotationInfo)(struct J9AnnotationInfo *annInfo, UDATA annotationType, char *memberName, U_32 memberNameLength, char *memberSignature, U_32 memberSignatureLength, char *annotationName, U_32 annotationNameLength) ;
 	void*  ( *getNamedElementFromAnnotation)(struct J9AnnotationInfoEntry *annotation, char *name, U_32 nameLength) ;
-	UDATA  ( *registerNativeLibrary)(struct J9VMThread * vmThread, struct J9ClassLoader * classLoader, const char * libName, char * libraryPath, struct J9NativeLibrary** libraryPtr, char* errorBuffer, UDATA bufferLength) ;
+	UDATA  ( *registerNativeLibrary)(struct J9VMThread *vmThread, struct J9ClassLoader *classLoader, const char *libName, const char *libraryPath, struct J9NativeLibrary **libraryPtr, char *errorBuffer, UDATA bufferLength) ;
 	UDATA  ( *registerBootstrapLibrary)(struct J9VMThread * vmThread, const char * libName, struct J9NativeLibrary** libraryPtr, UDATA suppressError) ;
 	UDATA  ( *startJavaThread)(struct J9VMThread * currentThread, j9object_t threadObject, UDATA privateFlags,  UDATA osStackSize, UDATA priority, omrthread_entrypoint_t entryPoint, void * entryArg, j9object_t schedulingParameters) ;
 	j9object_t  ( *createCachedOutOfMemoryError)(struct J9VMThread * currentThread, j9object_t threadObject) ;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -180,13 +180,16 @@ instanceOfOrCheckCastNoCacheUpdate( J9Class *instanceClass, J9Class *castClass )
 /* ---------------- defarg.c ---------------- */
 
 /**
-* @brief
-* @param arg
-* @param key
-* @return char *
-*/
-char *getDefineArgument(char* arg, char* key);
-
+ * Look for the defined argument starting at the bottom of
+ * the vmInitArgs->options array.
+ *
+ * @param vmInitArgs a JavaVMInitArgs structure
+ * @param defArg the defined argument to be found
+ *
+ * @return the argument string value found or NULL
+ */
+const char*
+getDefinedArgumentFromJavaVMInitArgs(JavaVMInitArgs *vmInitArgs, const char *defArg);
 
 /* ---------------- divhelp.c ---------------- */
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3907,7 +3907,7 @@ registerBootstrapLibrary(J9VMThread * vmThread, const char * libName, J9NativeLi
 * @return UDATA
 */
 UDATA
-registerNativeLibrary(J9VMThread * vmThread, J9ClassLoader * classLoader, const char * libName, char * libraryPath, J9NativeLibrary** libraryPtr, char* errorBuffer, UDATA bufferLength);
+registerNativeLibrary(J9VMThread *vmThread, J9ClassLoader *classLoader, const char *libName, const char *libraryPath, J9NativeLibrary **libraryPtr, char *errorBuffer, UDATA bufferLength);
 
 
 /**

--- a/runtime/util/defarg.c
+++ b/runtime/util/defarg.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,31 +25,63 @@
 #include "util_internal.h"
 #include "ut_j9util.h"
 
-/* parse arg to determine if it is of the form -Darg=foo, and return foo.
- * Returns an empty string for args of the form -Darg,
- * Returns NULL if the argument is not recognized
- */
-char *
-getDefineArgument(char* arg, char* key)
-{
-	Trc_Util_getDefineArgument_Entry(arg, key);
-	if (arg[0] == '-' && arg[1] == 'D') {
-		size_t keyLength = strlen(key);
+static const char* getDefineArgument(const char *arg, const char *key, const size_t keyLength);
 
-		if (strncmp(&arg[2], key, keyLength) == 0) {
+/**
+ * Parse arg to determine if it is of the form -Darg=foo, and return foo.
+ * Returns an empty string for args of the form -Darg.
+ * Returns NULL if the argument is not recognized.
+ *
+ * @param arg the defined argument
+ * @param key the argument key
+ * @param keyLength the key length
+ *
+ * @return the argument value or NULL
+ */
+static const char*
+getDefineArgument(const char *arg, const char *key, const size_t keyLength)
+{
+	const char *result = NULL;
+
+	Trc_Util_getDefineArgument_Entry(arg, key);
+	if (('-' == arg[0]) && ('D' == arg[1])) {
+		if (0 == strncmp(&arg[2], key, keyLength)) {
 			switch (arg[2 + keyLength]) {
-			case '=': 
+			case '=':
 				Trc_Util_getDefineArgument_Exit(&arg[3 + keyLength]);
-				return &arg[3 + keyLength];
-			case '\0': 
+				result = &arg[3 + keyLength];
+				break;
+			case '\0':
 				Trc_Util_getDefineArgument_Empty();
-				return "";
+				result = "";
+				/* Fall through case !!! */
+			default:
+				break;
 			}
 		}
 	}
 
-	Trc_Util_getDefineArgument_NotFound();
-	return NULL;
+	if (NULL == result) {
+		Trc_Util_getDefineArgument_NotFound();
+	}
+	return result;
 }
 
+const char*
+getDefinedArgumentFromJavaVMInitArgs(JavaVMInitArgs *vmInitArgs, const char *defArg)
+{
+	const char *result = NULL;
+	const size_t defArgLength = strlen(defArg);
+	jint count = 0;
 
+	Trc_Util_getDefinedArgumentFromJavaVMInitArgs_Entry(vmInitArgs, defArg);
+	for (count = (vmInitArgs->nOptions - 1); count >= 0; count--) {
+		JavaVMOption *option = &(vmInitArgs->options[count]);
+		result = getDefineArgument(option->optionString, defArg, defArgLength);
+		if (NULL != result){
+			break;
+		}
+	}
+	Trc_Util_getDefinedArgumentFromJavaVMInitArgs_Exit(result);
+	return result;
+}

--- a/runtime/util/util.tdf
+++ b/runtime/util/util.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2021 IBM Corp. and others
+// Copyright (c) 2006, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,3 +82,5 @@ TraceExit=Trc_Util_validateLibrary_Exit Noenv Overhead=1 Level=5 Template="valid
 
 TraceEvent=Trc_Util_thrhelp_initializeCurrentOSStackFree Overhead=1 Level=1 Template="Setup osStack free for osthread=%p requested stacksize=%zu realStacksize=%zu (zero is not found) stackfree=%zu starting sp=%p"
 
+TraceEntry=Trc_Util_getDefinedArgumentFromJavaVMInitArgs_Entry Noenv Overhead=1 Level=3 Template="getDefinedArgumentFromJavaVMInitArgs (vmInitArgs=%p, defArg=%s)"
+TraceExit=Trc_Util_getDefinedArgumentFromJavaVMInitArgs_Exit Noenv Overhead=1 Level=3 Template="getDefinedArgumentFromJavaVMInitArgs (result=%s)"

--- a/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/playlist.xml
@@ -67,4 +67,26 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTester_SysPropRepeatDefinesTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-DJARPATH=$(Q)$(TEST_RESROOT)$(D)SystemPropertiesTest.jar$(Q) \
+			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(SQ) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)sysproprepeatdefinestest.xml$(Q) \
+			-nonZeroExitWhenError; \
+			$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropRepeatDefinesTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropRepeatDefinesTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class SysPropRepeatDefinesTest {
+
+	public static void main(String args[]) throws Exception {
+		if (args.length < 2) {
+			throw new Exception("System property name and expected value are required!");
+		}
+
+		String propName = args[0];
+		String expectedPropValue = args[1];
+
+		assertEquals("system property: " + propName, System.getProperty(propName), expectedPropValue);
+		System.out.println("Test passed.");
+	}
+
+	private static void assertEquals(String message, String actual, String expected) throws Exception {
+		if (!expected.equals(actual)) {
+			throw new Exception("Test failed: " + message + " got: " + actual + ", but expected: " + expected);
+		}
+	}
+}

--- a/test/functional/cmdLineTests/SystemPropertiesTest/sysproprepeatdefinestest.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/sysproprepeatdefinestest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2022, 2022 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="System Properties Defines Tests" timeout="200">
+	<variable name="DEFINE_FILE_ENCODING_ISO88591" value="-Dfile.encoding=ISO-8859-1"/>
+	<variable name="DEFINE_FILE_ENCODING_UTF8" value="-Dfile.encoding=UTF-8"/>
+	<variable name="PROP_NAME_FILE_ENCODING" value="file.encoding"/>
+	<variable name="PROP_VALUE_UTF8" value="UTF-8"/>
+	<variable name="PROP_VALUE_ISO88591" value="ISO-8859-1"/>
+
+	<test id="Test 1: -Dfile.encoding=ISO-8859-1 -Dfile.encoding=UTF-8">
+		<command>$EXE$ $DEFINE_FILE_ENCODING_ISO88591$ $DEFINE_FILE_ENCODING_UTF8$ -cp $Q$$JARPATH$$Q$ SysPropRepeatDefinesTest $PROP_NAME_FILE_ENCODING$ $PROP_VALUE_UTF8$</command>
+		<output regex="no" type="success">Test passed.</output>
+		<output regex="no" type="required">Test passed.</output>
+		<output type="failure" caseSensitive="no" regex="no">Test failed:</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 2: -Dfile.encoding=UTF-8 -Dfile.encoding=ISO-8859-1">
+		<command>$EXE$ $DEFINE_FILE_ENCODING_UTF8$ $DEFINE_FILE_ENCODING_ISO88591$ -cp $Q$$JARPATH$$Q$ SysPropRepeatDefinesTest $PROP_NAME_FILE_ENCODING$ $PROP_VALUE_ISO88591$</command>
+		<output regex="no" type="success">Test passed.</output>
+		<output regex="no" type="required">Test passed.</output>
+		<output type="failure" caseSensitive="no" regex="no">Test failed:</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+</suite>


### PR DESCRIPTION
Add `getDefinedArgumentFromJavaVMInitArgs()` to look for the defined argument starting at the bottom of the `vmInitArgs->options` array; 
Refactor `getDefineArgument()` and its usages;
Replaced `getDefinedEncoding()` with `getDefinedArgumentFromJavaVMInitArgs()`;
Add a test.

[Internal personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/14543/)
[Internal IBM Java 8 build](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=38956)

closes https://github.com/eclipse-openj9/openj9/issues/16080

Signed-off-by: Jason Feng <fengj@ca.ibm.com>