### PR TITLE
Restore options file and vm support

### DIFF
--- a/runtime/criusupport/CMakeLists.txt
+++ b/runtime/criusupport/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021, 2022 IBM Corp. and others
+# Copyright (c) 2021, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,8 @@ target_link_libraries(j9criu
 		j9util
 		j9thr
 		dl
+		j9utilcore
+		j9pool
 )
 
 include(exports.cmake)

--- a/runtime/criusupport/criusupport.hpp
+++ b/runtime/criusupport/criusupport.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 extern "C" {
 
 void JNICALL
-Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory, jboolean unprivileged);
+Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory, jboolean unprivileged, jstring optionsFile);
 
 } /* extern "C" */
 

--- a/runtime/criusupport/module.xml
+++ b/runtime/criusupport/module.xml
@@ -59,6 +59,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux.*"/>
 			</library>
 			<library name="j9thr"/>
+			<library name="j9util"/>
+			<library name="j9utilcore"/>
+			<library name="j9pool" type="external"/>
 		</libraries>
 	</artifact>
 

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2022 IBM Corp. and others
+# Copyright (c) 2000, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -571,4 +571,12 @@ J9NLS_JCL_CRIU_LOADING_LIBCRIU_FUNCTIONS_FAILED.sample_input_1=1
 J9NLS_JCL_CRIU_LOADING_LIBCRIU_FUNCTIONS_FAILED.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_JCL_CRIU_LOADING_LIBCRIU_FUNCTIONS_FAILED.system_action=The JVM will throw a SystemCheckpointException.
 J9NLS_JCL_CRIU_LOADING_LIBCRIU_FUNCTIONS_FAILED.user_response=Check your installation of criu with `criu check`.
+# END NON-TRANSLATABLE
+
+J9NLS_JCL_CRIU_LOADING_OPTIONS_FILE_FAILED=The JVM could not load the options file
+# START NON-TRANSLATABLE
+J9NLS_JCL_CRIU_LOADING_OPTIONS_FILE_FAILED.sample_input_1=1
+J9NLS_JCL_CRIU_LOADING_OPTIONS_FILE_FAILED.explanation=CRIUSupport::checkpointJVM failed.
+J9NLS_JCL_CRIU_LOADING_OPTIONS_FILE_FAILED.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_JCL_CRIU_LOADING_OPTIONS_FILE_FAILED.user_response=Check the arguments to CRIUSupport::registerRestoreOptionsFile.
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -892,6 +892,7 @@ typedef struct J9VMInitArgs {
 	JavaVMInitArgs* actualVMArgs;
 	struct J9CmdLineOption* j9Options;
 	UDATA nOptions;
+	struct J9VMInitArgs *previousArgs;
 } J9VMInitArgs;
 
 /* @ddr_namespace: map_to_type=J9IdentityHashData */
@@ -4147,6 +4148,7 @@ typedef struct J9CRIUCheckpointState {
 	int (*criuInitOptsFunctionPointerType)(void);
 	int (*criuDumpFunctionPointerType)(void);
 	UDATA libCRIUHandle;
+	struct J9VMInitArgs *restoreArgsList;
 } J9CRIUCheckpointState;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4050,7 +4050,6 @@ setSystemPropertyValue(J9JavaVM * vm, J9VMSystemProperty * property, char * newV
  */
 UDATA
 addSystemProperty(J9JavaVM * vm, const char* propName,  const char* propValue, UDATA flags);
-
 /* ---------------- vmruntimestate.c ---------------- */
 
 /**

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -964,6 +964,8 @@ freeJavaVM(J9JavaVM * vm)
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	{
 		J9Pool *hookRecords = vm->checkpointState.hookRecords;
+		J9VMInitArgs *restoreArgsList = vm->checkpointState.restoreArgsList;
+
 		if (NULL != hookRecords) {
 			pool_kill(hookRecords);
 			vm->checkpointState.hookRecords = NULL;
@@ -974,6 +976,12 @@ freeJavaVM(J9JavaVM * vm)
 		if (NULL != vm->delayedLockingOperationsMutex) {
 			omrthread_monitor_destroy(vm->delayedLockingOperationsMutex);
 			vm->delayedLockingOperationsMutex = NULL;
+		}
+
+		while (NULL != restoreArgsList) {
+			J9VMInitArgs *previousArgs = restoreArgsList->previousArgs;
+			destroyJvmInitArgs(vm->portLibrary, restoreArgsList);
+			restoreArgsList = previousArgs;
 		}
 	}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2022, 2022 IBM Corp. and others
+  Copyright (c) 2022, 2023 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@
   <variable name="MAINCLASS_SINGLETHREADMODE_RESTORE" value="org.openj9.criu.TestSingleThreadModeRestoreException" />
   <variable name="MAINCLASS_DEADLOCK_TEST" value="org.openj9.criu.DeadlockTest" />
   <variable name="MAINCLASS_DELAYEDOPERATIONS" value="org.openj9.criu.TestDelayedOperations" />
+  <variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
@@ -265,12 +266,57 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
   </test>
-
-  <test id="Create and Restore Criu Checkpoint Image once with javacore generation">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:trigger=tpnid{j9criu.7-8,javadump},print={j9criu.12}" $MAINCLASS_SIMPLE$ 1 1 false</command>
+  <test id="Properties test1">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest1 1</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Properties test2">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest2 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Properties test3">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest3 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Properties test4">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest4 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Failed to load options from the options file</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.openj9.criu.*;
+
+public class OptionsFileTest {
+	public static void main(String[] args) {
+		String test = args[0];
+
+		switch (test) {
+		case "PropertiesTest1":
+			propertiesTest1();
+			break;
+		case "PropertiesTest2":
+			propertiesTest2();
+			break;
+		case "PropertiesTest3":
+			propertiesTest3();
+			break;
+		case "PropertiesTest4":
+			propertiesTest4();
+			break;
+		default:
+			throw new RuntimeException("incorrect parameters");
+		}
+
+	}
+
+	static void propertiesTest1() {
+		String optionsContents = "-Dprop1=val1\n-Dprop2=val2\n-Dprop3=val3";
+		Path optionsFilePath = createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+
+		if (!System.getProperty("prop1").equalsIgnoreCase("val1")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop2").equalsIgnoreCase("val2")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop3").equalsIgnoreCase("val3")) {
+			System.out.println("ERR: failed properties test");
+		}
+	}
+
+	static void propertiesTest2() {
+		String optionsContents = "-Dprop1=valA\n-Dprop2=valB\n-Dprop3=valC";
+		Path optionsFilePath = createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.setProperty("prop1", "val1");
+		System.setProperty("prop2", "val2");
+		System.setProperty("prop3", "val3");
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+
+		if (!System.getProperty("prop1").equalsIgnoreCase("valA")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop2").equalsIgnoreCase("valB")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop3").equalsIgnoreCase("valC")) {
+			System.out.println("ERR: failed properties test");
+		}
+	}
+
+	static void propertiesTest3() {
+		String optionsContents = "-Dprop1=val1\n-Dprop2=\\\nval2\n-Dprop3=v \\ \n a \\     \n  l3";
+		Path optionsFilePath = createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+
+		if (!System.getProperty("prop1").equalsIgnoreCase("val1")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop2").equalsIgnoreCase("val2")) {
+			System.out.println("ERR: failed properties test");
+		}
+
+		if (!System.getProperty("prop3").equalsIgnoreCase("val3")) {
+			System.out.println("ERR: failed properties test");
+		}
+	}
+
+	static void propertiesTest4() {
+		String optionsContents = "-Dprop1=val1\n-Dprop2=\\\nval2\n-Dprop3=v \\ \n a \\     \n  l3 \\";
+		Path optionsFilePath = createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+
+		//shouldnt get here
+		System.out.println("ERR: failed properties test");
+	}
+
+	static Path createOptionsFile(String name, String contents) {
+		try {
+			File options = new File(name);
+			if (!options.createNewFile()) {
+				System.out.println("WARN: File already exists but should not");
+			}
+
+			try (FileWriter writer = new FileWriter(options)) {
+				writer.write(contents);
+			}
+			options.deleteOnExit();
+			return options.toPath();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Restore options file and vm support

Introduce options file to provide the ability to supply cmdline options on restore. Initially only properties will be supported. Further support for JVM options will be added later.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>