### PR TITLE
[VaList/JDK17]Enable VaList related test suites on Power & zLinux

### DIFF
--- a/test/functional/Java17andUp/playlist.xml
+++ b/test/functional/Java17andUp/playlist.xml
@@ -43,7 +43,7 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>bits.64,^arch.x86,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -73,7 +73,7 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>bits.64,^arch.x86,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -103,7 +103,7 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>bits.64,^arch.x86,^arch.aarch64,^arch.ppc,^arch.390,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^arch.aarch64,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
@@ -24,21 +24,21 @@ package org.openj9.test.jep389.valist;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+import static org.testng.Assert.fail;
 
+import java.nio.ByteOrder;
 import java.lang.invoke.VarHandle;
+import java.util.NoSuchElementException;
 
-import jdk.incubator.foreign.CLinker;
 import static jdk.incubator.foreign.CLinker.*;
-import static jdk.incubator.foreign.CLinker.VaList.Builder;
 import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SegmentAllocator;
-import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.ValueLayout;
 
 /**
@@ -46,4 +46,755 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class ApiTests {
+	private static String osName = System.getProperty("os.name").toLowerCase();
+	private static String arch = System.getProperty("os.arch").toLowerCase();
+	private static boolean isAixOS = osName.contains("aix");
+	private static boolean isWinX64 = osName.contains("win") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static boolean isMacOsAarch64 = osName.contains("mac") && arch.contains("aarch64");
+	private static boolean isSysVPPC64le = osName.contains("linux") && arch.contains("ppc64");
+	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
+	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
+
+	@Test
+	public void test_emptyVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList emptyVaList = VaList.empty();
+			/* As specified in the implemention of OpenJDK, a NULL address is set to
+			 * the empty va_list on Windows/x86_64, MacOS/Aarch64, Linux/ppc64le and
+			 * AIX/ppc64 while the va_list without any argument is created on a fixed
+			 * address on other platforms.
+			 */
+			if (isWinX64 || isMacOsAarch64 || isSysVPPC64le || isAixOS) {
+				Assert.assertEquals(emptyVaList.address(), MemoryAddress.NULL);
+			} else {
+				Assert.assertNotEquals(emptyVaList.address(), MemoryAddress.NULL);
+			}
+		}
+	}
+
+	@Test
+	public void test_vaListScope() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 100), scope);
+			ResourceScope vaListScope = vaList.scope();
+			Assert.assertEquals(vaListScope, scope);
+		}
+	}
+
+	@Test
+	public void test_checkIntVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900), scope);
+
+			Assert.assertEquals(vaList.vargAsInt(C_INT), 700); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsInt(C_INT), 800); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsInt(C_INT), 900); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkLongVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L), scope);
+
+			Assert.assertEquals(vaList.vargAsLong(longLayout), 700000L); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsLong(longLayout), 800000L); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsLong(longLayout), 900000L); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkDoubleVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 111150.1001D)
+					.vargFromDouble(C_DOUBLE, 111160.2002D)
+					.vargFromDouble(C_DOUBLE, 111170.1001D), scope);
+
+			Assert.assertEquals(vaList.vargAsDouble(C_DOUBLE), 111150.1001D, 0.0001D); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsDouble(C_DOUBLE), 111160.2002D, 0.0001D); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsDouble(C_DOUBLE), 111170.1001D, 0.0001D); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkIntPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address()), scope);
+
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), intSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), intSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), intSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkLongPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address()), scope);
+
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), longSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), longSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), longSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkDoublePtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 111150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 111160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 111170.1001D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address()), scope);
+
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), doubleSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), doubleSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), doubleSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_checkIntStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(argSegmt), 1122333); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(intHandle2.get(argSegmt), 4455666); /* the 2nd element of the 1st struct argument */
+			argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(argSegmt), 2244668); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(intHandle2.get(argSegmt), 1133557); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_checkLongStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(argSegmt), 1122334455L); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(longHandle2.get(argSegmt), 6677889911L); /* the 2nd element of the 1st struct argument */
+			argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(argSegmt), 2233445566L); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(longHandle2.get(argSegmt), 7788991122L); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_checkDoubleStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 111150.1001D);
+			doubleHandle2.set(structSegmt1, 111160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 111170.1001D);
+			doubleHandle2.set(structSegmt2, 111180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(argSegmt), 111150.1001D, 0.0001D); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(argSegmt), 111160.2002D, 0.0001D); /* the 2nd element of the 1st struct argument */
+			argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(argSegmt), 111170.1001D, 0.0001D); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(argSegmt), 111180.2002D, 0.0001D); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_copyIntVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsInt(C_INT), 700); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsInt(C_INT), 800); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsInt(C_INT), 900); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyLongVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsLong(longLayout), 700000L); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsLong(longLayout), 800000L); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsLong(longLayout), 900000L); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyDoubleVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 111150.1001D)
+					.vargFromDouble(C_DOUBLE, 111160.2002D)
+					.vargFromDouble(C_DOUBLE, 111170.1001D), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsDouble(C_DOUBLE), 111150.1001D, 0001D); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsDouble(C_DOUBLE), 111160.2002D, 0001D); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsDouble(C_DOUBLE), 111170.1001D, 0001D); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyIntPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address()), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), intSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), intSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), intSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyLongPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address()), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), longSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), longSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), longSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyDoublePtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 111150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 111160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 111170.1001D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address()), scope);
+			VaList resultVaList = vaList.copy();
+
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), doubleSegmt1.address()); /* the 1st argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), doubleSegmt2.address()); /* the 2nd argument */
+			Assert.assertEquals(resultVaList.vargAsAddress(C_POINTER), doubleSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_copyIntStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList resultVaList = vaList.copy();
+
+			MemorySegment resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(resultArgSegmt), 1122333); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(intHandle2.get(resultArgSegmt), 4455666); /* the 2nd element of the 1st struct argument */
+			resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(resultArgSegmt), 2244668); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(intHandle2.get(resultArgSegmt), 1133557); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_copyLongStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList resultVaList = vaList.copy();
+
+			MemorySegment resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(resultArgSegmt), 1122334455L); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(longHandle2.get(resultArgSegmt), 6677889911L); /* the 2nd element of the 1st struct argument */
+			resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(resultArgSegmt), 2233445566L); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(longHandle2.get(resultArgSegmt), 7788991122L); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_copyDoubleStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 111150.1001D);
+			doubleHandle2.set(structSegmt1, 111160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 111170.1001D);
+			doubleHandle2.set(structSegmt2, 111180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList resultVaList = vaList.copy();
+
+			MemorySegment resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(resultArgSegmt), 111150.1001D, 0.0001D); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(resultArgSegmt), 111160.2002D, 0.0001D); /* the 2nd element of the 1st struct argument */
+			resultArgSegmt = resultVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(resultArgSegmt), 111170.1001D, 0.0001D); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(resultArgSegmt), 111180.2002D, 0.0001D); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_createIntVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			Assert.assertEquals(newVaList.vargAsInt(C_INT), 700); /* the 1st argument */
+			Assert.assertEquals(newVaList.vargAsInt(C_INT), 800); /* the 2nd argument */
+			Assert.assertEquals(newVaList.vargAsInt(C_INT), 900); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createLongVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			Assert.assertEquals(newVaList.vargAsLong(longLayout), 700000L); /* the 1st argument */
+			Assert.assertEquals(newVaList.vargAsLong(longLayout), 800000L); /* the 2nd argument */
+			Assert.assertEquals(newVaList.vargAsLong(longLayout), 900000L); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createDoubleVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 111150.1001D)
+					.vargFromDouble(C_DOUBLE, 111160.2002D)
+					.vargFromDouble(C_DOUBLE, 111170.1001D), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			Assert.assertEquals(newVaList.vargAsDouble(C_DOUBLE), 111150.1001D, 0.0001D); /* the 1st argument */
+			Assert.assertEquals(newVaList.vargAsDouble(C_DOUBLE), 111160.2002D, 0.0001D); /* the 2nd argument */
+			Assert.assertEquals(newVaList.vargAsDouble(C_DOUBLE), 111170.1001D, 0.0001D); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createIntPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address()), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			VarHandle resultHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
+			MemorySegment resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_INT.byteSize(), scope);
+			Assert.assertEquals((int)resultHandle.get(resultSegmt, 0), 700); /* the 1st argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_INT.byteSize(), scope);
+			Assert.assertEquals((int)resultHandle.get(resultSegmt, 0), 800); /* the 2nd argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_INT.byteSize(), scope);
+			Assert.assertEquals((int)resultHandle.get(resultSegmt, 0), 900); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createLongPtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address()), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			VarHandle resultHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+			MemorySegment resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(longLayout.byteSize(), scope);
+			Assert.assertEquals((long)resultHandle.get(resultSegmt, 0), 700000L); /* the 1st argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(longLayout.byteSize(), scope);
+			Assert.assertEquals((long)resultHandle.get(resultSegmt, 0), 800000L); /* the 2nd argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(longLayout.byteSize(), scope);
+			Assert.assertEquals((long)resultHandle.get(resultSegmt, 0), 900000L); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createDoublePtrVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 111150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 111160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 111170.1001D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address()), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			VarHandle resultHandle = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
+			MemorySegment resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_DOUBLE.byteSize(), scope);
+			Assert.assertEquals((double)resultHandle.get(resultSegmt, 0), 111150.1001D, 0.0001D); /* the 1st argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_DOUBLE.byteSize(), scope);
+			Assert.assertEquals((double)resultHandle.get(resultSegmt, 0), 111160.2002D, 0.0001D); /* the 2nd argument */
+			resultSegmt = newVaList.vargAsAddress(C_POINTER).asSegment(C_DOUBLE.byteSize(), scope);
+			Assert.assertEquals((double)resultHandle.get(resultSegmt, 0), 111170.1001D, 0.0001D); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_createIntStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			MemorySegment newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(newArgSegmt), 1122333); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(intHandle2.get(newArgSegmt), 4455666); /* the 2nd element of the 1st struct argument */
+			newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(newArgSegmt), 2244668); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(intHandle2.get(newArgSegmt), 1133557); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_createLongStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			MemorySegment newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(newArgSegmt), 1122334455L); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals(longHandle2.get(newArgSegmt), 6677889911L); /* the 2nd element of the 1st struct argument */
+			newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(newArgSegmt), 2233445566L); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(longHandle2.get(newArgSegmt), 7788991122L); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_createDoubleStructVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 11150.1001D);
+			doubleHandle2.set(structSegmt1, 11160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 11170.1001D);
+			doubleHandle2.set(structSegmt2, 11180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			VaList newVaList = VaList.ofAddress(vaList.address(), scope);
+
+			MemorySegment newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(newArgSegmt), 11150.1001D, 0.0001D); /* the 1st element of the 1st struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(newArgSegmt), 11160.2002D, 0.0001D); /* the 2nd element of the 1st struct argument */
+			newArgSegmt = newVaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(newArgSegmt), 11170.1001D, 0.0001D); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(newArgSegmt), 11180.2002D, 0.0001D); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_skipIntArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900)
+					.vargFromInt(C_INT, 1000), scope);
+			vaList.skip(C_INT);
+			Assert.assertEquals(vaList.vargAsInt(C_INT), 800); /* the 2nd argument */
+		}
+	}
+
+	@Test
+	public void test_skipLongArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L)
+					.vargFromLong(longLayout, 1000000L), scope);
+			vaList.skip(longLayout, longLayout);
+			Assert.assertEquals(vaList.vargAsLong(longLayout), 900000L); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_skipDoubleArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 111150.1001D)
+					.vargFromDouble(C_DOUBLE, 111160.2002D)
+					.vargFromDouble(C_DOUBLE, 111170.1001D)
+					.vargFromDouble(C_DOUBLE, 111180.2002D), scope);
+			vaList.skip(C_DOUBLE, C_DOUBLE, C_DOUBLE);
+			Assert.assertEquals(vaList.vargAsDouble(C_DOUBLE), 111180.2002D, 0.0001D); /* the 4th argument */
+		}
+	}
+
+	@Test
+	public void test_skipIntPtrArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+			MemorySegment intSegmt4 = allocator.allocate(C_INT, 1000);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address())
+					.vargFromAddress(C_POINTER, intSegmt4.address()), scope);
+			vaList.skip(C_POINTER);
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), intSegmt2.address()); /* the 2nd argument */
+		}
+	}
+
+	@Test
+	public void test_skipLongPtrArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+			MemorySegment longSegmt4 = allocator.allocate(longLayout, 1000000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address())
+					.vargFromAddress(C_POINTER, longSegmt4.address()), scope);
+			vaList.skip(C_POINTER, C_POINTER);
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), longSegmt3.address()); /* the 3rd argument */
+		}
+	}
+
+	@Test
+	public void test_skipDoublePtrArgOfVaList() throws Throwable {
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 111150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 111160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 111170.1001D);
+			MemorySegment doubleSegmt4 = allocator.allocate(C_DOUBLE, 111180.1002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address())
+					.vargFromAddress(C_POINTER, doubleSegmt4.address()), scope);
+			vaList.skip(C_POINTER, C_POINTER, C_POINTER);
+			Assert.assertEquals(vaList.vargAsAddress(C_POINTER), doubleSegmt4.address()); /* the 4th argument */
+		}
+	}
+
+	@Test
+	public void test_skipIntStructOfVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			vaList.skip(structLayout);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(intHandle1.get(argSegmt), 2244668); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(intHandle2.get(argSegmt), 1133557); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_skipLongStructOfVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			vaList.skip(structLayout);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals(longHandle1.get(argSegmt), 2233445566L); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals(longHandle2.get(argSegmt), 7788991122L); /* the 2nd element of the 2nd struct argument */
+		}
+	}
+
+	@Test
+	public void test_skipDoubleStructOfVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 11150.1001D);
+			doubleHandle2.set(structSegmt1, 11160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 11170.1001D);
+			doubleHandle2.set(structSegmt2, 11180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			vaList.skip(structLayout);
+
+			MemorySegment argSegmt = vaList.vargAsSegment(structLayout, allocator);
+			Assert.assertEquals((double)doubleHandle1.get(argSegmt), 11170.1001D, 0.0001D); /* the 1st element of the 2nd struct argument */
+			Assert.assertEquals((double)doubleHandle2.get(argSegmt), 11180.2002D, 0.0001D); /* the 2nd element of the 2nd struct argument */
+		}
+	}
 }

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
@@ -1,0 +1,1124 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep389.valist;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.CLinker;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.ValueLayout;
+
+/**
+ * Test cases for JEP 389: Foreign Linker API (Incubator) for the vararg list in downcall.
+ */
+@Test(groups = { "level.sanity" })
+public class DowncallTests {
+	private static String osName = System.getProperty("os.name").toLowerCase();
+	private static String arch = System.getProperty("os.arch").toLowerCase();
+	static boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static boolean isWinX64 = osName.contains("win") && isX64;
+	private static boolean isLinuxX64 = osName.contains("linux") && isX64;
+	private static boolean isLinuxAarch64 = osName.contains("linux") && arch.equals("aarch64");
+	/* The padding of struct is not required on Power in terms of VaList */
+	private static boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
+	private static boolean isAixOS = osName.contains("aix");
+	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
+	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
+	private static CLinker clinker = CLinker.getInstance();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+	private static final SymbolLookup defaultLibLookup = CLinker.systemLookup();
+
+	@Test
+	public void test_addIntsFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntsFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900)
+					.vargFromInt(C_INT, 1000), scope);
+			int result = (int)mh.invoke(4, vaList);
+			Assert.assertEquals(result, 3400);
+		}
+	}
+
+	@Test
+	public void test_addLongsFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongsFromVaList").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L)
+					.vargFromLong(longLayout, 1000000L), scope);
+			long result = (long)mh.invoke(4, vaList);
+			Assert.assertEquals(result, 3400000L);
+		}
+	}
+
+	@Test
+	public void test_addDoublesFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoublesFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 150.1001D)
+					.vargFromDouble(C_DOUBLE, 160.2002D)
+					.vargFromDouble(C_DOUBLE, 170.1001D)
+					.vargFromDouble(C_DOUBLE, 180.2002D), scope);
+			double result = (double)mh.invoke(4, vaList);
+			Assert.assertEquals(result, 660.6006D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_addMixedArgsFromVaList() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting this struct with
+		 * the mixed elements (confirmed by OpenJDK/Hotspot). Thus, the test is disabled
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			Addressable functionSymbol = nativeLibLookup.lookup("addMixedArgsFromVaList").get();
+			MethodType mt = MethodType.methodType(double.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+						.vargFromLong(longLayout, 800000L)
+						.vargFromDouble(C_DOUBLE, 160.2002D), scope);
+				double result = (double)mh.invoke(vaList);
+				Assert.assertEquals(result, 800860.2002D, 0.0001D);
+			}
+		}
+	}
+
+	@Test
+	public void test_addMoreMixedArgsFromVaList() throws Throwable {
+		/* VaList on x86_64(Linux, macOS and Windows) in OpenJDK is unable to handle
+		 * the va_list with over 8 arguments (confirmed by OpenJDK/Hotspot). So the
+		 * test is disabled for now till the issue is fixed by OpenJDK.
+		 */
+		if (!isX64) {
+			Addressable functionSymbol = nativeLibLookup.lookup("addMoreMixedArgsFromVaList").get();
+			MethodType mt = MethodType.methodType(double.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 100)
+						.vargFromLong(longLayout, 200000L)
+						.vargFromInt(C_INT, 300)
+						.vargFromLong(longLayout, 400000L)
+						.vargFromInt(C_INT, 500)
+						.vargFromLong(longLayout, 600000L)
+						.vargFromInt(C_INT, 700)
+						.vargFromDouble(C_DOUBLE, 161.2001D)
+						.vargFromInt(C_INT, 800)
+						.vargFromDouble(C_DOUBLE, 162.2002D)
+						.vargFromInt(C_INT, 900)
+						.vargFromDouble(C_DOUBLE, 163.2003D)
+						.vargFromInt(C_INT, 1000)
+						.vargFromDouble(C_DOUBLE, 164.2004D)
+						.vargFromInt(C_INT, 1100)
+						.vargFromDouble(C_DOUBLE, 165.2005D), scope);
+				double result = (double)mh.invoke(vaList);
+				Assert.assertEquals(result, 1206216.0015D, 0.0001D);
+			}
+		}
+	}
+
+	@Test
+	public void test_addIntsByPtrFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntsByPtrFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address()), scope);
+			int result = (int)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 2400);
+		}
+	}
+
+	@Test
+	public void test_addLongsByPtrFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongsByPtrFromVaList").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address()), scope);
+			long result = (long)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 2400000L);
+		}
+	}
+
+	@Test
+	public void test_addDoublesByPtrFromVaList() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoublesByPtrFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 111150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 111160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 111170.1001D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address()), scope);
+			double result = (double)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 333480.4004D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_add1ByteOfStructsFromVaList() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"));
+			VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1ByteOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt1, (byte)1);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt2, (byte)2);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt3, (byte)3);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt4, (byte)4);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt5, (byte)5);
+				MemorySegment structSegmt6 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt6, (byte)6);
+				MemorySegment structSegmt7 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt7, (byte)7);
+				MemorySegment structSegmt8 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt8, (byte)8);
+				MemorySegment structSegmt9 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt9, (byte)9);
+				MemorySegment structSegmt10 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt10, (byte)10);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5)
+						.vargFromSegment(structLayout, structSegmt6)
+						.vargFromSegment(structLayout, structSegmt7)
+						.vargFromSegment(structLayout, structSegmt8)
+						.vargFromSegment(structLayout, structSegmt9)
+						.vargFromSegment(structLayout, structSegmt10), scope);
+				byte result = (byte)mh.invoke(10, vaList);
+				Assert.assertEquals(result, 55);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2BytesOfStructsFromVaList() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with
+		 * two byte elements (confirmed by OpenJDK/Hotspot). Thus, the test is disabled
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"), C_CHAR.withName("elem2"));
+			VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+			VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add2BytesOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt1, (byte)1);
+				byteHandle2.set(structSegmt1, (byte)2);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt2, (byte)3);
+				byteHandle2.set(structSegmt2, (byte)4);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2), scope);
+				byte result = (byte)mh.invoke(2, vaList);
+				Assert.assertEquals(result, 10);
+			}
+		}
+	}
+
+	@Test
+	public void test_add3BytesOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3BytesOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)4);
+			byteHandle2.set(structSegmt2, (byte)5);
+			byteHandle3.set(structSegmt2, (byte)6);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			byte result = (byte)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 21);
+		}
+	}
+
+	@Test
+	public void test_add5BytesOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"), C_CHAR.withName("elem4"), C_CHAR.withName("elem5"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle byteHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle byteHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add5BytesOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			byteHandle4.set(structSegmt1, (byte)4);
+			byteHandle5.set(structSegmt1, (byte)5);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)6);
+			byteHandle2.set(structSegmt2, (byte)7);
+			byteHandle3.set(structSegmt2, (byte)8);
+			byteHandle4.set(structSegmt2, (byte)9);
+			byteHandle5.set(structSegmt2, (byte)10);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			byte result = (byte)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 55);
+		}
+	}
+
+	@Test
+	public void test_add7BytesOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"), C_CHAR.withName("elem4"),
+				C_CHAR.withName("elem5"), C_CHAR.withName("elem6"), C_CHAR.withName("elem7"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle byteHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle byteHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+		VarHandle byteHandle6 = structLayout.varHandle(byte.class, PathElement.groupElement("elem6"));
+		VarHandle byteHandle7 = structLayout.varHandle(byte.class, PathElement.groupElement("elem7"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add7BytesOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			byteHandle4.set(structSegmt1, (byte)4);
+			byteHandle5.set(structSegmt1, (byte)5);
+			byteHandle6.set(structSegmt1, (byte)6);
+			byteHandle7.set(structSegmt1, (byte)7);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)8);
+			byteHandle2.set(structSegmt2, (byte)9);
+			byteHandle3.set(structSegmt2, (byte)10);
+			byteHandle4.set(structSegmt2, (byte)11);
+			byteHandle5.set(structSegmt2, (byte)12);
+			byteHandle6.set(structSegmt2, (byte)13);
+			byteHandle7.set(structSegmt2, (byte)14);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			byte result = (byte)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 105);
+		}
+	}
+
+	@Test
+	public void test_add1ShortOfStructsFromVaList() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"));
+			VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1ShortOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(short.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt1, (short)111);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt2, (short)222);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt3, (short)333);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt4, (short)444);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt5, (short)555);
+				MemorySegment structSegmt6 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt6, (short)666);
+				MemorySegment structSegmt7 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt7, (short)777);
+				MemorySegment structSegmt8 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt8, (short)888);
+				MemorySegment structSegmt9 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt9, (short)999);
+				MemorySegment structSegmt10 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt10, (short)123);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5)
+						.vargFromSegment(structLayout, structSegmt6)
+						.vargFromSegment(structLayout, structSegmt7)
+						.vargFromSegment(structLayout, structSegmt8)
+						.vargFromSegment(structLayout, structSegmt9)
+						.vargFromSegment(structLayout, structSegmt10), scope);
+				short result = (short)mh.invoke(10, vaList);
+				Assert.assertEquals(result, 5118);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2ShortsOfStructsFromVaList() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with
+		 * two short elements (confirmed by OpenJDK/Hotspot). Thus, the test is disabled
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"), C_SHORT.withName("elem2"));
+			VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+			VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add2ShortsOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(short.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt1, (short)111);
+				shortHandle2.set(structSegmt1, (short)222);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt2, (short)333);
+				shortHandle2.set(structSegmt2, (short)444);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2), scope);
+				short result = (short)mh.invoke(2, vaList);
+				Assert.assertEquals(result, 1110);
+			}
+		}
+	}
+
+	@Test
+	public void test_add3ShortsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+				C_SHORT.withName("elem2"), C_SHORT.withName("elem3"));
+		VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+		VarHandle shortHandle3 = structLayout.varHandle(short.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3ShortsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(short.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt1, (short)111);
+			shortHandle2.set(structSegmt1, (short)222);
+			shortHandle3.set(structSegmt1, (short)333);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt2, (short)444);
+			shortHandle2.set(structSegmt2, (short)555);
+			shortHandle3.set(structSegmt2, (short)666);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			short result = (short)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 2331);
+		}
+	}
+
+	@Test
+	public void test_add1IntOfStructsFromVaList() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"));
+			VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1IntOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt1, 1111111);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt2, 2222222);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt3, 3333333);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt4, 4444444);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt5, 5555555);
+				MemorySegment structSegmt6 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt6, 6666666);
+				MemorySegment structSegmt7 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt7, 7777777);
+				MemorySegment structSegmt8 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt8, 8888888);
+				MemorySegment structSegmt9 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt9, 9999999);
+				MemorySegment structSegmt10 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt10, 1234567);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5)
+						.vargFromSegment(structLayout, structSegmt6)
+						.vargFromSegment(structLayout, structSegmt7)
+						.vargFromSegment(structLayout, structSegmt8)
+						.vargFromSegment(structLayout, structSegmt9)
+						.vargFromSegment(structLayout, structSegmt10), scope);
+				int result = (int)mh.invoke(10, vaList);
+				Assert.assertEquals(result, 51234562);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2IntsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			int result = (int)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 8956224);
+		}
+	}
+
+	@Test
+	public void test_add3IntsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				C_INT.withName("elem2"), C_INT.withName("elem3"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+		VarHandle intHandle3 = structLayout.varHandle(int.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3IntsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			intHandle3.set(structSegmt1, 7788999);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 1133555);
+			intHandle2.set(structSegmt2, 2244666);
+			intHandle3.set(structSegmt2, 3322111);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			int result = (int)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 20067330);
+		}
+	}
+
+	@Test
+	public void test_add2LongsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2LongsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			long result = (long)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 17822661054L);
+		}
+	}
+
+	@Test
+	public void test_add1FloatOfStructsFromVaList() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with only
+		 * one float element (confirmed by OpenJDK/Hotspot). Thus, the test is disabled on
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"));
+			VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1FloatOfStructsFromVaList").get();
+			MethodType mt = MethodType.methodType(float.class, int.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt1, 1.11F);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt2, 2.22F);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt3, 3.33F);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt4, 4.44F);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt5, 5.56F);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5), scope);
+				float result = (float)mh.invoke(5, vaList);
+				Assert.assertEquals(result, 16.66F, 0.01F);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2FloatsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"), C_FLOAT.withName("elem2"));
+		VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle floatHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2FloatsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(float.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt1, 1.11F);
+			floatHandle2.set(structSegmt1, 2.22F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt2, 3.33F);
+			floatHandle2.set(structSegmt2, 4.44F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt3, 5.55F);
+			floatHandle2.set(structSegmt3, 6.66F);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt4, 7.77F);
+			floatHandle2.set(structSegmt4, 8.88F);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt5, 9.99F);
+			floatHandle2.set(structSegmt5, 1.23F);
+			MemorySegment structSegmt6 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt6, 4.56F);
+			floatHandle2.set(structSegmt6, 7.89F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5)
+					.vargFromSegment(structLayout, structSegmt6), scope);
+			float result = (float)mh.invoke(6, vaList);
+			Assert.assertEquals(result, 63.63F, 0.01F);
+		}
+	}
+
+	@Test
+	public void test_add3FloatsOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = isStructPaddingNotRequired ? MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_FLOAT.withName("elem2"), C_FLOAT.withName("elem3")) : MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+						C_FLOAT.withName("elem2"), C_FLOAT.withName("elem3"), MemoryLayout.paddingLayout(32));
+		VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle floatHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+		VarHandle floatHandle3 = structLayout.varHandle(float.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3FloatsOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(float.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt1, 1.11F);
+			floatHandle2.set(structSegmt1, 2.22F);
+			floatHandle3.set(structSegmt1, 3.33F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt2, 4.44F);
+			floatHandle2.set(structSegmt2, 5.55F);
+			floatHandle3.set(structSegmt2, 6.66F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt3, 7.77F);
+			floatHandle2.set(structSegmt3, 8.88F);
+			floatHandle3.set(structSegmt3, 9.99F);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt4, 1.23F);
+			floatHandle2.set(structSegmt4, 4.56F);
+			floatHandle3.set(structSegmt4, 7.89F);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt5, 9.87F);
+			floatHandle2.set(structSegmt5, 6.54F);
+			floatHandle3.set(structSegmt5, 3.21F);
+			MemorySegment structSegmt6 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt6, 2.46F);
+			floatHandle2.set(structSegmt6, 8.13F);
+			floatHandle3.set(structSegmt6, 5.79F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5)
+					.vargFromSegment(structLayout, structSegmt6), scope);
+			float result = (float)mh.invoke(6, vaList);
+			Assert.assertEquals(result, 99.63F, 0.01F);
+		}
+	}
+
+	@Test
+	public void test_add1DoubleOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"));
+		VarHandle floatHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add1DoubleOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt1, 11111.1001D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt2, 11111.1002D);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt3, 11111.1003D);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt4, 11111.1004D);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt5, 11111.1005D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5), scope);
+			double result = (double)mh.invoke(5, vaList);
+			Assert.assertEquals(result, 55555.5015D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_add2DoublesOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2DoublesOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 11150.1001D);
+			doubleHandle2.set(structSegmt1, 11160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 11170.1001D);
+			doubleHandle2.set(structSegmt2, 11180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			double result = (double)mh.invoke(2, vaList);
+			Assert.assertEquals(result, 44660.6006D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_vprintfFromDefaultLibFromVaList() throws Throwable {
+		/* 1) Disable the test on Windows given a misaligned access exception coming from
+		 * java.base/java.lang.invoke.MemoryAccessVarHandleBase triggered by CLinker.toCString()
+		 * is also captured on OpenJDK/Hotspot.
+		 * 2) Disable the test on AIX as Valist is not yet implemented in OpenJDK.
+		 */
+		if (!isWinX64 && !isAixOS) {
+			Addressable functionSymbol = defaultLibLookup.lookup("vprintf").get();
+			MethodType mt = MethodType.methodType(int.class, MemoryAddress.class, VaList.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment formatSegmt = CLinker.toCString("%d * %d = %d\n", scope);
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 7)
+						.vargFromInt(C_INT, 8)
+						.vargFromInt(C_INT, 56), scope);
+				mh.invoke(formatSegmt.address(), vaList);
+			}
+		}
+	}
+
+	@Test
+	public void test_addIntShortOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				C_SHORT.withName("elem2"), MemoryLayout.paddingLayout(16));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntShortOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1111111);
+			elemHandle2.set(structSegmt1, (short)123);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2222222);
+			elemHandle2.set(structSegmt2, (short)456);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3333333);
+			elemHandle2.set(structSegmt3, (short)789);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			int result = (int)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 6668034);
+		}
+	}
+
+	@Test
+	public void test_addShortIntOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+				MemoryLayout.paddingLayout(16), C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addShortIntOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, (short)123);
+			elemHandle2.set(structSegmt1, 1111111);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, (short)456);
+			elemHandle2.set(structSegmt2, 2222222);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, (short)789);
+			elemHandle2.set(structSegmt3, 3333333);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			int result = (int)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 6668034);
+		}
+	}
+
+	@Test
+	public void test_addIntLongOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), longLayout.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntLongOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1111111);
+			elemHandle2.set(structSegmt1, 101010101010L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2222222);
+			elemHandle2.set(structSegmt2, 202020202020L);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3333333);
+			elemHandle2.set(structSegmt3, 303030303030L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			long result = (long)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 606067272726L);
+		}
+	}
+
+	@Test
+	public void test_addLongIntOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongIntOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 101010101010L);
+			elemHandle2.set(structSegmt1, 1111111);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 202020202020L);
+			elemHandle2.set(structSegmt2, 2222222);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 303030303030L);
+			elemHandle2.set(structSegmt3, 3333333);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			long result = (long)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 606067272726L);
+		}
+	}
+
+	@Test
+	public void test_addFloatDoubleOfStructsFromVaList() throws Throwable {
+		/* The size of [float, double] on AIX/PPC 64-bit is 12 bytes without padding by default
+		 * while the same struct is 16 bytes with padding on other platforms.
+		 */
+		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_DOUBLE.withName("elem2")) : MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addFloatDoubleOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1.11F);
+			elemHandle2.set(structSegmt1, 222.222D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2.22F);
+			elemHandle2.set(structSegmt2, 333.333D);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3.33F);
+			elemHandle2.set(structSegmt3, 444.444D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			double result = (double)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 1006.659D, 0.001D);
+		}
+	}
+
+	@Test
+	public void test_addDoubleFloatOfStructsFromVaList() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_FLOAT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoubleFloatOfStructsFromVaList").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 222.222D);
+			elemHandle2.set(structSegmt1, 1.11F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 333.333D);
+			elemHandle2.set(structSegmt2, 2.22F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 444.444D);
+			elemHandle2.set(structSegmt3, 3.33F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			double result = (double)mh.invoke(3, vaList);
+			Assert.assertEquals(result, 1006.659D, 0.001D);
+		}
+	}
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
@@ -1,0 +1,1186 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep389.valist;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.CLinker;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SymbolLookup;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.ValueLayout;
+
+/**
+ * Test cases for JEP 389: Foreign Linker API (Incubator) for the vararg list in upcall.
+ */
+@Test(groups = { "level.sanity" })
+public class UpcallTests {
+	private static String osName = System.getProperty("os.name").toLowerCase();
+	private static String arch = System.getProperty("os.arch").toLowerCase();
+	static boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static boolean isWinX64 = osName.contains("win") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static boolean isLinuxX64 = osName.contains("linux") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static boolean isLinuxAarch64 = osName.contains("linux") && arch.equals("aarch64");
+	/* The padding of struct is not required on Power in terms of VaList */
+	private static boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
+	private static boolean isAixOS = osName.contains("aix");
+	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
+	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
+	private static CLinker clinker = CLinker.getInstance();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_addIntsWithVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromInt(C_INT, 800)
+					.vargFromInt(C_INT, 900)
+					.vargFromInt(C_INT, 1000), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addIntsFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(4, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 3400);
+		}
+	}
+
+	@Test
+	public void test_addLongsFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromLong(longLayout, 700000L)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromLong(longLayout, 900000L)
+					.vargFromLong(longLayout, 1000000L), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addLongsFromVaList,
+					FunctionDescriptor.of(longLayout, C_INT, C_POINTER), scope);
+
+			long result = (long)mh.invoke(4, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 3400000L);
+		}
+	}
+
+	@Test
+	public void test_addDoublesFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoublesFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromDouble(C_DOUBLE, 111150.1001D)
+					.vargFromDouble(C_DOUBLE, 111160.2002D)
+					.vargFromDouble(C_DOUBLE, 111170.1001D)
+					.vargFromDouble(C_DOUBLE, 111180.2002D), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addDoublesFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(4, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 444660.6006D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_addMixedArgsFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addMixedArgsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 700)
+					.vargFromLong(longLayout, 800000L)
+					.vargFromDouble(C_DOUBLE, 160.2002D), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addMixedArgsFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_POINTER), scope);
+
+			double result = (double)mh.invoke(vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 800860.2002D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_addMoreMixedArgsFromVaListByUpcallMH() throws Throwable {
+		/* VaList on x86_64(Linux, macOS and Windows) in OpenJDK is unable to handle
+		 * the va_list with over 8 arguments (confirmed by OpenJDK/Hotspot). So the
+		 * test is disabled for now till the issue is fixed by OpenJDK.
+		 */
+		if (!isX64) {
+			Addressable functionSymbol = nativeLibLookup.lookup("addMoreMixedArgsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(double.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromInt(C_INT, 100)
+						.vargFromLong(longLayout, 200000L)
+						.vargFromInt(C_INT, 300)
+						.vargFromLong(longLayout, 400000L)
+						.vargFromInt(C_INT, 500)
+						.vargFromLong(longLayout, 600000L)
+						.vargFromInt(C_INT, 700)
+						.vargFromDouble(C_DOUBLE, 161.2001D)
+						.vargFromInt(C_INT, 800)
+						.vargFromDouble(C_DOUBLE, 162.2002D)
+						.vargFromInt(C_INT, 900)
+						.vargFromDouble(C_DOUBLE, 163.2003D)
+						.vargFromInt(C_INT, 1000)
+						.vargFromDouble(C_DOUBLE, 164.2004D)
+						.vargFromInt(C_INT, 1100)
+						.vargFromDouble(C_DOUBLE, 165.2005D), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addMoreMixedArgsFromVaList,
+						FunctionDescriptor.of(C_DOUBLE, C_POINTER), scope);
+
+				double result = (double)mh.invoke(vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 1206216.0015D, 0.0001D);
+			}
+		}
+	}
+
+	@Test
+	public void test_addIntsByPtrFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntsByPtrFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment intSegmt1 = allocator.allocate(C_INT, 700);
+			MemorySegment intSegmt2 = allocator.allocate(C_INT, 800);
+			MemorySegment intSegmt3 = allocator.allocate(C_INT, 900);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, intSegmt1.address())
+					.vargFromAddress(C_POINTER, intSegmt2.address())
+					.vargFromAddress(C_POINTER, intSegmt3.address()), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addIntsByPtrFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 2400);
+		}
+	}
+
+	@Test
+	public void test_addLongsByPtrFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongsByPtrFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment longSegmt1 = allocator.allocate(longLayout, 700000L);
+			MemorySegment longSegmt2 = allocator.allocate(longLayout, 800000L);
+			MemorySegment longSegmt3 = allocator.allocate(longLayout, 900000L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, longSegmt1.address())
+					.vargFromAddress(C_POINTER, longSegmt2.address())
+					.vargFromAddress(C_POINTER, longSegmt3.address()), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addLongsByPtrFromVaList,
+					FunctionDescriptor.of(longLayout, C_INT, C_POINTER), scope);
+
+			long result = (long)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 2400000L);
+		}
+	}
+
+	@Test
+	public void test_addDoublesByPtrFromVaListByUpcallMH() throws Throwable {
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoublesByPtrFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment doubleSegmt1 = allocator.allocate(C_DOUBLE, 150.1001D);
+			MemorySegment doubleSegmt2 = allocator.allocate(C_DOUBLE, 160.2002D);
+			MemorySegment doubleSegmt3 = allocator.allocate(C_DOUBLE, 170.1001D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromAddress(C_POINTER, doubleSegmt1.address())
+					.vargFromAddress(C_POINTER, doubleSegmt2.address())
+					.vargFromAddress(C_POINTER, doubleSegmt3.address()), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addDoublesByPtrFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 480.4004D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_add1ByteOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"));
+			VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1ByteOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+					SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+					MemorySegment structSegmt1 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt1, (byte)1);
+					MemorySegment structSegmt2 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt2, (byte)2);
+					MemorySegment structSegmt3 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt3, (byte)3);
+					MemorySegment structSegmt4 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt4, (byte)4);
+					MemorySegment structSegmt5 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt5, (byte)5);
+					MemorySegment structSegmt6 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt6, (byte)6);
+					MemorySegment structSegmt7 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt7, (byte)7);
+					MemorySegment structSegmt8 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt8, (byte)8);
+					MemorySegment structSegmt9 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt9, (byte)9);
+					MemorySegment structSegmt10 = allocator.allocate(structLayout);
+					byteHandle1.set(structSegmt10, (byte)10);
+
+					VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+							.vargFromSegment(structLayout, structSegmt2)
+							.vargFromSegment(structLayout, structSegmt3)
+							.vargFromSegment(structLayout, structSegmt4)
+							.vargFromSegment(structLayout, structSegmt5)
+							.vargFromSegment(structLayout, structSegmt6)
+							.vargFromSegment(structLayout, structSegmt7)
+							.vargFromSegment(structLayout, structSegmt8)
+							.vargFromSegment(structLayout, structSegmt9)
+							.vargFromSegment(structLayout, structSegmt10), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add1ByteOfStructsFromVaList,
+						FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER), scope);
+
+				byte result = (byte)mh.invoke(10, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 55);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2BytesOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with
+		 * two byte elements (confirmed by OpenJDK/Hotspot). Thus, the test is disabled
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"), C_CHAR.withName("elem2"));
+			VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+			VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add2BytesOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt1, (byte)1);
+				byteHandle2.set(structSegmt1, (byte)2);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				byteHandle1.set(structSegmt2, (byte)3);
+				byteHandle2.set(structSegmt2, (byte)4);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2BytesOfStructsFromVaList,
+						FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER), scope);
+
+				byte result = (byte)mh.invoke(2, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 10);
+			}
+		}
+	}
+
+	@Test
+	public void test_add3BytesOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3BytesOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)4);
+			byteHandle2.set(structSegmt2, (byte)5);
+			byteHandle3.set(structSegmt2, (byte)6);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add3BytesOfStructsFromVaList,
+					FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER), scope);
+
+			byte result = (byte)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 21);
+		}
+	}
+
+	@Test
+	public void test_add5BytesOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"), C_CHAR.withName("elem4"), C_CHAR.withName("elem5"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle byteHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle byteHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add5BytesOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			byteHandle4.set(structSegmt1, (byte)4);
+			byteHandle5.set(structSegmt1, (byte)5);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)6);
+			byteHandle2.set(structSegmt2, (byte)7);
+			byteHandle3.set(structSegmt2, (byte)8);
+			byteHandle4.set(structSegmt2, (byte)9);
+			byteHandle5.set(structSegmt2, (byte)10);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add5BytesOfStructsFromVaList,
+					FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER), scope);
+
+			byte result = (byte)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 55);
+		}
+	}
+
+	@Test
+	public void test_add7BytesOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"), C_CHAR.withName("elem4"),
+				C_CHAR.withName("elem5"), C_CHAR.withName("elem6"), C_CHAR.withName("elem7"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle byteHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle byteHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle byteHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+		VarHandle byteHandle6 = structLayout.varHandle(byte.class, PathElement.groupElement("elem6"));
+		VarHandle byteHandle7 = structLayout.varHandle(byte.class, PathElement.groupElement("elem7"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add7BytesOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(byte.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt1, (byte)1);
+			byteHandle2.set(structSegmt1, (byte)2);
+			byteHandle3.set(structSegmt1, (byte)3);
+			byteHandle4.set(structSegmt1, (byte)4);
+			byteHandle5.set(structSegmt1, (byte)5);
+			byteHandle6.set(structSegmt1, (byte)6);
+			byteHandle7.set(structSegmt1, (byte)7);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt2, (byte)8);
+			byteHandle2.set(structSegmt2, (byte)9);
+			byteHandle3.set(structSegmt2, (byte)10);
+			byteHandle4.set(structSegmt2, (byte)11);
+			byteHandle5.set(structSegmt2, (byte)12);
+			byteHandle6.set(structSegmt2, (byte)13);
+			byteHandle7.set(structSegmt2, (byte)14);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add7BytesOfStructsFromVaList,
+					FunctionDescriptor.of(C_CHAR, C_INT, C_POINTER), scope);
+
+			byte result = (byte)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 105);
+		}
+	}
+
+	@Test
+	public void test_add1ShortOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"));
+			VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1ShortOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(short.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt1, (short)111);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt2, (short)222);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt3, (short)333);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt4, (short)444);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt5, (short)555);
+				MemorySegment structSegmt6 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt6, (short)666);
+				MemorySegment structSegmt7 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt7, (short)777);
+				MemorySegment structSegmt8 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt8, (short)888);
+				MemorySegment structSegmt9 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt9, (short)999);
+				MemorySegment structSegmt10 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt10, (short)123);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5)
+						.vargFromSegment(structLayout, structSegmt6)
+						.vargFromSegment(structLayout, structSegmt7)
+						.vargFromSegment(structLayout, structSegmt8)
+						.vargFromSegment(structLayout, structSegmt9)
+						.vargFromSegment(structLayout, structSegmt10), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add1ShortOfStructsFromVaList,
+						FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER), scope);
+
+				short result = (short)mh.invoke(10, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 5118);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2ShortsOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with
+		 * two short elements (confirmed by OpenJDK/Hotspot). Thus, the test is disabled
+		 * on Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"), C_SHORT.withName("elem2"));
+			VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+			VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add2ShortsOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(short.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt1, (short)111);
+				shortHandle2.set(structSegmt1, (short)222);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				shortHandle1.set(structSegmt2, (short)333);
+				shortHandle2.set(structSegmt2, (short)444);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2ShortsOfStructsFromVaList,
+						FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER), scope);
+
+				short result = (short)mh.invoke(2, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 1110);
+			}
+		}
+	}
+
+	@Test
+	public void test_add3ShortsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+				C_SHORT.withName("elem2"), C_SHORT.withName("elem3"));
+		VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+		VarHandle shortHandle3 = structLayout.varHandle(short.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3ShortsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(short.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt1, (short)111);
+			shortHandle2.set(structSegmt1, (short)222);
+			shortHandle3.set(structSegmt1, (short)333);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt2, (short)444);
+			shortHandle2.set(structSegmt2, (short)555);
+			shortHandle3.set(structSegmt2, (short)666);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add3ShortsOfStructsFromVaList,
+					FunctionDescriptor.of(C_SHORT, C_INT, C_POINTER), scope);
+
+			short result = (short)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 2331);
+		}
+	}
+
+	@Test
+	public void test_add1IntOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* There are a few issues with the test on some platforms as follows:
+		 * 1) VaList on Linux/x86_64 in OpenJDK is unable to handle the va_list with
+		 *    over 8 arguments (confirmed by OpenJDK/Hotspot).
+		 * 2) VaList on Linux/Aarch64, Windows/x86_64 and MacOS/x86_64 in OpenJDK has problem
+		 *    in supporting the struct with only one integral element (confirmed by OpenJDK/Hotspot).
+		 * Thus, the test is disabled on both these platforms for now till these issues
+		 * are fixed in OpenJDK and verified on OpenJDK/Hotspot in the future.
+		 */
+		if (!isLinuxAarch64 && !isX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"));
+			VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1IntOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt1, 1111111);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt2, 2222222);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt3, 3333333);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt4, 4444444);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt5, 5555555);
+				MemorySegment structSegmt6 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt6, 6666666);
+				MemorySegment structSegmt7 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt7, 7777777);
+				MemorySegment structSegmt8 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt8, 8888888);
+				MemorySegment structSegmt9 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt9, 9999999);
+				MemorySegment structSegmt10 = allocator.allocate(structLayout);
+				intHandle1.set(structSegmt10, 1234567);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5)
+						.vargFromSegment(structLayout, structSegmt6)
+						.vargFromSegment(structLayout, structSegmt7)
+						.vargFromSegment(structLayout, structSegmt8)
+						.vargFromSegment(structLayout, structSegmt9)
+						.vargFromSegment(structLayout, structSegmt10), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add1IntOfStructsFromVaList,
+						FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+				int result = (int)mh.invoke(10, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 51234562);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2IntsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 2244668);
+			intHandle2.set(structSegmt2, 1133557);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2IntsOfStructsFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 8956224);
+		}
+	}
+
+	@Test
+	public void test_add3IntsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				C_INT.withName("elem2"), C_INT.withName("elem3"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+		VarHandle intHandle3 = structLayout.varHandle(int.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3IntsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 1122333);
+			intHandle2.set(structSegmt1, 4455666);
+			intHandle3.set(structSegmt1, 7788999);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 1133555);
+			intHandle2.set(structSegmt2, 2244666);
+			intHandle3.set(structSegmt2, 3322111);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add3IntsOfStructsFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 20067330);
+		}
+	}
+
+	@Test
+	public void test_add2LongsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle longHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle longHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2LongsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt1, 1122334455L);
+			longHandle2.set(structSegmt1, 6677889911L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			longHandle1.set(structSegmt2, 2233445566L);
+			longHandle2.set(structSegmt2, 7788991122L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2LongsOfStructsFromVaList,
+					FunctionDescriptor.of(longLayout, C_INT, C_POINTER), scope);
+
+			long result = (long)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 17822661054L);
+		}
+	}
+
+	@Test
+	public void test_add1FloatOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* VaList on Windows/x86_64 in OpenJDK has problem in supporting the struct with only
+		 * one float element (confirmed by OpenJDK/Hotspot). Thus, the test is disabled on
+		 * Windows/x86_64 for now till the issue is fixed in OpenJDK and verified on
+		 * OpenJDK/Hotspot in the future.
+		 */
+		if (!isWinX64) {
+			GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"));
+			VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+
+			Addressable functionSymbol = nativeLibLookup.lookup("add1FloatOfStructsFromVaListByUpcallMH").get();
+			MethodType mt = MethodType.methodType(float.class, int.class, VaList.class, MemoryAddress.class);
+			FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER, C_POINTER);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+			try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+				SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+				MemorySegment structSegmt1 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt1, 1.11F);
+				MemorySegment structSegmt2 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt2, 2.22F);
+				MemorySegment structSegmt3 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt3, 3.33F);
+				MemorySegment structSegmt4 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt4, 4.44F);
+				MemorySegment structSegmt5 = allocator.allocate(structLayout);
+				floatHandle1.set(structSegmt5, 5.56F);
+
+				VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+						.vargFromSegment(structLayout, structSegmt2)
+						.vargFromSegment(structLayout, structSegmt3)
+						.vargFromSegment(structLayout, structSegmt4)
+						.vargFromSegment(structLayout, structSegmt5), scope);
+				MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add1FloatOfStructsFromVaList,
+						FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER), scope);
+
+				float result = (float)mh.invoke(5, vaList, upcallFuncAddr);
+				Assert.assertEquals(result, 16.66F, 0.01F);
+			}
+		}
+	}
+
+	@Test
+	public void test_add2FloatsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"), C_FLOAT.withName("elem2"));
+		VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle floatHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2FloatsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(float.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt1, 1.11F);
+			floatHandle2.set(structSegmt1, 2.22F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt2, 3.33F);
+			floatHandle2.set(structSegmt2, 4.44F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt3, 5.55F);
+			floatHandle2.set(structSegmt3, 6.66F);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt4, 7.77F);
+			floatHandle2.set(structSegmt4, 8.88F);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt5, 9.99F);
+			floatHandle2.set(structSegmt5, 1.23F);
+			MemorySegment structSegmt6 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt6, 4.56F);
+			floatHandle2.set(structSegmt6, 7.89F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5)
+					.vargFromSegment(structLayout, structSegmt6), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2FloatsOfStructsFromVaList,
+					FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER), scope);
+
+			float result = (float)mh.invoke(6, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 63.63F, 0.01F);
+		}
+	}
+
+	@Test
+	public void test_add3FloatsOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = isStructPaddingNotRequired ? MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_FLOAT.withName("elem2"), C_FLOAT.withName("elem3")) : MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+						C_FLOAT.withName("elem2"), C_FLOAT.withName("elem3"), MemoryLayout.paddingLayout(32));
+		VarHandle floatHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle floatHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+		VarHandle floatHandle3 = structLayout.varHandle(float.class, PathElement.groupElement("elem3"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add3FloatsOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(float.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt1, 1.11F);
+			floatHandle2.set(structSegmt1, 2.22F);
+			floatHandle3.set(structSegmt1, 3.33F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt2, 4.44F);
+			floatHandle2.set(structSegmt2, 5.55F);
+			floatHandle3.set(structSegmt2, 6.66F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt3, 7.77F);
+			floatHandle2.set(structSegmt3, 8.88F);
+			floatHandle3.set(structSegmt3, 9.99F);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt4, 1.23F);
+			floatHandle2.set(structSegmt4, 4.56F);
+			floatHandle3.set(structSegmt4, 7.89F);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt5, 9.87F);
+			floatHandle2.set(structSegmt5, 6.54F);
+			floatHandle3.set(structSegmt5, 3.21F);
+			MemorySegment structSegmt6 = allocator.allocate(structLayout);
+			floatHandle1.set(structSegmt6, 2.46F);
+			floatHandle2.set(structSegmt6, 8.13F);
+			floatHandle3.set(structSegmt6, 5.79F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5)
+					.vargFromSegment(structLayout, structSegmt6), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add3FloatsOfStructsFromVaList,
+					FunctionDescriptor.of(C_FLOAT, C_INT, C_POINTER), scope);
+
+			float result = (float)mh.invoke(6, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 99.63F, 0.01F);
+		}
+	}
+
+	@Test
+	public void test_add1DoubleOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add1DoubleOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 11111.1001D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 11111.1002D);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt3, 11111.1003D);
+			MemorySegment structSegmt4 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt4, 11111.1004D);
+			MemorySegment structSegmt5 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt5, 11111.1005D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3)
+					.vargFromSegment(structLayout, structSegmt4)
+					.vargFromSegment(structLayout, structSegmt5), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add1DoubleOfStructsFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(5, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 55555.5015D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_add2DoublesOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle doubleHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle doubleHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("add2DoublesOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt1, 11150.1001D);
+			doubleHandle2.set(structSegmt1, 11160.2002D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			doubleHandle1.set(structSegmt2, 11170.1001D);
+			doubleHandle2.set(structSegmt2, 11180.2002D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_add2DoublesOfStructsFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(2, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 44660.6006D, 0.0001D);
+		}
+	}
+
+	@Test
+	public void test_addIntShortOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_SHORT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntShortOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1111111);
+			elemHandle2.set(structSegmt1, (short)123);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2222222);
+			elemHandle2.set(structSegmt2, (short)456);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3333333);
+			elemHandle2.set(structSegmt3, (short)789);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addIntShortOfStructsFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 6668034);
+		}
+	}
+
+	@Test
+	public void test_addShortIntOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+				MemoryLayout.paddingLayout(16), C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addShortIntOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(int.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, (short)123);
+			elemHandle2.set(structSegmt1, 1111111);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, (short)456);
+			elemHandle2.set(structSegmt2, 2222222);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, (short)789);
+			elemHandle2.set(structSegmt3, 3333333);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addShortIntOfStructsFromVaList,
+					FunctionDescriptor.of(C_INT, C_INT, C_POINTER), scope);
+
+			int result = (int)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 6668034);
+		}
+	}
+
+	@Test
+	public void test_addIntLongOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), longLayout.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addIntLongOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1111111);
+			elemHandle2.set(structSegmt1, 101010101010L);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2222222);
+			elemHandle2.set(structSegmt2, 202020202020L);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3333333);
+			elemHandle2.set(structSegmt3, 303030303030L);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addIntLongOfStructsFromVaList,
+					FunctionDescriptor.of(longLayout, C_INT, C_POINTER), scope);
+
+			long result = (long)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 606067272726L);
+		}
+	}
+
+	@Test
+	public void test_addLongIntOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"),
+				C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addLongIntOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(long.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(longLayout, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 101010101010L);
+			elemHandle2.set(structSegmt1, 1111111);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 202020202020L);
+			elemHandle2.set(structSegmt2, 2222222);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 303030303030L);
+			elemHandle2.set(structSegmt3, 3333333);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addLongIntOfStructsFromVaList,
+					FunctionDescriptor.of(longLayout, C_INT, C_POINTER), scope);
+
+			long result = (long)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 606067272726L);
+		}
+	}
+
+	@Test
+	public void test_addFloatDoubleOfStructsFromVaListByUpcallMH() throws Throwable {
+		/* The size of [float, double] on AIX/PPC 64-bit is 12 bytes without padding by default
+		 * while the same struct is 16 bytes with padding on other platforms.
+		 */
+		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_DOUBLE.withName("elem2")) : MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addFloatDoubleOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 1.11F);
+			elemHandle2.set(structSegmt1, 222.222D);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 2.22F);
+			elemHandle2.set(structSegmt2, 333.333D);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 3.33F);
+			elemHandle2.set(structSegmt3, 444.444D);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addFloatDoubleOfStructsFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 1006.659D, 0.001D);
+		}
+	}
+
+	@Test
+	public void test_addDoubleFloatOfStructsFromVaListByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_FLOAT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		Addressable functionSymbol = nativeLibLookup.lookup("addDoubleFloatOfStructsFromVaListByUpcallMH").get();
+		MethodType mt = MethodType.methodType(double.class, int.class, VaList.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER, C_POINTER);
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt1, 222.222D);
+			elemHandle2.set(structSegmt1, 1.11F);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt2, 333.333D);
+			elemHandle2.set(structSegmt2, 2.22F);
+			MemorySegment structSegmt3 = allocator.allocate(structLayout);
+			elemHandle1.set(structSegmt3, 444.444D);
+			elemHandle2.set(structSegmt3, 3.33F);
+
+			VaList vaList = VaList.make(vaListBuilder -> vaListBuilder.vargFromSegment(structLayout, structSegmt1)
+					.vargFromSegment(structLayout, structSegmt2)
+					.vargFromSegment(structLayout, structSegmt3), scope);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(VaListUpcallMethodHandles.MH_addDoubleFloatOfStructsFromVaList,
+					FunctionDescriptor.of(C_DOUBLE, C_INT, C_POINTER), scope);
+
+			double result = (double)mh.invoke(3, vaList, upcallFuncAddr);
+			Assert.assertEquals(result, 1006.659D, 0.001D);
+		}
+	}
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/VaListUpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/VaListUpcallMethodHandles.java
@@ -1,0 +1,600 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep389.valist;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.nio.ByteOrder;
+import java.lang.invoke.MethodType;
+import static java.lang.invoke.MethodType.methodType;
+import java.lang.invoke.VarHandle;
+
+import jdk.incubator.foreign.CLinker;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.ValueLayout;
+
+/**
+ * The helper class that contains all upcall method handles with VaList as arguments
+ *
+ * Note: VaList is simply treated as a pointer (specified in OpenJDK) in java
+ * when va_list is passed as argument in native.
+ */
+public class VaListUpcallMethodHandles {
+	private static final Lookup lookup = MethodHandles.lookup();
+	private static ResourceScope scope = ResourceScope.newImplicitScope();
+	private static SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+
+	private static String osName = System.getProperty("os.name").toLowerCase();
+	private static boolean isAixOS = osName.contains("aix");
+	private static boolean isWinOS = osName.contains("win");
+	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
+	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
+
+	static final MethodType MT_Byte_Int_MemAddr = methodType(byte.class, int.class, MemoryAddress.class);
+	static final MethodType MT_Short_Int_MemAddr = methodType(short.class, int.class, MemoryAddress.class);
+	static final MethodType MT_Int_Int_MemAddr = methodType(int.class, int.class, MemoryAddress.class);
+	static final MethodType MT_Long_Int_MemAddr = methodType(long.class, int.class, MemoryAddress.class);
+	static final MethodType MT_Float_Int_MemAddr = methodType(float.class, int.class, MemoryAddress.class);
+	static final MethodType MT_Double_Int_MemAddr = methodType(double.class, int.class, MemoryAddress.class);
+
+	public static final MethodHandle MH_addIntsFromVaList;
+	public static final MethodHandle MH_addLongsFromVaList;
+	public static final MethodHandle MH_addDoublesFromVaList;
+	public static final MethodHandle MH_addMixedArgsFromVaList;
+	public static final MethodHandle MH_addMoreMixedArgsFromVaList;
+	public static final MethodHandle MH_addIntsByPtrFromVaList;
+	public static final MethodHandle MH_addLongsByPtrFromVaList;
+	public static final MethodHandle MH_addDoublesByPtrFromVaList;
+	public static final MethodHandle MH_add1ByteOfStructsFromVaList;
+	public static final MethodHandle MH_add2BytesOfStructsFromVaList;
+	public static final MethodHandle MH_add3BytesOfStructsFromVaList;
+	public static final MethodHandle MH_add5BytesOfStructsFromVaList;
+	public static final MethodHandle MH_add7BytesOfStructsFromVaList;
+	public static final MethodHandle MH_add1ShortOfStructsFromVaList;
+	public static final MethodHandle MH_add2ShortsOfStructsFromVaList;
+	public static final MethodHandle MH_add3ShortsOfStructsFromVaList;
+	public static final MethodHandle MH_add1IntOfStructsFromVaList;
+	public static final MethodHandle MH_add2IntsOfStructsFromVaList;
+	public static final MethodHandle MH_add3IntsOfStructsFromVaList;
+	public static final MethodHandle MH_add2LongsOfStructsFromVaList;
+	public static final MethodHandle MH_add1FloatOfStructsFromVaList;
+	public static final MethodHandle MH_add2FloatsOfStructsFromVaList;
+	public static final MethodHandle MH_add3FloatsOfStructsFromVaList;
+	public static final MethodHandle MH_add1DoubleOfStructsFromVaList;
+	public static final MethodHandle MH_add2DoublesOfStructsFromVaList;
+	public static final MethodHandle MH_addIntShortOfStructsFromVaList;
+	public static final MethodHandle MH_addShortIntOfStructsFromVaList;
+	public static final MethodHandle MH_addIntLongOfStructsFromVaList;
+	public static final MethodHandle MH_addLongIntOfStructsFromVaList;
+	public static final MethodHandle MH_addFloatDoubleOfStructsFromVaList;
+	public static final MethodHandle MH_addDoubleFloatOfStructsFromVaList;
+
+	static {
+		try {
+			MH_addIntsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addIntsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_addLongsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addLongsFromVaList", MT_Long_Int_MemAddr); //$NON-NLS-1$
+			MH_addDoublesFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addDoublesFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+			MH_addMixedArgsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addMixedArgsFromVaList", methodType(double.class, MemoryAddress.class)); //$NON-NLS-1$
+			MH_addMoreMixedArgsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addMoreMixedArgsFromVaList", methodType(double.class, MemoryAddress.class)); //$NON-NLS-1$
+			MH_addIntsByPtrFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addIntsByPtrFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_addLongsByPtrFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addLongsByPtrFromVaList", MT_Long_Int_MemAddr); //$NON-NLS-1$
+			MH_addDoublesByPtrFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addDoublesByPtrFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+			MH_add1ByteOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add1ByteOfStructsFromVaList", MT_Byte_Int_MemAddr); //$NON-NLS-1$
+			MH_add2BytesOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2BytesOfStructsFromVaList", MT_Byte_Int_MemAddr); //$NON-NLS-1$
+			MH_add3BytesOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add3BytesOfStructsFromVaList", MT_Byte_Int_MemAddr); //$NON-NLS-1$
+			MH_add5BytesOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add5BytesOfStructsFromVaList", MT_Byte_Int_MemAddr); //$NON-NLS-1$
+			MH_add7BytesOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add7BytesOfStructsFromVaList", MT_Byte_Int_MemAddr); //$NON-NLS-1$
+			MH_add1ShortOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add1ShortOfStructsFromVaList", MT_Short_Int_MemAddr); //$NON-NLS-1$
+			MH_add2ShortsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2ShortsOfStructsFromVaList", MT_Short_Int_MemAddr); //$NON-NLS-1$
+			MH_add3ShortsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add3ShortsOfStructsFromVaList", MT_Short_Int_MemAddr); //$NON-NLS-1$
+			MH_add1IntOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add1IntOfStructsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_add2IntsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2IntsOfStructsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_add3IntsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add3IntsOfStructsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_add2LongsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2LongsOfStructsFromVaList", MT_Long_Int_MemAddr); //$NON-NLS-1$
+			MH_add1FloatOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add1FloatOfStructsFromVaList", MT_Float_Int_MemAddr); //$NON-NLS-1$
+			MH_add2FloatsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2FloatsOfStructsFromVaList", MT_Float_Int_MemAddr); //$NON-NLS-1$
+			MH_add3FloatsOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add3FloatsOfStructsFromVaList", MT_Float_Int_MemAddr); //$NON-NLS-1$
+			MH_add1DoubleOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add1DoubleOfStructsFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+			MH_add2DoublesOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "add2DoublesOfStructsFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+			MH_addIntShortOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addIntShortOfStructsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_addShortIntOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addShortIntOfStructsFromVaList", MT_Int_Int_MemAddr); //$NON-NLS-1$
+			MH_addIntLongOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addIntLongOfStructsFromVaList", MT_Long_Int_MemAddr); //$NON-NLS-1$
+			MH_addLongIntOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addLongIntOfStructsFromVaList", MT_Long_Int_MemAddr); //$NON-NLS-1$
+			MH_addFloatDoubleOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addFloatDoubleOfStructsFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+			MH_addDoubleFloatOfStructsFromVaList = lookup.findStatic(VaListUpcallMethodHandles.class, "addDoubleFloatOfStructsFromVaList", MT_Double_Int_MemAddr); //$NON-NLS-1$
+
+		} catch (IllegalAccessException | NoSuchMethodException e) {
+			throw new InternalError(e);
+		}
+	}
+
+	public static int addIntsFromVaList(int argCount, MemoryAddress intVaListAddr) {
+		VaList intVaList = VaList.ofAddress(intVaListAddr, scope);
+		int intSum = 0;
+		while (argCount > 0) {
+			intSum += intVaList.vargAsInt(C_INT);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static long addLongsFromVaList(int argCount, MemoryAddress longVaListAddr) {
+		VaList longVaList = VaList.ofAddress(longVaListAddr, scope);
+		long longSum = 0;
+		while (argCount > 0) {
+			longSum += longVaList.vargAsLong(longLayout);
+			argCount--;
+		}
+		return longSum;
+	}
+
+	public static double addDoublesFromVaList(int argCount, MemoryAddress doubleVaListAddr) {
+		VaList doubleVaList = VaList.ofAddress(doubleVaListAddr, scope);
+		double doubleSum = 0;
+		while (argCount > 0) {
+			doubleSum += doubleVaList.vargAsDouble(C_DOUBLE);
+			argCount--;
+		}
+		return doubleSum;
+	}
+
+	public static double addMixedArgsFromVaList(MemoryAddress argVaListAddr) {
+		VaList argVaList = VaList.ofAddress(argVaListAddr, scope);
+		double doubleSum = argVaList.vargAsInt(C_INT)
+				+ argVaList.vargAsLong(longLayout) + argVaList.vargAsDouble(C_DOUBLE);
+		return doubleSum;
+	}
+
+	public static double addMoreMixedArgsFromVaList(MemoryAddress argVaListAddr) {
+		VaList argVaList = VaList.ofAddress(argVaListAddr, scope);
+		double doubleSum = argVaList.vargAsInt(C_INT) + argVaList.vargAsLong(longLayout)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsLong(longLayout)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsLong(longLayout)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsDouble(C_DOUBLE)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsDouble(C_DOUBLE)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsDouble(C_DOUBLE)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsDouble(C_DOUBLE)
+							+ argVaList.vargAsInt(C_INT) + argVaList.vargAsDouble(C_DOUBLE);
+		return doubleSum;
+	}
+
+	public static int addIntsByPtrFromVaList(int argCount, MemoryAddress ptrVaListAddr) {
+		VaList ptrVaList = VaList.ofAddress(ptrVaListAddr, scope);
+		int intSum = 0;
+		while (argCount > 0) {
+			MemorySegment nextValueSegmt = ptrVaList.vargAsAddress(C_POINTER).asSegment(C_INT.byteSize(), scope);
+			VarHandle nextValueHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
+			intSum += (int)nextValueHandle.get(nextValueSegmt, 0);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static long addLongsByPtrFromVaList(int argCount, MemoryAddress ptrVaListAddr) {
+		VaList ptrVaList = VaList.ofAddress(ptrVaListAddr, scope);
+		long longSum = 0;
+		while (argCount > 0) {
+			MemorySegment nextValueSegmt = ptrVaList.vargAsAddress(C_POINTER).asSegment(longLayout.byteSize(), scope);
+			VarHandle nextValueHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+			longSum += (long)nextValueHandle.get(nextValueSegmt, 0);
+			argCount--;
+		}
+		return longSum;
+	}
+
+	public static double addDoublesByPtrFromVaList(int argCount, MemoryAddress ptrVaListAddr) {
+		VaList ptrVaList = VaList.ofAddress(ptrVaListAddr, scope);
+		double doubleSum = 0;
+		while (argCount > 0) {
+			MemorySegment nextValueSegmt = ptrVaList.vargAsAddress(C_POINTER).asSegment(C_DOUBLE.byteSize(), scope);
+			VarHandle nextValueHandle = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
+			doubleSum += (double)nextValueHandle.get(nextValueSegmt, 0);
+			argCount--;
+		}
+		return doubleSum;
+	}
+
+	public static byte add1ByteOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"));
+		VarHandle elemHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+
+		byte byteSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			byteSum += (byte)elemHandle1.get(argSegmt);
+			argCount--;
+		}
+		return byteSum;
+	}
+
+	public static byte add2BytesOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"), C_CHAR.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+
+		byte byteSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			byteSum += (byte)elemHandle1.get(argSegmt) + (byte)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return byteSum;
+	}
+
+	public static byte add3BytesOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"));
+		VarHandle elemHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+
+		byte byteSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			byteSum += (byte)elemHandle1.get(argSegmt) + (byte)elemHandle2.get(argSegmt) + (byte)elemHandle3.get(argSegmt);
+			argCount--;
+		}
+		return byteSum;
+	}
+
+	public static byte add5BytesOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"),
+				C_CHAR.withName("elem4"), C_CHAR.withName("elem5"));
+		VarHandle elemHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle elemHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle elemHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+
+		byte byteSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			byteSum += (byte)elemHandle1.get(argSegmt) + (byte)elemHandle2.get(argSegmt)
+						+ (byte)elemHandle3.get(argSegmt) + (byte)elemHandle4.get(argSegmt)
+						+ (byte)elemHandle5.get(argSegmt);
+			argCount--;
+		}
+		return byteSum;
+	}
+
+	public static byte add7BytesOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"),
+				C_CHAR.withName("elem2"), C_CHAR.withName("elem3"),
+				C_CHAR.withName("elem4"), C_CHAR.withName("elem5"),
+				C_CHAR.withName("elem6"), C_CHAR.withName("elem7"));
+		VarHandle elemHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(byte.class, PathElement.groupElement("elem3"));
+		VarHandle elemHandle4 = structLayout.varHandle(byte.class, PathElement.groupElement("elem4"));
+		VarHandle elemHandle5 = structLayout.varHandle(byte.class, PathElement.groupElement("elem5"));
+		VarHandle elemHandle6 = structLayout.varHandle(byte.class, PathElement.groupElement("elem6"));
+		VarHandle elemHandle7 = structLayout.varHandle(byte.class, PathElement.groupElement("elem7"));
+
+		byte byteSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			byteSum += (byte)elemHandle1.get(argSegmt) + (byte)elemHandle2.get(argSegmt)
+						+ (byte)elemHandle3.get(argSegmt) + (byte)elemHandle4.get(argSegmt)
+						+ (byte)elemHandle5.get(argSegmt) + (byte)elemHandle6.get(argSegmt)
+						+ (byte)elemHandle7.get(argSegmt);
+			argCount--;
+		}
+		return byteSum;
+	}
+
+	public static short add1ShortOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+
+		short shortSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			shortSum += (short)elemHandle1.get(argSegmt);
+			argCount--;
+		}
+		return shortSum;
+	}
+
+	public static short add2ShortsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"), C_SHORT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+		short shortSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			shortSum += (short)elemHandle1.get(argSegmt) + (short)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return shortSum;
+	}
+
+	public static short add3ShortsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+				C_SHORT.withName("elem2"), C_SHORT.withName("elem3"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(short.class, PathElement.groupElement("elem3"));
+
+		short shortSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			shortSum += (short)elemHandle1.get(argSegmt) + (short)elemHandle2.get(argSegmt) + (short)elemHandle3.get(argSegmt);
+			argCount--;
+		}
+		return shortSum;
+	}
+
+	public static int add1IntOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+
+		int intSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			intSum += (int)elemHandle1.get(argSegmt);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static int add2IntsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		int intSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			intSum += (int)elemHandle1.get(argSegmt) + (int)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static int add3IntsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+				C_INT.withName("elem2"), C_INT.withName("elem3"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(int.class, PathElement.groupElement("elem3"));
+
+		int intSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			intSum += (int)elemHandle1.get(argSegmt) + (int)elemHandle2.get(argSegmt) + (int)elemHandle3.get(argSegmt);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static long add2LongsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"), longLayout.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		long longSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			longSum += (long)elemHandle1.get(argSegmt) + (long)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return longSum;
+	}
+
+	public static float add1FloatOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+
+		float floatSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			floatSum += (float)elemHandle1.get(argSegmt);
+			argCount--;
+		}
+		return floatSum;
+	}
+
+	public static float add2FloatsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"), C_FLOAT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		float floatSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			floatSum += (float)elemHandle1.get(argSegmt) + (float)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return floatSum;
+	}
+
+	public static float add3FloatsOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_FLOAT.withName("elem2"), C_FLOAT.withName("elem3"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+		VarHandle elemHandle3 = structLayout.varHandle(float.class, PathElement.groupElement("elem3"));
+
+		float floatSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			floatSum += (float)elemHandle1.get(argSegmt) + (float)elemHandle2.get(argSegmt) + (float)elemHandle3.get(argSegmt);
+			argCount--;
+		}
+		return floatSum;
+	}
+
+	public static double add1DoubleOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"));
+		VarHandle elemHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+
+		double doubleSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			doubleSum += (double)elemHandle1.get(argSegmt);
+			argCount--;
+		}
+		return doubleSum;
+	}
+
+	public static double add2DoublesOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"), C_DOUBLE.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		double doubleSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			doubleSum += (double)elemHandle1.get(argSegmt) + (double)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return doubleSum;
+	}
+
+	public static int addIntShortOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_SHORT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+		int intSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			intSum += (int)elemHandle1.get(argSegmt) + (short)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static int addShortIntOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"),
+		MemoryLayout.paddingLayout(16), C_INT.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		int intSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			intSum += (short)elemHandle1.get(argSegmt) + (int)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return intSum;
+	}
+
+	public static long addLongIntOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(longLayout.withName("elem1"),
+				C_INT.withName("elem2"), MemoryLayout.paddingLayout(32));
+		VarHandle elemHandle1 = structLayout.varHandle(long.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		long longSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			longSum += (long)elemHandle1.get(argSegmt) + (int)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return longSum;
+	}
+
+	public static long addIntLongOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"),
+		MemoryLayout.paddingLayout(32), longLayout.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(long.class, PathElement.groupElement("elem2"));
+
+		long longSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			longSum += (int)elemHandle1.get(argSegmt) + (long)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return longSum;
+	}
+
+	public static double addFloatDoubleOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		/* The size of [float, double] on AIX/PPC 64-bit is 12 bytes without padding by default
+		 * while the same struct is 16 bytes with padding on other platforms.
+		 */
+		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				C_DOUBLE.withName("elem2")) : MemoryLayout.structLayout(C_FLOAT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"));
+		VarHandle elemHandle1 = structLayout.varHandle(float.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
+
+		double doubleSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			doubleSum += (float)elemHandle1.get(argSegmt) + (double)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return doubleSum;
+	}
+
+	public static double addDoubleFloatOfStructsFromVaList(int argCount, MemoryAddress struVaListAddr) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_DOUBLE.withName("elem1"),
+				C_FLOAT.withName("elem2"), MemoryLayout.paddingLayout(32));
+		VarHandle elemHandle1 = structLayout.varHandle(double.class, PathElement.groupElement("elem1"));
+		VarHandle elemHandle2 = structLayout.varHandle(float.class, PathElement.groupElement("elem2"));
+
+		double doubleSum = 0;
+		VaList struVaList = VaList.ofAddress(struVaListAddr, scope);
+		while (argCount > 0) {
+			MemorySegment argSegmt = struVaList.vargAsSegment(structLayout, allocator);
+			doubleSum += (double)elemHandle1.get(argSegmt) + (float)elemHandle2.get(argSegmt);
+			argCount--;
+		}
+		return doubleSum;
+	}
+}

--- a/test/functional/Java17andUp/testng_170.xml
+++ b/test/functional/Java17andUp/testng_170.xml
@@ -53,6 +53,8 @@
 	<test name="Jep389Tests_testClinkerFfi_VaList">
 		<classes>
 			<class name="org.openj9.test.jep389.valist.ApiTests"/>
+			<class name="org.openj9.test.jep389.valist.DowncallTests"/>
+			<class name="org.openj9.test.jep389.valist.UpcallTests"/>
 		</classes>
 	</test>
 	<test name="CloseScope0Tests">


### PR DESCRIPTION
The changes backport the same test suites in JEP424(JDK19) with the required APIs in JEP389/412(JDK17).

Note:
The PR is part of FFI downcall & upcall work at
eclipse-openj9/openj9#12412 and eclipse-openj9/openj9#15068.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>