### PR TITLE
Add paired TraceEntry

### DIFF
--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -407,10 +407,14 @@ static IDATA
 criuReloadXDumpAgents(J9JavaVM *vm, J9VMInitArgs *vmArgs)
 {
 	/* similar with startup except at CRIU restore */
-	IDATA result = configureDumpAgents(vm, vmArgs, FALSE);
+	IDATA result = 0;
+	J9VMThread *vmThread = vm->mainThread;
+
+	Trc_trcengine_criu_criuReloadXDumpAgents_Entry(vmThread);
+	result = configureDumpAgents(vm, vmArgs, FALSE);
 	unlockConfig();
 
-	Trc_trcengine_criu_criuReloadXDumpAgents_Exit(vm->mainThread, result);
+	Trc_trcengine_criu_criuReloadXDumpAgents_Exit(vmThread, result);
 	return result;
 }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/rasdump/j9dmp.tdf
+++ b/runtime/rasdump/j9dmp.tdf
@@ -40,4 +40,5 @@ TraceEvent=Trc_dump_unwindAfterSilentDump_Event1 NoEnv Overhead=1 Level=4 Templa
 
 TraceAssert=Assert_dump_true noEnv Overhead=1 Level=1 Assert="(P1)"
 
-TraceExit=Trc_trcengine_criu_criuReloadXDumpAgents_Exit Overhead=1 Level=5 Template="criuReloadXDumpAgents() returns %d"
+TraceExit=Trc_trcengine_criu_criuReloadXDumpAgents_Exit Overhead=1 Level=5 Template="criuReloadXDumpAgents() returns %zd"
+TraceEntry=Trc_trcengine_criu_criuReloadXDumpAgents_Entry Overhead=1 Level=5 Template="criuReloadXDumpAgents()"

--- a/runtime/rastrace/j9trc.tdf
+++ b/runtime/rastrace/j9trc.tdf
@@ -36,4 +36,5 @@ TraceEvent=Trc_trcengine_criu_enableMethodTraceHooks_failed Overhead=1 Level=1 T
 TraceEvent=Trc_trcengine_criu_startTraceWorkerThread_failed Overhead=1 Level=1 Template="criuRestoreInitializeTrace(): startTraceWorkerThread() failed"
 TraceEvent=Trc_trcengine_criu_traceInitializationHelper_failed Overhead=1 Level=1 Template="criuRestoreInitializeTrace(): traceInitializationHelper() failed"
 TraceEvent=Trc_trcengine_criu_nomethodentries_succeed Overhead=1 Level=5 Template="criuRestoreInitializeTrace(): no entries within traceMethodTable/triggerOnMethods, returns true"
-TraceExit=Trc_trcengine_criu_criuRestoreInitializeTrace_Exit Overhead=1 Level=5 Template="criuRestoreInitializeTrace() returns %d"
+TraceExit=Trc_trcengine_criu_criuRestoreInitializeTrace_Exit Overhead=1 Level=5 Template="criuRestoreInitializeTrace() returns %zd"
+TraceEntry=Trc_trcengine_criu_criuRestoreInitializeTrace_Entry Overhead=1 Level=5 Template="criuRestoreInitializeTrace()"

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -1014,6 +1014,7 @@ criuRestoreInitializeTrace(J9VMThread *thr)
 	BOOLEAN result = FALSE;
 	UtThreadData **tempThr = UT_THREAD_FROM_VM_THREAD(thr);
 
+	Trc_trcengine_criu_criuRestoreInitializeTrace_Entry(thr);
 	if (J9VMDLLMAIN_OK == traceInitializationHelper(vm, tempThr, vm->checkpointState.restoreArgsList, TRUE)) {
 		/* prepare the trace file first if an output is specified */
 		if (OMR_ERROR_NONE == startTraceWorkerThread(tempThr)) {


### PR DESCRIPTION
Added `Trc_trcengine_criu_criuRestoreInitializeTrace_Entry` & `Trc_trcengine_criu_criuReloadXDumpAgents_Entry`;
Updated `Trc_trcengine_criu_criuRestoreInitializeTrace_Exit` & `Trc_trcengine_criu_criuReloadXDumpAgents_Exit`.

Related https://github.com/eclipse-openj9/openj9/pull/17017

Signed-off-by: Jason Feng <fengj@ca.ibm.com>

