### PR TITLE
Fix bug while computing effective caller index

### DIFF
--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2408,9 +2408,9 @@ TR_CallSiteInfo::computeEffectiveCallerIndex(TR::Compilation *comp, TR::list<std
 
       TR_InlinedCallSite *cursor = &_callSites[i];
       auto itr = callStack.begin(), end = callStack.end();
+      auto next = itr;
       if (itr != end)
          {
-         auto next = itr;
          next++;
          while (cursor && next != end)
             {
@@ -2431,7 +2431,7 @@ TR_CallSiteInfo::computeEffectiveCallerIndex(TR::Compilation *comp, TR::list<std
 
       // both have terminated at the same time means we have a match for our callstack fragment
       // so return it
-      if (itr == end && cursor == NULL)
+      if (next == end && cursor == NULL)
          {
          effectiveCallerIndex = i;
          return true;


### PR DESCRIPTION
While working on fixing the block frequnecy calculation when previous inlining may be different in [1], a bug was introduced so that a flag that would notify the caller of computeEffectiveCallerIndex upon successfully  matching BCI was never set. This commit fixes that bug.

[1]. https://github.com/eclipse-openj9/openj9/commit/9f404bec672945f99f74483df59cbcbc974453b0

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>