### PR TITLE
Initial Post Restore compiler options processing

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2022 IBM Corp. and others
+# Copyright (c) 2000, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -286,6 +286,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/J9Options.cpp \
     compiler/control/JitDump.cpp \
     compiler/control/MethodToBeCompiled.cpp \
+    compiler/control/OptionsPostRestore.cpp \
     compiler/control/rossa.cpp \
     compiler/env/ClassLoaderTable.cpp \
     compiler/env/CpuUtilization.cpp \

--- a/runtime/compiler/control/CMakeLists.txt
+++ b/runtime/compiler/control/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2022 IBM Corp. and others
+# Copyright (c) 2017, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@ j9jit_files(
 	control/J9Recompilation.cpp
 	control/JitDump.cpp
 	control/MethodToBeCompiled.cpp
+	control/OptionsPostRestore.cpp
 	control/rossa.cpp
 )
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3285,6 +3285,7 @@ J9::Options::packOptions(const TR::Options *origOptions)
    uint8_t *curPos = ((uint8_t *)options) + sizeof(TR::Options);
 
    options->_optionSets = NULL;
+   options->_postRestoreOptionSets = NULL;
    options->_startOptions = NULL;
    options->_envOptions = NULL;
    options->_logFile = NULL;

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -616,4 +616,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+uintptr_t initializeCompilerArgsPostRestore(J9JavaVM* vm, intptr_t argIndex, char** xCommandLineOptionsPtr, bool isXjit, bool mergeCompilerOptions);
+#endif
+
 #endif

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+
+#include "control/OptionsPostRestore.hpp"
+
+void
+J9::OptionsPostRestore::processCompilerOptions()
+   {
+
+   }
+
+void
+J9::OptionsPostRestore::processOptionsPostRestore()
+   {
+   J9::OptionsPostRestore optsPostRestore = J9::OptionsPostRestore();
+   optsPostRestore.processCompilerOptions();
+   }
+
+#endif // J9VM_OPT_CRIU_SUPPORT

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -24,18 +24,437 @@
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 
+#include "control/CompilationRuntime.hpp"
+#include "control/Options.hpp"
 #include "control/OptionsPostRestore.hpp"
+
+J9::OptionsPostRestore::OptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo)
+   :
+   _jitConfig(jitConfig),
+   _compInfo(compInfo),
+   _argIndexXjit(-1),
+   _argIndexXjitcolon(-1),
+   _argIndexXnojit(-1),
+   _argIndexXaot(-1),
+   _argIndexXaotcolon(-1),
+   _argIndexXnoaot(-1),
+   _argIndexMergeOptionsEnabled(-1),
+   _argIndexMergeOptionsDisabled(-1),
+   _argIndexPrintCodeCache(-1),
+   _argIndexDisablePrintCodeCache(-1),
+   _argIndexUseJITServer(-1),
+   _argIndexDisableUseJITServer(-1),
+   _argIndexJITServerSSLKey(-1),
+   _argIndexJITServerSSLCert(-1),
+   _argIndexJITServerUseAOTCache(-1),
+   _argIndexDisableJITServerUseAOTCache(-1),
+   _argIndexRequireJITServer(-1),
+   _argIndexDisableRequireJITServer(-1),
+   _argIndexJITServerLogConnections(-1),
+   _argIndexDisableJITServerLogConnections(-1),
+   _argIndexJITServerAOTmx(-1),
+   _argIndexJITServerLocalSyncCompiles(-1),
+   _argIndexDisableJITServerLocalSyncCompiles(-1),
+   _argIndexJITServerAOTCachePersistence(-1),
+   _argIndexDisableJITServerAOTCachePersistence(-1),
+   _argIndexJITServerAOTCacheDir(-1),
+   _argIndexJITServerAOTCacheName(-1),
+   _argIndexJITServerAddress(-1),
+   _argIndexJITServerPort(-1),
+   _argIndexJITServerTimeout(-1)
+   {}
+
+void
+J9::OptionsPostRestore::iterateOverExternalOptions()
+   {
+   int32_t start = static_cast<int32_t>(J9::ExternalOptions::TR_FirstExternalOption);
+   int32_t end = static_cast<int32_t>(J9::ExternalOptions::TR_NumExternalOptions);
+   for (int32_t option = start; option < end; option++)
+      {
+      switch (option)
+         {
+         case J9::ExternalOptions::Xjit:
+         case J9::ExternalOptions::Xjitcolon:
+         case J9::ExternalOptions::Xnojit:
+         case J9::ExternalOptions::Xaot:
+         case J9::ExternalOptions::Xaotcolon:
+         case J9::ExternalOptions::Xnoaot:
+         case J9::ExternalOptions::XXplusMergeCompilerOptions:
+         case J9::ExternalOptions::XXminusMergeCompilerOptions:
+            {
+            // These will have already been consumed
+            }
+            break;
+
+         case J9::ExternalOptions::Xnodfpbd:
+         case J9::ExternalOptions::Xdfpbd:
+         case J9::ExternalOptions::Xhysteresis:
+         case J9::ExternalOptions::Xnoquickstart:
+         case J9::ExternalOptions::Xquickstart:
+         case J9::ExternalOptions::XtlhPrefetch:
+         case J9::ExternalOptions::XnotlhPrefetch:
+         case J9::ExternalOptions::XlockReservation:
+         case J9::ExternalOptions::Xnoclassgc:
+         case J9::ExternalOptions::Xlp:
+         case J9::ExternalOptions::Xlpcodecache:
+         case J9::ExternalOptions::Xcodecache:
+         case J9::ExternalOptions::Xcodecachetotal:
+         case J9::ExternalOptions::XXcodecachetotal:
+         case J9::ExternalOptions::XXdeterministic:
+         case J9::ExternalOptions::XXplusRuntimeInstrumentation:
+         case J9::ExternalOptions::XXminusRuntimeInstrumentation:
+         case J9::ExternalOptions::XXplusPerfTool:
+         case J9::ExternalOptions::XXminusPerfTool:
+         case J9::ExternalOptions::XXplusJITServerTechPreviewMessageOption:
+         case J9::ExternalOptions::XXminusJITServerTechPreviewMessageOption:
+         case J9::ExternalOptions::XXplusMetricsServer:
+         case J9::ExternalOptions::XXminusMetricsServer:
+         case J9::ExternalOptions::XXJITServerMetricsPortOption:
+         case J9::ExternalOptions::XXJITServerMetricsSSLKeyOption:
+         case J9::ExternalOptions::XXJITServerMetricsSSLCertOption:
+         case J9::ExternalOptions::XXplusJITServerShareROMClassesOption:
+         case J9::ExternalOptions::XXminusJITServerShareROMClassesOption:
+            {
+            // do nothing, maybe consume them to prevent errors
+            }
+            break;
+
+         case J9::ExternalOptions::XjniAcc:
+            {
+            // call preProcessJniAccelerator
+            }
+            break;
+
+         case J9::ExternalOptions::XsamplingExpirationTime:
+            {
+            // call preProcessSamplingExpirationTime
+            }
+            break;
+
+         case J9::ExternalOptions::XcompilationThreads:
+            {
+            // Need to allocate more if needed
+            }
+            break;
+
+         case J9::ExternalOptions::XaggressivenessLevel:
+            {
+            // maybe call preProcessMode after this loop
+            }
+            break;
+
+         case J9::ExternalOptions::XXLateSCCDisclaimTimeOption:
+            {
+            // set compInfo->getPersistentInfo()->setLateSCCDisclaimTime
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusPrintCodeCache:
+            {
+            // set xxPrintCodeCacheArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusPrintCodeCache:
+            {
+            // set xxDisablePrintCodeCacheArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXdoNotProcessJitEnvVars:
+            {
+            // set _doNotProcessEnvVars;
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusUseJITServerOption:
+            {
+            // set xxUseJITServerArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusUseJITServerOption:
+            {
+            // set xxDisableUseJITServerArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerAddressOption:
+            {
+            // set _argIndexJITServerAddress
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerPortOption:
+            {
+            // set _argIndexJITServerPort
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerTimeoutOption:
+            {
+            // set _argIndexJITServerTimeout
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerSSLKeyOption:
+            {
+            // set xxJITServerSSLKeyArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerSSLCertOption:
+            {
+            // set xxJITServerSSLCertArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerSSLRootCertsOption:
+            {
+            // set compInfo->setJITServerSslRootCerts
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusJITServerUseAOTCacheOption:
+            {
+            // set xxJITServerUseAOTCacheArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusJITServerUseAOTCacheOption:
+            {
+            // set xxDisableJITServerUseAOTCacheArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusRequireJITServerOption:
+            {
+            // set xxRequireJITServerArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusRequireJITServerOption:
+            {
+            // set xxDisableRequireJITServerArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusJITServerLogConnections:
+            {
+            // set xxJITServerLogConnectionsArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusJITServerLogConnections:
+            {
+            // set xxDisableJITServerLogConnectionsArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerAOTmxOption:
+            {
+            // set xxJITServerAOTmxArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusJITServerLocalSyncCompilesOption:
+            {
+            // set xxJITServerLocalSyncCompilesArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusJITServerLocalSyncCompilesOption:
+            {
+            // set xxDisableJITServerLocalSyncCompilesArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXplusJITServerAOTCachePersistenceOption:
+            {
+            // set xxJITServerAOTCachePersistenceArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXminusJITServerAOTCachePersistenceOption:
+            {
+            // set xxDisableJITServerAOTCachePersistenceArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerAOTCacheDirOption:
+            {
+            // set xxJITServerAOTCacheDirArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::XXJITServerAOTCacheNameOption:
+            {
+            // set xxJITServerAOTCacheNameArgIndex
+            }
+            break;
+
+         case J9::ExternalOptions::Xlockword:
+            {
+            // TBD
+            }
+            break;
+
+         case J9::ExternalOptions::Xtuneelastic:
+            {
+            // TODO
+            }
+            break;
+
+         default:
+            TR_ASSERT_FATAL(false, "Option %s not addressed post restore\n", TR::Options::_externalOptionStrings[option]);
+         }
+      }
+   }
+
+void
+J9::OptionsPostRestore::processJitServerOptions()
+   {
+   if (_argIndexUseJITServer >= _argIndexDisableUseJITServer)
+      {
+      // Do JITServer init
+
+      if (_argIndexJITServerAddress >= 0)
+         {
+         // set compInfo->getPersistentInfo()->setJITServerAddress
+         }
+
+      if (_argIndexJITServerPort >= 0)
+         {
+         // set compInfo->getPersistentInfo()->setJITServerPort
+         }
+
+      if (_argIndexJITServerTimeout >= 0)
+         {
+         // set compInfo->getPersistentInfo()->setSocketTimeout
+         }
+
+      if ((_argIndexJITServerSSLKey >= 0) && (_argIndexJITServerSSLCert >= 0))
+         {
+         // Init SSL key and cert
+         }
+
+      if (_argIndexJITServerUseAOTCache > _argIndexDisableJITServerUseAOTCache)
+         {
+         // compInfo->getPersistentInfo()->setJITServerUseAOTCache(true);
+         }
+      else
+         {
+         // compInfo->getPersistentInfo()->setJITServerUseAOTCache(false);
+         }
+
+      if (_argIndexRequireJITServer > _argIndexDisableRequireJITServer)
+         {
+         // compInfo->getPersistentInfo()->setRequireJITServer(true);
+         // compInfo->getPersistentInfo()->setSocketTimeout(60000);
+         }
+
+      if (_argIndexJITServerLogConnections > _argIndexDisableJITServerLogConnections)
+         {
+         TR::Options::setVerboseOption(TR_VerboseJITServerConns);
+         }
+
+      if (_argIndexJITServerAOTmx > 0)
+         {
+         // JITServerAOTCacheMap::setCacheMaxBytes
+         }
+
+      if (_argIndexJITServerLocalSyncCompiles > _argIndexDisableJITServerLocalSyncCompiles)
+         {
+         // compInfo->getPersistentInfo()->setLocalSyncCompiles
+         }
+
+      if (_argIndexJITServerAOTCachePersistence > _argIndexDisableJITServerAOTCachePersistence)
+         {
+         // compInfo->getPersistentInfo()->setJITServerUseAOTCachePersistence(true);
+
+         if (_argIndexJITServerAOTCacheDir > 0)
+            {
+            // compInfo->getPersistentInfo()->setJITServerAOTCacheDir(directory);
+            }
+         }
+
+      if (_argIndexJITServerAOTCacheName >= 0)
+         {
+         // compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
+         }
+      }
+   else
+      {
+      // Disable JITServer
+      }
+   }
 
 void
 J9::OptionsPostRestore::processCompilerOptions()
    {
+   // TODO: Check existing config from before checkpoint
+   bool jitEnabled = true;
+   bool aotEnabled = true;
 
+   // TODO: find and consume
+   // - J9::ExternalOptions::Xjit
+   // - J9::ExternalOptions::Xnojit
+   // - J9::ExternalOptions::Xaot
+   // - J9::ExternalOptions::Xnoaot
+
+   if (_argIndexXjit < _argIndexXnojit)
+      jitEnabled = false;
+
+   if (_argIndexXaot < _argIndexXnoaot)
+      aotEnabled = false;
+
+   if (jitEnabled || aotEnabled)
+      {
+      // TODO: Process -Xjit:/-Xaot: options
+
+      // TODO: Based on whether the following is enabled, do necessary compensation
+      // - exclude=
+      // - limit=
+      // - compilationThreads=
+      // - disableAsyncCompilation
+      // - disabling recompilation (optLevel=, inhibit recomp, etc)
+
+      // TODO: Look into
+      // - -Xrs
+      // - -Xtune:virtualized
+
+      iterateOverExternalOptions();
+
+      if (_argIndexPrintCodeCache > _argIndexDisablePrintCodeCache)
+         {
+         // self()->setOption(TR_PrintCodeCacheUsage);
+         }
+
+      if (jitEnabled)
+         {
+         processJitServerOptions();
+         }
+      }
+   else
+      {
+      // TODO: Look into what needs to be done if both -Xnojit and -Xaot
+
+      if (!aotEnabled)
+         {
+         // do necessary work to disable aot compilation
+         }
+
+      if (!jitEnabled)
+         {
+         // do necessary work to disable jit compilation
+         }
+      }
    }
 
 void
-J9::OptionsPostRestore::processOptionsPostRestore()
+J9::OptionsPostRestore::processOptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo)
    {
-   J9::OptionsPostRestore optsPostRestore = J9::OptionsPostRestore();
+   J9::OptionsPostRestore optsPostRestore = J9::OptionsPostRestore(jitConfig, compInfo);
    optsPostRestore.processCompilerOptions();
    }
 

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -26,17 +26,82 @@
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 
+struct J9JITConfig;
+namespace TR { class CompilationInfo; }
+
 namespace J9
 {
 
 class OptionsPostRestore
    {
    public:
-   OptionsPostRestore() {};
-   static void processOptionsPostRestore();
+   /**
+    * \brief OptionsPostRestore constructor
+    *
+    * \param jitConfig The J9JITConfig
+    * \param compInfo The TR::CompilationInfo
+    */
+   OptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
+
+   /**
+    * Public API to process options post restore
+    *
+    * \param jitConfig The J9JITConfig
+    * \param compInfo The TR::CompilationInfo
+    */
+   static void processOptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
 
    private:
+
+   /**
+    * Method to iterate and set indices of external options found in
+    * the Restore VM Args Array
+    */
+   void iterateOverExternalOptions();
+
+   /**
+    * Method to process JITServer options post restore.
+    */
+   void processJitServerOptions();
+
+   /**
+    * Method to process compiler options post restore.
+    */
    void processCompilerOptions();
+
+   J9JITConfig *_jitConfig;
+   TR::CompilationInfo *_compInfo;
+
+   int32_t _argIndexXjit;
+   int32_t _argIndexXjitcolon;
+   int32_t _argIndexXnojit;
+   int32_t _argIndexXaot;
+   int32_t _argIndexXaotcolon;
+   int32_t _argIndexXnoaot;
+   int32_t _argIndexMergeOptionsEnabled;
+   int32_t _argIndexMergeOptionsDisabled;
+   int32_t _argIndexPrintCodeCache;
+   int32_t _argIndexDisablePrintCodeCache;
+   int32_t _argIndexUseJITServer;
+   int32_t _argIndexDisableUseJITServer;
+   int32_t _argIndexJITServerSSLKey;
+   int32_t _argIndexJITServerSSLCert;
+   int32_t _argIndexJITServerUseAOTCache;
+   int32_t _argIndexDisableJITServerUseAOTCache;
+   int32_t _argIndexRequireJITServer;
+   int32_t _argIndexDisableRequireJITServer;
+   int32_t _argIndexJITServerLogConnections;
+   int32_t _argIndexDisableJITServerLogConnections;
+   int32_t _argIndexJITServerAOTmx;
+   int32_t _argIndexJITServerLocalSyncCompiles;
+   int32_t _argIndexDisableJITServerLocalSyncCompiles;
+   int32_t _argIndexJITServerAOTCachePersistence;
+   int32_t _argIndexDisableJITServerAOTCachePersistence;
+   int32_t _argIndexJITServerAOTCacheDir;
+   int32_t _argIndexJITServerAOTCacheName;
+   int32_t _argIndexJITServerAddress;
+   int32_t _argIndexJITServerPort;
+   int32_t _argIndexJITServerTimeout;
    };
 
 }

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#ifndef OPTIONS_POST_RESTORE_HPP
+#define OPTIONS_POST_RESTORE_HPP
+
+#include "j9cfg.h"
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+
+namespace J9
+{
+
+class OptionsPostRestore
+   {
+   public:
+   OptionsPostRestore() {};
+   static void processOptionsPostRestore();
+
+   private:
+   void processCompilerOptions();
+   };
+
+}
+
+#endif // J9VM_OPT_CRIU_SUPPORT
+
+#endif // OPTIONS_POST_RESTORE_HPP

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -54,15 +54,21 @@ class OptionsPostRestore
    private:
 
    /**
-    * Method to iterate and set indices of external options found in
-    * the Restore VM Args Array
+    * Helper Method to iterate and set indices of external options
+    * found in the Restore VM Args Array
     */
    void iterateOverExternalOptions();
 
    /**
-    * Method to process JITServer options post restore.
+    * Helper method to process JITServer options post restore.
     */
    void processJitServerOptions();
+
+   /**
+    * Helper method to get compiler options (such as -Xjit, -Xaot, etc.)
+    * from the Restore VM Args Array and process them.
+    */
+   void processInternalCompilerOptions(bool enabled, bool isAOT);
 
    /**
     * Method to process compiler options post restore.

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -27,7 +27,12 @@
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 
 struct J9JITConfig;
+struct J9VMThread;
+struct J9Method;
 namespace TR { class CompilationInfo; }
+namespace TR { struct Region; }
+struct TR_Memory;
+struct TR_J9VMBase;
 
 namespace J9
 {
@@ -38,18 +43,21 @@ class OptionsPostRestore
    /**
     * \brief OptionsPostRestore constructor
     *
+    * \param vmThread The J9VMThread
     * \param jitConfig The J9JITConfig
     * \param compInfo The TR::CompilationInfo
+    * \param region Reference to a TR::Region
     */
-   OptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
+   OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *jitConfig, TR::CompilationInfo *compInfo, TR::Region &region);
 
    /**
     * Public API to process options post restore
     *
+    * \param vmThread The J9VMThread
     * \param jitConfig The J9JITConfig
     * \param compInfo The TR::CompilationInfo
     */
-   static void processOptionsPostRestore(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
+   static void processOptionsPostRestore(J9VMThread *vmThread, J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
 
    private:
 
@@ -58,6 +66,26 @@ class OptionsPostRestore
     * found in the Restore VM Args Array
     */
    void iterateOverExternalOptions();
+
+   /**
+    * Invalidate existing method bodies if they can no longer be
+    * executed based on the exclude/include filters.
+    *
+    * \param fej9 The TR_J9VMBase front end
+    * \param method The J9Method of the method to be filtered
+    */
+   void filterMethod(TR_J9VMBase *fej9, J9Method *method);
+
+   /**
+    * Helper method to filter methods based on the
+    * exclude/include filters.
+    */
+   void filterMethods();
+
+   /**
+    * Helper method to post process internal compiler options.
+    */
+   void postProcessInternalCompilerOptions();
 
    /**
     * Helper method to process JITServer options post restore.
@@ -76,7 +104,9 @@ class OptionsPostRestore
    void processCompilerOptions();
 
    J9JITConfig *_jitConfig;
+   J9VMThread *_vmThread;
    TR::CompilationInfo *_compInfo;
+   TR::Region &_region;
 
    int32_t _argIndexXjit;
    int32_t _argIndexXjitcolon;


### PR DESCRIPTION
This PR adds the initial framework and infrastructure needed to process options post restore.

* Ensure `_postRestoreOptionSets` is initialized
* Add framework to process JIT, JITServer, and externally documented options
* Add framework to compensate options that follow Policy 3 described in https://github.com/eclipse-openj9/openj9/issues/16714

~depends on https://github.com/eclipse/omr/pull/6886~ (merged)
depends on https://github.com/eclipse/omr/pull/6896