### PR TITLE
Update default stream for reading core files

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,8 +141,8 @@ public class StructureReader {
 	 */
 	private void setStream() {
 		StructureDescriptor version = structures.get(DDRALGORITHM_STRUCTURE_NAME);
-		long vmMajorVersion = 2; // default: stream 23
-		long vmMinorVersion = 3;
+		long vmMajorVersion = 2; // default stream: 29
+		long vmMinorVersion = 9;
 
 		/* JAZZ 103906 : A hack was introduced when we split jvm.29 for ARM development.
 		 * The goal was to keep using the same values of VM_MAJOR_VERSION and


### PR DESCRIPTION
The old default, 23, corresponds to a version that is no longer supported.

Previously, some corrupt core files would experience the error
> Failed to load alias map from resource: /com/ibm/j9ddr/StructureAliases23.dat

This will allow further progress for such core files.