### PR TITLE
MH J2I Thunk API Nomenclature Clarification

### DIFF
--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -964,13 +964,13 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
    return returnValue;
    }
 
-TR_J2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
+TR_MHJ2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
    {
    int32_t codeSize = 4 * (instructionCountForArguments(callNode, cg) + 5); // 5 instructions for branch
    uintptr_t dispatcher;
    TR::Compilation *comp = cg->comp();
-   TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-   TR_J2IThunk *thunk = TR_J2IThunk::allocate(codeSize, signature, cg, thunkTable);
+   TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunk *thunk = TR_MHJ2IThunk::allocate(codeSize, signature, cg, thunkTable);
    uint8_t *buffer = thunk->entryPoint();
 
    TR_RuntimeHelper helper;

--- a/runtime/compiler/aarch64/codegen/CallSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 #include "env/VMJ9.h"
 
 namespace TR { class CodeGenerator; }
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 
 extern void arm64CodeSync(uint8_t *codePointer, uint32_t codeSize);
 
@@ -60,7 +60,7 @@ class ARM64CallSnippet : public TR::Snippet
    uint8_t *setCallRA(uint8_t *ra) {return (callRA=ra);}
 
    static uint8_t *generateVIThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
-   static TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
+   static TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
    };
 
 class ARM64UnresolvedCallSnippet : public TR::ARM64CallSnippet

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -564,12 +564,12 @@ uint8_t *TR::ARMCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
    return(returnValue);
    }
 
-TR_J2IThunk *TR::ARMCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
+TR_MHJ2IThunk *TR::ARMCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
    {
    int32_t  codeSize = 4*(instructionCountForArguments(callNode, cg) + 2) + 8; // Additional 4 bytes to hold size of thunk
    int32_t  dispatcher;
-   TR_J2IThunkTable *thunkTable = TR::comp()->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-   TR_J2IThunk      *thunk      = TR_J2IThunk::allocate(codeSize, signature, cg, thunkTable);
+   TR_MHJ2IThunkTable *thunkTable = TR::comp()->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunk      *thunk      = TR_MHJ2IThunk::allocate(codeSize, signature, cg, thunkTable);
    uint8_t          *buffer     = thunk->entryPoint();
 
    TR_RuntimeHelper helper;

--- a/runtime/compiler/arm/codegen/CallSnippet.hpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@
 #include "codegen/Snippet.hpp"
 #include "codegen/ARMInstruction.hpp"
 
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 
 extern void     armCodeSync(uint8_t *codePointer, uint32_t codeSize);
 
@@ -57,7 +57,7 @@ class ARMCallSnippet : public TR::Snippet
    TR_RuntimeHelper getHelper();
 
    static uint8_t *generateVIThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
-   static TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
+   static TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
    };
 
 class ARMUnresolvedCallSnippet : public TR::ARMCallSnippet

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4374,7 +4374,7 @@ void JitShutdown(J9JITConfig * jitConfig)
    // TODO:JSR292: Delete or protect with env var
    /*
    TR_FrontEnd *fe = TR_J9VMBase::get(jitConfig, vmThread);
-   TR_J2IThunkTable *thunkTable = TR::CompilationInfo::get(jitConfig)->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunkTable *thunkTable = TR::CompilationInfo::get(jitConfig)->getPersistentInfo()->getInvokeExactJ2IThunkTable();
    if (thunkTable)
    thunkTable->dumpTo(fe, TR::IO::Stdout);
    */

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -756,8 +756,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<std::string>();
          auto &signature = std::get<0>(recv);
 
-         TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-         TR_J2IThunk *thunk = thunkTable->findThunk((char *)signature.data(), fe);
+         TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+         TR_MHJ2IThunk *thunk = thunkTable->findThunk((char *)signature.data(), fe);
          client->write(response, thunk == NULL);
          }
          break;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1823,7 +1823,7 @@ onLoadInternal(
 
    if (!TR::Compiler->target.cpu.isI386())
       {
-      TR_J2IThunkTable *ieThunkTable = new (PERSISTENT_NEW) TR_J2IThunkTable(persistentMemory, "InvokeExactJ2IThunkTable");
+      TR_MHJ2IThunkTable *ieThunkTable = new (PERSISTENT_NEW) TR_MHJ2IThunkTable(persistentMemory, "InvokeExactJ2IThunkTable");
       if (ieThunkTable == NULL)
          return -1;
       persistentMemory->getPersistentInfo()->setInvokeExactJ2IThunkTable(ieThunkTable);

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -43,26 +43,26 @@ computeSignatureLength(char *signature)
    }
 
 
-TR_J2IThunk *
-TR_J2IThunk::allocate(
+TR_MHJ2IThunk *
+TR_MHJ2IThunk::allocate(
       int16_t codeSize,
       char *signature,
       TR::CodeGenerator *cg,
-      TR_J2IThunkTable *thunkTable)
+      TR_MHJ2IThunkTable *thunkTable)
    {
    int16_t terseSignatureBufLength = thunkTable->terseSignatureLength(signature)+1;
-   int16_t totalSize = (int16_t)sizeof(TR_J2IThunk) + codeSize + terseSignatureBufLength;
-   TR_J2IThunk *result;
+   int16_t totalSize = (int16_t)sizeof(TR_MHJ2IThunk) + codeSize + terseSignatureBufLength;
+   TR_MHJ2IThunk *result;
 #if defined(J9VM_OPT_JITSERVER)
    if (cg->comp()->isOutOfProcessCompilation())
       {
       // Don't need to use code cache because the entire thunk will be copied and sent to the client
-      result = (TR_J2IThunk*)cg->comp()->trMemory()->allocateMemory(totalSize, heapAlloc);
+      result = (TR_MHJ2IThunk*)cg->comp()->trMemory()->allocateMemory(totalSize, heapAlloc);
       }
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
+      result = (TR_MHJ2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
       }
    omrthread_jit_write_protect_disable();
    result->_codeSize  = codeSize;
@@ -73,7 +73,7 @@ TR_J2IThunk::allocate(
    }
 
 
-TR_J2IThunkTable::TR_J2IThunkTable(TR_PersistentMemory *m, char *name):
+TR_MHJ2IThunkTable::TR_MHJ2IThunkTable(TR_PersistentMemory *m, char *name):
    _name(name),
    _monitor(TR::Monitor::create(name)),
    _nodes(m)
@@ -83,7 +83,7 @@ TR_J2IThunkTable::TR_J2IThunkTable(TR_PersistentMemory *m, char *name):
 
 
 int16_t
-TR_J2IThunkTable::terseSignatureLength(char *signature)
+TR_MHJ2IThunkTable::terseSignatureLength(char *signature)
    {
    int16_t numArgs = 0;
    for (char *currentArgument = signature+1; currentArgument[0] != ')'; currentArgument = nextSignatureArgument(currentArgument))
@@ -92,7 +92,7 @@ TR_J2IThunkTable::terseSignatureLength(char *signature)
    }
 
 
-void TR_J2IThunkTable::getTerseSignature(char *buf, int16_t bufLength, char *signature)
+void TR_MHJ2IThunkTable::getTerseSignature(char *buf, int16_t bufLength, char *signature)
    {
    int16_t i=0;
    char *currentArgument;
@@ -104,7 +104,7 @@ void TR_J2IThunkTable::getTerseSignature(char *buf, int16_t bufLength, char *sig
    }
 
 
-char TR_J2IThunkTable::terseTypeChar(char *type)
+char TR_MHJ2IThunkTable::terseTypeChar(char *type)
    {
    switch (type[0])
       {
@@ -123,8 +123,8 @@ char TR_J2IThunkTable::terseTypeChar(char *type)
    }
 
 
-TR_J2IThunkTable::Node *
-TR_J2IThunkTable::Node::get(
+TR_MHJ2IThunkTable::Node *
+TR_MHJ2IThunkTable::Node::get(
       char *terseSignature,
       TR_PersistentArray<Node> &nodeArray,
       bool createIfMissing)
@@ -159,8 +159,8 @@ TR_J2IThunkTable::Node::get(
    }
 
 
-TR_J2IThunk *
-TR_J2IThunkTable::findThunk(
+TR_MHJ2IThunk *
+TR_MHJ2IThunkTable::findThunk(
       char *signature,
       TR_FrontEnd *fe,
       bool isForCurrentRun)
@@ -171,10 +171,10 @@ TR_J2IThunkTable::findThunk(
    }
 
 
-TR_J2IThunk *
-TR_J2IThunkTable::getThunk(char *signature, TR_FrontEnd *fe, bool isForCurrentRun)
+TR_MHJ2IThunk *
+TR_MHJ2IThunkTable::getThunk(char *signature, TR_FrontEnd *fe, bool isForCurrentRun)
    {
-   TR_J2IThunk *result = findThunk(signature, fe, isForCurrentRun);
+   TR_MHJ2IThunk *result = findThunk(signature, fe, isForCurrentRun);
    if (!result)
       {
       char terseSignature[260]; // 256 args + 1 return type + null terminator
@@ -187,19 +187,19 @@ TR_J2IThunkTable::getThunk(char *signature, TR_FrontEnd *fe, bool isForCurrentRu
    }
 
 
-TR_J2IThunk *
-TR_J2IThunkTable::findThunkFromTerseSignature(
+TR_MHJ2IThunk *
+TR_MHJ2IThunkTable::findThunkFromTerseSignature(
       char *terseSignature,
       TR_FrontEnd *fe,
       bool isForCurrentRun)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe);
-   TR_J2IThunk *returnThunk = NULL;
+   TR_MHJ2IThunk *returnThunk = NULL;
 
    if (fej9->isAOT_DEPRECATED_DO_NOT_USE() && !isForCurrentRun)
       {
       // Must use persistent thunks for compiles that will persist
-      return (TR_J2IThunk *)fej9->findPersistentJ2IThunk(terseSignature);
+      return (TR_MHJ2IThunk *)fej9->findPersistentJ2IThunk(terseSignature);
       }
    else
       {
@@ -214,8 +214,8 @@ TR_J2IThunkTable::findThunkFromTerseSignature(
 
 
 void
-TR_J2IThunkTable::addThunk(
-      TR_J2IThunk *thunk,
+TR_MHJ2IThunkTable::addThunk(
+      TR_MHJ2IThunk *thunk,
       TR_FrontEnd *fe, bool
       isForCurrentRun)
    {
@@ -236,7 +236,7 @@ TR_J2IThunkTable::addThunk(
       match->_thunk = thunk;
 
       // This assume must be in the monitor or else another thread could break it
-      TR_ASSERT(findThunkFromTerseSignature(thunk->terseSignature(), fe, isForCurrentRun) == thunk, "TR_J2IThunkTable: setThunk must cause findThunk(%s) to return %p", thunk->terseSignature(), thunk);
+      TR_ASSERT(findThunkFromTerseSignature(thunk->terseSignature(), fe, isForCurrentRun) == thunk, "TR_MHJ2IThunkTable: setThunk must cause findThunk(%s) to return %p", thunk->terseSignature(), thunk);
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseJ2IThunks))
          TR_VerboseLog::writeLineLocked(TR_Vlog_J2I,"add %s @%p", thunk->terseSignature(), thunk);
       }
@@ -244,7 +244,7 @@ TR_J2IThunkTable::addThunk(
 
 
 void
-TR_J2IThunkTable::Node::dumpTo(
+TR_MHJ2IThunkTable::Node::dumpTo(
       TR_FrontEnd *fe,
       TR::FILE *file,
       TR_PersistentArray<Node> &nodeArray,
@@ -267,7 +267,7 @@ TR_J2IThunkTable::Node::dumpTo(
 
 
 void
-TR_J2IThunkTable::dumpTo(TR_FrontEnd *fe, TR::FILE *file)
+TR_MHJ2IThunkTable::dumpTo(TR_FrontEnd *fe, TR::FILE *file)
    {
    OMR::CriticalSection criticalSection(_monitor);
    trfprintf(file, "J2IThunkTable \"%s\":", _name);

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -199,7 +199,7 @@ TR_MHJ2IThunkTable::findThunkFromTerseSignature(
    if (fej9->isAOT_DEPRECATED_DO_NOT_USE() && !isForCurrentRun)
       {
       // Must use persistent thunks for compiles that will persist
-      return (TR_MHJ2IThunk *)fej9->findPersistentJ2IThunk(terseSignature);
+      return (TR_MHJ2IThunk *)fej9->findPersistentMHJ2IThunk(terseSignature);
       }
    else
       {
@@ -224,7 +224,7 @@ TR_MHJ2IThunkTable::addThunk(
    if (fej9->isAOT_DEPRECATED_DO_NOT_USE() && !isForCurrentRun)
       {
       // Must use persistent thunks for compiles that will persist
-      fej9->persistJ2IThunk(thunk);
+      fej9->persistMHJ2IThunk(thunk);
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseJ2IThunks))
          TR_VerboseLog::writeLineLocked(TR_Vlog_J2I,"persist %s @%p", thunk->terseSignature(), thunk);
       }

--- a/runtime/compiler/env/J2IThunk.hpp
+++ b/runtime/compiler/env/J2IThunk.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,21 +27,21 @@
 #include "env/TRMemory.hpp"
 #include "env/IO.hpp"
 
-class TR_J2IThunkTable;
+class TR_MHJ2IThunkTable;
 namespace TR { class CodeGenerator; }
 namespace TR { class Monitor; }
 
-class TR_J2IThunk
+class TR_MHJ2IThunk
    {
    int16_t _totalSize;
    int16_t _codeSize;
 
    public:
 
-   static TR_J2IThunk *allocate(int16_t codeSize, char *signature, TR::CodeGenerator *cg, TR_J2IThunkTable *thunkTable);
+   static TR_MHJ2IThunk *allocate(int16_t codeSize, char *signature, TR::CodeGenerator *cg, TR_MHJ2IThunkTable *thunkTable);
 
-   static TR_J2IThunk *get(uint8_t *entryPoint)
-      { return ((TR_J2IThunk*)entryPoint)-1; }
+   static TR_MHJ2IThunk *get(uint8_t *entryPoint)
+      { return ((TR_MHJ2IThunk*)entryPoint)-1; }
 
    int16_t totalSize() { return _totalSize; }
    int16_t codeSize() { return _codeSize; }
@@ -49,7 +49,7 @@ class TR_J2IThunk
    char *terseSignature() { return (char*)(entryPoint() + codeSize()); }
    };
 
-class TR_J2IThunkTable
+class TR_MHJ2IThunkTable
    {
    enum TypeChars
       {
@@ -84,7 +84,7 @@ class TR_J2IThunkTable
       {
       typedef int32_t ChildIndex; // sad -- how many nodes are there really going to be in this array?  uint8_t would suffice for some workloads!
 
-      TR_J2IThunk *_thunk;
+      TR_MHJ2IThunk *_thunk;
       ChildIndex _children[NUM_TYPE_CHARS];
 
       Node *get(char *terseSignature, TR_PersistentArray<Node> &nodeArray, bool createIfMissing);
@@ -104,19 +104,19 @@ class TR_J2IThunkTable
    // can always tell where the end is from the Java signature string format,
    // and does not rely on null-termination.
 
-   TR_J2IThunk *findThunk(char *signature, TR_FrontEnd *frontend, bool isForCurrentRun=false); // may return NULL
-   TR_J2IThunk *getThunk (char *signature, TR_FrontEnd *frontend, bool isForCurrentRun=false); // same as findThunk but asserts !NULL
+   TR_MHJ2IThunk *findThunk(char *signature, TR_FrontEnd *frontend, bool isForCurrentRun=false); // may return NULL
+   TR_MHJ2IThunk *getThunk (char *signature, TR_FrontEnd *frontend, bool isForCurrentRun=false); // same as findThunk but asserts !NULL
 
    // Note: the 'isForCurrentRun' flag is meant for AOT-aware code.
    // If you don't know what this should be, you probably want to use its default value.
    //
-   void addThunk(TR_J2IThunk *thunk, TR_FrontEnd *fe, bool isForCurrentRun=false);
+   void addThunk(TR_MHJ2IThunk *thunk, TR_FrontEnd *fe, bool isForCurrentRun=false);
 
    char terseTypeChar(char *type);
    int16_t terseSignatureLength(char *signature);
    void getTerseSignature(char *buf, int16_t bufLength, char *signature);
 
-   TR_J2IThunkTable(TR_PersistentMemory *m, char *name);
+   TR_MHJ2IThunkTable(TR_PersistentMemory *m, char *name);
    TR_PERSISTENT_ALLOC(TR_Memory::JSR292)
 
    void dumpTo(TR_FrontEnd *fe, TR::FILE *file);
@@ -124,7 +124,7 @@ class TR_J2IThunkTable
    private:
 
    Node *root() { return &_nodes[0]; }
-   TR_J2IThunk *findThunkFromTerseSignature(char *terseSignature, TR_FrontEnd *frontend, bool isForCurrentRun);
+   TR_MHJ2IThunk *findThunkFromTerseSignature(char *terseSignature, TR_FrontEnd *frontend, bool isForCurrentRun);
    };
 
 #endif

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ class TR_FrontEnd;
 class TR_PersistentMemory;
 class TR_PersistentCHTable;
 class TR_PersistentClassLoaderTable;
-class TR_J2IThunkTable;
+class TR_MHJ2IThunkTable;
 namespace J9 { class Options; }
 
 enum JitStates {
@@ -281,8 +281,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void incNumGCRBodies() { _statNumGCRBodies++; }
    void incNumGCRSaves() { _statNumGCRSaves++; }
 
-   TR_J2IThunkTable *getInvokeExactJ2IThunkTable(){ return _invokeExactJ2IThunkTable; } // NULL if the platform needs no thunks, so J2I helpers can be called directly
-   void setInvokeExactJ2IThunkTable(TR_J2IThunkTable *table){ _invokeExactJ2IThunkTable = table; }
+   TR_MHJ2IThunkTable *getInvokeExactJ2IThunkTable(){ return _invokeExactJ2IThunkTable; } // NULL if the platform needs no thunks, so J2I helpers can be called directly
+   void setInvokeExactJ2IThunkTable(TR_MHJ2IThunkTable *table){ _invokeExactJ2IThunkTable = table; }
 
 
    TR_PersistentCHTable * getPersistentCHTable();
@@ -432,7 +432,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    int32_t _statNumGCRBodies;
    int32_t _statNumGCRSaves;
 
-   TR_J2IThunkTable *_invokeExactJ2IThunkTable;
+   TR_MHJ2IThunkTable *_invokeExactJ2IThunkTable;
 
    TR::Monitor *_gpuInitMonitor;
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4249,7 +4249,7 @@ TR_J9VMBase::setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *t
 void
 TR_J9VMBase::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    {
-   comp->getPersistentInfo()->getInvokeExactJ2IThunkTable()->addThunk((TR_J2IThunk*) thunkptr, this);
+   comp->getPersistentInfo()->getInvokeExactJ2IThunkTable()->addThunk((TR_MHJ2IThunk*) thunkptr, this);
    }
 
 void *
@@ -4339,8 +4339,8 @@ TR_J9VMBase::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *comp)
       // We need a j2i thunk when this call executes, in case the target MH has
       // no invokeExact thunk yet.
 
-      TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-      TR_J2IThunk      *thunk      = thunkTable->findThunk(methodSymbol->getMethod()->signatureChars(), this);
+      TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+      TR_MHJ2IThunk      *thunk      = thunkTable->findThunk(methodSymbol->getMethod()->signatureChars(), this);
       return (thunk == NULL);
       }
    else
@@ -9238,7 +9238,7 @@ TR_J9SharedCacheVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, 
 void *
 TR_J9SharedCacheVM::persistJ2IThunk(void *thunk)
    {
-   return persistThunk(((TR_J2IThunk *)thunk)->terseSignature(), strlen(((TR_J2IThunk *)thunk)->terseSignature()), (uint8_t*)thunk, ((TR_J2IThunk *)thunk)->totalSize());
+   return persistThunk(((TR_MHJ2IThunk *)thunk)->terseSignature(), strlen(((TR_MHJ2IThunk *)thunk)->terseSignature()), (uint8_t*)thunk, ((TR_MHJ2IThunk *)thunk)->totalSize());
    }
 
 void *

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4253,7 +4253,7 @@ TR_J9VMBase::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    }
 
 void *
-TR_J9VMBase::findPersistentJ2IThunk(char *signatureChars)
+TR_J9VMBase::findPersistentMHJ2IThunk(char *signatureChars)
    {
    return findPersistentThunk(signatureChars, strlen(signatureChars));
    }
@@ -4275,7 +4275,7 @@ TR_J9VMBase::findPersistentThunk(char *signatureChars, uint32_t signatureLength)
    }
 
 void *
-TR_J9VMBase::persistJ2IThunk(void *thunk)
+TR_J9VMBase::persistMHJ2IThunk(void *thunk)
    {
    return NULL;  // only needed for AOT compilations
    }
@@ -9236,7 +9236,7 @@ TR_J9SharedCacheVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, 
    }
 
 void *
-TR_J9SharedCacheVM::persistJ2IThunk(void *thunk)
+TR_J9SharedCacheVM::persistMHJ2IThunk(void *thunk)
    {
    return persistThunk(((TR_MHJ2IThunk *)thunk)->terseSignature(), strlen(((TR_MHJ2IThunk *)thunk)->terseSignature()), (uint8_t*)thunk, ((TR_MHJ2IThunk *)thunk)->totalSize());
    }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -802,9 +802,9 @@ public:
    virtual bool     needsInvokeExactJ2IThunk(TR::Node *node,  TR::Compilation *comp);
    virtual void setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp);
 
-   virtual void *findPersistentJ2IThunk(char *signatureChars);
+   virtual void *findPersistentMHJ2IThunk(char *signatureChars);
    virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength);
-   virtual void * persistJ2IThunk(void *thunk);
+   virtual void * persistMHJ2IThunk(void *thunk);
 
 
    // Object manipulation
@@ -1540,7 +1540,7 @@ public:
    virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp);
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp);
 
-   virtual void * persistJ2IThunk(void *thunk);
+   virtual void * persistMHJ2IThunk(void *thunk);
    virtual void *persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize);
 
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -803,7 +803,6 @@ public:
    virtual void setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp);
 
    virtual void *findPersistentMHJ2IThunk(char *signatureChars);
-   virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength);
    virtual void * persistMHJ2IThunk(void *thunk);
 
 
@@ -1541,7 +1540,6 @@ public:
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp);
 
    virtual void * persistMHJ2IThunk(void *thunk);
-   virtual void *persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize);
 
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *);
    virtual bool                   supportAllocationInlining( TR::Compilation *comp, TR::Node *node);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1691,14 +1691,14 @@ TR_J9ServerVM::isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz)
 void
 TR_J9ServerVM::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    {
-   std::string serializedThunk((char *) thunkptr, ((TR_J2IThunk *) thunkptr)->totalSize());
+   std::string serializedThunk((char *) thunkptr, ((TR_MHJ2IThunk *) thunkptr)->totalSize());
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_setInvokeExactJ2IThunk, serializedThunk);
    stream->read<JITServer::Void>();
 
    // Add terse signature of the thunk to the set of registered thunks
    OMR::CriticalSection thunkMonitor(_compInfoPT->getClientData()->getThunkSetMonitor());
-   TR_J2IThunk *thunk = reinterpret_cast<TR_J2IThunk *>(thunkptr);
+   TR_MHJ2IThunk *thunk = reinterpret_cast<TR_MHJ2IThunk *>(thunkptr);
    std::string signature(thunk->terseSignature(), strlen(thunk->terseSignature()));
    auto &thunkSet = _compInfoPT->getClientData()->getRegisteredInvokeExactJ2IThunkSet();
    thunkSet.insert(std::make_pair(signature, comp->compileRelocatableCode()));
@@ -1716,7 +1716,7 @@ TR_J9ServerVM::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *com
          || method->isArchetypeSpecimen()))
       {
       char terseSignature[260]; // 256 args + 1 return type + null terminator
-      TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+      TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
       thunkTable->getTerseSignature(terseSignature, sizeof(terseSignature), methodSymbol->getMethod()->signatureChars());
       std::string terseSignatureStr(terseSignature, strlen(terseSignature));
          {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -346,7 +346,7 @@ public:
    virtual TR::CodeCache * getResolvedTrampoline(TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) override { return 0; }
    virtual intptr_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override { TR_ASSERT_FATAL(0, "methodTrampolineLookup not implemented for AOT");  return 0; }
    virtual TR::CodeCache * getDesignatedCodeCache(TR::Compilation *comp) override;
-   virtual void * persistJ2IThunk(void *thunk) override { TR_ASSERT_FATAL(0, "persistJ2IThunk should not be called on the server"); return NULL; }
+   virtual void * persistMHJ2IThunk(void *thunk) override { TR_ASSERT_FATAL(0, "persistMHJ2IThunk should not be called on the server"); return NULL; }
    virtual void * persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize) { TR_ASSERT_FATAL(0, "persistThunk should not be called on the server"); return NULL; }
    virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength) override { TR_ASSERT_FATAL(0, "findPersistentThunk should not be called on the server"); return NULL; }
    virtual J9Class * getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -347,8 +347,7 @@ public:
    virtual intptr_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override { TR_ASSERT_FATAL(0, "methodTrampolineLookup not implemented for AOT");  return 0; }
    virtual TR::CodeCache * getDesignatedCodeCache(TR::Compilation *comp) override;
    virtual void * persistMHJ2IThunk(void *thunk) override { TR_ASSERT_FATAL(0, "persistMHJ2IThunk should not be called on the server"); return NULL; }
-   virtual void * persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize) { TR_ASSERT_FATAL(0, "persistThunk should not be called on the server"); return NULL; }
-   virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength) override { TR_ASSERT_FATAL(0, "findPersistentThunk should not be called on the server"); return NULL; }
+   virtual void * findPersistentMHJ2IThunk(char *signatureChars) override { TR_ASSERT_FATAL(0, "findPersistentMHJ2IThunk should not be called on the server"); return NULL; }
    virtual J9Class * getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
    virtual bool ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes) override;
    virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -970,7 +970,7 @@ uint8_t *TR::PPCCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
    return(returnValue);
    }
 
-TR_J2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
+TR_MHJ2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature)
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
@@ -978,8 +978,8 @@ TR_J2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode,
    intptr_t  dispatcher;
    int32_t sizeThunk;
 
-   TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-   TR_J2IThunk      *thunk      = TR_J2IThunk::allocate(codeSize, signature, cg, thunkTable);
+   TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunk      *thunk      = TR_MHJ2IThunk::allocate(codeSize, signature, cg, thunkTable);
    uint8_t          *buffer     = thunk->entryPoint();
 
    TR::SymbolReference *dispatcherSymbol;

--- a/runtime/compiler/p/codegen/CallSnippet.hpp
+++ b/runtime/compiler/p/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 #include "p/codegen/PPCInstruction.hpp"
 
 namespace TR { class CodeGenerator; }
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 
 extern void ppcCodeSync(uint8_t *codePointer, uint32_t codeSize);
 
@@ -88,7 +88,7 @@ class PPCCallSnippet : public TR::Snippet
    uint8_t *setUpArgumentsInRegister(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
 
    static uint8_t *generateVIThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
-   static TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
+   static TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg, char *signature);
    static int32_t instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg);
    };
 

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2288,7 +2288,7 @@ void J9::Power::PrivateLinkage::buildVirtualDispatch(TR::Node                   
          default:
             if (fej9->needsInvokeExactJ2IThunk(callNode, comp()))
                {
-               TR_J2IThunk *thunk = TR::PPCCallSnippet::generateInvokeExactJ2IThunk(callNode, sizeOfArguments, cg(), methodSymbol->getMethod()->signatureChars());
+               TR_MHJ2IThunk *thunk = TR::PPCCallSnippet::generateInvokeExactJ2IThunk(callNode, sizeOfArguments, cg(), methodSymbol->getMethod()->signatureChars());
                fej9->setInvokeExactJ2IThunk(thunk, comp());
                }
             break;

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1709,12 +1709,12 @@ void *initialInvokeExactThunk(j9object_t methodHandle, J9VMThread *vmThread)
 
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
    TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
-   TR_J2IThunkTable *j2iThunks = persistentInfo->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunkTable *j2iThunks = persistentInfo->getInvokeExactJ2IThunkTable();
 
    void *addressToDispatch = NULL;
    if (j2iThunks)
       {
-      TR_J2IThunk *thunk = j2iThunks->getThunk(thunkSignature, fej9);
+      TR_MHJ2IThunk *thunk = j2iThunks->getThunk(thunkSignature, fej9);
       addressToDispatch = thunk->entryPoint();
       if (details)
          TR_VerboseLog::writeLineLocked(TR_Vlog_MHD, "%p   J2I thunk is %p %s", vmThread, addressToDispatch, thunk->terseSignature());

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -239,7 +239,7 @@ TR_RelocationTarget::performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmH
    }
 
 void
-TR_RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk)
+TR_RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_MHJ2IThunk *thunk)
    {
    TR_ASSERT(0, "Error: performInvokeExactJ2IThunkRelocation not implemented in relocation target base class");
    }

--- a/runtime/compiler/runtime/RelocationTarget.hpp
+++ b/runtime/compiler/runtime/RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@
 class TR_OpaqueClassBlock;
 class TR_RelocationRecord;
 class TR_RelocationRuntimeLogger;
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 
 // TR_RelocationTarget defines how a platform target implements the individual steps of processing
 //    relocation records.
@@ -103,8 +103,8 @@ class TR_RelocationTarget
       virtual uint8_t *loadAddressSequence(uint8_t *reloLocation);
       virtual void storeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber);
 
-         
-      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber) 
+
+      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber)
          {
          storeAddressSequence(address, reloLocation, seqNumber);
          }
@@ -140,7 +140,7 @@ class TR_RelocationTarget
        *
        * @param thunk Pointer to a thunk to be relocated.
        */
-      virtual void performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk);
+      virtual void performInvokeExactJ2IThunkRelocation(TR_MHJ2IThunk *thunk);
 
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
 

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -608,7 +608,7 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::generateVirtualIndirectThunk(TR::Node *
    return thunkEntry;
    }
 
-TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature)
+TR_MHJ2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature)
    {
    TR::Compilation *comp = cg()->comp();
 
@@ -624,8 +624,8 @@ TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Nod
    else
       codeSize += 2; // TR::InstOpCode::JMPReg
 
-   TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-   TR_J2IThunk      *thunk      = TR_J2IThunk::allocate(codeSize, signature, cg(), thunkTable);
+   TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunk      *thunk      = TR_MHJ2IThunk::allocate(codeSize, signature, cg(), thunkTable);
    uint8_t          *cursor     = thunk->entryPoint();
 
    TR::SymbolReference  *glueSymRef;

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,7 +83,7 @@ class PrivateLinkage : public J9::X86::PrivateLinkage
    virtual TR::Instruction *buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site);
    virtual void buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk);
    virtual uint8_t *generateVirtualIndirectThunk(TR::Node *callNode);
-   virtual TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature);
+   virtual TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature);
 
    TR::Instruction *generateFlushInstruction(
          TR::Instruction *prev,

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1765,7 +1765,7 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
             default:
                if (fej9->needsInvokeExactJ2IThunk(callNode, comp()))
                   {
-                  TR_J2IThunk *thunk = generateInvokeExactJ2IThunk(callNode, methodSymbol->getMethod()->signatureChars());
+                  TR_MHJ2IThunk *thunk = generateInvokeExactJ2IThunk(callNode, methodSymbol->getMethod()->signatureChars());
                   fej9->setInvokeExactJ2IThunk(thunk, comp());
                   }
                break;

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 #include "codegen/RegisterDependency.hpp"
 #include "x/codegen/X86Register.hpp"
 
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 class TR_ResolvedMethod;
 namespace TR { class Instruction; }
 
@@ -276,7 +276,7 @@ class PrivateLinkage : public J9::PrivateLinkage
    // the vTable slot for the called method.
    //
    virtual uint8_t *generateVirtualIndirectThunk(TR::Node *callNode){ TR_ASSERT(0, "Thunks not implemented in X86Linkage"); return NULL; }
-   virtual TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature){ TR_ASSERT(0, "Thunks not implemented in X86Linkage"); return NULL; }
+   virtual TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature){ TR_ASSERT(0, "Thunks not implemented in X86Linkage"); return NULL; }
 
    struct TR::PicParameters IPicParameters;
    struct TR::PicParameters VPicParameters;

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ j9ThunkInvokeExactHelperFromTerseSignature(UDATA signatureLength, char *signatur
    }
 
 void
-TR_X86RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk)
+TR_X86RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_MHJ2IThunk *thunk)
    {
    char *signature = thunk->terseSignature();
    void *vmHelper = j9ThunkInvokeExactHelperFromTerseSignature(strlen(signature), signature, reloRuntime());

--- a/runtime/compiler/x/runtime/X86RelocationTarget.hpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@
 #include "runtime/RelocationRecord.hpp"
 
 #if defined(J9VM_OPT_JITSERVER)
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 /* Mfence patching constants */
@@ -63,21 +63,21 @@ class TR_X86RelocationTarget : public TR_RelocationTarget
       virtual void storeRelativeTarget(uintptr_t callTarget, uint8_t *reloLocation);
       virtual uint8_t *loadAddressSequence(uint8_t *reloLocation);
       virtual void storeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber);
-      
-      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber) 
+
+      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber)
          {
          address = (uint8_t *)((intptr_t)address - (intptr_t)(reloLocation + 4));
          storeAddressSequence(address, reloLocation, seqNumber);
          }
-      
+
       virtual uint32_t loadCPIndex(uint8_t *reloLocation);
       virtual uintptr_t loadThunkCPIndex(uint8_t *reloLocation);
-      
-      
+
+
 
       virtual void performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmHelper);
 #if defined(J9VM_OPT_JITSERVER)
-      virtual void performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk);
+      virtual void performInvokeExactJ2IThunkRelocation(TR_MHJ2IThunk *thunk);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
       virtual bool useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation) { return false; }
@@ -94,8 +94,8 @@ class TR_AMD64RelocationTarget : public TR_X86RelocationTarget
       TR_ALLOC(TR_Memory::Relocation)
       void * operator new(size_t, J9JITConfig *);
       TR_AMD64RelocationTarget(TR_RelocationRuntime *reloRuntime) : TR_X86RelocationTarget(reloRuntime) {}
-      
-      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber) 
+
+      virtual void storeRelativeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber)
          {
          storeAddressSequence(address, reloLocation, seqNumber);
          }

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ TR::S390J9CallSnippet::generateVIThunk(TR::Node * callNode, int32_t argSize, TR:
    return returnValue;
    }
 
-TR_J2IThunk *
+TR_MHJ2IThunk *
 TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t argSize, char* signature, TR::CodeGenerator * cg)
    {
    uint32_t rEP = (uint32_t) cg->getEntryPointRegister() - 1;
@@ -147,8 +147,8 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
    int32_t codeSize = instructionCountForArguments(callNode, cg) + lengthOfIEThunk;
    // TODO:JSR292: VI thunks have code to ensure they are double-word aligned.  Do we need that here?
 
-   TR_J2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
-   TR_J2IThunk      *thunk      = TR_J2IThunk::allocate(codeSize, signature, cg, thunkTable);
+   TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
+   TR_MHJ2IThunk      *thunk      = TR_MHJ2IThunk::allocate(codeSize, signature, cg, thunkTable);
    uint8_t          *cursor     = thunk->entryPoint();
 
    TR::SymbolReference *dispatcherSymbol;

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 #include "z/codegen/ConstantDataSnippet.hpp"
 #include "z/codegen/S390Instruction.hpp"
 
-class TR_J2IThunk;
+class TR_MHJ2IThunk;
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
@@ -56,7 +56,7 @@ class S390J9CallSnippet : public TR::S390CallSnippet
 
 
    static uint8_t *generateVIThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
-   static TR_J2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, char* signature, TR::CodeGenerator *cg);
+   static TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, char* signature, TR::CodeGenerator *cg);
 
    TR_RuntimeHelper getInterpretedDispatchHelper(TR::SymbolReference *methodSymRef, TR::DataType type);
 
@@ -65,7 +65,7 @@ class S390J9CallSnippet : public TR::S390CallSnippet
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
 
    virtual void print(TR::FILE *pOutFile, TR_Debug *debug);
-                                                 
+
    virtual uint8_t *emitSnippetBody();
    };
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1581,7 +1581,7 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
          default:
             if (fej9->needsInvokeExactJ2IThunk(callNode, comp()))
                {
-               TR_J2IThunk *thunk = TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(callNode, sizeOfArguments, methodSymbol->getMethod()->signatureChars(), cg());
+               TR_MHJ2IThunk *thunk = TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(callNode, sizeOfArguments, methodSymbol->getMethod()->signatureChars(), cg());
                fej9->setInvokeExactJ2IThunk(thunk, comp());
                }
             break;


### PR DESCRIPTION
There are two types of J2I thunks the JIT generates; thunks for normal J2I transitions, and thunks for invokeExact J2I transitions. Thunks of the former kind are stored in a hashtable maintained in the VM whereas thunks of the latter kind are stored in a table maintained by the JIT. However, both thunks are referred to as "J2I Thunks", which, while technically correct, can be very confusing to a reader of the code.

This PR renames `TR_J2IThunk` (which was the data structure to describe invokeExact J2I Thunks) to `TR_MHJ2IThunk`. It also updates frontend queries to refer to invokeExact J2I thunks as MH J2I Thunks.