### PR TITLE
Re-generate client UID after CRIU restore operation (0.38.0)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -23,9 +23,6 @@
 #include "control/J9Options.hpp"
 
 #include <algorithm>
-#if defined(J9VM_OPT_JITSERVER)
-#include <random>
-#endif /* defined(J9VM_OPT_JITSERVER) */
 #include <ctype.h>
 #include <stdint.h>
 #include "jitprotos.h"
@@ -2370,16 +2367,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
           compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          // Generate a random identifier for this JITServer instance.
-         // Collisions are possible, but very unlikely.
-         // Using more bits for the client UID can reduce the probability of a collision further.
-         std::random_device rd;
-         std::mt19937_64 rng(rd());
-         std::uniform_int_distribution<uint64_t> dist;
-         // Generated uid must not be 0
-         uint64_t uid = dist(rng);
-         while (0 == uid)
-            uid = dist(rng);
-
+         uint64_t uid = JITServerHelpers::generateUID();
          if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
             {
             compInfo->getPersistentInfo()->setClientUID(uid);
@@ -2398,7 +2386,6 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             jitConfig->clientUID = 0;
             jitConfig->serverUID = uid;
             }
-
          }
       else
          {

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1068,3 +1068,18 @@ JITServerHelpers::cacheRemoteROMClassBatch(ClientSessionData *clientData, const 
       cacheRemoteROMClassOrFreeIt(clientData, ramClasses[i], romClass, classInfoTuples[i]);
       }
    }
+
+uint64_t
+JITServerHelpers::generateUID()
+   {
+   // Collisions are possible, but very unlikely.
+   // Using more bits for the UID can reduce the probability of a collision further.
+   std::random_device rd;
+   std::mt19937_64 rng(rd());
+   std::uniform_int_distribution<uint64_t> dist;
+   // Generated uid must not be 0
+   uint64_t uid = dist(rng);
+   while (0 == uid)
+      uid = dist(rng);
+   return uid;
+   }

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -23,6 +23,7 @@
 #ifndef JITSERVER_HELPERS_H
 #define JITSERVER_HELPERS_H
 
+#include <random>
 #include "net/MessageTypes.hpp"
 #include "runtime/JITClientSession.hpp"
 
@@ -142,6 +143,8 @@ public:
 
    static void cacheRemoteROMClassBatch(ClientSessionData *clientData, const std::vector<J9Class *> &ramClasses,
                                         const std::vector<ClassInfoTuple> &classInfoTuples);
+   // Helper routine to generate a unique ID for the client or server
+   static uint64_t generateUID();
 
 private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -313,6 +313,10 @@ J9::OptionsPostRestore::processJitServerOptions()
          GET_OPTION_VALUE_RESTORE_ARGS(_argIndexJITServerAOTCacheName, '=', &name);
          _compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
          }
+      // Re-compute client UID post restore
+      uint64_t clientUID = JITServerHelpers::generateUID();
+      _compInfo->getPersistentInfo()->setClientUID(clientUID);
+      _jitConfig->clientUID = clientUID;
       }
    else
       {


### PR DESCRIPTION
With JITServer Technology, each client JVM has a unique ID that is generated during JVM bootstrap. When checkpointing a JVM that is supposed to be used in client mode, this client UID gets baked into the JVM snapshot, and all JVM processes that are restored from this snapshot will have the same UID, which confuses the server. This comit re-generates the client UID during the snapshot restore operation so that different clients will have different UIDs.

Issue: #17022