### PR TITLE
Fix Q types in lambda signature generation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -386,7 +386,7 @@ final class Access implements JavaLangAccess {
 		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.newStringUTF8NoRepl(bytes, offset, length);
 		/*[ELSE] JAVA_SPEC_VERSION < 17 */
-		/*[IF JAVA_SPEC_VERSION < 21]*/
+		/*[IF (JAVA_SPEC_VERSION < 21) | INLINE-TYPES]*/
 		return String.newStringUTF8NoRepl(bytes, offset, length);
 		/*[ELSE] JAVA_SPEC_VERSION < 21 */
 		return String.newStringUTF8NoRepl(bytes, offset, length, true);
@@ -696,7 +696,7 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
-/*[IF JAVA_SPEC_VERSION >= 21]*/
+/*[IF (JAVA_SPEC_VERSION >= 21) & !INLINE-TYPES]*/
 	@Override
 	public String getLoaderNameID(ClassLoader loader) {
 		StringBuilder buffer = new StringBuilder();
@@ -714,7 +714,7 @@ final class Access implements JavaLangAccess {
 
 		return buffer.toString();
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 21) & !INLINE-TYPES */
 
 /*[IF INLINE-TYPES]*/
 	@Override

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -270,7 +270,11 @@ getClassSignature(J9VMThread *currentThread, J9Class * clazz)
 				if (J9ROMCLASS_IS_ARRAY(clazz->romClass)) {
 					vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, sigString, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, 0, J9VMJAVALANGSTRING_LENGTH(currentThread, sigString), (U_8*)sig, utfLength);
 				} else {
-					sig[0] = 'L';
+					if (J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(clazz)) {
+						sig[0] = 'Q';
+					} else {
+						sig[0] = 'L';
+					}
 					vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, sigString, J9_STR_XLAT, 0, J9VMJAVALANGSTRING_LENGTH(currentThread, sigString), (U_8*)(sig + 1), utfLength - 1);
 					sig[utfLength - 2] = ';';
 					sig[utfLength - 1] = '\0';
@@ -306,7 +310,11 @@ getClassSignature(J9VMThread *currentThread, J9Class * clazz)
 				}
 
 				if (*name != '[') {
-					sig[i++] = 'L';
+					if (J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(myClass)) {
+						sig[i++] = 'Q';
+					} else {
+						sig[i++] = 'L';
+					}
 				}
 
 				memcpy(sig+i, name, nameLength);


### PR DESCRIPTION
Correctly generate method signatures for lambda functions that take Q type arguments

For #13182 (fixes error in WithFieldAccessorTest)