### PR TITLE
Fix CRIU test condition

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -239,7 +239,7 @@
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
-    <output type="failure" caseSensitive="yes" regex="no">Checkpoint blocked because thread</output>
+    <output type="success" caseSensitive="yes" regex="no">Checkpoint blocked because thread</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>


### PR DESCRIPTION
Fix CRIU test condition

Method deadlock test can output "Checkpoint blocked because thread" because thats the tracepoint printed when the checkpoint thread is waiting other threads to exit critical regions

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>