### PR TITLE
Check sequence boundary before generating next sequence transition

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -4090,15 +4090,14 @@ TR::Register *J9::Power::TreeEvaluator::VMinstanceOfEvaluator(TR::Node *node, TR
             break;
          }
 
-      genInstanceOfTransitionToNextSequence(node, iter, nextSequenceLabel, doneLabel, cr0Reg, resultReg, initialResult, oppositeResultLabel, profiledClassIsInstanceOf, cg);
-
-      --numSequencesRemaining;
-      ++iter;
-
-      if (*iter != HelperCall)
+      if (--numSequencesRemaining > 0)
          {
-         generateLabelInstruction(cg, TR::InstOpCode::label, node, nextSequenceLabel);
-         nextSequenceLabel = generateLabelSymbol(cg);
+         genInstanceOfTransitionToNextSequence(node, iter, nextSequenceLabel, doneLabel, cr0Reg, resultReg, initialResult, oppositeResultLabel, profiledClassIsInstanceOf, cg);
+         if (*++iter != HelperCall)
+            {
+            generateLabelInstruction(cg, TR::InstOpCode::label, node, nextSequenceLabel);
+            nextSequenceLabel = generateLabelSymbol(cg);
+            }
          }
       }
 


### PR DESCRIPTION
The instanceOf while-loop body always performs the "transition to the next sequence". The while-loop condition allows last entry of the sequence to enter the loop (`(numSequencesRemaining == 1 && *iter != HelperCall)`), which doesn't happen in checkCast given no boolean output is possible from checkCast.

This causes the "transition to the next sequence" to be generated even if no subsequent sequence item exists. This is mostly harmless except if the non-initialized sequence array, by chance after allocating, has a value representing `HelperCall` in the "next" element. Where generating the "transition to the next sequence" uses a different path that generates harmful code, causing #13078.

The fix basically wraps the "transition to the next sequence" code with a `numSequencesRemaining > 0` condition.

Tests: https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/14949/

Fixes #13078
