### PR TITLE
[FFI/Test] Add an exception case for the nested upcall

### DIFF
--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/InvalidUpCallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/InvalidUpCallTests.java
@@ -87,4 +87,32 @@ public class InvalidUpCallTests {
 			fail("Failed to throw out IllegalArgumentException from the the upcall method");
 		}
 	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "An exception is thrown from the upcall method")
+	public void test_nestedUpcall_throwExceptionFromUpcallMethod() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class, MemorySegment.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(structLayout, structLayout, structLayout, C_POINTER);
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntStructs_returnStructByUpcallMH").get();
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(UpcallMethodHandles.MH_add2IntStructs_returnStruct_nestedUpcall,
+					FunctionDescriptor.of(structLayout, structLayout, structLayout), scope);
+
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 11223344);
+			intHandle2.set(structSegmt1, 55667788);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 99001122);
+			intHandle2.set(structSegmt2, 33445566);
+
+			MemorySegment resultSegmt = (MemorySegment)mh.invokeExact(structSegmt1, structSegmt2, upcallFuncAddr);
+			fail("Failed to throw out IllegalArgumentException from the nested upcall");
+		}
+	}
 }

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/InvalidUpCallTests.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/InvalidUpCallTests.java
@@ -82,4 +82,30 @@ public class InvalidUpCallTests {
 			fail("Failed to throw out IllegalArgumentException from the the upcall method");
 		}
 	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "An exception is thrown from the upcall method")
+	public void test_nestedUpcall_throwExceptionFromUpcallMethod() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_INT.withName("elem1"), JAVA_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(structLayout, structLayout, structLayout, ADDRESS);
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntStructs_returnStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (MemorySession session = MemorySession.openConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_add2IntStructs_returnStruct_nestedUpcall,
+					FunctionDescriptor.of(structLayout, structLayout, structLayout), session);
+			SegmentAllocator allocator = SegmentAllocator.newNativeArena(session);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 11223344);
+			intHandle2.set(structSegmt1, 55667788);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 99001122);
+			intHandle2.set(structSegmt2, 33445566);
+
+			MemorySegment resultSegmt = (MemorySegment)mh.invoke(allocator, structSegmt1, structSegmt2, upcallFuncAddr);
+			fail("Failed to throw out IllegalArgumentException from the nested upcall");
+		}
+	}
 }


### PR DESCRIPTION
The changes add one test case to validate the exception handling code in the nested upcall.

Fixes: #16962

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>