### PR TITLE
GC Restore (CRIU): Introduce Restore Opts Parsing and Extend Failure Path Error Reporting

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -35,7 +35,6 @@ extern "C" {
 #include "j9jclnls.h"
 #include "jni.h"
 #include "jvmtinls.h"
-#include "modronnls.h"
 #include "omrlinkedlist.h"
 #include "omrthread.h"
 #include "ut_j9criu.h"
@@ -719,11 +718,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 
 		releaseSafeOrExcusiveVMAccess(currentThread, vmFuncs, safePoint);
 
-		if (FALSE == vm->memoryManagerFunctions->j9gc_reinitialize_for_restore(currentThread)) {
+		if (FALSE == vm->memoryManagerFunctions->j9gc_reinitialize_for_restore(currentThread, &nlsMsgFormat)) {
 			currentExceptionClass = vm->checkpointState.criuJVMRestoreExceptionClass;
-			/* The only way for j9gc_reinitialize_for_restore to fail is if GC dispatcher failed to startup threads. */
-			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
-					J9NLS_GC_FAILED_TO_INSTANTIATE_TASK_DISPATCHER, NULL);
 			goto wakeJavaThreads;
 		}
 

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -261,7 +261,7 @@ extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThrea
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 extern J9_CFUNC void j9gc_prepare_for_checkpoint(J9VMThread *vmThread);
-extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread);
+extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat);
 extern J9_CFUNC BOOLEAN j9gc_reinitializeDefaults(J9VMThread *vmThread);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3041,11 +3041,16 @@ BOOLEAN
 j9gc_reinitializeDefaults(J9VMThread* vmThread)
 {
 	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(vmThread);
+	J9JavaVM* vm = vmThread->javaVM;
+	bool result = true;
 
-	/* TODO: Parse restore options to set gc thread count */
 	extensions->gcThreadCountForced = false;
 
-	return true;
+	if (!gcParseReconfigurableArguments(vm, vm->checkpointState.restoreArgsList)) {
+		result = false;
+	}
+
+	return result;
 }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,6 +94,7 @@ bool scan_udata_memory_size_helper(J9JavaVM *javaVM, char **cursor, uintptr_t *v
 bool scan_u64_memory_size_helper(J9JavaVM *javaVM, char **cursor, uint64_t *value, const char *argName);
 bool scan_hex_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *argName);
 void gcParseXgcpolicy(MM_GCExtensions *extensions);
+bool gcParseReconfigurableArguments(J9JavaVM *vm, J9VMInitArgs* args);
 
 #ifdef __cplusplus
 } /* extern "C" { */

--- a/runtime/nls/j9gc/j9modron.nls
+++ b/runtime/nls/j9gc/j9modron.nls
@@ -962,3 +962,11 @@ J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU.system_action=The JVM will terminate
 J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU.user_response=Adjust the garbage collector policy option (-Xgcpolicy) with one of the following supported policies: gencon, optavgpause or optthruput
 
 # END NON-TRANSLATABLE
+
+J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS=Failed to initialize; unable to parse GC restore options
+# START NON-TRANSLATABLE
+J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS.explanation=The garbage collector failed to initialize because of an error in the restore options
+J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS.system_action=The JVM will terminate
+J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS.user_response=Check that all of the GC options are correctly specified
+
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4539,7 +4539,7 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_ensureLockedSynchronizersIntegrity)(struct J9VMThread *vmThread) ;
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	void  ( *j9gc_prepare_for_checkpoint)(struct J9VMThread *vmThread) ;
-	BOOLEAN  ( *j9gc_reinitialize_for_restore)(struct J9VMThread *vmThread) ;
+	BOOLEAN  ( *j9gc_reinitialize_for_restore)(struct J9VMThread *vmThread, const char **nlsMsgFormat) ;
 	BOOLEAN  ( *j9gc_reinitializeDefaults)(struct J9VMThread *vmThread) ;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9MemoryManagerFunctions;


### PR DESCRIPTION
- Now that there are multiple ways for GC restore to fail, the error message is set based on the failing GC component. j9gc_reinitialize_for_restore internally sets error message.
-  Introduced gcParseReconfigurableArguments to handle restore args and extended existing parser api to distinguish the argArray to parse.
- Added J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS error message for restore opt parsing failure.