### PR TITLE
Refactor Continuation.yield method naming to match RI

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 19]*/
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,6 +217,11 @@ public class Continuation {
 		/* TODO find matching scope to yield */
 		Thread carrierThread = JLA.currentCarrierThread();
 		Continuation cont = JLA.getContinuation(carrierThread);
+
+		return cont.yield0();
+	}
+
+	private boolean yield0() {
 		int rcPinned = isPinnedImpl();
 		if (rcPinned != 0) {
 			Pinned reason = null;
@@ -229,10 +234,10 @@ public class Continuation {
 			} else {
 				throw new AssertionError("Unknown pinned error code: " + rcPinned);
 			}
-			cont.onPinned(reason);
+			onPinned(reason);
 		} else {
 			yieldImpl();
-			cont.onContinue();
+			onContinue();
 		}
 		return (rcPinned == 0);
 	}

--- a/test/functional/Java19andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
@@ -167,6 +167,8 @@ public class VirtualThreadTests {
 
 	@Test
 	public void test_YieldedVirtualThreadGetStackTrace() {
+		// Expected frame count is based on test's callstack and OpenJ9's implementation of Continuation.yield().
+		int expected_frames = 12;
 		try {
 			Thread t = Thread.ofVirtual().name("yielded-stackwalker").start(() -> {
 					testThread1_ready = true;
@@ -181,12 +183,12 @@ public class VirtualThreadTests {
 			StackTraceElement[] ste = t.getStackTrace();
 
 			// If stacktrace doesn't match expected result, print out stacktrace for debuggging.
-			if ((11 != ste.length) || !ste[0].getMethodName().equals("yieldImpl")) {
+			if ((expected_frames != ste.length) || !ste[0].getMethodName().equals("yieldImpl")) {
 				for (StackTraceElement st : ste) {
 					System.out.println(st);
 				}
 			}
-			AssertJUnit.assertTrue("Expected 11 frames, got " + ste.length, (11 == ste.length));
+			AssertJUnit.assertTrue("Expected " + expected_frames + " frames, got " + ste.length, (expected_frames == ste.length));
 			AssertJUnit.assertTrue("Expected top frame to be yieldImpl, got " + ste[0].getMethodName(), ste[0].getMethodName().equals("yieldImpl"));
 			LockSupport.unpark(t);
 			t.join();


### PR DESCRIPTION
Matching the RI will allow us to run more OpenJDK tests without tweaking
them for our implementation and be better prepared to support
unimplemented/new features in the future.

- Move Continuation.yield state check to new yield0 method
- Update VirtualThreadTests to match impl change

Related: #16215 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>