### PR TITLE
Stress CRIU GC Thread Pool Contract/Expand Routines

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -93,6 +93,8 @@
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optavgpause</variation>
+			<variation>-Xgcpolicy:gencon -Xgcthreads64 -XX:CheckpointGCThreads=1</variation>
+			<variation>-Xgcpolicy:gencon -Xgcthreads1</variation>
 		</variations>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \


### PR DESCRIPTION
Extend existing cmdLineTester_criu_nonPortableRestore test case with GC threading opts variation to stress GC thread pool contraction and expansion.

- -Xgcthreads1 will test unbounded thread pool expansion as the thread pool will need to be reinited at restore
- -Xgcthreads64 -XX:CheckpointGCThreads=1 will force 63 threads to shutdown during checkpoint

Signed-off-by: Salman Rana <salman.rana@ibm.com>