### PR TITLE
Re-write valueType sub-tests

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -95,6 +95,79 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>ValueTypeArrayTests</testCaseName>
+		<variations>
+			<variation>-Xgcpolicy:optthruput</variation>
+			<variation> -XX:ValueTypeFlatteningThreshold=99999 -Xgcpolicy:optthruput -XX:-EnableArrayFlattening</variation>
+			<variation>-Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<!-- Use -XX:-EnableArrayFlattening. testDefaultValueInTriangleArray asserts the fields of each element are not NULL,
+					which is not true as a FlatteningThreshold is set. -->
+			<variation>-Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=12 -XX:-EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xnocompressedrefs -Xgcpolicy:gencon</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-Xint \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
+		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>ValueTypeArrayTestsJIT</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/pull/9392#issuecomment-661246648</comment>
+				<variation>-Xjit:count=0</variation>
+			</disable>
+		</disables>
+		<variations>
+			<variation>-Xjit:count=0</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -Xgcpolicy:optthruput</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
+		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTestsJIT \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>ValueTypeUnsafeTests</testCaseName>
 		<variations>
 			<variation>-Xcompressedrefs -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/DDRBackfillLayouTest.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/DDRBackfillLayouTest.java
@@ -22,6 +22,7 @@
 package org.openj9.test.lworld;
 
 import java.lang.reflect.Array;
+import static org.openj9.test.lworld.ValueTypeTestClasses.*;
 
 public class DDRBackfillLayouTest {
 	public static void main(String[] args) {
@@ -44,7 +45,6 @@ public class DDRBackfillLayouTest {
 		ValueTypeTests.testLayoutsWithPrimitives();
 		ValueTypeTests.testCreateFlatLayoutsWithValueTypes();
 		ValueTypeTests.testFlatLayoutsWithValueTypes();
-		ValueTypeTests.testCreateFlatLayoutsWithRecursiveLongs();
 		ValueTypeTests.testFlatLayoutsWithRecursiveLongs();
 		
 		Object flatSingleBackfillInstance =  ValueTypeTests.makeFlatSingleBackfillClass.invoke(ValueTypeTests.makeValueLong.invoke(ValueTypeTests.defaultLong), ValueTypeTests.makeValueObject.invoke(ValueTypeTests.defaultObject), ValueTypeTests.makeValueInt.invoke(ValueTypeTests.defaultInt));		
@@ -55,15 +55,17 @@ public class DDRBackfillLayouTest {
 		Object flatUnAlignedObjectBackfill2Instance = ValueTypeTests.makeFlatUnAlignedObjectBackfillClass2.invoke(ValueTypeTests.makeValueObject.invoke(ValueTypeTests.defaultObject), ValueTypeTests.makeFlatUnAlignedObjectClass.invoke(ValueTypeTests.makeValueObject.invoke(ValueTypeTests.defaultObject), ValueTypeTests.makeValueObject.invoke(ValueTypeTests.defaultObjectNew)), ValueTypeTests.makeValueLong.invoke(ValueTypeTests.defaultLong));
 		Object singleBackfillInstance = ValueTypeTests.makeSingleBackfillClass.invoke(ValueTypeTests.defaultLong, ValueTypeTests.defaultObject, ValueTypeTests.defaultInt);		
 		Object objectBackfillInstance2 = ValueTypeTests.makeObjectBackfillClass.invoke(ValueTypeTests.defaultLong, ValueTypeTests.defaultObject);
-		Object doubleLongInstance = ValueTypeTests.makeDoubleLongClass.invoke(ValueTypeTests.makeValueLong.invoke(ValueTypeTests.defaultLong), ValueTypeTests.defaultLongNew);
-		Object quadLongInstance = ValueTypeTests.makeQuadLongClass.invoke(doubleLongInstance, ValueTypeTests.makeValueLong.invoke(ValueTypeTests.defaultLongNew2), ValueTypeTests.defaultLongNew3);
-		Object doubleQuadLongInstance = ValueTypeTests.makeDoubleQuadLongClass.invoke(quadLongInstance, doubleLongInstance, ValueTypeTests.makeValueLong.invoke(ValueTypeTests.defaultLongNew4), ValueTypeTests.defaultLongNew5);
+
+		ValueTypeDoubleLong doubleLongInstance = new ValueTypeDoubleLong(new ValueTypeLong(ValueTypeTests.defaultLong), ValueTypeTests.defaultLongNew);
+		ValueTypeQuadLong quadLongInstance = new ValueTypeQuadLong(doubleLongInstance, new ValueTypeLong(ValueTypeTests.defaultLongNew2), ValueTypeTests.defaultLongNew3);
+		ValueTypeDoubleQuadLong doubleQuadLongInstance = new ValueTypeDoubleQuadLong(quadLongInstance, doubleLongInstance, new ValueTypeLong(ValueTypeTests.defaultLongNew4), ValueTypeTests.defaultLongNew5);
+		
 
 		Object flatUnAlignedSingleBackfill2Array = Array.newInstance(ValueTypeTests.flatUnAlignedSingleBackfillClass2, 3);
 		Array.set(flatUnAlignedSingleBackfill2Array, 1, flatUnAlignedSingleBackfill2Instance);
-		
-		Object quadLongArray = Array.newInstance(ValueTypeTests.quadLongClass, 3);
-		Array.set(quadLongArray, 1, quadLongInstance);
+
+		ValueTypeQuadLong[] quadLongArray = new ValueTypeQuadLong[3];
+		quadLongArray[1] = quadLongInstance;
 		
 		ValueTypeTests.checkObject(flatSingleBackfillInstance, 
 				objectBackfillInstance, 

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/DDRBackfillLayouTest.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/DDRBackfillLayouTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,6 @@ public class DDRBackfillLayouTest {
 		ValueTypeDoubleLong doubleLongInstance = new ValueTypeDoubleLong(new ValueTypeLong(ValueTypeTests.defaultLong), ValueTypeTests.defaultLongNew);
 		ValueTypeQuadLong quadLongInstance = new ValueTypeQuadLong(doubleLongInstance, new ValueTypeLong(ValueTypeTests.defaultLongNew2), ValueTypeTests.defaultLongNew3);
 		ValueTypeDoubleQuadLong doubleQuadLongInstance = new ValueTypeDoubleQuadLong(quadLongInstance, doubleLongInstance, new ValueTypeLong(ValueTypeTests.defaultLongNew4), ValueTypeTests.defaultLongNew5);
-		
 
 		Object flatUnAlignedSingleBackfill2Array = Array.newInstance(ValueTypeTests.flatUnAlignedSingleBackfillClass2, 3);
 		Array.set(flatUnAlignedSingleBackfill2Array, 1, flatUnAlignedSingleBackfill2Instance);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTestClasses.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTestClasses.java
@@ -107,7 +107,7 @@ public class ValueTypeTestClasses {
 		ValueTypeInt2(int i) { this.i = i; }
 		final int i;
 	}
-	
+
 	static primitive class ValueTypeFastSubVT {
 		final int x,y,z;
 		final Object[] arr;
@@ -118,7 +118,7 @@ public class ValueTypeTestClasses {
 			this.arr = arr;
 		}
 	}
-	
+
 	static primitive class ValueTypeDoubleLong {
 		final ValueTypeLong l;
 		final long l2;
@@ -178,5 +178,4 @@ public class ValueTypeTestClasses {
 			return l4;
 		}
 	}
-	
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTestClasses.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTestClasses.java
@@ -35,8 +35,11 @@ public class ValueTypeTestClasses {
 	}
 
 	static primitive class ValueTypeLong {
-		ValueTypeLong(long l) {this.l = l;}
 		final long l;
+		ValueTypeLong(long l) {this.l = l;}
+		public long getL() {
+			return l;
+		}
 	}
 
 	static primitive class ValueTypePoint2D {
@@ -104,4 +107,76 @@ public class ValueTypeTestClasses {
 		ValueTypeInt2(int i) { this.i = i; }
 		final int i;
 	}
+	
+	static primitive class ValueTypeFastSubVT {
+		final int x,y,z;
+		final Object[] arr;
+		ValueTypeFastSubVT(int x, int y, int z, Object[] arr) {
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.arr = arr;
+		}
+	}
+	
+	static primitive class ValueTypeDoubleLong {
+		final ValueTypeLong l;
+		final long l2;
+		ValueTypeDoubleLong(ValueTypeLong l, long l2) {
+			this.l = l;
+			this.l2 = l2;
+		}
+		public ValueTypeLong getL() {
+			return l;
+		}
+		public long getL2() {
+			return l2;
+		}
+	}
+
+	static primitive class ValueTypeQuadLong {
+		final ValueTypeDoubleLong l;
+		final ValueTypeLong l2;
+		final long l3;
+		ValueTypeQuadLong(ValueTypeDoubleLong l, ValueTypeLong l2, long l3) {
+			this.l = l;
+			this.l2 = l2;
+			this.l3 = l3;
+		}
+		public ValueTypeDoubleLong getL() {
+			return l;
+		}
+		public ValueTypeLong getL2() {
+			return l2;
+		}
+		public long getL3() {
+			return l3;
+		}
+	}
+
+	static primitive class ValueTypeDoubleQuadLong {
+		final ValueTypeQuadLong l;
+		final ValueTypeDoubleLong l2;
+		final ValueTypeLong l3;
+		final long l4;
+		ValueTypeDoubleQuadLong(ValueTypeQuadLong l, ValueTypeDoubleLong l2, ValueTypeLong l3, long l4) {
+			this.l = l;
+			this.l2 = l2;
+			this.l3 = l3;
+			this.l4 = l4;
+		}
+		public ValueTypeQuadLong getL() {
+			return l;
+		}
+		public ValueTypeDoubleLong getL2() {
+			return l2;
+		}
+		public ValueTypeLong getL3() {
+			return l3;
+		}
+		public long getL4() {
+			return l4;
+		}
+	}
+	
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1682,7 +1682,7 @@ public class ValueTypeTests {
 		assertEquals(quadLongInstance.getL().getL2(), defaultLongNew);
 		assertEquals(quadLongInstance.getL2().getL(), defaultLongNew2);
 		assertEquals(quadLongInstance.getL3(), defaultLongNew3);
-		
+
 		ValueTypeDoubleQuadLong doubleQuadLongInstance = new ValueTypeDoubleQuadLong(quadLongInstance, doubleLongInstance, new ValueTypeLong(defaultLongNew4), defaultLongNew5);
 
 		assertEquals(doubleQuadLongInstance.getL().getL().getL().getL(), defaultLong);
@@ -1693,7 +1693,6 @@ public class ValueTypeTests {
 		assertEquals(doubleQuadLongInstance.getL2().getL2(), defaultLongNew);
 		assertEquals(doubleQuadLongInstance.getL3().getL(), defaultLongNew4);
 		assertEquals(doubleQuadLongInstance.getL4(), defaultLongNew5);
-		
 	}
 	
 	/*

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -193,23 +193,7 @@ public class ValueTypeTests {
 	static MethodHandle getUnAlignedObjectflatObjectBackfill2InstanceO = null;
 	static MethodHandle getUnAlignedObjectflatObjectBackfill2InstanceObjects = null;
 	static MethodHandle getUnAlignedObjectflatObjectBackfill2InstanceL = null;
-	/* LayoutsWithRecursiveLongs classes */
-	static Class<?> doubleLongClass = null;
-	static MethodHandle makeDoubleLongClass = null;
-	static MethodHandle getDoubleLongL = null;
-	static MethodHandle getDoubleLongL2 = null;
-	static Class<?> quadLongClass = null;
-	static MethodHandle makeQuadLongClass = null;
-	static MethodHandle getQuadLongL = null;
-	static MethodHandle getQuadLongL2 = null;
-	static MethodHandle getQuadLongL3 = null;
-	static Class<?> doubleQuadLongClass = null;
-	static MethodHandle makeDoubleQuadLongClass = null;
-	static MethodHandle getDoubleQuadLongL = null;
-	static MethodHandle getDoubleQuadLongL2 = null;
-	static MethodHandle getDoubleQuadLongL3 = null;
-	static MethodHandle getDoubleQuadLongL4 = null;
-	
+
 	/* fields */
 	static String typeWithSingleAlignmentFields[] = {
 		"tri:QTriangle2D;:value",
@@ -872,16 +856,11 @@ public class ValueTypeTests {
 	@Test(priority=3)
 	static public void testACMPTestOnFastSubstitutableValueTypesVer2() throws Throwable {
 		/* these VTs will have array refs */
-		String fields[] = {"x:I", "y:I", "z:I", "arr:[Ljava/lang/Object;"};
-		Class<?> fastSubVT = ValueTypeGenerator.generateValueClass("FastSubVT", fields);
-		
-		MethodHandle makeFastSubVT = lookup.findStatic(fastSubVT, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
-		
 		Object[] arr = {"foo", "bar", "baz"};
 		Object[] arr2 = {"foozo", "barzo", "bazzo"};
-		Object valueType1 = makeFastSubVT.invoke(1, 2, 3, arr);
-		Object valueType2 = makeFastSubVT.invoke(1, 2, 3, arr);
-		Object newValueType = makeFastSubVT.invoke(3, 2, 1, arr2);
+		Object valueType1 = new ValueTypeFastSubVT(1, 2, 3, arr);
+		Object valueType2 = new ValueTypeFastSubVT(1, 2, 3, arr);
+		Object newValueType = new ValueTypeFastSubVT(3, 2, 1, arr2);
 		Object identityType = new String();
 		Object nullPointer = null;
 		
@@ -1691,52 +1670,30 @@ public class ValueTypeTests {
 		assertEquals(getObject.invoke(getUnAlignedObjectO2.invoke(getUnAlignedObjectflatObjectBackfill2InstanceObjects.invoke(flatUnAlignedObjectBackfill2Instance))), defaultObjectNew);
 		assertEquals(getObject.invoke(getUnAlignedObjectflatObjectBackfill2InstanceO.invoke(flatUnAlignedObjectBackfill2Instance)), defaultObject);		
 	}
-	
-	@Test(priority=3)
-	static public void testCreateFlatLayoutsWithRecursiveLongs() throws Throwable {
-		String doubleLongFields[] = {"l:QValueLong;", "l2:J"};
-		doubleLongClass = ValueTypeGenerator.generateValueClass("DoubleLong", doubleLongFields);
-		makeDoubleLongClass = lookup.findStatic(doubleLongClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class));
-		getDoubleLongL = generateGenericGetter(doubleLongClass, "l");
-		getDoubleLongL2 = generateGenericGetter(doubleLongClass, "l2");
-		
-		String quadLongFields[] = {"l:QDoubleLong;", "l2:QValueLong;", "l3:J"};
-		quadLongClass = ValueTypeGenerator.generateValueClass("QuadLong", quadLongFields);
-		makeQuadLongClass = lookup.findStatic(quadLongClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class));
-		getQuadLongL = generateGenericGetter(quadLongClass, "l");
-		getQuadLongL2 = generateGenericGetter(quadLongClass, "l2");
-		getQuadLongL3 = generateGenericGetter(quadLongClass, "l3");
-		
-		String doubleQuadLongFields[] = {"l:QQuadLong;", "l2:QDoubleLong;", "l3:QValueLong;", "l4:J"};
-		doubleQuadLongClass = ValueTypeGenerator.generateValueClass("DoubleQuadLong", doubleQuadLongFields);
-		makeDoubleQuadLongClass = lookup.findStatic(doubleQuadLongClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
-		getDoubleQuadLongL = generateGenericGetter(doubleQuadLongClass, "l");
-		getDoubleQuadLongL2 = generateGenericGetter(doubleQuadLongClass, "l2");
-		getDoubleQuadLongL3 = generateGenericGetter(doubleQuadLongClass, "l3");
-		getDoubleQuadLongL4 = generateGenericGetter(doubleQuadLongClass, "l4");
-	}
-	
+
 	@Test(priority=4, invocationCount=2)
 	static public void testFlatLayoutsWithRecursiveLongs() throws Throwable {
-		Object doubleLongInstance = makeDoubleLongClass.invoke(makeValueLong.invoke(defaultLong), defaultLongNew);
-		assertEquals(getLong.invoke(getDoubleLongL.invoke(doubleLongInstance)), defaultLong);
-		assertEquals(getDoubleLongL2.invoke(doubleLongInstance), defaultLongNew);
+		ValueTypeDoubleLong doubleLongInstance = new ValueTypeDoubleLong(new ValueTypeLong(defaultLong), defaultLongNew);
+		assertEquals(doubleLongInstance.getL().getL(), defaultLong);
+		assertEquals(doubleLongInstance.getL2(), defaultLongNew);
+
+		ValueTypeQuadLong quadLongInstance = new ValueTypeQuadLong(doubleLongInstance, new ValueTypeLong(defaultLongNew2), defaultLongNew3);
+		assertEquals(quadLongInstance.getL().getL().getL(), defaultLong);
+		assertEquals(quadLongInstance.getL().getL2(), defaultLongNew);
+		assertEquals(quadLongInstance.getL2().getL(), defaultLongNew2);
+		assertEquals(quadLongInstance.getL3(), defaultLongNew3);
 		
-		Object quadLongInstance = makeQuadLongClass.invoke(doubleLongInstance, makeValueLong.invoke(defaultLongNew2), defaultLongNew3);
-		assertEquals(getLong.invoke(getDoubleLongL.invoke(getQuadLongL.invoke(quadLongInstance))), defaultLong);
-		assertEquals(getDoubleLongL2.invoke(getQuadLongL.invoke(quadLongInstance)), defaultLongNew);
-		assertEquals(getLong.invoke(getQuadLongL2.invoke(quadLongInstance)), defaultLongNew2);
-		assertEquals(getQuadLongL3.invoke(quadLongInstance), defaultLongNew3);
+		ValueTypeDoubleQuadLong doubleQuadLongInstance = new ValueTypeDoubleQuadLong(quadLongInstance, doubleLongInstance, new ValueTypeLong(defaultLongNew4), defaultLongNew5);
+
+		assertEquals(doubleQuadLongInstance.getL().getL().getL().getL(), defaultLong);
+		assertEquals(doubleQuadLongInstance.getL().getL().getL2(), defaultLongNew);
+		assertEquals(doubleQuadLongInstance.getL().getL2().getL(), defaultLongNew2);
+		assertEquals(doubleQuadLongInstance.getL().getL3(), defaultLongNew3);
+		assertEquals(doubleQuadLongInstance.getL2().getL().getL(), defaultLong);
+		assertEquals(doubleQuadLongInstance.getL2().getL2(), defaultLongNew);
+		assertEquals(doubleQuadLongInstance.getL3().getL(), defaultLongNew4);
+		assertEquals(doubleQuadLongInstance.getL4(), defaultLongNew5);
 		
-		Object doubleQuadLongInstance = makeDoubleQuadLongClass.invoke(quadLongInstance, doubleLongInstance, makeValueLong.invoke(defaultLongNew4), defaultLongNew5);
-		assertEquals(getLong.invoke(getDoubleLongL.invoke(getQuadLongL.invoke(getDoubleQuadLongL.invoke(doubleQuadLongInstance)))), defaultLong);
-		assertEquals(getDoubleLongL2.invoke(getQuadLongL.invoke(getDoubleQuadLongL.invoke(doubleQuadLongInstance))), defaultLongNew);
-		assertEquals(getLong.invoke(getQuadLongL2.invoke(getDoubleQuadLongL.invoke(doubleQuadLongInstance))), defaultLongNew2);
-		assertEquals(getQuadLongL3.invoke(getDoubleQuadLongL.invoke(doubleQuadLongInstance)), defaultLongNew3);
-		assertEquals(getLong.invoke(getDoubleLongL.invoke(getDoubleQuadLongL2.invoke(doubleQuadLongInstance))), defaultLong);
-		assertEquals(getDoubleLongL2.invoke(getDoubleQuadLongL2.invoke(doubleQuadLongInstance)), defaultLongNew);
-		assertEquals(getLong.invoke(getDoubleQuadLongL3.invoke(doubleQuadLongInstance)), defaultLongNew4);
-		assertEquals(getDoubleQuadLongL4.invoke(doubleQuadLongInstance), defaultLongNew5);
 	}
 	
 	/*

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -28,12 +28,20 @@
 	<test name="ValueTypeTests">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeTests"/>
-			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
 		</classes>
 	</test>
 	<test name="ValueTypeTestsJIT">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeTests"/>
+		</classes>
+	</test>
+	<test name="ValueTypeArrayTests">
+		<classes>
+			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
+		</classes>
+	</test>
+	<test name="ValueTypeArrayTestsJIT">
+		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
 		</classes>
 	</test>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2019, 2021 IBM Corp. and others
+  Copyright (c) 2019, 2022 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 		<output regex="no" type="failure">Exception caught!</output>
 	</test>
 
- 	<test id="Test 2: Run !threads">
+	<test id="Test 2: Run !threads">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!threads</input>
@@ -530,7 +530,7 @@
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l.l2 \(offset = 16\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l3 = 0x33773377CC00CC00 \(offset = 24\) \(.*ValueTypeQuadLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
-		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">offset in top level container = 8;</output>		
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">offset in top level container = 8;</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -567,7 +567,7 @@
 		</command>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l2 = 0x11551155AAEEAAEE \(offset = 8\) \(.*ValueTypeDoubleLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l2.l \(offset = 0\) \(.*ValueTypeLong\)</output>
-		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>	
+		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
@@ -579,7 +579,7 @@
 		</command>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0xFAFBFCFD11223344 \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
-		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>	
+		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -591,7 +591,7 @@
 		</command>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0x44884488DD11DD11 \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
-		<output regex="no" type="success" showMatch="yes">offset in top level container = 56;</output>	
+		<output regex="no" type="success" showMatch="yes">offset in top level container = 56;</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -625,7 +625,7 @@
 		<output regex="no" type="success" showMatch="yes">[1] = !j9object 0x</output>
 		<output regex="no" type="success" showMatch="yes">[2] = !j9object 0x</output>
 		<output regex="no" type="success" showMatch="yes">U_32 size = 0x00000003;</output>
-		<output regex="no" type="success" showMatch="yes">// [L</output>	
+		<output regex="no" type="success" showMatch="yes">// [L</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -639,7 +639,7 @@
 		<output regex="no" type="success" showMatch="yes">[0].singles (offset = 0) (FlatUnAlignedSingle)</output>
 		<output regex="no" type="success" showMatch="yes">[0].singles2 (offset = 20) (FlatUnAlignedSingle)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>	
+		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -653,7 +653,7 @@
 		<output regex="no" type="success" showMatch="yes">[0].singles (offset = 0) (FlatUnAlignedSingle)</output>
 		<output regex="no" type="success" showMatch="yes">[0].singles2 (offset = 20) (FlatUnAlignedSingle)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>	
+		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -665,7 +665,7 @@
 		</command>
 		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344 (offset = 0) (ValueLong)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 52;</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>	
+		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -679,7 +679,7 @@
 		<output regex="no" type="success" showMatch="yes">I i = 0x12123434</output>
 		<output regex="no" type="success" showMatch="yes">I i = 0x45456767</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>	
+		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
@@ -693,7 +693,7 @@
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\[1\].l2 \(offset = 16\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l3 = 0x33773377CC00CC00 /(offset = 24/) /(.*ValueTypeQuadLong/)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>	
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
@@ -708,7 +708,7 @@
 		<output regex="no" type="success" showMatch="yes">J j = 0x22662266BBFFBBFF</output>
 		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>	
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -30,7 +30,7 @@
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRBackfillLayouTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />
 
-	<test id="Create core file">
+	<test id="Test 1: Create core file">
 		<exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
 		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 		<exec command="rm -f $DUMPFILE$" />
@@ -41,7 +41,7 @@
 		<output regex="no" type="failure">Exception caught!</output>
 	</test>
 
- 	<test id="Run !threads">
+ 	<test id="Test 2: Run !threads">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!threads</input>
@@ -52,7 +52,7 @@
 		<output regex="no" type="failure">DDR is not enabled for this core file</output>
  	</test>
 
-	<test id="Run !stackslots $mainThreadId$">
+	<test id="Test 3: Run !stackslots $mainThreadId$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!stackslots $mainThreadId$</input>
@@ -63,7 +63,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $objectAddr$ to display container array contents">
+	<test id="Test 4: Run !j9object $objectAddr$ to display container array contents">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $objectAddr$</input>
@@ -86,7 +86,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $flatSingleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 5: Run !j9object $flatSingleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatSingleBackfillInstance$</input>
@@ -99,7 +99,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $flatSingleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 6: Run !flatobject $flatSingleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatSingleBackfillInstance$</input>
@@ -113,7 +113,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !fj9object $flatSingleBackfillInstanceO$">
+	<test id="Test 7: Run !fj9object $flatSingleBackfillInstanceO$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $flatSingleBackfillInstanceO$</input>
@@ -123,7 +123,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $objectBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 8: Run !j9object $objectBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $objectBackfillInstance$</input>
@@ -135,7 +135,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $objectBackfillInstance$ l">
+	<test id="Test 9: Run !j9object $objectBackfillInstance$ l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $objectBackfillInstance$ l</input>
@@ -146,7 +146,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $objectBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 10: Run !flatobject $objectBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $objectBackfillInstance$</input>
@@ -157,7 +157,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $objectBackfillInstanceO$">
+	<test id="Test 11: Run !fj9object $objectBackfillInstanceO$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $objectBackfillInstanceO$</input>
@@ -167,7 +167,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $flatUnAlignedSingleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 12: Run !j9object $flatUnAlignedSingleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfillInstance$</input>
@@ -180,7 +180,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfillInstance$ l">
+	<test id="Test 13: Run !j9object $flatUnAlignedSingleBackfillInstance$ l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfillInstance$ l</input>
@@ -192,7 +192,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfillInstance$ singles">
+	<test id="Test 14: Run !j9object $flatUnAlignedSingleBackfillInstance$ singles">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfillInstance$ singles</input>
@@ -205,7 +205,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfillInstance$ o">
+	<test id="Test 15: Run !j9object $flatUnAlignedSingleBackfillInstance$ o">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfillInstance$ o</input>
@@ -217,7 +217,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $flatUnAlignedSingleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 16: Run !flatobject $flatUnAlignedSingleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatUnAlignedSingleBackfillInstance$</input>
@@ -231,7 +231,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $flatUnAlignedSingleBackfillInstanceO$">
+	<test id="Test 17: Run !fj9object $flatUnAlignedSingleBackfillInstanceO$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $flatUnAlignedSingleBackfillInstanceO$</input>
@@ -241,7 +241,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfill2Instance$ to show the fields of the reference object">
+	<test id="Test 18: Run !j9object $flatUnAlignedSingleBackfill2Instance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfill2Instance$</input>
@@ -254,7 +254,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $flatUnAlignedSingleBackfill2Instance$ to show the fields of the reference object">
+	<test id="Test 19: Run !flatobject $flatUnAlignedSingleBackfill2Instance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatUnAlignedSingleBackfill2Instance$</input>
@@ -270,7 +270,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $flatUnAlignedObjectBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 20: Run !j9object $flatUnAlignedObjectBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedObjectBackfillInstance$</input>
@@ -283,7 +283,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $flatUnAlignedObjectBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 21: Run !flatobject $flatUnAlignedObjectBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatUnAlignedObjectBackfillInstance$</input>
@@ -297,7 +297,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedObjectBackfill2Instance$ to show the fields of the reference object">
+	<test id="Test 22: Run !j9object $flatUnAlignedObjectBackfill2Instance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedObjectBackfill2Instance$</input>
@@ -310,7 +310,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $flatUnAlignedObjectBackfill2Instance$ to show the fields of the reference object">
+	<test id="Test 23: Run !flatobject $flatUnAlignedObjectBackfill2Instance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatUnAlignedObjectBackfill2Instance$</input>
@@ -324,7 +324,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $singleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 24: Run !j9object $singleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $singleBackfillInstance$</input>
@@ -337,7 +337,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $singleBackfillInstance$ to show the fields of the reference object">
+	<test id="Test 25: Run !flatobject $singleBackfillInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $singleBackfillInstance$</input>
@@ -350,7 +350,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $singleBackfillInstanceO$">
+	<test id="Test 26: Run !fj9object $singleBackfillInstanceO$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $singleBackfillInstanceO$</input>
@@ -360,7 +360,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $objectBackfillInstance2$ to show the fields of the reference object">
+	<test id="Test 27: Run !j9object $objectBackfillInstance2$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $objectBackfillInstance2$</input>
@@ -371,7 +371,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
-	<test id="Run !flatobject $objectBackfillInstance2$ to show the fields of the reference object">
+	<test id="Test 28: Run !flatobject $objectBackfillInstance2$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $objectBackfillInstance2$</input>
@@ -383,7 +383,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !fj9object $objectBackfillInstance2O$">
+	<test id="Test 29: Run !fj9object $objectBackfillInstance2O$">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $objectBackfillInstance2O$</input>
@@ -393,106 +393,106 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $doubleLongInstance$ to show the fields of the reference object">
+	<test id="Test 30: Run !j9object $doubleLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleLongInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE (offset = 12) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l2 = 0x11551155AAEEAAEE \(offset = 12\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l \(offset = 4\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// \(.*ValueTypeDoubleLong\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $doubleLongInstance$ l">
+	<test id="Test 31: Run !j9object $doubleLongInstance$ l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleLongInstance$ l</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344 (offset = 0) (ValueLong)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0xFAFBFCFD11223344 \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $doubleLongInstance$ to show the fields of the reference object">
+	<test id="Test 32: Run !flatobject $doubleLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $doubleLongInstance$</input>
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">(offset = 4)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeDoubleLong</output>
 		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344</output>
 		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $doubleLongInstance$ l">
+	<test id="Test 33: Run !flatobject $doubleLongInstance$ l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $doubleLongInstance$ l</input>
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $quadLongInstance$ to show the fields of the reference object">
+	<test id="Test 34: Run !j9object $quadLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $quadLongInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">l2 (offset = 20) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00 (offset = 28) (QuadLong)</output>
-		<output regex="no" type="success" showMatch="yes">// QuadLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l \(offset = 4\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l2 \(offset = 20\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l3 = 0x33773377CC00CC00 \(offset = 28\) \(.*ValueTypeQuadLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
-	<test id="Run !j9object $quadLongInstance$ l">
+	<test id="Test 35: Run !j9object $quadLongInstance$ l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $quadLongInstance$ l</input>
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">l.l (offset = 0) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE (offset = 8) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l.l \(offset = 0\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l2 = 0x11551155AAEEAAEE \(offset = 8\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeDoubleLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $quadLongInstance$ l.l">
+	<test id="Test 36: Run !j9object $quadLongInstance$ l.l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $quadLongInstance$ l</input>
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
-		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344 (offset = 0) (ValueLong)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0xFAFBFCFD11223344 \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $quadLongInstance$ l2">
+	<test id="Test 37: Run !j9object $quadLongInstance$ l2">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $quadLongInstance$ l2</input>
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 24;</output>
-		<output regex="no" type="success" showMatch="yes">J j = 0x22662266BBFFBBFF (offset = 0) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0x22662266BBFFBBFF \(offset = 0\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $quadLongInstance$ to show the fields of the reference object">
+	<test id="Test 38: Run !flatobject $quadLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $quadLongInstance$</input>
@@ -502,100 +502,100 @@
 		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE</output>
 		<output regex="no" type="success" showMatch="yes">J j = 0x22662266BBFFBBFF</output>
 		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00</output>
-		<output regex="no" type="success" showMatch="yes">// QuadLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ to show the fields of the reference object">
+	<test id="Test 39: Run !j9object $doubleQuadLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (QuadLong)</output>
-		<output regex="no" type="success" showMatch="yes">l2 (offset = 36) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">l3 (offset = 52) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l4 = 0x55995599EE22EE22 (offset = 60) (DoubleQuadLong)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleQuadLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l \(offset = 4\) \(.*ValueTypeQuadLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l2 \(offset = 36\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l3 \(offset = 52\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l4 = 0x55995599EE22EE22 \(offset = 60\) \(.*ValueTypeDoubleQuadLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeDoubleQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ l to show the fields of the reference object">
+	<test id="Test 40: Run !j9object $doubleQuadLongInstance$ l to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l.l (offset = 0) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">l.l2 (offset = 16) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00 (offset = 24) (QuadLong)</output>
-		<output regex="no" type="success" showMatch="yes">// QuadLong</output>
-		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>		
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l.l \(offset = 0\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l.l2 \(offset = 16\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l3 = 0x33773377CC00CC00 \(offset = 24\) \(.*ValueTypeQuadLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">offset in top level container = 8;</output>		
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ l.l to show the fields of the reference object">
+	<test id="Test 41: Run !j9object $doubleQuadLongInstance$ l.l to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l.l</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l.l.l (offset = 0) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE (offset = 8) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l.l.l \(offset = 0\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l2 = 0x11551155AAEEAAEE \(offset = 8\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeDoubleLong</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ l.l.l to show the fields of the reference object">
+	<test id="Test 42: Run !j9object $doubleQuadLongInstance$ l.l.l to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l.l.l</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344 (offset = 0) (ValueLong)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0xFAFBFCFD11223344 \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 8;</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ l2 to show the fields of the reference object">
+	<test id="Test 43: Run !j9object $doubleQuadLongInstance$ l2 to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l2</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J l2 = 0x11551155AAEEAAEE (offset = 8) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">l2.l (offset = 0) (ValueLong)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l2 = 0x11551155AAEEAAEE \(offset = 8\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">l2.l \(offset = 0\) \(.*ValueTypeLong\)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>	
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
-	<test id="Run !j9object $doubleQuadLongInstance$ l2.l to show the fields of the reference object">
+	<test id="Test 44: Run !j9object $doubleQuadLongInstance$ l2.l to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l2.l</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344 (offset = 0) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0xFAFBFCFD11223344 \(offset = 0\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>	
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $doubleQuadLongInstance$ l3 to show the fields of the reference object">
+	<test id="Test 45: Run !j9object $doubleQuadLongInstance$ l3 to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $doubleQuadLongInstance$ l3</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J j = 0x44884488DD11DD11 (offset = 0) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J j = 0x44884488DD11DD11 \(offset = 0\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeLong</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 56;</output>	
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $doubleQuadLongInstance$ to show the fields of the reference object">
+	<test id="Test 46: Run !flatobject $doubleQuadLongInstance$ to show the fields of the reference object">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $doubleQuadLongInstance$</input>
@@ -611,11 +611,11 @@
 		<output regex="no" type="success" showMatch="yes">(offset = 4)</output>
 		<output regex="no" type="success" showMatch="yes">(offset = 36)</output>
 		<output regex="no" type="success" showMatch="yes">(offset = 52)</output>
-		<output regex="no" type="success" showMatch="yes">// DoubleQuadLong</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeDoubleQuadLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfill2Array$ to show array">
+	<test id="Test 47: Run !j9object $flatUnAlignedSingleBackfill2Array$ to show array">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfill2Array$</input>
@@ -629,7 +629,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfill2Array$ [0]">
+	<test id="Test 48: Run !j9object $flatUnAlignedSingleBackfill2Array$ [0]">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfill2Array$ [0]</input>
@@ -643,7 +643,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfill2Array$ [1]">
+	<test id="Test 49: Run !j9object $flatUnAlignedSingleBackfill2Array$ [1]">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfill2Array$ [1]</input>
@@ -657,7 +657,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $flatUnAlignedSingleBackfill2Array$ [1].l">
+	<test id="Test 50: Run !j9object $flatUnAlignedSingleBackfill2Array$ [1].l">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $flatUnAlignedSingleBackfill2Array$ [1].l</input>
@@ -669,7 +669,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $flatUnAlignedSingleBackfill2Array$ [1]">
+	<test id="Test 51: Run !flatobject $flatUnAlignedSingleBackfill2Array$ [1]">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $flatUnAlignedSingleBackfill2Array$ [1]</input>
@@ -683,21 +683,21 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !j9object $quadLongArray$ [1]">
+	<test id="Test 52: Run !j9object $quadLongArray$ [1]">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $quadLongArray$ [1]</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">[1].l (offset = 0) (DoubleLong)</output>
-		<output regex="no" type="success" showMatch="yes">[1].l2 (offset = 16) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00 (offset = 24) (QuadLong)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\[1\].l \(offset = 0\) \(.*ValueTypeDoubleLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\[1\].l2 \(offset = 16\) \(.*ValueTypeLong\)</output>
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">J l3 = 0x33773377CC00CC00 /(offset = 24/) /(.*ValueTypeQuadLong/)</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes">// QuadLong</output>	
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>	
 		<output regex="no" type="failure">Problem running command</output>
 	</test>	
 
-	<test id="Run !flatobject $quadLongArray$ [1]">
+	<test id="Test 53: Run !flatobject $quadLongArray$ [1]">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $quadLongArray$ [1]</input>
@@ -708,7 +708,7 @@
 		<output regex="no" type="success" showMatch="yes">J j = 0x22662266BBFFBBFF</output>
 		<output regex="no" type="success" showMatch="yes">J l3 = 0x33773377CC00CC00</output>
 		<output regex="no" type="success" showMatch="yes">offset in top level container = 40;</output>
-		<output regex="no" type="success" showMatch="yes">// QuadLong</output>	
+		<output regex="no" type="success" showMatch="yes" regex="yes" javaUtilPattern="yes">\// .*ValueTypeQuadLong</output>	
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 </suite>


### PR DESCRIPTION
1. Re-write testFlatLayoutsWithRecursiveLongs and
testACMPTestOnFastSubstitutableValueTypesVer2 using classes from Javac
instead of ASM generated classes.

2. Put the new classes in ValueTypeTestClasses, the class names of
ValueLong, DoubleLong, QuadLong and DoubleQuadLong now become 
org/openj9/test/lworld/ValueTypeTestClasses$ValueTypeLong,
org/openj9/test/lworld/ValueTypeTestClasses$ValueTypeDoubleLong,
org/openj9/test/lworld/ValueTypeTestClasses$ValueTypeQuadLong,
org/openj9/test/lworld/ValueTypeTestClasses$ValueTypeDoubleQuadLong.

3. Update the DDR tests to check for the new class names.

4. Split ValueTypeArrayTests from ValueTypeTests.

Closes #16291 #16292
Closes #16284

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>