### PR TITLE
(0.38) Add a javaVM variant of isCheckpointAllowed

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2937,7 +2937,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 				extensions->concurrentScavengerHWSupport = hwSupported
 					&& !extensions->softwareRangeCheckReadBarrierForced
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-					&& !vm->internalVMFunctions->isCRIUSupportEnabled(vm->internalVMFunctions->currentVMThread(vm))
+					&& !vm->internalVMFunctions->isCRIUSupportEnabled_VM(vm)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 					&& !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
 			}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4929,6 +4929,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*jvmCheckpointHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*jvmRestoreHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*isCRIUSupportEnabled)(struct J9VMThread *currentThread);
+	BOOLEAN (*isCRIUSupportEnabled_VM)(struct J9JavaVM *vm);
 	BOOLEAN (*isCheckpointAllowed)(struct J9VMThread *currentThread);
 	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);
 	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -507,6 +507,16 @@ BOOLEAN
 isCRIUSupportEnabled(J9VMThread *currentThread);
 
 /**
+ * @brief Queries if CRIU support is enabled. By default support
+ * is not enabled, it can be enabled with `-XX:+EnableCRIUSupport`
+ *
+ * @param vm javaVM token
+ * @return TRUE if enabled, FALSE otherwise
+ */
+BOOLEAN
+isCRIUSupportEnabled_VM(J9JavaVM *vm);
+
+/**
  * @brief Queries if checkpointing is permitted. Note, when
  * -XX:+CRIURestoreNonPortableMode option is specified checkpointing
  * will not be permitted after the JVM has been restored from a checkpoint

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -108,7 +108,13 @@ jvmRestoreHooks(J9VMThread *currentThread)
 BOOLEAN
 isCRIUSupportEnabled(J9VMThread *currentThread)
 {
-	return currentThread->javaVM->checkpointState.isCheckPointEnabled;
+	return isCRIUSupportEnabled_VM(currentThread->javaVM);
+}
+
+BOOLEAN
+isCRIUSupportEnabled_VM(J9JavaVM *vm)
+{
+	return vm->checkpointState.isCheckPointEnabled;
 }
 
 BOOLEAN

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -405,6 +405,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jvmCheckpointHooks,
 	jvmRestoreHooks,
 	isCRIUSupportEnabled,
+	isCRIUSupportEnabled_VM,
 	isCheckpointAllowed,
 	isNonPortableRestoreMode,
 	runInternalJVMCheckpointHooks,


### PR DESCRIPTION
Add a javaVM variant of isCheckpointAllowed

Some JVM components need to query if checkpoint is allowed before VM threading is initialized.

Fixes https://github.com/eclipse-openj9/openj9/issues/16976