### PR TITLE
Update FFI & Access related code in OpenJ9 for compilation in JDK20

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- * Copyright (c) 2007, 2022 IBM Corp. and others
+ * Copyright (c) 2007, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,9 @@ import com.ibm.oti.reflect.AnnotationParser;
 import com.ibm.oti.reflect.TypeAnnotationParser;
 
 /*[IF Sidecar19-SE]*/
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+import java.io.InputStream;
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 import java.io.IOException;
 import java.lang.module.ModuleDescriptor;
 import java.net.URL;
@@ -487,6 +490,15 @@ final class Access implements JavaLangAccess {
 		return String.join(prefix, suffix, delimiter, elements, size);
 	}
 
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	public void ensureNativeAccess(Module mod, Class<?> clsOwner, String methodName) {
+		mod.ensureNativeAccess(clsOwner, methodName);
+	}
+
+	public void addEnableNativeAccessToAllUnnamed() {
+		Module.implAddEnableNativeAccessToAllUnnamed();
+	}
+/*[ELSE] JAVA_SPEC_VERSION >= 20 */
 	public boolean isEnableNativeAccess(Module mod) {
 		return mod.implIsEnableNativeAccess();
 	}
@@ -494,6 +506,7 @@ final class Access implements JavaLangAccess {
 	public void addEnableNativeAccessAllUnnamed() {
 		Module.implAddEnableNativeAccessAllUnnamed();
 	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
 	public Module addEnableNativeAccess(Module mod) {
 		return mod.implAddEnableNativeAccess();
@@ -543,6 +556,35 @@ final class Access implements JavaLangAccess {
 		thread.setContinuation(c);
 	}
 
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	public Object[] scopedValueCache() {
+		return Thread.scopedValueCache();
+	}
+
+	public void setScopedValueCache(Object[] cache) {
+		Thread.setScopedValueCache(cache);
+	}
+
+	public Object scopedValueBindings() {
+		return Thread.scopedValueBindings();
+	}
+
+	public Object findScopedValueBindings() {
+		return Thread.findScopedValueBindings();
+	}
+
+	public void setScopedValueBindings(Object scopeValueBindings) {
+		Thread.setScopedValueBindings(scopeValueBindings);
+	}
+
+	public void ensureMaterializedForStackWalk(Object obj) {
+		Thread.ensureMaterializedForStackWalk(obj);
+	}
+
+	public InputStream initialSystemIn() {
+		return System.initialIn;
+	}
+/*[ELSE] JAVA_SPEC_VERSION >= 20 */
 	public Object[] extentLocalCache() {
 		return Thread.extentLocalCache();
 	}
@@ -558,6 +600,7 @@ final class Access implements JavaLangAccess {
 	public void setExtentLocalBindings(Object bindings) {
 		Thread.setExtentLocalBindings(bindings);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
 	public StackableScope headStackableScope(Thread thread) {
 		return thread.headStackableScopes();

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2022 IBM Corp. and others
+ * Copyright (c) 1998, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,6 +79,11 @@ public final class System {
 	 * Default input stream
 	 */
 	public static final InputStream in = null;
+
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	static InputStream initialIn;
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
+
 	/**
 	 * Default output stream
 	 */
@@ -473,7 +478,11 @@ static void completeInitialization() {
 	/*[ENDIF]*/ // Sidecar18-SE-OpenJ9
 
 	/*[IF (Sidecar18-SE-OpenJ9|Sidecar19-SE)&!(PLATFORM-mz31|PLATFORM-mz64)]*/
-	setIn(new BufferedInputStream(new FileInputStream(FileDescriptor.in)));
+	InputStream tempIn = new BufferedInputStream(new FileInputStream(FileDescriptor.in));
+	setIn(tempIn);
+/*[IF JAVA_SPEC_VERSION >= 20]*/
+	initialIn = tempIn;
+/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 	/*[ELSE]*/
 	/*[PR 100718] Initialize System.in after the main thread*/
 	setIn(com.ibm.jvm.io.ConsoleInputStream.localize(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -480,9 +480,9 @@ static void completeInitialization() {
 	/*[IF (Sidecar18-SE-OpenJ9|Sidecar19-SE)&!(PLATFORM-mz31|PLATFORM-mz64)]*/
 	InputStream tempIn = new BufferedInputStream(new FileInputStream(FileDescriptor.in));
 	setIn(tempIn);
-/*[IF JAVA_SPEC_VERSION >= 20]*/
+	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	initialIn = tempIn;
-/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 	/*[ELSE]*/
 	/*[PR 100718] Initialize System.in after the main thread*/
 	setIn(com.ibm.jvm.io.ConsoleInputStream.localize(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));

--- a/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/DowncallLinker.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/DowncallLinker.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalUpcallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalUpcallHandler.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/UpcallMHMetaData.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/UpcallMHMetaData.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION == 19]*/
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2022 IBM Corp. and others
+ * Copyright (c) 1998, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -570,5 +570,27 @@ Java_java_lang_Thread_registerNatives(JNIEnv *env, jclass clazz)
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 #endif /* JAVA_SPEC_VERSION >= 19 */
+
+#if JAVA_SPEC_VERSION >= 20
+
+/* static native void ensureMaterializedForStackWalk(Object o);
+ *
+ * This is expected to invoke JVM_EnsureMaterializedForStackWalk and ensure
+ * that the stackwalk code sees a materialized value.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @param obj the object to be checked
+ */
+void JNICALL
+Java_java_lang_Thread_ensureMaterializedForStackWalk(JNIEnv *env, jclass unusedClass, jobject obj)
+{
+	/* An empty implementation is sufficient since the hotspot
+	 * JVM_EnsureMaterializedForStackWalk() does nothing.
+	 * https://github.com/eclipse-openj9/openj9/issues/16577
+	 */
+}
+
+#endif /* JAVA_SPEC_VERSION >= 20 */
 
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2022 IBM Corp. and others
+# Copyright (c) 2019, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -686,5 +686,12 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		Java_java_lang_Thread_registerNatives
 		Java_jdk_internal_vm_Continuation_pin
 		Java_jdk_internal_vm_Continuation_unpin
+	)
+endif()
+
+# Java 20+
+if(NOT JAVA_SPEC_VERSION LESS 20)
+	omr_add_exports(jclse
+		Java_java_lang_Thread_ensureMaterializedForStackWalk
 	)
 endif()

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2022 IBM Corp. and others
+Copyright (c) 2006, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<xi:include href="uma/se15_exports.xml"></xi:include>
 	<xi:include href="uma/se16_exports.xml"></xi:include>
 	<xi:include href="uma/se19_exports.xml"></xi:include>
+	<xi:include href="uma/se20_exports.xml"></xi:include>
 
 	<xi:include href="uma/vendor_jcl_exports.xml">
 		<xi:fallback/>

--- a/runtime/jcl/uma/se20_exports.xml
+++ b/runtime/jcl/uma/se20_exports.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2023, 2023 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<exports group="se20">
+	<export name="Java_java_lang_Thread_ensureMaterializedForStackWalk" />
+</exports>

--- a/test/functional/Java19andUp/build.xml
+++ b/test/functional/Java19andUp/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2022, 2022 IBM Corp. and others
+Copyright (c) 2022, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,17 +49,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-			<src path="${src}" />
-			<src path="${TestUtilities}" />
-			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-			<classpath>
-				<pathelement location="${LIB_DIR}/testng.jar" />
-				<pathelement location="${LIB_DIR}/jcommander.jar" />
-				<pathelement location="${LIB_DIR}/asm.jar" />
-				<pathelement location="${build}" />
-			</classpath>
-		</javac>
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="19"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/jcommander.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</then>
+		</if>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/Java19andUp/playlist.xml
+++ b/test/functional/Java19andUp/playlist.xml
@@ -52,7 +52,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -81,7 +81,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -110,7 +110,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 
@@ -139,7 +139,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>19+</version>
+			<version>19</version>
 		</versions>
 	</test>
 </playlist>


### PR DESCRIPTION
The change is to update all FFI & `java.lang.Access` related java code in JDK20
for the moment to get them compiled as we have been working on the changes
to address the  latest APIs intended for JEP434 in JDK20 as follows:

Commit 1: JDK20 java.lang.Access new API
1) added `Access.in()` to support `Access.initialSystemIn()`
2) added the stub implementation of `Java_java_lang_Thread_ensureMaterializedForStackWalk`

Commit 2: Disable FFI related code for JDK20

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>