### PR TITLE
CRIU Verbose Logging Reinit/Reconfig for Restore

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -309,6 +309,10 @@ public:
 	 */
 	static bool needScanStacksForContinuationObject(J9VMThread *vmThread, j9object_t objectPtr, bool isGlobalGC);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	MMINLINE virtual bool reinitializationInProgress() { return (NULL != ((J9JavaVM*)_omrVM->_language_vm)->checkpointState.checkpointThread); }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	/**
 	 * Create a GCExtensions object
 	 */

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -55,6 +55,7 @@
 #include "Configuration.hpp"
 #include "VerboseManager.hpp"
 #include "vmaccess.h"
+#include "verbosenls.h"
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 extern "C" {
@@ -1124,9 +1125,10 @@ j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat)
 {
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 	MM_GCExtensionsBase *extensions = env->getExtensions();
-	MM_VerboseManagerBase *verboseGCManager = extensions->verboseGCManager;
+	J9JavaVM *vm = vmThread->javaVM;
+	J9MemoryManagerVerboseInterface *mmFuncTable = (J9MemoryManagerVerboseInterface *)vm->memoryManagerFunctions->getVerboseGCFunctionTable(vm);
 
-	PORT_ACCESS_FROM_JAVAVM(vmThread->javaVM);
+	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	if (!j9gc_reinitializeDefaults(vmThread)) {
 		*nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
@@ -1145,10 +1147,13 @@ j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat)
 	}
 	acquireVMAccess(vmThread);
 
-	if (NULL != verboseGCManager) {
-		/* Verbose gc reinit failure can be ignored, it is safe for restore to continue on. */
-		verboseGCManager->reinitializeForRestore(env);
+	if (!mmFuncTable->checkOptsAndInitVerbosegclog(vm, vm->checkpointState.restoreArgsList)) {
+		*nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_VERB_FAILED_TO_INITIALIZE, NULL);
+		goto _error;
 	}
+
+	TRIGGER_J9HOOK_MM_OMR_REINITIALIZED( extensions->omrHookInterface, vmThread->omrVMThread, j9time_hires_clock());
 
 	return true;
 

--- a/runtime/gc_include/VerboseGCInterface.h
+++ b/runtime/gc_include/VerboseGCInterface.h
@@ -45,6 +45,7 @@ typedef struct J9MemoryManagerVerboseInterface {
 	void (*gcDumpMemorySizes)(J9JavaVM *javaVM);
 	UDATA (*configureVerbosegc)(J9JavaVM *javaVM, int enable, char* filename, UDATA numFiles, UDATA numCycles);
 	UDATA (*queryVerbosegc)(J9JavaVM *javaVM);
+	BOOLEAN (*checkOptsAndInitVerbosegclog)(J9JavaVM *javaVM, J9VMInitArgs* args);
 } J9MemoryManagerVerboseInterface;
 
 #ifdef __cplusplus

--- a/runtime/gc_modron_startup/GCVerboseInterface.cpp
+++ b/runtime/gc_modron_startup/GCVerboseInterface.cpp
@@ -104,6 +104,16 @@ dummygcDumpMemorySizes(J9JavaVM *javaVM)
 }
 
 /**
+ * Dummy function for verbose function table.
+ */
+BOOLEAN
+dummyCheckOptsAndInitVerbosegclog(J9JavaVM *javaVM, J9VMInitArgs* args)
+{
+	return TRUE;
+}
+
+
+/**
  * Initialises the verbose function table with the dummy routines.
  * @param table Pointer to the Verbose function table.
  */
@@ -115,6 +125,7 @@ initializeVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table
 	table->gcDumpMemorySizes = dummygcDumpMemorySizes;
 	table->configureVerbosegc = dummyconfigureVerbosegc;
 	table->queryVerbosegc = dummyQueryVerbosegc;
+	table->checkOptsAndInitVerbosegclog = dummyCheckOptsAndInitVerbosegclog;
 }
 
 } /* extern "C" */

--- a/runtime/gc_verbose_java/VerboseJava.cpp
+++ b/runtime/gc_verbose_java/VerboseJava.cpp
@@ -22,6 +22,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "mmhook.h"
+#include "verbose_api.h"
 
 #include "AtomicOperations.hpp"
 #include "Base.hpp"
@@ -55,7 +56,8 @@ J9MemoryManagerVerboseInterface functionTable = {
 	gcDebugVerboseShutdownLogging,
 	gcDumpMemorySizes,
 	configureVerbosegc,
-	queryVerbosegc
+	queryVerbosegc,
+	checkOptsAndInitVerbosegclog
 };
 
 /**
@@ -74,6 +76,7 @@ initializeVerboseFunctionTable(J9JavaVM *javaVM)
 	mmFuncTable->gcDumpMemorySizes = verboseTable->gcDumpMemorySizes;
 	mmFuncTable->configureVerbosegc = verboseTable->configureVerbosegc;
 	mmFuncTable->queryVerbosegc = verboseTable->queryVerbosegc;
+	mmFuncTable->checkOptsAndInitVerbosegclog = verboseTable->checkOptsAndInitVerbosegclog;
 }
 
 static UDATA

--- a/runtime/gc_verbose_java/VerboseManagerJava.cpp
+++ b/runtime/gc_verbose_java/VerboseManagerJava.cpp
@@ -177,3 +177,17 @@ MM_VerboseManagerJava::handleFileOpenError(MM_EnvironmentBase *env, char *fileNa
 	omrnls_printf(J9NLS_ERROR, J9NLS_GC_UNABLE_TO_OPEN_FILE, fileName);
 }
 
+int32_t
+MM_VerboseManagerJava::fileOpenMode(MM_EnvironmentBase *env)
+{
+	int32_t mode = EsOpenTruncate;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env->getOmrVM());
+	if (extensions->reinitializationInProgress()) {
+		mode = EsOpenAppend;
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
+	return mode;
+}
+

--- a/runtime/gc_verbose_java/VerboseManagerJava.hpp
+++ b/runtime/gc_verbose_java/VerboseManagerJava.hpp
@@ -77,6 +77,8 @@ public:
 
 	virtual void handleFileOpenError(MM_EnvironmentBase *env, char *fileName);
 
+	virtual int32_t fileOpenMode(MM_EnvironmentBase *env);
+
 	MM_VerboseManagerJava(OMR_VM *omrVM)
 		: MM_VerboseManager(omrVM)
 		, _mmHooks(NULL)

--- a/runtime/oti/verbose_api.h
+++ b/runtime/oti/verbose_api.h
@@ -121,6 +121,7 @@ typedef struct J9VerboseSettings {
 
 IDATA setVerboseState ( J9JavaVM *vm, J9VerboseSettings *verboseOptions, char **errorString );
 
+BOOLEAN checkOptsAndInitVerbosegclog(J9JavaVM* vm, J9VMInitArgs* args);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implementation to support CRIU Verbose GC logging.

> Verbose GC logging must be properly initialized and reconfigured, taking into account both restore options and initial verbose configuration at startup. There are multiple configuration scenarios possible depending on whether logging is enabled/disabled (pre/post restore) and the options provided at each phase.

- Introduced reinitalizationInProgress GC Extensions API, this is queried by GC to check if we're in the middle of restore reinit
- Introduced checkOptsAndInitVerbosegclog in verbose function table, high level method to check opt args and init verbose
- fileOpenMode implemented for VerboseManagerJava to signify that verbose file writers must append during reinit

Related: https://github.com/eclipse/omr/issues/6888#issuecomment-1458810193
Depends on: https://github.com/eclipse/omr/pull/6920

Signed-off-by: Salman Rana <salman.rana@ibm.com>