### PR TITLE
Fix reloErrorCodeNames mistake

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -93,7 +93,7 @@ char *TR_RelocationRuntime::_reloErrorCodeNames[] =
    "unknownRelocation",                                // 3
    "unknownReloAction",                                // 4
    "invalidRelocation",                                // 5
-   "exceptionThrown"                                   // 6
+   "exceptionThrown",                                  // 6
 
    "methodEnterValidationFailure",                     // 7
    "methodExitValidationFailure",                      // 8


### PR DESCRIPTION
The array of strings for relocation error types was missing a comma which meant that two entries were considered as one, and most error codes were misaligned.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>