### PR TITLE
CRIU getRestoreSystemProperites() skips non system property entries

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -938,6 +938,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 		}
 
 		if (NULL != vm->checkpointState.restoreArgsList) {
+			/* mark -Xoptionsfile= as consumed */
+			FIND_AND_CONSUME_ARG(vm->checkpointState.restoreArgsList, STARTSWITH_MATCH, VMOPT_XOPTIONSFILE_EQUALS, NULL);
 			bool dontIgnoreUnsupportedRestoreOptions = FIND_AND_CONSUME_ARG(vm->checkpointState.restoreArgsList, EXACT_MATCH, VMOPT_XXIGNOREUNRECOGNIZEDRESTOREOPTIONSENABLE, NULL) < 0;
 
 			if ((FALSE == vmFuncs->checkArgsConsumed(vm, vm->portLibrary, vm->checkpointState.restoreArgsList)) && dontIgnoreUnsupportedRestoreOptions) {

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -276,6 +276,8 @@
     <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">java.lang.NullPointerException</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
@@ -291,6 +293,8 @@
     <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">java.lang.NullPointerException</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
@@ -306,6 +310,8 @@
     <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">java.lang.NullPointerException</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -109,7 +109,7 @@ public class OptionsFileTest {
 	}
 
 	static void propertiesTest3() {
-		String optionsContents = "-Dprop1=val1\n-Dprop2=\\\nval2\n-Dprop3=v \\ \n a \\     \n  l3";
+		String optionsContents = "-Dprop1=val1\n-Dprop2=\\\nval2\n-Dprop3=v \\\n a \\\n  l3";
 		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
 
 		Path imagePath = Paths.get("cpData");


### PR DESCRIPTION
The `index` is only for the system property entries;
Mark `-Xoptionsfile=` as consumed;
Added explicit failure exception and error messages.;
Minor refactoring for format consistence.

This was discovered while investigating the test failure https://github.com/eclipse-openj9/openj9/pull/16775#issuecomment-1462042170
Initially, the test passed even though the `success` output string didn't appear due to an NPE such as
```
Exception in thread "main" java.lang.NullPointerException
	at java.base/java.lang.System.setProperty(System.java:633)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.setRestoreJavaProperties(CRIUSupport.java:600)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:116)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:80)
	at openj9.criu/org.eclipse.openj9.criu.J9InternalCheckpointHookAPI.runPostRestoreHooks(J9InternalCheckpointHookAPI.java:97)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVMImpl(Native Method)
	at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVM(CRIUSupport.java:635)
	at org.openj9.criu.CRIUTestUtils.checkPointJVM(CRIUTestUtils.java:77)
	at org.openj9.criu.OptionsFileTest.propertiesTest1(OptionsFileTest.java:68)
	at org.openj9.criu.OptionsFileTest.main(OptionsFileTest.java:38)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>