### PR TITLE
(v0.38.0-release) CRIU restore loads trace options with registerRestoreOptionsFile()

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -851,10 +851,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 		VM_VMHelpers::setVMState(currentThread, J9VMSTATE_CRIU_SUPPORT_CHECKPOINT_PHASE_INTERNAL_HOOKS);
 
 		/* Run internal checkpoint hooks, after iterating heap objects */
-		if (FALSE == vmFuncs->runInternalJVMCheckpointHooks(currentThread)) {
+		if (FALSE == vmFuncs->runInternalJVMCheckpointHooks(currentThread, &nlsMsgFormat)) {
 			currentExceptionClass = vm->checkpointState.criuJVMCheckpointExceptionClass;
-			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
-				J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_CHECKPOINT_HOOKS, NULL);
 			goto wakeJavaThreadsWithExclusiveVMAccess;
 		}
 
@@ -951,10 +949,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 		VM_VMHelpers::setVMState(currentThread, J9VMSTATE_CRIU_SUPPORT_RESTORE_PHASE_JAVA_HOOKS);
 
 		/* Run internal restore hooks, and cleanup */
-		if (FALSE == vmFuncs->runInternalJVMRestoreHooks(currentThread)) {
+		if (FALSE == vmFuncs->runInternalJVMRestoreHooks(currentThread, &nlsMsgFormat)) {
 			currentExceptionClass = vm->checkpointState.criuJVMRestoreExceptionClass;
-			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
-				J9NLS_JCL_CRIU_FAILED_TO_RUN_INTERNAL_RESTORE_HOOKS, NULL);
 			goto wakeJavaThreadsWithExclusiveVMAccess;
 		}
 

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2105,3 +2105,35 @@ J9NLS_VM_CRIU_SINGLETHREADMODE_JVMCRIUEXCEPTION.explanation=Blocking operation i
 J9NLS_VM_CRIU_SINGLETHREADMODE_JVMCRIUEXCEPTION.system_action=The JVM will throw a JVMCRIUException.
 J9NLS_VM_CRIU_SINGLETHREADMODE_JVMCRIUEXCEPTION.user_response=View CRIU documentation to determine how to resolve the exception.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED=The JVM could not initialize trace upon restoring the JVM
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.sample_input_1=1
+J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.explanation=CRIUSupport::checkpointJVM failed.
+J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.user_response=Check documentation for CRIUSupport restore options.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET=The JVM could not re-seed j.u.Random.seed.value due to invalid seed offset
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.sample_input_1=1
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.explanation=CRIUSupport::checkpointJVM failed.
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF=The JVM could not re-seed j.u.Random.seed.value due to j.u.c.a.AtomicLong not found
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.sample_input_1=1
+J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.explanation=CRIUSupport::checkpointJVM failed.
+J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.user_response=View CRIU documentation to determine how to resolve the exception.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET=The JVM could not re-seed j.u.Random.seed.value due to invalid value offset
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.sample_input_1=1
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.explanation=CRIUSupport::checkpointJVM failed.
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4091,8 +4091,8 @@ typedef struct J9JITConfig {
 } J9JITConfig;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-typedef BOOLEAN (*classIterationRestoreHookFunc)(struct J9VMThread *currentThread, J9Class *clazz);
-typedef BOOLEAN (*hookFunc)(struct J9VMThread *currentThread, void *userData);
+typedef BOOLEAN (*classIterationRestoreHookFunc)(struct J9VMThread *currentThread, J9Class *clazz, const char **nlsMsgFormat);
+typedef BOOLEAN (*hookFunc)(struct J9VMThread *currentThread, void *userData, const char **nlsMsgFormat);
 typedef struct J9InternalHookRecord {
 	BOOLEAN isRestore;
 	J9Class *instanceType;
@@ -4928,8 +4928,8 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*isCRIUSupportEnabled)(struct J9VMThread *currentThread);
 	BOOLEAN (*isCheckpointAllowed)(struct J9VMThread *currentThread);
 	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);
-	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread);
-	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread);
+	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);
+	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);
 	BOOLEAN (*runDelayedLockRelatedOperations)(struct J9VMThread *currentThread);
 	BOOLEAN (*delayedLockingOperation)(struct J9VMThread *currentThread, j9object_t instance, UDATA operation);
 	void (*addInternalJVMClassIterationRestoreHook)(struct J9VMThread *currentThread, classIterationRestoreHookFunc hookFunc);

--- a/runtime/oti/j9trace.h
+++ b/runtime/oti/j9trace.h
@@ -40,6 +40,9 @@ extern "C" {
  * rastrace options (-Xtrace:trigger etc.) as well as tracepoints
  */
 typedef omr_error_t (*ConfigureTraceFunction)(void *,const char *);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+typedef BOOLEAN (*CRIURestoreInitializeTrace)(void *);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 typedef struct RasGlobalStorage {
 	/* The utGlobalData reference here is unused by all Java code and inaccessible to OMR code
@@ -61,6 +64,9 @@ typedef struct RasGlobalStorage {
 	int     stackdepth;
 	unsigned int    stackCompressionLevel;
 	ConfigureTraceFunction configureTraceEngine;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	CRIURestoreInitializeTrace criuRestoreInitializeTrace;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } RasGlobalStorage;
 
 #define RAS_GLOBAL(x) ((RasGlobalStorage *)thr->javaVM->j9rasGlobalStorage)->x 

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -119,6 +119,7 @@ extern "C" {
 #define FIND_NEXT_ARG_IN_ARGS_FORWARD(argsArray, match, optionName, optionValue, lastArgIndex) vm->internalVMFunctions->findArgInVMArgs(vm->portLibrary, (argsArray), ((match | ((lastArgIndex+1) << STOP_AT_INDEX_SHIFT)) | SEARCH_FORWARD), optionName, optionValue, FALSE)
 #define FIND_AND_CONSUME_VMARG_FORWARD(match, optionName, optionValue) vm->internalVMFunctions->findArgInVMArgs(vm->portLibrary, vm->vmArgsArray, (match | SEARCH_FORWARD), optionName, optionValue, TRUE)
 #define FIND_AND_CONSUME_ARG_FORWARD(argsArray, match, optionName, optionValue) vm->internalVMFunctions->findArgInVMArgs(vm->portLibrary, (argsArray), (match | SEARCH_FORWARD), optionName, optionValue, TRUE)
+#define FIND_AND_CONSUME_NEXT_ARG_FORWARD(argsArray, match, optionName, optionValue, lastArgIndex) vm->internalVMFunctions->findArgInVMArgs(vm->portLibrary, (argsArray), ((match | ((lastArgIndex+1) << STOP_AT_INDEX_SHIFT)) | SEARCH_FORWARD), optionName, optionValue, TRUE)
 
 /* REMOVE - FOR BACKWARDS COMPATIBILITY */
 #define FIND_AND_CONSUME_VMARG2(match, optionName, optionValue) vm->internalVMFunctions->findArgInVMArgs(vm->portLibrary, vm->vmArgsArray, match, optionName, optionValue, TRUE)
@@ -663,6 +664,8 @@ enum INIT_STAGE {
 #define JAVA_BASE_MODULE "java.base"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."
+
+#define VMOPT_XTRACE "-Xtrace"
 
 #ifdef J9VM_INTERP_VERBOSE
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -555,23 +555,27 @@ jvmRestoreHooks(J9VMThread *currentThread);
  * ExclusiveVMAccess is required since J9InternalHookRecord holds live object references
  * and GC is not allowed while running these hook functions.
  *
- * @param currentThread vmthread token
+ * @param[in] currentThread vmthread token
+ * @param[in/out] nlsMsgFormat an NLS message
+ *
  * @return BOOLEAN TRUE if no error, otherwise FALSE
  */
 BOOLEAN
-runInternalJVMCheckpointHooks(J9VMThread *currentThread);
+runInternalJVMCheckpointHooks(J9VMThread *currentThread, const char **nlsMsgFormat);
 
 /**
  * @brief This runs the restore hook function, and cleanup.
  * ExclusiveVMAccess is required since J9InternalHookRecord hold live object references
  * and GC are not allowed while running these hook functions.
  *
- * @param currentThread vmthread token
- * @param isRestore If FALSE, run the hook specified for checkpoint, otherwise run the hook specified for restore
+ * @param[in] currentThread vmthread token
+ * @param[in] isRestore If FALSE, run the hook specified for checkpoint, otherwise run the hook specified for restore
+ * @param[in/out] nlsMsgFormat an NLS message
+ *
  * @return BOOLEAN TRUE if no error, otherwise FALSE
  */
 BOOLEAN
-runInternalJVMRestoreHooks(J9VMThread *currentThread);
+runInternalJVMRestoreHooks(J9VMThread *currentThread, const char **nlsMsgFormat);
 
 /**
  * @brief This function runs the identity operations that were delayed

--- a/runtime/rastrace/j9rastrace.h
+++ b/runtime/rastrace/j9rastrace.h
@@ -113,6 +113,17 @@ void trcTraceMethodExit(J9VMThread *thr, J9Method *method, void *exceptionPtr, v
 omr_error_t setMethodSpec(J9JavaVM *vm, char * value, J9UTF8 ** utf8Address, int * matchFlag);
 omr_error_t setMethod(J9JavaVM *vm, const char * value, BOOLEAN atRuntime);
 U_8 rasSetTriggerTrace(J9VMThread *thr, J9Method *method);
+/**
+ * A helper method shared by VM trace initialization hookRAMClassLoad()
+ * and CRIU restore using a trace option file via addInternalJVMClassIterationRestoreHook().
+ *
+ * @param[in] thr the current J9VMThread
+ * @param[in] clazz the J9Class to be iterated
+ * @param[in/out] nlsMsgFormat an NLS message
+ *
+ * @return BOOLEAN TRUE if no error, otherwise FALSE
+ */
+BOOLEAN setRAMClassExtendedMethodFlagsHelper(J9VMThread *thr, J9Class *clazz, const char **nlsMsgFormat);
 void rasTriggerMethod(J9VMThread *thr, J9Method *mb, I_32 entry, const TriggerPhase phase);
 BOOLEAN matchMethod (RasMethodTable * methodTable, J9Method *method);
 omr_error_t processTriggerMethodClause(OMR_VMThread *, char *, BOOLEAN atRuntime);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3789,6 +3789,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			vm->checkpointState.isCheckPointEnabled = TRUE;
 			vm->checkpointState.isCheckPointAllowed = TRUE;
 			vm->portLibrary->finalRestore = FALSE;
+			vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_DEBUG_MODE;
 			j9port_control(J9PORT_CTLDATA_CRIU_SUPPORT_FLAGS, OMRPORT_CRIU_SUPPORT_ENABLED);
 		}
 	}

--- a/runtime/vm/rastrace.c
+++ b/runtime/vm/rastrace.c
@@ -26,8 +26,6 @@
 #include <string.h>
 #include "vm_internal.h"
 
-
-#define VMOPT_XTRACE		 "-Xtrace"
 #define VMOPT_XTRACE_NONE	 "-Xtrace:none"
 
 #define VMOPT_XTRACE_DEFAULT VMOPT_XTRACE

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -540,4 +540,23 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
   </test>
+
+  <test id="Restore trace options test with no trace options specified before checkpoint">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="success" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
+    <output type="success" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties; bytecode static method</output>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable_Xtrace.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable_Xtrace.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2023, 2023 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Option Tests" timeout="300">
+  <variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
+
+  <test id="Restore trace options test with -Xtrace before checkpoint">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
+    <output type="required" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties; bytecode static method</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+</suite>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -119,6 +119,99 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>cmdLineTester_criu_nonPortableRestore_Xtrace_tracepoint</testCaseName>
+		<variations>
+			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xgcpolicy:optthruput</variation>
+			<variation>-Xgcpolicy:optavgpause</variation>
+		</variations>
+		<command>
+			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS) -Xtrace:print={j9jcl.219}$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_nonPortable_Xtrace.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_criu_nonPortableRestore_Xtrace_methodtrace</testCaseName>
+		<variations>
+			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xgcpolicy:optthruput</variation>
+			<variation>-Xgcpolicy:optavgpause</variation>
+		</variations>
+		<command>
+			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS) -Xtrace:print=mt,methods=org/eclipse/openj9/criu/CRIUSupport.registerRestoreOptionsFile()$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_nonPortable_Xtrace.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_criu_nonPortableRestore_Xtrace_outputFile</testCaseName>
+		<variations>
+			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
+			<variation>-Xgcpolicy:optthruput</variation>
+			<variation>-Xgcpolicy:optavgpause</variation>
+		</variations>
+		<command>
+			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS) -Xtrace:maximal=mt,methods=org/eclipse/openj9/criu/CRIUSupport.registerRestoreOptionsFile,output=beforeCheckpoint.txt$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_nonPortable_Xtrace.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>cmdLineTester_criu_nonPortableRestoreJDK11Up</testCaseName>
 		<variations>
 			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -46,6 +46,9 @@ public class OptionsFileTest {
 		case "PropertiesTest4":
 			propertiesTest4();
 			break;
+		case "TraceOptionsTest":
+			traceOptionsTest();
+			break;
 		default:
 			throw new RuntimeException("incorrect parameters");
 		}
@@ -149,5 +152,20 @@ public class OptionsFileTest {
 
 		//shouldnt get here
 		System.out.println("ERR: failed properties test");
+	}
+
+	static void traceOptionsTest() {
+		String optionsContents = "-Xtrace:print={j9vm.40}\n-Xtrace:print=mt,methods=java/lang/System.getProperties()\n-Xtrace:trigger=method{java/lang/System.getProperties,javadump}";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.getProperties();
+		System.out.println("Post-checkpoint");
 	}
 }


### PR DESCRIPTION
* Refactored trace initialization to be used by VM startup and CRIU restore using an options file;
* Added `RasGlobalStorage->criuRestoreInitializeTrace()`;
* Added `setRAMClassExtendedMethodFlagsHelper()` used by `hookRAMClassLoad()` and `addInternalJVMClassIterationRestoreHook()`;
* Set `methodTriggerType->runtimeModifiable` to true for CRIU;
* Moved some trace initialization code into `traceInitializationHelper()` for VM startup and CRIU restore using an options file;
* Added a parameter `J9VMInitArgs` for `initializeTraceOptions()`;
* Added a test to verify `-Xtrace:print={j9vm.40}`, `-Xtrace:print=mt,methods=java/lang/System.getProperties()`, `-Xtrace:trigger=method{java/lang/System.getProperties,javadump}`.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/16775

Signed-off-by: Jason Feng <fengj@ca.ibm.com>