### PR TITLE
Post Restore Options Processing Continued (0.38)

### DIFF
--- a/doc/compiler/control/OptionsPostRestore.md
+++ b/doc/compiler/control/OptionsPostRestore.md
@@ -1,0 +1,140 @@
+<!--
+Copyright (c) 2023, 2023 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Overview
+
+This doc goes over how options are processed post restore in a
+Checkpoint/Restore environment. The `TR::OptionsPostRestore` class
+encapsulates all the logic that performs this processing. The
+semantics of compiler options when they are processed post restore
+are described in
+[https://github.com/eclipse-openj9/openj9/issues/16714](this)
+issue.
+
+`TR::OptionsPostRestore` has two public APIs:
+1. The Constructor
+2. `processOptionsPostRestore`
+which are used to first construct the object, and initiate the process
+of parsing and processing compiler options to be applied in the
+post-restore environment. Some options are applied retroactively,
+whereas others only apply going forward. Unlike options processing at
+the JVM startup, post restore options processing uses the
+`vm->checkpointState.restoreArgsList` args array.
+
+First `OptionsPostRestore` searches the args array for `-Xjit`,
+`-Xnotjit`, `-Xaot`, and `-Xnoaot`. If `-Xnoaot` appears after `-Xaot`
+then both compiling and loading AOT code going forward is disabled.
+If `-Xnojit` appears before `-Xjit`, compiling JIT code going forward
+is disabled; however, additionlly, all previously compiled code in the
+code cache is invalidated.
+
+Next, `preProcessInternalCompilerOptions` performs tasks that should
+be done prior to parsing and processing `-Xjit:` and `-Xaot:` options.
+`processInternalCompilerOptions` is then called for both `-Xjit:` and
+`-Xaot:` which parses and processes the options (if they exist).
+Following this step, `iterateOverExternalOptions` iterates over and
+processes `-X` and `-XX` options. Then, if the JIT is not disabled
+(because of `-Xnojit`), JITServer options are processed in
+`processJitServerOptions`.
+
+Finally, `postProcessInternalCompilerOptions` performs tasks that need
+to be done after the `-Xjit:`, `-Xaot:`, and external options have all
+been processed.
+
+# Subtleties
+
+### JIT and AOT compiled code
+
+There is a difference in how compiled code is perceived post restore.
+In a normal JVM run, JIT code is code that is compiled in the current
+JVM instance; AOT code is code that is loaded from the SCC - it may or
+may not have been compiled in the current JVM instance. However,
+because at the start of the JVM, there is no code, it makes sense to
+distinguish code _that is yet to be placed into a code cache_
+based on its provenance.
+
+In a CRIU run, as far as the post-restore options processing is
+concerned, all existing code in the code cache is JIT code. The idea
+is that once code is installed in the code cache, whether the code
+was generated in this JVM instance or loaded from the SCC is
+irrelevant except for debugging (at which point, the provenance can
+still be determined by looking at the `TR_PersistentJittedBodyInfo`).
+
+### `-Xnojit` and `-Xnoaot`
+
+In a normal JVM run, `-Xnojit` means that the Compiler component will
+be initialized but it won't perform any JIT compilation; it will still
+perform AOT load and AOT compilation. Similarly, `-Xnoaot` means that
+the Compiler won't perform any AOT load or AOT compilation, but it
+will till perform JIT compilation.
+
+Post restore, these two options behave in a similar manner however there
+is one big difference: `-Xnojit` will invalidate all previously compiled
+code in the code cache regardless of whether it was a JIT compile or an
+AOT load. As such, in order to disable all compiled code, one needs to
+specify `-Xnojit` (to disable JIT compilation and invalidate all previously
+compiled code) and `-Xnoaot` to disable AOT load/compilation.
+
+If `-Xnoaot` was specified pre-checkpoint, there is a lot of infrastructure
+that needs to be set up, including validating the existing SCC. Therefore,
+if `-Xnoaot` was specified pre=chekpoint, `-Xaot` is ignored post-restore.
+
+### `-Xjit:exclude={*}`
+
+`-Xjit:exclude={*}` is very similar to `-Xnojit` in terms of its effect.
+All existing JIT code is invalidated. Further JIT compilation ends up
+disabled because `exclude={*}` filters out all methods.
+
+### Invalidating method bodies
+
+In order to invalidate code, the method body needs to have a
+`TR_PersistentJittedBodyInfo`; method bodies, such as JNI thunks, do
+not have a body info, and therefore it is impossible to prevent
+invalidate these bodies; they will continue to be executed even with
+`-Xnojit`/`-Xjit:exclude={*}`.
+
+### JIT code on the application stack at checkpoint
+
+If an application thread has a compiled method on its stack, it is not
+possible without OSR to prevent executing that code when the stack
+unwinds, even with `-Xnojit`/`-Xjit:exclude={*}`.
+
+### Asynchronous and Synchronous Compilation
+
+Because synchronous and asynchronous compiled methods have different
+preprologues, and because the logic to trigger patching of the Start PC
+if the body gets invalidated uses a global flag to determine whether the
+method was synchronous or asynchronous, at present the options
+processing ignores a request to compile synchronously if it wasn't
+already specified pre-checkpoint.
+
+### Vlog/RtLog Semantics
+
+Both the vlog and rtlog have the same semantics. If the vlog/rtlog are
+specified pre-checkpoint and not post-restore, they remain unchanged. If
+the vlog/rtlog is NOT specified pre-checkpoint but IS specified
+post-restore, then the vlog/rtlog is opened post-restore. If they are
+specified both pre-checkpoint and post-restore, then the pre-checkpoint
+file(s) are closed and the post-restore file(s) are opened. A
+consequence of this is that if the same file name is specified then a
+new file will be opened. This can have the consequence of overwriting
+the previous file if the PID of the restored process is the same.

--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -219,7 +219,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
 
    if (bodyInfo->getUsesPreexistence()
        || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation())) // go interpreted for failed recomps in sync mode
+       || (linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
+       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
       {
       // Patch the first instruction regardless of counting or sampling
       patchAddr = (int32_t *)((uint8_t *)oldStartPC + getJitEntryOffset(linkageInfo));

--- a/runtime/compiler/arm/runtime/Recomp.cpp
+++ b/runtime/compiler/arm/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,7 +261,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
 
    if (bodyInfo->getUsesPreexistence()  // TODO: reconsider whether this is a race cond for info
        || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation())) // go interpreted for failed recomps in sync mode
+       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
+       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
       {
       // Patch the first instruction regardless of counting or sampling
       // TODO: We may need to cross-check with Invalidation to avoid racing cond

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1217,6 +1217,8 @@ public:
    bool getSuspendThreadDueToLowPhysicalMemory() const { return _suspendThreadDueToLowPhysicalMemory; }
    void setSuspendThreadDueToLowPhysicalMemory(bool b) { _suspendThreadDueToLowPhysicalMemory = b; }
 
+   void initCPUEntitlement();
+
    bool getLowCompDensityMode() const { return _lowCompDensityMode; }
    void enterLowCompDensityMode() { _lowCompDensityMode = true; _hasEnteredLowCompDensityModeInThePast = true;}
    void exitLowCompDensityMode() { _lowCompDensityMode = false; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -862,12 +862,45 @@ void TR::CompilationInfo::freeCompilationInfo(J9JITConfig *jitConfig)
    rawAllocator.deallocate(compilationRuntime);
    }
 
-void TR::CompilationInfoPerThread::freeAllResources()
+void
+TR::CompilationInfoPerThread::closeRTLogFile()
    {
    if (_rtLogFile)
       {
       j9jit_fclose(_rtLogFile);
+      _rtLogFile = NULL;
       }
+   }
+
+void
+TR::CompilationInfoPerThread::openRTLogFile()
+   {
+   char *rtLogFileName = ((TR_JitPrivateConfig*)jitConfig->privateConfig)->rtLogFileName;
+   if (rtLogFileName)
+      {
+      char fn[1024];
+
+      bool truncated = TR::snprintfTrunc(fn, sizeof(fn), "%s.%i", rtLogFileName, getCompThreadId());
+
+      if (!truncated)
+         {
+         _rtLogFile = fileOpen(TR::Options::getAOTCmdLineOptions(), jitConfig, fn, "wb", true);
+         }
+      else
+         {
+         fprintf(stderr, "Did not attempt to open comp thread rtlog %s because filename was truncated\n", fn);
+         _rtLogFile = NULL;
+         }
+      }
+   else
+      {
+      _rtLogFile = NULL;
+      }
+   }
+
+void TR::CompilationInfoPerThread::freeAllResources()
+   {
+   closeRTLogFile();
 
 #if defined(J9VM_OPT_JITSERVER)
    if (_classesThatShouldNotBeNewlyExtended)
@@ -1085,27 +1118,7 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
    _lastTimeThreadWasSuspended = 0;
    _lastTimeThreadWentToSleep = 0;
 
-   char *rtLogFileName = ((TR_JitPrivateConfig*)jitConfig->privateConfig)->rtLogFileName;
-   if (rtLogFileName)
-      {
-      char fn[1024];
-
-      bool truncated = TR::snprintfTrunc(fn, sizeof(fn), "%s.%i", rtLogFileName, getCompThreadId());
-
-      if (!truncated)
-         {
-         _rtLogFile = fileOpen(TR::Options::getAOTCmdLineOptions(), jitConfig, fn, "wb", true);
-         }
-      else
-         {
-         fprintf(stderr, "Did not attempt to open comp thread rtlog %s because filename was truncated\n", fn);
-         _rtLogFile = NULL;
-         }
-      }
-   else
-      {
-      _rtLogFile = NULL;
-      }
+   openRTLogFile();
 
 #if defined(J9VM_OPT_JITSERVER)
    _serverVM = NULL;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1237,7 +1237,7 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    setSamplerState(TR::CompilationInfo::SAMPLER_NOT_INITIALIZED);
 
    setIsWarmSCC(TR_maybe);
-   _cpuEntitlement.init(jitConfig);
+   initCPUEntitlement();
    _lowPriorityCompilationScheduler.setCompInfo(this);
    _JProfilingQueue.setCompInfo(this);
    _interpSamplTrackingInfo = new (PERSISTENT_NEW) TR_InterpreterSamplingTracking(this);
@@ -1256,6 +1256,12 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    _JITServerAOTCacheMap = NULL;
    _JITServerAOTDeserializer = NULL;
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   }
+
+void
+TR::CompilationInfo::initCPUEntitlement()
+   {
+   _cpuEntitlement.init(_jitConfig);
    }
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1352,6 +1352,9 @@ void TR::CompilationInfo::setAllCompilationsShouldBeInterrupted()
 
 bool TR::CompilationInfo::asynchronousCompilation()
    {
+   // Because answer below is a static, this expression is only evaluated once during runtime.
+   // Therefore, in a checkpoint/restore scenario, post-restore this value will remain what it
+   // was pre-checkpoint.
    static bool answer = (!TR::Options::getJITCmdLineOptions()->getOption(TR_DisableAsyncCompilation) &&
                         TR::Options::getJITCmdLineOptions()->getInitialBCount() &&
                         TR::Options::getJITCmdLineOptions()->getInitialCount() &&

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -500,6 +500,8 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    bool                   isDiagnosticThread() const { return _isDiagnosticThread; }
    CpuSelfThreadUtilization& getCompThreadCPU() { return _compThreadCPU; }
    TR::FILE              *getRTLogFile() { return _rtLogFile; }
+   void                   closeRTLogFile();
+   void                   openRTLogFile();
    virtual void           freeAllResources();
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -942,6 +942,11 @@ JITServerHelpers::postStreamFailure(OMRPortLibrary *portLibrary, TR::Compilation
          }
       compInfo->getPersistentInfo()->setServerUID(0);
       _serverAvailable = false;
+
+      // Ensure that log files are not supressed if methods are now
+      // going to be compiled locally
+      if (TR::Options::requiresDebugObject())
+         TR::Options::suppressLogFileBecauseDebugObjectNotCreated(false);
 
       // Reset the activation policy flag in case we never reconnect to the server
       // and client compiles locally or connects to a new server

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -401,6 +401,10 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
    // - OMR::Options::_logFile (both global and subsets)
    //    - May have to close an existing file and open a new one?
 
+   // Ensure that log files are not suppressed if tracing is enabled post restore
+   if (TR::Options::requiresDebugObject())
+      TR::Options::suppressLogFileBecauseDebugObjectNotCreated(false);
+
    if (TR::Options::getDebug())
       filterMethods();
 

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -33,6 +33,7 @@ namespace TR { class CompilationInfo; }
 namespace TR { struct Region; }
 struct TR_Memory;
 struct TR_J9VMBase;
+struct TR_JitPrivateConfig;
 
 namespace J9
 {
@@ -51,7 +52,7 @@ class OptionsPostRestore
    OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *jitConfig, TR::CompilationInfo *compInfo, TR::Region &region);
 
    /**
-    * Public API to process options post restore
+    * \brief  API to process options post restore
     *
     * \param vmThread The J9VMThread
     * \param jitConfig The J9JITConfig
@@ -62,14 +63,39 @@ class OptionsPostRestore
    private:
 
    /**
-    * Helper Method to iterate and set indices of external options
-    * found in the Restore VM Args Array
+    * \brief Close the old vlog if needed and open the vlog.
+    *
+    * \param vLogFileName The name of the vlog specified in the
+    *                     post restore options
+    */
+   void openNewVlog(char *vLogFileName);
+
+   /**
+    * \brief Close the old RT log if needed (including the RT log
+    *        per compilation thread), and open the new RT log
+    *        (including the RT log per compilation thread).
+    *
+    * \param rtLogFileName The name of the rtLog specified in the
+    *                      post restore options
+    */
+   void openNewRTLog(char *rtLogFileName);
+
+   /**
+    * \brief Open vlog and rtLog if specified in the restore run options.
+    *        If specified in both, the old log file is closed, and the
+    *        new log file is opened.
+    */
+   void openLogFilesIfNeeded();
+
+   /**
+    * \brief Method to iterate and set indices of external options
+    *        found in the Restore VM Args Array
     */
    void iterateOverExternalOptions();
 
    /**
-    * Invalidate existing method bodies if they can no longer be
-    * executed based on the exclude/include filters.
+    * \brief Invalidate existing method bodies if they can no longer be
+    *        executed based on the exclude/include filters.
     *
     * \param fej9 The TR_J9VMBase front end
     * \param method The J9Method of the method to be filtered
@@ -77,29 +103,29 @@ class OptionsPostRestore
    void filterMethod(TR_J9VMBase *fej9, J9Method *method);
 
    /**
-    * Helper method to filter methods based on the
-    * exclude/include filters.
+    * \brief Helper method to filter methods based on the
+    *        exclude/include filters.
     */
    void filterMethods();
 
    /**
-    * Helper method to post process internal compiler options.
+    * \brief Helper method to post process internal compiler options.
     */
    void postProcessInternalCompilerOptions();
 
    /**
-    * Helper method to process JITServer options post restore.
+    * \brief Helper method to process JITServer options post restore.
     */
    void processJitServerOptions();
 
    /**
-    * Helper method to get compiler options (such as -Xjit, -Xaot, etc.)
-    * from the Restore VM Args Array and process them.
+    * \brief Helper method to get compiler options (such as -Xjit, -Xaot, etc.)
+    *        from the Restore VM Args Array and process them.
     */
    void processInternalCompilerOptions(bool enabled, bool isAOT);
 
    /**
-    * Method to process compiler options post restore.
+    * \brief Method to process compiler options post restore.
     */
    void processCompilerOptions();
 
@@ -107,6 +133,10 @@ class OptionsPostRestore
    J9VMThread *_vmThread;
    TR::CompilationInfo *_compInfo;
    TR::Region &_region;
+   TR_JitPrivateConfig *_privateConfig;
+
+   char *_oldVLogFileName;
+   char *_oldRtLogFileName;
 
    int32_t _argIndexXjit;
    int32_t _argIndexXjitcolon;

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -94,19 +94,33 @@ class OptionsPostRestore
    void iterateOverExternalOptions();
 
    /**
-    * \brief Invalidate existing method bodies if they can no longer be
-    *        executed based on the exclude/include filters.
+    * \brief Invalidate an existing method body if possible. JNI methods
+    *        do not have a bodyinfo/methodinfo and therefore cannot be
+    *        invalidated.
     *
-    * \param fej9 The TR_J9VMBase front end
     * \param method The J9Method of the method to be filtered
+    * \param fej9 The TR_J9VMBase front end
     */
-   void filterMethod(TR_J9VMBase *fej9, J9Method *method);
+   void invalidateCompiledMethod(J9Method *method, TR_J9VMBase *fej9);
 
    /**
-    * \brief Helper method to filter methods based on the
-    *        exclude/include filters.
+    * \brief Determine whether a method should be invalidated because the
+    *        method should be excluded because of the -Xjit:exclude option
+    *
+    * \param method The J9Method of the method to be filtered
+    * \param fej9 The TR_J9VMBase front end
+    * \param compilationFiltersExist bool to indicate whether there are any
+    *                                compilation filters
+    *
+    * \return true if the method should be invalidated, false otherwise.
     */
-   void filterMethods();
+   bool shouldInvalidateCompiledMethod(J9Method *method, TR_J9VMBase *fej9, bool compilationFiltersExist);
+
+   /**
+    * \brief Invalidate methods if needed.
+    */
+   void invalidateCompiledMethodsIfNeeded(bool invalidateAll = false);
+
 
    /**
     * \brief Helper method to perform tasks prior to processing

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -144,6 +144,8 @@ class OptionsPostRestore
    char *_oldVLogFileName;
    char *_oldRtLogFileName;
 
+   bool _asyncCompilationPreCheckpoint;
+
    int32_t _argIndexXjit;
    int32_t _argIndexXjitcolon;
    int32_t _argIndexXnojit;

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -109,6 +109,12 @@ class OptionsPostRestore
    void filterMethods();
 
    /**
+    * \brief Helper method to perform tasks prior to processing
+    *        the internal compiler options.
+    */
+   void preProcessInternalCompilerOptions();
+
+   /**
     * \brief Helper method to post process internal compiler options.
     */
    void postProcessInternalCompilerOptions();

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -141,8 +141,11 @@ class OptionsPostRestore
    /**
     * \brief Helper method to get compiler options (such as -Xjit, -Xaot, etc.)
     *        from the Restore VM Args Array and process them.
+    *
+    * \param isAOT bool to determine whether the AOT or JIT options should be
+    *              processed.
     */
-   void processInternalCompilerOptions(bool enabled, bool isAOT);
+   void processInternalCompilerOptions(bool isAOT);
 
    /**
     * \brief Method to process compiler options post restore.

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -159,6 +159,9 @@ class TR_PersistentMethodInfo
 
    bool doesntKillAnything() { return _flags.testAll(RefinedAliasesMask); }
 
+   bool isExcludedPostRestore() { return _flags.testAny(IsExcludedPostRestore); }
+   void setIsExcludedPostRestore(bool b = true) { _flags.set(IsExcludedPostRestore, b); }
+
    // Accessor methods for the "cpoCounter".  This does not really
    // need to be its own counter, as it is conceptually the same as
    // "_counter".  However, the original _counter is still during instrumentation, so
@@ -247,6 +250,11 @@ class TR_PersistentMethodInfo
                                                        // Attention: this is not always accurate
       WasScannedForInlining                = 0x00400000, // New scanning for warm method inlining
       IsInDataCache                        = 0x00800000, // This TR_PersistentMethodInfo is stored in the datacache for AOT
+
+      IsExcludedPostRestore                = 0x01000000, // Post-restore, if a method should be excluded, this bit will allow
+                                                         // J9::Recompilation::methodCannotBeRecompiled to patch the startPC
+                                                         // to call the interpreter
+
       lastFlag                             = 0x80000000
       };
 

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -206,7 +206,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
 
    if (bodyInfo->getUsesPreexistence()  // TODO: reconsider whether this is a race cond for info
        || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation())) // go interpreted for failed recomps in sync mode
+       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
+       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
       {
       // Patch the first instruction regardless of counting or sampling
       // TODO: We may need to cross-check with Invalidation to avoid racing cond

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -295,7 +295,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
 
    if (bodyInfo->getUsesPreexistence()
        || methodInfo->hasBeenReplaced()
-       || (usesSampling && ! fej9->isAsyncCompilation())) // go interpreted for failed recomps in sync mode
+       || (usesSampling && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
+       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
       {
       // We need to switch the method to interpreted.  Change the first instruction of the
       // method to jump back to the call to the interpreter dispatch

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -314,7 +314,8 @@ J9::Recompilation::methodCannotBeRecompiled(void * oldStartPC, TR_FrontEnd * fe)
 
    if (bodyInfo->getUsesPreexistence()
        || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation())) // go interpreted for failed recomps in sync mode
+       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
+       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
       {
       bool usesSampling = linkageInfo->isSamplingMethodBody();
       // We need to switch the method to interpreted.  Change the first instruction of the


### PR DESCRIPTION
Cherry-pick of https://github.com/eclipse-openj9/openj9/pull/16838

The patch is almost identical except for `RecompilationInfo.hpp` where 
1. I had to resolve a merge conflict because https://github.com/eclipse-openj9/openj9/pull/16799 was not ported to 0.38.
2. I had to update the copyright because it was also updated in https://github.com/eclipse-openj9/openj9/pull/16799.