### PR TITLE
Show 0 for MaxDirectMemorySize with PrintFlagsFinal when unset

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2022 IBM Corp. and others
+ * Copyright (c) 1998, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -490,7 +490,7 @@ jobject getPropertyList(JNIEnv *env)
 
 #if defined(OPENJ9_BUILD) && JAVA_SPEC_VERSION == 8
 	/* Set the maximum direct byte buffer allocation property if it has not been set manually */
-	if ((UDATA) -1 == javaVM->directByteBufferMemoryMax) {
+	if ((~(UDATA)0) == javaVM->directByteBufferMemoryMax) {
 		UDATA heapSize = javaVM->memoryManagerFunctions->j9gc_get_maximum_heap_size(javaVM);
 		/* allow up to 7/8 of the heap to be direct byte buffers */
 		javaVM->directByteBufferMemoryMax = heapSize - (heapSize / 8);
@@ -498,12 +498,12 @@ jobject getPropertyList(JNIEnv *env)
 #endif /* defined(OPENJ9_BUILD) && JAVA_SPEC_VERSION == 8 */
 #if !defined(OPENJ9_BUILD)
 	/* Don't set a default value for IBM Java 8. */
-	if ((UDATA) -1 != javaVM->directByteBufferMemoryMax)
+	if ((~(UDATA)0) != javaVM->directByteBufferMemoryMax)
 #endif /* !defined(OPENJ9_BUILD) */
 	{
 		strings[propIndex] = "sun.nio.MaxDirectMemorySize";
 		propIndex += 1;
-		if ((UDATA) -1 == javaVM->directByteBufferMemoryMax) {
+		if ((~(UDATA)0) == javaVM->directByteBufferMemoryMax) {
 			strcpy(maxDirectMemBuff, "-1");
 		} else {
 			j9str_printf(PORTLIB, maxDirectMemBuff, sizeof(maxDirectMemBuff), "%zu", javaVM->directByteBufferMemoryMax);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2319,7 +2319,7 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			}
 
 			parseError = setMemoryOptionToOptElse(vm, &(vm->directByteBufferMemoryMax),
-					VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS, (UDATA) -1, TRUE);
+					VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS, ~(UDATA)0, TRUE);
 			if (OPTION_OK != parseError) {
 				parseErrorOption = VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS;
 				goto _memParseError;
@@ -7283,7 +7283,7 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		IDATA disabled = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXPRINTFLAGSFINALDISABLE, NULL);
 		if (enabled > disabled) {
 			size_t maxHeapSize = (size_t) (vm->memoryManagerFunctions->j9gc_get_maximum_heap_size(vm));
-			uint64_t maxDirectMemorySize = (uint64_t) (vm->directByteBufferMemoryMax);
+			uint64_t maxDirectMemorySize = (uint64_t) (((~(UDATA)0) == vm->directByteBufferMemoryMax) ? 0 : vm->directByteBufferMemoryMax);
 			const char *howset = NULL;
 
 			/*


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/16637

java -XX:+PrintFlagsFinal
```
[Global flags]
   size_t MaxHeapSize                              = 2083651584                                {product} {ergonomic}
 uint64_t MaxDirectMemorySize                      = 0                                         {product} {ergonomic}
```