### PR TITLE
ThreadMXBean findMonitorDeadlockedThreads excludes virtual threads

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -2178,7 +2178,12 @@ findObjectDeadlockedThreads(J9VMThread *currentThread,
 	threadCount = 0;
 	vmThread = currentThread;
 	do {
-		if (vmThread->threadObject != NULL) {
+		if ((NULL != vmThread->threadObject)
+#if JAVA_SPEC_VERSION >= 19
+		/* Exclude J9VMThreads if a continuation is mounted to match the RI. */
+		&& (NULL == vmThread->currentContinuation)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+		) {
 			++threadCount;
 		}
 	} while ((vmThread = vmThread->linkNext) != currentThread);
@@ -2211,7 +2216,12 @@ findObjectDeadlockedThreads(J9VMThread *currentThread,
 	threadCount = 0;
 	vmThread = currentThread;
 	do {
-		if (vmThread->threadObject != NULL) {
+		if ((NULL != vmThread->threadObject)
+#if JAVA_SPEC_VERSION >= 19
+		/* Exclude J9VMThreads if a continuation is mounted to match the RI. */
+		&& (NULL == vmThread->currentContinuation)
+#endif /* JAVA_SPEC_VERSION >= 19 */
+		) {
 			UDATA state;
 			J9VMThread *owner;
 			j9object_t monitorObject;


### PR DESCRIPTION
As per RI, ThreadMXBean findMonitorDeadlockedThreads excludes virtual threads.

Fixes failing internal tests.
Testing done internally:
[Build](https://hyc-runtimes-jenkins.swg-devops.com/job/Build_JDK19_s390x_linux_Personal/44/)
[Sanity functional](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29113/)
[Extended functional](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29121/)
[Sanity openjdk](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29117/)
[Extended openjdk](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29123/)
[Rerun of failing tests](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/29116/)

fyi: @babsingh @tajila 