### PR TITLE
Fix continuation stackslot scanning issue in Concurrent Scavenger

### DIFF
--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -323,7 +323,7 @@ MM_ScavengerDelegate::doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *s
 			}
 			break;
 		case SCAN_REASON_SHOULDREMEMBER:
-			*shouldRemember = scavenger->shouldRememberSlot(slotPtr);
+			*shouldRemember |= scavenger->shouldRememberSlot(slotPtr);
 			break;
 		}
 	}


### PR DESCRIPTION
Concurrent Scavenger use SCAN_REASON_SHOULDREMEMBER scanning for rememberedSet prune phase, fix continuation stackslot scanning issue for rememberedSet prune phase to avoid the remembered flag has been overwritten to reset.

we should break the stack walking after seeing this first time the flag being set to true, but it's not in our control since the iteration loop is in the stack walker. the related enhancement could be done in future release.

fix:https://github.com/eclipse-openj9/openj9/issues/16434
Signed-off-by: Lin Hu <linhu@ca.ibm.com>