### PR TITLE
Use sharedCacheAPI to determine -Xshareclasses:disableOnRestore

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -371,8 +371,7 @@ char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOp
    "-XX:-JITServerAOTCachePersistence",   // = 64
    "-XX:JITServerAOTCacheDir=",           // = 65
    "-XX:JITServerAOTCacheName=",          // = 66
-   "-Xshareclasses:disableOnRestore",     // = 67
-   // TR_NumExternalOptions                  = 68
+   // TR_NumExternalOptions                  = 67
    };
 
 //************************************************************************

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -120,8 +120,7 @@ enum ExternalOptions
    XXminusJITServerAOTCachePersistenceOption   = 64,
    XXJITServerAOTCacheDirOption                = 65,
    XXJITServerAOTCacheNameOption               = 66,
-   XShareclassesDisableOnRestore               = 67,
-   TR_NumExternalOptions                       = 68
+   TR_NumExternalOptions                       = 67
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -61,7 +61,6 @@ J9::OptionsPostRestore::OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *ji
    _oldVLogFileName(_privateConfig->vLogFileName),
    _oldRtLogFileName(_privateConfig->rtLogFileName),
    _asyncCompilationPreCheckpoint(_compInfo->asynchronousCompilation()),
-   _disableAOTPostRestore(false),
    _argIndexXjit(-1),
    _argIndexXjitcolon(-1),
    _argIndexXnojit(-1),
@@ -77,6 +76,12 @@ J9::OptionsPostRestore::OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *ji
    _argIndexJITServerAddress(-1),
    _argIndexJITServerAOTCacheName(-1)
    {
+   J9JavaVM *vm = jitConfig->javaVM;
+   if (vm->sharedClassConfig)
+      _disableAOTPostRestore = (vm->sharedCacheAPI->xShareClassCacheDisabledOnCRIURestore == TRUE);
+   else
+      _disableAOTPostRestore = false;
+
    TR::Options *options = TR::Options::getCmdLineOptions();
    _disableTrapsPreCheckpoint
       = J9::Options::_xrsSync
@@ -261,13 +266,6 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::Xtuneelastic:
             {
             // TODO
-            }
-            break;
-
-         case J9::ExternalOptions::XShareclassesDisableOnRestore:
-            {
-            if (FIND_ARG_IN_RESTORE_ARGS(OPTIONAL_LIST_MATCH, optString, 0) >= 0)
-               _disableAOTPostRestore = true;
             }
             break;
 


### PR DESCRIPTION
The VM sets `vm->sharedCacheAPI->xShareClassCacheDisabledOnCRIURestore` when -Xshareclasses:disableOnRestore post-restore. Rather than parsing the option directly, the compiler should just use this field.