### PR TITLE
Don't need sync continuation scan during concurrent scavenger STW phases

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -309,6 +309,9 @@ public:
 	 */
 	static bool needScanStacksForContinuationObject(J9VMThread *vmThread, j9object_t objectPtr, bool isGlobalGC);
 
+	/* isCurrentScavengerPhaseConcurrent() is valid to use this from both mutator threads and GC threads */
+	bool isCurrentScavengerPhaseConcurrent(MM_EnvironmentBase* env);
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	MMINLINE virtual bool reinitializationInProgress() { return (NULL != ((J9JavaVM*)_omrVM->_language_vm)->checkpointState.checkpointThread); }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -352,8 +352,9 @@ MM_ScavengerDelegate::scanContinuationNativeSlots(MM_EnvironmentStandard *env, o
 		localData.env = env;
 		localData.reason = reason;
 		localData.shouldRemember = &shouldRemember;
+
 		/* In STW GC there are no racing carrier threads doing mount and no need for the synchronization. */
-		bool isConcurrentGC = _extensions->isConcurrentScavengerInProgress();
+		bool isConcurrentGC = _extensions->isCurrentScavengerPhaseConcurrent(env);
 
 		GC_VMThreadStackSlotIterator::scanSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForScavenge, false, false, isConcurrentGC, isGlobalGC);
 	}

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -1041,8 +1041,9 @@ void
 MM_StandardAccessBarrier::preMountContinuation(J9VMThread *vmThread, j9object_t contObject)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (_extensions->isConcurrentScavengerInProgress()) {
-		/* concurrent scavenger in progress */
+	/* preMountContinuation is a callback from mutator thread, check if concurrent scavenger is currently active. */
+	if (0 != vmThread->readBarrierRangeCheckTop) {
+		/* concurrent scavenger is currently active */
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
 		MM_ScavengeScanReason reason = SCAN_REASON_SCAVENGE;
 		_scavenger->getDelegate()->scanContinuationNativeSlots(env, contObject, reason);


### PR DESCRIPTION
current isConcurrentGC condition is isConcurrentScavengerInProgress()
which also includes STW phases( such as concurrent_phase_roots,
concurrent_phase_complete).

Mutator Thread and GC Thread need different way to check if concurrent
scavenger is currently active, new helper method
MM_GCExtensions::isCurrentScavengerPhaseConcurrent() is valid to use
from both mutator threads and GC threads.
