### PR TITLE
CRIU: correct type of pool elements in instanceObjects

### DIFF
--- a/runtime/criusupport/module.xml
+++ b/runtime/criusupport/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2021, 2022 IBM Corp. and others
+Copyright (c) 2021, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<include path="j9oti"/>
 			<include path="j9util"/>
 			<include path="j9gcinclude"/>
+			<include path="$(OMR_DIR)/gc/include" type="relativepath"/>
 		</includes>
 
 		<makefilestubs>


### PR DESCRIPTION
The `clazz` field of a `J9Object` isn't generally wide enough to properly capture an object pointer: use `j9object_t` instead. This issue was highlighted by a couple of cast errors in builds configured using `--with-mixedrefs=no`:
```
CRIUHelpers.cpp:195:52: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
CRIUHelpers.cpp:334:44: error: cast from 'j9object_t {aka J9Object*}' to 'j9objectclass_t {aka unsigned int}' loses precision [-fpermissive]
```

Also add missing include directory required in UMA builds.