### PR TITLE
Remove some uses of TR::comp()

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -727,7 +727,7 @@ J9::CodeGenerator::createReferenceReadBarrier(TR::TreeTop* treeTop, TR::Node* pa
    // isCollectedReference() responds false to generic int shadows because their type
    // is int. However, address type generic int shadows refer to collected slots.
 
-   if (symbol == TR::comp()->getSymRefTab()->findGenericIntShadowSymbol() || symbol->isCollectedReference())
+   if (symbol == self()->comp()->getSymRefTab()->findGenericIntShadowSymbol() || symbol->isCollectedReference())
       {
       TR::Node::recreate(parent, TR::ardbari);
       if (treeTop->getNode()->getOpCodeValue() == TR::NULLCHK                  &&

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3116,7 +3116,7 @@ J9::CodeGenerator::compressedReferenceRematerialization()
             prevTree->join(nextTree);
             }
 
-         if (node->canGCandReturn())
+         if (node->canGCandReturn(self()->comp()))
             {
             ListIterator<TR::Node> nodesIt(&rematerializedNodes);
             for (TR::Node * rematNode = nodesIt.getFirst(); rematNode != NULL; rematNode = nodesIt.getNext())

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1193,7 +1193,6 @@ uintptr_t
 TR_J9VMBase::getReferenceFieldAtAddress(uintptr_t fieldAddress)
    {
    TR_ASSERT(haveAccess(), "Must haveAccess in getReferenceFieldAtAddress");
-   TR::Compilation* comp = TR::comp();
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
    // Emit read barrier
    if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none)
@@ -1918,7 +1917,6 @@ int32_t TR_J9VMBase::getArraySpineShift(int32_t width)
 
 int32_t TR_J9VMBase::getArrayletMask(int32_t width)
    {
-   TR::Compilation* comp = TR::comp();
    TR_ASSERT(TR::Compiler->om.canGenerateArraylets(), "not supposed to be generating arraylets!");
    TR_ASSERT(width >= 0, "unexpected arraylet datatype width");
    int32_t mask=(1 << getArraySpineShift(width))-1;
@@ -1927,7 +1925,6 @@ int32_t TR_J9VMBase::getArrayletMask(int32_t width)
 
 int32_t TR_J9VMBase::getArrayletLeafIndex(int64_t index, int32_t elementSize)
    {
-   TR::Compilation* comp = TR::comp();
    TR_ASSERT(TR::Compiler->om.canGenerateArraylets(), "not supposed to be generating arraylets!");
    TR_ASSERT(elementSize >= 0, "unexpected arraylet datatype width");
 
@@ -1939,7 +1936,6 @@ int32_t TR_J9VMBase::getArrayletLeafIndex(int64_t index, int32_t elementSize)
 
 int32_t TR_J9VMBase::getLeafElementIndex(int64_t index , int32_t elementSize)
    {
-   TR::Compilation* comp = TR::comp();
    TR_ASSERT(TR::Compiler->om.canGenerateArraylets(), "not supposed to be generating arraylets!");
    TR_ASSERT(elementSize >= 0, "unexpected arraylet datatype width");
 
@@ -8774,7 +8770,7 @@ TR_J9SharedCacheVM::getSystemClassFromClassName(const char * name, int32_t lengt
       {
       if (isVettedForAOT)
          {
-         if (((TR_ResolvedRelocatableJ9Method *) TR::comp()->getCurrentMethod())->validateArbitraryClass(TR::comp(), (J9Class *) classPointer))
+         if (((TR_ResolvedRelocatableJ9Method *) TR::comp()->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
             validated = true;
          }
       }

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2029,11 +2029,10 @@ J9::Node::isSpineCheckWithArrayElementChild()
    }
 
 void
-J9::Node::setSpineCheckWithArrayElementChild(bool v)
+J9::Node::setSpineCheckWithArrayElementChild(bool v, TR::Compilation *comp)
    {
-   TR::Compilation * c = TR::comp();
    TR_ASSERT(self()->getOpCode().isSpineCheck(), "assertion failure");
-   if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting spineCHKWithArrayElementChild flag on node %p to %d\n", self(), v))
+   if (performNodeTransformation2(comp, "O^O NODE FLAGS: Setting spineCHKWithArrayElementChild flag on node %p to %d\n", self(), v))
       _flags.set(spineCHKWithArrayElementChild, v);
    }
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -860,9 +860,8 @@ J9::Node::alwaysGeneratesAKnownPositiveCleanSign()
 
 #ifdef TR_TARGET_S390
 int32_t
-J9::Node::getStorageReferenceSize()
+J9::Node::getStorageReferenceSize(TR::Compilation *comp)
    {
-   TR::Compilation *comp = TR::comp();
    if (self()->getType().isAggregate())
       {
       return self()->getSize();

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2574,7 +2574,12 @@ J9::Node::requiresRegisterPair(TR::Compilation *comp)
 bool
 J9::Node::canGCandReturn()
    {
-   TR::Compilation * comp = TR::comp();
+   return self()->canGCandReturn(TR::comp());
+   }
+
+bool
+J9::Node::canGCandReturn(TR::Compilation *comp)
+   {
    if (comp->getOption(TR_EnableFieldWatch))
       {
       if (self()->getOpCodeValue() == TR::treetop || self()->getOpCode().isNullCheck() || self()->getOpCode().isAnchor())

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -1155,42 +1155,6 @@ J9::Node::getSubTreeReferences(TR::SparseBitVector &references, vcount_t visitCo
     self()->getChild(i)->getSubTreeReferences(references, visitCount);
 }
 
-TR_ParentOfChildNode*
-J9::Node::referencesSymbolExactlyOnceInSubTree(
-   TR::Node* parent, int32_t childNum, TR::SymbolReference* symRef, vcount_t visitCount)
-   {
-   // The visit count in the node must be maintained by this method.
-   //
-   TR::Compilation * comp = TR::comp();
-   vcount_t oldVisitCount = self()->getVisitCount();
-   if (oldVisitCount == visitCount)
-      return NULL;
-   self()->setVisitCount(visitCount);
-
-   if (self()->getOpCode().hasSymbolReference() && (self()->getSymbolReference()->getReferenceNumber() == symRef->getReferenceNumber()))
-      {
-      TR_ParentOfChildNode* pNode = new (comp->trStackMemory()) TR_ParentOfChildNode(parent, childNum);
-      return pNode;
-      }
-
-   // For all other subtrees, see if any has a ref. If exactly one does, return it
-   TR_ParentOfChildNode* matchNode=NULL;
-   for (int32_t i = self()->getNumChildren()-1; i >= 0; i--)
-      {
-      TR::Node * child = self()->getChild(i);
-      TR_ParentOfChildNode* curr = child->referencesSymbolExactlyOnceInSubTree(self(), i, symRef, visitCount);
-      if (curr)
-         {
-         if (matchNode)
-            {
-            return NULL;
-            }
-         matchNode = curr;
-         }
-      }
-
-   return matchNode;
-   }
 
 /**
  * Node field functions

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2159,12 +2159,17 @@ J9::Node::isUnsafeGetPutCASCallOnNonArray()
 void
 J9::Node::setUnsafeGetPutCASCallOnNonArray()
    {
-   TR::Compilation * c = TR::comp();
+   self()->setUnsafeGetPutCASCallOnNonArray(TR::comp());
+   }
+
+void
+J9::Node::setUnsafeGetPutCASCallOnNonArray(TR::Compilation *comp)
+   {
    TR_ASSERT(self()->getSymbol()->isMethod() && self()->getSymbol()->getMethodSymbol(), "setUnsafeGetPutCASCallOnNonArray called on node which is not a call");
 
-   //TR_ASSERT(getSymbol()->getMethodSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->isUnsafeWithObjectArg(),"Attempt to change flag on a method that is not JNI Unsafe that needs special care for arraylets\n");
    TR_ASSERT(self()->getSymbol()->getMethodSymbol()->getMethod()->isUnsafeWithObjectArg() || self()->getSymbol()->getMethodSymbol()->getMethod()->isUnsafeCAS(),"Attempt to check flag on a method that is not JNI Unsafe that needs special care for arraylets\n");
-   if (performNodeTransformation1(c, "O^O NODE FLAGS: Setting unsafeGetPutOnNonArray flag on node %p\n", self()))
+
+   if (performNodeTransformation1(comp, "O^O NODE FLAGS: Setting unsafeGetPutOnNonArray flag on node %p\n", self()))
       _flags.set(unsafeGetPutOnNonArray);
    }
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -1126,9 +1126,8 @@ J9::Node::referencesSymbolInSubTree(TR::SymbolReference* symRef, vcount_t visitC
    }
 
 bool
-J9::Node::referencesMayKillAliasInSubTree(TR::Node * rootNode, vcount_t visitCount)
+J9::Node::referencesMayKillAliasInSubTree(TR::Node * rootNode, vcount_t visitCount, TR::Compilation *comp)
    {
-   TR::Compilation * comp = TR::comp();
    TR::SparseBitVector  references (comp->allocator());
    self()->getSubTreeReferences(references, visitCount);
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -475,12 +475,17 @@ J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol 
 void
 J9::Node::devirtualizeCall(TR::TreeTop *treeTop)
    {
+   return self()->devirtualizeCall(treeTop, TR::comp());
+   }
+
+void
+J9::Node::devirtualizeCall(TR::TreeTop *treeTop, TR::Compilation *comp)
+   {
    OMR::NodeConnector::devirtualizeCall(treeTop);
    TR::ResolvedMethodSymbol *methodSymbol = self()->getSymbol()->castToResolvedMethodSymbol();
 
    if (methodSymbol->isJNI())
       {
-      TR::Compilation *comp = TR::comp();
       self()->processJNICall(treeTop, comp->getMethodSymbol(), comp);
       }
    }

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -868,7 +868,7 @@ J9::Node::getStorageReferenceSize(TR::Compilation *comp)
       }
    else if (self()->getOpCode().isBCDToNonBCDConversion())
       {
-      return self()->getStorageReferenceSourceSize();
+      return self()->getStorageReferenceSourceSize(comp);
       }
    else
       {
@@ -911,9 +911,8 @@ J9::Node::getStorageReferenceSize(TR::Compilation *comp)
    }
 
 int32_t
-J9::Node::getStorageReferenceSourceSize()
+J9::Node::getStorageReferenceSourceSize(TR::Compilation *comp)
    {
-   TR::Compilation *comp = TR::comp();
    int32_t size = 0;
    switch (self()->getOpCodeValue())
       {

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2092,16 +2092,15 @@ J9::Node::isDontInlinePutOrderedCall()
    }
 
 void
-J9::Node::setDontInlinePutOrderedCall()
+J9::Node::setDontInlinePutOrderedCall(TR::Compilation *comp)
    {
-   TR::Compilation * c = TR::comp();
    TR_ASSERT(self()->getOpCode().isCall(), " Can only call this routine for a call node \n");
    bool isPutOrdered = self()->isUnsafePutOrderedCall();
 
    TR_ASSERT(isPutOrdered, "attempt to set dontInlinePutOrderedCall flag and not a putOrdered call");
    if (isPutOrdered)
       {
-      if (performNodeTransformation1(c, "O^O NODE FLAGS: Setting dontInlineUnsafePutOrderedCall flag on node %p\n", self()))
+      if (performNodeTransformation1(comp, "O^O NODE FLAGS: Setting dontInlineUnsafePutOrderedCall flag on node %p\n", self()))
          _flags.set(dontInlineUnsafePutOrderedCall);
       }
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -260,11 +260,15 @@ J9::Node::getCloneClassInNode()
    return (TR_OpaqueClassBlock *)_unionBase._children[1];
    }
 
+TR::Node *
+J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol *owningSymbol)
+   {
+   return self()->processJNICall(callNodeTreeTop, owningSymbol, TR::comp());
+   }
 
 TR::Node *
-J9::Node::processJNICall(TR::TreeTop * callNodeTreeTop, TR::ResolvedMethodSymbol * owningSymbol)
+J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol *owningSymbol, TR::Compilation *comp)
    {
-   TR::Compilation * comp = TR::comp();
    if (!comp->cg()->getSupportsDirectJNICalls() || comp->getOption(TR_DisableDirectToJNI) || (comp->compileRelocatableCode() && !comp->cg()->supportsDirectJNICallsForAOT()))
       return self();
 
@@ -332,8 +336,8 @@ J9::Node::processJNICall(TR::TreeTop * callNodeTreeTop, TR::ResolvedMethodSymbol
       }
 
 #if defined(TR_TARGET_POWER)
-   // Recognizing these methods on Power allows us to take a shortcut 
-   // in the JNI dispatch where we mangle the register dependencies and call 
+   // Recognizing these methods on Power allows us to take a shortcut
+   // in the JNI dispatch where we mangle the register dependencies and call
    // optimized helpers in the JIT library using what amounts to system/C dispatch.
    // The addresses of the optimized helpers in the server process will not necessarily
    // match the client-side addresses, so we can't take this shortcut in JITServer mode.
@@ -475,7 +479,10 @@ J9::Node::devirtualizeCall(TR::TreeTop *treeTop)
    TR::ResolvedMethodSymbol *methodSymbol = self()->getSymbol()->castToResolvedMethodSymbol();
 
    if (methodSymbol->isJNI())
-      self()->processJNICall(treeTop, TR::comp()->getMethodSymbol());
+      {
+      TR::Compilation *comp = TR::comp();
+      self()->processJNICall(treeTop, comp->getMethodSymbol(), comp);
+      }
    }
 
 bool

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,23 @@ public:
    /// given a direct call to Object.clone node, return the class of the receiver.
    ///
    TR_OpaqueClassBlock* getCloneClassInNode();
-   TR::Node *           processJNICall(TR::TreeTop *, TR::ResolvedMethodSymbol *);
+
+   /**
+    * @brief Stub method for OMR callers using the old API.  This function is
+    *    deprecated and will be removed once upstream OMR code is changed.
+    */
+   TR::Node *processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol *owningSymbol);
+
+   /**
+    * @brief Transform a call node to prepare it for JNI dispatch.
+    *
+    * @param[in] callNodeTreeTop : \c TR::TreeTop for the call node
+    * @param[in] owningSymbol : \c TR::ResolvedMethodSymbol of the method to call
+    * @param[in] comp : \c TR::Compilation object
+    *
+    * @return Transformed call  \c TR::Node
+    */
+   TR::Node *processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol *owningSymbol, TR::Compilation *comp);
 
    void                    devirtualizeCall(TR::TreeTop*);
 

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -293,7 +293,7 @@ public:
 
    // Flag used by TR::BNDCHK nodes
    bool isSpineCheckWithArrayElementChild();
-   void setSpineCheckWithArrayElementChild(bool v);
+   void setSpineCheckWithArrayElementChild(bool v, TR::Compilation *comp);
    bool chkSpineCheckWithArrayElementChild();
    const char *printSpineCheckWithArrayElementChild();
 

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -300,7 +300,7 @@ public:
    // Flags used by call nodes
    bool isUnsafePutOrderedCall();
    bool isDontInlinePutOrderedCall();
-   void setDontInlinePutOrderedCall();
+   void setDontInlinePutOrderedCall(TR::Compilation *comp);
    bool chkDontInlineUnsafePutOrderedCall();
    const char * printIsDontInlineUnsafePutOrderedCall();
 

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -140,7 +140,7 @@ public:
    bool alwaysGeneratesAKnownPositiveCleanSign();
 #ifdef TR_TARGET_S390
    int32_t getStorageReferenceSize(TR::Compilation *comp);
-   int32_t getStorageReferenceSourceSize();
+   int32_t getStorageReferenceSourceSize(TR::Compilation *comp);
 #endif
 
    bool         isEvenPrecision();

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -311,6 +311,7 @@ public:
 
    bool isUnsafeGetPutCASCallOnNonArray();
    void setUnsafeGetPutCASCallOnNonArray();
+   void setUnsafeGetPutCASCallOnNonArray(TR::Compilation *comp);
 
    bool isProcessedByCallCloneConstrain();
    void setProcessedByCallCloneConstrain();

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -162,6 +162,7 @@ public:
 
    bool canRemoveArithmeticOperand();
    bool canGCandReturn();
+   bool canGCandReturn(TR::Compilation *comp);
 
    static uint32_t hashOnBCDOrAggrLiteral(char *lit, size_t litSize);
 

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -93,7 +93,21 @@ public:
     */
    TR::Node *processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol *owningSymbol, TR::Compilation *comp);
 
-   void                    devirtualizeCall(TR::TreeTop*);
+   /**
+    * @brief Stub method for OMR callers using the old API.  This function is
+    *    deprecated and will be removed once upstream OMR code is changed.
+    */
+   void devirtualizeCall(TR::TreeTop *treeTop);
+
+   /**
+    * @brief Devirtualize the call under the given treetop.
+    *
+    * @param[in] treeTop : \c TR::TreeTop of the call to devirtualize
+    * @param[in] comp : \c TR::Compilation object
+    *
+    * @return None
+    */
+   void devirtualizeCall(TR::TreeTop *treeTop, TR::Compilation *comp);
 
    /**
     * @return the signature of the node's type if applicable.

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -168,7 +168,6 @@ public:
    bool referencesSymbolInSubTree(TR::SymbolReference * symRef, vcount_t visitCount);
    bool referencesMayKillAliasInSubTree(TR::Node * rootNode, vcount_t visitCount, TR::Compilation *comp);
    void getSubTreeReferences(TR::SparseBitVector &references, vcount_t visitCount);
-   TR_ParentOfChildNode * referencesSymbolExactlyOnceInSubTree(TR::Node *, int32_t, TR::SymbolReference *, vcount_t);
 
    /**
     * Node field functions

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -166,7 +166,7 @@ public:
    static uint32_t hashOnBCDOrAggrLiteral(char *lit, size_t litSize);
 
    bool referencesSymbolInSubTree(TR::SymbolReference * symRef, vcount_t visitCount);
-   bool referencesMayKillAliasInSubTree(TR::Node * rootNode, vcount_t visitCount);
+   bool referencesMayKillAliasInSubTree(TR::Node * rootNode, vcount_t visitCount, TR::Compilation *comp);
    void getSubTreeReferences(TR::SparseBitVector &references, vcount_t visitCount);
    TR_ParentOfChildNode * referencesSymbolExactlyOnceInSubTree(TR::Node *, int32_t, TR::SymbolReference *, vcount_t);
 

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -139,7 +139,7 @@ public:
    bool alwaysGeneratesAKnownCleanSign();
    bool alwaysGeneratesAKnownPositiveCleanSign();
 #ifdef TR_TARGET_S390
-   int32_t getStorageReferenceSize();
+   int32_t getStorageReferenceSize(TR::Compilation *comp);
    int32_t getStorageReferenceSourceSize();
 #endif
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1131,7 +1131,7 @@ TR_J9ByteCodeIlGenerator::genTreeTop(TR::Node * n)
 
    //In involuntaryOSR, exception points are OSR points but we don't need to
    //handle pending pushes for them because the operand stack is always empty at catch.
-   bool isExceptionOnlyPoint = comp()->getOSRMode() == TR::involuntaryOSR && !n->canGCandReturn() && n->canGCandExcept();
+   bool isExceptionOnlyPoint = comp()->getOSRMode() == TR::involuntaryOSR && !n->canGCandReturn(comp()) && n->canGCandExcept();
    if (comp()->getOption(TR_TraceOSR))
       traceMsg(comp(), "skip saving PPS for exceptionOnlyPoints %d node n%dn\n", isExceptionOnlyPoint, n->getGlobalIndex());
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6169,7 +6169,7 @@ TR_J9ByteCodeIlGenerator::loadArrayElement(TR::DataType dataType, TR::ILOpCodes 
          checkNode->setChild(2, checkNode->getChild(0));  // index
          }
 
-      checkNode->setSpineCheckWithArrayElementChild(true);
+      checkNode->setSpineCheckWithArrayElementChild(true, comp());
       checkNode->setAndIncChild(0, element);              // array element
       checkNode->setAndIncChild(1, arrayBaseAddress);     // base array
       }
@@ -7749,7 +7749,7 @@ TR_J9ByteCodeIlGenerator::storeArrayElement(TR::DataType dataType, TR::ILOpCodes
          checkNode->setAndIncChild(0, elementAddress);    // iwrtbar
       else
          {
-         checkNode->setSpineCheckWithArrayElementChild(true);
+         checkNode->setSpineCheckWithArrayElementChild(true, comp());
          checkNode->setAndIncChild(0, storeNode);         // primitive store
          }
       checkNode->setAndIncChild(1, arrayBaseAddress);     // base array

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4742,7 +4742,7 @@ break
       if (!resultNode)
          {
          if (symbol->isJNI())
-            resultNode = callNode->processJNICall(callNodeTreeTop, _methodSymbol);
+            resultNode = callNode->processJNICall(callNodeTreeTop, _methodSymbol, comp());
          else
             resultNode = callNode;
          }

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -7743,7 +7743,7 @@ bool TR_EscapeAnalysis::devirtualizeCallSites()
 
          directCallTree->setNode(directCallTreeNode);
 
-         directCall->devirtualizeCall(directCallTree);
+         directCall->devirtualizeCall(directCallTree, comp());
 
 
          TR::Node * coldCall = callNode->duplicateTree();

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2057,7 +2057,7 @@ TR_J9InlinerPolicy::inlineUnsafeCall(TR::ResolvedMethodSymbol *calleeSymbol, TR:
 bool
 TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode)
    {
-   TR::Compilation* comp = TR::comp();
+   TR::Compilation *comp = this->comp();
    TR::RecognizedMethod recognizedMethod = method->getRecognizedMethod();
    // Reflection's JNI
    //

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1126,7 +1126,7 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
       {
       symRef->getSymbol()->setOrdered();
       orderedCallNode = callNodeTreeTop->getNode()->duplicateTree();
-      orderedCallNode->getFirstChild()->setDontInlinePutOrderedCall();
+      orderedCallNode->getFirstChild()->setDontInlinePutOrderedCall(comp());
 
       debugTrace(tracer(), "\t Duplicate Tree for ordered call, orderedCallNode = %p\n", orderedCallNode);
       }

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -6640,8 +6640,6 @@ TR_J9InnerPreexistenceInfo::perform(TR::Compilation *comp, TR::Node *guardNode, 
          {
          TR_ASSERT(virtualGuard, "we cannot directly devirtualize anything thats not guarded");
 
-         //_callNode->devirtualizeCall(_callTree);
-
          // Add an inner assumption on the outer guard
          //
          TR_InnerAssumption *a  = new (comp->trHeapMemory()) TR_InnerAssumption(point->_ordinal, virtualGuard);

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4206,7 +4206,7 @@ bool mayKillInterferenceBetweenNodes(TR::Compilation * comp,
       comp->getDebug()->trace(" --- does node %p get killed somewhere in the subtree of node %p?\n", n2, n1);
       }
 
-   if (n1->referencesMayKillAliasInSubTree(n2, newVisitCount))
+   if (n1->referencesMayKillAliasInSubTree(n2, newVisitCount, comp))
       {
       if (trace)
          comp->getDebug()->trace(" ---- node %p is killed somewhere in the subtree of node %p\n", n2, n1);
@@ -4239,7 +4239,7 @@ bool mayKillInterferenceBetweenNodes(TR::Compilation * comp,
       comp->getDebug()->trace(" --- does node %p get killed somewhere in the subtree of node %p?\n", n2, n1);
       }
 
-   if (n1->referencesMayKillAliasInSubTree(n2, newVisitCount))
+   if (n1->referencesMayKillAliasInSubTree(n2, newVisitCount, comp))
       {
       if (trace)
          comp->getDebug()->trace(" ---- node %p is killed somewhere in the subtree of node %p\n", n2, n1);

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -219,7 +219,7 @@ bool TR_UnsafeFastPath::tryTransformUnsafeAtomicCallInVarHandleAccessMethod(TR::
          node->setIsSafeForCGToFastPathUnsafeCall(true);
          if (!isVarHandleOperationMethodOnArray(callerMethod))
             {
-            node->setUnsafeGetPutCASCallOnNonArray();
+            node->setUnsafeGetPutCASCallOnNonArray(comp());
             }
 
          if (trace())

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -848,7 +848,7 @@ int32_t TR_UnsafeFastPath::perform()
                      node = TR::Node::recreateWithoutProperties(node, comp()->il.opCodeForIndirectArrayStore(type), 2, addrCalc, value, unsafeSymRef);
 
                      spineCHK->setAndIncChild(0, node);
-                     spineCHK->setSpineCheckWithArrayElementChild(true);
+                     spineCHK->setSpineCheckWithArrayElementChild(true, comp());
                      }
 
                   if (trace())
@@ -879,7 +879,7 @@ int32_t TR_UnsafeFastPath::perform()
                      spineCHK->setAndIncChild(0, node);
                      }
 
-                  spineCHK->setSpineCheckWithArrayElementChild(true);
+                  spineCHK->setSpineCheckWithArrayElementChild(true, comp());
 
                   if (trace())
                      traceMsg(comp(), "Created node [" POINTER_PRINTF_FORMAT "] to load from location [" POINTER_PRINTF_FORMAT "] with spineCHK [" POINTER_PRINTF_FORMAT "]\n", node, addrCalc, spineCHK);

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -275,7 +275,7 @@ int32_t TR_VarHandleTransformer::perform()
                 spineCHK->setAndIncChild(2, index);
                 spineCHK->setSymbolReference(spineCHKSymRef);
                 spineCHK->setAndIncChild(0, methodHandle);
-                spineCHK->setSpineCheckWithArrayElementChild(true);
+                spineCHK->setSpineCheckWithArrayElementChild(true, comp());
                 callTree->insertBefore(TR::TreeTop::create(comp(), spineCHK));
                 }
 

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1594,8 +1594,8 @@ J9::Z::CodeGenerator::examineNode(
 
       if (nodeCanHaveHint &&
           bestNode &&
-          node->getStorageReferenceSize() > bestNode->getStorageReferenceSize() && // end hint before
-          endHintOnNode &&                                                                     // end hint after
+          node->getStorageReferenceSize(comp) > bestNode->getStorageReferenceSize(comp) && // end hint before
+          endHintOnNode &&                                                                 // end hint after
           !leftMostNodesList.empty())
          {
 
@@ -1626,7 +1626,7 @@ J9::Z::CodeGenerator::examineNode(
          // TODO: if a pdstore is to an auto then continually increase the size of this auto so it is the biggest on the left
          //       most subtree (i.e. force it to be the bestNode)
          if ((bestNode == NULL) ||
-             (node->getStorageReferenceSize() > bestNode->getStorageReferenceSize()) ||
+             (node->getStorageReferenceSize(comp) > bestNode->getStorageReferenceSize(comp)) ||
              (self()->nodeRequiresATemporary(node) && bestNode->getOpCode().isStore() && !self()->isAcceptableDestructivePDShiftRight(bestNode, NULL /* let the function find the load node */)))
             {
             if (!isAccumStore || node->useStoreAsAnAccumulator())
@@ -1636,10 +1636,10 @@ J9::Z::CodeGenerator::examineNode(
                   {
                   if (isAccumStore)
                      traceMsg(comp,"\t\tfound new store (canUse = %s) bestNode - %s (%p) with actual size %d and storageRefResultSize %d\n",
-                        bestNode->useStoreAsAnAccumulator() ? "yes":"no", bestNode->getOpCode().getName(),bestNode, bestNode->getSize(),bestNode->getStorageReferenceSize());
+                        bestNode->useStoreAsAnAccumulator() ? "yes":"no", bestNode->getOpCode().getName(),bestNode, bestNode->getSize(),bestNode->getStorageReferenceSize(comp));
                   else
                      traceMsg(comp,"\t\tfound new non-store bestNode - %s (%p) (isConversionToNonAggrOrNonBCD=%s, isForcedTemp=%s) with actual size %d and storageRefResultSize %d\n",
-                        bestNode->getOpCode().getName(),bestNode,isConversionToNonAggrOrNonBCD?"yes":"no",self()->nodeRequiresATemporary(node)?"yes":"no",bestNode->getSize(),bestNode->getStorageReferenceSize());
+                        bestNode->getOpCode().getName(),bestNode,isConversionToNonAggrOrNonBCD?"yes":"no",self()->nodeRequiresATemporary(node)?"yes":"no",bestNode->getSize(),bestNode->getStorageReferenceSize(comp));
                   }
                }
             }
@@ -1809,7 +1809,7 @@ J9::Z::CodeGenerator::processNodeList(
          {
          if (!leftMostNodesList.empty())
             {
-            int32_t bestNodeSize = bestNode->getStorageReferenceSize();
+            int32_t bestNodeSize = bestNode->getStorageReferenceSize(comp);
             int32_t tempSize = std::max(storeSize, bestNodeSize);
             if (self()->traceBCDCodeGen())
                {
@@ -2743,7 +2743,7 @@ J9::Z::CodeGenerator::materializeFullBCDValue(TR::Node *node,
    int32_t regSize = reg->getSize();
    if (self()->traceBCDCodeGen())
       traceMsg(comp,"\tmaterializeFullBCDValue evaluated %s (%p) (nodeSize %d, requested resultSize %d) to reg %s (regSize %d), clearSize=%d, updateStorageReference=%s\n",
-         node->getOpCode().getName(),node,node->getStorageReferenceSize(),resultSize,self()->getDebug()->getName(reg),regSize,clearSize,updateStorageReference?"yes":"no");
+         node->getOpCode().getName(),node,node->getStorageReferenceSize(comp),resultSize,self()->getDebug()->getName(reg),regSize,clearSize,updateStorageReference?"yes":"no");
 
    TR_ASSERT(clearSize >= 0,"invalid clearSize %d for node %p\n",clearSize,node);
    if (clearSize == 0)

--- a/runtime/compiler/z/codegen/S390Register.cpp
+++ b/runtime/compiler/z/codegen/S390Register.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -393,7 +393,7 @@ TR_StorageReference::getMaxSharedNodeSize()
       ListIterator<TR::Node> listIt(_sharedNodes);
       for (TR::Node *listNode = listIt.getFirst(); listNode; listNode = listIt.getNext())
          {
-         int32_t nodeSize = listNode->getStorageReferenceSize();
+         int32_t nodeSize = listNode->getStorageReferenceSize(comp());
          if (nodeSize > maxSize)
             {
             if (comp()->cg()->traceBCDCodeGen())


### PR DESCRIPTION
Remove uses of expensive `TR::comp()` queries.  Refactor APIs to pass available Compilation objects where appropriate.