### PR TITLE
Add new optimization catchBlockProfiler

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -23,6 +23,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/env/CHTable.cpp \
     compiler/env/PersistentCHTable.cpp \
     compiler/optimizer/AllocationSinking.cpp \
+    compiler/optimizer/CatchBlockProfiler.cpp \
     compiler/optimizer/DataAccessAccelerator.cpp \
     compiler/optimizer/DynamicLiteralPool.cpp \
     compiler/optimizer/EscapeAnalysis.cpp \

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -155,7 +155,6 @@ int32_t J9::Options::_compilationExpirationTime = -1;
 int32_t J9::Options::_minSamplingPeriod = 10; // ms
 int32_t J9::Options::_compilationBudget = 0;  // ms; 0 means disabled
 
-int32_t J9::Options::_catchSamplingSizeThreshold = -1; // measured in nodes; -1 means not initialized
 int32_t J9::Options::_compilationThreadPriorityCode = 4; // these codes are converted into
                                                          // priorities in startCompilationThread
 int32_t J9::Options::_disableIProfilerClassUnloadThreshold = 20000;// The usefulness of IProfiling is questionable at this point
@@ -849,9 +848,6 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_countForLoopyBootstrapMethods, 250, "F%d", NOT_IN_SUBSET },
    {"bigAppSampleThresholdAdjust=", "O\tadjust the hot and scorching threshold for certain 'big' apps",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_bigAppSampleThresholdAdjust, 0, "F%d", NOT_IN_SUBSET},
-   {"catchSamplingSizeThreshold=", "R<nnn>\tThe sample counter will not be decremented in a catch block "
-                                   "if the number of nodes in the compiled method exceeds this threshold",
-        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_catchSamplingSizeThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"classLoadPhaseInterval=", "O<nnn>\tnumber of sampling ticks before we run "
                                "again the code for a class loading phase detection",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_classLoadingPhaseInterval, 0, "P%d", NOT_IN_SUBSET},
@@ -2602,7 +2598,7 @@ J9::Options::fePreProcess(void * base)
 
    if (!self()->preProcessJitServer(vm, jitConfig))
       {
-         return false;
+      return false;
       }
 
 #if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER)) && defined(TR_TARGET_64BIT)
@@ -3177,12 +3173,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       TR::Options::_coldUpgradeSampleThreshold = 10;
       }
 
-   if (TR::Options::_catchSamplingSizeThreshold == -1) // not yet set
-      {
-      TR::Options::_catchSamplingSizeThreshold = 1100; // in number of nodes
-      if (TR::Compiler->target.numberOfProcessors() <= 2)
-         TR::Options::_catchSamplingSizeThreshold = 850;
-      }
    return true;
    }
 

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -257,7 +257,6 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _activeThreadsThreshold; // -1 means 'determine dynamically', 0 means feature disabled
    static int32_t _samplingThreadExpirationTime;
    static int32_t _compilationExpirationTime;
-   static int32_t _catchSamplingSizeThreshold;
    static int32_t _compilationThreadPriorityCode; // a number between 0 and 4
    static int32_t _disableIProfilerClassUnloadThreshold;
    static int32_t _iprofilerReactivateThreshold;

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -273,7 +273,7 @@ J9::Recompilation::beforeOptimization()
          }
       else
          {
-         if (!debug("disableCatchBlockProfiler"))
+         if (!debug("disableCatchBlockProfiler") && _compilation->getOption(TR_EnableOldEDO))
             {
             _profilers.add(new (_compilation->trHeapMemory()) TR_CatchBlockProfiler(_compilation, self(), true));
             }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2664,11 +2664,18 @@ TR_J9VMBase::shouldPerformEDO(
    if (recomp
       && comp->getOptions()->allowRecompilation()
       && recomp->useSampling()
-      && recomp->shouldBeCompiledAgain()
-      && comp->getMethodHotness() < hot
-      && comp->getNodeCount() < TR::Options::_catchSamplingSizeThreshold)
+      && recomp->shouldBeCompiledAgain())
       {
-      return true;
+      int32_t threshold = TR::Compiler->vm.isVMInStartupPhase(_jitConfig) ? comp->getOptions()->getEdoRecompSizeThresholdInStartupMode() : comp->getOptions()->getEdoRecompSizeThreshold();
+      if (comp->getOption(TR_EnableOldEDO))
+         {
+         return comp->getMethodHotness() < hot && comp->getNodeCount() < threshold;
+         }
+      else
+         {
+         ncount_t nodeCount = TR::Compiler->vm.isVMInStartupPhase(_jitConfig) ? comp->getNodeCount() : comp->getAccurateNodeCount();
+         return comp->getMethodHotness() <= hot && nodeCount < threshold;
+         }
       }
    else
       {

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -359,7 +359,10 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
    TR::Block * lastBlock = walker(0);
 
    if (hasExceptionHandlers())
+      {
+      _methodSymbol->setHasExceptionHandlers();
       lastBlock = genExceptionHandlers(lastBlock);
+      }
 
    _bcIndex = 0;
 

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -23,6 +23,7 @@
 j9jit_files(
 	optimizer/AllocationSinking.cpp
 	optimizer/BoolArrayStoreTransformer.cpp
+	optimizer/CatchBlockProfiler.cpp
 	optimizer/DataAccessAccelerator.cpp
 	optimizer/DynamicLiteralPool.cpp
 	optimizer/EscapeAnalysis.cpp

--- a/runtime/compiler/optimizer/CatchBlockProfiler.cpp
+++ b/runtime/compiler/optimizer/CatchBlockProfiler.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Recompilation.hpp"
+#include "il/Block.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "optimizer/CatchBlockProfiler.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimizations.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/Optimizer.hpp"
+
+TR::CatchBlockProfiler::CatchBlockProfiler(TR::OptimizationManager *manager)
+   : TR::Optimization(manager), _catchBlockCounterSymRef(NULL)
+   {}
+
+int32_t TR::CatchBlockProfiler::perform()
+   {
+   if (comp()->getOption(TR_DisableEDO))
+      {
+      if (trace())
+         traceMsg(comp(), "Catch Block Profiler is disabled because EDO is disabled\n");
+      return 0;
+      }
+   TR::Recompilation *recompilation = comp()->getRecompilationInfo();
+   if (!recompilation || !recompilation->couldBeCompiledAgain())
+      {
+      if (trace())
+         traceMsg(comp(), "Catch Block Profiler is disabled because method cannot be recompiled\n");
+      return 0;
+      }
+
+   if (trace())
+      traceMsg(comp(), "Starting Catch Block Profiler\n");
+
+   for (TR::Block * b = comp()->getStartBlock(); b; b = b->getNextBlock())
+      if (!b->getExceptionPredecessors().empty() &&
+          !b->isOSRCatchBlock() &&
+          !b->isEmptyBlock()) // VP may have removed all trees from the block
+         {
+         if (performTransformation(comp(), "%s Add profiling trees to track the execution frequency of catch block_%d\n", optDetailString(), b->getNumber()))
+            {
+            if (!_catchBlockCounterSymRef)
+               {
+               uint32_t *catchBlockCounterAddress = recompilation->getMethodInfo()->getCatchBlockCounterAddress();
+               _catchBlockCounterSymRef = comp()->getSymRefTab()->createKnownStaticDataSymbolRef(catchBlockCounterAddress, TR::Int32);
+               }
+            TR::TreeTop *profilingTree = TR::TreeTop::createIncTree(comp(), b->getEntry()->getNode(), _catchBlockCounterSymRef, 1, b->getEntry());
+            profilingTree->getNode()->setIsProfilingCode();
+            }
+         }
+
+   if (trace())
+      traceMsg(comp(), "\nEnding Catch Block Profiler\n");
+   return 1; // actual cost
+   }
+
+const char *
+TR::CatchBlockProfiler::optDetailString() const throw()
+   {
+   return "O^O CATCH BLOCK PROFILER: ";
+   }

--- a/runtime/compiler/optimizer/CatchBlockProfiler.hpp
+++ b/runtime/compiler/optimizer/CatchBlockProfiler.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CATCHBLOCKPROFILER_INCL
+#define CATCHBLOCKPROFILER_INCL
+
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
+
+
+namespace TR {
+
+/**
+   @class CatchBlockProfiler
+   @brief Catch block profiler is a simple optimization that aims to count
+          how many times all the catch blocks in the method are executed.
+ */
+class CatchBlockProfiler : public TR::Optimization
+   {
+   public:
+   CatchBlockProfiler(TR::OptimizationManager *manager);
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) CatchBlockProfiler(manager);
+      }
+
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   private :
+   TR::SymbolReference * _catchBlockCounterSymRef;
+   };
+}
+#endif

--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -126,7 +126,6 @@ class TR_EstimateCodeSize
    bool _hasExceptionHandlers;
    bool _mayHaveVirtualCallProfileInfo;
    bool _aggressivelyInlineThrows;
-   int32_t _throwCount;
 
    int32_t _recursionDepth;
    bool _recursedTooDeep;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1098,12 +1098,6 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (calltarget->_calleeMethod->numberOfExceptionHandlers() > 0)
       _hasExceptionHandlers = true;
 
-   if (_aggressivelyInlineThrows)
-      {
-      TR_CatchBlockProfileInfo * catchInfo = TR_CatchBlockProfileInfo::get(comp(), calltarget->_calleeMethod);
-      if (catchInfo)
-         _throwCount += catchInfo->getThrowCounter();
-      }
 
    //TR::Compilation * comp = _inliner->comp();
 
@@ -1605,7 +1599,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      //_optimisticSize = origOptimisticSize;
                      //_realSize = origRealSize;
                      calltargetSetTooBig = true;
-                        
+
                      }
                   }
 

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2374,8 +2374,6 @@ TR_BlockFrequencyInfo * TR_BlockFrequencyInfo::deserialize(uint8_t * &buffer, TR
    return new (PERSISTENT_NEW) TR_BlockFrequencyInfo(serializedData, buffer, currentProfileInfo);
    }
 
-const uint32_t TR_CatchBlockProfileInfo::EDOThreshold = 50;
-
 TR_CallSiteInfo::TR_CallSiteInfo(TR::Compilation * comp, TR_AllocationKind allocKind) :
    _numCallSites(comp->getNumInlinedCallSites()),
    _callSites(

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -821,8 +821,6 @@ class TR_CatchBlockProfileInfo
    static inline TR_CatchBlockProfileInfo * get(TR::Compilation *comp);
    static inline TR_CatchBlockProfileInfo * getCurrent(TR::Compilation *comp);
 
-   static const uint32_t EDOThreshold;
-
    uint32_t & getCatchCounter() { return _catchCounter; }
    uint32_t & getThrowCounter() { return _throwCounter; }
 


### PR DESCRIPTION
This optimization inserts a counter in the basic blocks that catch exceptions. The counter is stored in the `TR_PersistentMethodInfo` struct attached to the method being compiled.
The value of this counter is queried by the inliner, and if its value exceeds a threshold (`TR::Options::_catchBlockCounterThreshold`), the JIT inlines more aggressively on the `throw` path in order to facilitate the replacement of the `throw` instruction with a `goto` instruction. This mechanism is refered to as Exception Directed Optimization (EDO) in the literature.

This commit is intended to replace the old EDO mechanism, which used a special profiling compilation for measuring catch block frequency. With the current approach, every method will measure catch block frequency (if catch blocks exist), so an extra compilation is no longer needed. The overhead of profiling all the time (one extra increment instruction in the catch block) is expected to be dwarfed by the overhead of processing the exception.

Relevant options:

`-Xjit:edoRecompSizeThreshold=` and `-Xjit:edoRecompSizeThresholdInStartupMode=` can be used to control the number of times a catch block is entered before a recompilation at the next optimization level is triggered.

`-Xjit:catchBlockCounterThreshold=` is used by the inliner to determine when to inline more aggressively on the `throw` path.

`-Xjit:traceCatchBlockProfiler` is used for tracing the actions of the `catchBlockProfiler` optimization

`-Xjit:enableOldEDO` can be used to revert to the old EDO mechanism, just in case regressions are seen.

Depends on https://github.com/eclipse/omr/pull/6922
