### PR TITLE
Prepare to move Scavenger creation to createGlobalCollector()

### DIFF
--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,8 +45,6 @@
 bool 
 MM_ObjectAccessBarrier::initialize(MM_EnvironmentBase *env)
 {
-	_extensions = MM_GCExtensions::getExtensions(env);
-	_heap = _extensions->heap;
 	J9JavaVM *vm = (J9JavaVM*)env->getOmrVM()->_language_vm;
 	OMR_VM *omrVM = env->getOmrVM();
 	char *refSignature = (char*) "I";

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -605,8 +605,8 @@ public:
 	}
 
 	MM_ObjectAccessBarrier(MM_EnvironmentBase *env) : MM_BaseVirtual()
-		, _extensions(NULL) 
-		, _heap(NULL)
+		, _extensions(MM_GCExtensions::getExtensions(env))
+		, _heap(_extensions->heap)
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
 		, _compressObjectReferences(false)

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,7 @@ public:
 	MM_StandardAccessBarrier(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme) :
 		MM_ObjectAccessBarrier(env)
 #if defined(J9VM_GC_GENERATIONAL)
-		, _scavenger(NULL)
+		, _scavenger(_extensions->scavenger)
 #endif /* J9VM_GC_GENERATIONAL */
 		, _markingScheme(markingScheme)
 	{

--- a/runtime/gc_realtime/ConfigurationRealtime.cpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -229,6 +229,12 @@ MM_ConfigurationRealtime::newInstance(MM_EnvironmentBase *env)
 
 MM_GlobalCollector *
 MM_ConfigurationRealtime::createGlobalCollector(MM_EnvironmentBase *env)
+{
+	return MM_RealtimeGC::newInstance(env);
+}
+
+MM_GlobalCollector *
+MM_ConfigurationRealtime::createCollectors(MM_EnvironmentBase *env)
 {
 	return MM_RealtimeGC::newInstance(env);
 }

--- a/runtime/gc_realtime/ConfigurationRealtime.hpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,7 @@ private:
 /* Methods */
 public:
 	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
+	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);
 	virtual MM_MemorySpace *createDefaultMemorySpace(MM_EnvironmentBase *env, MM_Heap *heap, MM_InitializationParameters *parameters);

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,16 @@ MM_ConfigurationIncrementalGenerational::newInstance(MM_EnvironmentBase *env)
  */
 MM_GlobalCollector *
 MM_ConfigurationIncrementalGenerational::createGlobalCollector(MM_EnvironmentBase *envBase)
+{
+	MM_GCExtensionsBase *extensions = envBase->getExtensions();
+	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);
+	MM_HeapRegionManager *heapRegionManager = extensions->heapRegionManager;
+
+	return MM_IncrementalGenerationalGC::newInstance(env, heapRegionManager);
+}
+
+MM_GlobalCollector *
+MM_ConfigurationIncrementalGenerational::createCollectors(MM_EnvironmentBase *envBase)
 {
 	MM_GCExtensionsBase *extensions = envBase->getExtensions();
 	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,6 +53,7 @@ public:
 	static MM_Configuration *newInstance(MM_EnvironmentBase *env);
 
 	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
+	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, UDATA heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);
 	virtual J9Pool *createEnvironmentPool(MM_EnvironmentBase *env);


### PR DESCRIPTION
Current place of MM_Scavenger instantiation is
MM_ConfigurationGenerational::createDefaultMemorySpace(). It is relatively late in initialization path without any reason. Late creation required to have "Scavenger registration" in the classes created earlier. Moving Scavenger instantiation to
MM_ConfigurationGenerational::createGlobalCollector() makes more sense and resolves registration problem naturally. Method createGlobalCollector() is going to be renamed to createCollectors() to reflect the fact it might create not only Global, but Local collector too if necessary.

There is first step of refactoring:

- add _scavenger field initialization to Constructor of MM_StandardAccessBarrier
- move _extensions and _heap fields initialization to Constructor of MM_ObjectaccessBarrier
- duplicate createGlobalCollector() to creteCollectors() for Balanced and RealTime Configurations as a preparation to rename the method

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>