### PR TITLE
Obsolete Trc_CRIU_after_checkpoint and reuse it with a new signature

### DIFF
--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -34,10 +34,11 @@ TraceException=Trc_CRIU_getNativeString_getStringSizeFail Overhead=1 Level=1 Tem
 TraceException=Trc_CRIU_getNativeString_convertFail Overhead=1 Level=1 Template="Failed to convert Java string: mutf8String=%s mutf8StringSize=%zu requiredConvertedStringSize=%zd"
 
 TraceEvent=Trc_CRIU_before_checkpoint Overhead=1 Level=2 Template="Before checkpoint criu_dump(), j9time_nano_time() returns %lld, j9time_current_time_nanos() returns %llu"
-TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump(), j9time_nano_time() returns %lld, j9time_current_time_nanos() returns %llu"
+TraceEvent=Trc_CRIU_after_checkpoint Obsolete Overhead=1 Level=2 Template="After checkpoint criu_dump(), restoreNanoUTCTime = %llu, checkpointNanoUTCTime = %llu, checkpointRestoreTimeDelta = %lld, restoreNanoTimeMonotonic = %lld, checkpointNanoTimeMonotonic = %lld, nanoTimeMonotonicClockDelta = %lld"
 TraceEntry=Trc_CRIU_checkpointJVMImpl_Entry Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
 TraceExit=Trc_CRIU_checkpointJVMImpl_Exit Overhead=1 Level=2 Template="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_checkIfSafeToCheckpointBlocked Overhead=1 Level=2 Template="Checkpoint blocked because thread=%p is in method=%p marked as not safe to checkpoint"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_syslogOptions Overhead=1 Level=3 Template="Current syslogOptions: %s"
 TraceEvent=Trc_CRIU_checkpoint_nano_times Overhead=1 Level=2 Template="Before checkpoint, checkpointNanoTimeMonotonic = %lld, checkpointNanoUTCTime = %llu"
 TraceEvent=Trc_CRIU_restore_nano_times Overhead=1 Level=2 Template="After restore, restoreNanoUTCTime = %llu, checkpointNanoUTCTime = %llu, checkpointRestoreTimeDelta = %lld, restoreNanoTimeMonotonic = %lld, checkpointNanoTimeMonotonic = %lld, nanoTimeMonotonicClockDelta = %lld"
+TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoint criu_dump(), j9time_nano_time() returns %lld, j9time_current_time_nanos() returns %llu"


### PR DESCRIPTION
Obsolete `Trc_CRIU_after_checkpoint` and reuse it with a new signature

Related https://github.com/eclipse-openj9/openj9/pull/16091#pullrequestreview-1162282005

Signed-off-by: Jason Feng <fengj@ca.ibm.com>