### PR TITLE
Don't run jdk11 xlinux testing on cent6

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -313,6 +313,7 @@ x86-64_linux:
       # use default gcc for 8, 11 (v7.5)
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
   extra_test_labels:
+    11: '!sw.os.cent.6'
     17: '!sw.os.cent.6'
     19: '!sw.os.cent.6'
     20: '!sw.os.cent.6'


### PR DESCRIPTION
CRIU testing does not run on cent6. We can still
run jdk8 on cent6 since there is no CRIU support
for 8 for the foreseeable future.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>