### PR TITLE
Update top level OpenJ9 and OMR copyright to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Product: OpenJ9
 
-Copyright (c) 1991, 2022 IBM Corp. and others
+Copyright (c) 1991, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 

--- a/longabout.html
+++ b/longabout.html
@@ -8,7 +8,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
 
-<p><em>December 7, 2022</em></p>
+<p><em>January 18, 2023</em></p>
 <h3>License</h3>
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
@@ -36,7 +36,7 @@ for informational purposes only, and you should look to the Redistributor's lice
 terms and conditions of use.</p>
 
 <h4>Eclipse OMR</h4>
-<p>Copyright (c) 1991, 2022 IBM Corp. and others</p>
+<p>Copyright (c) 1991, 2023 IBM Corp. and others</p>
 <p>
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 <p>


### PR DESCRIPTION
See also the 2022 update https://github.com/eclipse-openj9/openj9/commit/6504162f