### PR TITLE
Update cmake workarounds for jdk11

### DIFF
--- a/sourcetools/CMakeLists.txt
+++ b/sourcetools/CMakeLists.txt
@@ -29,10 +29,9 @@ project(j9_sourcetools VERSION 1.0)
 
 set(CMAKE_JAVA_TARGET_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
-# Due to the way cmake generates the java class path, it will generate a leading path separator.
-# This prevents fixpath from JDKs after JDK11 from properly translating the path.
-# To work around the issue we tack on a dummy path at the beginning of the output classpath.
-if((WIN32 AND NOT CMAKE_HOST_WIN32) AND (JAVA_SPEC_VERSION GREATER 11))
+# CMake generates the java classpath with a leading path separator
+# which fixpath.sh in JDK11+ will not handle: Add a dummy prefix.
+if(WIN32 AND (NOT CMAKE_HOST_WIN32) AND (NOT JAVA_SPEC_VERSION LESS 11))
 	set(CMAKE_JAVA_INCLUDE_PATH_FINAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 

--- a/sourcetools/j9constantpool/CMakeLists.txt
+++ b/sourcetools/j9constantpool/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,15 +20,12 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-# CMake doesn't properly handle directory separators when building in cygwin
-# but using a windows java binary. IE it uses ':' as a directory separator,
-# rather than required ';'
-# Note: this isn't required for JDKs after JDK11 as fixpath will convert the path separators for us.
-
-# WIN32 will be true when the build is targeting windows, but CMAKE_HOST_WIN32 is false on cygwin
-if((WIN32 AND NOT CMAKE_HOST_WIN32) AND (NOT JAVA_SPEC_VERSION GREATER 11))
-	# put  "-cp <Path_to_objectmodel_jar>" into a text file we will pass in with '@file'
-	file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cygwin_classpath" CONTENT "-cp\n$<TARGET_PROPERTY:objectmodel,JAR_FILE>\n")
+# CMake uses ':' as the path separator when building in cygwin which isn't
+# appropriate for a Windows java executable (which expects path elements to
+# be separated by ';'). In JDK11+, fixpath.sh will compensate, but for JDK8,
+# we need to put the classpath in a file in a form that fixpath will support.
+if(WIN32 AND (NOT CMAKE_HOST_WIN32) AND (JAVA_SPEC_VERSION EQUAL 8))
+	file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cygwin_classpath" CONTENT "-classpath\n$<TARGET_PROPERTY:objectmodel,JAR_FILE>\n")
 	set(CYGWIN_CP "@${CMAKE_CURRENT_BINARY_DIR}/cygwin_classpath")
 else()
 	set(CYGWIN_CP)


### PR DESCRIPTION
* apply cmake classpath fix for sourcetools
* don't apply cmake classpath fix for j9vmcp

This is not compatible with the current content of the jdk11/openj9 branch; it must be merged concurrently with https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/599.
Fixes: https://github.com/eclipse-openj9/openj9/issues/16396.