### PR TITLE
Disable JIT artifact cache for temporary J9VMThreads

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -265,6 +265,11 @@ copyFieldsFromContinuation(J9VMThread *currentThread, J9VMThread *vmThread, J9VM
 	els->jitGlobalStorageBase = (UDATA*)&continuation->jitGPRs;
 	els->i2jState = continuation->i2jState;
 	vmThread->entryLocalStorage = els;
+
+	/* Disable the JIT artifact cache on the walk thread.  It provides little performance
+	 * benefit to a single walk and the cache memory must be managed.
+	 */
+	vmThread->jitArtifactSearchCache = (void*)((UDATA)vmThread->jitArtifactSearchCache | J9_STACKWALK_NO_JIT_CACHE);
 }
 
 UDATA


### PR DESCRIPTION
Temporary `J9VMThread`s are created to present `J9VMContinuation` thread data to the stackwalker.  Explicitly disable the JIT artifact cache on the temporary thread otherwise the stack walker will allocate a new 4K buffer for each temporary `J9VMThread` whose memory must be managed.

These threads exist to perform a single stack walk and the benefits of managing and using a JIT artifact cache appear to be limited.

Fixes: #16424

Signed-off-by: Daryl Maier <maier@ca.ibm.com>