### PR TITLE
Stack walk loop breaker for ASGCT

### DIFF
--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -375,16 +375,14 @@ extern "C" {
 #define J9_STARTPC_DLT_READY 0x8
 #define J9_STARTPC_STATUS 0xF
 
-/* Frame iterator return values */
-#define J9_STACKWALK_STOP_ITERATING 0x0
-#define J9_STACKWALK_KEEP_ITERATING 0x1
-
 /* Stackwalk return values */
 #define J9_STACKWALK_RC_NONE 0x0
-#define J9_STACKWALK_RC_NO_MEMORY 0x1
-#define J9_STACKWALK_RC_FRAME_NOT_FOUND 0x2
-#define J9_STACKWALK_RC_BAD_STATE_BUFFER 0x3
-#define J9_STACKWALK_RC_STACK_CORRUPT 0x4
+#define J9_STACKWALK_STOP_ITERATING 0x0 /* Must be the same as no error */
+#define J9_STACKWALK_KEEP_ITERATING 0x1
+#define J9_STACKWALK_RC_NO_MEMORY 0x2
+#define J9_STACKWALK_RC_FRAME_NOT_FOUND 0x3
+#define J9_STACKWALK_RC_BAD_STATE_BUFFER 0x4
+#define J9_STACKWALK_RC_STACK_CORRUPT 0x5
 
 /* Tag for JIT artifact search cache */
 #define J9_STACKWALK_NO_JIT_CACHE 0x1

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2537,10 +2537,11 @@ typedef struct J9StackWalkState {
 	void* inlinedCallSite;
 	void* stackMap;
 	void* inlineMap;
+	UDATA loopBreaker;
 	/* The size of J9StackWalkState must be a multiple of 8 because it is inlined into
 	 * J9VMThread where alignment assumotions are being made.
 	 */
-#if 0 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
+#if 1 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 padTo8;
 #endif /* !J9VM_ENV_DATA64 */
 } J9StackWalkState;


### PR DESCRIPTION
Prevent potential endless loop in the stack walker when examining the stack of a thread which has been interrupted when not at a safe point.

Same as #16288 with J9StackWalkState alignment fixed.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>