### PR TITLE
(0.36) Update LICENSE and about files for zlib 1.2.13, libffi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -509,7 +509,7 @@ MurmurHash3 was written by Austin Appleby, and is placed in the public domain. T
 Note - The x86 and x64 versions do _not_ produce the same results, as the algorithms are optimized for their respective platforms. You can still compile and run any of them on any platform, but your performance with the non-native version will be less than optimal
 
 E.      libffi
-libffi - Copyright (c) 1996-2021  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining
@@ -532,7 +532,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 F.      zlib
-  (C) 1995-2017 Jean-loup Gailly and Mark Adler
+  (C) 1995-2022 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/longabout.html
+++ b/longabout.html
@@ -8,7 +8,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
 
-<p><em>July 21, 2022</em></p>
+<p><em>December 7, 2022</em></p>
 <h3>License</h3>
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
@@ -189,7 +189,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <p>
-<h4>zlib 1.2.12</h4>
+<h4>zlib 1.2.13</h4>
   (C) 1995-2022 Jean-loup Gailly and Mark Adler
 <p>
   This software is provided 'as-is', without any express or implied

--- a/runtime/include/about.html
+++ b/runtime/include/about.html
@@ -6,7 +6,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
  
-<p><em>January 3, 2020</em></p>
+<p><em>December 7, 2020</em></p>
 <h3>License</h3>
 
 <p>This program and the accompanying materials are made available under the terms of the
@@ -40,7 +40,7 @@ License 2.0 still apply to any source code in the Content and such source code m
 Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you
 should look to the Redistributor's license for terms and conditions of use.</p>
 
-<h3>zlib 1.2.12</h3>
+<h3>zlib 1.2.13</h3>
 
 <p>zlib general purpose compression library obtained from http://zlib.net/</p>
 
@@ -79,13 +79,13 @@ This notice may not be removed or altered from any source distribution.
 jloup@gzip.org&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;madler@alumni.caltech.edu </p>
 
 
-<h3>libffi 3.2.1</h3>
+<h3>libffi pre 3.5</h3>
 
 <p>A Portable Foreign Function Interface Library, obtained from http://sourceware.org/libffi/<p>
 
 <p>The software is modified from the original version.</p>
 
-<p>libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.</p>
+<p>libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.</p>
 
 <p>
 Permission is hereby granted, free of charge, to any person obtaining

--- a/runtime/zlib/about.html
+++ b/runtime/zlib/about.html
@@ -6,7 +6,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
  
-<p><em>March 30, 2022</em></p>
+<p><em>December 7, 2022</em></p>
 <h3>License</h3>
 
 <p>This program and the accompanying materials are made available under the terms of the
@@ -39,7 +39,7 @@ License 2.0 still apply to any source code in the Content and such source code m
 Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you
 should look to the Redistributor's license for terms and conditions of use.</p>
 
-<h3>zlib 1.2.12</h3>
+<h3>zlib 1.2.13</h3>
 
 <p>zlib general purpose compression library obtained from http://zlib.net/</p>
 


### PR DESCRIPTION
This should have been done with previous changes
https://github.com/eclipse-openj9/openj9/pull/16305 https://github.com/eclipse-openj9/openj9/pull/14835

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/16425 for 0.36