### PR TITLE
CRIU Invoke Global Collector Reinit 

### DIFF
--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -1150,6 +1150,14 @@ j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat)
 	}
 	acquireVMAccess(vmThread);
 
+	Assert_MM_true(NULL != extensions->getGlobalCollector());
+
+	if (!extensions->getGlobalCollector()->reinitializeForRestore(env)) {
+		*nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_GLOBAL_GARBAGE_COLLECTOR, NULL);
+		goto _error;
+	}
+
 	if (!mmFuncTable->checkOptsAndInitVerbosegclog(vm, vm->checkpointState.restoreArgsList)) {
 		*nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
 				J9NLS_VERB_FAILED_TO_INITIALIZE, NULL);

--- a/runtime/nls/j9gc/j9modron.nls
+++ b/runtime/nls/j9gc/j9modron.nls
@@ -970,3 +970,11 @@ J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS.system_action=The JVM wi
 J9NLS_GC_FAILED_TO_REINITIALIZE_PARSING_RESTORE_OPTIONS.user_response=Check that all of the GC options are correctly specified
 
 # END NON-TRANSLATABLE
+
+J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN=-Xgcthreads will be ignored. The specified GC thread count must be greater than the checkpoint GC thread count %1$zu
+# START NON-TRANSLATABLE
+J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN.explanation=-Xgcthreads must be greater than the specified value
+J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN.system_action=The JVM will terminate
+J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN.user_response=Refer to the OpenJ9 documentation and adjust -Xgcthreads to specify a GC thread count greater than the checkpoint GC thread count
+
+# END NON-TRANSLATABLE


### PR DESCRIPTION
- Invoke newly introduced Global Collector reinit API in OMR.
- reset parSweepChunkSize to allow sweep to reinit. 
- verify thread count being set at restore time to enure that its greater than the checkpoint thread count.
  - WARN with J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN

Depends on: https://github.com/eclipse/omr/pull/6925

Signed-off-by: Salman Rana <salman.rana@ibm.com>