### PR TITLE
Remove ValueTypeArrayTestsJIT and ValueTypeTestsJIT from testng.xml

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -76,7 +76,7 @@
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
-		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTestsJIT \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
 		-groups $(TEST_GROUP) \
 		-excludegroups $(DEFAULT_EXCLUDE); \
 		$(TEST_STATUS)</command>
@@ -149,7 +149,7 @@
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
-		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTestsJIT \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTests \
 		-groups $(TEST_GROUP) \
 		-excludegroups $(DEFAULT_EXCLUDE); \
 		$(TEST_STATUS)</command>

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -30,17 +30,7 @@
 			<class name="org.openj9.test.lworld.ValueTypeTests"/>
 		</classes>
 	</test>
-	<test name="ValueTypeTestsJIT">
-		<classes>
-			<class name="org.openj9.test.lworld.ValueTypeTests"/>
-		</classes>
-	</test>
 	<test name="ValueTypeArrayTests">
-		<classes>
-			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
-		</classes>
-	</test>
-	<test name="ValueTypeArrayTestsJIT">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeArrayTests"/>
 		</classes>


### PR DESCRIPTION
ValueTypeTestsJIT has the same class as ValueTypeTests. ValueTypeArrayTestsJIT has the same class as ValueTypeArrayTests. They can be removed from testng.xml

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>