### PR TITLE
Remove wantToPatchClassPointer() and the hcrPatchClassPointers option

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -4089,7 +4089,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *srcReg, TR::R
       cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "ArrayStoreCHKEvaluator:010VMarrayStoreCHKEvaluator:02JavaLangObjectCheck"), *srm);
 
       TR::Register *javaLangObjectClassReg = srm->findOrCreateScratchRegister();
-      if (cg->wantToPatchClassPointer(objectClass, node) || cg->needClassAndMethodPointerRelocations())
+      if (cg->needClassAndMethodPointerRelocations())
          {
          loadAddressConstantInSnippet(cg, node, reinterpret_cast<intptr_t>(objectClass), javaLangObjectClassReg, TR_ClassPointer);
          }
@@ -4135,7 +4135,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *srcReg, TR::R
       TR_OpaqueClassBlock *arrayComponentClass = node->getArrayComponentClassInNode();
       cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "ArrayStoreCHKEvaluator:010VMarrayStoreCHKEvaluator:06ArrayComponentClassCheck"), *srm);
 
-      if (cg->wantToPatchClassPointer(arrayComponentClass, node) || cg->needClassAndMethodPointerRelocations())
+      if (cg->needClassAndMethodPointerRelocations())
          {
          loadAddressConstantInSnippet(cg, node, reinterpret_cast<intptr_t>(arrayComponentClass), arrayComponentClassReg, TR_ClassPointer);
          }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4690,26 +4690,6 @@ J9::CodeGenerator::setUpForInstructionSelection()
    }
 
 bool
-J9::CodeGenerator::wantToPatchClassPointer(TR::Compilation *comp,
-                             const TR_OpaqueClassBlock *allegedClassPointer,
-                             const uint8_t *inCodeAt)
-   {
-   return TR::CodeGenerator::wantToPatchClassPointer(comp, allegedClassPointer, "in code at", inCodeAt);
-   }
-
-bool
-J9::CodeGenerator::wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt)
-   {
-   return TR::CodeGenerator::wantToPatchClassPointer(self()->comp(), allegedClassPointer, inCodeAt);
-   }
-
-bool
-J9::CodeGenerator::wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode)
-   {
-   return TR::CodeGenerator::wantToPatchClassPointer(self()->comp(), allegedClassPointer, "for node", forNode);
-   }
-
-bool
 J9::CodeGenerator::supportsJitMethodEntryAlignment()
    {
    return self()->fej9()->supportsJitMethodEntryAlignment();

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -346,37 +346,6 @@ private:
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 
-   static bool wantToPatchClassPointer(TR::Compilation *comp,
-                                       const TR_OpaqueClassBlock *allegedClassPointer,
-                                       const char *locationDescription,
-                                       const void *location)
-      {
-      // If we have a class pointer to consider, it should look like one.
-      const uintptr_t j9classEyecatcher = 0x99669966;
-#if defined(J9VM_OPT_JITSERVER)
-      if (allegedClassPointer != NULL && !comp->isOutOfProcessCompilation())
-#else
-      if (allegedClassPointer != NULL)
-#endif /* defined(J9VM_OPT_JITSERVER) */
-         {
-         TR_ASSERT(*(const uintptr_t*)allegedClassPointer == j9classEyecatcher,
-                   "expected a J9Class* for omitted runtime assumption");
-         }
-
-      // Class pointer patching is restricted to HCR mode.
-      if (!comp->getOption(TR_EnableHCR))
-         return false;
-
-      // -Xjit:HCRPatchClassPointers re-enables all class pointer assumptions
-      if (comp->getOption(TR_HCRPatchClassPointers))
-         return true;
-
-      return !performTransformation(comp,
-                                    "O^O OMIT HCR CLASS POINTER ASSUMPTION: class=" POINTER_PRINTF_FORMAT ", %s " POINTER_PRINTF_FORMAT "\n", allegedClassPointer,
-                                    locationDescription,
-                                    location);
-      }
-
    uint32_t _stackLimitOffsetInMetaData;
 
    /*
@@ -407,14 +376,6 @@ protected:
    TR::Node *_dummyTempStorageRefNode;
 
 public:
-
-   static bool wantToPatchClassPointer(TR::Compilation *comp,
-                                       const TR_OpaqueClassBlock *allegedClassPointer,
-                                       const uint8_t *inCodeAt);
-
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt);
-
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode);
 
    bool getSupportsBigDecimalLongLookasideVersioning() { return _flags3.testAny(SupportsBigDecimalLongLookasideVersioning);}
    void setSupportsBigDecimalLongLookasideVersioning() { _flags3.set(SupportsBigDecimalLongLookasideVersioning);}

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,11 +145,6 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
                           __FILE__,
                           __LINE__,
                           getNode());
-   if (getDataSymbol()->isClassObject() && cg()->wantToPatchClassPointer(NULL, getAddressOfDataReference()))
-      {
-      uintptr_t dis = cursor - getAddressOfDataReference();
-      cg()->jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition((void *) getAddressOfDataReference());
-      }
    cursor += 4;
 
    *(intptr_t *)cursor = (intptr_t)getAddressOfDataReference();   // Code Cache RA

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2213,13 +2213,6 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
 
    if (!newAddress) return TR_RelocationErrorCode::classValidationFailure;
 
-   if (TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), newAddress, reloLocation))
-      {
-      createClassRedefinitionPicSite((void *)newAddress, (void *)reloLocation, sizeof(UDATA), 0,
-                                     getMetadataAssumptionList(reloRuntime->exceptionTable()));
-      RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: hcr enabled, registered class redefinition site\n");
-      }
-
    reloTarget->storeAddressSequence((uint8_t *)newAddress, reloLocation, reloFlags(reloTarget));
    return TR_RelocationErrorCode::relocationOK;
    }
@@ -2232,14 +2225,6 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
    TR_OpaqueClassBlock *newAddress = computeNewClassAddress(reloRuntime, newConstantPool, inlinedSiteIndex(reloTarget), cpIndex(reloTarget));
 
    if (!newAddress) return TR_RelocationErrorCode::classValidationFailure;
-
-   if (TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), newAddress, reloLocationHigh))
-      {
-      // This looks wrong
-      createClassRedefinitionPicSite((void *)newAddress, (void *)reloLocationHigh, sizeof(UDATA), 0,
-         getMetadataAssumptionList(reloRuntime->exceptionTable()));
-      RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tapplyRelocation: hcr enabled, registered class redefinition site\n");
-      }
 
    reloTarget->storeAddress((uint8_t *) newAddress, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
    return TR_RelocationErrorCode::relocationOK;
@@ -5480,7 +5465,7 @@ TR_RelocationRecordSymbolFromManager::needsRedefinitionAssumption(TR_RelocationR
    switch (symbolType)
       {
       case TR::SymbolType::typeClass:
-         needsAssumptions =  TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), clazz, reloLocation);
+         needsAssumptions = false;
          break;
 
       case TR::SymbolType::typeMethod:
@@ -5780,8 +5765,6 @@ TR_RelocationRecordClassPointer::activatePointer(TR_RelocationRuntime *reloRunti
    TR_RelocationRecordPointer::activatePointer(reloRuntime, reloTarget, reloLocation);
    TR_RelocationRecordPointerPrivateData *reloPrivateData = &(privateData()->pointer);
    TR_ASSERT((void*)reloPrivateData->_pointer == (void*)reloPrivateData->_clazz, "Pointer differs from class pointer");
-   if (TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), reloPrivateData->_clazz, reloLocation))
-      registerHCRAssumption(reloRuntime, reloLocation);
    }
 
 // TR_ArbitraryClassAddress

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6752,10 +6752,6 @@ static void genInitObjectHeader(TR::Node             *node,
          {
          instr = generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, generateX86MemoryReference(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), (int32_t)((uintptr_t)clazz|orFlagsClass), cg);
          }
-
-      // HCR in genInitObjectHeader
-      if (instr && cg->wantToPatchClassPointer(clazz, node))
-         comp->getStaticHCRPICSites()->push_front(instr);
       }
    else
       {
@@ -8200,10 +8196,6 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
 
          generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
-         // HCR in VMarrayStoreCHKEvaluator
-         if (cg->wantToPatchClassPointer(objectClass, node))
-            comp->getStaticHCRPICSites()->push_front(instr);
-
          // here we may have to convert the TR_OpaqueClassBlock into a J9Class pointer
          // and store it in destComponentClassReg
          // ..
@@ -8303,10 +8295,6 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
          }
 
       generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
-
-      // HCR in VMarrayStoreCHKEvaluator
-      if (cg->wantToPatchClassPointer(objectClass, node))
-         comp->getStaticHCRPICSites()->push_front(instr);
       */
 
 
@@ -8359,11 +8347,6 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
             }
 
          generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
-
-         // HCR in VMarrayStoreCHKEvaluator
-         if (cg->wantToPatchClassPointer(arrayComponentClass, node))
-            comp->getStaticHCRPICSites()->push_front(instr);
-
          }
 
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -384,15 +384,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
                {
                // Must pass symbol reference so that aot can put out a relocation for it
                //
-               TR::Instruction *instr = generateImmSymInstruction(TR::InstOpCode::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(), symRef, cg());
-
-               // HCR register the class passed as a parameter
-               //
-               if ((sym->isClassObject() || sym->isAddressOfClassObject())
-                   && cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)sym->getStaticAddress(), child))
-                  {
-                  comp()->getStaticHCRPICSites()->push_front(instr);
-                  }
+               generateImmSymInstruction(TR::InstOpCode::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(), symRef, cg());
                }
 
             cg()->decReferenceCount(child);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2972,9 +2972,6 @@ static bool generateInlineTest(TR::CodeGenerator * cg, TR::Node * node, TR::Node
       if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(guessClassArray[i]), comp->getCurrentMethod()))
          comp->getStaticPICSites()->push_front(unloadableConstInstr[i]);
 
-      if (cg->wantToPatchClassPointer(guessClassArray[i], node))
-         comp->getStaticHCRPICSites()->push_front(unloadableConstInstr[i]);
-
       result_bool = fej9->instanceOfOrCheckCast((J9Class*)(guessClassArray[i]), (J9Class*)castClassAddr);
       result_label = (falseLabel != trueLabel ) ? (result_bool ? trueLabel : falseLabel) : doneLabel;
 
@@ -3947,9 +3944,6 @@ J9::Z::TreeEvaluator::checkcastEvaluator(TR::Node * node, TR::CodeGenerator * cg
                // Adding profiled classes to static PIC sites
                if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
                   comp->getStaticPICSites()->push_front(temp);
-               // Adding profiled classes to HCR PIC sites
-               if (cg->wantToPatchClassPointer(profiledClassesList[numPICs].profiledClass, node))
-                  comp->getStaticHCRPICSites()->push_front(temp);
 
                temp = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, arbitraryClassReg1, objClassReg, TR::InstOpCode::COND_BE, resultLabel, false, false);
                numPICs++;
@@ -6330,7 +6324,7 @@ VMarrayStoreCHKEvaluator(
     */
    bool doObjectArrayCheck = objectClass != 0;
 
-   if (doObjectArrayCheck && (cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)objectClass, node) || cg->needClassAndMethodPointerRelocations()))
+   if (doObjectArrayCheck && cg->needClassAndMethodPointerRelocations())
       {
       if (cg->isLiteralPoolOnDemandOn())
          {
@@ -8282,9 +8276,6 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator(TR::Node * node, TR::CodeGene
                // Adding profiled class to the static PIC slots.
                if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
                   comp->getStaticPICSites()->push_front(temp);
-               // Adding profiled class to static HCR PIC sites.
-               if (cg->wantToPatchClassPointer(profiledClassesList[numPICs].profiledClass, node))
-                  comp->getStaticHCRPICSites()->push_front(temp);
 
                if (profiledClassesList[numPICs].isProfiledClassInstanceOfCastClass)
                   generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, arbitraryClassReg1, objClassReg, TR::InstOpCode::COND_BE, trueLabel, false, false);
@@ -9738,40 +9729,22 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
       // Store the class
       if (clzReg == NULL)
          {
-         if (cg->wantToPatchClassPointer(classAddress, node))
-            {
-            iCursor = genLoadAddressConstantInSnippet(cg, node, (intptr_t) classAddress | (intptr_t)orFlag, temp1Reg, iCursor, conditions, litPoolBaseReg, true);
-            if (orFlag != 0)
-               {
-               if (TR::Compiler->om.compressObjectReferences())
-                  iCursor = generateS390ImmOp(cg, TR::InstOpCode::O, node, temp1Reg, temp1Reg, (int32_t)orFlag, conditions, litPoolBaseReg);
-               else
-                  {
-                  if (comp->target().is64Bit())
-                     iCursor = generateS390ImmOp(cg, TR::InstOpCode::OG, node, temp1Reg, temp1Reg, (int64_t)orFlag, conditions, litPoolBaseReg);
-                  else
-                     iCursor = generateS390ImmOp(cg, TR::InstOpCode::O, node, temp1Reg, temp1Reg, (int32_t)orFlag, conditions, litPoolBaseReg);
-                  }
-               }
-            }
-         else
-            {
-            //case for arraynew and anewarray for compressedrefs and 31 bit
-            /*
-             * node->getOpCodeValue() == TR::newarray
-             [0x484DF88C20]   LGFI    GPR15,674009856
-             [0x484DF88DD8]   ST      GPR15,#613 0(GPR3)
-             [0x484DF88F60]   ST      GPR2,#614 4(GPR3)
+         //case for arraynew and anewarray for compressedrefs and 31 bit
+         /*
+          * node->getOpCodeValue() == TR::newarray
+          [0x484DF88C20]   LGFI    GPR15,674009856
+          [0x484DF88DD8]   ST      GPR15,#613 0(GPR3)
+          [0x484DF88F60]   ST      GPR2,#614 4(GPR3)
 
-            to
-            IIHF
-            STG      GPR2,#614 0(GPR3)
+         to
+         IIHF
+         STG      GPR2,#614 0(GPR3)
 
-             */
+          */
 
-            if (!canUseIIHF)
-               iCursor = genLoadAddressConstant(cg, node, (intptr_t) classAddress | (intptr_t)orFlag, temp1Reg, iCursor, conditions, litPoolBaseReg);
-            }
+         if (!canUseIIHF)
+            iCursor = genLoadAddressConstant(cg, node, (intptr_t) classAddress | (intptr_t)orFlag, temp1Reg, iCursor, conditions, litPoolBaseReg);
+
          if (canUseIIHF)
             {
             iCursor = generateRILInstruction(cg, TR::InstOpCode::IIHF, node, enumReg, static_cast<uint32_t>(reinterpret_cast<uintptr_t>(classAddress)) | orFlag, iCursor);


### PR DESCRIPTION
These were introduced a long time ago to allow a certain change to be toggled. The change was to stop generating runtime assumptions for patching class pointers on class redefinition, and to stop generating slower but more easily patchable instruction sequences to allow for those runtime assumptions. The patching was no longer needed because class redefinition had been made in-place.

As a result, `wantToPatchClassPointer()` and `hcrPatchClassPointers` are no longer necessary. They are removed, and all use sites now behave as though `hcrPatchClassPointers` is not set and `wantToPatchClassPointer()` returns false.