### PR TITLE
Transform array element load and store using type hint

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,6 +138,20 @@ J9::ObjectModel::areValueBasedMonitorChecksEnabled()
    return javaVM->internalVMFunctions->areValueBasedMonitorChecksEnabled(javaVM);
    }
 
+bool
+J9::ObjectModel::isValueTypeArrayFlatteningEnabled()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+	   return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   J9JavaVM *javaVM = TR::Compiler->javaVM;
+   return J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+   }
 
 int32_t
 J9::ObjectModel::sizeofReferenceField()
@@ -667,8 +681,8 @@ J9::ObjectModel::usesDiscontiguousArraylets()
    return _usesDiscontiguousArraylets;
    }
 
-int32_t 
-J9::ObjectModel::arrayletLeafSize() 
+int32_t
+J9::ObjectModel::arrayletLeafSize()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
@@ -681,7 +695,7 @@ J9::ObjectModel::arrayletLeafSize()
    }
 
 int32_t
-J9::ObjectModel::arrayletLeafLogSize() 
+J9::ObjectModel::arrayletLeafLogSize()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,10 @@ public:
    * @brief Whether the check is enabled on monitor object being value based class type
    */
    bool areValueBasedMonitorChecksEnabled();
+   /**
+   * @brief Whether the array flattening is enabled for value types
+   */
+   bool isValueTypeArrayFlatteningEnabled();
 
    int32_t sizeofReferenceField();
    bool isHotReferenceFieldRequired();

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5172,6 +5172,8 @@ TR_J9ByteCodeIlGenerator::loadFlattenableInstance(int32_t cpIndex)
 
    TR::Node * newValueNode = genNodeAndPopChildren(TR::newvalue, flattenedFieldCount + 1, symRefTab()->findOrCreateNewValueSymbolRef(_methodSymbol));
    newValueNode->setIdentityless(true);
+   _methodSymbol->setHasNews(true);
+
    genTreeTop(newValueNode);
    push(newValueNode);
    genFlush(0);
@@ -5903,7 +5905,11 @@ TR_J9ByteCodeIlGenerator::loadArrayElement(TR::DataType dataType, TR::ILOpCodes 
    // we won't have flattening, so no call to flattenable array element access
    // helper is needed.
    //
-   if (mayBeValueType && TR::Compiler->om.areValueTypesEnabled() && !TR::Compiler->om.canGenerateArraylets() && dataType == TR::Address)
+   if (mayBeValueType &&
+       TR::Compiler->om.areValueTypesEnabled() &&
+       TR::Compiler->om.isValueTypeArrayFlatteningEnabled() &&
+       !TR::Compiler->om.canGenerateArraylets() &&
+       dataType == TR::Address)
       {
       TR::Node* elementIndex = pop();
       TR::Node* arrayBaseAddress = pop();
@@ -6256,6 +6262,8 @@ TR_J9ByteCodeIlGenerator::genWithField(TR::SymbolReference * symRef, TR_OpaqueCl
 
    TR::Node *newValueNode = genNodeAndPopChildren(TR::newvalue, fieldCount+1, symRefTab()->findOrCreateNewValueSymbolRef(_methodSymbol));
    newValueNode->setIdentityless(true);
+   _methodSymbol->setHasNews(true);
+
    genTreeTop(newValueNode);
    push(newValueNode);
    genFlush(0);
@@ -6425,10 +6433,11 @@ TR_J9ByteCodeIlGenerator::genFlattenableWithField(int32_t fieldCpIndex, TR_Opaqu
 
       TR::Node *newValueNode = genNodeAndPopChildren(TR::newvalue, fieldCount+1, symRefTab()->findOrCreateNewValueSymbolRef(_methodSymbol));
       newValueNode->setIdentityless(true);
+      _methodSymbol->setHasNews(true);
+
       genTreeTop(newValueNode);
       push(newValueNode);
       genFlush(0);
-
       return;
       }
    else
@@ -6596,6 +6605,7 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
 
          newValueNode = genNodeAndPopChildren(TR::newvalue, fieldCount+1, symRefTab()->findOrCreateNewValueSymbolRef(_methodSymbol));
          newValueNode->setIdentityless(true);
+         _methodSymbol->setHasNews(true);
       }
 
    genTreeTop(newValueNode);

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -897,10 +897,11 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             }
          }
 
-      // If the array is known to be of a primitive value type that is not flattened,
-      // transform the helper call to regular aaload and aastore.
-      bool canTransformUnflattenedVTArrayElementLoadStore = false;
-      if (arrayConstraint &&
+      // Transform the helper call to regular aaload and aastore if array flattening is not enabled,
+      // or the array is known to be of a primitive value type that is not flattened.
+      bool canTransformUnflattenedVTArrayElementLoadStore = TR::Compiler->om.isValueTypeArrayFlatteningEnabled() ? false : true;
+      if (!canTransformUnflattenedVTArrayElementLoadStore &&
+          arrayConstraint &&
           (isCompTypePrimVT == TR_yes) &&
           (TR::Compiler->cls.isValueTypeClassFlattened(arrayConstraint->getClass()) == TR_no))
          {

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,20 @@ class ValuePropagation : public OMR::ValuePropagation
    uintptr_t* getObjectLocationFromConstraint(TR::VPConstraint *constraint);
    bool isKnownStringObject(TR::VPConstraint *constraint);
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
+
+   /**
+    * Determine whether the type is, or might be, a value type.  Note that
+    * a null reference can be cast to a value type that is not a primitive
+    * value type, but for the purposes of this method, a null reference is
+    * not considered to be a value type.
+    *
+    * @param[IN] constraint The \ref TR::VPConstraint type constraint for a node
+    * @param[OUT] clazz The \ref TR_OpaqueClassBlock type class of the constraint
+    * @return \c TR_yes if the type is definitely a value type;\n
+    *         \c TR_no if it is definitely not a value type; or\n
+    *         \c TR_maybe otherwise.
+    */
+   virtual TR_YesNoMaybe isValue(TR::VPConstraint *constraint, TR_OpaqueClassBlock *& clazz);
 
    /**
     * Determine whether the component type of an array is, or might be, a primitive value

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2017, 2022 IBM Corp. and others
+  Copyright (c) 2017, 2023 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,6 +144,16 @@
 			<variation>-Xjit:count=1,disableAsyncCompilation -Xnocompressedrefs -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-Xjit:count=1,disableAsyncCompilation -Xnocompressedrefs -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-Xjit:count=1,disableAsyncCompilation -Xnocompressedrefs -Xgcpolicy:gencon</variation>
+			<!-- Test the above options with initialOptLevel=warm -->
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=12 -XX:-EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xnocompressedrefs -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xnocompressedrefs -Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xnocompressedrefs -Xgcpolicy:gencon</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeArrayTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeArrayTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -357,49 +357,155 @@ public class ValueTypeArrayTests {
 		}
 	}
 
-   static primitive class SomeClassWithDoubleField{
+   static primitive class SomeVTClassWithDoubleField{
       public double d;
 
-		SomeClassWithDoubleField(double x) {
+		SomeVTClassWithDoubleField(double x) {
 			this.d = x;
 		}
    }
 
-   static primitive class SomeClassWithFloatField{
+   static primitive class SomeVTClassWithFloatField{
       public float f;
 
-		SomeClassWithFloatField(float x) {
+		SomeVTClassWithFloatField(float x) {
 			this.f = x;
 		}
    }
 
-   static primitive class SomeClassWithLongField{
+   static primitive class SomeVTClassWithLongField{
       public long l;
 
-		SomeClassWithLongField(long x) {
+		SomeVTClassWithLongField(long x) {
 			this.l = x;
 		}
    }
 
-   static void readArrayElementWithDoubleField(SomeClassWithDoubleField[] data) throws Throwable {
+   static class SomeIdentityClassWithDoubleField{
+      public double d;
+
+		SomeIdentityClassWithDoubleField(double x) {
+			this.d = x;
+		}
+   }
+
+   static class SomeIdentityClassWithFloatField{
+      public float f;
+
+		SomeIdentityClassWithFloatField(float x) {
+			this.f = x;
+		}
+   }
+
+   static class SomeIdentityClassWithLongField{
+      public long l;
+
+		SomeIdentityClassWithLongField(long x) {
+			this.l = x;
+		}
+   }
+
+   interface SomeInterface1WithSingleImplementer {}
+
+   interface SomeInterface2WithSingleImplementer {}
+
+   static primitive class SomeVTClassImplIf implements SomeInterface1WithSingleImplementer {
+      public double d;
+      public long l;
+
+		SomeVTClassImplIf(double val1, long val2) {
+			this.d = val1;
+			this.l = val2;
+		}
+   }
+
+   static class SomeIdentityClassImplIf implements SomeInterface2WithSingleImplementer {
+      public double d;
+      public long l;
+
+		SomeIdentityClassImplIf(double val1, long val2) {
+			this.d = val1;
+			this.l = val2;
+		}
+   }
+
+   static class SomeClassHolder {
+      public static int ARRAY_LENGTH = 10;
+      SomeInterface1WithSingleImplementer[] data_1;
+      SomeInterface1WithSingleImplementer[] data_2;
+
+      SomeInterface2WithSingleImplementer[] data_3;
+      SomeInterface2WithSingleImplementer[] data_4;
+      SomeInterface2WithSingleImplementer   data_5;
+
+		SomeClassHolder() {
+         data_1 = new SomeVTClassImplIf[ARRAY_LENGTH];
+         data_2 = new SomeVTClassImplIf[ARRAY_LENGTH];
+
+         data_3 = new SomeIdentityClassImplIf[ARRAY_LENGTH];
+         data_4 = new SomeIdentityClassImplIf[ARRAY_LENGTH];
+
+         data_5 = new SomeIdentityClassImplIf((double)(12345), (long)(12345));
+
+         for (int i = 0; i < ARRAY_LENGTH; i++) {
+            data_1[i] = new SomeVTClassImplIf((double)i, (long)i);
+            data_2[i] = new SomeVTClassImplIf((double)(i+1), (long)(i+1));
+
+            data_3[i] = data_5;
+            data_4[i] = new SomeIdentityClassImplIf((double)(i+1), (long)(i+1));
+         }
+      }
+   }
+
+   static void readArrayElementWithDoubleField(SomeVTClassWithDoubleField[] data) throws Throwable {
       for (int i=0; i<data.length; ++i) {
          assertEquals(data[i].d, (double)i);
       }
    }
 
-   static void readArrayElementWithFloatField(SomeClassWithFloatField[] data) throws Throwable {
+   static void readArrayElementWithFloatField(SomeVTClassWithFloatField[] data) throws Throwable {
       for (int i=0; i<data.length; ++i) {
          assertEquals(data[i].f, (float)i);
       }
    }
 
-   static void readArrayElementWithLongField(SomeClassWithLongField[] data) throws Throwable {
+   static void readArrayElementWithLongField(SomeVTClassWithLongField[] data) throws Throwable {
       for (int i=0; i<data.length; ++i) {
          assertEquals(data[i].l, (long)i);
       }
    }
 
-   static void writeArrayElementWithDoubleField(SomeClassWithDoubleField[] srcData, SomeClassWithDoubleField[] dstData) throws Throwable {
+   static void readArrayElementWithDoubleField(SomeIdentityClassWithDoubleField[] data) throws Throwable {
+      for (int i=0; i<data.length; ++i) {
+         assertEquals(data[i].d, (double)i);
+      }
+   }
+
+   static void readArrayElementWithFloatField(SomeIdentityClassWithFloatField[] data) throws Throwable {
+      for (int i=0; i<data.length; ++i) {
+         assertEquals(data[i].f, (float)i);
+      }
+   }
+
+   static void readArrayElementWithLongField(SomeIdentityClassWithLongField[] data) throws Throwable {
+      for (int i=0; i<data.length; ++i) {
+         assertEquals(data[i].l, (long)i);
+      }
+   }
+
+   static void readArrayElementWithSomeVTClassImplIf(SomeClassHolder holder) throws Throwable {
+      for (int i=0; i<holder.data_1.length; ++i) {
+         assertEquals(holder.data_1[i], new SomeVTClassImplIf((double)i, (long)i));
+      }
+   }
+
+   static void readArrayElementWithSomeIdentityClassImplIf(SomeClassHolder holder) throws Throwable {
+      for (int i=0; i<holder.data_3.length; ++i) {
+         assertEquals(holder.data_3[i], holder.data_5);
+      }
+   }
+
+   static void writeArrayElementWithDoubleField(SomeVTClassWithDoubleField[] srcData, SomeVTClassWithDoubleField[] dstData) throws Throwable {
       for (int i=0; i<dstData.length; ++i) {
          dstData[i] = srcData[i];
       }
@@ -409,7 +515,7 @@ public class ValueTypeArrayTests {
       }
    }
 
-   static void writeArrayElementWithFloatField(SomeClassWithFloatField[] srcData, SomeClassWithFloatField[] dstData) throws Throwable {
+   static void writeArrayElementWithFloatField(SomeVTClassWithFloatField[] srcData, SomeVTClassWithFloatField[] dstData) throws Throwable {
       for (int i=0; i<dstData.length; ++i) {
          dstData[i] = srcData[i];
       }
@@ -419,7 +525,7 @@ public class ValueTypeArrayTests {
       }
    }
 
-   static void writeArrayElementWithLongField(SomeClassWithLongField[] srcData, SomeClassWithLongField[] dstData) throws Throwable {
+   static void writeArrayElementWithLongField(SomeVTClassWithLongField[] srcData, SomeVTClassWithLongField[] dstData) throws Throwable {
       for (int i=0; i<dstData.length; ++i) {
          dstData[i] = srcData[i];
       }
@@ -429,46 +535,137 @@ public class ValueTypeArrayTests {
       }
    }
 
+   static void writeArrayElementWithDoubleField(SomeIdentityClassWithDoubleField[] srcData, SomeIdentityClassWithDoubleField[] dstData) throws Throwable {
+      for (int i=0; i<dstData.length; ++i) {
+         dstData[i] = srcData[i];
+      }
+
+      for (int i=0; i<dstData.length; ++i) {
+         assertEquals(dstData[i].d, (double)(i+1));
+      }
+   }
+
+   static void writeArrayElementWithFloatField(SomeIdentityClassWithFloatField[] srcData, SomeIdentityClassWithFloatField[] dstData) throws Throwable {
+      for (int i=0; i<dstData.length; ++i) {
+         dstData[i] = srcData[i];
+      }
+
+      for (int i=0; i<dstData.length; ++i) {
+         assertEquals(dstData[i].f, (float)(i+1));
+      }
+   }
+
+   static void writeArrayElementWithLongField(SomeIdentityClassWithLongField[] srcData, SomeIdentityClassWithLongField[] dstData) throws Throwable {
+      for (int i=0; i<dstData.length; ++i) {
+         dstData[i] = srcData[i];
+      }
+
+      for (int i=0; i<dstData.length; ++i) {
+         assertEquals(dstData[i].l, (long)(i+1));
+      }
+   }
+
+   static void writeArrayElementWithSomeVTClassImplIf(SomeClassHolder holder) throws Throwable {
+      for (int i=0; i<holder.data_1.length; ++i) {
+         holder.data_1[i] = holder.data_2[i];
+      }
+
+      for (int i=0; i<holder.data_1.length; ++i) {
+         assertEquals(holder.data_1[i], new SomeVTClassImplIf((double)(i+1), (long)(i+1)));
+      }
+   }
+
+   static void writeArrayElementWithSomeIdentityClassImplIf(SomeClassHolder holder) throws Throwable {
+      for (int i=0; i<holder.data_3.length; ++i) {
+         holder.data_3[i] = holder.data_4[i];
+      }
+
+      for (int i=0; i<holder.data_3.length; ++i) {
+         assertEquals(holder.data_3[i], holder.data_4[i]);
+      }
+   }
+
    @Test(priority=1,invocationCount=2)
 	static public void testValueTypeAaload() throws Throwable {
       int ARRAY_LENGTH = 10;
-      SomeClassWithDoubleField[] data1 = new SomeClassWithDoubleField[ARRAY_LENGTH];
-      SomeClassWithFloatField[]  data2 = new SomeClassWithFloatField[ARRAY_LENGTH];
-      SomeClassWithLongField[]   data3 = new SomeClassWithLongField[ARRAY_LENGTH];
+      SomeVTClassWithDoubleField[] data1  = new SomeVTClassWithDoubleField[ARRAY_LENGTH];
+      SomeVTClassWithFloatField[]  data2  = new SomeVTClassWithFloatField[ARRAY_LENGTH];
+      SomeVTClassWithLongField[]   data3  = new SomeVTClassWithLongField[ARRAY_LENGTH];
+
+      SomeIdentityClassWithDoubleField[] data4  = new SomeIdentityClassWithDoubleField[ARRAY_LENGTH];
+      SomeIdentityClassWithFloatField[]  data5  = new SomeIdentityClassWithFloatField[ARRAY_LENGTH];
+      SomeIdentityClassWithLongField[]   data6  = new SomeIdentityClassWithLongField[ARRAY_LENGTH];
+
+      SomeClassHolder holder = new SomeClassHolder();
 
       for (int i=0; i<ARRAY_LENGTH; ++i) {
-         data1[i] = new SomeClassWithDoubleField((double)i);
-         data2[i] = new SomeClassWithFloatField((float)i);
-         data3[i] = new SomeClassWithLongField((long)i);
+         data1[i] = new SomeVTClassWithDoubleField((double)i);
+         data2[i] = new SomeVTClassWithFloatField((float)i);
+         data3[i] = new SomeVTClassWithLongField((long)i);
+
+         data4[i] = new SomeIdentityClassWithDoubleField((double)i);
+         data5[i] = new SomeIdentityClassWithFloatField((float)i);
+         data6[i] = new SomeIdentityClassWithLongField((long)i);
       }
 
       readArrayElementWithDoubleField(data1);
       readArrayElementWithFloatField(data2);
       readArrayElementWithLongField(data3);
+
+      readArrayElementWithDoubleField(data4);
+      readArrayElementWithFloatField(data5);
+      readArrayElementWithLongField(data6);
+
+      readArrayElementWithSomeVTClassImplIf(holder);
+      readArrayElementWithSomeIdentityClassImplIf(holder);
    }
 
    @Test(priority=1,invocationCount=2)
 	static public void testValueTypeAastore() throws Throwable {
       int ARRAY_LENGTH = 10;
-      SomeClassWithDoubleField[] srcData1 = new SomeClassWithDoubleField[ARRAY_LENGTH];
-      SomeClassWithDoubleField[] dstData1 = new SomeClassWithDoubleField[ARRAY_LENGTH];
-      SomeClassWithFloatField[]  srcData2 = new SomeClassWithFloatField[ARRAY_LENGTH];
-      SomeClassWithFloatField[]  dstData2 = new SomeClassWithFloatField[ARRAY_LENGTH];
-      SomeClassWithLongField[]   srcData3 = new SomeClassWithLongField[ARRAY_LENGTH];
-      SomeClassWithLongField[]   dstData3 = new SomeClassWithLongField[ARRAY_LENGTH];
+      SomeVTClassWithDoubleField[] srcData1 = new SomeVTClassWithDoubleField[ARRAY_LENGTH];
+      SomeVTClassWithDoubleField[] dstData1 = new SomeVTClassWithDoubleField[ARRAY_LENGTH];
+      SomeVTClassWithFloatField[]  srcData2 = new SomeVTClassWithFloatField[ARRAY_LENGTH];
+      SomeVTClassWithFloatField[]  dstData2 = new SomeVTClassWithFloatField[ARRAY_LENGTH];
+      SomeVTClassWithLongField[]   srcData3 = new SomeVTClassWithLongField[ARRAY_LENGTH];
+      SomeVTClassWithLongField[]   dstData3 = new SomeVTClassWithLongField[ARRAY_LENGTH];
+
+      SomeIdentityClassWithDoubleField[] srcData4  = new SomeIdentityClassWithDoubleField[ARRAY_LENGTH];
+      SomeIdentityClassWithDoubleField[] dstData4  = new SomeIdentityClassWithDoubleField[ARRAY_LENGTH];
+      SomeIdentityClassWithFloatField[]  srcData5  = new SomeIdentityClassWithFloatField[ARRAY_LENGTH];
+      SomeIdentityClassWithFloatField[]  dstData5  = new SomeIdentityClassWithFloatField[ARRAY_LENGTH];
+      SomeIdentityClassWithLongField[]   srcData6  = new SomeIdentityClassWithLongField[ARRAY_LENGTH];
+      SomeIdentityClassWithLongField[]   dstData6  = new SomeIdentityClassWithLongField[ARRAY_LENGTH];
+
+      SomeClassHolder holder   = new SomeClassHolder();
 
       for (int i=0; i<ARRAY_LENGTH; ++i) {
-         srcData1[i] = new SomeClassWithDoubleField((double)(i+1));
-         srcData2[i] = new SomeClassWithFloatField((float)(i+1));
-         srcData3[i] = new SomeClassWithLongField((long)(i+1));
+         srcData1[i] = new SomeVTClassWithDoubleField((double)(i+1));
+         srcData2[i] = new SomeVTClassWithFloatField((float)(i+1));
+         srcData3[i] = new SomeVTClassWithLongField((long)(i+1));
 
-         dstData1[i] = new SomeClassWithDoubleField((double)i);
-         dstData2[i] = new SomeClassWithFloatField((float)i);
-         dstData3[i] = new SomeClassWithLongField((long)i);
+         dstData1[i] = new SomeVTClassWithDoubleField((double)i);
+         dstData2[i] = new SomeVTClassWithFloatField((float)i);
+         dstData3[i] = new SomeVTClassWithLongField((long)i);
+
+         srcData4[i] = new SomeIdentityClassWithDoubleField((double)(i+1));
+         srcData5[i] = new SomeIdentityClassWithFloatField((float)(i+1));
+         srcData6[i] = new SomeIdentityClassWithLongField((long)(i+1));
+
+         dstData4[i] = new SomeIdentityClassWithDoubleField((double)i);
+         dstData5[i] = new SomeIdentityClassWithFloatField((float)i);
+         dstData6[i] = new SomeIdentityClassWithLongField((long)i);
       }
 
       writeArrayElementWithDoubleField(srcData1, dstData1);
       writeArrayElementWithFloatField(srcData2, dstData2);
       writeArrayElementWithLongField(srcData3, dstData3);
+
+      writeArrayElementWithDoubleField(srcData4, dstData4);
+      writeArrayElementWithFloatField(srcData5, dstData5);
+      writeArrayElementWithLongField(srcData6, dstData6);
+
+      writeArrayElementWithSomeVTClassImplIf(holder);
+      writeArrayElementWithSomeIdentityClassImplIf(holder);
    }
 }


### PR DESCRIPTION
If the array constraint has a hint type, aaload and aastore helper calls can be transformed with a guard that checks if the array type is the hint type in runtime. If it is not, the slow path still calls the helper.
- If the type hint class is VT and it is flattened, transform the helper call with a guard to sym ref access on the fast path
- If the type hint class is VT and it is NOT flattened, transform the helper call with a guard to regular aaload/aastore on the fast path
- If the type hint class is identity class, transform the helper call with a guard to regular aaload/aastore on the fast path
    
Also add functional tests
- Test interface array and the interface has an single implementer
- Update the array tests with `initialOptLevel=warm` to have better test coverage on JIT'd methods.
