### PR TITLE
Fix variable declaration

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -965,13 +965,13 @@ freeJavaVM(J9JavaVM * vm)
 	{
 		J9Pool *hookRecords = vm->checkpointState.hookRecords;
 		J9VMInitArgs *restoreArgsList = vm->checkpointState.restoreArgsList;
+		J9Pool *classIterationRestoreHookRecords = vm->checkpointState.classIterationRestoreHookRecords;
 
 		if (NULL != hookRecords) {
 			pool_kill(hookRecords);
 			vm->checkpointState.hookRecords = NULL;
 		}
 
-		J9Pool *classIterationRestoreHookRecords = vm->checkpointState.classIterationRestoreHookRecords;
 		if (NULL != classIterationRestoreHookRecords) {
 			pool_kill(classIterationRestoreHookRecords);
 			vm->checkpointState.classIterationRestoreHookRecords = NULL;


### PR DESCRIPTION
Moved the variable declaration at top of the scope.

Related https://github.com/eclipse-openj9/openj9/pull/16622#discussion_r1120098379

Signed-off-by: Jason Feng <fengj@ca.ibm.com>