### PR TITLE
cmdLineTest_J9test_firstThreadName not for openjdk

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -283,5 +283,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
cmdLineTest_J9test_firstThreadName not for openjdk, -Xdump is only for openj9

Fixes: #16641

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>