### PR TITLE
[Jtreg/FFI]Fix the OOM issue with thunk allocation

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5783,8 +5783,8 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t cifNativeCalloutDataCacheMutex;
 	struct J9Pool *cifArgumentTypesCache;
 	omrthread_monitor_t cifArgumentTypesCacheMutex;
-	struct J9UpcallThunkHeapWrapper *thunkHeapWrapper;
-	omrthread_monitor_t thunkHeapWrapperMutex;
+	struct J9UpcallThunkHeapList *thunkHeapHead;
+	omrthread_monitor_t thunkHeapListMutex;
 #endif /* JAVA_SPEC_VERSION >= 16 */
 	struct J9HashTable* ensureHashedClasses;
 #if JAVA_SPEC_VERSION >= 19
@@ -5933,6 +5933,18 @@ typedef struct J9UpcallNativeSignature {
 	J9UpcallSigType *sigArray;
 } J9UpcallNativeSignature;
 
+typedef struct J9UpcallThunkHeapWrapper {
+	J9Heap *heap;
+	uintptr_t heapSize;
+	J9PortVmemIdentifier vmemID;
+} J9UpcallThunkHeapWrapper;
+
+typedef struct J9UpcallThunkHeapList {
+	J9UpcallThunkHeapWrapper *thunkHeapWrapper;
+	J9HashTable *metaDataHashTable;
+	struct J9UpcallThunkHeapList *next;
+} J9UpcallThunkHeapList;
+
 typedef struct J9UpcallMetaData {
 	J9JavaVM *vm;
 	J9VMThread *downCallThread; /* The thread is mainly used to set exceptions in dispatcher if a native thread is created locally */
@@ -5942,19 +5954,13 @@ typedef struct J9UpcallMetaData {
 	UDATA thunkSize; /* The size of the generated thunk */
 	J9UpcallNativeSignature *nativeFuncSignature; /* The native function signature extracted from FunctionDescriptor */
 	UDATA functionPtr[3]; /* The address of the generated thunk on AIX or z/OS */
+	J9UpcallThunkHeapWrapper *thunkHeapWrapper; /* The thunk heap associated with the metaData */
 } J9UpcallMetaData;
 
 typedef struct J9UpcallMetaDataEntry {
 	UDATA thunkAddrValue;
 	J9UpcallMetaData *upcallMetaData;
 } J9UpcallMetaDataEntry;
-
-typedef struct J9UpcallThunkHeapWrapper {
-	J9Heap *heap;
-	uintptr_t heapSize;
-	J9PortVmemIdentifier vmemID;
-	J9HashTable *metaDataHashTable;
-} J9UpcallThunkHeapWrapper;
 
 #endif /* JAVA_SPEC_VERSION >= 16 */
 

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1267,7 +1267,7 @@ void JNICALL
 Java_jdk_internal_foreign_abi_UpcallStubs_registerNatives(JNIEnv *env, jclass clazz);
 
 jboolean JNICALL
-Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0(JNIEnv *env, jobject receiver, jlong address);
+Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0(JNIEnv *env, jclass clazz, jlong address);
 
 void JNICALL
 Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass clazz);

--- a/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler.cpp
+++ b/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler.cpp
@@ -138,7 +138,7 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalUpcallHandler_allocateUpcallStu
 	}
 
 done:
-	VM_OutOfLineINL_Helpers::returnDouble(currentThread, (I_64)(uintptr_t)thunkAddr, 3);
+	VM_OutOfLineINL_Helpers::returnDouble(currentThread, (I_64)(intptr_t)thunkAddr, 3);
 	return rc;
 
 freeAllMemoryThenExit:

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -923,3 +923,5 @@ TraceEvent=Trc_VM_allocateThunkHeap_create_metadata_hash_table_failed NoEnv Over
 TraceEvent=Trc_VM_allocateThunkHeap_reserve_memory_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate reserve the memory with the requested page size(%zu)"
 TraceEvent=Trc_VM_allocateThunkHeap_create_heap_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to create a heap from the reserved memory (%p) with the requested page size(%zu)"
 TraceExit=Trc_VM_allocateThunkHeap_Exit NoEnv Overhead=1 Level=3 Template="Exit allocateThunkHeap - The suballocated thunk heap is %p"
+
+TraceEvent=Trc_VM_allocateThunkHeap_allocate_thunk_heap_node_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate memory for the thunk heap node"

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -87,7 +87,7 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 #if JAVA_SPEC_VERSION >= 16
 		omrthread_monitor_init_with_name(&vm->cifNativeCalloutDataCacheMutex, 0, "CIF cache mutex") ||
 		omrthread_monitor_init_with_name(&vm->cifArgumentTypesCacheMutex, 0, "CIF argument types mutex") ||
-		omrthread_monitor_init_with_name(&vm->thunkHeapWrapperMutex, 0, "Wait mutex for allocating the upcall thunk memory") ||
+		omrthread_monitor_init_with_name(&vm->thunkHeapListMutex, 0, "Wait mutex for allocating the upcall thunk memory") ||
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 19
@@ -187,9 +187,9 @@ void terminateVMThreading(J9JavaVM *vm)
 		vm->cifArgumentTypesCacheMutex = NULL;
 	}
 
-	if (NULL != vm->thunkHeapWrapperMutex) {
-		omrthread_monitor_destroy(vm->thunkHeapWrapperMutex);
-		vm->thunkHeapWrapperMutex = NULL;
+	if (NULL != vm->thunkHeapListMutex) {
+		omrthread_monitor_destroy(vm->thunkHeapListMutex);
+		vm->thunkHeapListMutex = NULL;
 	}
 #endif /* JAVA_SPEC_VERSION >= 16 */
 


### PR DESCRIPTION
The changes aim to address the OOM issue with thunk allocation on the platforms with a small page size (e.g. 4KB) by maintaining a circular thunk heap list in which case a new thunk heap is created only when there is no free thunk heap available in the list to allocate thunk.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>