### PR TITLE
GC Thread Pool Tuning for CRIU

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -257,5 +257,9 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_get_jit_string_dedup_policy,
 	j9gc_stringHashFn,
 	j9gc_stringHashEqualFn,
-	j9gc_ensureLockedSynchronizersIntegrity
+	j9gc_ensureLockedSynchronizersIntegrity,
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	j9gc_prepare_for_checkpoint,
+	j9gc_reinitialize_for_restore
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 };

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -259,6 +259,10 @@ extern J9_CFUNC UDATA j9gc_arraylet_getLeafLogSize(J9JavaVM* javaVM);
 extern J9_CFUNC void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64* mainCpuMillis, U_64* workerCpuMillis, U_32* maxThreads, U_32* currentThreads);
 extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThread);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+extern J9_CFUNC void j9gc_prepare_for_checkpoint(J9VMThread *vmThread);
+extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /* J9VMFinalizeSupport*/
 extern J9_CFUNC void runFinalization(J9VMThread *vmThread);

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1305,7 +1305,38 @@ gcParseXXArguments(J9JavaVM *vm)
 		}
 	}
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	{
+		IDATA index = -1;
+		IDATA result = 0;
+
+		PORT_ACCESS_FROM_JAVAVM(vm);
+
+		if (-1 != FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, "-XX:CheckpointGCThreads=", NULL)) {
+			result = option_set_to_opt_integer(vm, "-XX:CheckpointGCThreads=", &index, EXACT_MEMORY_MATCH, &extensions->checkpointGCthreadCount);
+			if (OPTION_OK != result) {
+				if (OPTION_MALFORMED == result) {
+					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-XX:CheckpointGCThreads=");
+				} else {
+					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_OVERFLOWED, "-XX:CheckpointGCThreads=");
+				}
+				goto _error;
+			}
+
+			if (0 == extensions->checkpointGCthreadCount) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_MUST_BE_ABOVE, "-XX:CheckpointGCThreads=", (UDATA)0);
+				goto _error;
+			}
+		}
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	return 1;
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+_error:
+	return 0;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 }
 
 /**

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -238,6 +238,11 @@ public:
 	void setGCCode(MM_GCCode gcCode) {_gcCode = gcCode;}
 
 	void collectorInitialized(MM_RealtimeGC *gc);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	virtual bool expandThreadPool(MM_EnvironmentBase *env) { return true; }
+	virtual void contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount) {};
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_Scheduler(MM_EnvironmentBase *env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize) :
 		MM_ParallelDispatcher(env, handler, handler_arg, defaultOSStackSize),

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4534,6 +4534,10 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA ( *j9gc_stringHashFn)(void *key, void *userData);
 	BOOLEAN ( *j9gc_stringHashEqualFn)(void *leftKey, void *rightKey, void *userData);
 	void  ( *j9gc_ensureLockedSynchronizersIntegrity)(struct J9VMThread *vmThread) ;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	void  ( *j9gc_prepare_for_checkpoint)(struct J9VMThread *vmThread) ;
+	BOOLEAN  ( *j9gc_reinitialize_for_restore)(struct J9VMThread *vmThread) ;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9MemoryManagerFunctions;
 
 typedef struct J9InternalVMFunctions {

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -442,10 +442,15 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 	omrthread_monitor_exit(vm->vmThreadListMutex);
 
 	/* Do the java dance to indicate thread death */
-
-	acquireVMAccess(vmThread);
-	cleanUpAttachedThread(vmThread);
-	releaseVMAccess(vmThread);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/* Dont allow non-java threads to run cleanup code in single thread mode */
+	if (!VM_CRIUHelpers::isJVMInSingleThreadMode(vm) && VM_VMHelpers::threadCanRunJavaCode(vmThread))
+#endif
+	{
+		acquireVMAccess(vmThread);
+		cleanUpAttachedThread(vmThread);
+		releaseVMAccess(vmThread);
+	}
 	
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 	/* Concurrent scavenge enabled and JIT loaded implies running on supported h/w.


### PR DESCRIPTION
Integrate CRIU support with new OMR GC APIs for thread pool adjustments, contract the thread pool for checkpoint and expand it for restore. 

For background, see https://github.com/eclipse/omr/pull/6831.

- Introduced `j9gc_prepare_for_checkpoint` and `j9gc_reinitialize_for_restore` APIs to consolidate GC specific routines used for checkpoint/restore
  Report `J9NLS_GC_FAILED_TO_INSTANTIATE_TASK_DISPATCHER` on `j9gc_reinitialize_for_restore` failure
- Introduced `-XX:CheckpointGCThreads=` option to allow the user to tune checkpoint thread count

Depends on: https://github.com/eclipse/omr/pull/6831

Signed-off-by: Salman Rana <salman.rana@ibm.com>