### PR TITLE
AArch64: Fix getArgPointer() for FFI upcall

### DIFF
--- a/runtime/vm/xr64/UpcallThunkGen.cpp
+++ b/runtime/vm/xr64/UpcallThunkGen.cpp
@@ -717,6 +717,7 @@ getArgPointer(J9UpcallNativeSignature *nativeSig, void *argListPtr, I_32 argIdx)
 	/* Loop through the arguments */
 	for (I_32 i = 0; i <= argIdx; i++) {
 		tempInt = sigArray[i].sizeInByte;
+		isPointerToStruct = false;
 		switch (sigArray[i].type) {
 #if defined(LINUX)
 			case J9_FFI_UPCALL_SIG_TYPE_CHAR:    /* Fall through */


### PR DESCRIPTION
This commit fixes getArgPointer() for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>