### PR TITLE
Revert "Temporarily avoid zlinux jdk11+ testing on RH8"

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -242,9 +242,6 @@ s390x_linux:
     11: 'linux-s390x-normal-server-release'
   node_labels:
     build: 'ci.role.build && hw.arch.s390x && sw.os.rhel.7'
-  extra_test_labels:
-    all: '!sw.os.rhel.8'
-    8: ''
   build_env:
     cmd:
       all: 'source /home/jenkins/set_gcc_10.3.0_env'


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#16596

See https://github.com/eclipse-openj9/openj9/pull/16596#issuecomment-1401302242