### PR TITLE
Remove special treatment of <init> for value types

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4846,10 +4846,7 @@ TR_ResolvedJ9Method::methodModifiers()
 bool
 TR_ResolvedJ9Method::isConstructor()
    {
-   if (!TR::Compiler->om.areValueTypesEnabled())
-      return (nameLength()==6 && !strncmp(nameChars(), "<init>", 6));
-   else
-      return (nameLength()==6 && !isStatic() && (returnType()==TR::NoType) && !strncmp(nameChars(), "<init>", 6));
+   return (nameLength()==6 && !strncmp(nameChars(), "<init>", 6));
    }
 
 bool TR_ResolvedJ9Method::isStatic()            { return methodModifiers() & J9AccStatic ? true : false; }


### PR DESCRIPTION
Early prototype handling of value type classes used `<init>` as a special factory method name distinct from its use as an instance initialization method name.  That has been dropped in favor of `<vnew>` as a factory method name for value type classes.  This change removes the special treatment of `<init>` as a value type factory method name from `TR_ResolvedJ9Method::isConstructor`.

Fixes #14959