### PR TITLE
Downgrade/postpone compilations that are unlikely to improve throughput (0.38.0)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -125,7 +125,7 @@ int32_t J9::Options::_cpuCompTimeExpensiveThreshold = 4000;
 uintptr_t J9::Options::_compThreadAffinityMask = 0;
 
 #if defined(J9VM_OPT_JITSERVER)
-int64_t J9::Options::_oldAge = 1000 * 60 * 1000; // 1000 minutes
+int64_t J9::Options::_oldAge = 1000 * 60 * 90; // 90 minutes
 int64_t J9::Options::_oldAgeUnderLowMemory = 1000 * 60 * 5; // 5 minutes
 int64_t J9::Options::_timeBetweenPurges = 1000 * 60 * 1; // 1 minute
 bool J9::Options::_shareROMClasses = false;
@@ -135,6 +135,9 @@ int32_t J9::Options::_highActiveThreadThreshold = -1;
 int32_t J9::Options::_veryHighActiveThreadThreshold = -1;
 int32_t J9::Options::_aotCachePersistenceMinDeltaMethods = 200;
 int32_t J9::Options::_aotCachePersistenceMinPeriodMs = 10000; // ms
+int32_t J9::Options::_lowCompDensityModeEnterThreshold = 4; // Maximum number of compilations per 10 min of CPU required to enter low compilation density mode. Use 0 to disable feature
+int32_t J9::Options::_lowCompDensityModeExitThreshold = 15; // Minimum number of compilations per 10 min of CPU required to exit low compilation density mode
+int32_t J9::Options::_lowCompDensityModeExitLPQSize = 120;  // Minimum number of compilations in LPQ to take us out of low compilation density mode
 TR::CompilationFilters *J9::Options::_JITServerAOTCacheStoreFilters = NULL;
 TR::CompilationFilters *J9::Options::_JITServerAOTCacheLoadFilters = NULL;
 TR::CompilationFilters *J9::Options::_JITServerRemoteExcludeFilters = NULL;
@@ -1061,6 +1064,14 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_LoopyMethodDivisionFactor, 0, "F%d", NOT_IN_SUBSET},
    {"loopyMethodSubtractionFactor=", "O<nnn>\tCounts Subtraction factor for Loopy methods",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_LoopyMethodSubtractionFactor, 0, "F%d", NOT_IN_SUBSET},
+#if defined(J9VM_OPT_JITSERVER)
+   {"lowCompDensityModeEnterThreshold=", "M<nnn>\tMaximum number of compilations per 10 min of CPU required to enter low compilation density mode. Use 0 to disable feature.",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_lowCompDensityModeEnterThreshold, 0, "F%d", NOT_IN_SUBSET},
+   {"lowCompDensityModeExitLPQSize=", "M<nnn>\tMinimum number of compilations in LPQ to take us out of low compilation density mode",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_lowCompDensityModeExitLPQSize, 0, "F%d", NOT_IN_SUBSET},
+   {"lowCompDensityModeExitThreshold=", "M<nnn>\tMinimum number of compilations per 10 min of CPU required to exit low compilation density mode",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_lowCompDensityModeExitThreshold, 0, "F%d", NOT_IN_SUBSET},
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"lowerBoundNumProcForScaling=", "M<nnn>\tLower than this numProc we'll use the default scorchingSampleThreshold",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_lowerBoundNumProcForScaling, 0, "F%d", NOT_IN_SUBSET},
    {"lowVirtualMemoryMBThreshold=","M<nnn>\tThreshold when we declare we are running low on virtual memory. Use 0 to disable the feature",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -355,6 +355,9 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
    static int32_t _aotCachePersistenceMinDeltaMethods;
    static int32_t _aotCachePersistenceMinPeriodMs;
+   static int32_t _lowCompDensityModeEnterThreshold;
+   static int32_t _lowCompDensityModeExitThreshold;
+   static int32_t _lowCompDensityModeExitLPQSize;
    static TR::CompilationFilters *_JITServerAOTCacheStoreFilters;
    static TR::CompilationFilters *_JITServerAOTCacheLoadFilters;
    static TR::CompilationFilters *_JITServerRemoteExcludeFilters;


### PR DESCRIPTION
Experiments have shown that the stream of compilations from Java web applications subsides over time (as expected), but it doesn't go down to 0 even after many hours of load. The rare compilations that come after 30-60 minutes of load are very unlikely to improve throughput, and they only consume CPU cycles for no good reason. In a JITServer scenario this behavior has another negative effect: as long as the server continues to receive compilation requests from the client, it will hold on to the client session cache it builds inside. This commit adds some code that measures the "density of compilations" and when this metric shrinks under a threshold, first time compilations will be downgraded from warm to cold optlevel, while cold-->warm recompilations are postponed. Hot/scorching compilations are not affected because they might contribute to throughput. Note that cold compilations can be performed locally by the client JVM, so a desired side effect of this commit is that it increases the likelihood of JITServer freeing its associated client session cache.

Details of implementation:
"Density of compilations" is measured as the number of compilations per 10 minutes of CPU consumed by the JVM. We look at CPU and not at elapsed time because an idle JVM may not issue many compilation requests, yet it can still do so in the future, once load is applied to it. A JVM that is active will exercise various methods and create a flurry of compilations that is expected to gradually go down.
The sampling thread is responsible for measuring the density of compilations. The relevant data structure is a circular buffer with 21 entries, each entry accounting roughly for 30 sec of CPU time and holding the total number of compilation requests up to that point. A new entry in the circular buffer is filled once the JVM has spent approximately 30 sec of CPU.

Once the density of compilations drops under 4 per 10 minutes of CPU, the JVM enters the "low compilation density mode". Under this mode the following will happen:
- Cold compilations will pe performed locally (not sent to JITServer)
- First-time warm compilations will be downgraded to cold and an upgrade request will be added to the Low Priority Queue (LPQ). Such compilations will not use GCR as a means for recompilation.
- Recompilation requests at warm will be postponed by adding them to the LPQ
- Hot/scorching recompilations can proceed normally and will be sent to JITServer (ideally, all needed hot/schorching compilations should have already happened by now)
- Processing entries from LPQ is prohibited

If the density of compilations grows back to over 15 per 10 minutes of CPU, the JVM exits the "low compilation density mode". The same happens if the number of compilation requests buffered in LPQ grows over a limit (120 entries by default). Apart from allowing the compilations to proceed normally, this state also allows the entries from LPQ to be processed regardless of the CPU available at the client JVM (typically, entries from LPQ are processed only if the JVM does not consume its entire CPU entitlement). The idea is that, since the client will connect to the server anyway, why not solve the LPQ backlog that has accumulated. Most of the compilation overhead will be felt by the JITServer instance.

Options to control this feature:
-Xjit:lowCompDensityModeEnterThreshold=<N>  default 4. Use 0 to disable this feature
-Xjit:lowCompDensityModeExitThreshold=<N>   default 15
-Xjit:lowCompDensityModeExitLPQSize=<N>     default 120

Moreover, if the environment variable `TR_DontUpgradeDuringLowCompDensityMode` is set, upgrade compilations for the first-time compilations downgraded to cold will no longer be added to LPQ.

In order to increase the likelihood of JITServer freeing some session caches for inactive clients, this commit changed the default value for the following option: -Xjit:oldAge=<N>  changed from 1000 minutes to 90 minutes. The server will free the session cache for a client that hasn't issued a compilation request for a duration longer than the specified value. If the server is running very low on memory, the server will purge session caches for clients that where inactive for 5 or more minutes. This commit changes what "very low memory" means for JITServer, increasing the value from 16 MB to 80 MB.

Issue: #16347