### PR TITLE
(v0.38.0-release) CRIU restore setup Xtrace output file

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -628,9 +628,11 @@
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">terminateRemainingThreads</output>
     <output type="success" caseSensitive="yes" regex="no">java/lang/System.getProperties()Ljava/util/Properties;</output>
+    <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="success" caseSensitive="yes" regex="no">User requested Java dump</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -155,7 +155,11 @@ public class OptionsFileTest {
 	}
 
 	static void traceOptionsTest() {
-		String optionsContents = "-Xtrace:print={j9vm.40}\n-Xtrace:print=mt,methods=java/lang/System.getProperties()\n-Xtrace:trigger=method{java/lang/System.getProperties,javadump}";
+		String traceOutput = "traceOutput.txt";
+		String optionsContents = "-Xtrace:print={j9vm.40}\n"
+				+ "-Xtrace:print=mt,methods=java/lang/System.getProperties()\n"
+				+ "-Xtrace:trigger=method{java/lang/System.getProperties,javadump}\n"
+				+ "-Xtrace:maximal=mt,methods=java/lang/System.getProperties(),output=" + traceOutput;
 		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
 
 		Path imagePath = Paths.get("cpData");
@@ -167,5 +171,10 @@ public class OptionsFileTest {
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
 		System.getProperties();
 		System.out.println("Post-checkpoint");
+		if (new File(traceOutput).exists()) {
+			System.out.println("TEST PASSED - " + traceOutput + "was created successfully");
+		} else {
+			System.out.println("TEST FAILED - " + traceOutput + "was NOT created");
+		}
 	}
 }


### PR DESCRIPTION
Add support for `-Xtrace:maximal=mt,methods=java/lang/System.setProperties(),output=traceOutput.txt`;
Added a test.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/16944

Signed-off-by: Jason Feng <fengj@ca.ibm.com>