### PR TITLE
JDK21 Access invoke String.newStringUTF8NoRepl(bytes, offset, len, true)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -383,7 +383,11 @@ final class Access implements JavaLangAccess {
 		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.newStringUTF8NoRepl(bytes, offset, length);
 		/*[ELSE] JAVA_SPEC_VERSION < 17 */
+		/*[IF JAVA_SPEC_VERSION < 21]*/
 		return String.newStringUTF8NoRepl(bytes, offset, length);
+		/*[ELSE] JAVA_SPEC_VERSION < 21 */
+		return String.newStringUTF8NoRepl(bytes, offset, length, true);
+		/*[ENDIF] JAVA_SPEC_VERSION < 21 */
 		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
 	public byte[] getBytesUTF8NoRepl(String str) {


### PR DESCRIPTION
`JDK21` `Access.newStringUTF8NoRepl()` invokes `String.newStringUTF8NoRepl(bytes, offset, length, true)`.

Required by https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/558

Signed-off-by: Jason Feng <fengj@ca.ibm.com>