### PR TITLE
Pin virtual threads in JVMTI RawMonitorEnter and RawMonitorExit

### DIFF
--- a/runtime/jvmti/jvmtiRawMonitor.c
+++ b/runtime/jvmti/jvmtiRawMonitor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,6 +134,9 @@ block:
 					}
 				}
 			}
+#if JAVA_SPEC_VERSION >= 19
+			currentThread->ownedMonitorCount += 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		} else {
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 			if (currentThread->inNative)
@@ -169,6 +172,10 @@ jvmtiRawMonitorExit(jvmtiEnv* env,
 	if (rc == JVMTI_ERROR_NONE) {
 		if (omrthread_monitor_exit((omrthread_monitor_t) monitor) != 0) {
 			rc = JVMTI_ERROR_NOT_MONITOR_OWNER;
+#if JAVA_SPEC_VERSION >= 19
+		} else {
+			currentThread->ownedMonitorCount -= 1;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		}
 
 		/* JDK blocks here if the current thread is suspended - don't do VM access stuff if the current thread has exclusive */


### PR DESCRIPTION
JVMTI functions RawMonitorEnter and RawMonitorExit can be invoked
from Java code using native methods.

ownedMonitorCount is incremented for the current J9VMThread in
RawMonitorEnter after successfully acquiring the monitor, and
it is decremented for the current J9VMThread in RawMonitorExit
after successfully releasing the monitor.

This prevents virtual threads to yield if it owns a monitor.

Related: #16753