### PR TITLE
Cleanup after Scavenger instantiation refactoring

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -290,15 +290,6 @@ MM_GCExtensions::getContinuationObjectListsExternal(J9VMThread *vmThread)
 
 
 void
-MM_GCExtensions::registerScavenger(MM_Scavenger *scavenger)
-{
-	MM_GCExtensionsBase::registerScavenger(scavenger);
-	Assert_MM_true(isStandardGC());
-	Assert_MM_true(isScavengerEnabled());
-	((MM_StandardAccessBarrier *)accessBarrier)->registerScavenger(scavenger);
-}
-
-void
 MM_GCExtensions::releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9object_t objectPtr)
 {
 #if JAVA_SPEC_VERSION >= 19

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -216,8 +216,6 @@ public:
 
 	void computeDefaultMaxHeapForJava(bool enableOriginalJDK8HeapSizeCompatibilityOption);
 
-	virtual void registerScavenger(MM_Scavenger *scavenger);
-
 	MMINLINE J9HookInterface** getHookInterface() { return J9_HOOK_INTERFACE(hookInterface); };
 
 	/**

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -79,13 +79,6 @@ public:
 		_typeId = __FUNCTION__;
 	}
 
-	void registerScavenger(MM_Scavenger *scavenger)
-	{
-#if defined(J9VM_GC_GENERATIONAL)
-		_scavenger = scavenger;
-#endif /* J9VM_GC_GENERATIONAL */
-	}
-
 	virtual J9Object* asConstantPoolObject(J9VMThread *vmThread, J9Object* toConvert, UDATA allocationFlags);
 
 	virtual void rememberObjectImpl(MM_EnvironmentBase *env, J9Object* object);

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -447,7 +447,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 	GC_OMRVMInterface::initializeExtensions(extensions);
 
 	/* Initialize the global collector */
-	globalCollector = extensions->configuration->createGlobalCollector(&env);
+	globalCollector = extensions->configuration->createCollectors(&env);
 	if (NULL == globalCollector) {
 		if(MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_METRONOME_DOES_NOT_SUPPORT_4BIT_SHIFT == extensions->heapInitializationFailureReason) {
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, displayXmxOrMaxRAMPercentage(memoryParameterTable));

--- a/runtime/gc_realtime/ConfigurationRealtime.cpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.cpp
@@ -228,12 +228,6 @@ MM_ConfigurationRealtime::newInstance(MM_EnvironmentBase *env)
 }
 
 MM_GlobalCollector *
-MM_ConfigurationRealtime::createGlobalCollector(MM_EnvironmentBase *env)
-{
-	return MM_RealtimeGC::newInstance(env);
-}
-
-MM_GlobalCollector *
 MM_ConfigurationRealtime::createCollectors(MM_EnvironmentBase *env)
 {
 	return MM_RealtimeGC::newInstance(env);

--- a/runtime/gc_realtime/ConfigurationRealtime.hpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.hpp
@@ -51,7 +51,6 @@ private:
 	
 /* Methods */
 public:
-	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
 	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -75,16 +75,6 @@ MM_ConfigurationIncrementalGenerational::newInstance(MM_EnvironmentBase *env)
  * Create the global collector for a Tarok configuration
  */
 MM_GlobalCollector *
-MM_ConfigurationIncrementalGenerational::createGlobalCollector(MM_EnvironmentBase *envBase)
-{
-	MM_GCExtensionsBase *extensions = envBase->getExtensions();
-	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);
-	MM_HeapRegionManager *heapRegionManager = extensions->heapRegionManager;
-
-	return MM_IncrementalGenerationalGC::newInstance(env, heapRegionManager);
-}
-
-MM_GlobalCollector *
 MM_ConfigurationIncrementalGenerational::createCollectors(MM_EnvironmentBase *envBase)
 {
 	MM_GCExtensionsBase *extensions = envBase->getExtensions();

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
@@ -52,7 +52,6 @@ private:
 public:
 	static MM_Configuration *newInstance(MM_EnvironmentBase *env);
 
-	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
 	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, UDATA heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);


### PR DESCRIPTION
- remove registerScavenger() methods
- remove createGlobalCollector() methods
- call createCollectors() instead of createGlobalCollector()

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>