### PR TITLE
Fix use of Thread.resume(), stop(), suspend() in tests for jdk20

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/clinit/InvokeStaticDuringClinit.java
+++ b/test/functional/VM_Test/src/j9vm/test/clinit/InvokeStaticDuringClinit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,8 @@ class InvokeStaticTestHelper {
 			try {
 				Thread.sleep(1000000);
 			} catch(InterruptedException e) {
+				InvokeStaticDuringClinit.interrupted = true;
+				break;
 			}
 		}
 	}
@@ -48,7 +50,8 @@ public class InvokeStaticDuringClinit {
 	public static Object lock = new Object();
 	public static boolean runBlocker = false;
 	public static boolean threadsReady = false;
-	public static boolean passed = true;
+	public static volatile boolean passed = true;
+	public static volatile boolean interrupted = false;
 
 	public static void staticMethod() {
 	}
@@ -82,9 +85,11 @@ public class InvokeStaticDuringClinit {
 					lock.notifyAll();
 				}
 				jitSend();
-				// <clinit> for InvokeStaticTestHelper never returns, so if execution reaches
-				// here, the VM has allowed an invalid invokestatic.
-				passed = false;
+				if (!interrupted) {
+					// <clinit> for InvokeStaticTestHelper never returns, so if execution reaches
+					// here, the VM has allowed an invalid invokestatic.
+					passed = false;
+				}
 			}
 		};
 		initializer.start();
@@ -104,8 +109,8 @@ public class InvokeStaticDuringClinit {
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}
-		initializer.stop();
-		blocker.stop();
+		initializer.interrupt();
+		blocker.interrupt();
 		try {
 			initializer.join(); 
 		} catch (InterruptedException e) {

--- a/test/functional/VM_Test/src/j9vm/test/clinit/NewDuringClinit.java
+++ b/test/functional/VM_Test/src/j9vm/test/clinit/NewDuringClinit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,8 @@ class NewTestHelper {
 			try {
 				Thread.sleep(1000000);
 			} catch(InterruptedException e) {
+				NewDuringClinit.interrupted = true;
+				break;
 			}
 		}
 	}
@@ -47,7 +49,8 @@ public class NewDuringClinit {
 	public static Object lock = new Object();
 	public static boolean runBlocker = false;
 	public static boolean threadsReady = false;
-	public static boolean passed = true;
+	public static volatile boolean passed = true;
+	public static volatile boolean interrupted = false;
 
 	public static void jitNew() {
 		try {
@@ -83,9 +86,11 @@ public class NewDuringClinit {
 					lock.notifyAll();
 				}
 				jitNew();
-				// <clinit> for NewTestHelper never returns, so if execution reaches
-				// here, the VM has allowed an invalid new.
-				passed = false;
+				if (!interrupted) {
+					// <clinit> for NewTestHelper never returns, so if execution reaches
+					// here, the VM has allowed an invalid new.
+					passed = false;
+				}
 			}
 		};
 		initializer.start();
@@ -105,8 +110,8 @@ public class NewDuringClinit {
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}
-		initializer.stop();
-		blocker.stop();
+		initializer.interrupt();
+		blocker.interrupt();
 		try {
 			initializer.join(); 
 		} catch (InterruptedException e) {


### PR DESCRIPTION
Tested in grinders
jdk20: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1476/
jdk11: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1477

Fixes https://github.com/eclipse-openj9/openj9/issues/16213