### PR TITLE
Update JVM_IsUseContainerSupport

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corp. and others
+ * Copyright (c) 2015, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1659,9 +1659,15 @@ JVM_IsSharingEnabled(JNIEnv *env)
 JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(JNIEnv *env)
 {
-	PORT_ACCESS_FROM_ENV(env);
-	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
-	BOOLEAN inContainer = omrsysinfo_is_running_in_container();
+	J9VMThread *const currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	BOOLEAN inContainer = FALSE;
+
+	if (J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_USE_CONTAINER_SUPPORT)) {
+		PORT_ACCESS_FROM_ENV(env);
+		OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+		inContainer = omrsysinfo_is_running_in_container();
+	}
 
 	return inContainer ? JNI_TRUE : JNI_FALSE;
 }

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -358,6 +358,7 @@ extern "C" {
 #define J9_EXTENDED_RUNTIME2_TUNE_QUICKSTART 0x40000
 #define J9_EXTENDED_RUNTIME2_DISABLE_FINALIZATION 0x80000
 #define J9_EXTENDED_RUNTIME2_CRIU_SINGLE_THREAD_MODE 0x100000
+#define J9_EXTENDED_RUNTIME2_USE_CONTAINER_SUPPORT 0x200000
 
 #define J9_OBJECT_HEADER_AGE_DEFAULT 0xA /* OBJECT_HEADER_AGE_DEFAULT */
 #define J9_OBJECT_HEADER_SHAPE_MASK 0xE /* OBJECT_HEADER_SHAPE_MASK */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2297,6 +2297,7 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 
 			/* Enable -XX:+UseContainerSupport by default */
 			if (argIndex >= argIndex2) {
+				vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_USE_CONTAINER_SUPPORT;
 				uint64_t subsystemsEnabled = omrsysinfo_cgroup_enable_subsystems(OMR_CGROUP_SUBSYSTEM_ALL);
 
 				if (OMR_CGROUP_SUBSYSTEM_ALL != subsystemsEnabled) {


### PR DESCRIPTION
JVM_IsUseContainerSupport returns JNI_FALSE if -XX:-UseContainerSupport
is specified in order to match the RI.

Fixes: #16461

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>