### PR TITLE
Temporarily avoid zlinux jdk11+ testing on RH8 (2nd try)

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -242,6 +242,12 @@ s390x_linux:
     11: 'linux-s390x-normal-server-release'
   node_labels:
     build: 'ci.role.build && hw.arch.s390x && sw.os.rhel.7'
+  extra_test_labels:
+    11: '!sw.os.rhel.8'
+    17: '!sw.os.rhel.8'
+    19: '!sw.os.rhel.8'
+    20: '!sw.os.rhel.8'
+    next: '!sw.os.rhel.8'
   build_env:
     cmd:
       all: 'source /home/jenkins/set_gcc_10.3.0_env'


### PR DESCRIPTION
The RH8 machines are z15, the combination supports zlib hardware compression/decompression. jdk11 currently fails pack200 testing in sanity.openjdk due to zlib hardware compression/decompression, which we are working to resolve in the future. jdk11+ fails java/util/zip/CloseInflaterDeflaterTest.java in jdk_util.

This change allows jdk8 to test on the RH8/z15 machines when the ci.role.test label is added to the machines.

jdk8 uses a bundled zlib that doesn't support hardware compressions/decompression, and doesn't run pack200 testing in sanity.openjdk. Note pack200 was removed in jdk14.

Issue https://github.com/eclipse-openj9/openj9/issues/14948
See also https://github.com/eclipse-openj9/openj9/issues/16037

Previous attempt was https://github.com/eclipse-openj9/openj9/pull/16596