### PR TITLE
Handle GC thread shutdown during checkpoint

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5822,6 +5822,9 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t tlsPoolMutex;
 	jobject vthreadGroup;
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	omrthread_monitor_t delayedLockingOperationsMutex;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9JavaVM;
 
 #define J9VM_PHASE_STARTUP  1

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -970,6 +970,11 @@ freeJavaVM(J9JavaVM * vm)
 		}
 
 		j9sl_close_shared_library(vm->checkpointState.libCRIUHandle);
+
+		if (NULL != vm->delayedLockingOperationsMutex) {
+			omrthread_monitor_destroy(vm->delayedLockingOperationsMutex);
+			vm->delayedLockingOperationsMutex = NULL;
+		}
 	}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,6 +96,9 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 		omrthread_monitor_init_with_name(&vm->tlsFinalizersMutex, 0, "TLS finalizers mutex") ||
 		omrthread_monitor_init_with_name(&vm->tlsPoolMutex, 0, "TLS pool mutex") ||
 #endif /* JAVA_SPEC_VERSION >= 19 */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		omrthread_monitor_init_with_name(&vm->delayedLockingOperationsMutex, 0, "Delayed locking operations mutex") ||
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 		initializeMonitorTable(vm)
 	)


### PR DESCRIPTION
Handle GC thread shutdown during checkpoint

Add synchronzation to the delayedLockingOperations path to handle the
case where the GC is shutting down its threads simulatneously.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>