### PR TITLE
On jdk11+ don't call Charset.defaultEncoding() at startup

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_consoleUpTo17.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_consoleUpTo17.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2022, 2022 IBM Corp. and others
+Copyright (c) 2022, 2023 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
@@ -53,5 +53,13 @@
   <test id="$DEFAULT_ENCODING_PROP$ System.err $ENCODING2$">
     <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ $TARGET$ err $ENCODING2$</command>
     <return type="success" value="0" />
+  </test>
+
+  <test id="With -Dfile.encoding=CP943C default Charset is x-IBM943C">
+    <command>$EXE$ -Dfile.encoding=CP943C -cp $Q$$JARPATH$$Q$ DefaultCharset</command>
+    <output regex="no" type="success">x-IBM943C</output>
+    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
   </test>
 </suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/DefaultCharset.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/DefaultCharset.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.nio.charset.Charset;
+
+public class DefaultCharset {
+
+	public static void main(String[] args) {
+		System.out.println(Charset.defaultCharset());
+	}
+}


### PR DESCRIPTION
Calling Charset.defaultEncoding() at startup initializes the default encoding before the jdk.charsets module is loaded.

There is no need to initialize the encoder on jdk11, the JVM starts up without it even when file.encoding is set to an invalid value.

Also set the fallback console Charset on jdk18+ to UTF8 instead of ASCII, since UTF8 is the default.

Fixes https://github.com/eclipse-openj9/openj9/issues/16586

Originally tested by https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/331/

Verified the added test using the previous build.
jdk8 https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1876
jdk11 https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1875
jdk17 https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1878