### PR TITLE
Disable CRC-32C acceleration on Z when arraylets are enabled

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4077,7 +4077,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       }
 
    static bool disableCRC32CAcceleration = (feGetEnv("TR_DisableCRC32CAcceleration") != NULL);
-   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters())
+   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets())
       {
       switch (methodSymbol->getRecognizedMethod())
          {


### PR DESCRIPTION
The CRC-32C acceleration works on the assumption the the array it is working on is contiguous. As arraylets break this assumption, they also break this acceleration.