### PR TITLE
JDK21 adds JVM_VirtualThreadMount/JVM_VirtualThreadUnmount

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -32,6 +32,9 @@ import java.lang.foreign.SegmentScope;
 /*[ELSE] JAVA_SPEC_VERSION >= 20 */
 import java.lang.foreign.MemorySession;
 /*[ENDIF] JAVA_SPEC_VERSION >= 20 */
+/*[IF JAVA_SPEC_VERSION >= 21]*/
+import jdk.internal.foreign.abi.AbstractLinker.UpcallStubFactory;
+/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 import openj9.internal.foreign.abi.InternalUpcallHandler;
 
 /**
@@ -96,4 +99,19 @@ public final class UpcallLinker {
 		UpcallLinker upcallLinker = new UpcallLinker(target, mt, cDesc, session);
 		return UpcallStubs.makeUpcall(upcallLinker.entryPoint(), session);
 	}
+
+	/*[IF JAVA_SPEC_VERSION >= 21]*/
+	/**
+	 * A stub method to be implemented.
+	 *
+	 * @param targetType
+	 * @param abi
+	 * @param callingSequence
+	 * @return
+	 * @throws UnsupportedOperationException
+	 */
+	public static UpcallStubFactory makeFactory(MethodType targetType, ABIDescriptor abi, CallingSequence callingSequence) {
+		throw new UnsupportedOperationException();
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 }

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -413,6 +413,13 @@ else()
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 21)
+	jvm_add_exports(jvm
+		JVM_VirtualThreadMount
+		JVM_VirtualThreadUnmount
+	)
+endif()
+
 if(J9VM_OPT_JITSERVER)
 	jvm_add_exports(jvm
 		JITServer_CreateServer

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -420,4 +420,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_VirtualThreadHideFrames"/>
 	</exports>
 
+	<exports group="jdk21">
+		<!-- Additions for Java 21 (General) -->
+		<export name="JVM_VirtualThreadMount"/>
+		<export name="JVM_VirtualThreadUnmount"/>
+	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -575,6 +575,28 @@ JVM_VirtualThreadHideFrames(JNIEnv *env, jobject vthread, jboolean hide)
 }
 #endif /* JAVA_SPEC_VERSION >= 20 */
 
+#if JAVA_SPEC_VERSION >= 21
+JNIEXPORT void JNICALL
+JVM_VirtualThreadMount(JNIEnv* env, jobject vthread, jboolean hide, jboolean firstMount)
+{
+	if (hide) {
+		JVM_VirtualThreadMountBegin(env, vthread, firstMount);
+	} else {
+		JVM_VirtualThreadMountEnd(env, vthread, firstMount);
+	}
+}
+
+JNIEXPORT void JNICALL
+JVM_VirtualThreadUnmount(JNIEnv* env, jobject vthread, jboolean hide, jboolean lastUnmount)
+{
+	if (hide) {
+		JVM_VirtualThreadUnmountBegin(env, vthread, lastUnmount);
+	} else {
+		JVM_VirtualThreadUnmountEnd(env, vthread, lastUnmount);
+	}
+}
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 JNIEXPORT jboolean JNICALL
 JVM_IsValhallaEnabled()

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -79,6 +79,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk20">
 				<include-if condition="spec.java20"/>
 			</group>
+			<group name="jdk21">
+				<include-if condition="spec.java21"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -404,5 +404,9 @@ _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])
 _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
+_IF([JAVA_SPEC_VERSION >= 21],
+	[_X(JVM_VirtualThreadMount, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide, jboolean firstMount)])
+_IF([JAVA_SPEC_VERSION >= 21],
+	[_X(JVM_VirtualThreadUnmount, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide, jboolean lastUnmount)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -80,6 +80,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk20">
 				<include-if condition="spec.java20"/>
 			</group>
+			<group name="jdk21">
+				<include-if condition="spec.java21"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
`JVM_VirtualThreadMount` invokes `JVM_VirtualThreadMountBegin` if `hide` is `true`, otherwise `JVM_VirtualThreadMountEnd`;
Similarly for `JVM_VirtualThreadUnmount`;
Added stub methods UpcallLinker.makeFactory().

Related https://github.com/eclipse-openj9/openj9/issues/16984
Required by https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/572

Signed-off-by: Jason Feng <fengj@ca.ibm.com>