### PR TITLE
Inline jdk/internal/util/Preconditions.checkIndex

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -445,6 +445,7 @@
 
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,
+   jdk_internal_util_Preconditions_checkIndex,
 
    FirstVectorMethod,
    jdk_internal_vm_vector_VectorSupport_load = FirstVectorMethod,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2988,6 +2988,14 @@ void TR_ResolvedJ9Method::construct()
       };
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
+
+   static X PreconditionsMethods[] =
+      {
+      {x(TR::jdk_internal_util_Preconditions_checkIndex, "checkIndex", "(IILjava/util/function/BiFunction;)I")},
+      {  TR::unknownMethod}
+      };
+
+
    static X VectorSupportMethods[] =
       {
       {x(TR::jdk_internal_vm_vector_VectorSupport_load, "load", "(Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Object;JLjava/lang/Object;JLjdk/internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/internal/vm/vector/VectorSupport$LoadOperation;)Ljdk/internal/vm/vector/VectorSupport$VectorPayload;")},
@@ -4079,6 +4087,8 @@ void TR_ResolvedJ9Method::construct()
       {
       { "com/ibm/jit/DecimalFormatHelper", DecimalFormatHelperMethods},
       { "jdk/internal/reflect/Reflection", ReflectionMethods },
+      { "jdk/internal/util/Preconditions", PreconditionsMethods },
+
       { 0 }
       };
    static Y class32[] =

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -356,6 +356,8 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_String_regionMatchesInternal:
       case TR::java_lang_String_regionMatches:
       case TR::java_lang_Class_newInstance:
+      case TR::jdk_internal_util_Preconditions_checkIndex:
+
       // we rely on inlining compareAndSwap so we see the inner native call and can special case it
       case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInObject:
       case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInObject:


### PR DESCRIPTION
- this method contains a simple check whether provided index is greater than 0 and less than provided upper bound. This check lands itself well to various JIT optimizations (e.g. moving out of a loop).