### PR TITLE
Minor enhancements for performance investigation of Escape Analysis

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -508,8 +508,8 @@ class TR_EscapeAnalysis : public TR::Optimization
 
    int32_t  performAnalysisOnce();
    void     findCandidates();
-   void     findIgnoreableUses();
-   void     findIgnoreableUses(TR::Node *node, TR::NodeChecklist& visited);
+   void     findIgnorableUses();
+   void     markUsesAsIgnorable(TR::Node *node, TR::NodeChecklist& visited);
    void     findLocalObjectsValueNumbers();
    void     findLocalObjectsValueNumbers(TR::Node *node, TR::NodeChecklist& visited);
 
@@ -585,7 +585,6 @@ class TR_EscapeAnalysis : public TR::Optimization
     */
    void     collectAliasesOfAllocations(TR::Node *node, TR::Node *allocNode);
 
-   bool     checkAllNewsOnRHSInLoop(TR::Node *defNode, TR::Node *useNode, Candidate *candidate);
    bool     checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR::Node *useNode, Candidate *candidate);
    bool     usesValueNumber(Candidate *candidate, int32_t valueNumber);
    Candidate *findCandidate(int32_t valueNumber);
@@ -709,7 +708,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    TR_UseDefInfo             *_useDefInfo;
    bool                      _invalidateUseDefInfo;
    TR_BitVector              *_otherDefsForLoopAllocation;
-   TR_BitVector              *_ignoreableUses;
+   TR_BitVector              *_ignorableUses;
    TR_BitVector              *_nonColdLocalObjectsValueNumbers;
    TR_BitVector              *_allLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalObjectsValueNumbers;
@@ -769,7 +768,6 @@ class TR_EscapeAnalysis : public TR::Optimization
 #endif
    bool                       _repeatAnalysis;
    bool                       _somethingChanged;
-   bool                       _doLoopAllocationAliasChecking;
    TR_ScratchList<TR_DependentAllocations> _dependentAllocations;
    TR_BitVector *             _vnTemp;
    TR_BitVector *             _vnTemp2;


### PR DESCRIPTION
This pull request contains two enhancements for investigation of the run time performance impact of Escape Analysis:

1. Check the setting of the `suppressEA` option to decide whether a particular candidate for stack allocation should be prevented from being stack allocated.  This can help test the effect on performance of individual opportunities for stack allocation.
2. Added dynamic debug counters to gauge the number of contiguous and non-contiguous stack allocation opportunities that were found.

There are also a number of minor clean-up items:

1. There are two `findIgnoreableUses` methods, one of which finds uses that can be ignored, the other which marks them as ignorable.  Renamed the second to `markUsesAsIgnorable` for clarity.  Also corrected the spelling of "ignorable."
2. Fixed some trace code that printed the address of a `Candidate` object rather than the address of the `TR::Node` object associated with the `Candidate` - that is, the `Candidate::_node` field.
3. Removed method `checkAllNewsOnRHSInLoop` which was only used under control of an environment variable.  After three years, it is probably safe to remove it.

Depends on OMR pull request eclipse/omr#6872