### PR TITLE
(v0.38.0-release) CRIU tests use success and explicit failure conditions before checkpoint

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -544,9 +544,9 @@
   <test id="Restore trace options test with no trace options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest 1</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
-    <output type="success" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
-    <output type="success" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties; bytecode static method</output>
+    <output type="success" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties;</output>
     <output type="success" caseSensitive="yes" regex="no">User requested Java dump</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable_Xtrace.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable_Xtrace.xml
@@ -31,10 +31,11 @@
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest 1</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
-    <output type="required" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
-    <output type="required" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties; bytecode static method</output>
+    <output type="success" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
+    <output type="success" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties;</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">User requested Java dump</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->


### PR DESCRIPTION
CRIU tests use `success` and explicit `failure` conditions before `checkpoint`

Removed `bytecode static method` to accommodate both bytecode and jitted methods.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/16913

Signed-off-by: Jason Feng <fengj@ca.ibm.com>