### PR TITLE
Remove uses of unsupported freetype configure options

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -355,7 +355,7 @@ x86-64_windows:
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
   extra_configure_options:
     all: '--disable-ccache --with-cuda="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.0"'
-    8: '--with-toolchain-version=2017 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3'
+    8: '--with-toolchain-version=2017'
     11: '--with-toolchain-version=2019'
     17: '--with-toolchain-version=2019'
     18: '--with-toolchain-version=2019'
@@ -378,7 +378,7 @@ x86-32_windows:
   release:
     8: 'windows-x86-normal-server-release'
   extra_configure_options:
-    8: '--with-toolchain-version=2017 --with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-target-bits=32 --disable-ccache'
+    8: '--with-toolchain-version=2017 --with-target-bits=32 --disable-ccache'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
   node_labels:
     build:
@@ -401,7 +401,7 @@ x86-64_mac:
     8: 'macosx-x86_64-normal-server-release'
     11: 'macosx-x86_64-normal-server-release'
   extra_configure_options:
-    8: '--with-toolchain-type=clang --with-freetype=/usr/local/freetype-2.9.1'
+    8: '--with-toolchain-type=clang'
   freemarker: '/Users/jenkins/freemarker.jar'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -471,15 +471,13 @@ When you have all the source files that you need, run the configure script, whic
 1) Win 64-bit
 ```
 bash configure --disable-ccache \
-               --with-boot-jdk=/cygdrive/c/<path to_jdk8> \
-               --with-freetype-src=/cygdrive/c/temp/freetype
+               --with-boot-jdk=/cygdrive/c/<path to_jdk8>
 ```
 
 2) Win 32-bit
 ```
 bash configure --disable-ccache \
                --with-boot-jdk=/cygdrive/c/<path_to_jdk8> \
-               --with-freetype-src=/cygdrive/c/temp/freetype \
                --with-target-bits=32
 ```
 Note: If you have multiple versions of Visual Studio installed, you can enforce a specific version to be used by setting `--with-toolchain-version`, i.e., by including `--with-toolchain-version=2013` option in the configure command.
@@ -660,8 +658,6 @@ When you have all the source files that you need, run the configure script, whic
 bash configure \
     TAR=gtar \
     --with-boot-jdk=<path_to_boot_JDK8> \
-    --with-freetype-include=/usr/local/include/freetype2 \
-    --with-freetype-lib=/usr/local/lib \
     --with-toolchain-type=clang
 ```
 


### PR DESCRIPTION
* remove uses of `--with-freetype=`
* remove uses of `--with-freetype-src=`

Must be merged concurrently with https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/631.