### PR TITLE
Handle Unsupported GC policies with CRIU 

### DIFF
--- a/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
+++ b/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
@@ -31,6 +31,7 @@
 #include "j2sever.h"
 #include "jvminit.h"
 #include "mmparse.h"
+#include "modronnls.h"
 
 #include "Configuration.hpp"
 #include "GCExtensions.hpp"
@@ -82,6 +83,15 @@ isSubpoolAliasGCPolicySupported(MM_GCExtensions *extensions)
 bool MMINLINE
 isMetronomeGCPolicySupported(MM_GCExtensions *extensions)
 {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	J9JavaVM *vm = extensions->getJavaVM();
+	if (TRUE == vm->checkpointState.isCheckPointEnabled) {
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "metronome");
+		return false;
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 #if defined(J9VM_GC_REALTIME)
 #if defined(AIXPPC)
 	return true;
@@ -95,6 +105,15 @@ isMetronomeGCPolicySupported(MM_GCExtensions *extensions)
 bool MMINLINE
 isBalancedGCPolicySupported(MM_GCExtensions *extensions)
 {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	J9JavaVM *vm = extensions->getJavaVM();
+	if (TRUE == vm->checkpointState.isCheckPointEnabled) {
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "balanced");
+		return false;
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 #if defined (J9VM_GC_VLHGC) && defined (J9VM_ENV_DATA64)
 	return true;
 #endif /* J9VM_GC_VLHGC && J9VM_ENV_DATA64 */

--- a/runtime/nls/j9gc/j9modron.nls
+++ b/runtime/nls/j9gc/j9modron.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2021 IBM Corp. and others
+# Copyright (c) 2000, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -951,4 +951,14 @@ J9NLS_GC_OPTIONS_PREFERREDHEAPBASE_NOT_SUPPORTED_ON_ZOS_WARN=The -Xgc:preferredH
 J9NLS_GC_OPTIONS_PREFERREDHEAPBASE_NOT_SUPPORTED_ON_ZOS_WARN.explanation=The JVM was started with the -Xgc:preferredHeapBase option, which has no effect on z/OS.
 J9NLS_GC_OPTIONS_PREFERREDHEAPBASE_NOT_SUPPORTED_ON_ZOS_WARN.system_action=The JVM ignores the -Xgc:preferredHeapBase option.
 J9NLS_GC_OPTIONS_PREFERREDHEAPBASE_NOT_SUPPORTED_ON_ZOS_WARN.user_response=Refer to the IBM SDK documentation.
+
+# END NON-TRANSLATABLE
+
+# Note %s gc policy ("balanced" or "metronome")
+J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU=-Xgcpolicy:%s is currently unsupported with -XX:+EnableCRIUSupport
+# START NON-TRANSLATABLE
+J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU.explanation=The specified GC policy is currently unsuppourted with CRIU
+J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU.system_action=The JVM will terminate
+J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU.user_response=Adjust the garbage collector policy option (-Xgcpolicy) with one of the following supported policies: gencon, optavgpause or optthruput
+
 # END NON-TRANSLATABLE

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -87,25 +87,12 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_criu_nonPortableRestore</testCaseName>
-		<disables>
-			<disable>
-				<comment>Metronome GC policy is not supported on IBM Z</comment>
-				<variation>-Xgcpolicy:metronome</variation>
-				<platform>s390x_.*</platform>
-			</disable>
-			<disable>
-				<comment>Metronome GC policy is not supported on Power PC for Linux</comment>
-				<variation>-Xgcpolicy:metronome</variation>
-				<platform>ppc64le_linux.*</platform>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
-			<variation>-Xgcpolicy:balanced</variation>
 			<variation>-Xgcpolicy:optthruput</variation>
-			<variation>-Xgcpolicy:metronome</variation>
+			<variation>-Xgcpolicy:optavgpause</variation>
 		</variations>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \


### PR DESCRIPTION
- Metronome and Balanced GC policies are currently unsupported with CRIU. JVM should report an error if these are specified while CRIU support is enabled. 
- Disable Metronome/Balanced test variants for CRIU tests.
- Add missing optavgpause test variant.

Signed-off-by: Salman Rana <salman.rana@ibm.com>