### PR TITLE
Add support for -XX:[+|-]HandleSIGUSR2

### DIFF
--- a/runtime/jcl/common/sigusr2.c
+++ b/runtime/jcl/common/sigusr2.c
@@ -48,7 +48,7 @@ J9SigUsr2Startup(J9JavaVM *vm)
 
 #if defined(SIGUSR2)
 	if (OMR_ARE_ANY_BITS_SET(vm->sigFlags, J9_SIG_NO_SIG_USR2)) {
-		/* Set if -Xrs command-line option. */
+		/* Set if either -Xrs or -XX:-HandleSIGUSR2 command-line options are specified. */
 		Trc_JCL_J9SigUsr2Startup_Disabled();
 		return 0;
 	}

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -349,6 +349,8 @@ enum INIT_STAGE {
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
 #define VMOPT_XXNOHANDLESIGABRT "-XX:-HandleSIGABRT"
 #define VMOPT_XXHANDLESIGABRT "-XX:+HandleSIGABRT"
+#define VMOPT_XXNOHANDLESIGUSR2 "-XX:-HandleSIGUSR2"
+#define VMOPT_XXHANDLESIGUSR2 "-XX:+HandleSIGUSR2"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
 #define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -7527,6 +7527,23 @@ setSignalOptions(J9JavaVM *vm, J9PortLibrary *portLibrary)
 		/* argIndex == argIndex2 i.e. no option supplied. Enable the JVM abort handler by default. */
 	}
 
+	argIndex = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXNOHANDLESIGUSR2, NULL);
+	argIndex2 = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXHANDLESIGUSR2, NULL);
+
+	if (argIndex2 > argIndex) {
+		/* Enable the JVM SIGUSR2 handler since -XX:+HandleSIGUSR2 is seen last. */
+		if (OMR_ARE_ALL_BITS_SET(vm->sigFlags, J9_SIG_XRS_ASYNC)) {
+			/* Throw error message if both -XX:+HandleSIGUSR2 and -Xrs/-Xrs:async are supplied. */
+			j9nls_printf(portLibrary, J9NLS_ERROR, J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR, VMOPT_XXHANDLESIGUSR2, VMOPT_XRS);
+			return -1;
+		}
+	} else if (argIndex > argIndex2) {
+		/* Disable the JVM SIGUSR2 handler since -XX:-HandleSIGUSR2 is seen last. */
+		vm->sigFlags |= J9_SIG_NO_SIG_USR2;
+	} else {
+		/* argIndex == argIndex2 i.e. no option supplied. Enable the JVM SIGUSR2 handler by default. */
+	}
+
 #if defined(J9VM_PORT_ZOS_CEEHDLRSUPPORT)
 	if (FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XUSE_CEEHDLR, NULL) >= 0) {
 		sigOptions |= J9PORT_SIG_OPTIONS_ZOS_USE_CEEHDLR;


### PR DESCRIPTION
The default setting is -XX:+HandleSIGUSR2.

-XX:-HandleSIGUSR2 allows a user to install a signal handler for
SIGUSR2 without relying upon signal handler chaining (jsig).