### PR TITLE
Add Disable Global Continuation Lists option

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -197,6 +197,13 @@ public:
 	UDATA freeSizeThresholdForSurvivor; /**< if average freeSize(freeSize/freeCount) of the region is smaller than the Threshold, the region would not be reused by collector as survivor, for balanced GC only */
 	bool recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
 
+	enum ContinuationListOption {
+		disable_continuation_list = 0,
+		enable_continuation_list = 1,
+		verify_continuation_list = 2,
+	};
+	ContinuationListOption continuationListOption;
+
 protected:
 private:
 protected:
@@ -290,6 +297,8 @@ public:
 	MMINLINE MM_ContinuationObjectList* getContinuationObjectLists() { return continuationObjectLists; }
 	MMINLINE void setContinuationObjectLists(MM_ContinuationObjectList* newContinuationObjectLists) { continuationObjectLists = newContinuationObjectLists; }
 
+	void releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9object_t objectPtr);
+
 	/**
 	 * Create a GCExtensions object
 	 */
@@ -337,6 +346,7 @@ public:
 		, minimumFreeSizeForSurvivor(DEFAULT_SURVIVOR_MINIMUM_FREESIZE)
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
+		, continuationListOption(verify_continuation_list)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -1036,10 +1036,14 @@ continuationObjectCreated(J9VMThread *vmThread, j9object_t object)
 	Assert_MM_true(NULL != object);
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 
-	env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
-	MM_ObjectAllocationInterface *objectAllocation = env->_objectAllocationInterface;
-	if (NULL != objectAllocation) {
-		objectAllocation->getAllocationStats()->_continuationObjectCount += 1;
+	if (MM_GCExtensions::disable_continuation_list != MM_GCExtensions::getExtensions(env)->continuationListOption) {
+
+		env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
+		MM_ObjectAllocationInterface *objectAllocation = env->_objectAllocationInterface;
+
+		if (NULL != objectAllocation) {
+			objectAllocation->getAllocationStats()->_continuationObjectCount += 1;
+		}
 	}
 	return 0;
 }

--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -331,7 +331,7 @@ MM_MarkingSchemeRootClearer::scanContinuationObjects(MM_EnvironmentBase *env)
 							} else {
 								/* object was not previously marked */
 								gcEnv->_markJavaStats._continuationCleared += 1;
-								VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), object);
+								_extensions->releaseNativesForContinuationObject(env, object);
 							}
 							object = next;
 						}

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1342,7 +1342,7 @@ MM_MetronomeDelegate::scanContinuationObjects(MM_EnvironmentRealtime *env)
 						buffer->add(env, object);
 					} else {
 						gcEnv->_markJavaStats._continuationCleared += 1;
-						VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), object);
+						_extensions->releaseNativesForContinuationObject(env, object);
 					}
 					object = next;
 

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -241,7 +241,7 @@ MM_ScavengerRootClearer::scavengeContinuationObjects(MM_EnvironmentStandard *env
 							if (!forwardedHeader.isForwardedPointer()) {
 								Assert_GC_true_with_message2(env, _scavenger->isObjectInEvacuateMemory(object), "Continuation object  %p should be a dead object, forwardedHeader=%p\n", object, &forwardedHeader);
 								gcEnv->_scavengerJavaStats._continuationCleared += 1;
-								VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), object);
+								_extensions->releaseNativesForContinuationObject(env, object);
 							} else {
 								omrobjectptr_t forwardedPtr = forwardedHeader.getForwardedObject();
 								Assert_GC_true_with_message(env, NULL != forwardedPtr, "Continuation object  %p should be forwarded\n", object);

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1515,6 +1515,20 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "disableContinuationList")) {
+			extensions->continuationListOption = MM_GCExtensions::disable_continuation_list;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "enableContinuationList")) {
+			extensions->continuationListOption = MM_GCExtensions::enable_continuation_list;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "verifyContinuationList")) {
+			extensions->continuationListOption = MM_GCExtensions::verify_continuation_list;
+			continue;
+		}
 
 		/* Couldn't find a match for arguments */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_UNKNOWN, error_scan);

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3549,7 +3549,7 @@ MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 					if (NULL == forwardedPtr) {
 						/* object was not previously marked, clean up */
 						env->_copyForwardStats._continuationCleared += 1;
-						VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), pointer);
+						_extensions->releaseNativesForContinuationObject(env, pointer);
 					} else {
 						env->getGCEnvironment()->_continuationObjectBuffer->add(env, forwardedPtr);
 					}

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1111,8 +1111,8 @@ MM_GlobalMarkingScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 						if (isMarked(object)) {
 							env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
 						} else {
-							VM_VMHelpers::cleanupContinuationObject((J9VMThread *)env->getLanguageVMThread(), object);
 							env->_markVLHGCStats._continuationCleared += 1;
+							_extensions->releaseNativesForContinuationObject(env, object);
 						}
 						object = next;
 					}

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2157,14 +2157,6 @@ exit:
 		return needScan;
 	}
 
-	static VMINLINE void
-	cleanupContinuationObject(J9VMThread *vmThread, J9Object *objectPtr)
-	{
-#if JAVA_SPEC_VERSION >= 19
-		vmThread->javaVM->internalVMFunctions->freeContinuation(vmThread, objectPtr);
-#endif /* JAVA_SPEC_VERSION >= 19 */
-	}
-
 	static VMINLINE UDATA
 	setVMState(J9VMThread *currentThread, UDATA newState)
 	{


### PR DESCRIPTION
The Continuation Buffers/Lists keep all of "live" Continuation Objects
and be maintained by GC in order to free up the related native structure
and java stacks in case the Continuation Object has not been terminated
normally.

currently the global Virtual Thread List will keep all of unterminated
Continuation Objects traceable, so Continuation Buffers/Lists are not
useful for current case, can disable it by XXgc:disableContinuationList
for saving extra scan.
cycle.

- new XXgc options
  disableContinuationList,
  enaleContinuationList,
  verifyContinuationList -- (default) verify if there is an exceptional
  case.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>