### PR TITLE
Accelerate ArraysSupport.vectorizedMismatch in IL

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -77,6 +77,12 @@ J9::ARM64::CodeGenerator::initialize()
       comp->setOption(TR_EnableMonitorCacheLookup);
       }
 
+   static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
+   if (cg->getSupportsArrayCmpLen() && !disableInlineVectorizedMismatch)
+      {
+      cg->setSupportsInlineVectorizedMismatch();
+      }
+
    if (comp->fej9()->hasFixedFrameC_CallingConvention())
       cg->setHasFixedFrameC_CallingConvention();
    }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -492,6 +492,16 @@ public:
 	*/
    void setSupportsInlineEncodeASCII() { _j9Flags.set(SupportsInlineEncodeASCII); }
 
+   /** \brief
+   *   Determines whether the code generator supports inlining of jdk/internal/util/ArraysSupport.vectorizedMismatch
+   */
+   bool getSupportsInlineVectorizedMismatch() { return _j9Flags.testAny(SupportsInlineVectorizedMismatch); }
+
+   /** \brief
+   *   The code generator supports inlining of jdk/internal/util/ArraysSupport.vectorizedMismatch
+   */
+   void setSupportsInlineVectorizedMismatch() { _j9Flags.set(SupportsInlineVectorizedMismatch); }
+
    /**
     * \brief
     *    The number of nodes between a monext and the next monent before
@@ -649,6 +659,7 @@ private:
       SupportsIntegerToChars                              = 0x00000200,
       SupportsInlineEncodeASCII                           = 0x00000400,
       SavesNonVolatileGPRsForGC                           = 0x00000800,
+      SupportsInlineVectorizedMismatch                    = 0x00001000,
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -433,6 +433,7 @@
 
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,
+   jdk_internal_util_ArraysSupport_vectorizedMismatch,
    jdk_internal_util_Preconditions_checkIndex,
 
    FirstVectorMethod,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3970,6 +3970,12 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod},
       };
 
+   static X ArraysSupportMethods [] =
+      {
+      {x(TR::jdk_internal_util_ArraysSupport_vectorizedMismatch, "vectorizedMismatch", "(Ljava/lang/Object;JLjava/lang/Object;JII)I")},
+      {  TR::unknownMethod}
+      };
+
    struct Y { const char * _class; X * _methods; };
 
    /* classXX where XX is the number of characters in the class name */
@@ -4151,7 +4157,7 @@ void TR_ResolvedJ9Method::construct()
       { "com/ibm/jit/DecimalFormatHelper", DecimalFormatHelperMethods},
       { "jdk/internal/reflect/Reflection", ReflectionMethods },
       { "jdk/internal/util/Preconditions", PreconditionsMethods },
-
+      { "jdk/internal/util/ArraysSupport", ArraysSupportMethods },
       { 0 }
       };
    static Y class32[] =

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -77,6 +77,12 @@ J9::Power::CodeGenerator::initialize()
       cg->setSupportsInlineConcurrentLinkedQueue();
       }
 
+   static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
+   if (cg->getSupportsArrayCmpLen() && !disableInlineVectorizedMismatch)
+      {
+      cg->setSupportsInlineVectorizedMismatch();
+      }
+
    cg->setSupportsNewInstanceImplOpt();
 
    static char *disableMonitorCacheLookup = feGetEnv("TR_disableMonitorCacheLookup");

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -135,6 +135,12 @@ J9::X86::CodeGenerator::initialize()
       cg->setSupportsBDLLHardwareOverflowCheck();
       }
 
+   static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
+   if (cg->getSupportsArrayCmpLen() && !disableInlineVectorizedMismatch)
+      {
+      cg->setSupportsInlineVectorizedMismatch();
+      }
+
    // Disable fast gencon barriers for AOT compiles because relocations on
    // the inlined heap addresses are not available (yet).
    //

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -124,6 +124,12 @@ J9::Z::CodeGenerator::initialize()
       cg->setSupportsInlineEncodeASCII();
       }
 
+   static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
+   if (cg->getSupportsArrayCmpLen() && !disableInlineVectorizedMismatch)
+      {
+      cg->setSupportsInlineVectorizedMismatch();
+      }
+
    // Let's turn this on.  There is more work needed in the opt
    // to catch the case where the BNDSCHK is inserted after
    //


### PR DESCRIPTION
This patch adds `ArraysSupport.vectorizedMismatch` as a recognized method. If the `arraycmp` IL opcode is supported, `vectorizedMismatch` call nodes are transformed to a functionally equivalent tree using `arraycmp`.

`vectorizedMismatch` is functionally equivalent to:
```
   lengthInBytes = length << log2ArrayIndexScale
   mask = (log2ArrayIndexScale<2) ? 3 : 7
   n = lengthInBytes & ~(mask)
   res = arrayCmpLen(a+aOffset, b+bOffset, n)
   if (res == n)  // no mismatch found
      return ~((lengthInBytes & mask) >> log2ArrayIndexScale)
   else           // mismatch found
      return res >> log2ArrayIndexScale
```
Therefore the call nodes can be translated like so:
```
n9n    icall  jdk/internal/util/ArraysSupport.vectorizedMismatch(Ljava/lang/Object;JLjava/lang/Object;JII)I
n3n      <a>
n4n      <aOffset>
n5n      <b>
n6n      <bOffset>
n7n      <length>
n8n      <log2ArrayIndexScale>
```
becomes
```
n9n         iselect ()
n31n          lcmpeq
n22n            arraycmp (arrayCmpLen )
n23n              aladd
n3n                 <a>
n4n                 <aOffset>
n24n              aladd
n5n                 <b>
n6n                 <bOffset>
n21n              land
n14n                lshl
n13n                  i2l
n7n                     <length>
n12n                  i2l
n8n                     <log2ArrayIndexScale>
n20n                lxor
n18n                  lor
n16n                    lshl
n12n                      ==>i2l
n15n                      lconst 1
n17n                    lconst 3
n19n                  lconst -1
n21n            ==>land
n29n          ixor
n27n            l2i
n26n              lshr
n25n                land
n14n                  ==>lshl
n18n                  ==>lor
n12n                ==>i2l
n28n            iconst -1
n30n          ishr
n22n            ==>arraycmp
n8n             <log2ArrayIndexScale>
```

`ArraysSupport.vectorizedMismatch` is used in the implementations of `Arrays.mismatch`, `Arrays.compare`, and `Arrays.equals` for primitive types.

Benchmarking `Arrays.compare` on x86, Power, and Z for 128, 4096, and 8192 element arrays of all primitive types shows a speedup of around 4.2× on x86, 2.7× on Power, and 4.1× on Z. Benchmark arrays of 1 or 2 elements shows no significant slowdown, and in some cases a speedup (notably, I saw a speedup of 3× comparing two element arrays of `long`).
*Full benchmarking results here, for the curious:* [arraycompare-results.zip](https://github.com/eclipse-openj9/openj9/files/10573754/arraycompare-results.zip)


Fixes: #15204