### PR TITLE
Initialize thread names in thread constructors, don't call setName()

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corp. and others
+ * Copyright (c) 2009, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,8 +123,8 @@ public class AttachHandler extends Thread {
 	 * Keep the constructor private
 	 */
 	private AttachHandler() {
+		super("Attach API initializer"); //$NON-NLS-1$
 		setDaemon(true);
-		setName("Attach API initializer"); //$NON-NLS-1$
 	}
 
 	/**
@@ -518,12 +518,14 @@ public class AttachHandler extends Thread {
 	 * wind up the attach API on termination
 	 */
 	static final class teardownHook extends Thread {
+		teardownHook() {
+			super("Attach API teardown"); //$NON-NLS-1$)
+		}
 
 		@Override
 		public void run() {
 			/*[PR CMVC 188652]  Suppress OOM messages from attach API*/
 			try {
-				Thread.currentThread().setName("Attach API teardown"); //$NON-NLS-1$
 				/* Set  the current thread as a System Thread */
 				com.ibm.oti.vm.VM.markCurrentThreadAsSystem();
 				if (LOGGING_DISABLED != loggingStatus) {

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corp. and others
+ * Copyright (c) 2009, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,7 @@ final class Attachment extends Thread implements Response {
 	 * @param key           Security key to validate transaction
 	 */
 	Attachment(AttachHandler attachHandler, int portNumber, String key) {
-		setName("Attachment portNumber: " + portNumber); //$NON-NLS-1$
+		super("Attachment portNumber: " + portNumber); //$NON-NLS-1$
 		this.portNumber = portNumber;
 		this.key = key;
 		this.handler = attachHandler;

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corp. and others
+ * Copyright (c) 2017, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,8 +29,8 @@ import static openj9.internal.tools.attach.target.IPC.LOGGING_DISABLED;
 final class WaitLoop extends Thread {
 
 	WaitLoop() {
+		super("Attach API wait loop"); //$NON-NLS-1$
 		setDaemon(true);
-		setName("Attach API wait loop"); //$NON-NLS-1$
 		/*[PR Jazz 33224 go to max priority to prevent starvation]*/
 		/*
 		 * Give the handler thread increased priority so it responds promptly to

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryNotificationThreadShutdown.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryNotificationThreadShutdown.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@ final class MemoryNotificationThreadShutdown extends Thread {
 	 * @param victim The thread to notify on shutdown
 	 */
 	MemoryNotificationThreadShutdown(Thread victim) {
-		super();
+		super("MemoryNotificationThreadShutdown"); //$NON-NLS-1$
 		myVictim = victim;
 	}
 

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/BuilderShutdownHook.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/BuilderShutdownHook.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,7 @@ public class BuilderShutdownHook extends Thread
 	
 	public BuilderShutdownHook()
 	{
+		super("BuilderShutdownHook"); //$NON-NLS-1$
 		_openFiles = new Vector();
 	}
 	

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_firstThreadName.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_firstThreadName.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Copyright (c) 2023, 2023 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 first thread name" timeout="180">
+	<test id="Confirm the first thread name">
+		<command>$EXE$ -cp $Q$$JARPATH$$Q$ ThreadName</command>
+		<output type="success" caseSensitive="yes" regex="no">Thread-0</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright (c) 2016, 2022 IBM Corp. and others
+Copyright (c) 2016, 2023 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<test>
@@ -265,5 +265,23 @@
 			<impl>ibm</impl>
 			<impl>openj9</impl>
 		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTest_J9test_firstThreadName</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_firstThreadName.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ThreadName.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ThreadName.java
@@ -1,6 +1,5 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corp. and others
+ * Copyright (c) 2023, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,48 +19,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package com.ibm.lang.management.internal;
 
-/**
- * A thread hooked as a VM shutdown hook to tell an OperatingSystemNotificationThread
- * to terminate.
- *
- * @since 1.5
- */
-final class OperatingSystemNotificationThreadShutdown extends Thread {
-
-	private final Thread myVictim;
-
-	/**
-	 * Basic constructor
-	 * @param victim The thread to notify on shutdown
-	 */
-	OperatingSystemNotificationThreadShutdown(Thread victim) {
-		super("OperatingSystemNotificationThreadShutdown"); //$NON-NLS-1$
-		myVictim = victim;
+public class ThreadName {
+	public static void main(String[] args) throws Exception {
+		System.out.println(new Thread().getName());
 	}
-
-	/**
-	 * Shutdown hook code that coordinates the termination of a memory
-	 * notification thread.
-	 */
-	@Override
-	public void run() {
-		sendShutdownNotification();
-
-		try {
-			// wait for the notification thread to terminate
-			myVictim.join();
-		} catch (InterruptedException e) {
-			// don't care
-		}
-	}
-
-	/**
-	 * Unregisters the SIGRECONFIG handler, then wipes any pending
-	 * notifications and puts a shutdown request on an internal notification
-	 * queue.
-	 */
-	private native void sendShutdownNotification();
-
 }


### PR DESCRIPTION
This avoids having a default name created.

Fixes https://github.com/eclipse-openj9/openj9/issues/16621

Built in https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/333/
Tested in https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1903 - passed

Also ran the test on a build without the fix, which failed.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1904