### PR TITLE
Clean up J9HookDisable calls in the compiler

### DIFF
--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -28,6 +28,7 @@
 #include "j9nonbuilder.h"
 #include "jvminit.h"
 #include "j9comp.h"
+#include "j9hookable.h"
 #include "jitprotos.h"
 #include "env/CompilerEnv.hpp"
 #include "env/TRMemory.hpp"
@@ -621,12 +622,8 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
    // post-restore (and not pre-checkpoint), invalidate all method bodies
    bool invalidateAll = false;
    bool disableAOT = _disableAOTPostRestore;
-   bool exceptionCatchEventHooked
-      = J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_EXCEPTION_CATCH)
-        || J9_EVENT_IS_RESERVED(vm->hookInterface, J9HOOK_VM_EXCEPTION_CATCH);
-   bool exceptionThrowEventHooked
-      = J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_EXCEPTION_THROW)
-        || J9_EVENT_IS_RESERVED(vm->hookInterface, J9HOOK_VM_EXCEPTION_THROW);
+   bool exceptionCatchEventHooked = J9_EVENT_CAN_BE_HOOKED(vm, J9HOOK_VM_EXCEPTION_CATCH);
+   bool exceptionThrowEventHooked = J9_EVENT_CAN_BE_HOOKED(vm, J9HOOK_VM_EXCEPTION_THROW);
 
    if (!_disableTrapsPreCheckpoint
        && (J9_ARE_ALL_BITS_SET(vm->sigFlags, J9_SIG_XRS_SYNC)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -50,6 +50,7 @@
 #include "stackwalk.h"
 #include "thrtypes.h"
 #include "vmaccess.h"
+#include "j9hookable.h"
 #undef min
 #undef max
 #include "codegen/AheadOfTimeCompile.hpp"
@@ -2935,18 +2936,16 @@ bool
 TR_J9VMBase::canMethodEnterEventBeHooked()
    {
    J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
 
-   return ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_ENTER) != 0);
+   return J9_EVENT_CAN_BE_HOOKED(javaVM, J9HOOK_VM_METHOD_ENTER);
    }
 
 bool
 TR_J9VMBase::canMethodExitEventBeHooked()
    {
    J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
 
-   return ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_RETURN) != 0);
+   return J9_EVENT_CAN_BE_HOOKED(javaVM, J9HOOK_VM_METHOD_RETURN);
    }
 
 bool
@@ -2959,20 +2958,9 @@ bool
 TR_J9VMBase::canExceptionEventBeHooked()
    {
    J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
 
-   bool catchCanBeHooked =
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-      J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH);
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
-      ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_CATCH) != 0);
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-   bool throwCanBeHooked =
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-      J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW);
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
-      ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_THROW) != 0);
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+   bool catchCanBeHooked = J9_EVENT_CAN_BE_HOOKED(javaVM, J9HOOK_VM_EXCEPTION_CATCH);
+   bool throwCanBeHooked = J9_EVENT_CAN_BE_HOOKED(javaVM, J9HOOK_VM_EXCEPTION_THROW);
 
    return (catchCanBeHooked || throwCanBeHooked);
    }

--- a/runtime/oti/j9hookable.h
+++ b/runtime/oti/j9hookable.h
@@ -25,4 +25,6 @@
 
 #include "omrhookable.h"
 
+#define J9_EVENT_CAN_BE_HOOKED(javaVM, J9_EVENT_MASK) (J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9_EVENT_MASK) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9_EVENT_MASK))
+
 #endif /* J9HOOKABLE_H_ */


### PR DESCRIPTION
The compiler uses `J9HookDisable` not to disable a hook but rather to check if the hook is disabled. However, this can have unintended consequences in CRIU mode (see https://github.com/eclipse-openj9/openj9/issues/16959). Therefore, this PR cleans up the code to check the flag rather than check if `J9HookDisable` fails.