### PR TITLE
Make CRIU tests more resilient to OS failures

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2022, 2022 IBM Corp. and others
+  Copyright (c) 2022, 2023 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
-    <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
@@ -69,7 +69,7 @@
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTime" 3 3 false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
-    <output type="required" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
+    <output type="success" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: System.nanoTime() after CRIU restore:</output>
@@ -236,8 +236,9 @@
   <test id="Create and Restore Criu Checkpoint Image once - MethodTypeDeadlockTest">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.11 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ MethodTypeDeadlockTest 1</command>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
+    <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
-    <output type="success" caseSensitive="yes" regex="no">Checkpoint blocked because thread</output>
+    <output type="failure" caseSensitive="yes" regex="no">Checkpoint blocked because thread</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>


### PR DESCRIPTION
Make CRIU tests more resilient to OS failures

Fixes: https://github.com/eclipse-openj9/openj9/issues/16610

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>