### PR TITLE
Invalidate compiles if -Xdump on exception is specified post restore

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -728,6 +728,9 @@ public:
    void setVMMethodTraceEnabled(bool trace) { _vmMethodTraceEnabled = trace; }
    bool isVMMethodTraceEnabled()            { return _vmMethodTraceEnabled;  }
 
+   void setVMExceptionEventsHooked(bool trace) { _vmExceptionEventsHooked = trace; }
+   bool isVMExceptionEventsHooked()            { return _vmExceptionEventsHooked;  }
+
    bool resetStartAndElapsedTime()              { return _resetStartAndElapsedTime;  }
    void setResetStartAndElapsedTime(bool reset) { _resetStartAndElapsedTime = reset; }
 #endif
@@ -1375,6 +1378,7 @@ private:
    TR::Monitor *_crMonitor;
    TR_CheckpointStatus _checkpointStatus;
    bool _vmMethodTraceEnabled;
+   bool _vmExceptionEventsHooked;
    bool _resetStartAndElapsedTime;
 #endif
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1189,6 +1189,18 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    // stage, whereas J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED is set in the
    // TRACE_ENGINE_INITIALIZED stage, which happens first.
    _vmMethodTraceEnabled = jitConfig->javaVM->extendedRuntimeFlags & J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED;
+
+   // TR::CompilationInfo is initialized in the JIT_INITIALIZED bootstrap
+   // stage, whereas dump agents are initialized in the
+   // PORT_LIBRARY_GUARANTEED stage, which happens first.
+   bool exceptionCatchEventHooked
+      = J9_EVENT_IS_HOOKED(jitConfig->javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH)
+        || J9_EVENT_IS_RESERVED(jitConfig->javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH);
+   bool exceptionThrowEventHooked
+      = J9_EVENT_IS_HOOKED(jitConfig->javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW)
+        || J9_EVENT_IS_RESERVED(jitConfig->javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW);
+   _vmExceptionEventsHooked = exceptionCatchEventHooked || exceptionThrowEventHooked;
+
    _resetStartAndElapsedTime = false;
 #endif
    _iprofilerBufferArrivalMonitor = TR::Monitor::create("JIT-IProfilerBufferArrivalMonitor");


### PR DESCRIPTION
If `-Xdump` is specified to dump on exception post-restore (but not pre-checkpoint), then invalidate all compilations, since they will not have been generated to support it.