### PR TITLE
Override isCompilable for TR_ResolveRelocatableJ9Method

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1082,6 +1082,7 @@ public:
    bool importantMethodForStartup(J9Method *method);
    bool shouldDowngradeCompReq(TR_MethodToBeCompiled *entry);
 
+   bool isMethodIneligibleForAot(J9Method *method);
 
    int32_t computeDynamicDumbInlinerBytecodeSizeCutoff(TR::Options *options);
    TR_YesNoMaybe shouldActivateNewCompThread();
@@ -1533,4 +1534,3 @@ private:
 
 
 #endif // COMPILATIONRUNTIME_HPP
-

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -179,7 +179,6 @@ class CompilationInfoPerThreadBase
                               bool eligibleForRelocatableCompile,
                               TR_RelocationRuntime *reloRuntime);
    const void* findAotBodyInSCC(J9VMThread *vmThread, const J9ROMMethod *romMethod);
-   bool isMethodIneligibleForAot(J9Method *method);
 
 #if defined(J9VM_OPT_SHARED_CLASSES) && defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT)
    TR_MethodMetaData *installAotCachedMethod(

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1127,6 +1127,17 @@ bool
 TR_ResolvedRelocatableJ9Method::isInterpretedForHeuristics()
    {
    return TR_ResolvedJ9Method::isInterpreted();
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isCompilable(TR_Memory * trMemory)
+   {
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(fej9()->_jitConfig);
+
+   if (compInfo->isMethodIneligibleForAot(ramMethod()))
+      return false;
+
+   return TR_ResolvedJ9Method::isCompilable(trMemory);
    }
 
 void *

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -576,6 +576,13 @@ public:
    virtual bool                    hasBackwardBranches();
    virtual bool                    isObjectConstructor();
    virtual bool                    isNonEmptyObjectConstructor();
+
+   /**
+    * @brief Check if method is a compilable method
+    *
+    * @param[in] TR_Memory *
+    */
+   virtual bool                    isCompilable(TR_Memory *);
 
    virtual void *                  startAddressForJittedMethod();
    virtual void *                  startAddressForJNIMethod( TR::Compilation *);


### PR DESCRIPTION
TR_ResolvedRelocatableJ9Method::isCompilable should match what TR::CompilationInfoPerThreadBase::isMethodIneligibleForAot returns for a method. This override is necessary because methods in java/lang/invoke/* are marked ineligible from AOT compilations, and therefore isCompilable should also return false for these methods during AOT. This impacts what methods are considered for inlining.

Fixes: #16161, #14135

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>