### PR TITLE
Look for interface call targets using the known non-null interface

### DIFF
--- a/runtime/compiler/optimizer/J9CallGraph.hpp
+++ b/runtime/compiler/optimizer/J9CallGraph.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,7 @@ class TR_J9InterfaceCallSite : public TR_ProfileableCallSite
    public:
       TR_CALLSITE_TR_ALLOC_AND_INHERIT_EMPTY_CONSTRUCTOR(TR_J9InterfaceCallSite, TR_ProfileableCallSite)
       virtual bool findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner);
-      bool findCallSiteTargetImpl (TR_CallStack *callStack, TR_InlinerBase* inliner);
+      bool findCallSiteTargetImpl (TR_CallStack *callStack, TR_InlinerBase *inliner, TR_OpaqueClassBlock *iface);
       virtual TR_OpaqueClassBlock* getClassFromMethod ();
 		virtual const char*  name () { return "TR_J9InterfaceCallSite"; }
    protected:


### PR DESCRIPTION
In f544293aaa4c38ef `findCallSiteTarget()` was updated to ensure that the interface is found before attempting `findCallSiteTargetImpl()`. This is necessary because `getClassFromMethod()` can return null in AOT. However, the resulting interface was used only for assertions that run after successfully finding a target, and `findCallSiteTargetImpl()` would repeat `getClassFromMethod()` to find the interface again, creating a second opportunity to fail and get null in AOT.

With this commit, the interface obtained by `findCallSiteTarget()` is now reused when actually selecting a target, since it's known to be non-null by the time we reach `findCallSiteTargetImpl()`.

Fixes #16400 (again)