### PR TITLE
Redesign StackWalker implementation

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -263,7 +263,7 @@ public class StackWalkerUtils
 		if (J9BuildFlags.arch_x86 && !J9BuildFlags.env_data64) {
 			return walkState.bp.at(parmNumber);
 		} else {
-			return walkState.walkedEntryLocalStorage.jitGlobalStorageBase().at(jitArgumentRegisterNumbers[parmNumber - 1]);
+			return walkState.jitGlobalStorageBase.at(jitArgumentRegisterNumbers[parmNumber - 1]);
 		}
 	}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/WalkState.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/WalkState.java
@@ -27,6 +27,7 @@ import com.ibm.j9ddr.vm29.pointer.U8Pointer;
 import com.ibm.j9ddr.vm29.pointer.UDATAPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ConstantPoolPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9I2JStatePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JITDecompilationInfoPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JITExceptionTablePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9MethodPointer;
@@ -44,9 +45,10 @@ import static com.ibm.j9ddr.vm29.structure.J9StackWalkConstants.*;
  */
 public class WalkState
 {
-	
 	/** Thread to be walked */
-	public J9VMThreadPointer walkThread;
+	public J9VMThreadPointer walkThread = J9VMThreadPointer.NULL;
+
+	public J9JavaVMPointer javaVM = J9JavaVMPointer.NULL;
 	
 	/** Flags controlling the walk
 	 * @see StackWalkerConstants 
@@ -54,36 +56,36 @@ public class WalkState
 	public long flags;
 	
 	/** Base pointer */
-	public UDATAPointer bp;
+	public UDATAPointer bp = UDATAPointer.NULL;
 	
-	public UDATAPointer unwindSP;
+	public UDATAPointer unwindSP = UDATAPointer.NULL;
 	
 	/** Program counter */
-	public U8Pointer pc;
+	public U8Pointer pc = U8Pointer.NULL;
 	
 	/** Top-of-stack pointer */
-	public UDATAPointer sp;
+	public UDATAPointer sp = UDATAPointer.NULL;
 	
 	/** Address of argument 0 */
-	public UDATAPointer arg0EA;
+	public UDATAPointer arg0EA = UDATAPointer.NULL;
 	
-	public J9MethodPointer literals;
+	public J9MethodPointer literals = J9MethodPointer.NULL;
 	
-	public UDATAPointer walkSP;
+	public UDATAPointer walkSP = UDATAPointer.NULL;
 	
-	public UDATA argCount;
+	public UDATA argCount = new UDATA(0);
 	
-	public J9ConstantPoolPointer constantPool;
+	public J9ConstantPoolPointer constantPool = J9ConstantPoolPointer.NULL;
 	
-	public J9MethodPointer method;
+	public J9MethodPointer method = J9MethodPointer.NULL;
 	
 	public J9JITExceptionTablePointer jitInfo = J9JITExceptionTablePointer.NULL;
 	
-	public UDATA frameFlags;
+	public UDATA frameFlags = new UDATA(0);
 	
-	public UDATA resolveFrameFlags;
+	public UDATA resolveFrameFlags = new UDATA(0);
 	
-	public UDATAPointer searchValue;
+	public UDATAPointer searchValue = UDATAPointer.NULL;
 	
 	public int skipCount;
 	
@@ -105,9 +107,9 @@ public class WalkState
 	
 	public long inlineDepth;
 	
-	public UDATAPointer cacheCursor;
+	public UDATAPointer cacheCursor = UDATAPointer.NULL;
 	
-	public J9JITDecompilationInfoPointer decompilationRecord;
+	public J9JITDecompilationInfoPointer decompilationRecord = J9JITDecompilationInfoPointer.NULL;
 	
 	public boolean searchFrameFound;
 	
@@ -121,27 +123,35 @@ public class WalkState
 		}
 	}
 	
-	public J9VMEntryLocalStoragePointer walkedEntryLocalStorage;
+	public J9VMEntryLocalStoragePointer walkedEntryLocalStorage = J9VMEntryLocalStoragePointer.NULL;
 	
-	public J9I2JStatePointer i2jState;
+	public J9I2JStatePointer i2jState = J9I2JStatePointer.NULL;
 	
-	public J9JITDecompilationInfoPointer decompilationStack;
+	public J9JITDecompilationInfoPointer decompilationStack = J9JITDecompilationInfoPointer.NULL;
 	
-	public PointerPointer pcAddress;
+	public PointerPointer pcAddress = PointerPointer.NULL;
 	
-	public UDATA outgoingArgCount;
+	public UDATA outgoingArgCount = new UDATA(0);
 	
-	public U8Pointer objectSlotBitVector;
+	public U8Pointer objectSlotBitVector = U8Pointer.NULL;
 	
-	public UDATA elsBitVector;
+	public UDATA elsBitVector = new UDATA(0);
 	
-	public U8Pointer bytecodePCOffset;
+	public U8Pointer bytecodePCOffset = U8Pointer.NULL;
 	
-	public UDATAPointer j2iFrame;
+	public UDATAPointer j2iFrame = UDATAPointer.NULL;
 	
-	public UDATA previousFrameFlags;
+	public UDATA previousFrameFlags = new UDATA(0);
 	
 	public int slotIndex;
 	
 	public int slotType;
+
+	public UDATA privateFlags = new UDATA(0);
+
+	public UDATAPointer jitGlobalStorageBase = UDATAPointer.NULL;
+
+	public UDATAPointer jitFPRegisterStorageBase = UDATAPointer.NULL;
+
+	public J9VMEntryLocalStoragePointer oldEntryLocalStorage = J9VMEntryLocalStoragePointer.NULL;
 }

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -79,7 +79,7 @@ fixStackForSyntheticHandler(J9VMThread *currentThread)
 	if (NULL != decomp) {
 		J9SFJITResolveFrame *resolveFrame = (J9SFJITResolveFrame*)currentThread->sp;
 		void *jitPC = MASK_PC(resolveFrame->returnAddress);
-		J9JITExceptionTable *metaData = jitGetExceptionTableFromPC(currentThread, (UDATA)jitPC);
+		J9JITExceptionTable *metaData = jitGetExceptionTableFromPC(currentThread, (UDATA)jitPC, currentThread->javaVM);
 		Assert_CodertVM_false(NULL == metaData);
 		UDATA *oldSP = (UDATA*)(resolveFrame + 1);
 		UDATA *bp = oldSP + getJitTotalFrameSize(metaData);
@@ -1722,7 +1722,7 @@ slow_jitMonitorEnterImpl(J9VMThread *currentThread, bool forMethod)
 			void * stackMap = NULL;
 			void * inlineMap = NULL;
 			J9JavaVM *vm = currentThread->javaVM;
-			J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, (UDATA)oldPC);
+			J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, (UDATA)oldPC, currentThread->javaVM);
 			Assert_CodertVM_false(NULL == metaData);
 			jitGetMapsFromPC(currentThread, vm, metaData, (UDATA)oldPC, &stackMap, &inlineMap);
 			Assert_CodertVM_false(NULL == inlineMap);
@@ -2650,7 +2650,7 @@ old_slow_jitRetranslateMethod(J9VMThread *currentThread)
 	 *		- a decompile point
 	 */
 	bool callerAlreadyBeingDecompiled  = false;
-	if (NULL == jitGetExceptionTableFromPC(currentThread, (UDATA)jitEIP)) {
+	if (NULL == jitGetExceptionTableFromPC(currentThread, (UDATA)jitEIP, currentThread->javaVM)) {
 		U_8 **returnTable = (U_8**)jitConfig->i2jReturnTable;
 		callerAlreadyBeingDecompiled = true;
 		for (UDATA i = 0; i < J9SW_JIT_RETURN_TABLE_SIZE; ++i) {

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -265,7 +265,7 @@ jitResetAllMethods(J9VMThread *currentThread)
 			if (0 == (extra & J9_STARTPC_NOT_TRANSLATED)) {
 				/* Do not reset JIT INLs (currently in FSD there are no compiled JNI natives) */
 				if (0 == (J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccNative)) {
-					J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, extra);
+					J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, extra, currentThread->javaVM);
 					if (NULL != metaData) {
 						/* 0xCC is the "int3" instruction on x86.
 						 * This will cause a crash if this instruction is executed.

--- a/runtime/codert_vm/dlt.c
+++ b/runtime/codert_vm/dlt.c
@@ -86,7 +86,7 @@ retry:
 
 	/* Check for stack overflow */
 
-	metaData = jitGetExceptionTableFromPC(currentThread, (UDATA) dltEntry);
+	metaData = jitGetExceptionTableFromPC(currentThread, (UDATA) dltEntry, currentThread->javaVM);
 	checkSP = walkState->sp - (metaData->totalFrameSize + J9SW_JIT_STACK_SLOTS_USED_BY_CALL);
 	if (checkSP < currentThread->stackOverflowMark2) {
 #if defined(J9VM_INTERP_GROWABLE_STACKS)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7678,7 +7678,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          }
       else if (entry->_oldStartPC)
          {
-         J9JITExceptionTable *oldMetaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)entry->_oldStartPC);
+         J9JITExceptionTable *oldMetaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)entry->_oldStartPC, vmThread->javaVM);
          if (oldMetaData)
             {
             TR_PersistentJittedBodyInfo *oldBodyInfo = (TR_PersistentJittedBodyInfo *)oldMetaData->bodyInfo;

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -759,7 +759,7 @@ static UDATA dltTestIterator(J9VMThread * currentThread, J9StackWalkState * walk
    switch(walkState->framesWalked)
       {
       case 1 :
-         if (((UDATA) walkState->pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) || (walkState->pc == walkState->walkThread->javaVM->callInReturnPC))
+         if (((UDATA) walkState->pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) || (walkState->pc == walkState->javaVM->callInReturnPC))
             return J9_STACKWALK_KEEP_ITERATING;
          if (walkState->jitInfo!=NULL)
             return J9_STACKWALK_STOP_ITERATING;
@@ -768,7 +768,7 @@ static UDATA dltTestIterator(J9VMThread * currentThread, J9StackWalkState * walk
          break;
 
       case 2 :
-         if (((UDATA) walkState->pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) || (walkState->pc == walkState->walkThread->javaVM->callInReturnPC))
+         if (((UDATA) walkState->pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) || (walkState->pc == walkState->javaVM->callInReturnPC))
             return J9_STACKWALK_STOP_ITERATING;
 
          if (walkState->jitInfo!=NULL)
@@ -781,7 +781,7 @@ static UDATA dltTestIterator(J9VMThread * currentThread, J9StackWalkState * walk
 
       case 3 : // unused currently
          if (walkState->jitInfo!=NULL || ((UDATA) walkState->pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) ||
-             (walkState->pc == walkState->walkThread->javaVM->callInReturnPC) || (*walkState->bp & J9SF_A0_INVISIBLE_TAG))
+             (walkState->pc == walkState->javaVM->callInReturnPC) || (*walkState->bp & J9SF_A0_INVISIBLE_TAG))
             return J9_STACKWALK_STOP_ITERATING;
          break;
       }

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -825,7 +825,7 @@ J9::CompilationStrategy::ProcessJittedSample::determineWhetherToRecompileBasedOn
    // When codeSize==avgCodeSize, we want the scaling factor to be 1.0
    // The scaling of the threshold can be turned off by having
    // the sampleThresholdVariationAllowance equal to 0
-   J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(_event->_vmThread, (UDATA)_startPC);
+   J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(_event->_vmThread, (UDATA)_startPC, _event->_vmThread->javaVM);
    int32_t codeSize = 0; // TODO eliminate the overhead; we already have metadata
    if (metaData)
       codeSize = _compInfo->calculateCodeSize(metaData);

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -473,7 +473,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
             J9Method *userMethod = allMethodsFromSignatureStartDo(&state, context->javaVM, 0, className, classNameLength, methodName, methodNameLength, methodSig, methodSigLength);
             while (NULL != userMethod)
                {
-               J9JITExceptionTable *metadata = jitConfig->jitGetExceptionTableFromPC(crashedThread, reinterpret_cast<UDATA>(userMethod->extra));
+               J9JITExceptionTable *metadata = jitConfig->jitGetExceptionTableFromPC(crashedThread, reinterpret_cast<UDATA>(userMethod->extra), crashedThread->javaVM);
                if (NULL != metadata)
                   {
                   auto *bodyInfo = reinterpret_cast<TR_PersistentJittedBodyInfo *>(metadata->bodyInfo);
@@ -542,7 +542,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
 
             if (J9PORT_SIG_VALUE_ADDRESS == infoType)
                {
-               J9JITExceptionTable *metadata = jitConfig->jitGetExceptionTableFromPC(crashedThread, *reinterpret_cast<UDATA*>(value));
+               J9JITExceptionTable *metadata = jitConfig->jitGetExceptionTableFromPC(crashedThread, *reinterpret_cast<UDATA*>(value), crashedThread->javaVM);
                if (NULL != metadata)
                   {
                   auto *bodyInfo = reinterpret_cast<TR_PersistentJittedBodyInfo *>(metadata->bodyInfo);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2220,7 +2220,7 @@ TR_J9VMBase::releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart)
       TR::VMAccessCriticalSection releaseCodeMemory(this);
       J9JavaVM            *vm        = jitConfig->javaVM;
       J9VMThread          *vmContext = vm->internalVMFunctions->currentVMThread(vm);
-      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)startPC);
+      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)startPC, vmContext->javaVM);
       vlogReclamation("Queuing for reclamation", metaData, bytesToSaveAtStart);
       TR::CodeCacheManager::instance()->addFaintCacheBlock(metaData, bytesToSaveAtStart);
       }

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -56,7 +56,7 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
    int numSymsThatShareSlot = (slotData >> 16) & 0xFFF;
    int totalNumSlots = slotData & 0xFFFF;
    J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
-   J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA) vmThread->osrBuffer->jitPC);
+   J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA) vmThread->osrBuffer->jitPC, vmThread->javaVM);
    UDATA jitPCOffset = (UDATA) vmThread->osrBuffer->jitPC - metaData->startPC;
    J9OSRFrame *osrFrame = (J9OSRFrame*)((uint8_t*)vmThread->osrBuffer + vmThread->osrFrameIndex);
 

--- a/runtime/compiler/runtime/GPUHelpers.cpp
+++ b/runtime/compiler/runtime/GPUHelpers.cpp
@@ -1096,7 +1096,7 @@ initCUDA(J9VMThread *vmThread, int tracing, const char *ptxSource, int deviceId,
 static GpuMetaData* getGPUMetaData(uint8_t* startPC)
    {
       J9VMThread *vmThread = jitConfig->javaVM->internalVMFunctions->currentVMThread(jitConfig->javaVM);
-      TR_MethodMetaData * metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)startPC);
+      TR_MethodMetaData * metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)startPC, vmThread->javaVM);
       return (GpuMetaData*)metaData->gpuCode;
    }
 

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -723,7 +723,7 @@ TR_HWProfiler::getBytecodePCFromIA(J9VMThread *vmThread, uint8_t *IA)
    {
    if (vmThread)
       {
-      J9JITExceptionTable *metaData = _jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA) IA);
+      J9JITExceptionTable *metaData = _jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA) IA, vmThread->javaVM);
       if (metaData &&
           metaData->riData &&
           ((TR_HWPBytecodePCToIAMap *)metaData->riData)->_bytecodePC == reinterpret_cast<void *>(static_cast<intptr_t>(METADATA_MAPPING_EYECATCHER)))

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -784,7 +784,7 @@ UDATA jitExceptionHandlerSearch(J9VMThread * currentThread, J9StackWalkState * w
       UDATA deltaPC;
       J9Class * thrownClass = (J9Class *) walkState->userData4;
       UDATA (* isExceptionTypeCaughtByHandler) (J9VMThread *, J9Class *, J9ConstantPool *, UDATA, J9StackWalkState *) =
-         walkState->walkThread->javaVM->internalVMFunctions->isExceptionTypeCaughtByHandler;
+         walkState->javaVM->internalVMFunctions->isExceptionTypeCaughtByHandler;
 
       /* we subtract one from the jitPC as jitPCs that come in are always pointing at the beginning of the next instruction
        * (ie: the return address from the child call).  In the case of trap handlers, the GP handler has already bumped the PC
@@ -814,7 +814,7 @@ UDATA jitExceptionHandlerSearch(J9VMThread * currentThread, J9StackWalkState * w
                   if (bytecodePCBytes)
                      walkState->userData1 = (void *)(intptr_t)*get32BitByteCodeIndexFromExceptionTable(walkState->jitInfo);
                   walkState->userData2 = (void *) (getJittedMethodStartPC(walkState->jitInfo) + getJit32BitTableEntryHandlerPC(handlerCursor));
-                  walkState->restartPoint = walkState->walkThread->javaVM->jitConfig->runJITHandler;
+                  walkState->restartPoint = walkState->javaVM->jitConfig->runJITHandler;
                   walkState->userData3 = (void *) J9_EXCEPT_SEARCH_JIT_HANDLER;
                   walkState->userData4 = (void *) synthetic;
                   return J9_STACKWALK_STOP_ITERATING;
@@ -845,7 +845,7 @@ UDATA jitExceptionHandlerSearch(J9VMThread * currentThread, J9StackWalkState * w
                   if (bytecodePCBytes)
                      walkState->userData1 = (void *)(intptr_t)*get16BitByteCodeIndexFromExceptionTable(walkState->jitInfo);
                   walkState->userData2 = (void *) (getJittedMethodStartPC(walkState->jitInfo) + getJit16BitTableEntryHandlerPC(handlerCursor));
-                  walkState->restartPoint = walkState->walkThread->javaVM->jitConfig->runJITHandler;
+                  walkState->restartPoint = walkState->javaVM->jitConfig->runJITHandler;
                   walkState->userData3 = (void *) J9_EXCEPT_SEARCH_JIT_HANDLER;
                   walkState->userData4 = (void *) synthetic;
                   return J9_STACKWALK_STOP_ITERATING;
@@ -1426,7 +1426,7 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
        /* If base array was moved by a non zero displacement
        */
 #if defined(J9VM_INTERP_STACKWALK_TRACING)
-      if ((displacement != 0) || (walkState->walkThread->javaVM->runtimeFlags & J9_RUNTIME_SNIFF_AND_WHACK))
+      if ((displacement != 0) || (walkState->javaVM->runtimeFlags & J9_RUNTIME_SNIFF_AND_WHACK))
 #else
       if (displacement != 0)
 #endif
@@ -2506,5 +2506,5 @@ UDATA osrScratchBufferSize(J9VMThread* currentThread, J9JITExceptionTable *metaD
 J9JITExceptionTable *
 jitGetMetaDataFromPC(J9VMThread* currentThread, UDATA pc)
    {
-   return jitGetExceptionTableFromPC(currentThread, pc);
+   return jitGetExceptionTableFromPC(currentThread, pc, currentThread->javaVM);
    }

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -6166,7 +6166,7 @@ TR_RelocationRecordMethodCallAddress::computeTargetMethodAddress(TR_RelocationRu
    if (reloRuntime->options()->getOption(TR_StressTrampolines) || reloTarget->useTrampoline(callTargetAddress, baseLocation))
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\tredirecting call to " POINTER_PRINTF_FORMAT " through trampoline\n", callTargetAddress);
-      auto metadata = jitGetExceptionTableFromPC(reloRuntime->currentThread(), (UDATA)callTargetAddress);
+      auto metadata = jitGetExceptionTableFromPC(reloRuntime->currentThread(), (UDATA)callTargetAddress, reloRuntime->currentThread()->javaVM);
       auto j9method = metadata->ramMethod;
       TR::VMAccessCriticalSection computeTargetMethodAddress(reloRuntime->fej9());
       // getResolvedTrampoline will create the trampoline if it doesn't exist, but we pass inBinaryEncoding=true because we want the compilation to fail

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -76,7 +76,7 @@ void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched)
    {
       J9JavaVM            *vm        = jitConfig->javaVM;
       J9VMThread          *vmContext = vm->internalVMFunctions->currentVMThread(vm);
-      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)addressToBePatched);
+      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)addressToBePatched, vmContext->javaVM);
 
       if (!createClassUnloadPicSite(classPointer, addressToBePatched, sizeof(uintptr_t),
                                     (OMR::RuntimeAssumption**)(&metaData->runtimeAssumptionList))
@@ -100,7 +100,7 @@ void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePat
 
       J9JavaVM            *vm        = jitConfig->javaVM;
       J9VMThread          *vmContext = vm->internalVMFunctions->currentVMThread(vm);
-      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)addressToBePatched);
+      J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmContext, (UDATA)addressToBePatched, vmContext->javaVM);
 
       if (!createClassUnloadPicSite(classPointer, addressToBePatched, 4,
                                     (OMR::RuntimeAssumption**)(&metaData->runtimeAssumptionList))
@@ -131,7 +131,7 @@ void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePa
    {
    J9JavaVM            *vm        = jitConfig->javaVM;
    J9VMThread          *vmThread  = vm->internalVMFunctions->currentVMThread(vm);
-   J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched);
+   J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched, vmThread->javaVM);
    createClassRedefinitionPicSite(classPointer, addressToBePatched, sizeof(uintptr_t), unresolved,
                                   (OMR::RuntimeAssumption**)(&metaData->runtimeAssumptionList));
    }
@@ -140,7 +140,7 @@ void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressT
    {
    J9JavaVM            *vm        = jitConfig->javaVM;
    J9VMThread          *vmThread  = vm->internalVMFunctions->currentVMThread(vm);
-   J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched);
+   J9JITExceptionTable *metaData  = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched, vmThread->javaVM);
    createClassRedefinitionPicSite(classPointer, addressToBePatched, 4, unresolved,
                                   (OMR::RuntimeAssumption**)(&metaData->runtimeAssumptionList));
    }

--- a/runtime/compiler/runtime/SignalHandler.c
+++ b/runtime/compiler/runtime/SignalHandler.c
@@ -329,7 +329,7 @@ UDATA jitX86Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 		} else if ((eip >= (U_8 *) & jitMathHelpersRemainderBegin) && (eip < (U_8 *) & jitMathHelpersRemainderEnd)) {
 			exceptionTable = (J9JITExceptionTable *) 2; /* make it non-0 to allow exception to be handled */
 		} else {
-			exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)eip);
+			exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)eip, vmThread->javaVM);
 		}
 
 		if (exceptionTable == NULL) {
@@ -533,7 +533,7 @@ UDATA jitPPCHandler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 		}
 		iarPtr = (UDATA *) infoValue;
 
-		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *iarPtr);
+		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *iarPtr, vmThread->javaVM);
 
 		if( !exceptionTable && J9PORT_SIG_FLAG_SIGBUS == sigType ){
 		   // We might be in a jit helper routine (like arraycopy) so look at the link register as well...
@@ -543,7 +543,7 @@ UDATA jitPPCHandler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 		      return J9PORT_SIG_EXCEPTION_CONTINUE_SEARCH;
 		   }
 		   lrPtr = (UDATA *) infoValue;
-		   exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *lrPtr);
+		   exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *lrPtr, vmThread->javaVM);
 		   if (exceptionTable) {
 				vmThread->jitException = (J9Object *) (*lrPtr);  /* the lr points at the instruction after the helper call */
 #if (defined(LINUXPPC64) && !defined(__LITTLE_ENDIAN__)) || defined(AIXPPC)
@@ -1240,7 +1240,7 @@ UDATA jit390Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
             }
          } /* End of DAA Signal Handling */
 
-      exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, controlPCValue);
+      exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, controlPCValue, vmThread->javaVM);
 
       if (exceptionTable)
          {
@@ -1760,7 +1760,7 @@ UDATA jitAMD64Handler(J9VMThread* vmThread, U_32 sigType, void *sigInfo)
 		}
 		rbpPtr = (UDATA*) infoValue;
 
-		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, (U_64)rip);
+		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, (U_64)rip, vmThread->javaVM);
 		if (exceptionTable == NULL) {
 			return J9PORT_SIG_EXCEPTION_CONTINUE_SEARCH;
 		} else {
@@ -1906,7 +1906,7 @@ UDATA jitARM64Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 		}
 		pcPtr = (UDATA *) infoValue;
 
-		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *pcPtr);
+		exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *pcPtr, vmThread->javaVM);
 
 		if (!exceptionTable && J9PORT_SIG_FLAG_SIGBUS == sigType) {
 			// We might be in a jit helper routine (like arraycopy) so look at the link register as well...
@@ -1917,7 +1917,7 @@ UDATA jitARM64Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 				return J9PORT_SIG_EXCEPTION_CONTINUE_SEARCH;
 			}
 			lrPtr = (UDATA *) infoValue;
-			exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *lrPtr);
+			exceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, *lrPtr, vmThread->javaVM);
 			if (exceptionTable) {
 				vmThread->jitException = (J9Object *) (*lrPtr);  /* the lr points at the instruction after the helper call */
 				*pcPtr = (UDATA) ((void *) &jitHandleInternalErrorTrap);

--- a/runtime/j9vm/asgct.cpp
+++ b/runtime/j9vm/asgct.cpp
@@ -161,7 +161,7 @@ protectedASGCT(J9PortLibrary *portLib, void *arg)
 		if (NULL != ucontext) {
 			greg_t *regs = ((ucontext_t*)ucontext)->uc_mcontext.gregs;
 			greg_t rip = regs[REG_RIP];
-			J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(currentThread, rip);
+			J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(currentThread, rip, currentThread->javaVM);
 			if (NULL != metaData) {
 				greg_t rsp = regs[REG_RSP];
 				/* Build a JIT resolve frame on the C stack to avoid writing to the java

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -250,7 +250,7 @@ extern J9_CFUNC UtInterface * getTraceInterfaceFromVM(J9JavaVM *j9vm);
 #define PORT_ACCESS_FROM_VMC(vmContext) J9PortLibrary *privatePortLibrary = (vmContext)->javaVM->portLibrary
 #define PORT_ACCESS_FROM_GINFO(javaVM) J9PortLibrary *privatePortLibrary = (javaVM)->portLibrary
 #define PORT_ACCESS_FROM_JITCONFIG(jitConfig) J9PortLibrary *privatePortLibrary = (jitConfig)->javaVM->portLibrary
-#define PORT_ACCESS_FROM_WALKSTATE(walkState) J9PortLibrary *privatePortLibrary = (walkState)->walkThread->javaVM->portLibrary
+#define PORT_ACCESS_FROM_WALKSTATE(walkState) J9PortLibrary *privatePortLibrary = (walkState)->javaVM->portLibrary
 #define OMRPORT_ACCESS_FROM_J9VMTHREAD(vmContext) OMRPORT_ACCESS_FROM_J9PORT((vmContext)->javaVM->portLibrary)
 #define PORT_ACCESS_FROM_VMI(vmi) J9PortLibrary *privatePortLibrary = (*vmi)->GetPortLibrary(vmi)
 /** @} */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -290,6 +290,7 @@ struct J9ClassLoader;
 struct J9ConstantPool;
 struct J9HashTable;
 struct J9HookedNative;
+struct J9JavaStack;
 struct J9JavaVM;
 struct J9JVMTIClassPair;
 struct J9JXEDescription;
@@ -311,9 +312,11 @@ struct J9RASdumpFunctions;
 struct J9ROMClass;
 struct J9ROMMethod;
 struct J9SharedInternSRPHashTableEntry;
+struct J9StackWalkState;
 struct J9Statistic;
 struct J9UTF8;
 struct J9VerboseSettings;
+struct J9VMEntryLocalStorage;
 struct J9VMInterface;
 struct J9VMThread;
 struct JNINativeInterface_;
@@ -2543,6 +2546,12 @@ typedef struct J9StackWalkState {
 	void* stackMap;
 	void* inlineMap;
 	UDATA loopBreaker;
+	UDATA privateFlags;
+	struct J9JavaStack* stackObject;
+	struct J9StackWalkState* stackWalkState;
+	UDATA* jitGlobalStorageBase;
+	UDATA* jitFPRegisterStorageBase;
+	struct J9VMEntryLocalStorage* oldEntryLocalStorage;
 	/* The size of J9StackWalkState must be a multiple of 8 because it is inlined into
 	 * J9VMThread where alignment assumotions are being made.
 	 */
@@ -4007,7 +4016,7 @@ typedef struct J9JITConfig {
 	UDATA codeCachePadKB;
 	UDATA codeCacheTotalKB;
 	UDATA dataCacheTotalKB;
-	struct J9JITExceptionTable*  ( *jitGetExceptionTableFromPC)(struct J9VMThread * vmThread, UDATA jitPC) ;
+	struct J9JITExceptionTable*  ( *jitGetExceptionTableFromPC)(struct J9VMThread *vmThread, UDATA jitPC, struct J9JavaVM *javaVM);
 	void*  ( *jitGetStackMapFromPC)(struct J9VMThread * currentThread, struct J9JavaVM * vm, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
 	void*  ( *jitGetInlinerMapFromPC)(struct J9VMThread * currentThread, struct J9JavaVM * vm, struct J9JITExceptionTable * exceptionTable, UDATA jitPC) ;
 	UDATA  ( *getJitInlineDepthFromCallSite)(struct J9JITExceptionTable *metaData, void *inlinedCallSite) ;
@@ -5026,6 +5035,7 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
 	I_32 (*invoke31BitJNI_OnXLoad)(struct J9JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved);
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
+	UDATA (*commonWalker)(struct J9VMThread *currentThread, J9StackWalkState *walkState);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -102,7 +102,7 @@ extern J9_CFUNC UDATA  jitWalkStackFrames (J9StackWalkState *walkState);
  *
  * @note           If jitPC is NULL this function will return NULL.
  */
-extern J9_CFUNC J9JITExceptionTable * jitGetExceptionTableFromPC (J9VMThread * vmThread, UDATA jitPC);
+extern J9_CFUNC J9JITExceptionTable * jitGetExceptionTableFromPC(J9VMThread *vmThread, UDATA jitPC, J9JavaVM *javaVM);
 extern J9_CFUNC UDATA  jitGetOwnedObjectMonitors(J9StackWalkState *state);
 #if (defined(J9VM_INTERP_STACKWALK_TRACING)) /* priv. proto (autogen) */
 extern J9_CFUNC void jitPrintRegisterMapArray (J9StackWalkState * walkState, char * description);

--- a/runtime/oti/stackwalk.h
+++ b/runtime/oti/stackwalk.h
@@ -179,7 +179,7 @@ extern "C" {
 
 #define J9SW_ARGUMENT_REGISTER_COUNT 0x4
 #define J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT 0x8
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_POTENTIAL_SAVED_REGISTERS 0x10
 #define J9SW_REGISTER_MAP_MASK 0xFFFF
 #define J9SW_JIT_FIRST_RESOLVE_PARM_REGISTER 0x3
@@ -232,7 +232,7 @@ extern "C" {
 
 #define J9SW_ARGUMENT_REGISTER_COUNT 0x8
 #define J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT 0x8
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_JIT_STACK_SLOTS_USED_BY_CALL 0x0
 #define J9SW_POTENTIAL_SAVED_REGISTERS 0x20
 #define J9SW_REGISTER_MAP_MASK 0xFFFFFFFF
@@ -272,7 +272,7 @@ extern "C" {
 
 #define J9SW_ARGUMENT_REGISTER_COUNT 0x3
 #define J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT 0x4
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_JIT_STACK_SLOTS_USED_BY_CALL 0x0
 #undef  J9SW_JIT_LOOKUP_INTERFACE_RESOLVE_OFFSET_TO_SAVED_RECEIVER
 #undef  J9SW_JIT_VIRTUAL_METHOD_RESOLVE_OFFSET_TO_SAVED_RECEIVER
@@ -315,7 +315,7 @@ extern "C" {
 
 #define J9SW_ARGUMENT_REGISTER_COUNT 0x4
 #undef  J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_JIT_STACK_SLOTS_USED_BY_CALL 0x0
 #define J9SW_POTENTIAL_SAVED_REGISTERS 0xC
 #define J9SW_REGISTER_MAP_MASK 0xFFFFFFFF
@@ -342,7 +342,7 @@ extern "C" {
 
 #define J9SW_ARGUMENT_REGISTER_COUNT 0x8
 #define J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT 0x8
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_JIT_STACK_SLOTS_USED_BY_CALL 0x0
 #define J9SW_POTENTIAL_SAVED_REGISTERS 0x20
 #define J9SW_REGISTER_MAP_MASK 0xFFFFFFFF
@@ -381,7 +381,7 @@ extern "C" {
 
 /* @ddr_namespace: map_to_type=J9StackWalkConstants */
 
-#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
 #define J9SW_REGISTER_MAP_MASK 0xFFFF
 #define J9SW_JIT_FIRST_RESOLVE_PARM_REGISTER 0x3
 #define J9SW_JIT_CALLEE_PRESERVED_SIZE 8

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3594,6 +3594,16 @@ invalidJITReturnAddress(J9StackWalkState *walkState);
 void
 walkBytecodeFrameSlots(J9StackWalkState *walkState, J9Method *method, UDATA offsetPC, UDATA *pendingBase, UDATA pendingStackHeight, UDATA *localBase, UDATA numberOfLocals, UDATA alwaysLocalMap);
 
+/**
+ * @brief Walk the stackframes specified by a walkState.
+ *
+ * @param currentThread current thread
+ * @param walkState the walkState specifying the stackframes
+ * @return 0 on success and non-zero on failure
+ */
+UDATA
+commonWalker(J9VMThread *currentThread, J9StackWalkState *walkState);
+
 
 /* ---------------- trace.c ---------------- */
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3640,7 +3640,7 @@ JavaCoreDumpWriter::writeJitMethod(J9VMThread* vmThread)
 
 			switch (kind) {
 			case J9PORT_SIG_VALUE_ADDRESS:
-				table = jitConfig->jitGetExceptionTableFromPC(vmThread, *(UDATA*)value);
+				table = jitConfig->jitGetExceptionTableFromPC(vmThread, *(UDATA*)value, vmThread->javaVM);
 				if (NULL != table) {
 					ramMethod = table->ramMethod;
 					insideJitMethod = true;

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -410,13 +410,43 @@ walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continu
 	UDATA rc = J9_STACKWALK_RC_NONE;
 
 	if (NULL != continuation) {
-		J9VMThread stackThread = {0};
-		J9VMEntryLocalStorage els = {0};
+		walkState->javaVM = currentThread->javaVM;
+		walkState->currentThread = currentThread;
+		walkState->cache = NULL;
+		walkState->framesWalked = 0;
+		walkState->previousFrameFlags = 0;
+		walkState->arg0EA = continuation->arg0EA;
+		walkState->pcAddress = &(continuation->pc);
+		walkState->pc = continuation->pc;
+		walkState->nextPC = NULL;
+		walkState->walkSP = continuation->sp;
+		walkState->literals = continuation->literals;
+		walkState->argCount = 0;
+		walkState->linearSlotWalker = NULL;
+		walkState->stackMap = NULL;
+		walkState->inlineMap = NULL;
+		walkState->inlinedCallSite = NULL;
+		walkState->stackObject = continuation->stackObject;
+		walkState->walkThread = NULL;
+		walkState->loopBreaker = 0;
+#ifdef J9VM_INTERP_NATIVE_SUPPORT
+		walkState->jitInfo = NULL;
+		walkState->inlineDepth = 0;
+		walkState->inlinerMap = NULL;
+		walkState->walkedEntryLocalStorage = NULL;
+		walkState->j2iFrame = continuation->j2iFrame;
+		walkState->i2jState = &(continuation->i2jState);
+		walkState->jitGlobalStorageBase = (UDATA*)&continuation->jitGPRs;
+		walkState->jitFPRegisterStorageBase = NULL;
+		walkState->oldEntryLocalStorage = continuation->oldEntryLocalStorage;
+#ifdef J9VM_JIT_FULL_SPEED_DEBUG
+		walkState->decompilationStack = continuation->decompilationStack;
+		walkState->decompilationRecord = NULL;
+		walkState->resolveFrameFlags = 0;
+#endif /* J9VM_JIT_FULL_SPEED_DEBUG */
+#endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
-		copyFieldsFromContinuation(currentThread, &stackThread, &els, continuation);
-
-		walkState->walkThread = &stackThread;
-		rc = currentThread->javaVM->walkStackFrames(currentThread, walkState);
+		rc = currentThread->javaVM->internalVMFunctions->commonWalker(currentThread, walkState);
 	}
 
 	return rc;

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -276,7 +276,7 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 			J9JITConfig * jitConfig = vm->jitConfig;
 
 			if (jitConfig) {
-				metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, methodPC);
+				metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, methodPC, vmThread->javaVM);
 				if (metaData) {
 					inlineMap = jitConfig->jitGetInlinerMapFromPC(vmThread, vm, metaData, methodPC);
 					if (inlineMap) {

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -254,7 +254,7 @@ methodBeingTraced(J9JavaVM *vm, J9Method *method)
 UDATA   
 exceptionHandlerSearch(J9VMThread *currentThread, J9StackWalkState *walkState)
 {
-	J9JavaVM * vm = walkState->walkThread->javaVM;
+	J9JavaVM *vm = walkState->javaVM;
 
 	Trc_VM_exceptionHandlerSearch_Entry(currentThread);
 
@@ -339,9 +339,9 @@ exceptionHandlerSearch(J9VMThread *currentThread, J9StackWalkState *walkState)
 						}
 						currentThread->stackWalkState = tempWalkState.previous;
 						walkState->restartException = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
-#ifdef J9VM_JIT_FULL_SPEED_DEBUG						
-						walkState->decompilationStack = walkState->walkThread->decompilationStack;
-#endif									
+#ifdef J9VM_JIT_FULL_SPEED_DEBUG
+						walkState->decompilationStack = walkState->decompilationStack;
+#endif
 					}
 				}
 

--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -1065,7 +1065,7 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 		if (jitConfig->jitGetExceptionTableFromPC == NULL) {
 			return numBytesWritten;
 		}
-		jitExceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, pc);
+		jitExceptionTable = jitConfig->jitGetExceptionTableFromPC(vmThread, pc, vmThread->javaVM);
 
 		if (jitExceptionTable) {
 			J9Method *ramMethod = jitExceptionTable->ramMethod;

--- a/runtime/vm/growstack.cpp
+++ b/runtime/vm/growstack.cpp
@@ -107,15 +107,15 @@ UDATA   growJavaStack(J9VMThread * vmThread, UDATA newStackSize)
 static UDATA internalGrowJavaStack(J9VMThread * vmThread, UDATA newStackSize)
 {
 	PORT_ACCESS_FROM_VMC(vmThread);
-	J9JavaStack * oldStack = vmThread->stackObject;
-	J9JavaStack * newStack;
-	UDATA delta;
-	J9StackWalkState walkState;
-	UDATA usedBytes = ((U_8 *) oldStack->end) - ((U_8 *) vmThread->sp);
-	J9StackWalkState * currentWalkState;
-	UDATA oldStackStart = (UDATA) (oldStack +1);
-	UDATA oldStackEnd = (UDATA) (oldStack->end);
-	UDATA oldState;
+	J9JavaStack *oldStack = vmThread->stackObject;
+	J9JavaStack *newStack = NULL;
+	UDATA delta = 0;
+	J9StackWalkState walkState = {0};
+	UDATA usedBytes = ((U_8 *)oldStack->end) - ((U_8 *)vmThread->sp);
+	J9StackWalkState *currentWalkState = NULL;
+	UDATA oldStackStart = (UDATA)(oldStack + 1);
+	UDATA oldStackEnd = (UDATA)(oldStack->end);
+	UDATA oldState = 0;
 	UDATA rc = 0;
 
 	oldState = vmThread->omrVMThread->vmState;
@@ -145,7 +145,6 @@ static UDATA internalGrowJavaStack(J9VMThread * vmThread, UDATA newStackSize)
 #ifdef PAINT_OLD_STACK
 	vmThread->tempSlot = (UDATA) vmThread->sp;
 #endif
-
 	walkState.walkThread = vmThread;
 	walkState.flags = J9_STACKWALK_ITERATE_FRAMES | J9_STACKWALK_SKIP_INLINES;
 	walkState.frameWalkFunction = growFrameIterator;
@@ -169,7 +168,7 @@ static UDATA internalGrowJavaStack(J9VMThread * vmThread, UDATA newStackSize)
 	}
 #endif
 
-	vmThread->javaVM->walkStackFrames(vmThread, &walkState);
+	vmThread->javaVM->walkStackFrames(vmThread, & walkState);
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	if (vmThread->javaVM->jitConfig) {
@@ -410,7 +409,7 @@ static UDATA growFrameIterator(J9VMThread * vmThread, J9StackWalkState * walkSta
 					if ((UDATA) walkState->pc > J9SF_MAX_SPECIAL_FRAME_TYPE) {
 						if (*walkState->pc == 0xFF) { /* impdep2 = 0xFF - indicates a JNI call-in frame */
 							if (walkState->walkedEntryLocalStorage) {
-								if (addI2J(walkState, &(walkState->walkedEntryLocalStorage->i2jState))) {
+								if (addI2J(walkState, walkState->i2jState)) {
 addFailed:
 									walkState->restartException = (void *) 1;
 									return J9_STACKWALK_STOP_ITERATING;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -444,4 +444,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
 	invoke31BitJNI_OnXLoad,
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
+	commonWalker,
 };

--- a/runtime/vm/linearswalk.c
+++ b/runtime/vm/linearswalk.c
@@ -123,7 +123,7 @@ lswInitialize(J9JavaVM * vm, J9StackWalkState * walkState)
 
 
 	slotWalker->sp = walkState->walkSP;
-	slotWalker->stackBottom = walkState->walkThread->stackObject->end;
+	slotWalker->stackBottom = walkState->stackObject->end;
 	slotArraySize = sizeof(J9SWSlot) * (slotWalker->stackBottom - slotWalker->sp);
 
 	slots = j9mem_allocate_memory(slotArraySize, OMRMEM_CATEGORY_VM);

--- a/runtime/vm/ownedmonitors.c
+++ b/runtime/vm/ownedmonitors.c
@@ -121,7 +121,7 @@ getOwnedObjectMonitorsIterator(J9VMThread *currentThread, J9StackWalkState *walk
 	UDATA rc = J9_STACKWALK_KEEP_ITERATING;
 
 	/* Take the J9JavaVM from the targetThread as currentThread may be null. */
-	J9JavaVM* javaVM = walkState->walkThread->javaVM;
+	J9JavaVM* javaVM = walkState->javaVM;
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	if (walkState->jitInfo) {
 		/* The jit walk may increment/decrement the stack depth */


### PR DESCRIPTION
Expands J9StackWalkState to directly hold all necessary fields instead of accessing them from walkThread/ELS. Initializing those fields is done in walkStackFrames() for a vm thread and walkContinuationStackFrames() for a continuation. Then commonWalker is called to walk the stack frames. This is done to both native implementation and DDR to ensure consistency.

Also adds assertion for a non-null jitFPRegisterStorageBase to ensure it's not accessed while walking continuation which cannot hold a FPRegister.

Signed-off-by: Gengchen Tuo <gengchen.tuo@ibm.com>

Related: #16209