### PR TITLE
AArch64: Enable fast_jitCheckAssignable

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -210,6 +210,13 @@ bool
 J9::ARM64::CodeGenerator::supportsInliningOfIsInstance()
    {
    return !self()->comp()->getOption(TR_DisableInlineIsInstance);
+   }
+
+bool
+J9::ARM64::CodeGenerator::supportsInliningOfIsAssignableFrom()
+   {
+   static const bool disableInliningOfIsAssignableFrom = feGetEnv("TR_disableInlineIsAssignableFrom") != NULL;
+   return !disableInliningOfIsAssignableFrom;
    }
 
 bool

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,6 +105,12 @@ public:
     * @return true if isInstance inline fast helper is supported
     */
    bool supportsInliningOfIsInstance();
+
+   /**
+    * @brief Answers whether isAssignableFrom inline fast helper is supported
+    * @return true if AssignableFrom inline fast helper is supported
+    */
+   bool supportsInliningOfIsAssignableFrom();
 
    /**
     * @brief Answers whether inlining of the specified recognized method should be suppressed

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1002,7 +1002,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 #else
    SET(TR_instanceOf,                 (void *)jitInstanceOf,             TR_Helper);
 #endif
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || (defined(TR_HOST_S390) && defined(J9VM_JIT_NEW_DUAL_HELPERS))
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || (defined(TR_HOST_S390) && defined(J9VM_JIT_NEW_DUAL_HELPERS)) || defined(TR_HOST_ARM64)
    SET(TR_checkAssignable,            (void *)fast_jitCheckAssignable,   TR_CHelper);
 #endif
    SET(TR_induceOSRAtCurrentPC,       (void *)jitInduceOSRAtCurrentPC,   TR_Helper);


### PR DESCRIPTION
This commit enables fast_jitCheckAssignable helper on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>