### PR TITLE
Disable TM when generating portable code

### DIFF
--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,8 +46,16 @@ J9::CompilerEnv::initializeTargetEnvironment()
    OMR::CompilerEnvConnector::initializeTargetEnvironment();
    }
 
+void
+J9::CompilerEnv::initializeRelocatableTargetEnvironment()
+   {
+   OMR::CompilerEnvConnector::initializeRelocatableTargetEnvironment();
+   if (J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))
+      relocatableTarget.cpu = TR::CPU::detectRelocatable(omrPortLib);
+   }
+
 /**
- * \brief Determines whether methods are compiled and the generated code simply 
+ * \brief Determines whether methods are compiled and the generated code simply
  *        "tossed" without execution.
  * \return true if compiles have been requested to be tossed; false otherwise.
  */

--- a/runtime/compiler/env/J9CompilerEnv.hpp
+++ b/runtime/compiler/env/J9CompilerEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,8 @@ public:
    J9JavaVM * const javaVM;
 
    void initializeTargetEnvironment();
+
+   void initializeRelocatableTargetEnvironment();
 
    bool isCodeTossed();
 

--- a/runtime/compiler/p/env/J9CPU.cpp
+++ b/runtime/compiler/p/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,11 +35,17 @@ J9::Power::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
    OMRProcessorDesc portableProcessorDescription;
    omrsysinfo_get_processor_description(&portableProcessorDescription);
-   
+
    if (portableProcessorDescription.processor > OMR_PROCESSOR_PPC_P8)
       {
       portableProcessorDescription.processor = OMR_PROCESSOR_PPC_P8;
       portableProcessorDescription.physicalProcessor = OMR_PROCESSOR_PPC_P8;
+      }
+
+   const uint32_t disabledFeatures [] = { OMR_FEATURE_PPC_HTM };
+   for (size_t i = 0; i < sizeof(disabledFeatures)/sizeof(uint32_t); i++)
+      {
+      omrsysinfo_processor_set_feature(&portableProcessorDescription, disabledFeatures[i], FALSE);
       }
 
    return TR::CPU::customize(portableProcessorDescription);
@@ -60,12 +66,12 @@ J9::Power::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    // Backwards compatibility only applies to p4,p5,p6,p7 and onwards
    // Looks for equality otherwise
    if ((processor == OMR_PROCESSOR_PPC_GP
-       || processor == OMR_PROCESSOR_PPC_GR 
-       || processor == OMR_PROCESSOR_PPC_P6 
+       || processor == OMR_PROCESSOR_PPC_GR
+       || processor == OMR_PROCESSOR_PPC_P6
        || (processor >= OMR_PROCESSOR_PPC_P7 && processor <= OMR_PROCESSOR_PPC_LAST))
-       && (targetProcessor == OMR_PROCESSOR_PPC_GP 
-        || targetProcessor == OMR_PROCESSOR_PPC_GR 
-        || targetProcessor == OMR_PROCESSOR_PPC_P6 
+       && (targetProcessor == OMR_PROCESSOR_PPC_GP
+        || targetProcessor == OMR_PROCESSOR_PPC_GR
+        || targetProcessor == OMR_PROCESSOR_PPC_P6
         || targetProcessor >= OMR_PROCESSOR_PPC_P7 && targetProcessor <= OMR_PROCESSOR_PPC_LAST))
       {
       return targetProcessor >= processor;
@@ -87,6 +93,6 @@ J9::Power::CPU::enableFeatureMasks()
       {
       omrsysinfo_processor_set_feature(&_supportedFeatureMasks, utilizedFeatures[i], TRUE);
       }
-   
+
    _isSupportedFeatureMasksEnabled = true;
    }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1057,7 +1057,7 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hdrInCa
    {
    bool defaultMessage = true;
 
-   if (!TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription))
+   if (!TR::Compiler->relocatableTarget.cpu.isCompatible(hdrInCache->processorDescription))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_WRONG_HARDWARE, "AOT header validation failed: Processor incompatible.");
    if ((featureFlags & TR_FeatureFlag_sanityCheckBegin) != (hdrInCache->featureFlags & TR_FeatureFlag_sanityCheckBegin))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_START_SANITY_BIT_MANGLED, "AOT header validation failed: Processor feature sanity bit mangled.");
@@ -1188,7 +1188,7 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
          }
       else if
          (hdrInCache->featureFlags != featureFlags ||
-          !TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription)
+          !TR::Compiler->relocatableTarget.cpu.isCompatible(hdrInCache->processorDescription)
          )
          {
          checkAOTHeaderFlags(hdrInCache, featureFlags);
@@ -1276,16 +1276,7 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
-
-      if (J9_ARE_ANY_BITS_SET(javaVM()->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))
-         {
-         TR::Compiler->relocatableTarget.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
-         aotHeader->processorDescription = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
-         }
-      else
-         {
-         aotHeader->processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
-         }
+      aotHeader->processorDescription = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
 
       // Set up other feature flags
       aotHeader->featureFlags = generateFeatureFlags(fe);
@@ -1374,7 +1365,7 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
 
    featureFlags |= TR_FeatureFlag_sanityCheckBegin;
 
-   if (TR::Compiler->target.isSMP())
+   if (TR::Compiler->relocatableTarget.isSMP())
       featureFlags |= TR_FeatureFlag_IsSMP;
 
    if (TR::Options::useCompressedPointers())
@@ -1396,7 +1387,7 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
       featureFlags |= TR_FeatureFlag_HCREnabled;
 
 #ifdef TR_TARGET_S390
-   if (TR::Compiler->target.cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY))
+   if (TR::Compiler->relocatableTarget.cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY))
       featureFlags |= TR_FeatureFlag_SIMDEnabled;
 #endif
 
@@ -1405,7 +1396,7 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
       featureFlags |= TR_FeatureFlag_ConcurrentScavenge;
 
 #ifdef TR_TARGET_S390
-      if (!TR::Compiler->target.cpu.supportsFeature(OMR_FEATURE_S390_GUARDED_STORAGE))
+      if (!TR::Compiler->relocatableTarget.cpu.supportsFeature(OMR_FEATURE_S390_GUARDED_STORAGE))
          featureFlags |= TR_FeatureFlag_SoftwareReadBarrier;
 #endif
       }
@@ -1418,7 +1409,7 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableTM) &&
        !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableTM))
       {
-      if (TR::Compiler->target.cpu.supportsTransactionalMemoryInstructions())
+      if (TR::Compiler->relocatableTarget.cpu.supportsTransactionalMemoryInstructions())
          {
          featureFlags |= TR_FeatureFlag_UsesTM;
          }

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -52,9 +52,15 @@ J9::Z::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
    omrsysinfo_get_processor_description(&processorDescription);
 
    if (processorDescription.processor > OMR_PROCESSOR_S390_Z10)
-      { 
+      {
       processorDescription.processor = OMR_PROCESSOR_S390_Z10;
       processorDescription.physicalProcessor = OMR_PROCESSOR_S390_Z10;
+      }
+
+   const uint32_t disabledFeatures [] = { OMR_FEATURE_S390_TE };
+   for (size_t i = 0; i < sizeof(disabledFeatures)/sizeof(uint32_t); i++)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, disabledFeatures[i], FALSE);
       }
 
    return TR::CPU::customize(processorDescription);


### PR DESCRIPTION
This PR disables the TM feature when generating portable code. 

Fixes https://github.com/eclipse-openj9/openj9/issues/16009