### PR TITLE
ClassScanner should ignore "PermittedSubclasses" attribute in Java 17

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corp. and others
+ * Copyright (c) 2012, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,5 +149,20 @@ public class ClassScanner extends ClassVisitor {
 
 		}
 	}
+
+	/*[IF JAVA_SPEC_VERSION == 17]*/
+	@Deprecated
+	@Override
+	public void visitPermittedSubclassExperimental(String className) {
+		/*
+		 * Sealed classes (JEP 409) were introduced as a preview feature in Java 15
+		 * and (supposedly) completed in Java 17. Unfortunately, the ClassReader and
+		 * ClassVisitor classes in Java 17 still consider the "PermittedSubclasses"
+		 * attribute experimental. On the other hand, the Java 17 compiler generates
+		 * the attribute in some classes (e.g. com.ibm.dtfj.utils.file.ImageSourceType).
+		 * To avoid throwing UnsupportedOperationException, we just ignore them.
+		 */
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION == 17 */
 
 }


### PR DESCRIPTION
Otherwise the inherited method (inappropriately) throws `UnsupportedOperationException`.

To reproduce, run `jdmpview` from jdk17 on any core file and use this command sequence:
```
> log com.ibm.java.diagnostics.plugins FINE
> plugins reload
```
the result is this:
```
FINE: Scanning path modules/openj9.dtfj in search of plugins
Feb 22, 2023 12:02:30 PM com.ibm.java.diagnostics.utils.plugins.impl.PluginManagerImpl lambda$listClassFiles$1
FINE: Error occurred scanning modules/openj9.dtfj/com/ibm/dtfj/utils/file/ImageSourceType.class
java.lang.UnsupportedOperationException: This feature requires ASM9_EXPERIMENTAL
	at java.base/jdk.internal.org.objectweb.asm.ClassVisitor.visitPermittedSubclassExperimental(ClassVisitor.java:299)
	at java.base/jdk.internal.org.objectweb.asm.ClassReader.accept(ClassReader.java:715)
	at java.base/jdk.internal.org.objectweb.asm.ClassReader.accept(ClassReader.java:432)
	at openj9.dtfj/com.ibm.java.diagnostics.utils.plugins.impl.PluginManagerImpl.scanClassFile(PluginManagerImpl.java:308)
	at openj9.dtfj/com.ibm.java.diagnostics.utils.plugins.impl.PluginManagerImpl.examineClassFile(PluginManagerImpl.java:295)
	at openj9.dtfj/com.ibm.java.diagnostics.utils.plugins.impl.PluginManagerImpl.lambda$listClassFiles$1(PluginManagerImpl.java:183)
	...
```