### PR TITLE
Remove redundant check that liveVirtualThreadList is non-null

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -369,7 +369,7 @@ JVM_VirtualThreadMountEnd(JNIEnv *env, jobject thread, jboolean firstMount)
 			J9OBJECT_OBJECT_STORE(currentThread, rootVirtualThread, vm->virtualThreadLinkPreviousOffset, rootVirtualThread);
 		}
 
-		if (NULL != vm->liveVirtualThreadList) {
+		{
 			j9object_t threadPrev = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset);
 			j9object_t threadNext = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkNextOffset);
 


### PR DESCRIPTION
While the mutex is held, that pointer is checked on line 356; if it was `NULL`, that changes on line 366. There's no need to check it again on line 372.