### PR TITLE
Avoid to scan the finished Continuation Object

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -298,6 +298,16 @@ public:
 	MMINLINE void setContinuationObjectLists(MM_ContinuationObjectList* newContinuationObjectLists) { continuationObjectLists = newContinuationObjectLists; }
 
 	void releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9object_t objectPtr);
+
+	/**
+	 * Check if we need to scan the java stack for the Continuation Object
+	 * Used during main scan phase of GC (object graph traversal) or heap object iteration (in sliding compact).
+	 * Not meant to be used during root scanning (neither strong roots nor weak roots)!
+	 * @param[in] vmThread the current J9VMThread
+	 * @param[in] continuationObject the continuation object
+	 * @return true if we need to scan the java stack
+	 */
+	static bool needScanStacksForContinuationObject(J9VMThread *vmThread, j9object_t objectPtr);
 
 	/**
 	 * Create a GCExtensions object

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,7 @@ MM_CompactSchemeFixupObject::fixupContinuationNativeSlots(MM_EnvironmentStandard
 	 * mounted Virtual threads later during root fixup, we will skip it during this heap fixup pass
 	 * (hence passing true for scanOnlyUnmounted parameter).
 	 */
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4CompactSchemeFixupObject localData;
 		localData.compactSchemeFixupObject = this;
 		localData.env = env;

--- a/runtime/gc_glue_java/HeapWalkerDelegate.cpp
+++ b/runtime/gc_glue_java/HeapWalkerDelegate.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@
 
 #include "j9.h"
 #include "EnvironmentBase.hpp"
+#include "GCExtensions.hpp"
 #include "ObjectModel.hpp"
 #include "VMHelpers.hpp"
 #include "VMThreadStackSlotIterator.hpp"
@@ -59,7 +60,7 @@ MM_HeapWalkerDelegate::doContinuationNativeSlots(MM_EnvironmentBase *env, omrobj
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
 
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4HeapWalker localData;
 		localData.heapWalker = _heapWalker;
 		localData.env = env;

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corp. and others
+ * Copyright (c) 2017, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,7 +261,7 @@ void
 MM_MarkingDelegate::scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4MarkingDelegate localData;
 		localData.markingDelegate = this;
 		localData.env = env;

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1647,7 +1647,7 @@ void
 MM_MetronomeDelegate::scanContinuationNativeSlots(MM_EnvironmentRealtime *env, J9Object *objectPtr)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4RealtimeMarkingScheme localData;
 		localData.realtimeMarkingScheme = _markingScheme;
 		localData.env = env;

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -345,7 +345,7 @@ MM_ScavengerDelegate::scanContinuationNativeSlots(MM_EnvironmentStandard *env, o
 	bool shouldRemember = false;
 
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4Scavenge localData;
 		localData.scavengerDelegate = this;
 		localData.env = env;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2322,7 +2322,7 @@ MMINLINE void
 MM_CopyForwardScheme::scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4CopyForward localData;
 		localData.copyForwardScheme = this;
 		localData.env = env;

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,7 +192,7 @@ bool MM_GlobalMarkCardScrubber::scrubContinuationNativeSlots(MM_EnvironmentVLHGC
 {
 	bool doScrub = true;
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4GlobalMarkCardScrubber localData;
 		localData.globalMarkCardScrubber = this;
 		localData.env = env;

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -792,7 +792,7 @@ void
 MM_GlobalMarkingScheme::scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason)
 {
 	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4GlobalMarkingScheme localData;
 		localData.globalMarkingScheme = this;
 		localData.env = env;

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1240,7 +1240,7 @@ MM_WriteOnceCompactor::fixupContinuationNativeSlots(MM_EnvironmentVLHGC* env, J9
 	 * mounted Virtual threads later during root fixup, we will skip it during this heap fixup pass
 	 * (hence passing true for scanOnlyUnmounted parameter).
 	 */
-	if (VM_VMHelpers::needScanStacksForContinuation(currentThread, objectPtr)) {
+	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr)) {
 		StackIteratorData4WriteOnceCompactor localData;
 		localData.writeOnceCompactor = this;
 		localData.env = env;


### PR DESCRIPTION
There is no need to scan any continuation Objects, which are marked finished, plus there could be potential race condition between continuation concurrent scan and continuation free up for finished Continuation Object.

fix:https://github.com/eclipse-openj9/openj9/issues/15939#issuecomment-1331427527
Signed-off-by: Lin Hu <linhu@ca.ibm.com>