### PR TITLE
Use assertion with message to simplify debugging

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -305,7 +305,7 @@ MM_GCExtensions::releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9
 
 	if (verify_continuation_list == continuationListOption) {
 		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, objectPtr);
-		Assert_MM_true(NULL == continuation);
+		Assert_GC_true_with_message2(env, (NULL == continuation), "Continuation expected to be NULL, but it is %p, from Continuation object %p\n", continuation, objectPtr);
 	} else {
 		getJavaVM()->internalVMFunctions->freeContinuation(vmThread, objectPtr);
 	}


### PR DESCRIPTION
Currently regular assertion is used in
MM_GCExtensions::releaseNativesForContinuationObject(). Replace it to assertion with message to simplify debugging process: print Continuation object address as well as address of J9VMContinuation structure.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>