### PR TITLE
CRIU internal JVM hook iterates J9Class and its ramMethods

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4091,6 +4091,7 @@ typedef struct J9JITConfig {
 } J9JITConfig;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+typedef BOOLEAN (*classIterationRestoreHookFunc)(struct J9VMThread *currentThread, J9Class *clazz);
 typedef BOOLEAN (*hookFunc)(struct J9VMThread *currentThread, void *userData);
 typedef struct J9InternalHookRecord {
 	BOOLEAN isRestore;
@@ -4099,6 +4100,10 @@ typedef struct J9InternalHookRecord {
 	hookFunc hookFunc;
 	struct J9Pool *instanceObjects;
 } J9InternalHookRecord;
+
+typedef struct J9InternalClassIterationRestoreHookRecord {
+	classIterationRestoreHookFunc hookFunc;
+} J9InternalClassIterationRestoreHookRecord;
 
 typedef struct J9DelayedLockingOpertionsRecord {
 	jobject globalObjectRef;
@@ -4117,6 +4122,7 @@ typedef struct J9CRIUCheckpointState {
 	BOOLEAN isNonPortableRestoreMode;
 	struct J9DelayedLockingOpertionsRecord *delayedLockingOperationsRoot;
 	struct J9Pool *hookRecords;
+	struct J9Pool *classIterationRestoreHookRecords;
 	struct J9Pool *delayedLockingOperationsRecords;
 	struct J9VMThread *checkpointThread;
 	/* The delta between Checkpoint and Restore of j9time_current_time_nanos() return values.
@@ -4924,6 +4930,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*runDelayedLockRelatedOperations)(struct J9VMThread *currentThread);
 	BOOLEAN (*delayedLockingOperation)(struct J9VMThread *currentThread, j9object_t instance, UDATA operation);
+	void (*addInternalJVMClassIterationRestoreHook)(struct J9VMThread *currentThread, classIterationRestoreHookFunc hookFunc);
 	void (*setCRIUSingleThreadModeJVMCRIUException)(struct J9VMThread *vmThread, U_32 moduleName, U_32 messageNumber);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	j9object_t (*getClassNameString)(struct J9VMThread *currentThread, j9object_t classObject, jboolean internAndAssign);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -594,6 +594,18 @@ runDelayedLockRelatedOperations(J9VMThread *currentThread);
  */
 BOOLEAN
 delayedLockingOperation(J9VMThread *currentThread, j9object_t instance, UDATA operation);
+
+/**
+ * This adds an internal CRIU restore hook to be invoked for each class iterated
+ * via allClassesStartDo/allClassesNextDo.
+ *
+ * @param[in] currentThread vmThread token
+ * @param[in] hookFunc The hook function to be invoked for the hook record
+ *
+ * @return void
+ */
+void
+addInternalJVMClassIterationRestoreHook(J9VMThread *currentThread, classIterationRestoreHookFunc hookFunc);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /* ---------------- classloadersearch.c ---------------- */

--- a/runtime/vm/CRIUHelpers.hpp
+++ b/runtime/vm/CRIUHelpers.hpp
@@ -97,6 +97,18 @@ throwOOM:
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 		goto done;
 	}
+
+	static VMINLINE void
+	addInternalJVMClassIterationRestoreHook(J9VMThread *currentThread, classIterationRestoreHookFunc hookFunc)
+	{
+		J9JavaVM *vm = currentThread->javaVM;
+		J9InternalClassIterationRestoreHookRecord *newHook = (J9InternalClassIterationRestoreHookRecord*)pool_newElement(vm->checkpointState.classIterationRestoreHookRecords);
+		if (NULL == newHook) {
+			setNativeOutOfMemoryError(currentThread, 0, 0);
+		} else {
+			newHook->hookFunc = hookFunc;
+		}
+	}
 };
 
 #endif /* CRIUHELPERS_HPP_ */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -411,6 +411,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	runInternalJVMRestoreHooks,
 	runDelayedLockRelatedOperations,
 	delayedLockingOperation,
+	addInternalJVMClassIterationRestoreHook,
 	setCRIUSingleThreadModeJVMCRIUException,
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	getClassNameString,

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2022 IBM Corp. and others
+// Copyright (c) 2006, 2023 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -886,7 +886,7 @@ TraceEntry=Trc_VM_WalkStackFrames_Entry Overhead=1 Level=1 Template="WalkStackFr
 TraceExit=Trc_VM_WalkStackFrames_Exit Overhead=1 Level=1 Template="WalkStackFrames - walkThread=%p, rc=%d"
 
 TraceEntry=Trc_VM_criu_initHooks_Entry Overhead=1 Level=5 Template="initializeCriuHooks"
-TraceExit=Trc_VM_criu_initHooks_Exit Overhead=1 Level=5 Template="initializeCriuHooks - checkpointState.hookRecords (%p)"
+TraceExit=Trc_VM_criu_initHooks_Exit Obsolete Overhead=1 Level=5 Template="initializeCriuHooks - checkpointState.hookRecords (%p)"
 TraceException=Trc_VM_criu_jur_invalid_seedOffset Overhead=1 Level=3 Template="juRandomReseed instanceType (%p) - invalid seedOffset"
 TraceException=Trc_VM_criu_jur_AtomicLong_CNF Overhead=1 Level=3 Template="juRandomReseed java.util.concurrent.atomic.AtomicLong not found"
 TraceException=Trc_VM_criu_jur_invalid_valueOffset Overhead=1 Level=3 Template="juRandomReseed jucaAtomicLongClass (%p) - invalid valueOffset"
@@ -925,3 +925,5 @@ TraceEvent=Trc_VM_allocateThunkHeap_create_heap_failed NoEnv Overhead=1 Level=3 
 TraceExit=Trc_VM_allocateThunkHeap_Exit NoEnv Overhead=1 Level=3 Template="Exit allocateThunkHeap - The suballocated thunk heap is %p"
 
 TraceEvent=Trc_VM_allocateThunkHeap_allocate_thunk_heap_node_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate memory for the thunk heap node"
+
+TraceExit=Trc_VM_criu_initHooks_Exit Overhead=1 Level=5 Template="initializeCriuHooks - checkpointState.hookRecords (%p), classIterationRestoreHookRecords (%p), delayedLockingOperationsRecords (%p)"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -971,6 +971,12 @@ freeJavaVM(J9JavaVM * vm)
 			vm->checkpointState.hookRecords = NULL;
 		}
 
+		J9Pool *classIterationRestoreHookRecords = vm->checkpointState.classIterationRestoreHookRecords;
+		if (NULL != classIterationRestoreHookRecords) {
+			pool_kill(classIterationRestoreHookRecords);
+			vm->checkpointState.classIterationRestoreHookRecords = NULL;
+		}
+
 		j9sl_close_shared_library(vm->checkpointState.libCRIUHandle);
 
 		if (NULL != vm->delayedLockingOperationsMutex) {


### PR DESCRIPTION
This prepares for options reloading via loadRestoreArguments().

Signed-off-by: Jason Feng <fengj@ca.ibm.com>