### PR TITLE
AArch64: Accelerate CRC-32C calculation

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -215,6 +215,9 @@ J9::ARM64::CodeGenerator::supportsInliningOfIsInstance()
 bool
 J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
    {
+   TR::Compilation *comp = self()->comp();
+   static const bool disableCRC32 = feGetEnv("TR_aarch64DisableCRC32") != NULL;
+
    if (method == TR::java_lang_Math_min_F ||
        method == TR::java_lang_Math_max_F ||
        method == TR::java_lang_Math_fma_D ||
@@ -223,6 +226,11 @@ J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMetho
        method == TR::java_lang_StrictMath_fma_F)
       {
       return true;
+      }
+   if (method == TR::java_util_zip_CRC32C_updateBytes ||
+       method == TR::java_util_zip_CRC32C_updateDirectByteBuffer)
+      {
+      return (!TR::Compiler->om.canGenerateArraylets()) && comp->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32);
       }
    return false;
    }

--- a/runtime/compiler/aarch64/env/J9CPU.cpp
+++ b/runtime/compiler/aarch64/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ void
 J9::ARM64::CPU::enableFeatureMasks()
    {
    // Only enable the features that compiler currently uses
-   const uint32_t utilizedFeatures [] = {OMR_FEATURE_ARM64_FP, OMR_FEATURE_ARM64_ASIMD, OMR_FEATURE_ARM64_LSE};
+   const uint32_t utilizedFeatures [] = {OMR_FEATURE_ARM64_FP, OMR_FEATURE_ARM64_ASIMD, OMR_FEATURE_ARM64_CRC32, OMR_FEATURE_ARM64_LSE};
 
    memset(_supportedFeatureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);


### PR DESCRIPTION
Accelerate `CRC32C.updateBytes` and `CRC32C.updateDirectByteBuffers` recognized methods by inlining them with CRC32C instruction families if FEAT_CRC32 extension (which is mandatory for Armv8.1 or later) is available.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>