### PR TITLE
Rewrite pthread_jit_write_protect_np()

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,10 +34,6 @@
 #include "ObjectAccessBarrierAPI.hpp"
 #include "MethodMetaData.h"
 #include "ut_j9codertvm.h"
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 #undef DEBUG
 
@@ -2241,9 +2237,7 @@ retry:
 		}
 		goto retry;
 	} else {
-#if defined(OSX) && defined(AARCH64)
-		pthread_jit_write_protect_np(0);
-#endif
+		omrthread_jit_write_protect_disable();
 		indexAndLiteralsEA[2] = (UDATA)interfaceClass;
 		UDATA methodIndex = methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
 		UDATA iTableOffset = 0;
@@ -2262,9 +2256,7 @@ retry:
 			iTableOffset = (methodIndex * sizeof(UDATA)) + sizeof(J9ITable);
 		}
 		indexAndLiteralsEA[3] = iTableOffset;
-#if defined(OSX) && defined(AARCH64)
-		pthread_jit_write_protect_np(1);
-#endif
+		omrthread_jit_write_protect_enable();
 		JIT_RETURN_UDATA(1);
 	}
 done:

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,10 +37,6 @@
 #include "pcstack.h"
 #include "VMHelpers.hpp"
 #include "OMR/Bytes.hpp"
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 extern "C" {
 
@@ -262,9 +258,7 @@ jitResetAllMethods(J9VMThread *currentThread)
 		J9Method *method = clazz->ramMethods;
 		U_32 methodCount = clazz->romClass->romMethodCount;
 
-#if defined(OSX) && defined(AARCH64)
-		pthread_jit_write_protect_np(0);
-#endif
+		omrthread_jit_write_protect_disable();
 
 		while (methodCount != 0) {
 			UDATA extra = (UDATA)method->extra;
@@ -286,9 +280,7 @@ jitResetAllMethods(J9VMThread *currentThread)
 			methodCount -= 1;
 		}
 
-#if defined(OSX) && defined(AARCH64)
-		pthread_jit_write_protect_np(1);
-#endif
+		omrthread_jit_write_protect_enable();
 
 		clazz = vmFuncs->allClassesNextDo(&state);
 	}

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,10 +34,6 @@
 #include "il/LabelSymbol.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-
-#if defined(OSX)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 static uint8_t *storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, TR::RealRegister *reg, int32_t offset, TR::CodeGenerator *cg)
    {
@@ -927,9 +923,7 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
                          cg->getDebug()->getName(dataType));
       }
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
 
    dispatcher = (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
@@ -965,9 +959,7 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
    arm64CodeSync(thunk, codeSize);
 #endif
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+   omrthread_jit_write_protect_enable();
 
    return returnValue;
    }
@@ -1007,9 +999,7 @@ TR_J2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNod
                   cg->getDebug()->getName(dataType));
       }
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
 
    dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
@@ -1042,9 +1032,7 @@ TR_J2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNod
    arm64CodeSync(thunk->entryPoint(), codeSize);
 #endif
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+   omrthread_jit_write_protect_enable();
 
    return thunk;
    }

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,10 +31,6 @@
 #include "env/j9method.h"
 #include "env/VMJ9.h"
 #include "env/VerboseLog.hpp"
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 static int32_t
 computeSignatureLength(char *signature)
@@ -68,15 +64,11 @@ TR_J2IThunk::allocate(
       {
       result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
       }
-#if defined(OSX) && defined(AARCH64)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
    result->_codeSize  = codeSize;
    result->_totalSize = totalSize;
    thunkTable->getTerseSignature(result->terseSignature(), terseSignatureBufLength, signature);
-#if defined(OSX) && defined(AARCH64)
-   pthread_jit_write_protect_np(1);
-#endif
+   omrthread_jit_write_protect_enable();
    return result;
    }
 

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,10 +54,6 @@
 #include "runtime/HookHelpers.hpp"
 #include "env/VerboseLog.hpp"
 #include "omrformatconsts.h"
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 OMR::CodeCacheMethodHeader *getCodeCacheMethodHeader(char *p, int searchLimit, J9JITExceptionTable * metaData);
 
@@ -334,25 +330,17 @@ J9::CodeCache::addFreeBlock(OMR::FaintCacheBlock *block)
    size_t endPtr = (size_t) warmBlock+warmBlock->_size;
    if (endPtr > realStartPC+sizeof(OMR::CodeCacheFreeCacheBlock))
       {
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(0);
-#endif
+      omrthread_jit_write_protect_disable();
       warmBlock->_size = realStartPC - (UDATA)warmBlock;
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(1);
-#endif
+      omrthread_jit_write_protect_enable();
       }
 
    if (self()->addFreeBlock2((uint8_t *) realStartPC, (uint8_t *)endPtr))
       {
       // Update the block size to reflect the remaining stub
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(0);
-#endif
+      omrthread_jit_write_protect_disable();
       warmBlock->_size = realStartPC - (UDATA)warmBlock;
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(1);
-#endif
+      omrthread_jit_write_protect_enable();
       }
    else
       {

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,10 +61,6 @@
 #include "control/CompilationThread.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 // TODO: move this someplace common for RuntimeAssumptions.cpp and here
 #if defined(__IBMCPP__) && !defined(AIXPPC) && !defined(LINUXPPC)
@@ -1040,13 +1036,9 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
             uint8_t *reloLocationHigh = reloOrigin + offsetHigh + 2; // Add 2 to skip the first 16 bits of instruction
             uint8_t *reloLocationLow = reloOrigin + offsetLow + 2; // Add 2 to skip the first 16 bits of instruction
             RELO_LOG(reloRuntime->reloLogger(), 6, "\treloLocation: from %p high %p low %p (offsetHigh %x offsetLow %x)\n", offsetPtr, reloLocationHigh, reloLocationLow, offsetHigh, offsetLow);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(0);
-#endif
+            omrthread_jit_write_protect_disable();
             TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(1);
-#endif
+            omrthread_jit_write_protect_enable();
             if (rc != TR_RelocationErrorCode::relocationOK)
                {
                RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
@@ -1065,13 +1057,9 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
             uint8_t *reloLocationHigh = reloOrigin + offsetHigh + 2; // Add 2 to skip the first 16 bits of instruction
             uint8_t *reloLocationLow = reloOrigin + offsetLow + 2; // Add 2 to skip the first 16 bits of instruction
             RELO_LOG(reloRuntime->reloLogger(), 6, "\treloLocation: from %p high %p low %p (offsetHigh %x offsetLow %x)\n", offsetPtr, reloLocationHigh, reloLocationLow, offsetHigh, offsetLow);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(0);
-#endif
+            omrthread_jit_write_protect_disable();
             TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocationHigh, reloLocationLow);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(1);
-#endif
+            omrthread_jit_write_protect_enable();
             if (rc != TR_RelocationErrorCode::relocationOK)
                {
                RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
@@ -1091,13 +1079,9 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
             int32_t offset = *offsetPtr;
             uint8_t *reloLocation = reloOrigin + offset;
             RELO_LOG(reloRuntime->reloLogger(), 6, "\treloLocation: from %p at %p (offset %x)\n", offsetPtr, reloLocation, offset);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(0);
-#endif
+            omrthread_jit_write_protect_disable();
             TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(1);
-#endif
+            omrthread_jit_write_protect_enable();
             if (rc != TR_RelocationErrorCode::relocationOK)
                {
                RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
@@ -1114,13 +1098,9 @@ TR_RelocationRecord::applyRelocationAtAllOffsets(TR_RelocationRuntime *reloRunti
             int16_t offset = *offsetPtr;
             uint8_t *reloLocation = reloOrigin + offset;
             RELO_LOG(reloRuntime->reloLogger(), 6, "\treloLocation: from %p at %p (offset %x)\n", offsetPtr, reloLocation, offset);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(0);
-#endif
+            omrthread_jit_write_protect_disable();
             TR_RelocationErrorCode rc = applyRelocation(reloRuntime, reloTarget, reloLocation);
-#if defined(OSX) && defined(AARCH64)
-            pthread_jit_write_protect_np(1);
-#endif
+            omrthread_jit_write_protect_enable();
             if (rc != TR_RelocationErrorCode::relocationOK)
                {
                RELO_LOG(reloRuntime->reloLogger(), 6, "\tapplyRelocationAtAllOffsets: rc = %s\n", reloRuntime->getReloErrorCodeName(rc));
@@ -2366,9 +2346,7 @@ static TR_RelocationErrorCode relocateAndRegisterThunk(
       // the old cache (which is not switched) will fail
       U_8 *thunkStart = TR::CodeCacheManager::instance()->allocateCodeMemory(firstDescriptor.length, 0, &codeCache, &coldCode, true);
       U_8 *thunkAddress;
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(0);
-#endif
+      omrthread_jit_write_protect_disable();
       if (thunkStart)
          {
          // Relocate the thunk

--- a/runtime/jcl/common/jdk_internal_foreign_abi_UpcallStubs.cpp
+++ b/runtime/jcl/common/jdk_internal_foreign_abi_UpcallStubs.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,10 +30,6 @@
 extern "C" {
 
 #if JAVA_SPEC_VERSION >= 16
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> /* for pthread_jit_write_protect_np */
-#endif
 
 /**
  * A memory segment is associated with a native scope/session owned by a thread, in which case
@@ -90,13 +86,9 @@ Java_jdk_internal_foreign_abi_UpcallStubs_freeUpcallStub0(JNIEnv *env, jclass cl
 				hashTableRemove(metaDataHashTable, result);
 
 				if (NULL != thunkHeap) {
-#if defined(OSX) && defined(AARCH64)
-					pthread_jit_write_protect_np(0);
-#endif /* defined(OSX) && defined(AARCH64) */
+					omrthread_jit_write_protect_disable();
 					j9heap_free(thunkHeap, thunkAddr);
-#if defined(OSX) && defined(AARCH64)
-					pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+					omrthread_jit_write_protect_enable();
 				}
 			}
 		}

--- a/runtime/vm/UpcallThunkMem.cpp
+++ b/runtime/vm/UpcallThunkMem.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,10 +28,6 @@
 extern "C" {
 
 #if JAVA_SPEC_VERSION >= 16
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 static void * subAllocateThunkFromHeap(J9UpcallMetaData *data);
 static J9UpcallThunkHeapList * allocateThunkHeap(J9UpcallMetaData *data);
@@ -105,9 +101,7 @@ retry:
 	}
 	thunkHeapNode = thunkHeapHead;
 
-#if defined(OSX) && defined(AARCH64)
-	pthread_jit_write_protect_np(0);
-#endif /* defined(OSX) && defined(AARCH64) */
+	omrthread_jit_write_protect_disable();
 	while (!succeeded) {
 		J9UpcallThunkHeapWrapper *thunkHeapWrapper = thunkHeapNode->thunkHeapWrapper;
 		J9Heap *thunkHeap = thunkHeapWrapper->heap;
@@ -147,17 +141,13 @@ retry:
 				thunkHeapNode = thunkHeapNode->next;
 			} else {
 				/* Attempt to allocate a new thunk heap given all thunk heaps are out of memory. */
-#if defined(OSX) && defined(AARCH64)
-				pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+				omrthread_jit_write_protect_enable();
 				goto retry;
 			}
 
 		}
 	}
-#if defined(OSX) && defined(AARCH64)
-	pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+	omrthread_jit_write_protect_enable();
 
 done:
 
@@ -212,9 +202,7 @@ allocateThunkHeap(J9UpcallMetaData *data)
 		goto freeAllMemoryThenExit;
 	}
 
-#if defined(OSX) && defined(AARCH64)
-	pthread_jit_write_protect_np(0);
-#endif /* defined(OSX) && defined(AARCH64) */
+	omrthread_jit_write_protect_disable();
 
 	/* Initialize the allocated memory as a J9Heap */
 	thunkHeap = j9heap_create(allocMemPtr, pageSize, 0);
@@ -250,9 +238,7 @@ allocateThunkHeap(J9UpcallMetaData *data)
 		vm->thunkHeapHead = thunkHeapNode;
 	}
 
-#if defined(OSX) && defined(AARCH64)
-	pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+	omrthread_jit_write_protect_enable();
 
 done:
 	Trc_VM_allocateThunkHeap_Exit(thunkHeap);
@@ -271,9 +257,7 @@ freeAllMemoryThenExit:
 		thunkHeapWrapper = NULL;
 	}
 	if (NULL != allocMemPtr) {
-#if defined(OSX) && defined(AARCH64)
-		pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+		omrthread_jit_write_protect_enable();
 		j9vmem_free_memory(allocMemPtr, pageSize, &vmemID);
 		allocMemPtr = NULL;
 	}

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -43,9 +43,6 @@
 #include "util_api.h"
 #if JAVA_SPEC_VERSION >= 16
 #include "vm_internal.h"
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> /* for pthread_jit_write_protect_np */
-#endif
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if !defined(stdout)
@@ -8430,13 +8427,9 @@ freeUpcallMetaDataDoFn(J9UpcallMetaDataEntry *entry, void *userData)
 		metaData = NULL;
 
 		if (NULL != thunkHeap) {
-#if defined(OSX) && defined(AARCH64)
-			pthread_jit_write_protect_np(0);
-#endif /* defined(OSX) && defined(AARCH64) */
+			omrthread_jit_write_protect_disable();
 			j9heap_free(thunkHeap, thunkAddr);
-#if defined(OSX) && defined(AARCH64)
-			pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(AARCH64) */
+			omrthread_jit_write_protect_enable();
 		}
 		entry->thunkAddrValue = 0;
 	}

--- a/runtime/vm/xr64/UpcallThunkGen.cpp
+++ b/runtime/vm/xr64/UpcallThunkGen.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,10 +30,6 @@
  * Given an upcallMetaData, an upcall thunk/adaptor will be generated;
  * Given an upcallSignature, argListPtr, and argIndex, a pointer to that specific arg will be returned
  */
-
-#if defined(OSX)
-#include <pthread.h> /* for pthread_jit_write_protect_np */
-#endif /* defined(OSX) */
 
 extern "C" {
 
@@ -416,9 +412,7 @@ createUpcallThunk(J9UpcallMetaData *metaData)
 	const I_32 LR_OFFSET = 8; /* offset for saving the return address */
 	const I_32 HIDDEN_PARAM_OFFSET = 16; /* offset for saving the hidden param */
 
-#if defined(OSX)
-	pthread_jit_write_protect_np(0); /* Start writing instructions to memory */
-#endif /* defined(OSX) */
+	omrthread_jit_write_protect_disable();
 
 	thunkMem[instrIdx++] = SUB(C_SP, C_SP, frameSize);
 	thunkMem[instrIdx++] = STR(LR, C_SP, LR_OFFSET);
@@ -613,9 +607,7 @@ createUpcallThunk(J9UpcallMetaData *metaData)
 
 	Assert_VM_true(instrIdx == instrCount);
 
-#if defined(OSX)
-	pthread_jit_write_protect_np(1); /* Stop writing instructions to memory */
-#endif /* defined(OSX) */
+	omrthread_jit_write_protect_enable();
 
 	/* Finish up before returning */
 	vmFuncs->doneUpcallThunkGeneration(metaData, (void *)(metaData->thunkAddress));


### PR DESCRIPTION
This commit rewrites API calls to `pthread_jit_write_protect_np()` for AArch64 macOS by `omrthread_jit_write_protect_disable/enable()` introduced by https://github.com/eclipse/omr/pull/6857.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>