### PR TITLE
Add options for JITServer AOT caching exclusion

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1262,6 +1262,9 @@ public:
 
    JITServerAOTDeserializer *getJITServerAOTDeserializer() const { return _JITServerAOTDeserializer; }
    void setJITServerAOTDeserializer(JITServerAOTDeserializer *deserializer) { _JITServerAOTDeserializer = deserializer; }
+
+   bool methodCanBeJITServerAOTCacheStored(const char *methodSig, TR::Method::Type ty);
+   bool methodCanBeJITServerAOTCacheLoaded(const char *methodSig, TR::Method::Type ty);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static void replenishInvocationCount(J9Method* method, TR::Compilation* comp);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -13037,4 +13037,30 @@ TR::CompilationInfo::requeueOutOfProcessEntry(TR_MethodToBeCompiled *entry)
       getCompilationMonitor()->notifyAll();
       }
    }
+
+static bool
+queryJITServerAOTCacheFilter(const char *methodSig, TR::Method::Type ty, TR::CompilationFilters *filters)
+   {
+   if (!filters)
+      return true;
+
+   TR_Debug *debug = TR::Options::getDebug();
+   if (!debug)
+      return true;
+
+   TR_FilterBST *filter = NULL;
+   return debug->methodSigCanBeFound(methodSig, filters, filter, ty);
+   }
+
+bool
+TR::CompilationInfo::methodCanBeJITServerAOTCacheStored(const char *methodSig, TR::Method::Type ty)
+   {
+   return queryJITServerAOTCacheFilter(methodSig, ty, TR::Options::_JITServerAOTCacheStoreFilters);
+   }
+
+bool
+TR::CompilationInfo::methodCanBeJITServerAOTCacheLoaded(const char *methodSig, TR::Method::Type ty)
+   {
+   return queryJITServerAOTCacheFilter(methodSig, ty, TR::Options::_JITServerAOTCacheLoadFilters);
+   }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -279,6 +279,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
    static int32_t _aotCachePersistenceMinDeltaMethods;
    static int32_t _aotCachePersistenceMinPeriodMs;
+   static TR::CompilationFilters *_JITServerAOTCacheStoreFilters;
+   static TR::CompilationFilters *_JITServerAOTCacheLoadFilters;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
@@ -356,6 +358,11 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static char *loadLimitOption(char *option, void *, TR::OptionTable *entry);
 
    static char *loadLimitfileOption(char *option, void *, TR::OptionTable *entry);
+
+#if defined(J9VM_OPT_JITSERVER)
+   static char *JITServerAOTCacheStoreLimitOption(char *option, void *, TR::OptionTable *entry);
+   static char *JITServerAOTCacheLoadLimitOption(char *option, void *, TR::OptionTable *entry);
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    static char *vmStateOption(char *option, void *, TR::OptionTable *entry);
 
@@ -518,6 +525,12 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    int writeLogFileFromServer(const std::string& logFileContent);
    void setLogFileForClientOptions(int suffixNumber = 0);
    void closeLogFileForClientOptions();
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   private:
+
+#if defined(J9VM_OPT_JITSERVER)
+   static char *JITServerAOTCacheLimitOption(char *option, void *base, TR::OptionTable *entry, TR::CompilationFilters *&filters, const char *optName);
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3052,9 +3052,10 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
    TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
    bool useAotCompilation = entry->_useAotCompilation;
 
-   bool aotCacheStore = useAotCompilation && persistentInfo->getJITServerUseAOTCache();
-   bool aotCacheLoad = useAotCompilation && persistentInfo->getJITServerUseAOTCache() &&
-                       !entry->_doNotLoadFromJITServerAOTCache;
+   bool aotCacheStore = useAotCompilation && persistentInfo->getJITServerUseAOTCache() &&
+                        compInfo->methodCanBeJITServerAOTCacheStored(compiler->signature(), compilee->convertToMethod()->methodType());
+   bool aotCacheLoad = aotCacheStore && !entry->_doNotLoadFromJITServerAOTCache &&
+                       compInfo->methodCanBeJITServerAOTCacheLoaded(compiler->signature(), compilee->convertToMethod()->methodType());
    auto deserializer = compInfo->getJITServerAOTDeserializer();
    if (!aotCacheLoad && deserializer)
       deserializer->incNumCacheBypasses();


### PR DESCRIPTION
The `-Xaot:jitserverLoadExclude` and `-Xaot:jitserverStoreExclude` options reuse the existing method filtering framework so that clients can selectively exclude particular methods from AOT cache loading or storing in a connected JITServer.

Fixes: #15399
Signed-off-by: Christian Despres <despresc@ibm.com>