### PR TITLE
[FFI]Disable the FFI test suites for JDK20

### DIFF
--- a/test/functional/Java19andUp/build.xml
+++ b/test/functional/Java19andUp/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2022, 2022 IBM Corp. and others
+Copyright (c) 2022, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,17 +49,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-			<src path="${src}" />
-			<src path="${TestUtilities}" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-			<classpath>
-				<pathelement location="${LIB_DIR}/testng.jar" />
-				<pathelement location="${LIB_DIR}/jcommander.jar" />
-				<pathelement location="${LIB_DIR}/asm.jar" />
-				<pathelement location="${build}" />
-			</classpath>
-		</javac>
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="19"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</then>
+		</if>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/Java19andUp/playlist.xml
+++ b/test/functional/Java19andUp/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2022, 2022 IBM Corp. and others
+  Copyright (c) 2022, 2023 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -81,7 +81,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -110,7 +110,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -139,7 +139,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 </playlist>


### PR DESCRIPTION
The change is to disable all FFI specific test suites in JEP424 for JDK20
as we need to prepare the new test suites for the updated APIs in
JEP434/JDK20.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>