### PR TITLE
Add GLIBC_TUNABLES values in criu cmdline tests

### DIFF
--- a/test/functional/cmdLineTests/criu/criuScript.sh
+++ b/test/functional/cmdLineTests/criu/criuScript.sh
@@ -32,6 +32,11 @@ echo "start running script";
 # $6 is the NUM_CHECKPOINT
 # $7 is the KEEP_CHECKPOINT
 
+echo "export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.pthread.rseq=0:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+
 $2 -XX:+EnableCRIUSupport $3 -cp "$1/criu.jar" $4 $5 $6 >testOutput 2>&1;
 
 if [ "$7" != true ]; then


### PR DESCRIPTION
- Add GLIBC_TUNABLES values in criu cmdline tests
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/16382 This PR alone will not solve this issue, but it is required for portable test on various micro-architectures.

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>