### PR TITLE
(0.38) Fixing wrong address elementSize calculation

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1096,7 +1096,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
    if (isWrite)
       {
       TR::DataType dt = node->getDataType();
-      int32_t elementSize = dt == TR::Address ? TR::Compiler->om.sizeofReferenceField() : TR::Symbol::convertTypeToSize(dt);
+      int32_t elementSize = TR::Symbol::convertTypeToSize(dt);
       TR::InstOpCode::Mnemonic storeOp = getLoadOrStoreFromDataType(cg, dt, elementSize, node->getOpCode().isUnsigned(), false);
       TR::SymbolReference *location = cg->allocateLocalTemp(dt);
       TR::MemoryReference *valueMR = TR::MemoryReference::createWithSymRef(cg, node, location, node->getSize());
@@ -1263,7 +1263,7 @@ J9::Power::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGe
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, scratchReg, scratchReg, cndReg, J9ClassHasWatchedFields);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, fieldReportLabel, cndReg);
 
-	generateReportOOL->swapInstructionListsWithCompilation();
+   generateReportOOL->swapInstructionListsWithCompilation();
 
    generateLabelInstruction(cg, TR::InstOpCode::label, node, fieldReportLabel);
    generateReportFieldAccessOutlinedInstructions(node, endLabel, dataSnippetRegister, isWrite, cg, sideEffectRegister, valueReg);


### PR DESCRIPTION
generateReportFieldAccessOutlinedInstructions incorrectly believes that when it is run on a awrtbar/awrtbari node and compressed refs is active, it is being passed a compressed object address to pass into a call to the VM. In reality, it is being given an uncompressed object address and the VM is expecting an uncompressed value. This causes a problem where a stw instruction is used to store a 64 bit value.

This change removes the special case handling of a compressed ref value for calculating elementSize. By default, convertTypeToSize already returns the correct value of 8 for 64 bit (and 4 for 32 bit).

Issue: #16750

Port of https://github.com/eclipse-openj9/openj9/pull/16925