### PR TITLE
Initial CRIU serviceability infrastructure

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,12 +70,12 @@ static IDATA initializeCompilerArgs(J9JavaVM* vm,
    char *fatalErrorStr;
    if (isXjit)
       {
-      VMOPT_WITH_COLON = VMOPT_XJIT_COLON;
+      VMOPT_WITH_COLON = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xjitcolon];
       fatalErrorStr = "no arguments for -Xjit:";
       }
    else
       {
-      VMOPT_WITH_COLON = VMOPT_XAOT_COLON;
+      VMOPT_WITH_COLON = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xaotcolon];
       fatalErrorStr = "no arguments for -Xaot:";
       }
 
@@ -260,46 +260,46 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             }
 
          /* Find and consume these before the library might be unloaded */
-         FIND_AND_CONSUME_ARG(EXACT_MATCH, "-Xnodfpbd", 0);
-         if (FIND_ARG_IN_VMARGS(EXACT_MATCH, "-Xdfpbd", 0) >= 0)
+         FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xnodfpbd], 0);
+         if (FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xdfpbd], 0) >= 0)
             {
-            FIND_AND_CONSUME_ARG( EXACT_MATCH, "-Xhysteresis", 0);
+            FIND_AND_CONSUME_ARG( EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xhysteresis], 0);
             }
-         FIND_AND_CONSUME_ARG( EXACT_MATCH, "-Xnoquickstart", 0); // deprecated
-         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, "-Xtune:elastic", 0);
-         argIndexQuickstart = FIND_AND_CONSUME_ARG( EXACT_MATCH, "-Xquickstart", 0);
-         tlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XtlhPrefetch", 0);
-         notlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XnotlhPrefetch", 0);
-         lockReservation = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XlockReservation", 0);
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-Xcodecache", 0);
-         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, "-XjniAcc:", 0);
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-Xcodecachetotal", 0);
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XX:codecachetotal=", 0);
+         FIND_AND_CONSUME_ARG( EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xnoquickstart], 0); // deprecated
+         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xtuneelastic], 0);
+         argIndexQuickstart = FIND_AND_CONSUME_ARG( EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xquickstart], 0);
+         tlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XtlhPrefetch], 0);
+         notlhPrefetch = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XnotlhPrefetch], 0);
+         lockReservation = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XlockReservation], 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecache], 0);
+         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XjniAcc], 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecachetotal], 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotal], 0);
 
-         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, "-Xlp:codecache:", 0);
+         FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xlpcodecache], 0);
 
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XsamplingExpirationTime", 0);
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XcompilationThreads", 0);
-         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, "-XaggressivenessLevel", 0);
-         argIndexXjit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, VMOPT_XJIT, 0);
-         argIndexXaot = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, VMOPT_XAOT, 0);
-         argIndexXnojit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, "-Xnojit", 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XsamplingExpirationTime], 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XcompilationThreads], 0);
+         FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XaggressivenessLevel], 0);
+         argIndexXjit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xjit], 0);
+         argIndexXaot = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xaot], 0);
+         argIndexXnojit = FIND_AND_CONSUME_ARG(OPTIONAL_LIST_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xnojit], 0);
 
-         argIndexRIEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:+RuntimeInstrumentation", 0);
-         argIndexRIDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:-RuntimeInstrumentation", 0);
+         argIndexRIEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusRuntimeInstrumentation], 0);
+         argIndexRIDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusRuntimeInstrumentation], 0);
 
          // Determine if user disabled Runtime Instrumentation
          if (argIndexRIEnabled >= 0 || argIndexRIDisabled >= 0)
             TR::Options::_hwProfilerEnabled = (argIndexRIDisabled > argIndexRIEnabled) ? TR_no : TR_yes;
 
-         argIndexPerfEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:+PerfTool", 0);
-         argIndexPerfDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:-PerfTool", 0);
+         argIndexPerfEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusPerfTool], 0);
+         argIndexPerfDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusPerfTool], 0);
 
          // Determine if user disabled PerfTool
          if (argIndexPerfEnabled >= 0 || argIndexPerfDisabled >= 0)
             TR::Options::_perfToolEnabled = (argIndexPerfDisabled > argIndexPerfEnabled) ? TR_no : TR_yes;
 
-         TR::Options::_doNotProcessEnvVars = (FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:doNotProcessJitEnvVars", 0) >= 0);
+         TR::Options::_doNotProcessEnvVars = (FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXdoNotProcessJitEnvVars], 0) >= 0);
 
          isQuickstart = J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_TUNE_QUICKSTART);
 
@@ -408,8 +408,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             /* We need to initialize the following if we allow JIT compilation, AOT compilation or AOT relocation to be done */
             try
                {
-               argIndexMergeOptionsEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:+MergeCompilerOptions", 0);
-               argIndexMergeOptionsDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, "-XX:-MergeCompilerOptions", 0);
+               argIndexMergeOptionsEnabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusMergeCompilerOptions], 0);
+               argIndexMergeOptionsDisabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusMergeCompilerOptions], 0);
 
                // Determine if user wants to merge compiler options
                bool mergeCompilerOptions = false;
@@ -419,8 +419,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                /*
                 * Note that the option prefix we need to match includes the colon.
                 */
-               argIndexXjit = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, VMOPT_XJIT_COLON, 0);
-               argIndexXaot = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, VMOPT_XAOT_COLON, 0);
+               argIndexXjit = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xjitcolon], 0);
+               argIndexXaot = FIND_ARG_IN_VMARGS( STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xaotcolon], 0);
 
                /* do initializations for -Xjit options */
                if (isJIT && argIndexXjit >= 0)

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,6 +290,83 @@ int32_t J9::Options::_expensiveCompWeight = TR::CompilationInfo::JSR292_WEIGHT;
 int32_t J9::Options::_jProfilingEnablementSampleThreshold = 10000;
 
 bool J9::Options::_aggressiveLockReservation = false;
+
+/**
+ * This string array should be kept in sync with the
+ * J9::ExternalOptions enum in J9Options.hpp
+ */
+char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOptions] =
+   {
+   // TR_FirstExternalOption                 = 0
+   "-Xnodfpbd",                           // = 0
+   "-Xdfpbd",                             // = 1
+   "-Xhysteresis",                        // = 2
+   "-Xnoquickstart",                      // = 3
+   "-Xquickstart",                        // = 4
+   "-Xtune:elastic",                      // = 5
+   "-XtlhPrefetch",                       // = 6
+   "-XnotlhPrefetch",                     // = 7
+   "-Xlockword",                          // = 8
+   "-XlockReservation",                   // = 9
+   "-XjniAcc:",                           // = 10
+   "-Xlp",                                // = 11
+   "-Xlp:codecache:",                     // = 12
+   "-Xcodecache",                         // = 13
+   "-Xcodecachetotal",                    // = 14
+   "-XX:codecachetotal=",                 // = 15
+   "-XX:+PrintCodeCache",                 // = 16
+   "-XX:-PrintCodeCache",                 // = 17
+   "-XsamplingExpirationTime",            // = 18
+   "-XcompilationThreads",                // = 19
+   "-XaggressivenessLevel",               // = 20
+   "-Xnoclassgc",                         // = 21
+   VMOPT_XJIT,                            // = 22
+   VMOPT_XNOJIT,                          // = 23
+   VMOPT_XJIT_COLON,                      // = 24
+   VMOPT_XAOT,                            // = 25
+   VMOPT_XNOAOT,                          // = 26
+   VMOPT_XAOT_COLON,                      // = 27
+   "-XX:deterministic=",                  // = 28
+   "-XX:+RuntimeInstrumentation",         // = 29
+   "-XX:-RuntimeInstrumentation",         // = 30
+   "-XX:+PerfTool",                       // = 31
+   "-XX:-PerfTool",                       // = 32
+   "-XX:doNotProcessJitEnvVars",          // = 33
+   "-XX:+MergeCompilerOptions",           // = 34
+   "-XX:-MergeCompilerOptions",           // = 35
+   "-XX:LateSCCDisclaimTime=",            // = 36
+   "-XX:+UseJITServer",                   // = 37
+   "-XX:-UseJITServer",                   // = 38
+   "-XX:+JITServerTechPreviewMessage",    // = 39
+   "-XX:-JITServerTechPreviewMessage",    // = 40
+   "-XX:JITServerAddress=",               // = 41
+   "-XX:JITServerPort=",                  // = 42
+   "-XX:JITServerTimeout=",               // = 43
+   "-XX:JITServerSSLKey=",                // = 44
+   "-XX:JITServerSSLCert=",               // = 45
+   "-XX:JITServerSSLRootCerts=",          // = 46
+   "-XX:+JITServerUseAOTCache",           // = 47
+   "-XX:-JITServerUseAOTCache",           // = 48
+   "-XX:+RequireJITServer",               // = 49
+   "-XX:-RequireJITServer",               // = 50
+   "-XX:+JITServerLogConnections",        // = 51
+   "-XX:-JITServerLogConnections",        // = 52
+   "-XX:JITServerAOTmx=",                 // = 53
+   "-XX:+JITServerLocalSyncCompiles",     // = 54
+   "-XX:-JITServerLocalSyncCompiles",     // = 55
+   "-XX:+JITServerMetrics",               // = 56
+   "-XX:-JITServerMetrics",               // = 57
+   "-XX:JITServerMetricsPort=",           // = 58
+   "-XX:JITServerMetricsSSLKey=",         // = 59
+   "-XX:JITServerMetricsSSLCert=",        // = 60
+   "-XX:+JITServerShareROMClasses",       // = 61
+   "-XX:-JITServerShareROMClasses",       // = 62
+   "-XX:+JITServerAOTCachePersistence",   // = 63
+   "-XX:-JITServerAOTCachePersistence",   // = 64
+   "-XX:JITServerAOTCacheDir=",           // = 65
+   "-XX:JITServerAOTCacheName=",          // = 66
+   // TR_NumExternalOptions                  = 67
+   };
 
 //************************************************************************
 //

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1274,18 +1274,18 @@ static std::string readFileToString(char *fileName)
 
 static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compInfo)
    {
-   const char *xxJITServerPortOption = "-XX:JITServerPort=";
-   const char *xxJITServerTimeoutOption = "-XX:JITServerTimeout=";
-   const char *xxJITServerSSLKeyOption = "-XX:JITServerSSLKey=";
-   const char *xxJITServerSSLCertOption = "-XX:JITServerSSLCert=";
-   const char *xxJITServerSSLRootCertsOption = "-XX:JITServerSSLRootCerts=";
-   const char *xxJITServerUseAOTCacheOption = "-XX:+JITServerUseAOTCache";
-   const char *xxDisableJITServerUseAOTCacheOption = "-XX:-JITServerUseAOTCache";
-   const char *xxRequireJITServerOption = "-XX:+RequireJITServer";
-   const char *xxDisableRequireJITServerOption = "-XX:-RequireJITServer";
-   const char *xxJITServerLogConnections = "-XX:+JITServerLogConnections";
-   const char *xxDisableJITServerLogConnections = "-XX:-JITServerLogConnections";
-   const char *xxJITServerAOTmxOption = "-XX:JITServerAOTmx=";
+   const char *xxJITServerPortOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerPortOption];
+   const char *xxJITServerTimeoutOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerTimeoutOption];
+   const char *xxJITServerSSLKeyOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerSSLKeyOption];
+   const char *xxJITServerSSLCertOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerSSLCertOption];
+   const char *xxJITServerSSLRootCertsOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerSSLRootCertsOption];
+   const char *xxJITServerUseAOTCacheOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerUseAOTCacheOption];
+   const char *xxDisableJITServerUseAOTCacheOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerUseAOTCacheOption];
+   const char *xxRequireJITServerOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusRequireJITServerOption];
+   const char *xxDisableRequireJITServerOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusRequireJITServerOption];
+   const char *xxJITServerLogConnections = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerLogConnections];
+   const char *xxDisableJITServerLogConnections = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerLogConnections];
+   const char *xxJITServerAOTmxOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerAOTmxOption];
 
    int32_t xxJITServerPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerPortOption, 0);
    int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
@@ -1381,8 +1381,8 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
 
 static void JITServerParseLocalSyncCompiles(J9JavaVM *vm, TR::CompilationInfo *compInfo, bool isFSDEnabled)
    {
-   const char *xxJITServerLocalSyncCompilesOption = "-XX:+JITServerLocalSyncCompiles";
-   const char *xxDisableJITServerLocalSyncCompilesOption = "-XX:-JITServerLocalSyncCompiles";
+   const char *xxJITServerLocalSyncCompilesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerLocalSyncCompilesOption];
+   const char *xxDisableJITServerLocalSyncCompilesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerLocalSyncCompilesOption];
 
    int32_t xxJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLocalSyncCompilesOption, 0);
    int32_t xxDisableJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLocalSyncCompilesOption, 0);
@@ -1513,7 +1513,7 @@ void J9::Options::preProcessMode(J9JavaVM *vm, J9JITConfig *jitConfig)
          // The aggressivenessLevel can be set directly with -XaggressivenessLevel
          // This option is a second hand citizen option; if other options contradict it, this option is
          // ignored even if it appears later
-         char *aggressiveOption = "-XaggressivenessLevel";
+         char *aggressiveOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XaggressivenessLevel];
          int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, aggressiveOption, 0);
          if (argIndex >= 0)
             {
@@ -1531,7 +1531,7 @@ void J9::Options::preProcessMode(J9JavaVM *vm, J9JITConfig *jitConfig)
 void J9::Options::preProcessJniAccelerator(J9JavaVM *vm)
    {
    static bool doneWithJniAcc = false;
-   char *jniAccOption = "-XjniAcc:";
+   char *jniAccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XjniAcc];
    if (!doneWithJniAcc)
       {
       int32_t argIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, jniAccOption, 0);
@@ -1572,8 +1572,8 @@ void J9::Options::preProcessCodeCacheIncreaseTotalSize(J9JavaVM *vm, J9JITConfig
    if (!codecachetotalAlreadyParsed) // avoid processing twice for AOT and JIT and produce duplicate messages
       {
       codecachetotalAlreadyParsed = true;
-      char *xccOption  = "-Xcodecachetotal";
-      char *xxccOption = "-XX:codecachetotal=";
+      char *xccOption  = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecachetotal];
+      char *xxccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotal];
       int32_t codeCacheTotalArgIndex   = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, xccOption, 0);
       int32_t XXcodeCacheTotalArgIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, xxccOption, 0);
       int32_t argIndex = 0;
@@ -1633,8 +1633,8 @@ void J9::Options::preProcessCodeCacheIncreaseTotalSize(J9JavaVM *vm, J9JITConfig
 void J9::Options::preProcessCodeCachePrintCodeCache(J9JavaVM *vm)
    {
    // -XX:+PrintCodeCache will be parsed twice into both AOT and JIT options here.
-   const char *xxPrintCodeCacheOption = "-XX:+PrintCodeCache";
-   const char *xxDisablePrintCodeCacheOption = "-XX:-PrintCodeCache";
+   const char *xxPrintCodeCacheOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusPrintCodeCache];
+   const char *xxDisablePrintCodeCacheOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusPrintCodeCache];
    int32_t xxPrintCodeCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxPrintCodeCacheOption, 0);
    int32_t xxDisablePrintCodeCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisablePrintCodeCacheOption, 0);
 
@@ -1664,8 +1664,8 @@ bool J9::Options::preProcessCodeCacheXlpCodeCache(J9JavaVM *vm, J9JITConfig *jit
       UDATA requestedLargeCodePageFlags = J9PORT_VMEM_PAGE_FLAG_NOT_USED;
       UDATA largePageSize = 0;
       UDATA largePageFlags = 0;
-      int32_t xlpCodeCacheIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, "-Xlp:codecache:", NULL);
-      int32_t xlpIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, "-Xlp", NULL);
+      int32_t xlpCodeCacheIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xlpcodecache], NULL);
+      int32_t xlpIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xlp], NULL);
 
       // Parse -Xlp:codecache:pagesize=<size> as the right most option
       if (xlpCodeCacheIndex > xlpIndex)
@@ -1996,7 +1996,7 @@ bool J9::Options::preProcessCodeCache(J9JavaVM *vm, J9JITConfig *jitConfig)
    PORT_ACCESS_FROM_JAVAVM(vm);
    OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
-   char *ccOption = "-Xcodecache";
+   char *ccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecache];
    int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, ccOption, 0);
    if (argIndex >= 0)
       {
@@ -2020,7 +2020,7 @@ bool J9::Options::preProcessCodeCache(J9JavaVM *vm, J9JITConfig *jitConfig)
 
 void J9::Options::preProcessSamplingExpirationTime(J9JavaVM *vm)
    {
-   char *samplingOption = "-XsamplingExpirationTime";
+   char *samplingOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XsamplingExpirationTime];
    int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, samplingOption, 0);
    if (argIndex >= 0)
       {
@@ -2038,7 +2038,7 @@ void J9::Options::preProcessCompilationThreads(J9JavaVM *vm, J9JITConfig *jitCon
       {
       notYetParsed = false;
       TR::CompilationInfo *compInfo = getCompilationInfo(jitConfig);
-      char *compThreadsOption = "-XcompilationThreads";
+      char *compThreadsOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XcompilationThreads];
       int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, compThreadsOption, 0);
       if (argIndex >= 0)
          {
@@ -2070,8 +2070,8 @@ void J9::Options::preProcessTLHPrefetch(J9JavaVM *vm)
    self()->setOption(TR_DisableTM);
 #endif
 
-   IDATA notlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XnotlhPrefetch", 0);
-   IDATA tlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XtlhPrefetch", 0);
+   IDATA notlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XnotlhPrefetch], 0);
+   IDATA tlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XtlhPrefetch], 0);
    if (preferTLHPrefetch)
       {
       if (notlhPrefetch <= tlhPrefetch)
@@ -2134,7 +2134,7 @@ void J9::Options::preProcessDeterministicMode(J9JavaVM *vm)
    // Process the deterministic mode
    if (TR::Options::_deterministicMode == -1) // not yet set
       {
-      char *deterministicOption = "-XX:deterministic=";
+      char *deterministicOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXdeterministic];
       const UDATA MAX_DETERMINISTIC_MODE = 9; // only levels 0-9 are allowed
       int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, deterministicOption, 0);
       if (argIndex >= 0)
@@ -2169,14 +2169,14 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          compInfo->getPersistentInfo()->setSocketTimeout(DEFAULT_JITSERVER_TIMEOUT);
 
          // Check if we should open the port for the MetricsServer
-         const char *xxEnableMetricsServer  = "-XX:+JITServerMetrics";
-         const char *xxDisableMetricsServer = "-XX:-JITServerMetrics";
+         const char *xxEnableMetricsServer  = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusMetricsServer];
+         const char *xxDisableMetricsServer = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusMetricsServer];
          int32_t xxEnableMetricsServerArgIndex  = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxEnableMetricsServer, 0);
          int32_t xxDisableMetricsServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableMetricsServer, 0);
          if (xxEnableMetricsServerArgIndex > xxDisableMetricsServerArgIndex)
             {
             // Default port is already set at 38500; see if the user wants to change that
-            const char *xxJITServerMetricsPortOption = "-XX:JITServerMetricsPort=";
+            const char *xxJITServerMetricsPortOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerMetricsPortOption];
             int32_t xxJITServerMetricsPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerMetricsPortOption, 0);
             if (xxJITServerMetricsPortArgIndex >= 0)
                {
@@ -2187,8 +2187,8 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                }
 
             // For optional metrics server encryption. Key and cert have to be set as a pair.
-            const char *xxJITServerMetricsSSLKeyOption = "-XX:JITServerMetricsSSLKey=";
-            const char *xxJITServerMetricsSSLCertOption = "-XX:JITServerMetricsSSLCert=";
+            const char *xxJITServerMetricsSSLKeyOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerMetricsSSLKeyOption];
+            const char *xxJITServerMetricsSSLCertOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerMetricsSSLCertOption];
             int32_t xxJITServerMetricsSSLKeyArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerMetricsSSLKeyOption, 0);
             int32_t xxJITServerMetricsSSLCertArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerMetricsSSLCertOption, 0);
 
@@ -2219,8 +2219,8 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             }
 
          // Check if cached ROM classes should be shared between clients
-         const char *xxJITServerShareROMClassesOption = "-XX:+JITServerShareROMClasses";
-         const char *xxDisableJITServerShareROMClassesOption = "-XX:-JITServerShareROMClasses";
+         const char *xxJITServerShareROMClassesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerShareROMClassesOption];
+         const char *xxDisableJITServerShareROMClassesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerShareROMClassesOption];
 
          int32_t xxJITServerShareROMClassesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerShareROMClassesOption, 0);
          int32_t xxDisableJITServerShareROMClassesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerShareROMClassesOption, 0);
@@ -2234,8 +2234,8 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             }
 
          // Check if the JITServer AOT cache persistence feature is enabled
-         const char *xxJITServerAOTCachePersistenceOption = "-XX:+JITServerAOTCachePersistence";
-         const char *xxDisableJITServerAOTCachePersistenceOption = "-XX:-JITServerAOTCachePersistence";
+         const char *xxJITServerAOTCachePersistenceOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerAOTCachePersistenceOption];
+         const char *xxDisableJITServerAOTCachePersistenceOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerAOTCachePersistenceOption];
          int32_t xxJITServerAOTCachePersistenceArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerAOTCachePersistenceOption, 0);
          int32_t xxDisableJITServerAOTCachePersistenceArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerAOTCachePersistenceOption, 0);
          if (xxJITServerAOTCachePersistenceArgIndex > xxDisableJITServerAOTCachePersistenceArgIndex)
@@ -2243,7 +2243,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             compInfo->getPersistentInfo()->setJITServerUseAOTCachePersistence(true);
 
             // If enabled, get the name of the directory where the AOT cache files will be stored
-            const char *xxJITServerAOTCacheDirOption = "-XX:JITServerAOTCacheDir=";
+            const char *xxJITServerAOTCacheDirOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerAOTCacheDirOption];
             int32_t xxJITServerAOTCacheDirArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTCacheDirOption, 0);
             if (xxJITServerAOTCacheDirArgIndex >= 0)
                {
@@ -2257,8 +2257,8 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          {
          // Check option -XX:+UseJITServer
          // -XX:-UseJITServer disables JITServer at the client
-         const char *xxUseJITServerOption = "-XX:+UseJITServer";
-         const char *xxDisableUseJITServerOption = "-XX:-UseJITServer";
+         const char *xxUseJITServerOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusUseJITServerOption];
+         const char *xxDisableUseJITServerOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusUseJITServerOption];
 
          int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxUseJITServerOption, 0);
          int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableUseJITServerOption, 0);
@@ -2287,8 +2287,8 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             compInfo->getPersistentInfo()->setSocketTimeout(DEFAULT_JITCLIENT_TIMEOUT);
 
             // Check if the technology preview message should be displayed.
-            const char *xxJITServerTechPreviewMessageOption = "-XX:+JITServerTechPreviewMessage";
-            const char *xxDisableJITServerTechPreviewMessageOption = "-XX:-JITServerTechPreviewMessage";
+            const char *xxJITServerTechPreviewMessageOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerTechPreviewMessageOption];
+            const char *xxDisableJITServerTechPreviewMessageOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerTechPreviewMessageOption];
 
             int32_t xxJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerTechPreviewMessageOption, 0);
             int32_t xxDisableJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerTechPreviewMessageOption, 0);
@@ -2298,7 +2298,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                j9tty_printf(PORTLIB, "JITServer is currently a technology preview. Its use is not yet supported\n");
                }
 
-            const char *xxJITServerAddressOption = "-XX:JITServerAddress=";
+            const char *xxJITServerAddressOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerAddressOption];
             int32_t xxJITServerAddressArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAddressOption, 0);
 
             if (xxJITServerAddressArgIndex >= 0)
@@ -2308,7 +2308,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                compInfo->getPersistentInfo()->setJITServerAddress(address);
                }
 
-            const char *xxJITServerAOTCacheNameOption = "-XX:JITServerAOTCacheName=";
+            const char *xxJITServerAOTCacheNameOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerAOTCacheNameOption];
             int32_t xxJITServerAOTCacheNameArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTCacheNameOption, 0);
 
             if (xxJITServerAOTCacheNameArgIndex >= 0)
@@ -2403,7 +2403,7 @@ J9::Options::fePreProcess(void * base)
       bool forceSuffixLogs = true;
    #endif
 
-   const char *xxLateSCCDisclaimTimeOption = "-XX:LateSCCDisclaimTime=";
+   const char *xxLateSCCDisclaimTimeOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXLateSCCDisclaimTimeOption];
    int32_t xxLateSCCDisclaimTime = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxLateSCCDisclaimTimeOption, 0);
    if (xxLateSCCDisclaimTime >= 0)
       {
@@ -2456,7 +2456,7 @@ J9::Options::fePreProcess(void * base)
 
    self()->preProcessMmf(vm, jitConfig);
 
-   if (FIND_ARG_IN_VMARGS(EXACT_MATCH, "-Xnoclassgc", 0) >= 0)
+   if (FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xnoclassgc], 0) >= 0)
       self()->setOption(TR_NoClassGC);
 
    self()->preProcessMode(vm, jitConfig);

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,82 @@ namespace TR { class CompilationInfoPerThreadBase; }
 
 namespace J9
 {
+/**
+ * This enum and the associated string array _externalOptionStrings
+ * in J9Options.cpp should be kept in sync.
+ */
+enum ExternalOptions
+   {
+   TR_FirstExternalOption                      = 0,
+   Xnodfpbd                                    = 0,
+   Xdfpbd                                      = 1,
+   Xhysteresis                                 = 2,
+   Xnoquickstart                               = 3,
+   Xquickstart                                 = 4,
+   Xtuneelastic                                = 5,
+   XtlhPrefetch                                = 6,
+   XnotlhPrefetch                              = 7,
+   Xlockword                                   = 8,
+   XlockReservation                            = 9,
+   XjniAcc                                     = 10,
+   Xlp                                         = 11,
+   Xlpcodecache                                = 12,
+   Xcodecache                                  = 13,
+   Xcodecachetotal                             = 14,
+   XXcodecachetotal                            = 15,
+   XXplusPrintCodeCache                        = 16,
+   XXminusPrintCodeCache                       = 17,
+   XsamplingExpirationTime                     = 18,
+   XcompilationThreads                         = 19,
+   XaggressivenessLevel                        = 20,
+   Xnoclassgc                                  = 21,
+   Xjit                                        = 22,
+   Xnojit                                      = 23,
+   Xjitcolon                                   = 24,
+   Xaot                                        = 25,
+   Xnoaot                                      = 26,
+   Xaotcolon                                   = 27,
+   XXdeterministic                             = 28,
+   XXplusRuntimeInstrumentation                = 29,
+   XXminusRuntimeInstrumentation               = 30,
+   XXplusPerfTool                              = 31,
+   XXminusPerfTool                             = 32,
+   XXdoNotProcessJitEnvVars                    = 33,
+   XXplusMergeCompilerOptions                  = 34,
+   XXminusMergeCompilerOptions                 = 35,
+   XXLateSCCDisclaimTimeOption                 = 36,
+   XXplusUseJITServerOption                    = 37,
+   XXminusUseJITServerOption                   = 38,
+   XXplusJITServerTechPreviewMessageOption     = 39,
+   XXminusJITServerTechPreviewMessageOption    = 40,
+   XXJITServerAddressOption                    = 41,
+   XXJITServerPortOption                       = 42,
+   XXJITServerTimeoutOption                    = 43,
+   XXJITServerSSLKeyOption                     = 44,
+   XXJITServerSSLCertOption                    = 45,
+   XXJITServerSSLRootCertsOption               = 46,
+   XXplusJITServerUseAOTCacheOption            = 47,
+   XXminusJITServerUseAOTCacheOption           = 48,
+   XXplusRequireJITServerOption                = 49,
+   XXminusRequireJITServerOption               = 50,
+   XXplusJITServerLogConnections               = 51,
+   XXminusJITServerLogConnections              = 52,
+   XXJITServerAOTmxOption                      = 53,
+   XXplusJITServerLocalSyncCompilesOption      = 54,
+   XXminusJITServerLocalSyncCompilesOption     = 55,
+   XXplusMetricsServer                         = 56,
+   XXminusMetricsServer                        = 57,
+   XXJITServerMetricsPortOption                = 58,
+   XXJITServerMetricsSSLKeyOption              = 59,
+   XXJITServerMetricsSSLCertOption             = 60,
+   XXplusJITServerShareROMClassesOption        = 61,
+   XXminusJITServerShareROMClassesOption       = 62,
+   XXplusJITServerAOTCachePersistenceOption    = 63,
+   XXminusJITServerAOTCachePersistenceOption   = 64,
+   XXJITServerAOTCacheDirOption                = 65,
+   XXJITServerAOTCacheNameOption               = 66,
+   TR_NumExternalOptions                       = 67
+   };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    {
@@ -341,6 +417,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _jProfilingEnablementSampleThreshold;
 
    static bool _aggressiveLockReservation;
+
+   static char * _externalOptionStrings[ExternalOptions::TR_NumExternalOptions];
 
    static void  printPID();
 

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1531,6 +1531,13 @@ createMethodMetaData(
    if (comp->isDeserializedAOTMethod())
       {
       data->flags |= JIT_METADATA_IS_DESERIALIZED_COMP;
+      }
+#endif
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   if (comp->fej9()->inSnapshotMode())
+      {
+      data->flags |= JIT_METADATA_IS_PRECHECKPOINT_COMP;
       }
 #endif
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1103,7 +1103,7 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hdrInCa
 uint32_t
 TR_SharedCacheRelocationRuntime::getCurrentLockwordOptionHashValue(J9JavaVM *vm) const
    {
-   IDATA currentLockwordArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, "-Xlockword", NULL);
+   IDATA currentLockwordArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::Xlockword], NULL);
    uint32_t currentLockwordOptionHashValue = 0;
    if (currentLockwordArgIndex >= 0)
       {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -574,6 +574,7 @@ typedef struct J9JITExceptionTable {
 #define JIT_METADATA_NOT_INITIALIZED 0x8
 #define JIT_METADATA_IS_REMOTE_COMP 0x10
 #define JIT_METADATA_IS_DESERIALIZED_COMP 0x20
+#define JIT_METADATA_IS_PRECHECKPOINT_COMP 0x40
 
 typedef struct J9JIT16BitExceptionTableEntry {
 	U_16 startPC;


### PR DESCRIPTION
Options passed to the JVM are consumed by the JIT in different places and at different points during the bootstrap process. However, often the string literals that are used for the comparison are scattered across various locations. This is particularly problematic for something like the CRIU feature where we may need to process options post restore.

This PR gathers all the string literals and puts them in an array. The reason for doing this, rather than just have them be a bunch of `#define`s in a header file, is so that for the CRIU feature post restore options processing, we can just iterate over the array and explicitly decide what we want to do with the option.

This PR introduces a new enum class called `TR::ExternalOptions`, wherein each enum value has a 1-1 mapping with the string literal associated with the VM option consumed by the JIT.

This PR also introduces the `JIT_METADATA_IS_PRECHECKPOINT_COMP` flag that is set on the `J9JITExceptionTable` to indicate whether a compilation was performed pre-checkpoint.