### PR TITLE
Unbounded GC Thread Pool Expansion for CRIU Restore

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -260,6 +260,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_ensureLockedSynchronizersIntegrity,
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	j9gc_prepare_for_checkpoint,
-	j9gc_reinitialize_for_restore
+	j9gc_reinitialize_for_restore,
+	j9gc_reinitializeDefaults
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 };

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -262,6 +262,7 @@ extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThrea
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 extern J9_CFUNC void j9gc_prepare_for_checkpoint(J9VMThread *vmThread);
 extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread);
+extern J9_CFUNC BOOLEAN j9gc_reinitializeDefaults(J9VMThread *vmThread);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /* J9VMFinalizeSupport*/

--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corp. and others
+ * Copyright (c) 2017, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ class MM_ConfigurationDelegate
  * Member data and types
  */
 private:
-	static const uintptr_t _maximumDefaultNumberOfGCThreads = 64;
+	uintptr_t _maximumDefaultNumberOfGCThreads = 64;
 	const MM_GCPolicy _gcPolicy;
 
 protected:
@@ -352,6 +352,11 @@ public:
 	uintptr_t getMaxGCThreadCount(MM_EnvironmentBase* env)
 	{
 		return _maximumDefaultNumberOfGCThreads;
+	}
+
+	void setMaxGCThreadCount(MM_EnvironmentBase* env, uintptr_t maxGCThreads)
+	{
+		_maximumDefaultNumberOfGCThreads = maxGCThreads;
 	}
 
 	MM_GCPolicy getGCPolicy() { return _gcPolicy; }

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,13 +183,12 @@ MM_GlobalCollectorDelegate::mainThreadGarbageCollectFinished(MM_EnvironmentBase 
 	/* Check that all reference object lists are empty:
 	 * lists must be processed at Mark and nothing should be flushed after
 	 */
-	UDATA listCount = _extensions->gcThreadCount;
 	MM_HeapRegionDescriptorStandard *region = NULL;
 	GC_HeapRegionIteratorStandard regionIterator(_extensions->heap->getHeapRegionManager());
 	while(NULL != (region = regionIterator.nextRegion())) {
 		/* check all lists for regions, they should be empty */
 		MM_HeapRegionDescriptorStandardExtension *regionExtension =  MM_ConfigurationDelegate::getHeapRegionDescriptorStandardExtension(env, region);
-		for (UDATA i = 0; i < listCount; i++) {
+		for (UDATA i = 0; i < regionExtension->_maxListIndex; i++) {
 			MM_ReferenceObjectList *list = &regionExtension->_referenceObjectLists[i];
 			Assert_MM_true(list->isWeakListEmpty());
 			Assert_MM_true(list->isSoftListEmpty());

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3029,6 +3029,25 @@ error:
 	}
 	return J9VMDLLMAIN_FAILED;
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+/**
+ * Initialize GC parameters for Restore.
+ * Initialize GC parameters with default values, parse the command line, massage values
+ * as required and finally verify values.
+ * @return
+ */
+BOOLEAN
+j9gc_reinitializeDefaults(J9VMThread* vmThread)
+{
+	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(vmThread);
+
+	/* TODO: Parse restore options to set gc thread count */
+	extensions->gcThreadCountForced = false;
+
+	return true;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 static void

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4540,6 +4540,7 @@ typedef struct J9MemoryManagerFunctions {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	void  ( *j9gc_prepare_for_checkpoint)(struct J9VMThread *vmThread) ;
 	BOOLEAN  ( *j9gc_reinitialize_for_restore)(struct J9VMThread *vmThread) ;
+	BOOLEAN  ( *j9gc_reinitializeDefaults)(struct J9VMThread *vmThread) ;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9MemoryManagerFunctions;
 


### PR DESCRIPTION
Initial set of changes to expand the GC thread pool beyond the dispatcher initialization done at VM startup. These changes are required by the consumed OMR GC dispatcher/configuration APIs called for restore.

- Converted reference obj list iteration count from `gcThreadCount` to `regionExtension->_maxListIndex`, this is more correct. This is the only instance in the code where iteration implies the listCount from GC thread count. This inference was not an issue as the lists are inited based on the GC thread count, however now that the thread count may change, it is incorrect to assume the list count from the thread count.
- Release restore thread's VM access for the duration of `reinitializeGCThreadCountForRestore`
- Introduced `j9gc_reinitializeDefaults` in `mminit`, this is meant to be the top level init/verify method (e.g parsing/initing GC params based on restore cmd line opts). This is symmetrical restore call to VM startup `gcInitializeDefaults` call .
- Introduced `setMaxGCThreadCount` in Configuration Delegate to simply computation of default gc thread count at restore time

Signed-off-by: Salman Rana <salman.rana@ibm.com>