### PR TITLE
Rectify the flag setting for uninitializedThis in the stackmaps

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -312,6 +312,7 @@ matchStack(J9BytecodeVerificationData * verifyData, J9BranchTargetStack *liveSta
 	/* Note: Target stack frame flag needs to be subset of ours. See JVM sepc 4.10.1.4 */
 	if (liveStack->uninitializedThis && !targetStack->uninitializedThis) {
 		rc = BCV_FAIL;
+		verifyData->errorDetailCode = BCV_ERR_INIT_FLAGS_MISMATCH;
 		goto _finished;
 	}
 

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -567,6 +567,7 @@ extern "C" {
 #define BCV_ERR_INACCESSIBLE_CLASS						-33
 #define BCV_ERR_BYTECODE_ERROR							-34
 #define BCV_ERR_NEW_OJBECT_MISMATCH						-35
+#define BCV_ERR_INIT_FLAGS_MISMATCH						-36
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #define J9_GC_MULTI_SLOT_HOLE 0x1


### PR DESCRIPTION
The changes are to fix the issue with the flags setting intended for uninitializedThis
in the stackmaps so as to match the JVM Spec and the RI's behavior by explicitly
outputting the detailed error messages for the mismatch captured in the stackmaps.

Internal ref 147737

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>