### PR TITLE
Fix unused variable in ObjectMonitor.cpp

### DIFF
--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -316,7 +316,9 @@ objectMonitorEnterNonBlocking(J9VMThread *currentThread, j9object_t object)
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) || (JAVA_SPEC_VERSION >= 16)
 	J9Class * objClass = J9OBJECT_CLAZZ(currentThread, object);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) || (JAVA_SPEC_VERSION >= 16) */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
 	BOOLEAN retry = FALSE;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	if (J9_IS_J9CLASS_VALUETYPE(objClass)) {


### PR DESCRIPTION
The variable was added by
https://github.com/eclipse-openj9/openj9/pull/16812 for use when defined(J9VM_OPT_CRIU_SUPPORT)

Fixes https://github.com/eclipse-openj9/openj9/issues/16818