### PR TITLE
Fix the return type of VectorSupport.fromBitsCoerced

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -148,6 +148,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    static int32_t const MODE_BROADCAST = 0;
    static int32_t const MODE_BITS_COERCED_LONG_TO_MASK = 1;
 
+   // Position of the parameters in the intrinsics.
+   static int32_t const BROADCAST_TYPE_CHILD = 4;
+
   /** \brief
    *  Is passed to methods handlers during analysis and transforamtion phases
    *


### PR DESCRIPTION
The return type of `jdk_internal_vm_vector_VectorSupport_fromBitsCoerced` can be either of Vector or Mask.
Change the type field of the `fromBitsCoerced` entry in the method table to `unknown` and update `visitNodeToBuildVectorAliases` to get the correct type for the call by checking the value of the 5th child node.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>