### PR TITLE
Accelerate CRC-32C calculation on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,6 +138,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *inlineStringHashCode(TR::Node *node, TR::CodeGenerator *cg, bool isCompressed);
    static TR::Register *inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* inlineUTF16BEEncode    (TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineCRC32CUpdateBytes(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer);
 
    static TR::Register *zdloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Accelerate `CRC32C.updateBytes` and `CRC32C.updateDirectByteBuffers` recognized methods by inlining them with a vector assembly sequence.

The implementation is based on the bit-reflected algorithm described in Intel's whitepaper *"Fast CRC Computation for Generic Polynomials Using `PCLMULQDQ` Instruction"* [1] using equivalent Z instructions. The basic layout of the implementation is as follows:
- While there are more than 64B of data remaining, consume 64B chunks using 4 vectors in parallel, then
- while there are more than 16B of data remaining, consume 16B chunks using 1 vector, then
- if there is remaining data, call the original implementation on the remainder

Preliminary benchmarking shows approximately 22× speedup for 4kB and 16kB byte arrays, and no significant speedup or slowdown for 15B arrays.

[1] https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/fast-crc-computation-generic-polynomials-pclmulqdq-paper.pdf