### PR TITLE
Enable vectorized blend() IL opcode

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -192,6 +192,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
       MaskReduction,
       Reduction,
       Test,
+      Blend,
       Other
       };
 


### PR DESCRIPTION
Re-enable `blendIntrinsicHandler()` and generate `vbitselect` IL opcode when vector blend() operation is vectorized.