### PR TITLE
Implement JITServer AOT cache thunk handling

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,6 +64,7 @@ namespace TR { class IlGenRequest; }
 struct SerializedRuntimeAssumption;
 class ClientSessionData;
 class AOTCacheRecord;
+class AOTCacheThunkRecord;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #define COMPILATION_AOT_HAS_INVOKEHANDLE -9
@@ -362,6 +363,12 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    // will be used when the result of this out-of-process compilation is serialized and stored in
    // JITServer AOT cache. If record is NULL, fails serialization by setting _aotCacheStore to false.
    void addSerializationRecord(const AOTCacheRecord *record, uintptr_t reloDataOffset);
+
+   UnorderedSet<const AOTCacheThunkRecord *> &getThunkRecords() { return _thunkRecords; }
+   // Adds an AOT cache thunk record to the set of thunks that this compilation depends on, and also adds it
+   // to the list of records that this compilation depends on if the thunk record is new. If the record is NULL,
+   // fails serialization by setting _aotCacheStore to false.
+   void addThunkRecord(const AOTCacheThunkRecord *record);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -489,6 +496,8 @@ private:
    // List of AOT cache records and corresponding offsets into AOT relocation data that will
    // be used to store the result of this compilation in AOT cache; always empty at the client
    Vector<std::pair<const AOTCacheRecord *, uintptr_t>> _serializationRecords;
+   // Set of AOT cache thunk records that this compilation depends on; always empty at the client
+   UnorderedSet<const AOTCacheThunkRecord *> _thunkRecords;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -248,6 +248,8 @@ public:
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
    bool checkCHTableIfClassInfoExistsAndHasBeenExtended(TR_OpaqueClassBlock *clazz, bool &bClassHasBeenExtended);
+   void *getClientJ2IThunk(const std::string &signature, TR::Compilation *comp);
+   void *sendJ2IThunkToClient(const std::string &signature, const uint8_t *thunkStart, const uint32_t thunkSize, TR::Compilation *comp);
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 41;
+   static const uint16_t MINOR_NUMBER = 42;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -343,33 +343,33 @@ AOTCacheAOTHeaderRecord::create(uintptr_t id, const TR_AOTHeader *header)
    }
 
 ThunkSerializationRecord::ThunkSerializationRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize,
-                                                   const uint8_t *thunkCode,  uint32_t thunkCodeSize) :
-   AOTSerializationRecord(size(signatureSize, thunkCodeSize), id, AOTSerializationRecordType::Thunk),
+                                                   const uint8_t *thunkStart,  uint32_t thunkSize) :
+   AOTSerializationRecord(size(signatureSize, thunkSize), id, AOTSerializationRecordType::Thunk),
    _signatureSize(signatureSize),
-   _thunkCodeSize(thunkCodeSize)
+   _thunkSize(thunkSize)
    {
    memcpy((void *)this->signature(), signature, signatureSize);
-   memcpy((void *)this->thunkCode(), thunkCode, thunkCodeSize);
+   memcpy((void *)this->thunkStart(), thunkStart, thunkSize);
    }
 
 ThunkSerializationRecord::ThunkSerializationRecord() :
    AOTSerializationRecord(0, 0, AOTSerializationRecordType::Thunk),
    _signatureSize(0),
-   _thunkCodeSize(0)
+   _thunkSize(0)
    {
    }
 
 AOTCacheThunkRecord::AOTCacheThunkRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize,
-                                         const uint8_t *thunkCode, uint32_t thunkCodeSize) :
-   _data(id, signature, signatureSize, thunkCode, thunkCodeSize)
+                                         const uint8_t *thunkStart, uint32_t thunkSize) :
+   _data(id, signature, signatureSize, thunkStart, thunkSize)
    {
    }
 
 AOTCacheThunkRecord *
-AOTCacheThunkRecord::create(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkCode, uint32_t thunkCodeSize)
+AOTCacheThunkRecord::create(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkStart, uint32_t thunkSize)
    {
-   void *ptr = AOTCacheRecord::allocate(size(signatureSize, thunkCodeSize));
-   return new (ptr) AOTCacheThunkRecord(id, signature, signatureSize, thunkCode, thunkCodeSize);
+   void *ptr = AOTCacheRecord::allocate(size(signatureSize, thunkSize));
+   return new (ptr) AOTCacheThunkRecord(id, signature, signatureSize, thunkStart, thunkSize);
    }
 
 

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -319,22 +319,22 @@ public:
    const AOTSerializationRecord *dataAddr() const override { return &_data; }
 
    static const char *getRecordName() { return "thunk"; }
-   static AOTCacheThunkRecord *create(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkCode, uint32_t thunkCodeSize);
+   static AOTCacheThunkRecord *create(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkStart, uint32_t thunkSize);
 
 private:
    using SerializationRecord = ThunkSerializationRecord;
 
    friend AOTCacheThunkRecord *AOTCacheRecord::readRecord<>(FILE *f, const JITServerAOTCacheReadContext &context);
 
-   AOTCacheThunkRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkCode, uint32_t thunkCodeSize);
+   AOTCacheThunkRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkStart, uint32_t thunkSize);
    AOTCacheThunkRecord(const JITServerAOTCacheReadContext &context, const ThunkSerializationRecord &header) {}
 
-   static size_t size(uint32_t signatureSize, uint32_t thunkCodeSize)
+   static size_t size(uint32_t signatureSize, uint32_t thunkSize)
       {
-      return offsetof(AOTCacheThunkRecord, _data) + ThunkSerializationRecord::size(signatureSize, thunkCodeSize);
+      return offsetof(AOTCacheThunkRecord, _data) + ThunkSerializationRecord::size(signatureSize, thunkSize);
       }
 
-   static size_t size(const ThunkSerializationRecord &header) { return size(header.signatureSize(), header.thunkCodeSize()); }
+   static size_t size(const ThunkSerializationRecord &header) { return size(header.signatureSize(), header.thunkSize()); }
 
    const ThunkSerializationRecord _data;
 };

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -409,9 +409,10 @@ public:
 
    const std::string &name() const { return _name; }
 
-   // Each get{Type}Record() method returns the record for given parameters (which fully identify
+   // Each get{Type}Record() method except getThunkRecord returns the record for given parameters (which fully identify
    // the unique record), by either looking up the existing record or creating a new one if there is sufficient
-   // space.
+   // space. The getThunkRecord method instead has an accompanying createAndStoreThunk method that will create and store
+   // a new thunk record if there is sufficient space.
    const AOTCacheClassLoaderRecord *getClassLoaderRecord(const uint8_t *name, size_t nameLength);
    const AOTCacheClassRecord *getClassRecord(const AOTCacheClassLoaderRecord *loaderRecord, const J9ROMClass *romClass);
    const AOTCacheMethodRecord *getMethodRecord(const AOTCacheClassRecord *definingClassRecord,
@@ -419,6 +420,8 @@ public:
    const AOTCacheClassChainRecord *getClassChainRecord(const AOTCacheClassRecord *const *classRecords, size_t length);
    const AOTCacheWellKnownClassesRecord *getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
                                                                    size_t length, uintptr_t includedClasses);
+   const AOTCacheThunkRecord *getThunkRecord(const uint8_t *signature, uint32_t signatureSize);
+   const AOTCacheThunkRecord *createAndStoreThunk(const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkCode, uint32_t thunkCodeSize);
    const AOTCacheAOTHeaderRecord *getAOTHeaderRecord(const TR_AOTHeader *header, uint64_t clientUID);
 
    // Add a serialized AOT method to the cache. The key identifying the method is a combination of:
@@ -427,6 +430,8 @@ public:
    // - AOT header record for the TR_AOTHeader of the client JVM this method was compiled for;
    // - optimization level.
    // Each item in the `records` vector corresponds to an SCC offset stored in the AOT method's relocation data.
+   // Note that the SCC offsets corresponding to AOTCacheThunkRecord records will not be used, as thunks are defined
+   // globally in each client and are addressed by signature.
    // Returns true if the method was successfully added, false otherwise (if a method already exists for this key).
    bool storeMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
                     TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,6 +117,7 @@ private:
    bool cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
    bool cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
    bool cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+   bool cacheRecord(const ThunkSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
 
    // Returns the class loader for given class loader ID, either cached or
    // looked up using the cached SCC offset if the class loader was unloaded.

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -292,28 +292,29 @@ struct ThunkSerializationRecord : public AOTSerializationRecord
 {
 public:
    uint32_t signatureSize() const { return _signatureSize; }
-   uint32_t thunkCodeSize() const { return _thunkCodeSize; }
+   uint32_t thunkSize() const { return _thunkSize; }
    const uint8_t *signature() const { return _varSizedData; }
-   const uint8_t *thunkCode() const { return _varSizedData + _signatureSize; }
+   const uint8_t *thunkStart() const { return _varSizedData + _signatureSize; }
+   void *thunkAddress() const { return (void *)(thunkStart() + 8); }
 
 private:
    friend class AOTCacheRecord;
    friend class AOTCacheThunkRecord;
 
-   ThunkSerializationRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkCode,  uint32_t thunkCodeSize);
+   ThunkSerializationRecord(uintptr_t id, const uint8_t *signature, uint32_t signatureSize, const uint8_t *thunkStart,  uint32_t thunkSize);
    ThunkSerializationRecord();
 
-   static size_t size(uint32_t signatureSize, uint32_t thunkCodeSize)
+   static size_t size(uint32_t signatureSize, uint32_t thunkSize)
       {
-      return sizeof(ThunkSerializationRecord) + OMR::alignNoCheck(signatureSize + thunkCodeSize, sizeof(size_t));
+      return sizeof(ThunkSerializationRecord) + OMR::alignNoCheck(signatureSize + thunkSize, sizeof(size_t));
       }
 
    bool isValidHeader(const JITServerAOTCacheReadContext &context) const
       { return AOTSerializationRecord::isValidHeader(AOTSerializationRecordType::Thunk); }
 
    const uint32_t _signatureSize;
-   const uint32_t _thunkCodeSize;
-   // Layout: uint8_t _signature[_signatureSize], uint8_t _thunkCode[_thunkCodeSize]
+   const uint32_t _thunkSize;
+   // Layout: uint8_t _signature[_signatureSize], uint8_t _thunkStart[_thunkSize]
    uint8_t _varSizedData[];
 };
 


### PR DESCRIPTION
These commits add J2I thunk handling to the JITServer AOT cache. The server now tracks any thunks created during the compilation of methods that will be stored in the JITServer AOT cache. These thunks are stored in the cache, and also serialized and sent in the `SerializedAOTMethod` records that are sent to the client. The client will deserialize these thunk records and store the thunks in their local shared class cache as necessary.