### PR TITLE
Ensure LOGNAME is captured on z/OS

### DIFF
--- a/test/functional/cmdLineTests/modularityddrtests/modularityddrtests17.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/modularityddrtests17.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2018, 2022 IBM Corp. and others
+  Copyright (c) 2018, 2023 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,10 @@
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
   <output regex="no" type="failure">0001.dmp</output>
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
  </test>
 
  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />


### PR DESCRIPTION
Command to get `LOGNAME` copied fom `modularityddrtests11.xml`.