### PR TITLE
(v0.37.0-release) Remove setImmutableField on currentThread for JDK19 and up

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1356,7 +1356,14 @@ J9::SymbolReferenceTable::findOrCreateCurrentThreadSymbolRef()
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
       TR::Symbol * sym = TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(), "CurrentThread");
       sym->setDataType(TR::Address);
-      sym->setImmutableField();
+      if (fej9->isJ9VMThreadCurrentThreadImmutable())
+         {
+         sym->setImmutableField();
+         }
+      else
+         {
+         sym->setVolatile();
+         }
       element(currentThreadSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), currentThreadSymbol, sym);
       element(currentThreadSymbol)->setOffset(fej9->thisThreadGetCurrentThreadOffset());
       }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9376,6 +9376,16 @@ TR_J9VMBase::isSnapshotModeEnabled()
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
    }
 
+bool
+TR_J9VMBase::isJ9VMThreadCurrentThreadImmutable()
+   {
+#if JAVA_SPEC_VERSION >= 19
+   return false;
+#else
+   return true;
+#endif /* JAVA_SPEC_VERSION >= 19 */
+   }
+
 // Native method bodies
 //
 #if defined(TR_HOST_X86)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1361,6 +1361,13 @@ public:
     */
    bool isSnapshotModeEnabled();
 
+   /**
+    * \brief Answers whether or not Thread.currentThread() is immutable.
+    *
+    * \return True if Thread.currentThread() is immutable.
+    */
+   virtual bool isJ9VMThreadCurrentThreadImmutable();
+
 protected:
 
    enum // _flags


### PR DESCRIPTION
`Thread.currentThread` can be changed by JCL in JDK19 and up. Set it as volatile for JDK19 and up.

Add `isJ9VMThreadCurrentThreadImmutable` in FrontEnd to query whether or not `Thread.currentThread` is immutable based on `JAVA_SPEC_VERSION`.

Cherry-picked:
- [x]  https://github.com/eclipse-openj9/openj9/pull/17009

Fixes #16258