### PR TITLE
Init Scheduler Window

### DIFF
--- a/runtime/gc_realtime/MetronomeAlarmThread.cpp
+++ b/runtime/gc_realtime/MetronomeAlarmThread.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -172,7 +172,7 @@ MM_MetronomeAlarmThread::run(MM_EnvironmentRealtime *env)
 
 		_alarm->sleep();
 
-		if (env->getTimer()->hasTimeElapsed(_scheduler->getStartTimeOfCurrentMutatorSlice(), _scheduler->beatNanos)) {
+		if (env->getTimer()->hasTimeElapsed(_scheduler->getStartTimeOfCurrentMutatorSlice(), _scheduler->_beatNanos)) {
 			_scheduler->continueGC(env, TIME_TRIGGER, 0, NULL, true);
 		}
 

--- a/runtime/gc_realtime/RealtimeGC.cpp
+++ b/runtime/gc_realtime/RealtimeGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,47 +105,6 @@ MM_RealtimeGC::initialize(MM_EnvironmentBase *env)
 	_extensions->realtimeGC = this;
 	_allowGrowth = false;
 	
-	if (_extensions->gcTrigger == 0) {
-		_extensions->gcTrigger = (_extensions->memoryMax / 2);
-		_extensions->gcInitialTrigger = (_extensions->memoryMax / 2);
-	}
-
-	_extensions->distanceToYieldTimeCheck = 0;
-
-	/* Only SRT passes this check as the commandline option to specify beatMicro is only enabled on SRT */
-	if (METRONOME_DEFAULT_BEAT_MICRO != _extensions->beatMicro) {
-		/* User-specified quanta time, adjust related parameters */
-		_extensions->timeWindowMicro = 20 * _extensions->beatMicro;
-		/* Currently all supported SRT platforms - AIX and Linux, can only use HRT for alarm thread implementation.
-		 * The default value for HRT period is 1/3 of the default quanta: 1 msec for HRT period and 3 msec quanta,
-		 * we will attempt to adjust the HRT period to 1/3 of the specified quanta.
-		 */
-		uintptr_t hrtPeriodMicro = _extensions->beatMicro / 3;
-		if ((hrtPeriodMicro < METRONOME_DEFAULT_HRT_PERIOD_MICRO) && (METRONOME_DEFAULT_HRT_PERIOD_MICRO < _extensions->beatMicro)) {
-			/* If the adjusted value is too small for the hires clock resolution, we will use the default HRT period provided that
-			 * the default period is smaller than the quanta time specified.
-			 * Otherwise we fail to initialize the alarm thread with an error message.
-			 */
-			hrtPeriodMicro = METRONOME_DEFAULT_HRT_PERIOD_MICRO;
-		}
-		Assert_MM_true(0 != hrtPeriodMicro);
-		_extensions->hrtPeriodMicro = hrtPeriodMicro;
-
-		/* On Windows SRT we still use interrupt-based alarm. Set the interrupt period the same as hires timer period.
-		 * We will fail to init the alarm if this is too small a resolution for Windows.
-		 */
-		_extensions->itPeriodMicro = _extensions->hrtPeriodMicro;
-
-		/* if the pause time user specified is larger than the default value, calculate if there is opportunity
-		 * for the GC to do time checking less often inside condYieldFromGC.
-		 */
-		if (METRONOME_DEFAULT_BEAT_MICRO < _extensions->beatMicro) {
-			uintptr_t intervalToSkipYieldCheckMicro = _extensions->beatMicro - METRONOME_DEFAULT_BEAT_MICRO;
-			uintptr_t maxInterYieldTimeMicro = INTER_YIELD_MAX_NS / 1000;
-			_extensions->distanceToYieldTimeCheck = (U_32)(intervalToSkipYieldCheckMicro / maxInterYieldTimeMicro);
-		}
-	}
-
 	_osInterface = MM_OSInterface::newInstance(env);
 	if (_osInterface == NULL) {
 		return false;

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,9 +123,9 @@ public:
 	MM_OSInterface *_osInterface;
 
 	/* Params generated from command-line options from mmparse */
-	double window;
-	double beat;
-	U_64 beatNanos;
+	double _window;
+	double _beat;
+	U_64 _beatNanos;
 	double _staticTargetUtilization;
 
 	MM_UtilizationTracker* _utilTracker;
@@ -272,9 +272,9 @@ public:
 		_completeCurrentGCSynchronouslyReasonParameter(0),
 		_mainThreadMonitor(NULL),
 		_osInterface(NULL),
-		window(),
-		beat(),
-		beatNanos(),
+		_window(),
+		_beat(),
+		_beatNanos(),
 		_staticTargetUtilization(),
 		_utilTracker(NULL)
 	{

--- a/runtime/gc_realtime/SweepSchemeRealtime.cpp
+++ b/runtime/gc_realtime/SweepSchemeRealtime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ void
 MM_SweepSchemeRealtime::preSweep(MM_EnvironmentBase *env)
 {
 	_realtimeGC->setCollectorSweeping();
-	_scheduler->condYieldFromGC(env, _scheduler->beatNanos);
+	_scheduler->condYieldFromGC(env, _scheduler->_beatNanos);
 
 	MM_GCExtensionsBase *ext = env->getExtensions();
 	MM_SweepSchemeSegregated::preSweep(env);


### PR DESCRIPTION
Move some of Scheduler/Alarm specific initializaiton parameters that are stored in GCExtensions from Collector (RealtimeGC) to Scheduler.

Those parameter will now be initialized earlier. Specifically, timeWindowMicro will be initialized before its value is cached by Scheduler into window parameter.

All that to help window parameter be properly adjusted if beat parameter is changed by command line option.