### PR TITLE
For z/TPF disable ATOE mappings in J9IO and InternalFunctions

### DIFF
--- a/runtime/compiler/env/J9IO.cpp
+++ b/runtime/compiler/env/J9IO.cpp
@@ -20,6 +20,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#if defined(J9ZTPF)
+#if !defined(__TPF_DO_NOT_MAP_ATOE)
+#define __TPF_DO_NOT_MAP_ATOE
+#endif /* !defined(__TPF_DO_NOT_MAP_ATOE) */
+#endif /* defined(J9ZTPF) */
+
 #include <stdio.h>
 #include <stdarg.h>
 #include "env/IO.hpp"

--- a/runtime/compiler/ras/InternalFunctions.cpp
+++ b/runtime/compiler/ras/InternalFunctions.cpp
@@ -20,6 +20,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#if defined(J9ZTPF)
+#if !defined(__TPF_DO_NOT_MAP_ATOE)
+#define __TPF_DO_NOT_MAP_ATOE
+#endif /* !defined(__TPF_DO_NOT_MAP_ATOE) */
+#endif /* defined(J9ZTPF) */
+
 #include "ras/InternalFunctions.hpp"
 
 #include <stdarg.h>


### PR DESCRIPTION
Add guard macros to J9IO.cpp and InternalFunctions.cpp to prevent z/TPF from redefining vfprintf to atoe_vfprintf.