### PR TITLE
Add support to disable JITServer and AOT post restore

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7402,6 +7402,10 @@ TR::CompilationInfoPerThreadBase::cannotPerformRemoteComp(
           // after the process is restored. In portable restore mode checkpoints are always possible
           // so there's no point to delaying remote compilations.
           (_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread) && _jitConfig->javaVM->internalVMFunctions->isNonPortableRestoreMode(vmThread)) ||
+
+          // If -XX:-UseJITServer is specified post-restore, then the Remote Compilation Mode will
+          // be set to JITServer::NONE
+          _compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::NONE ||
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
           !JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
           (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -371,7 +371,8 @@ char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOp
    "-XX:-JITServerAOTCachePersistence",   // = 64
    "-XX:JITServerAOTCacheDir=",           // = 65
    "-XX:JITServerAOTCacheName=",          // = 66
-   // TR_NumExternalOptions                  = 67
+   "-Xshareclasses:disableOnRestore",     // = 67
+   // TR_NumExternalOptions                  = 68
    };
 
 //************************************************************************

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -120,7 +120,8 @@ enum ExternalOptions
    XXminusJITServerAOTCachePersistenceOption   = 64,
    XXJITServerAOTCacheDirOption                = 65,
    XXJITServerAOTCacheNameOption               = 66,
-   TR_NumExternalOptions                       = 67
+   XShareclassesDisableOnRestore               = 67,
+   TR_NumExternalOptions                       = 68
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -36,6 +36,7 @@
 #include "control/Options.hpp"
 #include "control/OptionsPostRestore.hpp"
 #include "control/J9Recompilation.hpp"
+#include "env/J9PersistentInfo.hpp"
 #include "env/SystemSegmentProvider.hpp"
 #include "env/RawAllocator.hpp"
 #include "env/Region.hpp"
@@ -306,7 +307,11 @@ J9::OptionsPostRestore::processJitServerOptions()
       }
    else
       {
-      // TODO: Disable JITServer
+      _compInfo->getPersistentInfo()->setClientUID(0);
+      _compInfo->getPersistentInfo()->setServerUID(0);
+      _jitConfig->clientUID = 0;
+      _jitConfig->serverUID = 0;
+      J9::PersistentInfo::_remoteCompilationMode = JITServer::NONE;
       }
 #endif // defined(J9VM_OPT_JITSERVER)
    }

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -60,6 +60,7 @@ J9::OptionsPostRestore::OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *ji
    _oldVLogFileName(_privateConfig->vLogFileName),
    _oldRtLogFileName(_privateConfig->rtLogFileName),
    _asyncCompilationPreCheckpoint(_compInfo->asynchronousCompilation()),
+   _disableAOTPostRestore(false),
    _argIndexXjit(-1),
    _argIndexXjitcolon(-1),
    _argIndexXnojit(-1),
@@ -259,6 +260,13 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::Xtuneelastic:
             {
             // TODO
+            }
+            break;
+
+         case J9::ExternalOptions::XShareclassesDisableOnRestore:
+            {
+            if (FIND_ARG_IN_RESTORE_ARGS(OPTIONAL_LIST_MATCH, optString, 0) >= 0)
+               _disableAOTPostRestore = true;
             }
             break;
 
@@ -473,6 +481,9 @@ J9::OptionsPostRestore::disableAOTCompilation()
    // but not during a compilation as all compilation threads are suspended at
    // this point, and so it won't impact AOT code.
 
+   if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Disabling AOT Compilation and Load");
+
    TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
    TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
    TR::Options::setSharedClassCache(false);
@@ -608,7 +619,7 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
    // If -Xrs, -Xtrace, or disabling traps is specified post-restore,
    // invalidate all method bodies
    bool invalidateAll = false;
-   bool disableAOT = false;
+   bool disableAOT = _disableAOTPostRestore;
    if (!_disableTrapsPreCheckpoint
        && (J9_ARE_ALL_BITS_SET(vm->sigFlags, J9_SIG_XRS_SYNC)
            || TR::Options::getCmdLineOptions()->getOption(TR_NoResumableTrapHandler)
@@ -678,11 +689,15 @@ J9::OptionsPostRestore::processCompilerOptions()
 
    if (!aotEnabled)
       {
+      _disableAOTPostRestore = true;
       disableAOTCompilation();
       }
 
    if (!jitEnabled)
       {
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Disabling JIT Compilation");
+
       TR::Options::setCanJITCompile(false);
       invalidateCompiledMethodsIfNeeded(true);
       }

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -167,6 +167,7 @@ class OptionsPostRestore
 
    bool _asyncCompilationPreCheckpoint;
    bool _disableTrapsPreCheckpoint;
+   bool _disableAOTPostRestore;
 
    int32_t _argIndexXjit;
    int32_t _argIndexXjitcolon;


### PR DESCRIPTION
Since JITServer is enabled implicitly in Non Portable Mode, specifying `-XX:-UseJITServer` should disable it post-restore.

Additionally, if `-Xshareclasses:disableOnRestore` is specified, disable AOT (see https://github.com/eclipse-openj9/openj9/issues/16868).