### PR TITLE
Change the default SCC directory

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -233,6 +233,7 @@
 #define J9SH_BASEDIR "javasharedresources\\"
 #else
 #define J9SH_BASEDIR "javasharedresources/"
+#define J9SH_HIDDENDIR ".cache/"
 #endif
 
 /**


### PR DESCRIPTION
Change the default SCC directory on Linux, AIX and MacOS to  $HOME/.cache/javasharedresources/

Depends on https://github.com/eclipse-openj9/openj9-docs/issues/1016
Closes #11417

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>