### PR TITLE
Delete remnant of OFFLOAD support that was missed

### DIFF
--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -410,12 +410,6 @@ J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			freeUnsafeMemory(vm);
 			break;
 
-		case OFFLOAD_JCL_PRECONFIGURE:
-			if (scarPreconfigure(vm) != JNI_OK) {
-				returnVal = J9VMDLLMAIN_FAILED;
-			}
-			break;
-
 		case INTERPRETER_SHUTDOWN:
 			break;
 	}

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -213,9 +213,7 @@ enum INIT_STAGE {
 	INTERPRETER_SHUTDOWN,
 	LIBRARIES_ONUNLOAD,
 	HEAP_STRUCTURES_FREED,
-	GC_SHUTDOWN_COMPLETE,
-	/* this stage will only be invoked for the jcl shared library when it is being run remotely */
-	OFFLOAD_JCL_PRECONFIGURE
+	GC_SHUTDOWN_COMPLETE
 };
 
 #define VMOPT_EXIT "exit"


### PR DESCRIPTION
The startup stage OFFLOAD_JCL_PRECONFIGURE is unused.