### PR TITLE
Fix ContinuationObjectList ScavengerBackOut issue

### DIFF
--- a/runtime/gc_glue_java/ScavengerBackOutScanner.cpp
+++ b/runtime/gc_glue_java/ScavengerBackOutScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corp. and others
+ * Copyright (c) 2015, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,9 @@
 #include "ObjectAccessBarrier.hpp"
 #include "ReferenceObjectBuffer.hpp"
 #include "UnfinalizedObjectBuffer.hpp"
+#include "ContinuationObjectBuffer.hpp"
 #include "ContinuationObjectList.hpp"
+
 #include "ScavengerBackOutScanner.hpp"
 
 void
@@ -317,22 +319,85 @@ MM_ScavengerBackOutScanner::backoutUnfinalizedObjects(MM_EnvironmentStandard *en
 	env->getGCEnvironment()->_unfinalizedObjectBuffer->flush(env);
 }
 #endif /* J9VM_GC_FINALIZATION */
+
 void
 MM_ScavengerBackOutScanner::backoutContinuationObjects(MM_EnvironmentStandard *env)
 {
-	/* TODO: need to solution to handle the backout in case the list has been refreshed. (the related J9VMContinuations has been cleaned up)  */
-	if (!_extensions->isConcurrentScavengerEnabled()) {
-	/* Back out Continuation Processing */
-		MM_HeapRegionDescriptorStandard *region = NULL;
-		GC_HeapRegionIteratorStandard regionIterator(_extensions->heapRegionManager);
-		while (NULL != (region = regionIterator.nextRegion())) {
+	MM_Heap *heap = _extensions->heap;
+	MM_HeapRegionManager *regionManager = heap->getHeapRegionManager();
+	MM_HeapRegionDescriptorStandard *region = NULL;
+	bool const compressed = _extensions->compressObjectReferences();
+
+	GC_HeapRegionIteratorStandard regionIterator(regionManager);
+	while (NULL != (region = regionIterator.nextRegion())) {
+		MM_HeapRegionDescriptorStandardExtension *regionExtension = MM_ConfigurationDelegate::getHeapRegionDescriptorStandardExtension(env, region);
+		for (uintptr_t i = 0; i < regionExtension->_maxListIndex; i++) {
+			MM_ContinuationObjectList *list = &regionExtension->_continuationObjectLists[i];
+			list->startProcessing();
+		}
+	}
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		GC_HeapRegionIteratorStandard regionIterator2(regionManager);
+		while (NULL != (region = regionIterator2.nextRegion())) {
 			MM_HeapRegionDescriptorStandardExtension *regionExtension = MM_ConfigurationDelegate::getHeapRegionDescriptorStandardExtension(env, region);
 			for (uintptr_t i = 0; i < regionExtension->_maxListIndex; i++) {
 				MM_ContinuationObjectList *list = &regionExtension->_continuationObjectLists[i];
-				list->backoutList();
+				if (!list->wasEmpty()) {
+					omrobjectptr_t object = list->getPriorList();
+					while (NULL != object) {
+						MM_ForwardedHeader forwardHeader(object, compressed);
+						omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
+						if (NULL != forwardPtr) {
+							if (forwardHeader.isSelfForwardedPointer()) {
+								forwardHeader.restoreSelfForwardedPointer();
+							} else {
+								object = forwardPtr;
+							}
+						}
+
+						omrobjectptr_t next = _extensions->accessBarrier->getContinuationLink(object);
+						env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
+
+						object = next;
+					}
+				}
+			}
+		}
+	} else
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	{
+		GC_HeapRegionIteratorStandard regionIterator2(regionManager);
+		while (NULL != (region = regionIterator2.nextRegion())) {
+			MM_HeapRegionDescriptorStandardExtension *regionExtension = MM_ConfigurationDelegate::getHeapRegionDescriptorStandardExtension(env, region);
+			for (uintptr_t i = 0; i < regionExtension->_maxListIndex; i++) {
+				MM_ContinuationObjectList *list = &regionExtension->_continuationObjectLists[i];
+				if (!list->wasEmpty()) {
+					omrobjectptr_t object = list->getPriorList();
+					while (NULL != object) {
+						omrobjectptr_t next = NULL;
+						MM_ForwardedHeader forwardHeader(object, compressed);
+						Assert_MM_false(forwardHeader.isForwardedPointer());
+						if (forwardHeader.isReverseForwardedPointer()) {
+							omrobjectptr_t originalObject = forwardHeader.getReverseForwardedPointer();
+							Assert_MM_true(NULL != originalObject);
+							next = _extensions->accessBarrier->getContinuationLink(originalObject);
+							env->getGCEnvironment()->_continuationObjectBuffer->add(env, originalObject);
+						} else {
+							next = _extensions->accessBarrier->getContinuationLink(object);
+							env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
+						}
+
+						object = next;
+					}
+				}
 			}
 		}
 	}
+
+	/* restore everything to a flushed state before exiting */
+	env->getGCEnvironment()->_continuationObjectBuffer->flush(env);
 
 	/* Done backout */
 }


### PR DESCRIPTION
Fix backoutContinuationObjects missing to handle tenure region for ScavengerBackOut case.

fix: https://github.com/eclipse-openj9/openj9/issues/16538
Signed-off-by: Lin Hu <linhu@ca.ibm.com>