### PR TITLE
Set proper z/OS Java 8 OMR compile options for compatibility and tuning

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corp. and others
+# Copyright (c) 2016, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,9 +42,16 @@ ifeq (zos_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		OMR_GC_POINTER_MODE=compressed
-ifneq (8,$(VERSION_MAJOR))
+ifeq (8,$(VERSION_MAJOR))
+	CONFIGURE_ARGS += \
+		OMR_ZOS_COMPILE_ARCHITECTURE=7 \
+		OMR_ZOS_COMPILE_TUNE=10 \
+		OMR_ZOS_COMPILE_TARGET=zOSV1R13 \
+		OMR_ZOS_LINK_COMPAT=ZOSV1R13
+else
 	CONFIGURE_ARGS += \
 		OMR_ZOS_COMPILE_ARCHITECTURE=10 \
+		OMR_ZOS_COMPILE_TUNE=12 \
 		OMR_ZOS_COMPILE_TARGET=zOSV2R3 \
 		OMR_ZOS_LINK_COMPAT=ZOSV2R3
 endif
@@ -59,9 +66,16 @@ ifeq (zos_390-64, $(SPEC))
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		OMR_GC_POINTER_MODE=full
-ifneq (8,$(VERSION_MAJOR))
+ifeq (8,$(VERSION_MAJOR))
+	CONFIGURE_ARGS += \
+		OMR_ZOS_COMPILE_ARCHITECTURE=7 \
+		OMR_ZOS_COMPILE_TUNE=10 \
+		OMR_ZOS_COMPILE_TARGET=zOSV1R13 \
+		OMR_ZOS_LINK_COMPAT=ZOSV1R13
+else
 	CONFIGURE_ARGS += \
 		OMR_ZOS_COMPILE_ARCHITECTURE=10 \
+		OMR_ZOS_COMPILE_TUNE=12 \
 		OMR_ZOS_COMPILE_TARGET=zOSV2R3 \
 		OMR_ZOS_LINK_COMPAT=ZOSV2R3
 endif
@@ -74,6 +88,13 @@ ifeq (zos_390, $(SPEC))
 		--enable-OMR_PORT_ZOS_CEEHDLRSUPPORT \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		OMR_GC_POINTER_MODE=full
+ifeq (8,$(VERSION_MAJOR))
+	CONFIGURE_ARGS += \
+		OMR_ZOS_COMPILE_ARCHITECTURE=7 \
+		OMR_ZOS_COMPILE_TUNE=10 \
+		OMR_ZOS_COMPILE_TARGET=zOSV1R13 \
+		OMR_ZOS_LINK_COMPAT=ZOSV1R13
+endif
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o


### PR DESCRIPTION
They need to be explicitly set for Java 8 because the defaults were changed by https://github.com/eclipse/omr/pull/6250

With this change
`c89  -I.  -I../../../include -I../../include_core -I../../nls -I../../util/a2e/headers -DJ9ZOS390 -DLONGLONG -D_ALL_SOURCE -D_XOPEN_SOURCE_EXTENDED -D_POSIX_SOURCE -D__STDC_LIMIT_MACROS -DIBM_ATOE -DJ9ZOS39064 -Wc,DLL,EXPORTALL -c -Wc,"SERVICE(j20230215)" -Wc,"ARCH(7)" -O3 -Wc,"TUNE(10)" -Wc,"inline(auto,noreport,600,5000)" -Wl,compat=ZOSV1R13 -Wc,"langlvl(extc99)" -Wc,"xplink,rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"TARGET(zOSV1R13)" -Wc,"convlit(ISO8859-1)" -Wc,lp64 -Wa,"SYSPARM(BIT64)"   -o sysTranslate.o sysTranslate.c`

Before the change:
`c89  -I.  -I../../../include -I../../include_core -I../../nls -I../../util/a2e/headers -DJ9ZOS390 -DLONGLONG -D_ALL_SOURCE -D_XOPEN_SOURCE_EXTENDED -D_POSIX_SOURCE -D__STDC_LIMIT_MACROS -DIBM_ATOE -DJ9ZOS39064 -Wc,DLL,EXPORTALL -c -Wc,"SERVICE(j20230215)" -Wc,"ARCH(10)" -O3 -Wc,"TUNE(12)" -Wc,"inline(auto,noreport,600,5000)" -Wl,compat=ZOSV2R3 -Wc,"langlvl(extc99)" -Wc,"xplink,rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"TARGET(ZOSV2R3)" -Wc,"convlit(ISO8859-1)" -Wc,lp64 -Wa,"SYSPARM(BIT64)"   -o sysTranslate.o sysTranslate.c`
```
WARNING CCN0461 ./sysTranslate.c:0     "12" is not a valid sub-option for "TUNE". Option is ignored.
WARNING CCN0461 ./sysTranslate.c:0     "ZOSV2R3" is not a valid sub-option for "TARGET". Option is ignored.
```