### PR TITLE
Updated 0.36.0 release note with OpenSSL memory leak limitation

### DIFF
--- a/doc/release-notes/0.36/0.36.md
+++ b/doc/release-notes/0.36/0.36.md
@@ -147,10 +147,19 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 
 <tr>
 <td valign="top">-</td>
-<td valign="top">Support for OpenJDK 19 is not yet available due to outstanding issues, as listed in the <a href="https://github.com/eclipse-openj9/openj9/milestone/35">milestone 35</a> plan.</td>
+<td valign="top">Support for OpenJDK 19 is not yet available due to outstanding issues, as listed in the <a href="https://github.com/eclipse-openj9/openj9/milestone/35">milestone 35</a> plan</td>
 <td valign="top">All platforms</td>
 <td valign="top">OpenJDK 19 support will be added in a future OpenJ9 release if possible before the release of OpenJDK 20 in March. This work might delay support for OpenJDK 20 (you can follow the progress of OpenJDK 20 support in the <a href="https://github.com/eclipse-openj9/openj9/milestone/40">milestone 40</a> plan). The information in the <a href=https://www.eclipse.org/openj9/docs/openj9_support/#eclipse-openj9-releases>Eclipse OpenJ9 releases table</a> in the documentation is therefore more likely to change than usual.</td>
 <td valign="top">None</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16451">#16451</a></td>
+<td valign="top">OpenSSL leaks native memory</td>
+<td valign="top">All platforms</td>
+<td valign="top">Application servers crash from memory starvation caused by OpenSSL memory leak.</td>
+<td valign="top">Restart the application on a regular basis.
+You can also <a href="https://www.eclipse.org/openj9/docs/djdknativecrypto">disable use of OpenSSL</a>, either in whole or in part (if you can identify the parts containing the leaks). However, disabling use of OpenSSL might have a big impact on performance.</td>
 </tr>
 
 </tbody>
@@ -158,5 +167,4 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.36.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.0).
-A full commit history for this release is available at [Eclipse OpenJ9 v0.36.1](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.1).
+A full commit history for 0.36.0 release is available at [Eclipse OpenJ9 v0.36.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.0). A full commit history for 0.36.1 release is available at [Eclipse OpenJ9 v0.36.1](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.36.1).


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1047

Updated the release notes

[skip ci]

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>