### PR TITLE
CRIU requires Xdump::dynamic to support exception throw/catch options

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2882,20 +2882,12 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       }
 
    bool exceptionEventHooked = false;
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-   if (J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH))
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
    if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_CATCH))
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
       {
       jitConfig->jitExceptionCaught = jitExceptionCaught;
       exceptionEventHooked = true;
       }
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-   if (J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW))
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
    if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_THROW))
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
       {
       exceptionEventHooked = true;
       }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2962,17 +2962,9 @@ TR_J9VMBase::canExceptionEventBeHooked()
    J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
 
    bool catchCanBeHooked =
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-      J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_CATCH);
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
       ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_CATCH) != 0);
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
    bool throwCanBeHooked =
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-      J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW) || J9_EVENT_IS_RESERVED(javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW);
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
       ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_THROW) != 0);
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
    return (catchCanBeHooked || throwCanBeHooked);
    }

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -35,6 +35,7 @@
   <variable name="MAINCLASS_TEST_SECURITYMANAGER" value="org.openj9.criu.TestSecurityManager" />
   <variable name="OPTION_SET_SECURITYMANAGER" value="-Djava.security.manager" />
   <variable name="MAINCLASS_ENVVAR_TEST" value="org.openj9.criu.EnvVarFileTest" />
+  <variable name="XDUMP_DYNAMIC" value="-Xdump:dynamic" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
@@ -646,6 +647,22 @@
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ DumpOptionsTest 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Processing dump event "vmstop"</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Restore dump options test with no dump options specified before checkpoint and -Xdump:dynamic required">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $XDUMP_DYNAMIC$" $MAINCLASS_OPTIONSFILE_TEST$ dumpOptionsTestRequireDynamic 1</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Processing dump event "vmstop"</output>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable_RAS.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable_RAS.xml
@@ -26,6 +26,7 @@
 
 <suite id="J9 Criu Command-Line Option Tests" timeout="300">
   <variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
+  <variable name="XDUMP_DYNAMIC" value="-Xdump:dynamic" />
 
   <test id="Restore trace options test with -Xtrace before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest 1</command>
@@ -47,6 +48,22 @@
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ DumpOptionsTest 1</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Processing dump event "vmstop"</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+  </test>
+  <test id="Restore dump options test with no dump options specified before checkpoint and -Xdump:dynamic required">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $XDUMP_DYNAMIC$" $MAINCLASS_OPTIONSFILE_TEST$ dumpOptionsTestRequireDynamic 1</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Processing dump event "vmstop"</output>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -52,6 +52,9 @@ public class OptionsFileTest {
 		case "DumpOptionsTest":
 			dumpOptionsTest();
 			break;
+		case "dumpOptionsTestRequireDynamic":
+			dumpOptionsTestRequireDynamic();
+			break;
 		default:
 			throw new RuntimeException("incorrect parameters");
 		}
@@ -182,6 +185,25 @@ public class OptionsFileTest {
 	}
 
 	static void dumpOptionsTest() {
+		String optionsContents = "-Xdump:java:events=vmstop";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		try {
+			throw new OutOfMemoryError("dumpOptionsTest");
+		} catch (OutOfMemoryError ome) {
+			ome.printStackTrace();
+		}
+		System.out.println("Post-checkpoint");
+	}
+
+	static void dumpOptionsTestRequireDynamic() {
 		String optionsContents = "-Xdump:java:events=vmstop\n"
 				+ "-Xdump:nofailover\n"
 				+ "-Xdump:java:events=throw,filter=java/lang/OutOfMemoryError,request=exclusive+prepwalk+serial+preempt";
@@ -195,7 +217,7 @@ public class OptionsFileTest {
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
 		try {
-			throw new OutOfMemoryError("dumpOptionsTest");
+			throw new OutOfMemoryError("dumpOptionsTestRequireDynamic");
 		} catch (OutOfMemoryError ome) {
 			ome.printStackTrace();
 		}


### PR DESCRIPTION
Restore JIT `J9HookDisable` `J9HOOK_VM_EXCEPTION_CATCH`/`J9HOOK_VM_EXCEPTION_THROW`;
Update tests.

closes https://github.com/eclipse-openj9/openj9/issues/16958

Signed-off-by: Jason Feng <fengj@ca.ibm.com>