### PR TITLE
(0.38) Disable CRC32C optimization when arraylets are enabled on Power

### DIFF
--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2891,7 +2891,8 @@ TR::Register *J9::Power::PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
          }
       }
 
-   if (comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
+   if (!comp()->requiresSpineChecks() &&
+       comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
        comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) &&
        (callNode->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateBytes ||
 	callNode->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateDirectByteBuffer)) {


### PR DESCRIPTION
Backport  #16813 to 0.38 release