### PR TITLE
Add missed class declarations to StandardAccessBarrier.hpp

### DIFF
--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -40,6 +40,9 @@
 #include "RememberedSetSATB.hpp"
 #endif /* OMR_GC_REALTIME */
 
+class MM_MarkingScheme;
+class MM_Scavenger;
+
 /**
  * Access barrier for Modron collector.
  */


### PR DESCRIPTION
This is not functional change:
 - add missed declarations for MM_MarkingScheme and MM_Scavenger to MM_StandardAccessBarrier