### PR TITLE
Build jdk19+ Windows with VS 2022

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -361,9 +361,9 @@ x86-64_windows:
     8: '--with-toolchain-version=2017'
     11: '--with-toolchain-version=2019'
     17: '--with-toolchain-version=2019'
-    19: '--with-toolchain-version=2019'
-    20: '--with-toolchain-version=2019'
-    next: '--with-toolchain-version=2019'
+    19: '--with-toolchain-version=2022'
+    20: '--with-toolchain-version=2022'
+    next: '--with-toolchain-version=2022'
   node_labels:
     build: 'ci.role.build && hw.arch.x86 && sw.os.windows'
   build_env:


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/16701

Created https://github.com/adoptium/temurin-build/pull/3251 for the Adoptium pipelines.

Doc issue https://github.com/eclipse-openj9/openj9-docs/issues/1055