### PR TITLE
Unset Valhalla modifiers in Class.toGenericString()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2804,6 +2804,22 @@ public String toGenericString() {
 	boolean isArray = isArray();
 	boolean isInterface = !isArray && (0 != (modifiers & Modifier.INTERFACE));
 	
+/*[IF INLINE-TYPES]*/
+	String valueType;
+	if (Modifier.VALUE == (Modifier.VALUE & modifiers)) {
+		/**
+		 * Modifier.PRIMITIVE is not added by OpenJDK yet. It shares the same bit as Modifier.STRICT.
+		 * TODO: Change Modifier.STRICT to Modifier.PRIMITIVE.
+		 */
+		if (Modifier.STRICT == (Modifier.STRICT & modifiers)) {
+			valueType = "primitive "; //$NON-NLS-1$
+		} else {
+			valueType = "value "; //$NON-NLS-1$
+		}
+	} else {
+		valueType = ""; //$NON-NLS-1$
+	}
+/*[ENDIF] INLINE-TYPES */
 	// Get kind of type before modifying the modifiers
 	String kindOfType;
 	if ((!isArray) && ((modifiers & ANNOTATION) != 0)) {
@@ -2824,6 +2840,16 @@ public String toGenericString() {
 	if (isInterface) {
 		modifiers -= Modifier.INTERFACE;
 	}
+/*[IF INLINE-TYPES]*/
+	/**
+	 * IDENTITY shares the same bit as SYNCHRONIZED. VALUE shares the same bit as VOLATILE.
+	 * Modifier.toString() is used later in this function which translates them to "synchronized" and "volatile",
+	 * which is incorrect. So remove these bits if they are set.
+	 * Modifier.PRIMITIVE is not added by OpenJDK yet. It shares the same bit as Modifier.STRICT.
+	 * TODO: Change Modifier.STRICT to Modifier.PRIMITIVE.
+	 */
+	modifiers &= ~(Modifier.IDENTITY | Modifier.VALUE | Modifier.STRICT);
+/*[ENDIF] INLINE-TYPES */
 	
 	// Build generic string
 /*[IF Sidecar19-SE]*/
@@ -2850,6 +2876,9 @@ public String toGenericString() {
 	if (result.length() > 0) {
 		result.append(' ');
 	}
+/*[IF INLINE-TYPES]*/
+	result.append(valueType);
+/*[ENDIF] INLINE-TYPES */
 	result.append(kindOfType);
 	result.append(getName());
 	

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -998,24 +998,34 @@ public void test_getModifiers_classTypes() {
 		AnnotationClazz.class,
 		EnumClazz.class,
 	};
+	int IDENTITY = 0;
+	try {
+		Field f = Modifier.class.getDeclaredField("IDENTITY");
+		IDENTITY = f.getInt(null);
+	} catch (NoSuchFieldException e) {
+		/* Let IDENTITY be 0 in non-Valhalla builds. */
+	} catch(Exception e) {
+		Assert.fail("Unexpected exception " + e.getClass().getName() + " thrown when getting the value of modifier");
+	}
+
 	int[] modifiers = new int[] {
-		0x0000, //
-		0x0004, // protected
-		0x0002, // private
-		0x0000, //
-		0x0001, // public
-		0x0010, // final
-		0x0008, // static
-		0x0018, // final static
-		0x0009, // public static
-		0x0011, // public final
-		0x0019, // public final static
-		0x0000, //
-		0x0410, // static
-		0x0400, // abstract
-		0x1001, // public synthetic
-		0x2608, // static abstract interface annotation
-		0x4018, // static final enum
+		0x0000 | IDENTITY, // (Identity)
+		0x0004 | IDENTITY, // protected (Identity)
+		0x0002 | IDENTITY, // private (Identity)
+		0x0000 | IDENTITY, // (Identity)
+		0x0001 | IDENTITY, // public (Identity)
+		0x0010 | IDENTITY, // final (Identity)
+		0x0008 | IDENTITY, // static (Identity)
+		0x0018 | IDENTITY, // final static (Identity)
+		0x0009 | IDENTITY, // public static (Identity)
+		0x0011 | IDENTITY, // public final (Identity)
+		0x0019 | IDENTITY, // public final static (Identity)
+		0x0000 | IDENTITY, // (Identity)
+		0x0410,            // static
+		0x0400 | IDENTITY, // abstract (Identity)
+		0x1001 | IDENTITY, // public synthetic (Identity)
+		0x2608,            // static abstract interface annotation
+		0x4018 | IDENTITY, // static final enum (Identity)
 	};
 
 	StringBuilder errors = new StringBuilder();


### PR DESCRIPTION
1. Add "primitive"/"value" for primitive VT and value classes.
2. Unset Valhalla modifiers before calling Modifier.toString()
3. Modify test_getModifiers_classTypes to recognize Modifer.IDENTITY

Closes #16327
Closes #16319

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>