### PR TITLE
Fix getting username from env in checkpoint mode

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -188,7 +188,7 @@ jstring JNICALL Java_java_lang_System_mapLibraryName(JNIEnv * env, jclass unused
 {
 	PORT_ACCESS_FROM_ENV(env);
 	jboolean isCopy = FALSE;
-	char *outNameUTF;	
+	char *outNameUTF;
 	const char *inNameUTF;
 	jstring result;
 
@@ -367,7 +367,7 @@ jobject getPropertyList(JNIEnv *env)
 		strings[propIndex++] = "true";
 	}
 
-	/* The JCLs use ibm.signalhandling.rs to determine if they should prevent the registration of signal handlers for what 
+	/* The JCLs use ibm.signalhandling.rs to determine if they should prevent the registration of signal handlers for what
 	 * 	we consider to be asynchronous signals.
 	 * The JCLs do not install handlers for any synchronous signals */
 	strings[propIndex++] = "ibm.signalhandling.rs";
@@ -409,10 +409,10 @@ jobject getPropertyList(JNIEnv *env)
 	/*[PR 95709]*/
 
 	/* Get the language, region and variant */
-	language = j9nls_get_language();	
+	language = j9nls_get_language();
 	region = j9nls_get_region();
 	variant = j9nls_get_variant();
-	
+
 	/* CMVC 144405 : Norwegian Bokmal and Nynorsk need special consideration */
 	if ((0 == strcmp(language, "nn")) && (0 == strcmp(region, "NO"))) {
 		variant = "NY";
@@ -422,7 +422,7 @@ jobject getPropertyList(JNIEnv *env)
 	}
 
 	strings[propIndex++] = "user.language";
-	strings[propIndex++] = language;	
+	strings[propIndex++] = language;
 
 	propertyKey = "user.country";
 	strings[propIndex++] = propertyKey;
@@ -439,6 +439,7 @@ jobject getPropertyList(JNIEnv *env)
 	/* Skip j9sysinfo_get_username if a checkpoint can be taken.
 	 * https://github.com/eclipse-openj9/openj9/issues/15800
 	 */
+	result = -1;
 	if (!vmFuncs->isCheckpointAllowed(currentThread))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	{
@@ -535,12 +536,12 @@ systemPropertyIterator(char* key, char* value, void* userData)
 	if ( iteratorData->errorOccurred ) {
 		return;
 	}
-	
+
 	if (0 == strcmp("com.ibm.oti.shared.enabled", key)) {
 		/* JAZZ103 85641: Prevent com.ibm.oti.shared.enabled from being overwritten by a command line option */
 		return;
 	}
-	
+
 
 	/* check for overridden system properties, use linear scan for now */
 	for (i=0; i < defaultCount; i+=2) {
@@ -548,7 +549,7 @@ systemPropertyIterator(char* key, char* value, void* userData)
 			defaultValues[i] = NULL;
 			defaultValues[i+1] = NULL;
 			break;
-		} 
+		}
 	}
 
 	/* First do the key */
@@ -576,7 +577,7 @@ Java_java_lang_System_startSNMPAgent(JNIEnv *env, jclass jlClass)
 	if (J9_ARE_ALL_BITS_SET(vm->jclFlags, J9_JCL_FLAG_COM_SUN_MANAGEMENT_PROP)) {
 		jclass smAClass = NULL;
 		jmethodID startAgent = NULL;
-		
+
 		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			smAClass = (*env)->FindClass(env, "jdk/internal/agent/Agent");
 		} else {

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -35,6 +35,7 @@
   <variable name="MAINCLASS_TEST_SECURITYMANAGER" value="org.openj9.criu.TestSecurityManager" />
   <variable name="OPTION_SET_SECURITYMANAGER" value="-Djava.security.manager" />
   <variable name="MAINCLASS_ENVVAR_TEST" value="org.openj9.criu.EnvVarFileTest" />
+  <variable name="MAINCLASS_USERNAME_TEST" value="org.openj9.criu.UsernameTest" />
   <variable name="XDUMP_DYNAMIC" value="-Xdump:dynamic" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
@@ -671,6 +672,21 @@
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">Dump option unrecognized: -Xdump:nofailover</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+
+  <test id="Username test">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_USERNAME_TEST$ unusedArgument 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="success" caseSensitive="yes" regex="no">SUCCESS</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILURE</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/UsernameTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/UsernameTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class UsernameTest {
+
+	private static String getUsernameFromProperty() {
+		return System.getProperty("user.name");
+	}
+
+	private static String getExpectedUsername() throws IOException {
+		// Getting the username from the USER env var is easier, but
+		// since env vars also have special treatment in checkpoint mode
+		// we don't want to rely on them to validate username handling.
+		// Instead we call the `id` system command.
+		return new BufferedReader(new InputStreamReader(Runtime.getRuntime().exec("id --user --name").getInputStream())).readLine().trim();
+	}
+
+	public static void main(String args[]) throws IOException {
+		Path path = Paths.get("cpData");
+		String expectedUsernamePreCheckpoint = getExpectedUsername();
+		// Checkpointing allowed, should skip getpwuid and fall back to env.
+		String usernamePreCheckpoint = getUsernameFromProperty();
+		CRIUTestUtils.checkPointJVM(path);
+		String expectedUsernamePostCheckpoint = getExpectedUsername();
+		// Checkpointing not allowed, should call getpwuid and only fall back on error.
+		String usernamePostCheckpoint = getUsernameFromProperty();
+		boolean failed = false;
+		if (!usernamePreCheckpoint.equals(usernamePostCheckpoint)) {
+			System.out.println("FAILURE: user.name property value has changed across checkpoint (" + usernamePreCheckpoint + " -> " + usernamePostCheckpoint + ")");
+			failed = true;
+		}
+		if (!expectedUsernamePreCheckpoint.equals(expectedUsernamePostCheckpoint)) {
+			System.out.println("FAILURE: expected user name has changed across checkpoint (" + expectedUsernamePreCheckpoint + " -> " + expectedUsernamePostCheckpoint + ")");
+			failed = true;
+		}
+		if (!usernamePreCheckpoint.equals(expectedUsernamePreCheckpoint)) {
+			System.out.println("FAILURE: user.name property value (" + usernamePreCheckpoint + ") does not match expected user name (" + expectedUsernamePreCheckpoint + ")");
+			failed = true;
+		}
+		if (!failed)
+			System.out.println("SUCCESS");
+	}
+}


### PR DESCRIPTION
When checkpoints are possible we avoid calling `j9sysinfo_get_username` but don't fall back to `j9sysinfo_get_env` as intended. Fix it by making sure that path will be taken in this case.