### PR TITLE
Comp Threads and JIT Server options post restore

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -764,7 +764,7 @@ public:
    // It makes sure the number of usable compilation threads is within allowed bounds.
    // If not, set it to the upper bound based on the mode: JITClient/non-JITServer or JITServer.
    void updateNumUsableCompThreads(int32_t &numUsableCompThreads);
-   bool allocateCompilationThreads(int32_t numUsableCompThreads);
+   bool allocateCompilationThreads(int32_t numCompThreads);
    void freeAllCompilationThreads();
    void freeAllResources();
 
@@ -1060,10 +1060,15 @@ public:
    TR::CompilationInfoPerThread *getCompInfoForThread(J9VMThread *vmThread);
    int32_t getNumUsableCompilationThreads() const { return _numCompThreads; }
    int32_t getNumTotalCompilationThreads() const { return _numCompThreads + _numDiagnosticThreads; }
+   int32_t getNumAllocatedCompilationThreads() const { return _numAllocatedCompThreads; }
+   int32_t getNumTotalAllocatedCompilationThreads() const { return _numAllocatedCompThreads + _numDiagnosticThreads; }
    int32_t getFirstCompThreadID() const { return _firstCompThreadID; }
    int32_t getFirstDiagThreadID() const { return _firstDiagnosticThreadID; }
    int32_t getLastCompThreadID() const { return _lastCompThreadID; }
    int32_t getLastDiagThreadID() const { return _lastDiagnosticTheadID; }
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   void setNumUsableCompilationThreadsPostRestore(int32_t &numUsableCompThreads);
+#endif
    TR::CompilationInfoPerThreadBase *getCompInfoWithID(int32_t ID);
    TR::Compilation *getCompilationWithID(int32_t ID);
    TR::CompilationInfoPerThread *getFirstSuspendedCompilationThread();
@@ -1451,10 +1456,12 @@ private:
    bool                   _isInShutdownMode;
    int32_t                _numCompThreads; // Number of usable compilation threads that does not include the diagnostic thread
    int32_t                _numDiagnosticThreads;
+   int32_t                _numAllocatedCompThreads; // Number of allocated compilation threads that does not include the diagnostic thread
    int32_t                _firstCompThreadID;
    int32_t                _firstDiagnosticThreadID;
    int32_t                _lastCompThreadID;
    int32_t                _lastDiagnosticTheadID;
+   int32_t                _lastAllocatedCompThreadID;
    int32_t                _iprofilerMaxCount;
    int32_t                _numGCRQueued; // how many GCR requests are in the queue
                                          // We should disable GCR counting if too many

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -47,6 +47,7 @@
 #include "compile/CompilationTypes.hpp"
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #include "control/CompileBeforeCheckpoint.hpp"
+#include "control/OptionsPostRestore.hpp"
 #endif
 #include "compile/ResolvedMethod.hpp"
 #include "control/JitDump.hpp"
@@ -2891,8 +2892,13 @@ void TR::CompilationInfo::prepareForCheckpoint()
 
 void TR::CompilationInfo::prepareForRestore()
    {
+   J9JavaVM   *vm       = _jitConfig->javaVM;
+   J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
+
    if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
       TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Preparing for restore");
+
+   J9::OptionsPostRestore::processOptionsPostRestore(vmThread, _jitConfig, this);
 
    {
    OMR::CriticalSection resumeCompThreadsCriticalSection(getCompilationMonitor());

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -621,7 +621,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
             TR_ASSERT(arrayOfCompInfoPT, "TR::CompilationInfo::_arrayOfCompilationInfoPerThread is null\n");
 
-            for (int32_t i = 0; i < compInfo->getNumTotalCompilationThreads(); i++)
+            for (int32_t i = 0; i < compInfo->getNumTotalAllocatedCompilationThreads(); i++)
                {
                TR::CompilationInfoPerThread *curCompThreadInfoPT = arrayOfCompInfoPT[i];
                TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2712,6 +2712,15 @@ J9::Options::fePostProcessJIT(void * base)
          }
       }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+#if defined(J9VM_OPT_JITSERVER)
+   if (!javaVM->internalVMFunctions->isJITServerEnabled(javaVM))
+#endif
+      {
+      _numAllocatedCompilationThreads = TR::CompilationInfo::MAX_CLIENT_USABLE_COMP_THREADS;
+      }
+#endif // defined(J9VM_OPT_CRIU_SUPPORT)
+
    // patch Lock OR if mfence is not being used
    //
    if (!self()->getOption(TR_X86UseMFENCE) && (jitConfig->runtimeFlags & J9JIT_PATCHING_FENCE_TYPE))

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1308,7 +1308,8 @@ static std::string readFileToString(char *fileName)
       }
    }
 
-static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compInfo)
+bool
+J9::Options::JITServerParseCommonOptions(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo)
    {
    const char *xxJITServerPortOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerPortOption];
    const char *xxJITServerTimeoutOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerTimeoutOption];
@@ -1323,23 +1324,23 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    const char *xxDisableJITServerLogConnections = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerLogConnections];
    const char *xxJITServerAOTmxOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXJITServerAOTmxOption];
 
-   int32_t xxJITServerPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerPortOption, 0);
-   int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
-   int32_t xxJITServerSSLKeyArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLKeyOption, 0);
-   int32_t xxJITServerSSLCertArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLCertOption, 0);
-   int32_t xxJITServerSSLRootCertsArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLRootCertsOption, 0);
-   int32_t xxJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerUseAOTCacheOption, 0);
-   int32_t xxDisableJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerUseAOTCacheOption, 0);
-   int32_t xxRequireJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxRequireJITServerOption, 0);
-   int32_t xxDisableRequireJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableRequireJITServerOption, 0);
-   int32_t xxJITServerLogConnectionsArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLogConnections, 0);
-   int32_t xxDisableJITServerLogConnectionsArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLogConnections, 0);
-   int32_t xxJITServerAOTmxArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerAOTmxOption, 0);
+   int32_t xxJITServerPortArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerPortOption, 0);
+   int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
+   int32_t xxJITServerSSLKeyArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerSSLKeyOption, 0);
+   int32_t xxJITServerSSLCertArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerSSLCertOption, 0);
+   int32_t xxJITServerSSLRootCertsArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerSSLRootCertsOption, 0);
+   int32_t xxJITServerUseAOTCacheArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxJITServerUseAOTCacheOption, 0);
+   int32_t xxDisableJITServerUseAOTCacheArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxDisableJITServerUseAOTCacheOption, 0);
+   int32_t xxRequireJITServerArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxRequireJITServerOption, 0);
+   int32_t xxDisableRequireJITServerArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxDisableRequireJITServerOption, 0);
+   int32_t xxJITServerLogConnectionsArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxJITServerLogConnections, 0);
+   int32_t xxDisableJITServerLogConnectionsArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxDisableJITServerLogConnections, 0);
+   int32_t xxJITServerAOTmxArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, STARTSWITH_MATCH, xxJITServerAOTmxOption, 0);
 
    if (xxJITServerPortArgIndex >= 0)
       {
       UDATA port=0;
-      IDATA ret = GET_INTEGER_VALUE(xxJITServerPortArgIndex, xxJITServerPortOption, port);
+      IDATA ret = GET_INTEGER_VALUE_ARGS(vmArgsArray, xxJITServerPortArgIndex, xxJITServerPortOption, port);
       if (ret == OPTION_OK)
          compInfo->getPersistentInfo()->setJITServerPort(port);
       }
@@ -1356,7 +1357,7 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    if (xxJITServerTimeoutArgIndex >= 0)
       {
       UDATA timeoutMs=0;
-      IDATA ret = GET_INTEGER_VALUE(xxJITServerTimeoutArgIndex, xxJITServerTimeoutOption, timeoutMs);
+      IDATA ret = GET_INTEGER_VALUE_ARGS(vmArgsArray, xxJITServerTimeoutArgIndex, xxJITServerTimeoutOption, timeoutMs);
       if (ret == OPTION_OK)
          compInfo->getPersistentInfo()->setSocketTimeout(timeoutMs);
       }
@@ -1366,8 +1367,8 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
       {
       char *keyFileName = NULL;
       char *certFileName = NULL;
-      GET_OPTION_VALUE(xxJITServerSSLKeyArgIndex, '=', &keyFileName);
-      GET_OPTION_VALUE(xxJITServerSSLCertArgIndex, '=', &certFileName);
+      GET_OPTION_VALUE_ARGS(vmArgsArray, xxJITServerSSLKeyArgIndex, '=', &keyFileName);
+      GET_OPTION_VALUE_ARGS(vmArgsArray, xxJITServerSSLCertArgIndex, '=', &certFileName);
       std::string key = readFileToString(keyFileName);
       std::string cert = readFileToString(certFileName);
 
@@ -1385,7 +1386,7 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    if (xxJITServerSSLRootCertsArgIndex >= 0)
       {
       char *fileName = NULL;
-      GET_OPTION_VALUE(xxJITServerSSLRootCertsArgIndex, '=', &fileName);
+      GET_OPTION_VALUE_ARGS(vmArgsArray, xxJITServerSSLRootCertsArgIndex, '=', &fileName);
       std::string cert = readFileToString(fileName);
       if (!cert.empty())
          compInfo->setJITServerSslRootCerts(cert);
@@ -1406,7 +1407,7 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    if (xxJITServerAOTmxArgIndex >= 0)
       {
       uint32_t aotMaxBytes = 0;
-      if (GET_MEMORY_VALUE(xxJITServerAOTmxArgIndex, xxJITServerAOTmxOption, aotMaxBytes) == OPTION_OK)
+      if (GET_MEMORY_VALUE_ARGS(vmArgsArray, xxJITServerAOTmxArgIndex, xxJITServerAOTmxOption, aotMaxBytes) == OPTION_OK)
          {
          JITServerAOTCacheMap::setCacheMaxBytes(aotMaxBytes);
          }
@@ -1415,13 +1416,14 @@ static bool JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    return true;
    }
 
-static void JITServerParseLocalSyncCompiles(J9JavaVM *vm, TR::CompilationInfo *compInfo, bool isFSDEnabled)
+void
+J9::Options::JITServerParseLocalSyncCompiles(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo, bool isFSDEnabled)
    {
    const char *xxJITServerLocalSyncCompilesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerLocalSyncCompilesOption];
    const char *xxDisableJITServerLocalSyncCompilesOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerLocalSyncCompilesOption];
 
-   int32_t xxJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerLocalSyncCompilesOption, 0);
-   int32_t xxDisableJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerLocalSyncCompilesOption, 0);
+   int32_t xxJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxJITServerLocalSyncCompilesOption, 0);
+   int32_t xxDisableJITServerLocalSyncCompilesArgIndex = FIND_ARG_IN_ARGS(vmArgsArray, EXACT_MATCH, xxDisableJITServerLocalSyncCompilesOption, 0);
 
    // We either obey the command line option, or make sure to disable LocalSyncCompiles if
    // something is set that interferes with remote async recompilations.
@@ -2355,7 +2357,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                }
             }
          }
-      if (!JITServerParseCommonOptions(vm, compInfo))
+      if (!JITServerParseCommonOptions(vm->vmArgsArray, vm, compInfo))
          {
          // Could not parse JITServer options successfully
          return false;
@@ -2951,7 +2953,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       _highActiveThreadThreshold  = _veryHighActiveThreadThreshold;
 
    // This option needs to be parsed late so that we can account for FullSpeedDebug
-   JITServerParseLocalSyncCompiles(javaVM, compInfo, self()->getOption(TR_FullSpeedDebug));
+   JITServerParseLocalSyncCompiles(javaVM->vmArgsArray, javaVM, compInfo, self()->getOption(TR_FullSpeedDebug));
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    // Determine whether or not to inline monitor enter/exit

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -38,8 +38,11 @@ namespace J9 { typedef J9::Options OptionsConnector; }
 #include "control/OptionsUtil.hpp"
 #include "env/jittypes.h"
 #if defined(J9VM_OPT_JITSERVER)
+namespace TR { class CompilationInfo; }
 namespace TR { class CompilationInfoPerThreadBase; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
+
+struct J9VMInitArgs;
 
 namespace J9
 {
@@ -445,6 +448,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static char *JITServerAOTCacheStoreLimitOption(char *option, void *, TR::OptionTable *entry);
    static char *JITServerAOTCacheLoadLimitOption(char *option, void *, TR::OptionTable *entry);
    static char *JITServerRemoteExclude(char *option, void *base, TR::OptionTable *entry);
+   static bool JITServerParseCommonOptions(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo);
+   static void JITServerParseLocalSyncCompiles(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo, bool isFSDEnabled);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static char *vmStateOption(char *option, void *, TR::OptionTable *entry);

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -120,24 +120,8 @@ class OptionsPostRestore
    int32_t _argIndexDisablePrintCodeCache;
    int32_t _argIndexUseJITServer;
    int32_t _argIndexDisableUseJITServer;
-   int32_t _argIndexJITServerSSLKey;
-   int32_t _argIndexJITServerSSLCert;
-   int32_t _argIndexJITServerUseAOTCache;
-   int32_t _argIndexDisableJITServerUseAOTCache;
-   int32_t _argIndexRequireJITServer;
-   int32_t _argIndexDisableRequireJITServer;
-   int32_t _argIndexJITServerLogConnections;
-   int32_t _argIndexDisableJITServerLogConnections;
-   int32_t _argIndexJITServerAOTmx;
-   int32_t _argIndexJITServerLocalSyncCompiles;
-   int32_t _argIndexDisableJITServerLocalSyncCompiles;
-   int32_t _argIndexJITServerAOTCachePersistence;
-   int32_t _argIndexDisableJITServerAOTCachePersistence;
-   int32_t _argIndexJITServerAOTCacheDir;
-   int32_t _argIndexJITServerAOTCacheName;
    int32_t _argIndexJITServerAddress;
-   int32_t _argIndexJITServerPort;
-   int32_t _argIndexJITServerTimeout;
+   int32_t _argIndexJITServerAOTCacheName;
    };
 
 }

--- a/runtime/compiler/runtime/JITServerStatisticsThread.cpp
+++ b/runtime/compiler/runtime/JITServerStatisticsThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
             }
 
          // Print operational statistics to vlog if enabled
-         CpuUtilization *cpuUtil = compInfo->getCpuUtil(); 
+         CpuUtilization *cpuUtil = compInfo->getCpuUtil();
          if ((statsThreadObj->getStatisticsFrequency() != 0) && (crtTime - lastStatsTime > statsThreadObj->getStatisticsFrequency()))
             {
             int32_t cpuUsage = 0, avgCpuUsage = 0, vmCpuUsage = 0;
@@ -115,7 +115,7 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
                vmCpuUsage = cpuUtil->getVmCpuUsage();
                }
             omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", crtTime, OMRSTR_FTIME_FLAG_LOCAL);
-            
+
             TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::writeLine(TR_Vlog_JITServer, "CurrentTime: %s", timestamp);
             TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Compilation Queue Size: %d", compInfo->getMethodQueueSize());
@@ -132,7 +132,7 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
                }
             lastStatsTime = crtTime;
             }
-            
+
          if (cpuUtil->isFunctional() && TR::Options::isAnyVerboseOptionSet() && ((crtTime - lastCpuUpdate) >= 500))
             {
             lastCpuUpdate = crtTime;


### PR DESCRIPTION
* Add the concept of Number of Allocated Threads
    * In CRIU mode, the number of threads allocated is `TR::CompilationInfo::MAX_CLIENT_USABLE_COMP_THREADS` (unless it exceeds the number of code caches).
    * In non-CRIU mode, the number of threads allocated is the same as the number of usable threads.
* Refactor JITServer options processing code so it can be reused post-restore
* Process JITServer options post restore
* Enable the post restore options processing code