### PR TITLE
Update release note 0.37.0 with tokenlabel support on Linux Z

### DIFF
--- a/doc/release-notes/0.37/0.37.md
+++ b/doc/release-notes/0.37/0.37.md
@@ -76,6 +76,15 @@ The following table covers notable changes in v0.37.0. Further information about
 <td valign="top">The Visual Studio redistributable files included with the build are updated to match.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/547">#547</a></td>
+<td valign="top">Support for PKCS#11 token labels is added on z/OS&reg; and Linux on IBM Z&reg;.</td>
+<td valign="top">OpenJDK 11 and later (z/OS and Linux on IBM Z)</td>
+<td valign="top">On restarting an application, or creating or removing of tokens, the token might move to a different slot. An application that uses the <tt>slot</tt> or <tt>slotListIndex</tt> attributes might fail if it doesn’t first check which slot the token is in.
+
+ OpenJ9 now supports the use of an extra attribute, <tt>tokenlabel</tt>, in the SunPKCS11 configuration file on z/OS and Linux on IBM Z, which helps to avoid this issue.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9/issues/16824

Updated the release note with tokenlabel support for SunPKCS11 configuration on Linux on Z based on https://github.com/eclipse-openj9/openj9-docs/issues/1057

[skip ci]

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>