### PR TITLE
Export dtfj packages required for plugins

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfj/share/classes/module-info.java
@@ -43,7 +43,7 @@ module openj9.dtfj {
   exports com.ibm.dtfj.java;
   exports com.ibm.dtfj.runtime;
   exports com.ibm.dtfj.utils.file to openj9.dtfjview;
-  exports com.ibm.java.diagnostics.utils to openj9.dtfjview;
-  exports com.ibm.java.diagnostics.utils.commands to openj9.dtfjview;
-  exports com.ibm.java.diagnostics.utils.plugins to openj9.dtfjview;
+  exports com.ibm.java.diagnostics.utils;
+  exports com.ibm.java.diagnostics.utils.commands;
+  exports com.ibm.java.diagnostics.utils.plugins;
 }


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/16783

A test plugin installed via `-Dcom.ibm.java.diagnostics.plugins` uses the following classes:
```
import com.ibm.java.diagnostics.utils.IContext;
import com.ibm.java.diagnostics.utils.commands.BaseCommand;
import com.ibm.java.diagnostics.utils.commands.CommandException;
import com.ibm.java.diagnostics.utils.plugins.DTFJPlugin;
```