### PR TITLE
(0.37) Fix GetThreadState to return correct state for carrier threads

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -109,7 +109,11 @@ jvmtiGetThreadState(jvmtiEnv *env,
 				} else {
 					vm->internalVMFunctions->haltThreadForInspection(currentThread, targetThread);
 					/* The VM thread can't be recycled because getVMThread() prevented it from exiting. */
+#if JAVA_SPEC_VERSION >= 19
+					rv_thread_state = getThreadState(currentThread, targetThread->carrierThreadObject);
+#else /* JAVA_SPEC_VERSION >= 19 */
 					rv_thread_state = getThreadState(currentThread, targetThread->threadObject);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 					vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
 				}
 				releaseVMThread(currentThread, targetThread, thread);


### PR DESCRIPTION
JVMTI GetThreadState returns 0 (invalid state) for carrier threads
when a virtual thread is mounted over them. 0 indicates that the
thread has not started but this state is invalid for the carrier
threads when they have a virtual thread mounted.

Helper function getThreadState should not be given virtual thread
objects. It should only receive platform thread objects. Instead of
targetThread->threadObject which can be a virtual thread object, it is
given targetThread->carrierThreadObject to correctly evaluate the
state of carrier threads. This change should also be compatible with
all platform threads since carrierThreadObject is set only once during
thread creation, and it stays the same until thread termination.

Related: #16690