### PR TITLE
[FFI] Remove the restriction on all sessions in downcall

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -228,9 +228,7 @@ public class InternalDowncallHandler {
 	private final void addMemArgScope(ResourceScope memArgSessionOrScope)
 	/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 	{
-		if ((memArgSessionOrScope.ownerThread() != null)
-		&& !sessionOrScopeSet.contains(memArgSessionOrScope)
-		) {
+		if (!sessionOrScopeSet.contains(memArgSessionOrScope)) {
 			sessionOrScopeSet.add(memArgSessionOrScope);
 		}
 	}
@@ -645,7 +643,10 @@ public class InternalDowncallHandler {
 			 */
 			if (memArgSession.isAlive()) {
 				Thread owner = memArgSession.ownerThread();
-				if (owner == Thread.currentThread()) { // For the confined session
+				/* The check is intended for the confined session or
+				 * the shared session(e.g. implicit/global session).
+				 */
+				if ((owner == Thread.currentThread()) || (owner == null)) {
 					MemorySessionImpl memArgSessionImpl = (MemorySessionImpl)memArgSession;
 					memArgSessionImpl.acquire0();
 					session.addCloseAction(memArgSessionImpl::release0);
@@ -663,7 +664,10 @@ public class InternalDowncallHandler {
 		for (ResourceScope memArgScope : sessionOrScopeSet) {
 			if (memArgScope.isAlive()) {
 				Thread owner = memArgScope.ownerThread();
-				if (owner == Thread.currentThread()) { // For the confined scope
+				/* The check is intended for the confined scope or
+				 * the shared scope(e.g. implicit/global scope).
+				 */
+				if ((owner == Thread.currentThread()) || (owner == null)) {
 					scope.keepAlive(memArgScope); // keepAlive() is only used in JDK18
 				}
 			}
@@ -676,7 +680,10 @@ public class InternalDowncallHandler {
 		for (ResourceScope memArgScope : sessionOrScopeSet) {
 			if (memArgScope.isAlive()) {
 				Thread owner = memArgScope.ownerThread();
-				if (owner == Thread.currentThread()) { // For the confined scope
+				/* The check is intended for the confined scope or
+				 * the shared scope(e.g. implicit/global scope).
+				 */
+				if ((owner == Thread.currentThread()) || (owner == null)) {
 					Handle scopeHandle = memArgScope.acquire();
 					scopeHandleMap.put(memArgScope, scopeHandle);
 				}
@@ -689,7 +696,10 @@ public class InternalDowncallHandler {
 		for (ResourceScope memArgScope : sessionOrScopeSet) {
 			if (memArgScope.isAlive()) {
 				Thread owner = memArgScope.ownerThread();
-				if (owner == Thread.currentThread()) { // For the confined scope
+				/* The check is intended for the confined scope or
+				 * the shared scope(e.g. implicit/global scope).
+				 */
+				if ((owner == Thread.currentThread()) || (owner == null)) {
 					Handle scopeHandle = scopeHandleMap.get(memArgScope);
 					memArgScope.release(scopeHandle);
 				}


### PR DESCRIPTION
The changes remove the restriction for any session regardless of the session's type
to ensure the memory of upcall stub is kept alive during the downcall.

Fixes: #16606

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>