### PR TITLE
Avoid calling getEnclosingBlock

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -9153,7 +9153,7 @@ int32_t TR_LocalFlushElimination::perform()
          _allocationInfo->empty();
          }
 
-      examineNode(node, treeTop, visited);
+      examineNode(node, treeTop, block, visited);
       }
 
    FlushCandidate *flushCandidate;
@@ -9174,7 +9174,7 @@ int32_t TR_LocalFlushElimination::perform()
    }
 
 
-bool TR_LocalFlushElimination::examineNode(TR::Node *node, TR::TreeTop *tt, TR::NodeChecklist& visited)
+bool TR_LocalFlushElimination::examineNode(TR::Node *node, TR::TreeTop *tt, TR::Block *currBlock, TR::NodeChecklist& visited)
    {
    if (visited.contains(node))
       return true;
@@ -9356,7 +9356,7 @@ bool TR_LocalFlushElimination::examineNode(TR::Node *node, TR::TreeTop *tt, TR::
                   {
                   if (reachingFlushCandidate->isOptimallyPlaced() ||
                      reachingFlushCandidate->getFlush()->getNode()->getAllocation() == NULL ||
-                     reachingFlushCandidate->getBlockNum() != tt->getEnclosingBlock()->getNumber())
+                     reachingFlushCandidate->getBlockNum() != currBlock->getNumber())
                      continue;
                   reachingCandidate = getCandidate(_candidates, reachingFlushCandidate);
                   if (!reachingCandidate)
@@ -9531,7 +9531,7 @@ bool TR_LocalFlushElimination::examineNode(TR::Node *node, TR::TreeTop *tt, TR::
       {
       TR::Node *child = node->getChild(i);
 
-      if (!examineNode(child, tt, visited))
+      if (!examineNode(child, tt, currBlock, visited))
          return false;
       }
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -803,7 +803,7 @@ class TR_LocalFlushElimination
    TR_LocalFlushElimination(TR_EscapeAnalysis *, int32_t numAllocations);
 
    virtual int32_t perform();
-   bool examineNode(TR::Node *, TR::TreeTop *, TR::NodeChecklist& visited);
+   bool examineNode(TR::Node *, TR::TreeTop *, TR::Block *, TR::NodeChecklist& visited);
 
    TR::Optimizer *        optimizer()                     { return _escapeAnalysis->optimizer(); }
    TR::Compilation *        comp()                          { return _escapeAnalysis->comp(); }


### PR DESCRIPTION
While performing analysis for flush elimination, `LocalFlushElimination::examineNode` called `TR::TreeTop::getEnclosingBlock` on the current `TR::TreeTop`.  As that method walks through the linked list chaining together the `TR::TreeTop`s to find the corresponding `BBStart`, calling it in nested loops becomes very expensive when large blocks are encountered.

Fixed this by passing the current block as an argument to `LocalFlushElimination::examineNode`.

Fixes #16353