### PR TITLE
Handling of non-TLS client connect failures to an encrypted JITServer

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -106,6 +106,7 @@
 #include "runtime/JITServerAOTDeserializer.hpp"
 #include "net/ClientStream.hpp"
 #include "net/ServerStream.hpp"
+#include "net/CommunicationStream.hpp"
 #include "omrformatconsts.h"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #ifdef COMPRESS_AOT_DATA
@@ -7405,6 +7406,7 @@ TR::CompilationInfoPerThreadBase::cannotPerformRemoteComp(
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
           !JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
           (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||
+	  (!JITServer::CommunicationStream::shouldReadRetry() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||
           (TR::Compiler->target.cpu.isPower() && _jitConfig->inlineFieldWatches); // Power codegen is missing some FieldWatch relocation support
    }
 

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -33,6 +33,8 @@ uint32_t CommunicationStream::CONFIGURATION_FLAGS = 0;
 
 uint32_t CommunicationStream::_msgTypeCount[] = {0};
 uint64_t CommunicationStream::_totalMsgSize = 0;
+uint32_t CommunicationStream::_lastReadError = 0;
+uint32_t CommunicationStream::_numConsecutiveReadErrorsOfSameType = 0;
 #if defined(MESSAGE_SIZE_STATS)
 TR_Stats CommunicationStream::_msgSizeStats[];
 #endif /* defined(MESSAGE_SIZE_STATS) */


### PR DESCRIPTION
This fix is proposed for the Issue #17003 and is composed of 2 parts:
1. Using the  MethodToBeCompiled->_compilationAttemptsLeft counter the client will locally compile the method after the MAX_COMPILE_ATTEMPTS has reached.
2. In the readOnceBlocking code if the same read error is encountered more than 3 times then we assume that there is something wrong with the server accepting requests from the client and hence do all further method compilation locally and retry after waitTime as in the case of retry logic for connection failures.