### PR TITLE
Support for Scoped Values (JEP 429)

### DIFF
--- a/runtime/gc_structs/VMThreadSlotIterator.cpp
+++ b/runtime/gc_structs/VMThreadSlotIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ GC_VMThreadSlotIterator::nextSlot()
 	case 10:
 		return &(_vmThread->carrierThreadObject);
 	case 11:
-		return &(_vmThread->extentLocalCache);
+		return &(_vmThread->scopedValueCache);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	default:
 		break;

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -452,28 +452,6 @@ Java_java_lang_Thread_currentCarrierThread(JNIEnv *env, jclass clazz)
 	return result;
 }
 
-/* static native Object[] extentLocalCache(); */
-jobjectArray JNICALL
-Java_java_lang_Thread_extentLocalCache(JNIEnv *env, jclass clazz)
-{
-	J9VMThread *currentThread = (J9VMThread*)env;
-	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
-	jobjectArray result = (jobjectArray)VM_VMHelpers::createLocalRef(env, currentThread->extentLocalCache);
-	VM_VMAccess::inlineExitVMToJNI(currentThread);
-
-	return result;
-}
-
-/* static native void setExtentLocalCache(Object[] cache); */
-void JNICALL
-Java_java_lang_Thread_setExtentLocalCache(JNIEnv *env, jclass clazz, jobjectArray cache)
-{
-	J9VMThread *currentThread = (J9VMThread*)env;
-	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
-	currentThread->extentLocalCache = J9_JNI_UNWRAP_REFERENCE(cache);
-	VM_VMAccess::inlineExitVMToJNI(currentThread);
-}
-
 /* private static native StackTraceElement[][] dumpThreads(Thread[] threads); */
 jobjectArray JNICALL
 Java_java_lang_Thread_dumpThreads(JNIEnv *env, jclass clazz, jobjectArray threads)
@@ -569,11 +547,106 @@ Java_java_lang_Thread_registerNatives(JNIEnv *env, jclass clazz)
 	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
+
+#if JAVA_SPEC_VERSION >= 20
+/**
+ * static native Object[] scopedValueCache();
+ *
+ * Get the scoped value cache.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @return jobjectArray the scoped value cache object array
+ */
+jobjectArray JNICALL
+Java_java_lang_Thread_scopedValueCache(JNIEnv *env, jclass unusedClass)
+{
+	J9VMThread *currentThread = (J9VMThread*)env;
+	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
+	jobjectArray result = (jobjectArray)VM_VMHelpers::createLocalRef(env, currentThread->scopedValueCache);
+	VM_VMAccess::inlineExitVMToJNI(currentThread);
+
+	return result;
+}
+
+/**
+ * static native void setScopedValueCache(Object[] cache);
+ *
+ * Set the scoped value cache.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @param cache the scoped value cache object array
+ */
+void JNICALL
+Java_java_lang_Thread_setScopedValueCache(JNIEnv *env, jclass unusedClass, jobjectArray cache)
+{
+	J9VMThread *currentThread = (J9VMThread*)env;
+	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
+	currentThread->scopedValueCache = J9_JNI_UNWRAP_REFERENCE(cache);
+	VM_VMAccess::inlineExitVMToJNI(currentThread);
+}
+#else /* JAVA_SPEC_VERSION >= 20 */
+/**
+ * static native Object[] extentLocalCache();
+ *
+ * Get the extent local cache.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @return jobjectArray
+ */
+jobjectArray JNICALL
+Java_java_lang_Thread_extentLocalCache(JNIEnv *env, jclass unusedClass)
+{
+	J9VMThread *currentThread = (J9VMThread*)env;
+	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
+	jobjectArray result = (jobjectArray)VM_VMHelpers::createLocalRef(env, currentThread->scopedValueCache);
+	VM_VMAccess::inlineExitVMToJNI(currentThread);
+
+	return result;
+}
+
+/**
+ * static native void setExtentLocalCache(Object[] cache);
+ *
+ * Set the extent local cache.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @param cache the extent local cache object array
+ */
+void JNICALL
+Java_java_lang_Thread_setExtentLocalCache(JNIEnv *env, jclass unusedClass, jobjectArray cache)
+{
+	J9VMThread *currentThread = (J9VMThread*)env;
+	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
+	currentThread->scopedValueCache = J9_JNI_UNWRAP_REFERENCE(cache);
+	VM_VMAccess::inlineExitVMToJNI(currentThread);
+}
+#endif /* JAVA_SPEC_VERSION >= 20 */
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 #if JAVA_SPEC_VERSION >= 20
+/**
+ * static native Object findScopedValueBindings();
+ *
+ * Find the most recent scoped value bindings in the stack.
+ * TODO: Complete the function description.
+ *
+ * @param env instance of JNIEnv
+ * @param unusedClass
+ * @return jobject
+ */
+jobject JNICALL
+Java_java_lang_Thread_findScopedValueBindings(JNIEnv *env, jclass unusedClass)
+{
+	/* TODO: Implement. See https://github.com/eclipse-openj9/openj9/issues/16677. */
+	return NULL;
+}
 
-/* static native void ensureMaterializedForStackWalk(Object o);
+/**
+ * static native void ensureMaterializedForStackWalk(Object o);
  *
  * This is expected to invoke JVM_EnsureMaterializedForStackWalk and ensure
  * that the stackwalk code sees a materialized value.
@@ -590,7 +663,6 @@ Java_java_lang_Thread_ensureMaterializedForStackWalk(JNIEnv *env, jclass unusedC
 	 * https://github.com/eclipse-openj9/openj9/issues/16577
 	 */
 }
-
 #endif /* JAVA_SPEC_VERSION >= 20 */
 
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -673,16 +673,22 @@ if(J9VM_OPT_CRIU_SUPPORT)
 	)
 endif()
 
-# java 19+
+# Java 19 only
+if(JAVA_SPEC_VERSION EQUAL 19)
+	omr_add_exports(jclse
+		Java_java_lang_Thread_extentLocalCache
+		Java_java_lang_Thread_setExtentLocalCache
+	)
+endif()
+
+# Java 19+
 if(NOT JAVA_SPEC_VERSION LESS 19)
 	omr_add_exports(jclse
 		Java_java_lang_StackWalker_walkContinuationImpl
 		Java_java_lang_Thread_currentCarrierThread
 		Java_java_lang_Thread_dumpThreads
-		Java_java_lang_Thread_extentLocalCache
 		Java_java_lang_Thread_getNextThreadIdOffset
 		Java_java_lang_Thread_getThreads
-		Java_java_lang_Thread_setExtentLocalCache
 		Java_java_lang_Thread_registerNatives
 		Java_jdk_internal_vm_Continuation_pin
 		Java_jdk_internal_vm_Continuation_unpin
@@ -693,5 +699,8 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 20)
 	omr_add_exports(jclse
 		Java_java_lang_Thread_ensureMaterializedForStackWalk
+		Java_java_lang_Thread_findScopedValueBindings
+		Java_java_lang_Thread_scopedValueCache
+		Java_java_lang_Thread_setScopedValueCache
 	)
 endif()

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -40,6 +40,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<xi:include href="uma/se14_exports.xml"></xi:include>
 	<xi:include href="uma/se15_exports.xml"></xi:include>
 	<xi:include href="uma/se16_exports.xml"></xi:include>
+	<xi:include href="uma/se19only_exports.xml"></xi:include>
 	<xi:include href="uma/se19_exports.xml"></xi:include>
 	<xi:include href="uma/se20_exports.xml"></xi:include>
 
@@ -125,8 +126,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="se16">
 				<include-if condition="spec.java16"/>
 			</group>
+			<group name="se19only">
+				<include-if condition="spec.java19"/>
+				<exclude-if condition="spec.java20"/>
+			</group>
 			<group name="se19">
 				<include-if condition="spec.java19"/>
+			</group>
+			<group name="se20">
+				<include-if condition="spec.java20"/>
 			</group>
 		</exports>
 

--- a/runtime/jcl/uma/se19only_exports.xml
+++ b/runtime/jcl/uma/se19only_exports.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2022, 2023 IBM Corp. and others
+Copyright (c) 2023, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,13 +19,7 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-<exports group="se19">
-	<export name="Java_java_lang_StackWalker_walkContinuationImpl" />
-	<export name="Java_java_lang_Thread_currentCarrierThread" />
-	<export name="Java_java_lang_Thread_dumpThreads" />
-	<export name="Java_java_lang_Thread_getNextThreadIdOffset" />
-	<export name="Java_java_lang_Thread_getThreads" />
-	<export name="Java_java_lang_Thread_registerNatives" />
-	<export name="Java_jdk_internal_vm_Continuation_pin" />
-	<export name="Java_jdk_internal_vm_Continuation_unpin" />
+<exports group="se19only">
+	<export name="Java_java_lang_Thread_extentLocalCache" />
+	<export name="Java_java_lang_Thread_setExtentLocalCache" />
 </exports>

--- a/runtime/jcl/uma/se20_exports.xml
+++ b/runtime/jcl/uma/se20_exports.xml
@@ -21,4 +21,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 <exports group="se20">
 	<export name="Java_java_lang_Thread_ensureMaterializedForStackWalk" />
+	<export name="Java_java_lang_Thread_findScopedValueBindings" />
+	<export name="Java_java_lang_Thread_scopedValueCache" />
+	<export name="Java_java_lang_Thread_setScopedValueCache" />
 </exports>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5281,7 +5281,7 @@ typedef struct J9VMThread {
 	UDATA ownedMonitorCount;
 	UDATA callOutCount;
 	j9object_t carrierThreadObject;
-	j9object_t extentLocalCache;
+	j9object_t scopedValueCache;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9VMThread;
 

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -266,7 +266,7 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 	newThread->ownedMonitorCount = 0;
 	newThread->callOutCount = 0;
 	newThread->carrierThreadObject = threadObject;
-	newThread->extentLocalCache = NULL;
+	newThread->scopedValueCache = NULL;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 	/* If an exclusive access request is in progress, mark this thread */


### PR DESCRIPTION
In JDK20, `extentLocalCache` is renamed to `scopedValueCache`.

JDK19 and JDK20 changes are completely segregated to avoid
cross-contamination if the implementation differs a lot across
JDK versions.

TODO: `Thread.findScopedValueBindings` needs to be implemented.
This is tracked in #16677.

Related: #16439
Fixes: #16657

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>