### PR TITLE
AttachAPI TestJps should search a unique needle

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -100,8 +100,9 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-m")); //$NON-NLS-1$
-		Optional<String> searchResult = StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
+		String needle = tgtMgr.targetId + " TargetVM";
+		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
 		for (String a: targetArgs) {
 			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
 		}
@@ -114,8 +115,9 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, null, vmArgs, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-v")); //$NON-NLS-1$
-		Optional<String> searchResult = StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
+		String needle = tgtMgr.targetId + " TargetVM";
+		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
 		for (String a: vmArgs) {
 			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
 		}
@@ -128,7 +130,8 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-ml")); //$NON-NLS-1$
-		Optional<String> searchResult = StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
+		String needle = tgtMgr.targetId + " org.openj9.test.attachAPI.TargetVM";
+		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
 		for (String a: targetArgs) {
 			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));

--- a/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,17 @@ public class StringUtilities {
 	public static Optional<String> searchSubstring(String needle, Collection<String> haystack) {
 		return searchSubstring(needle, haystack.stream());
 	}
-	
+
+	/**
+	 * Find the first occurrence of a string starting with a specified prefix in a list of Strings.
+	 * @param needle pattern for which to search
+	 * @param haystack list of Strings to search
+	 * @return Optional which is either empty or contains matching string
+	 */
+	public static Optional<String> searchPrefixSubstring(String needle, Collection<String> haystack) {
+		return searchPrefixSubstring(needle, haystack.stream());
+	}
+
 	/**
 	 * Find the first occurrence of two substrings within one string in a list of Strings.
 	 * @param needleOne first pattern for which to search
@@ -61,6 +71,16 @@ public class StringUtilities {
 	 */
 	public static Optional<String> searchSubstring(String needle, Stream<String> haystack) {
 		return haystack.filter(s -> s.contains(needle)).findFirst();
+	}
+
+	/**
+	 * Find the first occurrence of a string starting with a specified prefix in a list of Strings.
+	 * @param needle pattern for which to search
+	 * @param haystack list of Strings to search
+	 * @return Optional which is either empty or contains matching string
+	 */
+	public static Optional<String> searchPrefixSubstring(String needle, Stream<String> haystack) {
+		return haystack.filter(s -> s.startsWith(needle)).findFirst();
 	}
 
 	/**


### PR DESCRIPTION
Created a unique needle with `tgtMgr.targetId` and `TargetVM/org.openj9.test.attachAPI.TargetVM` for
`testApplicationArguments`, `testJvmArguments` and `testComposedArguments`.

closes https://github.com/eclipse-openj9/openj9/issues/11509
closes https://github.com/eclipse-openj9/openj9/issues/5450

Signed-off-by: Jason Feng <fengj@ca.ibm.com>