### PR TITLE
Remove unused OPENJDK_THREAD_SUPPORT & J9VM_OPT_OPENJDK_THREAD_SUPPORT

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE configurationreg SYSTEM "http://home.ottawa.ibm.com/teams/bluebird/web/eclipse_site/jpp.dtd">
 <!--
 /*******************************************************************************
- * Copyright (c) 2002, 2022 IBM Corp. and others
+ * Copyright (c) 2002, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@
 	<!-- START SET DEFINITIONS -->
 	<set
 		label="newflags"
-		flags="CRIU_SUPPORT,INLINE-TYPES,OPENJDK_METHODHANDLES,OPENJDK_THREAD_SUPPORT"/>
+		flags="CRIU_SUPPORT,INLINE-TYPES,OPENJDK_METHODHANDLES"/>
 
 	<set
 		label="oldflags"

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2022 IBM Corp. and others
+# Copyright (c) 2017, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,7 +139,6 @@ option(J9VM_OPT_METHOD_HANDLE_COMMON "Enables common dependencies between OpenJ9
 option(J9VM_OPT_MODULE "Turns on module support")
 option(J9VM_OPT_MULTI_VM "Decides if multiple VMs can be created in the same address space")
 option(J9VM_OPT_OPENJDK_METHODHANDLE "Enables support for OpenJDK MethodHandles. J9VM_OPT_METHOD_HANDLE should be disabled.")
-option(J9VM_OPT_OPENJDK_THREAD_SUPPORT "Enables OpenJDK Thread support for Project Loom.")
 
 option(J9VM_OPT_PANAMA "Enables support for Project Panama features such as native method handles")
 option(J9VM_OPT_VALHALLA_VALUE_TYPES "Enables support for Project Valhalla Value Types")

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2022 IBM Corp. and others
+ * Copyright (c) 1998, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -235,7 +235,6 @@ extern "C" {
 #cmakedefine J9VM_OPT_NO_CLASSLOADERS
 #cmakedefine J9VM_OPT_NRR
 #cmakedefine J9VM_OPT_OPENJDK_METHODHANDLE
-#cmakedefine J9VM_OPT_OPENJDK_THREAD_SUPPORT
 #cmakedefine J9VM_OPT_PACKED
 #cmakedefine J9VM_OPT_PANAMA
 #cmakedefine J9VM_OPT_PHP_SUPPORT


### PR DESCRIPTION
Remove unused `OPENJDK_THREAD_SUPPORT` & `J9VM_OPT_OPENJDK_THREAD_SUPPORT`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>