### PR TITLE
Fix DDR Compilation of "gcddrstructs.ic"

### DIFF
--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -61,7 +61,7 @@ class MM_ConfigurationDelegate
  * Member data and types
  */
 private:
-	uintptr_t _maximumDefaultNumberOfGCThreads = 64;
+	uintptr_t _maximumDefaultNumberOfGCThreads;
 	const MM_GCPolicy _gcPolicy;
 
 protected:
@@ -364,8 +364,9 @@ public:
 	/**
 	 * Constructor.
 	 */
-	MM_ConfigurationDelegate(MM_GCPolicy gcPolicy)
-		: _gcPolicy(gcPolicy)
+	MM_ConfigurationDelegate(MM_GCPolicy gcPolicy) :
+		_maximumDefaultNumberOfGCThreads(64)
+		, _gcPolicy(gcPolicy)
 	{}
 };
 


### PR DESCRIPTION
Move init of `_maximumDefaultNumberOfGCThreads` field to ctor init list.

Config Delegate's field `_maximumDefaultNumberOfGCThreads` const declaration was removed in.
https://github.com/eclipse-openj9/openj9/pull/16666, init was left with declaration, this resulted in DDR compile errors:
```
  [exec] "gc_glue_java/ConfigurationDelegate.hpp", line 67: error: data
member
     [exec]           initializer is not allowed
     [exec]    uintptr_t _maximumDefaultNumberOfGCThreads = 64;
```

Signed-off-by: Salman Rana <salman.rana@ibm.com>