### PR TITLE
Disable CRC32C optimization on Power when arraylets are enabled

### DIFF
--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2891,7 +2891,8 @@ TR::Register *J9::Power::PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
          }
       }
 
-   if (comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
+   if (!comp()->requiresSpineChecks() &&
+       comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
        comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) &&
        (callNode->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateBytes ||
 	callNode->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateDirectByteBuffer)) {


### PR DESCRIPTION
CRC32C acceleration works on the assumption the the array is contiguous. Discontiguous arraylets breaks this assumption and thus fail.