### PR TITLE
Delay creation of TLS Key in JVMTI

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -1015,6 +1015,11 @@ jvmtiSetThreadLocalStorage(jvmtiEnv *env,
 				goto release;
 			}
 #endif /* JAVA_SPEC_VERSION >= 19 */
+			if (0 == j9env->tlsKey) {
+				if (0 != jvmtiTLSAlloc(vm, &j9env->tlsKey)) {
+					goto release;
+				}
+			}
 			rc = createThreadData(j9env, targetThread, threadObject);
 			if (JVMTI_ERROR_NONE != rc) {
 				goto release;


### PR DESCRIPTION
TODO: There is a timing gap between the two locations where
j9env->tlsKey is being allocated. This gap should be addressed
before the PR is merged.

Related: https://github.com/eclipse-openj9/openj9/issues/15853