### PR TITLE
Handle continuation mounting case during Metronome GC

### DIFF
--- a/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
@@ -68,9 +68,8 @@ stackSlotIteratorForCompactScheme(J9JavaVM *javaVM, J9Object **slotPtr, void *lo
 
 
 void
-MM_CompactSchemeFixupObject::fixupContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
+MM_CompactSchemeFixupObject::fixupContinuationNativeSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
 {
-	fixupMixedObject(objectPtr);
 	/* fixup Java Stacks in J9VMContinuation */
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	/* In sliding compaction we must fix slots exactly once. Since we will fixup stack slots of
@@ -85,6 +84,14 @@ MM_CompactSchemeFixupObject::fixupContinuationObject(MM_EnvironmentStandard *env
 
 		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForCompactScheme, false, false);
 	}
+}
+
+void
+MM_CompactSchemeFixupObject::fixupContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
+{
+	/* fixup continuation java stack first and then fixup the Object itself, fixup order shouldn't matter. */
+	fixupContinuationNativeSlots(env, objectPtr);
+	fixupMixedObject(objectPtr);
 }
 
 void

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
@@ -74,6 +74,7 @@ private:
 	 */
 	void fixupFlattenedArrayObject(omrobjectptr_t objectPtr);
 
+	void fixupContinuationNativeSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	void fixupContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	/**
 	 * Called whenever a ownable synchronizer object is fixed up during compact. Places the object on the thread-specific buffer of gc work thread.

--- a/runtime/gc_glue_java/HeapWalkerDelegate.cpp
+++ b/runtime/gc_glue_java/HeapWalkerDelegate.cpp
@@ -37,7 +37,7 @@ MM_HeapWalkerDelegate::objectSlotsDo(OMR_VMThread *omrVMThread, omrobjectptr_t o
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 	switch(_objectModel->getScanType(objectPtr)) {
 	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-		doContinuationObject(env, objectPtr, function, userData);
+		doContinuationNativeSlots(env, objectPtr, function, userData);
 		break;
 	default:
 		break;
@@ -55,7 +55,7 @@ stackSlotIteratorForHeapWalker(J9JavaVM *javaVM, J9Object **slotPtr, void *local
 }
 
 void
-MM_HeapWalkerDelegate::doContinuationObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData)
+MM_HeapWalkerDelegate::doContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {

--- a/runtime/gc_glue_java/HeapWalkerDelegate.hpp
+++ b/runtime/gc_glue_java/HeapWalkerDelegate.hpp
@@ -48,7 +48,7 @@ public:
 	 * Function members
 	 */
 private:
-	void doContinuationObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData);
+	void doContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_HeapWalkerSlotFunc function, void *userData);
 protected:
 
 public:

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -258,7 +258,7 @@ stackSlotIteratorForMarkingDelegate(J9JavaVM *javaVM, J9Object **slotPtr, void *
 
 
 void
-MM_MarkingDelegate::scanContinuationObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
+MM_MarkingDelegate::scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -116,7 +116,7 @@ public:
 	uintptr_t setupIndexableScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo, uintptr_t *sizeInElementsToDo, fomrobject_t **basePtr, uintptr_t *flags) { return 0; }
 
 	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr);
-	void scanContinuationObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
+	void scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 
 	MMINLINE GC_ObjectScanner *
 	getObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, void *scannerSpace, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo)
@@ -140,7 +140,7 @@ public:
 			*sizeToDo = referenceSize + ((GC_MixedObjectScanner *)objectScanner)->getBytesRemaining();
 			break;
 		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-			scanContinuationObject(env, objectPtr);
+			scanContinuationNativeSlots(env, objectPtr);
 			objectScanner = GC_MixedObjectScanner::newInstance(env, objectPtr, scannerSpace, 0);
 			*sizeToDo = referenceSize + ((GC_MixedObjectScanner *)objectScanner)->getBytesRemaining();
 			break;

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -176,6 +176,7 @@ public:
 	void setUnmarkedImpliesCleared();
 	void unsetUnmarkedImpliesCleared();
 
+	void  scanContinuationNativeSlots(MM_EnvironmentRealtime *env, J9Object *objectPtr);
 	UDATA scanContinuationObject(MM_EnvironmentRealtime *env, J9Object *objectPtr);
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -340,7 +340,7 @@ stackSlotIteratorForScavenge(J9JavaVM *javaVM, J9Object **slotPtr, void *localDa
 }
 
 bool
-MM_ScavengerDelegate::doContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, MM_ScavengeScanReason reason)
+MM_ScavengerDelegate::scanContinuationNativeSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, MM_ScavengeScanReason reason)
 {
 	bool shouldRemember = false;
 
@@ -440,7 +440,7 @@ MM_ScavengerDelegate::getObjectScanner(MM_EnvironmentStandard *env, omrobjectptr
 		objectScanner = GC_MixedObjectScanner::newInstance(env, objectPtr, allocSpace, flags);
 		break;
 	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-		*shouldRemember = doContinuationObject(env, objectPtr, reason);
+		*shouldRemember = scanContinuationNativeSlots(env, objectPtr, reason);
 		objectScanner = GC_MixedObjectScanner::newInstance(env, objectPtr, allocSpace, flags);
 		break;
 	case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -156,7 +156,7 @@ public:
 
 	void setShouldScavengeUnfinalizedObjects(bool shouldScavenge) { _shouldScavengeUnfinalizedObjects = shouldScavenge; }
 	void setShouldScavengeContinuationObjects(bool shouldScavenge) { _shouldScavengeContinuationObjects = shouldScavenge; }
-	bool doContinuationObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, MM_ScavengeScanReason reason);
+	bool scanContinuationNativeSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, MM_ScavengeScanReason reason);
 
 	volatile bool getShouldScavengeFinalizableObjects() { return _shouldScavengeFinalizableObjects; }
 	volatile bool getShouldScavengeUnfinalizedObjects() { return _shouldScavengeUnfinalizedObjects; }

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -1043,9 +1043,9 @@ MM_StandardAccessBarrier::preMountContinuation(J9VMThread *vmThread, j9object_t 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->isConcurrentScavengerInProgress()) {
 		/* concurrent scavenger in progress */
-		MM_EnvironmentStandard *env = (MM_EnvironmentStandard *) MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
 		MM_ScavengeScanReason reason = SCAN_REASON_SCAVENGE;
-		_scavenger->getDelegate()->doContinuationObject(env, contObject, reason);
+		_scavenger->getDelegate()->scanContinuationNativeSlots(env, contObject, reason);
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 }

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -953,9 +953,9 @@ MM_RealtimeAccessBarrier::forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J
 void
 MM_RealtimeAccessBarrier::preMountContinuation(J9VMThread *vmThread, j9object_t contObject)
 {
-	MM_EnvironmentRealtime *env = (MM_EnvironmentRealtime *) MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+	MM_EnvironmentRealtime *env =  MM_EnvironmentRealtime::getEnvironment(vmThread->omrVMThread);
 	if (isBarrierActive(env)) {
-		_realtimeGC->getRealtimeDelegate()->scanContinuationObject(env, contObject);
+		_realtimeGC->getRealtimeDelegate()->scanContinuationNativeSlots(env, contObject);
 	}
 }
 

--- a/runtime/gc_realtime/RealtimeAccessBarrier.hpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.hpp
@@ -113,7 +113,6 @@ protected:
 
 private:
 	/* New methods */
-	void rememberObject(MM_EnvironmentBase *env, J9Object *object);
 	void rememberObjectIfBarrierEnabled(J9VMThread *vmThread, J9Object* object);
 
 	bool preObjectStoreInternal(J9VMThread *vmThread, J9Object *destClass, J9Object **destAddress, J9Object *value, bool isVolatile);
@@ -140,6 +139,7 @@ private:
 
 public:
 	static MM_RealtimeAccessBarrier *newInstance(MM_EnvironmentBase *env);
+	void rememberObject(MM_EnvironmentBase *env, J9Object *object);
 	MMINLINE void setDoubleBarrierActive() { _doubleBarrierActive = true; }
 	MMINLINE void setDoubleBarrierInactive() { _doubleBarrierActive = false; }
 	MMINLINE bool isDoubleBarrierActive() { return _doubleBarrierActive; }

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2319,9 +2319,8 @@ stackSlotIteratorForCopyForwardScheme(J9JavaVM *javaVM, J9Object **slotPtr, void
 }
 
 MMINLINE void
-MM_CopyForwardScheme::scanContinuationObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason)
+MM_CopyForwardScheme::scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason)
 {
-	scanMixedObjectSlots(env, reservingContext, objectPtr, reason);
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
 		StackIteratorData4CopyForward localData;
@@ -2335,6 +2334,13 @@ MM_CopyForwardScheme::scanContinuationObjectSlots(MM_EnvironmentVLHGC *env, MM_A
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForCopyForwardScheme, bStackFrameClassWalkNeeded, false);
 	}
+}
+
+MMINLINE void
+MM_CopyForwardScheme::scanContinuationObject(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason)
+{
+	scanContinuationNativeSlots(env, reservingContext, objectPtr, reason);
+	scanMixedObjectSlots(env, reservingContext, objectPtr, reason);
 }
 
 /**
@@ -2943,7 +2949,7 @@ MM_CopyForwardScheme::scanObject(MM_EnvironmentVLHGC *env, MM_AllocationContextT
 		scanOwnableSynchronizerObjectSlots(env, reservingContext, objectPtr, reason);
 		break;
 	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-		scanContinuationObjectSlots(env, reservingContext, objectPtr, reason);
+		scanContinuationObject(env, reservingContext, objectPtr, reason);
 		break;
 	case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 		scanReferenceObjectSlots(env, reservingContext, objectPtr, reason);

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -302,7 +302,8 @@ private:
 	MMINLINE void scanOwnableSynchronizerObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 
 
-	MMINLINE void scanContinuationObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
+	MMINLINE void scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
+	MMINLINE void scanContinuationObject(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 	/**
 	 * Called whenever a ownable synchronizer object is scaned during CopyForwardScheme. Places the object on the thread-specific buffer of gc work thread.
 	 * @param env -- current thread environment

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
@@ -83,7 +83,9 @@ private:
 	 */
 	bool scrubMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr);
 
+	bool scrubContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr);
 	bool scrubContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr);
+
 	/**
 	 * Scrub a SCAN_POINTER_ARRAY_OBJECT.
 	 * @param env[in] the current thread

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -789,9 +789,8 @@ stackSlotIteratorForGlobalMarkingScheme(J9JavaVM *javaVM, J9Object **slotPtr, vo
 }
 
 void
-MM_GlobalMarkingScheme::scanContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason)
+MM_GlobalMarkingScheme::scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason)
 {
-	scanMixedObject(env, objectPtr, reason);
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
 		StackIteratorData4GlobalMarkingScheme localData;
@@ -805,6 +804,13 @@ MM_GlobalMarkingScheme::scanContinuationObject(MM_EnvironmentVLHGC *env, J9Objec
 
 		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForGlobalMarkingScheme, bStackFrameClassWalkNeeded, false);
 	}
+}
+
+void
+MM_GlobalMarkingScheme::scanContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason)
+{
+	scanContinuationNativeSlots(env, objectPtr, reason);
+	scanMixedObject(env, objectPtr, reason);
 }
 
 void 

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -319,6 +319,7 @@ private:
 	 */
 	void scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 	
+	void scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 	void scanContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 
 	/**

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1232,10 +1232,8 @@ stackSlotIteratorForWriteOnceCompactor(J9JavaVM *javaVM, J9Object **slotPtr, voi
 }
 
 void
-MM_WriteOnceCompactor::fixupContinuationObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache)
+MM_WriteOnceCompactor::fixupContinuationNativeSlots(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache)
 {
-	fixupMixedObject(env, objectPtr, cache);
-
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 	/* In sliding compaction we must fix slots exactly once. Since we will fixup stack slots of
 	 * mounted Virtual threads later during root fixup, we will skip it during this heap fixup pass
@@ -1249,6 +1247,13 @@ MM_WriteOnceCompactor::fixupContinuationObject(MM_EnvironmentVLHGC* env, J9Objec
 
 		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForWriteOnceCompactor, false, false);
 	}
+}
+
+void
+MM_WriteOnceCompactor::fixupContinuationObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache)
+{
+	fixupContinuationNativeSlots(env, objectPtr, cache);
+	fixupMixedObject(env, objectPtr, cache);
 }
 
 #if defined (J9ZOS39064)

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -203,6 +203,7 @@ private:
 	MMINLINE void preObjectMove(MM_EnvironmentVLHGC* env, J9Object *objectPtr, UDATA *objectSizeAfterMove);
 	MMINLINE void postObjectMove(MM_EnvironmentVLHGC* env, J9Object *newLocation, J9Object *objectPtr);
 	void fixupMixedObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
+	void fixupContinuationNativeSlots(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
 	void fixupContinuationObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr, J9MM_FixupCache *cache);
 	void fixupClassObject(MM_EnvironmentVLHGC* env, J9Object *classObject, J9MM_FixupCache *cache);
 	void fixupClassLoaderObject(MM_EnvironmentVLHGC* env, J9Object *classLoaderObject, J9MM_FixupCache *cache);


### PR DESCRIPTION
We use scanning the continuation object to trigger related preReadBarrier processing in order to handle concurrent case during Metronome GC, but for root scanning and tracing phase, the mounting carrier thread(mutator thread) has not been initialized for markObject. so update to use rememberObject instead of markObject for handling preCountinuationMount case.

depends on:https://github.com/eclipse-openj9/openj9/pull/16157

Signed-off-by: Lin Hu <linhu@ca.ibm.com>