### PR TITLE
Rename Continuation.execute to match the RI

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -166,7 +166,7 @@ public class Continuation {
 		isAccessible = true;
 	}
 
-	private static void execute(Continuation cont) {
+	private static void enter(Continuation cont) {
 		try {
 			cont.runnable.run();
 		} finally {

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -484,7 +484,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="19-"/>
 
 	<!-- Static method references needed to support VirtualThread/Continuation. -->
-	<staticmethodref class="jdk/internal/vm/Continuation" name="execute" signature="(Ljdk/internal/vm/Continuation;)V" versions="19-"/>
+	<staticmethodref class="jdk/internal/vm/Continuation" name="enter" signature="(Ljdk/internal/vm/Continuation;)V" versions="19-"/>
 	<!-- Security manager check -->
 	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5231,7 +5231,7 @@ ffi_OOM:
 		_vm->memoryManagerFunctions->preMountContinuation(_currentThread, continuationObject);
 
 		if (enterContinuation(_currentThread, continuationObject)) {
-			_sendMethod = J9VMJDKINTERNALVMCONTINUATION_EXECUTE_METHOD(_currentThread->javaVM);
+			_sendMethod = J9VMJDKINTERNALVMCONTINUATION_ENTER_METHOD(_currentThread->javaVM);
 			rc = GOTO_RUN_METHOD;
 		}
 


### PR DESCRIPTION
Continuation.execute is renamed to Continuation.enter.

Matching the RI will allow us to run more OpenJDK tests without
tweaking them for our implementation and be better prepared to
support unimplemented/new features in the future.

Related: #16688
Related: #16751