### PR TITLE
Set VirtualGuard do not kill fear if has VectorAPIMethod

### DIFF
--- a/runtime/compiler/optimizer/FearPointAnalysis.cpp
+++ b/runtime/compiler/optimizer/FearPointAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,10 +34,10 @@
 #include "infra/BitVector.hpp"
 #include "infra/Checklist.hpp"
 
-bool TR_FearPointAnalysis::virtualGuardsKillFear()
+bool TR_FearPointAnalysis::virtualGuardsKillFear(TR::Compilation *comp)
    {
    static bool kill = (feGetEnv("TR_FPAnalaysisGuardsDoNotKillFear") == NULL);
-   return kill;
+   return kill && !(!comp->getOption(TR_DisableVectorAPIExpansion) && comp->getMethodSymbol()->hasVectorAPI());
    }
 
 int32_t TR_FearPointAnalysis::getNumberOfBits() { return 1; }
@@ -246,7 +246,7 @@ void TR_FearPointAnalysis::initializeGenAndKillSetInfo()
          }
 
       // kill any fear originating from inside
-      if (virtualGuardsKillFear()
+      if (virtualGuardsKillFear(comp())
           && treeTop->getNode()->isTheVirtualGuardForAGuardedInlinedCall()
           && comp()->cg()->supportsMergingGuards())
          {

--- a/runtime/compiler/optimizer/FearPointAnalysis.hpp
+++ b/runtime/compiler/optimizer/FearPointAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ class TR_FearPointAnalysis : public TR_BackwardUnionSingleBitContainerAnalysis
    virtual bool postInitializationProcessing();
    TR_SingleBitContainer *generatedFear(TR::Node *node);
 
-   static bool virtualGuardsKillFear();
+   static bool virtualGuardsKillFear(TR::Compilation *comp);
 
    private:
    void computeFear(TR::Compilation *comp, TR::Node *node, TR::NodeChecklist &checklist);

--- a/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
+++ b/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -191,7 +191,7 @@ void TR_HCRGuardAnalysis::initializeGenAndKillSetInfo()
             }
          }
       else if (ttNode->isTheVirtualGuardForAGuardedInlinedCall()
-               && TR_FearPointAnalysis::virtualGuardsKillFear()
+               && TR_FearPointAnalysis::virtualGuardsKillFear(comp())
                && comp()->cg()->supportsMergingGuards())
          {
          TR_VirtualGuard *guardInfo = comp()->findVirtualGuardInfo(ttNode);

--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -386,7 +386,7 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR
 
             // if virtual guards kill fear we can short cut additional analysis if the method still has a guard
             // we can mark that guard as an OSR guard and continue without needing a data flow analysis
-            if (TR_FearPointAnalysis::virtualGuardsKillFear()
+            if (TR_FearPointAnalysis::virtualGuardsKillFear(comp())
                 && additionalVirtualGuard
                 && comp()->cg()->supportsMergingGuards())
                {
@@ -412,7 +412,7 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR
             {
             comp()->addClassForOSRRedefinition(guardInfo->getThisClass());
             guardInfo->setMergedWithHCRGuard(false);
-            if (TR_FearPointAnalysis::virtualGuardsKillFear())
+            if (TR_FearPointAnalysis::virtualGuardsKillFear(comp()))
                guardInfo->setMergedWithOSRGuard();
             else
                {
@@ -475,7 +475,7 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
          continue;
          }
 
-      if (TR_FearPointAnalysis::virtualGuardsKillFear()
+      if (TR_FearPointAnalysis::virtualGuardsKillFear(comp())
           && cursor->getNode()->isTheVirtualGuardForAGuardedInlinedCall()
           && comp()->cg()->supportsMergingGuards())
          {


### PR DESCRIPTION
If a method we are compining contains the vector API intrinsic method call, set virtual guards kills fear fear flag to false which will prevent merging of Virtual guards with OSR guard and allows expansion of Vector API intrinsic methods.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>