### PR TITLE
Test result of arraycmp for value type comparison

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -2765,15 +2765,17 @@ J9::ValuePropagation::transformVTObjectEqNeCompare(TR_OpaqueClassBlock *containi
        *
        * After transformation:
        * n40n   treetop
-       * n39n     arraycmp  <arraycmp>
-       * n100n      aladd
-       * n30n         aloadi  ACMPWideFieldsPrimitive$Holder._wfp QWideFieldsPrimitive;
-       * n28n           ...
-       * n99n         lconst 4
-       * n101n      aladd
-       * n36n         aload  ACMPWideFieldsPrimitive.VALUE1 QWideFieldsPrimitive;
-       * n99n         ==>lconst 4
-       * n98n       iconst 12
+       * n39n     icmpne
+       * n103n      arraycmp  <arraycmp>
+       * n100n        aladd
+       * n30n           aloadi  ACMPWideFieldsPrimitive$Holder._wfp QWideFieldsPrimitive;
+       * n28n             ...
+       * n99n           lconst 4
+       * n101n        aladd
+       * n36n           aload  ACMPWideFieldsPrimitive.VALUE1 QWideFieldsPrimitive;
+       * n99n           ==>lconst 4
+       * n98n         iconst 12
+       * n102n      iconst 0
        */
       int32_t totalFieldSize = 0;
       for (size_t idx = 0; idx < fieldCount; idx++)
@@ -2808,17 +2810,23 @@ J9::ValuePropagation::transformVTObjectEqNeCompare(TR_OpaqueClassBlock *containi
       lhsOffsetNode->setIsInternalPointer(true);
       rhsOffsetNode->setIsInternalPointer(true);
 
-      if (isObjectEqualityCompare)
-         {
-         TR::Node *arraycmpNode = TR::Node::create(TR::arraycmp, 3, lhsOffsetNode, rhsOffsetNode, totalFieldSizeNode);
-         arraycmpNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateArrayCmpSymbol());
-
-         TR::Node::recreateWithoutProperties(callNode, TR::ixor, 2, arraycmpNode, TR::Node::iconst(callNode, 1));
-         }
-      else
-         {
-         TR::Node::recreateWithoutProperties(callNode, TR::arraycmp, 3, lhsOffsetNode, rhsOffsetNode, totalFieldSizeNode, comp()->getSymRefTab()->findOrCreateArrayCmpSymbol());
-         }
+      // arraycmp returns 0, 1 or 2 - zero, for equality; one or two for inequality
+      // In order to yield a result in {0,1}, so transform <objectEqualityComparison> into
+      //
+      //   icmpeq
+      //     arraycmp
+      //     iconst 0
+      //
+      // and transform <objectInequalityComparison> into
+      //
+      //   icmpne
+      //     arraycmp
+      //     iconst 0
+      //
+      TR::Node *arraycmpNode = TR::Node::createWithSymRef(TR::arraycmp, 3, 3, lhsOffsetNode, rhsOffsetNode,
+                                                totalFieldSizeNode, comp()->getSymRefTab()->findOrCreateArrayCmpSymbol());
+      TR::Node::recreateWithoutProperties(callNode, isObjectEqualityCompare ? TR::icmpeq : TR::icmpne, 2,
+                                          arraycmpNode, TR::Node::iconst(callNode, 0));
 
       if (trace())
          {


### PR DESCRIPTION
The `arraycmp` operation produces a result of zero if the memory being compared is equal, one if the first operand is less than the second, or two if the second operand is less than the first.  The transformation of `<object{Equality|Inequality}Comparison>` used `arraycmp` assuming that the result would be zero for equality or one for inequality.  This change adds an `icmpeq` or `icmpne` to compare the result of the `arraycmp` with zero in order to yield a value in the expected range:  {0,1}.