### PR TITLE
Missing bounds check for offsetByCodePoints

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -3592,7 +3592,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				int index = start + codePointCount;
 
-				if (index > len) {
+				if ((index > len) || (index < 0)) {
 					throw new IndexOutOfBoundsException();
 				} else {
 					return index;
@@ -8052,7 +8052,7 @@ written authorization of the copyright holder.
 			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				int index = start + codePointCount;
 
-				if (index > len) {
+				if ((index > len) || (index < 0)) {
 					throw new IndexOutOfBoundsException();
 				} else {
 					return index;

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -2759,7 +2759,7 @@ public synchronized int offsetByCodePoints(int start, int codePointCount) {
 		if (String.COMPACT_STRINGS && count >= 0) {
 			int index = start + codePointCount;
 
-			if (index >= currentLength) {
+			if ((index > currentLength) || (index < 0)) {
 				throw new IndexOutOfBoundsException();
 			} else {
 				return index;

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -2773,7 +2773,7 @@ public int offsetByCodePoints(int start, int codePointCount) {
 		if (String.COMPACT_STRINGS && count >= 0) {
 			int index = start + codePointCount;
 
-			if (index >= currentLength) {
+			if ((index > currentLength) || (index < 0)) {
 				throw new IndexOutOfBoundsException();
 			} else {
 				return index;

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1566,28 +1566,41 @@ public class Test_String {
 	@Test
 	public void test_offsetByCodePoints() {
 		String s1 = "A\ud800\udc00C";
-		AssertJUnit.assertTrue("wrong offset 0, 0", s1.offsetByCodePoints(0, 0) == 0);
-		AssertJUnit.assertTrue("wrong offset 0, 1", s1.offsetByCodePoints(0, 1) == 1);
-		AssertJUnit.assertTrue("wrong offset 0, 2", s1.offsetByCodePoints(0, 2) == 3);
-		AssertJUnit.assertTrue("wrong offset 0, 3", s1.offsetByCodePoints(0, 3) == 4);
-		AssertJUnit.assertTrue("wrong offset 1, 0", s1.offsetByCodePoints(1, 0) == 1);
-		AssertJUnit.assertTrue("wrong offset 1, 1", s1.offsetByCodePoints(1, 1) == 3);
-		AssertJUnit.assertTrue("wrong offset 1, 2", s1.offsetByCodePoints(1, 2) == 4);
-		AssertJUnit.assertTrue("wrong offset 2, 0", s1.offsetByCodePoints(2, 0) == 2);
-		AssertJUnit.assertTrue("wrong offset 2, 1", s1.offsetByCodePoints(2, 1) == 3);
-		AssertJUnit.assertTrue("wrong offset 2, 2", s1.offsetByCodePoints(2, 2) == 4);
-		AssertJUnit.assertTrue("wrong offset 3, 0", s1.offsetByCodePoints(3, 0) == 3);
-		AssertJUnit.assertTrue("wrong offset 3, 1", s1.offsetByCodePoints(3, 1) == 4);
-		AssertJUnit.assertTrue("wrong offset 4, 0", s1.offsetByCodePoints(4, 0) == 4);
+		AssertJUnit.assertEquals("wrong offset 0, 0", 0, s1.offsetByCodePoints(0, 0));
+		AssertJUnit.assertEquals("wrong offset 0, 1", 1, s1.offsetByCodePoints(0, 1));
+		AssertJUnit.assertEquals("wrong offset 0, 2", 3, s1.offsetByCodePoints(0, 2));
+		AssertJUnit.assertEquals("wrong offset 0, 3", 4, s1.offsetByCodePoints(0, 3));
+		AssertJUnit.assertEquals("wrong offset 1, 0", 1, s1.offsetByCodePoints(1, 0));
+		AssertJUnit.assertEquals("wrong offset 1, 1", 3, s1.offsetByCodePoints(1, 1));
+		AssertJUnit.assertEquals("wrong offset 1, 2", 4, s1.offsetByCodePoints(1, 2));
+		AssertJUnit.assertEquals("wrong offset 2, 0", 2, s1.offsetByCodePoints(2, 0));
+		AssertJUnit.assertEquals("wrong offset 2, 1", 3, s1.offsetByCodePoints(2, 1));
+		AssertJUnit.assertEquals("wrong offset 2, 2", 4, s1.offsetByCodePoints(2, 2));
+		AssertJUnit.assertEquals("wrong offset 3, 0", 3, s1.offsetByCodePoints(3, 0));
+		AssertJUnit.assertEquals("wrong offset 3, 1", 4, s1.offsetByCodePoints(3, 1));
+		AssertJUnit.assertEquals("wrong offset 4, 0", 4, s1.offsetByCodePoints(4, 0));
 
-		AssertJUnit.assertTrue("wrong offset 4, -1", s1.offsetByCodePoints(4, -1) == 3);
-		AssertJUnit.assertTrue("wrong offset 4, -2", s1.offsetByCodePoints(4, -2) == 1);
-		AssertJUnit.assertTrue("wrong offset 4, -3", s1.offsetByCodePoints(4, -3) == 0);
-		AssertJUnit.assertTrue("wrong offset 3, -1", s1.offsetByCodePoints(3, -1) == 1);
-		AssertJUnit.assertTrue("wrong offset 3, -2", s1.offsetByCodePoints(3, -2) == 0);
-		AssertJUnit.assertTrue("wrong offset 2, -1", s1.offsetByCodePoints(2, -1) == 1);
-		AssertJUnit.assertTrue("wrong offset 2, -2", s1.offsetByCodePoints(2, -2) == 0);
-		AssertJUnit.assertTrue("wrong offset 1, -1", s1.offsetByCodePoints(1, -1) == 0);
+		AssertJUnit.assertEquals("wrong offset 4, -1", 3, s1.offsetByCodePoints(4, -1));
+		AssertJUnit.assertEquals("wrong offset 4, -2", 1, s1.offsetByCodePoints(4, -2));
+		AssertJUnit.assertEquals("wrong offset 4, -3", 0, s1.offsetByCodePoints(4, -3));
+		AssertJUnit.assertEquals("wrong offset 3, -1", 1, s1.offsetByCodePoints(3, -1));
+		AssertJUnit.assertEquals("wrong offset 3, -2", 0, s1.offsetByCodePoints(3, -2));
+		AssertJUnit.assertEquals("wrong offset 2, -1", 1, s1.offsetByCodePoints(2, -1));
+		AssertJUnit.assertEquals("wrong offset 2, -2", 0, s1.offsetByCodePoints(2, -2));
+		AssertJUnit.assertEquals("wrong offset 1, -1", 0, s1.offsetByCodePoints(1, -1));
+
+		try {
+			s1.offsetByCodePoints(s1.length(), 1);
+			AssertJUnit.fail("returned index greater than length should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
+		try {
+			s1.offsetByCodePoints(0, -1);
+			AssertJUnit.fail("returned index less than zero should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
 	}
 
 	/**

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuffer.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuffer.java
@@ -766,6 +766,49 @@ public class Test_StringBuffer {
 	}
 
 	/**
+	 * @tests java.lang.StringBuffer#offsetByCodePoints(int, int)
+	 */
+	@Test
+	public void test_offsetByCodePoints() {
+		StringBuffer s1 = new StringBuffer("A\ud800\udc00C");
+		AssertJUnit.assertEquals("wrong offset 0, 0", 0, s1.offsetByCodePoints(0, 0));
+		AssertJUnit.assertEquals("wrong offset 0, 1", 1, s1.offsetByCodePoints(0, 1));
+		AssertJUnit.assertEquals("wrong offset 0, 2", 3, s1.offsetByCodePoints(0, 2));
+		AssertJUnit.assertEquals("wrong offset 0, 3", 4, s1.offsetByCodePoints(0, 3));
+		AssertJUnit.assertEquals("wrong offset 1, 0", 1, s1.offsetByCodePoints(1, 0));
+		AssertJUnit.assertEquals("wrong offset 1, 1", 3, s1.offsetByCodePoints(1, 1));
+		AssertJUnit.assertEquals("wrong offset 1, 2", 4, s1.offsetByCodePoints(1, 2));
+		AssertJUnit.assertEquals("wrong offset 2, 0", 2, s1.offsetByCodePoints(2, 0));
+		AssertJUnit.assertEquals("wrong offset 2, 1", 3, s1.offsetByCodePoints(2, 1));
+		AssertJUnit.assertEquals("wrong offset 2, 2", 4, s1.offsetByCodePoints(2, 2));
+		AssertJUnit.assertEquals("wrong offset 3, 0", 3, s1.offsetByCodePoints(3, 0));
+		AssertJUnit.assertEquals("wrong offset 3, 1", 4, s1.offsetByCodePoints(3, 1));
+		AssertJUnit.assertEquals("wrong offset 4, 0", 4, s1.offsetByCodePoints(4, 0));
+
+		AssertJUnit.assertEquals("wrong offset 4, -1", 3, s1.offsetByCodePoints(4, -1));
+		AssertJUnit.assertEquals("wrong offset 4, -2", 1, s1.offsetByCodePoints(4, -2));
+		AssertJUnit.assertEquals("wrong offset 4, -3", 0, s1.offsetByCodePoints(4, -3));
+		AssertJUnit.assertEquals("wrong offset 3, -1", 1, s1.offsetByCodePoints(3, -1));
+		AssertJUnit.assertEquals("wrong offset 3, -2", 0, s1.offsetByCodePoints(3, -2));
+		AssertJUnit.assertEquals("wrong offset 2, -1", 1, s1.offsetByCodePoints(2, -1));
+		AssertJUnit.assertEquals("wrong offset 2, -2", 0, s1.offsetByCodePoints(2, -2));
+		AssertJUnit.assertEquals("wrong offset 1, -1", 0, s1.offsetByCodePoints(1, -1));
+
+		try {
+			s1.offsetByCodePoints(s1.length(), 1);
+			AssertJUnit.fail("returned index greater than length should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
+		try {
+			s1.offsetByCodePoints(0, -1);
+			AssertJUnit.fail("returned index less than zero should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
+	}
+
+	/**
 	 * @tests java.lang.StringBuffer#appendCodePoint(int)
 	 */
 	@Test

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuilder.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_StringBuilder.java
@@ -266,6 +266,49 @@ public class Test_StringBuilder {
 	}
 
 	/**
+	 * @tests java.lang.StringBuilder#offsetByCodePoints(int, int)
+	 */
+	@Test
+	public void test_offsetByCodePoints() {
+		StringBuilder s1 = new StringBuilder("A\ud800\udc00C");
+		AssertJUnit.assertEquals("wrong offset 0, 0", 0, s1.offsetByCodePoints(0, 0));
+		AssertJUnit.assertEquals("wrong offset 0, 1", 1, s1.offsetByCodePoints(0, 1));
+		AssertJUnit.assertEquals("wrong offset 0, 2", 3, s1.offsetByCodePoints(0, 2));
+		AssertJUnit.assertEquals("wrong offset 0, 3", 4, s1.offsetByCodePoints(0, 3));
+		AssertJUnit.assertEquals("wrong offset 1, 0", 1, s1.offsetByCodePoints(1, 0));
+		AssertJUnit.assertEquals("wrong offset 1, 1", 3, s1.offsetByCodePoints(1, 1));
+		AssertJUnit.assertEquals("wrong offset 1, 2", 4, s1.offsetByCodePoints(1, 2));
+		AssertJUnit.assertEquals("wrong offset 2, 0", 2, s1.offsetByCodePoints(2, 0));
+		AssertJUnit.assertEquals("wrong offset 2, 1", 3, s1.offsetByCodePoints(2, 1));
+		AssertJUnit.assertEquals("wrong offset 2, 2", 4, s1.offsetByCodePoints(2, 2));
+		AssertJUnit.assertEquals("wrong offset 3, 0", 3, s1.offsetByCodePoints(3, 0));
+		AssertJUnit.assertEquals("wrong offset 3, 1", 4, s1.offsetByCodePoints(3, 1));
+		AssertJUnit.assertEquals("wrong offset 4, 0", 4, s1.offsetByCodePoints(4, 0));
+
+		AssertJUnit.assertEquals("wrong offset 4, -1", 3, s1.offsetByCodePoints(4, -1));
+		AssertJUnit.assertEquals("wrong offset 4, -2", 1, s1.offsetByCodePoints(4, -2));
+		AssertJUnit.assertEquals("wrong offset 4, -3", 0, s1.offsetByCodePoints(4, -3));
+		AssertJUnit.assertEquals("wrong offset 3, -1", 1, s1.offsetByCodePoints(3, -1));
+		AssertJUnit.assertEquals("wrong offset 3, -2", 0, s1.offsetByCodePoints(3, -2));
+		AssertJUnit.assertEquals("wrong offset 2, -1", 1, s1.offsetByCodePoints(2, -1));
+		AssertJUnit.assertEquals("wrong offset 2, -2", 0, s1.offsetByCodePoints(2, -2));
+		AssertJUnit.assertEquals("wrong offset 1, -1", 0, s1.offsetByCodePoints(1, -1));
+
+		try {
+			s1.offsetByCodePoints(s1.length(), 1);
+			AssertJUnit.fail("returned index greater than length should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
+		try {
+			s1.offsetByCodePoints(0, -1);
+			AssertJUnit.fail("returned index less than zero should fail");
+		} catch (IndexOutOfBoundsException e) {
+			// correct exception thrown
+		}
+	}
+
+	/**
 	 * @tests java.lang.StringBuilder#appendCodePoint(int)
 	 */
 	@Test
@@ -368,7 +411,7 @@ public class Test_StringBuilder {
 	 */
 	@Test
 	public void test_setLength_replace() {
-		StringBuffer sb1 = new StringBuffer();
+		StringBuilder sb1 = new StringBuilder();
 		sb1.append("abcdefg");
 		sb1.replace(2, 5, "z");
 		sb1.setLength(7);


### PR DESCRIPTION
Add missing bounds check for offsetByCodePoints method in String, StringBuffer, and StringBuilder classes.
Add tests for offsetByCodePoints which result in out of bounds indices. 
Change a StringBuffer constructor to StringBuilder in StringBuilder test.

Fixes https://github.com/eclipse-openj9/openj9/issues/16188

Testing done on internal jenkins:
[Compile](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline-Build-Test-Personal/14589/) - only difference between the commit used for the build and this PR is a copyright update.

`sanity.functional` tests running with `-XX:+CompactStrings`:
[JDK8](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29008/)
[JDK11](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29009/)