### PR TITLE
JVMTI Extension Functions: GetVirtualThread and GetCarrierThread

### DIFF
--- a/runtime/include/ibmjvmti.h
+++ b/runtime/include/ibmjvmti.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,6 +99,9 @@
 
 #define COM_IBM_REGISTER_TRACEPOINT_SUBSCRIBER "com.ibm.RegisterTracePointSubscriber"
 #define COM_IBM_DEREGISTER_TRACEPOINT_SUBSCRIBER "com.ibm.DeregisterTracePointSubscriber"
+
+#define COM_SUN_HOTSPOT_FUNCTIONS_GET_VIRTUAL_THREAD "com.sun.hotspot.functions.GetVirtualThread"
+#define COM_SUN_HOTSPOT_FUNCTIONS_GET_CARRIER_THREAD "com.sun.hotspot.functions.GetCarrierThread"
 
 #define COM_IBM_SHARED_CACHE_MODLEVEL_JAVA5 1
 #define COM_IBM_SHARED_CACHE_MODLEVEL_JAVA6 2

--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -1,4 +1,4 @@
-//Copyright (c) 2006, 2022 IBM Corp. and others
+//Copyright (c) 2006, 2023 IBM Corp. and others
 //	
 //This program and the accompanying materials are made available under
 //the terms of the Eclipse Public License 2.0 which accompanies this
@@ -646,3 +646,9 @@ TraceExit=Trc_JVMTI_jvmtiResumeAllVirtualThreads_Exit Overhead=1 Level=5 Noenv T
 
 TraceEntry=Trc_JVMTI_jvmtiSuspendAllVirtualThreads_Entry Overhead=1 Level=5 Noenv Template="SuspendAllVirtualThreads env=%p"
 TraceExit=Trc_JVMTI_jvmtiSuspendAllVirtualThreads_Exit Overhead=1 Level=5 Noenv Template="SuspendAllVirtualThreads returning %d"
+
+TraceEntry=Trc_JVMTI_jvmtiGetVirtualThread_Entry Overhead=1 Level=1 Noenv Template="GetVirtualThread env=%p"
+TraceEntry=Trc_JVMTI_jvmtiGetVirtualThread_Exit Overhead=1 Level=1 Noenv Template="GetVirtualThread returning %d"
+
+TraceEntry=Trc_JVMTI_jvmtiGetCarrierThread_Entry Overhead=1 Level=1 Noenv Template="GetCarrierThread env=%p"
+TraceEntry=Trc_JVMTI_jvmtiGetCarrierThread_Exit Overhead=1 Level=1 Noenv Template="GetCarrierThread returning %d"

--- a/runtime/nls/j9ti/jvmti.nls
+++ b/runtime/nls/j9ti/jvmti.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2021 IBM Corp. and others
+# Copyright (c) 2000, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -609,4 +609,18 @@ J9NLS_JVMTI_COM_IBM_JVM_DEREGISTER_TRACEPOINT_SUBSCRIBER_DESCRIPTION=Cancel a su
 J9NLS_JVMTI_COM_IBM_JVM_DEREGISTER_TRACEPOINT_SUBSCRIBER_DESCRIPTION.explanation=Internationalized description of a JVMTI extension
 J9NLS_JVMTI_COM_IBM_JVM_DEREGISTER_TRACEPOINT_SUBSCRIBER_DESCRIPTION.system_action=None
 J9NLS_JVMTI_COM_IBM_JVM_DEREGISTER_TRACEPOINT_SUBSCRIBER_DESCRIPTION.user_response=None
+# END NON-TRANSLATABLE
+
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_VIRTUAL_THREAD=Get the virtual thread running on the carrier thread
+# START NON-TRANSLATABLE
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_VIRTUAL_THREAD.explanation=Internationalized description of a JVMTI extension
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_VIRTUAL_THREAD.system_action=None
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_VIRTUAL_THREAD.user_response=None
+# END NON-TRANSLATABLE
+
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_CARRIER_THREAD=Get the carrier thread which is running the virtual thread
+# START NON-TRANSLATABLE
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_CARRIER_THREAD.explanation=Internationalized description of a JVMTI extension
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_CARRIER_THREAD.system_action=None
+J9NLS_JVMTI_COM_SUN_HOTSPOT_FUNCTIONS_GET_CARRIER_THREAD.user_response=None
 # END NON-TRANSLATABLE


### PR DESCRIPTION
The following JVMTI extension functions are implemented:
- **GetVirtualThread**: Gets the virtual thread corresponding to a
   carrier thread.
- **GetCarrierThread**: Gets the carrier thread corresponding to a
   virtual thread.

Related: #16168
Related: #16203

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>