### PR TITLE
Make VP erase interface types in array types from signatures

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -51,6 +51,8 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual void constrainRecognizedMethod(TR::Node *node);
    virtual bool transformUnsafeCopyMemoryCall(TR::Node *arrayCopyNode);
    virtual bool transformDirectLoad(TR::Node *node);
+   virtual bool isUnreliableSignatureType(
+      TR_OpaqueClassBlock *klass, TR_OpaqueClassBlock *&erased);
    virtual void doDelayedTransformations();
    void transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR::Node *result);
    void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true, bool requiresGuard = false);


### PR DESCRIPTION
The verifier treats interface types as `java/lang/Object` even within array component types. In particular, when any parameter, instance or static field, or return type is declared with a signature naming an array of an interface type, its value is guaranteed to be a reference array, but not necessarily the named array type. For example, if a parameter is declared to be of type `List[]`, it can actually be any `Object[]`.

----

There is one preparatory refactoring commit:
- Factor VP interface type signature detection logic into its own method