### PR TITLE
Add NULL check for VM args array

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ findArgInVMArgs(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, UDATA match
 
 	PORT_ACCESS_FROM_PORT(portLibrary);
 
-	if (optionName==NULL || 0==j9vm_args->nOptions) {
+	if ((NULL == optionName) || (NULL == j9vm_args) || (0 == j9vm_args->nOptions)) {
 		return returnVal;
 	}
 
@@ -648,7 +648,7 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 	return OPTION_OK;
 }
 
-static char * 
+static char *
 getStartOfOptionValue(J9VMInitArgs* j9vm_args, IDATA element, const char *optionName)
 {
 	const char *option = optionName;
@@ -659,7 +659,7 @@ getStartOfOptionValue(J9VMInitArgs* j9vm_args, IDATA element, const char *option
 	}
 
 	Assert_Util_true(NULL != option);
-	
+
 	value = j9vm_args->actualVMArgs->options[element].optionString + strlen(option);
 
 	return value;
@@ -690,7 +690,7 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 	char *argString = NULL;
 	UDATA j2seReleaseValue = j2seVersion & J2SE_RELEASE_MASK;
 	J9JavaVMArgInfo *optArg = NULL;
-	
+
 	PORT_ACCESS_FROM_PORT(portLib);
 #ifdef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
 	Assert_Util_unreachable();
@@ -1058,7 +1058,7 @@ addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jr
 }
 
 IDATA
-addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *cwd) 
+addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *cwd)
 {
 	size_t argumentLength = 1; /* space for the \0 */
 	char *optionsArgumentBuffer = NULL;
@@ -1302,7 +1302,7 @@ addJarArguments(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, c
  * @return 0 on success, negative on failure
  */
 static IDATA
-mapEnvVarToArgument(J9PortLibrary* portLibrary, const char* envVar, const char* j9opt, J9JavaVMArgInfoList *vmArgumentsList, UDATA mapType, UDATA verboseFlags) 
+mapEnvVarToArgument(J9PortLibrary* portLibrary, const char* envVar, const char* j9opt, J9JavaVMArgInfoList *vmArgumentsList, UDATA mapType, UDATA verboseFlags)
 {
 	J9JavaVMArgInfo *optArg = NULL;
 	IDATA valueSize = 0;
@@ -1363,7 +1363,7 @@ mapEnvVarToArgument(J9PortLibrary* portLibrary, const char* envVar, const char* 
 
 
 IDATA
-addEnvironmentVariableArguments(J9PortLibrary *portLib, const char *envVarName, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags) 
+addEnvironmentVariableArguments(J9PortLibrary *portLib, const char *envVarName, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 	IDATA envVarSize = j9sysinfo_get_env(envVarName, NULL, 0);
@@ -1383,7 +1383,7 @@ addEnvironmentVariableArguments(J9PortLibrary *portLib, const char *envVarName, 
 }
 
 IDATA
-addEnvironmentVariables(J9PortLibrary *portLib, JavaVMInitArgs *launcherArgs, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags) 
+addEnvironmentVariables(J9PortLibrary *portLib, JavaVMInitArgs *launcherArgs, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags)
 {
 	IDATA status = 0;
 	if (
@@ -1536,7 +1536,7 @@ addLauncherArgs(J9PortLibrary * portLib, JavaVMInitArgs *launcherArgs, UDATA lau
 }
 
 IDATA
-addXserviceArgs(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *xServiceBuffer, UDATA verboseFlags) 
+addXserviceArgs(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *xServiceBuffer, UDATA verboseFlags)
 {
 
 	PORT_ACCESS_FROM_PORT(portLib);


### PR DESCRIPTION
With the introduction of vm->checkpointState.restoreArgsList it is possible that the args list passed into findArgInVMArgs(..) can be NULL. This PR adds a NULL check in additon to the count check as a fast path to exit