### PR TITLE
Fix up global continuation lists instead of rebuilding for compaction

### DIFF
--- a/runtime/gc_glue_java/CompactDelegate.cpp
+++ b/runtime/gc_glue_java/CompactDelegate.cpp
@@ -31,8 +31,6 @@
 #include "MarkMap.hpp"
 #include "OwnableSynchronizerObjectBuffer.hpp"
 #include "OwnableSynchronizerObjectList.hpp"
-#include "ContinuationObjectBuffer.hpp"
-#include "ContinuationObjectList.hpp"
 #include "PointerContiguousArrayIterator.hpp"
 
 #if defined(OMR_GC_MODRON_COMPACTION)
@@ -132,8 +130,6 @@ MM_CompactDelegate::workerCleanupAfterGC(MM_EnvironmentBase *env)
 {
 	/* flush ownable synchronizer object buffer after rebuild the ownableSynchronizerObjectList during fixupObjects */
 	env->getGCEnvironment()->_ownableSynchronizerObjectBuffer->flush(env);
-	/* flush continuation object buffer after rebuild the continuationObjectList during fixupObjects */
-	env->getGCEnvironment()->_continuationObjectBuffer->flush(env);
 }
 
 void
@@ -146,7 +142,6 @@ MM_CompactDelegate::mainSetupForGC(MM_EnvironmentBase *env)
 		MM_HeapRegionDescriptorStandardExtension *regionExtension = MM_ConfigurationDelegate::getHeapRegionDescriptorStandardExtension(env, region);
 		for (uintptr_t i = 0; i < regionExtension->_maxListIndex; i++) {
 			regionExtension->_ownableSynchronizerObjectLists[i].startOwnableSynchronizerProcessing();
-			regionExtension->_continuationObjectLists[i].startProcessing();
 		}
 	}
 }

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
@@ -32,7 +32,6 @@
 #include "MixedObjectIterator.hpp"
 #include "ObjectAccessBarrier.hpp"
 #include "OwnableSynchronizerObjectBuffer.hpp"
-#include "ContinuationObjectBuffer.hpp"
 #include "VMHelpers.hpp"
 #include "ParallelDispatcher.hpp"
 #include "PointerContiguousArrayIterator.hpp"
@@ -126,12 +125,6 @@ MM_CompactSchemeFixupObject::addOwnableSynchronizerObjectInList(MM_EnvironmentBa
 	}
 }
 
-MMINLINE void
-MM_CompactSchemeFixupObject::addContinuationObjectInList(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
-{
-	env->getGCEnvironment()->_continuationObjectBuffer->add(env, objectPtr);
-}
-
 void
 MM_CompactSchemeFixupObject::fixupObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
 {
@@ -158,7 +151,6 @@ MM_CompactSchemeFixupObject::fixupObject(MM_EnvironmentStandard *env, omrobjectp
 		fixupMixedObject(objectPtr);
 		break;
 	case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-		addContinuationObjectInList(env, objectPtr);
 		fixupContinuationObject(env, objectPtr);
 		break;
 	case GC_ObjectModel::SCAN_FLATTENED_ARRAY_OBJECT:

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.hpp
@@ -82,8 +82,6 @@ private:
 	 * @param object -- The object of type or subclass of java.util.concurrent.locks.AbstractOwnableSynchronizer.
 	 */
 	MMINLINE void addOwnableSynchronizerObjectInList(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
-
-	MMINLINE void addContinuationObjectInList(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 };
 
 typedef struct StackIteratorData4CompactSchemeFixupObject {

--- a/runtime/gc_glue_java/CompactSchemeFixupRoots.hpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupRoots.hpp
@@ -73,7 +73,6 @@ public:
 	virtual void scanUnfinalizedObjects(MM_EnvironmentBase *env) {
 		/* allow the compact scheme to handle this */
 		reportScanningStarted(RootScannerEntity_UnfinalizedObjects);
-		MM_CompactSchemeFixupObject fixupObject(env, _compactScheme);
 		fixupUnfinalizedObjects(env);
 		reportScanningEnded(RootScannerEntity_UnfinalizedObjects);
 	}
@@ -87,7 +86,6 @@ public:
 	virtual void scanFinalizableObjects(MM_EnvironmentBase *env) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			reportScanningStarted(RootScannerEntity_FinalizableObjects);
-			MM_CompactSchemeFixupObject fixupObject(env, _compactScheme);
 			fixupFinalizableObjects(env);
 			reportScanningEnded(RootScannerEntity_FinalizableObjects);
 		}
@@ -99,7 +97,10 @@ public:
 	}
 
 	virtual void scanContinuationObjects(MM_EnvironmentBase *env) {
-		/* empty, move continuation processing in fixupObject */
+		/* allow the compact scheme to handle this */
+		reportScanningStarted(RootScannerEntity_ContinuationObjects);
+		fixupContinuationObjects(env);
+		reportScanningEnded(RootScannerEntity_ContinuationObjects);
 	}
 
 private:
@@ -107,5 +108,6 @@ private:
 	void fixupFinalizableObjects(MM_EnvironmentBase *env);
 	void fixupUnfinalizedObjects(MM_EnvironmentBase *env);
 #endif
+	void fixupContinuationObjects(MM_EnvironmentBase *env);
 };
 #endif /* FIXUPROOTS_HPP_ */

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -514,11 +514,6 @@ private:
 		}
 	}
 
-	MMINLINE void addContinuationObjectInList(MM_EnvironmentVLHGC *env, J9Object *objectPtr)
-	{
-		((MM_ContinuationObjectBufferVLHGC*) env->getGCEnvironment()->_continuationObjectBuffer)->addForOnlyCompactedRegion(env, objectPtr);
-	}
-
 #if defined(J9VM_GC_FINALIZATION)
 	void fixupFinalizableObjects(MM_EnvironmentVLHGC *env);
 


### PR DESCRIPTION
Once continuation Object is constructed, the Object would be added in global continuation lists and the "dead" Object would be collected by GC, since logically compaction would not collect any continuation Object in the list, so we piggyback heap fix up to rebuild the list to reduce the extra cycle to walk the old list for fixing up. But between the Object is created and added into the list, GC could be triggered and find the live Object, which has not be added in the list, it could cause a circular linklist case, so changing fix up the existing list instead of rebuilding the list for compaction.

fix:https://github.com/eclipse-openj9/openj9/issues/15938 (assertion failure in ContinuationObjectBuffer/List)

Signed-off-by: Lin Hu <linhu@ca.ibm.com>