### PR TITLE
Re-enable gtgc001 on JDK20

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_20.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_20.xml
@@ -56,8 +56,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<reason>Nestmates are not enabled on java10</reason>
 	</exclude>
 
-	<exclude id="gtgc001" platform="all">
-		<reason>GetThreadGroupChildren requires refactor for Project Loom</reason>
-	</exclude>
-
 </suite>


### PR DESCRIPTION
GetThreadGroupChildren was fixed by #15539.

The above PR removed the exclude for JDK19.

But, the exclude for JDK20 was not removed.

Related: #15244

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>