### PR TITLE
Defining JITServer AOT cache thunks

### DIFF
--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -454,7 +454,7 @@ CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &contex
          case AOTSerializationRecordType::ClassLoader:
             if ((subrecordId >= context._classLoaderRecords.size()) || !context._classLoaderRecords[subrecordId])
                {
-               invalidSubrecordName = "class loader";
+               invalidSubrecordName = AOTCacheClassLoaderRecord::getRecordName();
                goto error;
                }
             records()[i] = context._classLoaderRecords[subrecordId];
@@ -462,7 +462,7 @@ CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &contex
          case AOTSerializationRecordType::Class:
             if ((subrecordId >= context._classRecords.size()) || !context._classRecords[subrecordId])
                {
-               invalidSubrecordName = "class";
+               invalidSubrecordName = AOTCacheClassRecord::getRecordName();
                goto error;
                }
             records()[i] = context._classRecords[subrecordId];
@@ -470,7 +470,7 @@ CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &contex
          case AOTSerializationRecordType::Method:
             if ((subrecordId >= context._methodRecords.size()) || !context._methodRecords[subrecordId])
                {
-               invalidSubrecordName = "method";
+               invalidSubrecordName = AOTCacheMethodRecord::getRecordName();
                goto error;
                }
             records()[i] = context._methodRecords[subrecordId];
@@ -478,7 +478,7 @@ CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &contex
          case AOTSerializationRecordType::ClassChain:
             if ((subrecordId >= context._classChainRecords.size()) || !context._classChainRecords[subrecordId])
                {
-               invalidSubrecordName = "class chain";
+               invalidSubrecordName = AOTCacheClassChainRecord::getRecordName();
                goto error;
                }
             records()[i] = context._classChainRecords[subrecordId];
@@ -486,18 +486,18 @@ CachedAOTMethod::setSubrecordPointers(const JITServerAOTCacheReadContext &contex
          case AOTSerializationRecordType::WellKnownClasses:
             if ((subrecordId >= context._wellKnownClassesRecords.size()) || !context._wellKnownClassesRecords[subrecordId])
                {
-               invalidSubrecordName = "well-known classes";
+               invalidSubrecordName = AOTCacheWellKnownClassesRecord::getRecordName();
                goto error;
                }
             records()[i] = context._wellKnownClassesRecords[subrecordId];
             break;
          case AOTSerializationRecordType::AOTHeader: // never associated with an SCC offset
-            invalidSubrecordName = "AOT header";
+            invalidSubrecordName = AOTCacheAOTHeaderRecord::getRecordName();
             goto error;
          case AOTSerializationRecordType::Thunk:
             if ((subrecordId >= context._thunkRecords.size()) || !context._thunkRecords[subrecordId])
                {
-               invalidSubrecordName = "thunk";
+               invalidSubrecordName = AOTCacheThunkRecord::getRecordName();
                goto error;
                }
             records()[i] = context._thunkRecords[subrecordId];

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -29,7 +29,7 @@
 #include "env/PersistentCollections.hpp"
 #include "runtime/JITServerAOTSerializationRecords.hpp"
 
-static const uint32_t JITSERVER_AOTCACHE_VERSION = 0;
+static const uint32_t JITSERVER_AOTCACHE_VERSION = 1;
 static const char JITSERVER_AOTCACHE_EYECATCHER[] = "AOTCACHE";
 // the eye-catcher is not null-terminated in the snapshot files
 static const size_t JITSERVER_AOTCACHE_EYECATCHER_LENGTH = sizeof(JITSERVER_AOTCACHE_EYECATCHER) - 1;
@@ -57,6 +57,7 @@ struct JITServerAOTCacheHeader
    size_t _numClassChainRecords;
    size_t _numWellKnownClassesRecords;
    size_t _numAOTHeaderRecords;
+   size_t _numThunkRecords;
    size_t _numCachedAOTMethods;
    size_t _nextClassLoaderId;
    size_t _nextClassId;
@@ -64,6 +65,7 @@ struct JITServerAOTCacheHeader
    size_t _nextClassChainId;
    size_t _nextWellKnownClassesId;
    size_t _nextAOTHeaderId;
+   size_t _nextThunkId;
    };
 
 struct AOTCacheClassLoaderRecord;


### PR DESCRIPTION
These commits start to address #16482 by defining the basic thunk serialization types and adding them to the persistence framework. They also clean up the existing code very slightly. Once this is merged I can work on the next parts of the implementation (modifying record deserialization at the client to handle thunks and handling thunk caching/tracking during compilation at the server).

Attn @mpirvu.