### PR TITLE
(0.38) Include the product name in the DTFJ JavaRuntime version, print vm props

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
@@ -385,6 +385,7 @@ J9RAS.osarch = required
 J9RAS.osname = required
 J9RAS.osversion = required
 J9RAS.pid = required
+J9RAS.productName = U8*
 J9RAS.serviceLevel = required
 J9RAS.startTimeMillis = required
 J9RAS.startTimeNanos = required

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
@@ -22,7 +22,8 @@
 package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
 
 import java.io.PrintStream;
-import java.util.Enumeration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Properties;
 
 import com.ibm.dtfj.image.DataUnavailable;
@@ -115,7 +116,6 @@ public class CoreInfoCommand extends Command
 			out.println(properties.get("java.fullversion"));
 			out.println(); 
 
-			
 			/* Print Platform Info */
 			boolean is64BitPlatform = (process.bytesPerPointer() == 8) ? true : false;
 			ICore core = vm.getProcess().getAddressSpace().getCore();
@@ -131,15 +131,23 @@ public class CoreInfoCommand extends Command
 			out.println("Processors -");
 			out.println("  Architecture\t: " + ras.osarchEA().getCStringAtOffset(0));
 			out.println("  How Many\t: " + ras.cpus().longValue());
-			
+
+			out.println();
+			out.println("VM PROPERTIES (these are not Java system properties)");
+			ArrayList<String> propNames = new ArrayList(properties.stringPropertyNames());
+			Collections.sort(propNames);
+			for (String key : propNames) {
+				out.println("  " + key + " = " + properties.get(key));
+			}
+
 			try {
-				properties = ddrProcess.getEnvironment();
-				Enumeration processPropEnum = properties.keys();
+				Properties environment = ddrProcess.getEnvironment();
+				ArrayList<String> envNames = new ArrayList(environment.stringPropertyNames());
+				Collections.sort(envNames);
 				out.println();
 				out.println("ENVIRONMENT VARIABLES");
-				while (processPropEnum.hasMoreElements()) {
-					String key = (String)processPropEnum.nextElement();
-					out.println(key + "=" + properties.get(key));
+				for (String key : envNames) {
+					out.println("  " + key + "=" + environment.get(key));
 				}
 			} catch (com.ibm.dtfj.image.CorruptDataException e) {
 				throw new DDRInteractiveCommandException("CorruptDataException occured while getting the environment variables from process");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
@@ -36,6 +36,7 @@ import com.ibm.j9ddr.tools.ddrinteractive.Context;
 import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
 import com.ibm.j9ddr.view.dtfj.image.J9DDRImageProcess;
 import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.pointer.U8Pointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9RASPointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9JavaVMHelper;
@@ -111,6 +112,15 @@ public class CoreInfoCommand extends Command
 			/* Print VM service level info */
 			out.println("JAVA SERVICE LEVEL INFO");
 			out.println(ras.serviceLevel().getCStringAtOffset(0));
+			try {
+				U8Pointer productName = ras.productName();
+				if (productName.notNull()) {
+					out.println("JAVA PRODUCT INFO");
+					out.println(productName.getCStringAtOffset(0));
+				}
+			} catch (NoSuchFieldException e) {
+				// ignore if the product name doesn't exist
+			}
 			/* Print Java Version Info */
 			out.println("JAVA VERSION INFO");
 			out.println(properties.get("java.fullversion"));

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
@@ -68,6 +68,7 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JITConfigPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectMonitorPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9RASPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ThreadAbstractMonitorPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9VMThreadPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.MM_MemorySpacePointer;
@@ -932,7 +933,17 @@ public class DTFJJavaRuntime implements JavaRuntime {
 		try {
 			//starting with 26 stream, RAS structure contains the JRE version which avoids the potential pitfall
 			//of using system properties which may have their name and/or value stored in native libraries
-			return DTFJContext.getVm().j9ras().serviceLevel().getCStringAtOffset(0);
+			J9RASPointer ras = DTFJContext.getVm().j9ras();
+			String version = ras.serviceLevel().getCStringAtOffset(0);
+			try {
+				U8Pointer productName = ras.productName();
+				if (productName.notNull()) {
+					version = version + " " + productName.getCStringAtOffset(0);
+				}
+			} catch (NoSuchFieldException e) {
+				// ignore if the product name doesn't exist
+			}
+			return version;
 		} catch (Throwable t) {
 			throw J9DDRDTFJUtils.handleAsCorruptDataException(DTFJContext.getProcess(), t);
 		}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1400,6 +1400,7 @@ typedef struct J9RAS {
 	UDATA pid;
 	UDATA tid;
 	char* serviceLevel;
+	const char *productName;
 	struct J9RASSystemInfo* systemInfo;
 	I_64 startTimeMillis;
 	I_64 startTimeNanos;

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -29,6 +29,7 @@
 #include "j2sever.h"
 #include "omrlinkedlist.h"
 #include "j9version.h"
+#include "vendor_version.h"
 
 #if defined(J9ZOS390)
 #include "atoe.h"
@@ -336,6 +337,10 @@ J9RASInitialize(J9JavaVM* javaVM)
 
 	/* Set the basic service level which may be updated later by java.lang.System.rasInitializeVersion. */
 	j9rasSetServiceLevel(javaVM, NULL);
+
+#if defined(J9PRODUCT_NAME)
+	javaVM->j9ras->productName = J9PRODUCT_NAME;
+#endif /* defined(J9PRODUCT_NAME) */
 }
 
 void


### PR DESCRIPTION
The jdmpview `info system` output includes the JavaRuntime version.
Also include the product name in the !coreinfo output.

Only OpenJ9 builds have a product name.

Issue https://github.com/eclipse-openj9/openj9/issues/16930

Update jdmpview !coreinfo to print vm properties and also sort the environment variables.

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/16931 and https://github.com/eclipse-openj9/openj9/pull/16941 for 0.38