### PR TITLE
Deprecate support for running JDK 8 and 11 on CentOS 6

### DIFF
--- a/doc/release-notes/0.36/0.36.md
+++ b/doc/release-notes/0.36/0.36.md
@@ -49,6 +49,13 @@ The following table covers notable changes in v0.36.0. Further information about
 <tbody>
 
 <tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16532">#16532</a></td>
+<td valign="top">Support for running OpenJDK 8 and OpenJDK 11 on CentOS 6.10 is deprecated and might be removed in a future release.</td>
+<td valign="top">OpenJDK 8 and 11 (CentOS 6.10)</td>
+<td valign="top">OpenJ9 will no longer test OpenJDK 11 on CentOS 6.10 after 0.36.0 release and might stop testing OpenJDK 8 in the future.</td>
+</tr>
+
+<tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16256">#16256</a></td>
 <td valign="top">The location of the default directory for the shared cache and snapshot is changed to the <tt>.cache/javasharedresources</tt> in the user's home directory.</td>
 <td valign="top">All versions (AIX&reg;, Linux&reg;, macOS&reg;)</td>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1037

Updated the release notes with the information related to deprecating of the support for running JDK 8 and 11 on CentOS 6.10

[skip ci]

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>