### PR TITLE
Exit DEEPIDLE state when two threads are active

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5740,7 +5740,7 @@ void samplerThreadStateLogic(TR::CompilationInfo *compInfo, TR_FrontEnd *fe, int
             break;
 
          case TR::CompilationInfo::SAMPLER_DEEPIDLE: // we may go IDLE or directly DEFAULT
-            if (numActiveThreads > 2)
+            if (numActiveThreads >= 2)
                {
                newSamplerState = TR::CompilationInfo::SAMPLER_DEFAULT;
                jitConfig->samplingFrequency = TR::Options::getCmdLineOptions()->getSamplingFrequency();


### PR DESCRIPTION
The original idle detection code contained a small bug: we want to transition from DEEPIDLE directly to ACTIVE state if the sampler finds two or more Java threads being active, but the code was checking for >2 (greater than 2 threads).

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>