### PR TITLE
Update release notes 0.36.0

### DIFF
--- a/doc/release-notes/0.36/0.36.md
+++ b/doc/release-notes/0.36/0.36.md
@@ -22,13 +22,15 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Eclipse OpenJ9 version 0.36.0 release notes
+# Eclipse OpenJ9 version 0.36.x release notes
 
-These release notes support the [Eclipse OpenJ9 0.36.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.36.0/plan).
+These release notes support  the [Eclipse OpenJ9&trade; 0.36.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.36.0/plan) and the [Eclipse OpenJ9 0.36.1 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.36.1/plan).
 
 ## Supported environments
 
-OpenJ9 release 0.36.0 supports OpenJDK 8, 11, 17.
+OpenJ9 release 0.36.0 supports OpenJDK 8 and 17.
+
+Release 0.36.1 supports OpenJDK 11.
 
 All releases are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests provided by Adoptium.
 
@@ -36,7 +38,7 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 ## Notable changes in this release
 
-The following table covers notable changes in v0.36.0. Further information about these changes can be found in the [user documentation](https://www.eclipse.org/openj9/docs/version0.36/).
+The following table covers notable changes in v0.36.x. Further information about these changes can be found in the [user documentation](https://www.eclipse.org/openj9/docs/version0.36/).
 
 <table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1"><thead align="left">
 <tr>
@@ -52,7 +54,7 @@ The following table covers notable changes in v0.36.0. Further information about
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16532">#16532</a></td>
 <td valign="top">Support for running OpenJDK 8 and OpenJDK 11 on CentOS 6.10 is deprecated and might be removed in a future release.</td>
 <td valign="top">OpenJDK 8 and 11 (CentOS 6.10)</td>
-<td valign="top">OpenJ9 will no longer test OpenJDK 11 on CentOS 6.10 after 0.36.0 release and might stop testing OpenJDK 8 in the future.</td>
+<td valign="top">OpenJ9 will no longer test OpenJDK 11 on CentOS 6.10 after 0.36.1 release and might stop testing OpenJDK 8 in the future.</td>
 </tr>
 
 <tr>
@@ -102,7 +104,7 @@ The following table covers notable changes in v0.36.0. Further information about
 
 ## Known issues
 
-The v0.36.0 release contains the following known issues and limitations:
+The v0.36.x release contains the following known issues and limitations:
 
 <table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1">
 <thead align="left">
@@ -157,3 +159,4 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 ## Other changes
 
 A full commit history for this release is available at [Eclipse OpenJ9 v0.36.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.36.1](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.1).


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1042

Updated information regarding 0.36.1 release.

[skip ci]

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>