### PR TITLE
Re-enable CFGSimplifier

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,8 +34,9 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
-   if (enableCFGSimplification == NULL)
+   static char *disableCFGSimplification = feGetEnv("TR_disableCFGSimplificaiton");
+
+   if (disableCFGSimplification != NULL)
       return false;
 
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)


### PR DESCRIPTION
Re-enable CFGSimplifier which has been disabled by [1].
The motivation for re-enabling it is that we want to use it for removing boundary check code from the loop when using Vector JEP.
When vectorizing library calls of `jdk.incubator.vector` package, there are many calls to `Preconditions.checkIndex()` [2] left in the loop. It checks if index is in the range and throws an OOB exception when the check fails. We want to take this boundary check code out of the loop. 
CFGSimplifier should be able to transform the boundary check pattern into a BNDCHK node [3] and we can let loopVersioner remove the BNDCHK from the loop.
The original issue with CFGSimplifier [4] seems to be already fixed by [5]. I am not able to reproduce it with multiple runs of system test using this commit. It seems that the most recent problem with CFGSimplifier [6] was seen in sanity.functional but I am not able to reproduce it either.

[1] https://github.com/eclipse-openj9/openj9/pull/9783
[2] https://github.com/ibmruntimes/openj9-openjdk-jdk19/blob/d78ba9640fed4fc0b5cda490a2ac8c2f21622059/src/java.base/share/classes/jdk/internal/util/Preconditions.java#L299
[3] https://github.com/eclipse/omr/pull/5085
[4] https://github.com/eclipse-openj9/openj9/issues/9754
[5] https://github.com/eclipse-openj9/openj9/pull/10224
[6] https://github.com/eclipse-openj9/openj9/pull/10961#issuecomment-716512676

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>