### PR TITLE
Fix jvmtiGetThreadInfo to return correct thread group

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -525,8 +525,13 @@ jvmtiGetThreadInfo(jvmtiEnv *env,
 						group = J9_JNI_UNWRAP_REFERENCE(vm->vthreadGroup);
 					}
 				} else {
-					/* For platform threads, a NULL vmthread indicates that a thread is terminated. */
-					if ((NULL != targetThread) && (NULL != threadHolder)) {
+					/* For platform threads, a NULL vmthread indicates that a thread is either unstarted or terminated.
+					 * As per the JVMTI spec, the thread group should be NULL IFF the thread is terminated.
+					 */
+					if (((NULL != targetThread)
+						|| !(jboolean)J9VMJAVALANGTHREAD_STARTED(currentThread, threadObject))
+					&& (NULL != threadHolder)
+					) {
 						group = (j9object_t)J9VMJAVALANGTHREADFIELDHOLDER_GROUP(currentThread, threadHolder);
 					}
 				}


### PR DESCRIPTION
The jvmtiGetThreadInfo returns the invalid thread group in case of unstarted threads. A NULL targetThread indicates that the thread is either unstarted or terminated so this check is not sufficient to validate terminated threads.

The boolean check is updated in jvmtiGetThreadInfo to return a valid thread group for unstarted threads.

Fixes: #16226

Signed-off-by: Dipak Bagadiya <dipak.bagadiya@ibm.com>