### PR TITLE
Fix missing parameter for scanContinuationNativeSlots

### DIFF
--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -805,7 +805,7 @@ MM_GlobalMarkingScheme::scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9
 		/* In STW GC there are no racing carrier threads doing mount and no need for the synchronization. */
 		bool syncWithContinuationMounting = (MM_VLHGCIncrementStats::mark_concurrent == static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._globalMarkIncrementType);
 
-		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForGlobalMarkingScheme, stackFrameClassWalkNeeded, syncWithContinuationMounting);
+		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForGlobalMarkingScheme, stackFrameClassWalkNeeded, false, syncWithContinuationMounting);
 	}
 }
 


### PR DESCRIPTION
there is missing parameter for scanContinuationNativeSlots in VLHGC GlobalMarkingScheme, it would disable sync between concurrent scan and mounting continuation, then causes potential crash.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>