### PR TITLE
Evaluate Class methods calls at compile time when possible

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -124,6 +124,7 @@
    java_lang_Object_clone,
    java_lang_Object_newInstancePrototype,
    java_lang_Object_getAddressAsPrimitive,
+   java_lang_Object_hashCode,
    java_lang_ref_Reference_getImpl,
    java_lang_ref_Reference_reachabilityFence,
    java_lang_ref_SoftReference_get,

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,11 @@
    java_lang_Class_isInstance,
    java_lang_Class_isInterface,
    java_lang_Class_cast,
+   java_lang_Class_isHidden,
+   java_lang_Class_isAnonymousClass,
+   java_lang_Class_isEnum,
+   java_lang_Class_isSynthetic,
+   java_lang_Class_isAnnotation,
    java_lang_ClassLoader_callerClassLoader,
    java_lang_ClassLoader_getCallerClassLoader,
    java_lang_ClassLoader_getStackClassLoader,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6778,6 +6778,23 @@ TR_J9VMBase::isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *
    return (isModFlagSet && (enumClass == superClass));
    }
 
+bool
+TR_J9VMBase::isHiddenClass(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccClassHidden) ? true : false;
+   }
+
+bool
+TR_J9VMBase::isSyntheticClass(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccSynthetic) ? true : false;
+   }
+
+bool
+TR_J9VMBase::isAnnotationClass(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccAnnotation) ? true : false;
+   }
 
 bool
 TR_J9VMBase::isAbstractClass(TR_OpaqueClassBlock * clazzPointer)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -270,6 +270,9 @@ public:
    virtual bool sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *);
    virtual bool jitStaticsAreSame(TR_ResolvedMethod *, int32_t, TR_ResolvedMethod *, int32_t);
    virtual bool jitFieldsAreSame(TR_ResolvedMethod *, int32_t, TR_ResolvedMethod *, int32_t, int32_t);
+   virtual bool isHiddenClass(TR_OpaqueClassBlock * clazzPointer);
+   virtual bool isSyntheticClass(TR_OpaqueClassBlock * clazzPointer);
+   virtual bool isAnnotationClass(TR_OpaqueClassBlock * clazzPointer);
 
    virtual uintptr_t getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz);//d169771 [2177]
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2303,6 +2303,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Object_clone,                "clone",                "()Ljava/lang/Object;")},
       {x(TR::java_lang_Object_newInstancePrototype, "newInstancePrototype", "(Ljava/lang/Class;)Ljava/lang/Object;")},
       {x(TR::java_lang_Object_getAddressAsPrimitive, "getAddressAsPrimitive", "(Ljava/lang/Object;)I")},
+      {x(TR::java_lang_Object_hashCode,             "hashCode",             "()I")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2086,6 +2086,11 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Class_isInstance,           "isInstance",           "(Ljava/lang/Object;)Z")},
       {x(TR::java_lang_Class_isInterface,          "isInterface",          "()Z")},
       {x(TR::java_lang_Class_cast,                 "cast",                 "(Ljava/lang/Object;)Ljava/lang/Object;")},
+      {x(TR::java_lang_Class_isHidden,             "isHidden",             "()Z")},
+      {x(TR::java_lang_Class_isEnum,               "isEnum",               "()Z")},
+      {x(TR::java_lang_Class_isAnonymousClass,     "isAnonymousClass",     "()Z")},
+      {x(TR::java_lang_Class_isSynthetic,          "isSynthetic",          "()Z")},
+      {x(TR::java_lang_Class_isAnnotation,         "isAnnotation",         "()Z")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4780,6 +4780,18 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          return true;
       case TR::java_lang_Class_cast:
          return true; // Call will be transformed into checkcast
+      case TR::java_lang_Object_hashCode:
+         if (callNode &&
+             callNode->getFirstChild() &&
+             callNode->getFirstChild()->getOpCode().hasSymbolReference())
+            {
+            TR::SymbolReference * classChildSymRef = callNode->getFirstChild()->getSymbolReference();
+            if (classChildSymRef->hasKnownObjectIndex() &&
+                classChildSymRef->getSymbol()->isClassObject() &&
+                classChildSymRef->getSymbol()->isConstObjectRef())
+               return true; // VP may be able to determine the hash code and fold away the call
+            }
+         return false; // VP will not be able to fold away the call
       case TR::java_lang_String_hashCodeImplDecompressed:
          /*
           * X86 and z want to avoid inlining both java_lang_String_hashCodeImplDecompressed and java_lang_String_hashCodeImplCompressed

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4780,16 +4780,24 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          return true;
       case TR::java_lang_Class_cast:
          return true; // Call will be transformed into checkcast
+      case TR::java_lang_Class_isHidden:
+      case TR::java_lang_Class_isAnonymousClass:
+      case TR::java_lang_Class_isEnum:
+      case TR::java_lang_Class_isSynthetic:
+      case TR::java_lang_Class_isArray:
+      case TR::java_lang_Class_isPrimitive:
+      case TR::java_lang_Class_isAnnotation:
       case TR::java_lang_Object_hashCode:
-         if (callNode &&
-             callNode->getFirstChild() &&
-             callNode->getFirstChild()->getOpCode().hasSymbolReference())
+         if (callNode
+             && callNode->getNumChildren() > 0
+             && callNode->getLastChild()->getOpCode().hasSymbolReference())
             {
-            TR::SymbolReference * classChildSymRef = callNode->getFirstChild()->getSymbolReference();
-            if (classChildSymRef->hasKnownObjectIndex() &&
-                classChildSymRef->getSymbol()->isClassObject() &&
-                classChildSymRef->getSymbol()->isConstObjectRef())
-               return true; // VP may be able to determine the hash code and fold away the call
+            TR::SymbolReference * classChildSymRef = callNode->getLastChild()->getSymbolReference();
+            if (classChildSymRef
+                && classChildSymRef->hasKnownObjectIndex()
+                && classChildSymRef->getSymbol()->isClassObject()
+                && classChildSymRef->getSymbol()->isConstObjectRef())
+               return true; // VP may be able to determine the result of the call and fold it
             }
          return false; // VP will not be able to fold away the call
       case TR::java_lang_String_hashCodeImplDecompressed:


### PR DESCRIPTION
Several java/lang/Class methods, such as Class.isAnonymous, Class.hashCode(), etc. can often be determined at compile time, and is safe to do so if the class is a constant class that is known at compile time. This changeset introduces the following:
 * Recognize various Class methods to be folded
 * VP transformation that checks if the call can be folded, and obtains the values to replace the call node

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>