### PR TITLE
Initialize _catchSamplingSizeThreshold in J9Options.cpp

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3182,7 +3182,12 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    //
    self()->setOption(TR_DisableEDO);
 #endif
-
+   if (TR::Options::_catchSamplingSizeThreshold == -1) // not yet set
+      {
+      TR::Options::_catchSamplingSizeThreshold = 1100; // in number of nodes
+      if (TR::Compiler->target.numberOfProcessors() <= 2)
+         TR::Options::_catchSamplingSizeThreshold = 850;
+      }
    return true;
    }
 


### PR DESCRIPTION
`Options::_catchSamplingSizeThreshold` is a field declared in OpenJ9 but initialized in omr project. The intent is to remove this field, but to avoid build breaking (or a coordinated merge) we first need to bring the declaration and initialization of this field into the same project.