### PR TITLE
Refactor JITServer AOT cache reading

### DIFF
--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -58,8 +58,41 @@ AOTCacheRecord::free(void *ptr)
    TR::Compiler->persistentGlobalMemory()->freePersistentMemory(ptr);
    }
 
+// Read a single AOT cache record R from a cache file
+template<class R> R *
+AOTCacheRecord::readRecord(FILE *f, const JITServerAOTCacheReadContext &context)
+   {
+   typename R::SerializationRecord header;
+   if (1 != fread(&header, sizeof(header), 1, f))
+      return NULL;
+
+   if (!header.isValidHeader(context))
+      return NULL;
+
+   R *record = new (AOTCacheRecord::allocate(R::size(header))) R(context, header);
+   memcpy((void *)record->dataAddr(), &header, sizeof(header));
+
+   size_t variableDataBytes = record->dataAddr()->size() - sizeof(header);
+   if (0 != variableDataBytes)
+      {
+      if (1 != fread((uint8_t *)record->dataAddr() + sizeof(header), variableDataBytes, 1, f))
+         {
+         AOTCacheRecord::free(record);
+         return NULL;
+         }
+      }
+
+   if (!record->setSubrecordPointers(context))
+      {
+      AOTCacheRecord::free(record);
+      return NULL;
+      }
+
+   return record;
+   }
+
 bool
-AOTSerializationRecord::isValid(AOTSerializationRecordType type) const
+AOTSerializationRecord::isValidHeader(AOTSerializationRecordType type) const
    {
    return (type == this->type()) &&
           (0 != this->id());
@@ -91,27 +124,6 @@ AOTCacheClassLoaderRecord::create(uintptr_t id, const uint8_t *name, size_t name
    return new (ptr) AOTCacheClassLoaderRecord(id, name, nameLength);
    }
 
-AOTCacheClassLoaderRecord *
-AOTCacheClassLoaderRecord::read(FILE *f, const JITServerAOTCacheReadContext &context)
-   {
-   ClassLoaderSerializationRecord header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if (!header.isValid())
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(size(header.nameLength()))) AOTCacheClassLoaderRecord();
-   memcpy((void *)record->dataAddr(), &header, sizeof(header));
-   if (1 != fread((uint8_t *)record->dataAddr() + sizeof(header), header.AOTSerializationRecord::size() - sizeof(header), 1, f))
-      {
-      AOTCacheRecord::free(record);
-      return NULL;
-      }
-
-   return record;
-   }
-
 ClassSerializationRecord::ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
                                                    const JITServerROMClassHash &hash, const J9ROMClass *romClass) :
    AOTSerializationRecord(size(J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass))), id, AOTSerializationRecordType::Class),
@@ -127,6 +139,14 @@ ClassSerializationRecord::ClassSerializationRecord() :
    {
    }
 
+bool
+ClassSerializationRecord::isValidHeader(const JITServerAOTCacheReadContext &context) const
+   {
+   return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::Class) &&
+          (classLoaderId() < context._classLoaderRecords.size()) &&
+          context._classLoaderRecords[classLoaderId()];
+   }
+
 AOTCacheClassRecord::AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
                                          const JITServerROMClassHash &hash, const J9ROMClass *romClass) :
    _classLoaderRecord(classLoaderRecord),
@@ -134,8 +154,8 @@ AOTCacheClassRecord::AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoader
    {
    }
 
-AOTCacheClassRecord::AOTCacheClassRecord(const AOTCacheClassLoaderRecord *classLoaderRecord) :
-   _classLoaderRecord(classLoaderRecord)
+AOTCacheClassRecord::AOTCacheClassRecord(const JITServerAOTCacheReadContext &context, const ClassSerializationRecord &header) :
+   _classLoaderRecord(context._classLoaderRecords[header.classLoaderId()])
    {
    }
 
@@ -153,29 +173,6 @@ AOTCacheClassRecord::subRecordsDo(const std::function<void(const AOTCacheRecord 
    f(_classLoaderRecord);
    }
 
-AOTCacheClassRecord *
-AOTCacheClassRecord::read(FILE *f, const JITServerAOTCacheReadContext &context)
-   {
-   ClassSerializationRecord header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if (!header.isValid() ||
-       (header.classLoaderId() >= context._classLoaderRecords.size()) ||
-       !context._classLoaderRecords[header.classLoaderId()])
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(size(header.nameLength()))) AOTCacheClassRecord(context._classLoaderRecords[header.classLoaderId()]);
-   memcpy((void *)record->dataAddr(), &header, sizeof(header));
-   if (1 != fread((uint8_t *)record->dataAddr() + sizeof(header), header.AOTSerializationRecord::size() - sizeof(header), 1, f))
-      {
-      AOTCacheRecord::free(record);
-      return NULL;
-      }
-
-   return record;
-   }
-
 MethodSerializationRecord::MethodSerializationRecord(uintptr_t id, uintptr_t definingClassId, uint32_t index) :
    AOTSerializationRecord(sizeof(*this), id, AOTSerializationRecordType::Method),
    _definingClassId(definingClassId), _index(index)
@@ -188,6 +185,14 @@ MethodSerializationRecord::MethodSerializationRecord() :
    {
    }
 
+bool
+MethodSerializationRecord::isValidHeader(const JITServerAOTCacheReadContext &context) const
+      {
+      return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::Method) &&
+             (definingClassId() < context._classRecords.size()) &&
+             context._classRecords[definingClassId()];
+      }
+
 AOTCacheMethodRecord::AOTCacheMethodRecord(uintptr_t id, const AOTCacheClassRecord *definingClassRecord,
                                            uint32_t index) :
    _definingClassRecord(definingClassRecord),
@@ -195,8 +200,8 @@ AOTCacheMethodRecord::AOTCacheMethodRecord(uintptr_t id, const AOTCacheClassReco
    {
    }
 
-AOTCacheMethodRecord::AOTCacheMethodRecord(const AOTCacheClassRecord *definingClassRecord) :
-   _definingClassRecord(definingClassRecord)
+AOTCacheMethodRecord::AOTCacheMethodRecord(const JITServerAOTCacheReadContext &context, const MethodSerializationRecord &header) :
+   _definingClassRecord(context._classRecords[header.definingClassId()])
    {
    }
 
@@ -211,24 +216,6 @@ void
 AOTCacheMethodRecord::subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const
    {
    f(_definingClassRecord);
-   }
-
-AOTCacheMethodRecord *
-AOTCacheMethodRecord::read(FILE *f, const JITServerAOTCacheReadContext &context)
-   {
-   MethodSerializationRecord header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if (!header.isValid() ||
-       (header.definingClassId() >= context._classRecords.size()) ||
-       !context._classRecords[header.definingClassId()])
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(sizeof(AOTCacheMethodRecord))) AOTCacheMethodRecord(context._classRecords[header.definingClassId()]);
-   memcpy((void *)record->dataAddr(), &header, sizeof(header));
-
-   return record;
    }
 
 template<class D, class R, typename... Args>
@@ -248,37 +235,19 @@ AOTCacheListRecord<D, R, Args...>::subRecordsDo(const std::function<void(const A
       f(records()[i]);
    }
 
-template<class D, class R, typename... Args> AOTCacheListRecord<D, R, Args...>*
-AOTCacheListRecord<D, R, Args...>::read(FILE *f, const Vector<R *> &cacheRecords)
+template<class D, class R, typename... Args> bool
+AOTCacheListRecord<D, R, Args...>::setSubrecordPointers(const Vector<R *> &cacheRecords)
    {
-   D header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if (!header.isValid())
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(size(header.list().length()))) AOTCacheListRecord();
-   memcpy((void *)record->dataAddr(), &header, sizeof(header));
-
-   if (1 != fread((uint8_t *)record->dataAddr() + sizeof(header), header.AOTSerializationRecord::size() - sizeof(header), 1, f))
+   for (size_t i = 0; i < data().list().length(); ++i)
       {
-      AOTCacheRecord::free(record);
-      return NULL;
-      }
-
-   for (size_t i = 0; i < header.list().length(); ++i)
-      {
-      uintptr_t id = record->data().list().ids()[i];
+      uintptr_t id = data().list().ids()[i];
       if ((id >= cacheRecords.size()) || !cacheRecords[id])
          {
-         AOTCacheRecord::free(record);
-         return NULL;
+         return false;
          }
-      record->records()[i] = cacheRecords[id];
+      records()[i] = cacheRecords[id];
       }
-
-   return record;
+   return true;
    }
 
 ClassChainSerializationRecord::ClassChainSerializationRecord(uintptr_t id, size_t length) :
@@ -300,6 +269,11 @@ AOTCacheClassChainRecord::create(uintptr_t id, const AOTCacheClassRecord *const 
    return new (ptr) AOTCacheClassChainRecord(id, records, length);
    }
 
+bool
+AOTCacheClassChainRecord::setSubrecordPointers(const JITServerAOTCacheReadContext &context)
+   {
+   return AOTCacheListRecord::setSubrecordPointers(context._classRecords);
+   }
 
 WellKnownClassesSerializationRecord::WellKnownClassesSerializationRecord(uintptr_t id, size_t length,
                                                                          uintptr_t includedClasses) :
@@ -322,6 +296,11 @@ AOTCacheWellKnownClassesRecord::create(uintptr_t id, const AOTCacheClassChainRec
    return new (ptr) AOTCacheWellKnownClassesRecord(id, records, length, includedClasses);
    }
 
+bool
+AOTCacheWellKnownClassesRecord::setSubrecordPointers(const JITServerAOTCacheReadContext &context)
+   {
+   return AOTCacheListRecord::setSubrecordPointers(context._classChainRecords);
+   }
 
 AOTHeaderSerializationRecord::AOTHeaderSerializationRecord(uintptr_t id, const TR_AOTHeader *header) :
    AOTSerializationRecord(sizeof(*this), id, AOTSerializationRecordType::AOTHeader),
@@ -347,22 +326,6 @@ AOTCacheAOTHeaderRecord::create(uintptr_t id, const TR_AOTHeader *header)
    return new (ptr) AOTCacheAOTHeaderRecord(id, header);
    }
 
-AOTCacheAOTHeaderRecord *
-AOTCacheAOTHeaderRecord::read(FILE *f, const JITServerAOTCacheReadContext &context)
-   {
-   AOTHeaderSerializationRecord header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if (!header.isValid())
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(sizeof(AOTCacheAOTHeaderRecord))) AOTCacheAOTHeaderRecord();
-   memcpy((void *)record->dataAddr(), &header, sizeof(header));
-
-   return record;
-   }
-
 SerializedAOTMethod::SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
                                          TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
                                          const void *code, size_t codeSize, const void *data, size_t dataSize) :
@@ -384,9 +347,13 @@ SerializedAOTMethod::SerializedAOTMethod() :
    }
 
 bool
-SerializedAOTMethod::isValid() const
+SerializedAOTMethod::isValidHeader(const JITServerAOTCacheReadContext &context) const
    {
-   return _optLevel < TR_Hotness::numHotnessLevels;
+   return _optLevel < TR_Hotness::numHotnessLevels &&
+          (definingClassChainId() < context._classChainRecords.size()) &&
+          (aotHeaderId() < context._aotHeaderRecords.size()) &&
+          context._classChainRecords[definingClassChainId()] &&
+          context._aotHeaderRecords[aotHeaderId()];
    }
 
 CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
@@ -406,9 +373,9 @@ CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassCh
       }
    }
 
-CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord) :
+CachedAOTMethod::CachedAOTMethod(const JITServerAOTCacheReadContext &context, const SerializedAOTMethod &header) :
    _nextRecord(NULL),
-   _definingClassChainRecord(definingClassChainRecord)
+   _definingClassChainRecord(context._classChainRecords[header.definingClassChainId()])
    {
    }
 
@@ -423,68 +390,48 @@ CachedAOTMethod::create(const AOTCacheClassChainRecord *definingClassChainRecord
                                     records, code, codeSize, data, dataSize);
    }
 
-CachedAOTMethod *
-CachedAOTMethod::read(FILE *f, const JITServerAOTCacheReadContext &context)
+bool
+CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &context)
    {
-   SerializedAOTMethod header;
-   if (1 != fread(&header, sizeof(header), 1, f))
-      return NULL;
-
-   if ((!header.isValid()) ||
-       (header.definingClassChainId() >= context._classChainRecords.size()) ||
-       (header.aotHeaderId() >= context._aotHeaderRecords.size()) ||
-       !context._classChainRecords[header.definingClassChainId()])
-      return NULL;
-
-   auto record = new (AOTCacheRecord::allocate(size(header.numRecords(), header.codeSize(), header.dataSize())))
-                     CachedAOTMethod(context._classChainRecords[header.definingClassChainId()]);
-   memcpy(&record->_data, &header, sizeof(header));
-
-   if (1 != fread(record->data().offsets(), sizeof(SerializedSCCOffset) * header.numRecords() + header.codeSize() + header.dataSize(), 1, f))
-      goto error;
-
-   for (size_t i = 0; i < header.numRecords(); ++i)
+   // The defining class chain record pointer for the record will have been set by the CachedAOTMethod constructor at this point
+   for (size_t i = 0; i < data().numRecords(); ++i)
       {
-      const SerializedSCCOffset &sccOffset = record->data().offsets()[i];
+      const SerializedSCCOffset &sccOffset = data().offsets()[i];
 
       switch (sccOffset.recordType())
          {
          case AOTSerializationRecordType::ClassLoader:
             if ((sccOffset.recordId() >= context._classLoaderRecords.size()) || !context._classLoaderRecords[sccOffset.recordId()])
-               goto error;
-            record->records()[i] = context._classLoaderRecords[sccOffset.recordId()];
+               return false;
+            records()[i] = context._classLoaderRecords[sccOffset.recordId()];
             break;
          case AOTSerializationRecordType::Class:
             if ((sccOffset.recordId() >= context._classRecords.size()) || !context._classRecords[sccOffset.recordId()])
-               goto error;
-            record->records()[i] = context._classRecords[sccOffset.recordId()];
+               return false;
+            records()[i] = context._classRecords[sccOffset.recordId()];
             break;
          case AOTSerializationRecordType::Method:
             if ((sccOffset.recordId() >= context._methodRecords.size()) || !context._methodRecords[sccOffset.recordId()])
-               goto error;
-            record->records()[i] = context._methodRecords[sccOffset.recordId()];
+               return false;
+            records()[i] = context._methodRecords[sccOffset.recordId()];
             break;
          case AOTSerializationRecordType::ClassChain:
             if ((sccOffset.recordId() >= context._classChainRecords.size()) || !context._classChainRecords[sccOffset.recordId()])
-               goto error;
-            record->records()[i] = context._classChainRecords[sccOffset.recordId()];
+               return false;
+            records()[i] = context._classChainRecords[sccOffset.recordId()];
             break;
          case AOTSerializationRecordType::WellKnownClasses:
             if ((sccOffset.recordId() >= context._wellKnownClassesRecords.size()) || !context._wellKnownClassesRecords[sccOffset.recordId()])
-               goto error;
-            record->records()[i] = context._wellKnownClassesRecords[sccOffset.recordId()];
+               return false;
+            records()[i] = context._wellKnownClassesRecords[sccOffset.recordId()];
             break;
          case AOTSerializationRecordType::AOTHeader: // never associated with an SCC offset
          default:
-            goto error;
+            return false;
          }
       }
 
-   return record;
-
-error:
-   AOTCacheRecord::free(record);
-   return NULL;
+   return true;
    }
 
 bool
@@ -1279,7 +1226,7 @@ JITServerAOTCache::readRecords(FILE *f,
       if (!JITServerAOTCacheMap::cacheHasSpace())
          return false;
 
-      V *record = V::read(f, context);
+      V *record = AOTCacheRecord::readRecord<V>(f, context);
       if (!record)
          return false;
 
@@ -1337,9 +1284,8 @@ JITServerAOTCache::readCache(FILE *f, const JITServerAOTCacheHeader &header, TR_
       if (!JITServerAOTCacheMap::cacheHasSpace())
          return false;
 
-      auto record = CachedAOTMethod::read(f, context);
-
-      if (!record || !context._aotHeaderRecords[record->data().aotHeaderId()])
+      auto record = AOTCacheRecord::readRecord<CachedAOTMethod>(f, context);
+      if (!record)
          return false;
 
       CachedMethodKey key(record->definingClassChainRecord(),

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -126,13 +126,7 @@ public:
 
    static AOTCacheClassLoaderRecord *create(uintptr_t id, const uint8_t *name, size_t nameLength);
 
-   static AOTCacheClassLoaderRecord *read(FILE *f,
-                                          const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                          const Vector<AOTCacheClassRecord *> &classRecords,
-                                          const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                          const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                          const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                          const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
+   static AOTCacheClassLoaderRecord *read(FILE *f, const JITServerAOTCacheReadContext &context);
 
 private:
    AOTCacheClassLoaderRecord(uintptr_t id, const uint8_t *name, size_t nameLength);
@@ -158,13 +152,7 @@ public:
                                       const JITServerROMClassHash &hash, const J9ROMClass *romClass);
    void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
 
-   static AOTCacheClassRecord *read(FILE *f,
-                                    const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                    const Vector<AOTCacheClassRecord *> &classRecords,
-                                    const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                    const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                    const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                    const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
+   static AOTCacheClassRecord *read(FILE *f, const JITServerAOTCacheReadContext &context);
 
 private:
    AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
@@ -191,13 +179,7 @@ public:
    static AOTCacheMethodRecord *create(uintptr_t id, const AOTCacheClassRecord *definingClassRecord, uint32_t index);
    void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
 
-   static AOTCacheMethodRecord *read(FILE *f,
-                                     const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                     const Vector<AOTCacheClassRecord *> &classRecords,
-                                     const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                     const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                     const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                     const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
+   static AOTCacheMethodRecord *read(FILE *f, const JITServerAOTCacheReadContext &context);
 
 private:
    AOTCacheMethodRecord(uintptr_t id, const AOTCacheClassRecord *definingClassRecord, uint32_t index);
@@ -247,14 +229,8 @@ public:
    const AOTCacheClassRecord *rootClassRecord() const { return records()[0]; }
    const AOTCacheClassLoaderRecord *rootClassLoaderRecord() const { return rootClassRecord()->classLoaderRecord(); }
 
-   static AOTCacheClassChainRecord *read(FILE *f,
-                                         const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                         const Vector<AOTCacheClassRecord *> &classRecords,
-                                         const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                         const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                         const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                         const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords)
-      { return (AOTCacheClassChainRecord *)AOTCacheListRecord<ClassChainSerializationRecord, AOTCacheClassRecord>::read(f, classRecords); }
+   static AOTCacheClassChainRecord *read(FILE *f, const JITServerAOTCacheReadContext &context)
+      { return (AOTCacheClassChainRecord *)AOTCacheListRecord<ClassChainSerializationRecord, AOTCacheClassRecord>::read(f, context._classRecords); }
 
 private:
    using AOTCacheListRecord::AOTCacheListRecord;
@@ -268,15 +244,9 @@ public:
    static AOTCacheWellKnownClassesRecord *create(uintptr_t id, const AOTCacheClassChainRecord *const *records,
                                                  size_t length, uintptr_t includedClasses);
 
-   static AOTCacheWellKnownClassesRecord *read(FILE *f,
-                                               const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                               const Vector<AOTCacheClassRecord *> &classRecords,
-                                               const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                               const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                               const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                               const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords)
+   static AOTCacheWellKnownClassesRecord *read(FILE *f, const JITServerAOTCacheReadContext &context)
       { return (AOTCacheWellKnownClassesRecord *)
-               AOTCacheListRecord<WellKnownClassesSerializationRecord, AOTCacheClassChainRecord>::read(f, classChainRecords); }
+               AOTCacheListRecord<WellKnownClassesSerializationRecord, AOTCacheClassChainRecord>::read(f, context._classChainRecords); }
 
 private:
    using AOTCacheListRecord::AOTCacheListRecord;
@@ -291,13 +261,7 @@ public:
 
    static AOTCacheAOTHeaderRecord *create(uintptr_t id, const TR_AOTHeader *header);
 
-   static AOTCacheAOTHeaderRecord *read(FILE *f,
-                                        const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                        const Vector<AOTCacheClassRecord *> &classRecords,
-                                        const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                        const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                        const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                        const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
+   static AOTCacheAOTHeaderRecord *read(FILE *f, const JITServerAOTCacheReadContext &context);
 
 private:
    AOTCacheAOTHeaderRecord(uintptr_t id, const TR_AOTHeader *header);
@@ -328,15 +292,7 @@ public:
                                   const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
                                   const void *code, size_t codeSize, const void *data, size_t dataSize);
 
-   static CachedAOTMethod *read(FILE *f,
-                                const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                                const Vector<AOTCacheClassRecord *> &classRecords,
-                                const Vector<AOTCacheMethodRecord *> &methodRecords,
-                                const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                                const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                                const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
-
-   static CachedAOTMethod *read(FILE *f, const Vector<AOTCacheClassChainRecord *> &classChainRecords);
+   static CachedAOTMethod *read(FILE *f, const JITServerAOTCacheReadContext &context);
 
    CachedAOTMethod *getNextRecord() const { return _nextRecord; }
    void setNextRecord(CachedAOTMethod *record) { _nextRecord = record; }
@@ -503,14 +459,8 @@ private:
    bool readCache(FILE *f, const JITServerAOTCacheHeader &header, TR_Memory &trMemory);
 
    template<typename K, typename V, typename H>
-   static bool readRecords(FILE *f, size_t numRecordsToRead, PersistentUnorderedMap<K, V *, H> &map, V *&traversalHead, V *&traversalTail,
-                           Vector<V *> &records,
-                           const Vector<AOTCacheClassLoaderRecord *> &classLoaderRecords,
-                           const Vector<AOTCacheClassRecord *> &classRecords,
-                           const Vector<AOTCacheMethodRecord *> &methodRecords,
-                           const Vector<AOTCacheClassChainRecord *> &classChainRecords,
-                           const Vector<AOTCacheWellKnownClassesRecord *> &wellKnownClassesRecords,
-                           const Vector<AOTCacheAOTHeaderRecord *> &aotHeaderRecords);
+   static bool readRecords(FILE *f, JITServerAOTCacheReadContext &context, size_t numRecordsToRead,
+                           PersistentUnorderedMap<K, V *, H> &map, V *&traversalHead, V *&traversalTail, Vector<V *> &records);
 
    const std::string _name;
 

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -27,6 +27,7 @@
 #include "runtime/JITServerROMClassHash.hpp"
 #include "runtime/RelocationRuntime.hpp"
 
+struct JITServerAOTCacheReadContext;
 
 enum AOTSerializationRecordType
    {
@@ -64,7 +65,6 @@ public:
    //NOTE: 0 signifies an invalid record ID
    uintptr_t id() const { return getId(_idAndType); }
    AOTSerializationRecordType type() const { return getType(_idAndType); }
-   bool isValid(AOTSerializationRecordType type) const;
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
 
    static const AOTSerializationRecord *get(const std::string &str)
@@ -96,6 +96,11 @@ protected:
    AOTSerializationRecord(size_t size, uintptr_t id, AOTSerializationRecordType type) :
       _size(size), _idAndType(idAndType(id, type)) { }
 
+   // Check the well-formedness of the statically-sized portion of a serialization record.
+   // The variable-sized portion can't be checked here, only in setSubrecordPointers, as it
+   // is read based on the information in the statically-sized portion.
+   bool isValidHeader(AOTSerializationRecordType type) const;
+
 private:
    static const uintptr_t idShift = 3;
    static const uintptr_t typeMask = (1 << idShift) - 1;
@@ -111,9 +116,9 @@ struct ClassLoaderSerializationRecord : public AOTSerializationRecord
 public:
    size_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::ClassLoader); }
 
 private:
+   friend class AOTCacheRecord;
    friend class AOTCacheClassLoaderRecord;
 
    ClassLoaderSerializationRecord(uintptr_t id, const uint8_t *name, size_t nameLength);
@@ -123,6 +128,9 @@ private:
       {
       return sizeof(ClassLoaderSerializationRecord) + OMR::alignNoCheck(nameLength, sizeof(size_t));
       }
+
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const
+      { return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::ClassLoader); }
 
    // Name of the 1st class loaded by the class loader
    const size_t _nameLength;
@@ -138,9 +146,9 @@ public:
    uint32_t romClassSize() const { return _romClassSize; }
    size_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::Class); }
 
 private:
+   friend class AOTCacheRecord;
    friend class AOTCacheClassRecord;
 
    ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
@@ -151,6 +159,8 @@ private:
       {
       return sizeof(ClassSerializationRecord) + OMR::alignNoCheck(nameLength, sizeof(size_t));
       }
+
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const;
 
    const uintptr_t _classLoaderId;
    const JITServerROMClassHash _hash;
@@ -167,13 +177,15 @@ struct MethodSerializationRecord : public AOTSerializationRecord
 public:
    uintptr_t definingClassId() const { return _definingClassId; }
    uint32_t index() const { return _index; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::Method); }
 
 private:
+   friend class AOTCacheRecord;
    friend class AOTCacheMethodRecord;
 
    MethodSerializationRecord(uintptr_t id, uintptr_t definingClassId, uint32_t index);
    MethodSerializationRecord();
+
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const;
 
    const uintptr_t _definingClassId;
    // Index in the array of methods of the defining class
@@ -202,9 +214,9 @@ struct ClassChainSerializationRecord : public AOTSerializationRecord
    {
 public:
    const IdList &list() const { return _list; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::ClassChain); }
 
 private:
+   friend class AOTCacheRecord;
    template<class D, class R, typename... Args> friend class AOTCacheListRecord;
 
    ClassChainSerializationRecord(uintptr_t id, size_t length);
@@ -217,6 +229,9 @@ private:
       return offsetof(ClassChainSerializationRecord, _list) + IdList::size(length);
       }
 
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const
+      { return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::ClassChain); }
+
    // List of class IDs
    IdList _list;
    };
@@ -227,9 +242,9 @@ struct WellKnownClassesSerializationRecord : public AOTSerializationRecord
 public:
    uintptr_t includedClasses() const { return _includedClasses; }
    const IdList &list() const { return _list; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::WellKnownClasses); }
 
 private:
+   friend class AOTCacheRecord;
    template<class D, class R, typename... Args> friend class AOTCacheListRecord;
 
    WellKnownClassesSerializationRecord(uintptr_t id, size_t length, uintptr_t includedClasses);
@@ -242,6 +257,9 @@ private:
       return offsetof(WellKnownClassesSerializationRecord, _list) + IdList::size(length);
       }
 
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const
+      { return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::WellKnownClasses); }
+
    // Bit mask representing which classes out of the predefined well-known set are included
    const uintptr_t _includedClasses;
    // List of class chain IDs
@@ -253,13 +271,16 @@ struct AOTHeaderSerializationRecord : public AOTSerializationRecord
    {
 public:
    const TR_AOTHeader *header() const { return &_header; }
-   bool isValid() const { return AOTSerializationRecord::isValid(AOTSerializationRecordType::AOTHeader); }
 
 private:
+   friend class AOTCacheRecord;
    friend class AOTCacheAOTHeaderRecord;
 
    AOTHeaderSerializationRecord(uintptr_t id, const TR_AOTHeader *header);
    AOTHeaderSerializationRecord();
+
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const
+      { return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::AOTHeader); }
 
    const TR_AOTHeader _header;
    };
@@ -307,7 +328,6 @@ public:
    const uint8_t *data() const { return code() + _codeSize; }
    uint8_t *data() { return (uint8_t *)(code() + _codeSize); }
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
-   bool isValid() const;
 
    static SerializedAOTMethod *get(std::string &str)
       {
@@ -317,6 +337,7 @@ public:
       }
 
 private:
+   friend class AOTCacheRecord;
    friend class CachedAOTMethod;
 
    SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
@@ -329,6 +350,8 @@ private:
       return sizeof(SerializedAOTMethod) + numRecords * sizeof(SerializedSCCOffset) +
              OMR::alignNoCheck(codeSize + dataSize, sizeof(size_t));
       }
+
+   bool isValidHeader(const JITServerAOTCacheReadContext &context) const;
 
    const size_t _size;
    const uintptr_t _definingClassChainId;


### PR DESCRIPTION
This PR cleans up some of the JITServer AOT cache reading code from the recent #15949. 

- A new cache read context struct simplifies passing around the relevant state when reading a cache file
- The various read functions for the individual cache records (other than `CachedAOTMethod`) have been consolidated into a single `AOTCacheRecord::readRecord` function template.

Related: #16109