### PR TITLE
(v0.38.0)Ensure JDWP threads are not halted when hooks run for CRIU

### DIFF
--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -1116,7 +1116,10 @@ j9gc_prepare_for_checkpoint(J9VMThread *vmThread)
 		verboseGCManager->prepareForCheckpoint(env);
 	}
 
+	/* Threads being terminated may trigger a hook that may acquire exclusive VM access via JVMTI callback */
+	releaseVMAccess(vmThread);
 	extensions->configuration->adjustGCThreadCountForCheckpoint(env);
+	acquireVMAccess(vmThread);
 }
 
 BOOLEAN

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4120,6 +4120,7 @@ typedef struct J9CRIUCheckpointState {
 	BOOLEAN isCheckPointEnabled;
 	BOOLEAN isCheckPointAllowed;
 	BOOLEAN isNonPortableRestoreMode;
+	BOOLEAN isJdwpEnabled;
 	struct J9DelayedLockingOpertionsRecord *delayedLockingOperationsRoot;
 	struct J9Pool *hookRecords;
 	struct J9Pool *classIterationRestoreHookRecords;

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -539,6 +539,7 @@ enum INIT_STAGE {
 #define VMOPT_XXNODYNAMICHEAPIFICATION "-XX:-DynamicHeapification"
 
 #define MAPOPT_AGENTLIB_JDWP_EQUALS "-agentlib:jdwp="
+#define MAPOPT_XRUNJDWP "-Xrunjdwp:"
 
 #define MAPOPT_XCOMP "-Xcomp"
 #define MAPOPT_XDISABLEJAVADUMP "-Xdisablejavadump"


### PR DESCRIPTION
A breakpoint set during a pre-checkpoint or post-restore hook will cause Java to hang because the JDWP threads are suspended at that time. This change will delay the suspending of JDWP threads for pre-checkpoint hooks and resume them early for post-restore hooks if VM is run with the JDWP agentlib loaded.

Port of https://github.com/eclipse-openj9/openj9/pull/16653 to 0.38.0

fyi @tajila 