### PR TITLE
CRIU throws UnsupportedOperationException for SecurityManager

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF]*/
 #
-# Copyright (c) 1998, 2022 IBM Corp. and others
+# Copyright (c) 1998, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -480,6 +480,7 @@ K0A02="Bootstrap method returned null."
 #java.lang.System
 K0B00="The Security Manager is deprecated and will be removed in a future release"
 K0B01="Library name must not contain a file path: {0}"
+K0B02="Enabling a SecurityManager currently unsupported when -XX:+EnableCRIUSupport is specified"
 
 #java.lang.Throwable
 K0C00="Non-standard List class not permitted in suppressedExceptions serial stream"

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1197,6 +1197,12 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 @CallerSensitive
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public static void setSecurityManager(final SecurityManager s) {
+/*[IF CRIU_SUPPORT]*/
+	if (openj9.internal.criu.InternalCRIUSupport.isCRIUSupportEnabled()) {
+		/*[MSG "K0B02", "Enabling a SecurityManager currently unsupported when -XX:+EnableCRIUSupport is specified"]*/
+		throw new UnsupportedOperationException(Msg.getString("K0B02")); //$NON-NLS-1$
+	}
+/*[ENDIF] CRIU_SUPPORT */
 	/*[PR 113606] security field could be modified by another Thread */
 	@SuppressWarnings("removal")
 	final SecurityManager currentSecurity = security;

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -32,6 +32,8 @@
   <variable name="MAINCLASS_DEADLOCK_TEST" value="org.openj9.criu.DeadlockTest" />
   <variable name="MAINCLASS_DELAYEDOPERATIONS" value="org.openj9.criu.TestDelayedOperations" />
   <variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
+  <variable name="MAINCLASS_TEST_SECURITYMANAGER" value="org.openj9.criu.TestSecurityManager" />
+  <variable name="OPTION_SET_SECURITYMANAGER" value="-Djava.security.manager" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
@@ -318,6 +320,32 @@
     <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Failed to load options from the options file</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Test setting SecurityManager via -Djava.security.manager">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $OPTION_SET_SECURITYMANAGER$ $MAINCLASS_TEST_SECURITYMANAGER$ setSMCommandOption 1</command>
+    <output type="success" caseSensitive="no" regex="no">UnsupportedOperationException: Enabling a SecurityManager currently unsupported</output>
+    <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Test setting SecurityManager programmatically">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_TEST_SECURITYMANAGER$ setSMProgrammatically 1</command>
+    <output type="success" caseSensitive="no" regex="no">TEST PASSED</output>
+    <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSecurityManager.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSecurityManager.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+public class TestSecurityManager {
+
+	public static void main(String[] args) {
+		String test = args[0];
+
+		switch (test) {
+		case "setSMProgrammatically":
+			testUnsupportedOperationExceptionSM();
+			break;
+		case "setSMCommandOption":
+			System.out.println("TEST FAILED - -Djava.security.manager finished");
+			break;
+		default:
+			throw new RuntimeException("incorrect parameters");
+		}
+
+	}
+
+	@SuppressWarnings("removal")
+	private static void testUnsupportedOperationExceptionSM() {
+		try {
+			System.setSecurityManager(null);
+			System.out.println("TEST FAILED - setSecurityManager(null) finished");
+		} catch (UnsupportedOperationException e) {
+			System.out.println("TEST PASSED - setSecurityManager(null) throws UnsupportedOperationException");
+		}
+
+		try {
+			System.setSecurityManager(new SecurityManager());
+			System.out.println("TEST FAILED - setSecurityManager(new SecurityManager()) finished");
+		} catch (UnsupportedOperationException e) {
+			System.out.println(
+					"TEST PASSED - setSecurityManager(new SecurityManager()) throws UnsupportedOperationException");
+		}
+
+		try {
+			System.setSecurityManager(new MySecurityManager());
+			System.out.println("TEST FAILED - setSecurityManager(new MySecurityManager()) finished");
+		} catch (UnsupportedOperationException e) {
+			System.out.println(
+					"TEST PASSED - setSecurityManager(new MySecurityManager()) throws UnsupportedOperationException");
+		}
+	}
+
+	@SuppressWarnings("removal")
+	static class MySecurityManager extends SecurityManager {
+	}
+}


### PR DESCRIPTION
Enabling a SecurityManager currently unsupported when `-XX:+EnableCRIUSupport` is specified.;
Added tests to verify that` UnsupportedOperationException` is thrown when the `SecurityManager` is set programmatically or via `-Djava.security.manager`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>