### PR TITLE
Get threadObject from targetThread in mgmtthread.c::getThreadInfo

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -1326,9 +1326,9 @@ getThreadInfo(J9VMThread *currentThread, J9VMThread *targetThread, ThreadInfo *i
 	J9VMThread stackThread = {0};
 	J9VMEntryLocalStorage els = {0};
 	J9VMContinuation *continuation = targetThread->currentContinuation;
-	j9object_t threadObject = currentThread->carrierThreadObject;
+	j9object_t threadObject = targetThread->carrierThreadObject;
 #else /* JAVA_SPEC_VERSION >= 19 */
-	j9object_t threadObject = currentThread->threadObject;
+	j9object_t threadObject = targetThread->threadObject;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 	Trc_JCL_threadmxbean_getThreadInfo_Entry(currentThread, targetThread);


### PR DESCRIPTION
Fixes the typo introduced in #15956. `targetThread` should be used instead
of `currentThread` for retrieving the `threadObject`.

Related: https://github.com/eclipse-openj9/openj9/commit/ce4d4a3c5811ee3e446df6b066e9bbdfd39f2751#r87746489
Related: #14538

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>