### PR TITLE
Remove invalid arch.s390x

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -747,7 +747,7 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,^arch.s390x,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
arch.s390x is invalid. We should use arch.390.
Since testJITServer is currently running and passing on zlinux, 
update platformRequirements to avoid confusion.

Signed-off-by: Lan Xia <Lan_Xia@ca.ibm.com>