### PR TITLE
Disable FFI specific test suites for JDK21

### DIFF
--- a/test/functional/Java20andUp/build.xml
+++ b/test/functional/Java20andUp/build.xml
@@ -77,7 +77,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<target name="build">
 		<if>
 			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15|16|17|18|19)$$" />
+				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15|16|17|18|19|21)$$" />
 			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />

--- a/test/functional/Java20andUp/playlist.xml
+++ b/test/functional/Java20andUp/playlist.xml
@@ -52,7 +52,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 		</impls>
 		<versions>
-			<version>20+</version>
+			<version>20</version>
 		</versions>
 	</test>
 
@@ -82,7 +82,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>hotspot</impl>
 		</impls>
 		<versions>
-			<version>20+</version>
+			<version>20</version>
 		</versions>
 	</test>
 
@@ -112,7 +112,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>hotspot</impl>
 		</impls>
 		<versions>
-			<version>20+</version>
+			<version>20</version>
 		</versions>
 	</test>
 
@@ -142,7 +142,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>hotspot</impl>
 		</impls>
 		<versions>
-			<version>20+</version>
+			<version>20</version>
 		</versions>
 	</test>
 </playlist>


### PR DESCRIPTION
The changes temporarily disable all FFI specific
test suites as we might need to update them
accordingly in OpenJDK & OpenJ9 once the new
changes for OpenJDK are merged to the HEAD
repository.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>