### PR TITLE
Update common.mk to compile new OMR Register Allocator files

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -209,11 +209,13 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/LoopReducer.cpp \
     omr/compiler/optimizer/LoopReplicator.cpp \
     omr/compiler/optimizer/LoopVersioner.cpp \
+    omr/compiler/optimizer/OMRGlobalRegister.cpp \
     omr/compiler/optimizer/OMRLocalCSE.cpp \
     omr/compiler/optimizer/OMROptimization.cpp \
     omr/compiler/optimizer/OMROptimizationManager.cpp \
     omr/compiler/optimizer/OMROptimizer.cpp \
     omr/compiler/optimizer/OMRRecognizedCallTransformer.cpp \
+    omr/compiler/optimizer/OMRRegisterCandidate.cpp \
     omr/compiler/optimizer/OMRSimplifier.cpp \
     omr/compiler/optimizer/OMRSimplifierHandlers.cpp \
     omr/compiler/optimizer/OMRSimplifierHelpers.cpp \
@@ -227,7 +229,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/ReachingDefinitions.cpp \
     omr/compiler/optimizer/RedundantAsyncCheckRemoval.cpp \
     omr/compiler/optimizer/RegDepCopyRemoval.cpp \
-    omr/compiler/optimizer/RegisterCandidate.cpp \
     omr/compiler/optimizer/RematTools.cpp \
     omr/compiler/optimizer/ReorderIndexExpr.cpp \
     omr/compiler/optimizer/SinkStores.cpp \


### PR DESCRIPTION
OMR pull request eclipse/omr#6577 renames `RegisterCandidate.cpp` to `OMRRegisterCandidate.cpp`, and adds a new file, `OMRGlobalRegister.cpp`. Both of these files are located in `omr/compiler/optimizer`.  This change updates the OpenJ9 `common.mk` file that is used by older versions of the build infrastructure to compile those files.