### PR TITLE
[Test/FFI] Change the alignment of long in JDK17

### DIFF
--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithMixedSigStruTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithMixedSigStruTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -859,12 +859,12 @@ public class UpcallMHWithMixedSigStruTests {
 
 	@Test
 	public void test_addDoubleAndIntDoubleLongFromStructByUpcallMH() throws Throwable {
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 16 bytes without padding by default
+		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
 		 * while the same struct is 24 bytes with padding on other platforms.
 		 */
-		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_INT.withName("elem1"),
-				C_DOUBLE.withName("elem2"), longLayout.withName("elem3")) : MemoryLayout.structLayout(C_INT.withName("elem1"),
-						MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"), longLayout.withName("elem3"));
+		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_INT.withName("elem1"), C_DOUBLE.withName("elem2"),
+								longLayout.withName("elem3").withBitAlignment(32)) : MemoryLayout.structLayout(C_INT.withName("elem1"),
+								MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"), longLayout.withName("elem3"));
 		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
 		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
 		VarHandle elemHandle3 = structLayout.varHandle(long.class, PathElement.groupElement("elem3"));

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2585,11 +2585,11 @@ public class UpcallMethodHandles {
 	}
 
 	public static double addDoubleAndIntDoubleLongFromStruct(double arg1, MemorySegment arg2) {
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 16 bytes without padding by default
+		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
 		 * while the same struct is 24 bytes with padding on other platforms.
 		 */
 		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_INT.withName("elem1"),
-				C_DOUBLE.withName("elem2"), longLayout.withName("elem3"))
+				C_DOUBLE.withName("elem2"), longLayout.withName("elem3").withBitAlignment(32))
 				: MemoryLayout.structLayout(C_INT.withName("elem1"), MemoryLayout.paddingLayout(32),
 						C_DOUBLE.withName("elem2"), longLayout.withName("elem3"));
 		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMHWithMixedSigStruTests.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMHWithMixedSigStruTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -821,7 +821,7 @@ public class UpcallMHWithMixedSigStruTests {
 
 	@Test
 	public void test_addDoubleAndIntDoubleLongFromStructByUpcallMH() throws Throwable {
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 16 bytes without padding by default
+		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
 		 * while the same struct is 24 bytes with padding on other platforms.
 		 */
 		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(JAVA_INT.withName("elem1"),

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1853,7 +1853,7 @@ public class UpcallMethodHandles {
 
 	public static double addDoubleAndIntDoubleLongFromStruct(double arg1, MemorySegment arg2) {
 		int structElem1 = arg2.get(JAVA_INT, 0);
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 16 bytes without padding by default
+		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
 		 * while the same struct is 24 bytes with padding on other platforms.
 		 */
 		double structElem2 = (isAixOS) ? arg2.get(JAVA_DOUBLE.withBitAlignment(32), 4) : arg2.get(JAVA_DOUBLE, 8);


### PR DESCRIPTION
The change is to change the alignment for the long type in the case of
the [int, double, long] struct on AIX as it proves to work in JDK19.

Fixes: #16561

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>