### PR TITLE
[FFI/Test] Restore the fix for addDoubleAndIntDoubleLongFromStruct

### DIFF
--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
@@ -2440,13 +2440,14 @@ public class UpcallMethodHandles {
 	}
 
 	public static double addDoubleAndIntDoubleLongFromStruct(double arg1, MemorySegment arg2) {
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
-		 * while the same struct is 24 bytes with padding on other platforms.
+		/* The padding in the struct [int, double, long] on AIX/PPC 64-bit is different from
+		 * other platforms as follows:
+		 * 1) there is no padding between int and double.
+		 * 2) there is a 4-byte padding between double and long.
 		 */
-		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_INT.withName("elem1"),
-				C_DOUBLE.withName("elem2"), longLayout.withName("elem3").withBitAlignment(32))
-				: MemoryLayout.structLayout(C_INT.withName("elem1"), MemoryLayout.paddingLayout(32),
-						C_DOUBLE.withName("elem2"), longLayout.withName("elem3"));
+		GroupLayout structLayout = isAixOS ? MemoryLayout.structLayout(C_INT.withName("elem1"), C_DOUBLE.withName("elem2"),
+				MemoryLayout.paddingLayout(32), longLayout.withName("elem3")) : MemoryLayout.structLayout(C_INT.withName("elem1"),
+				MemoryLayout.paddingLayout(32), C_DOUBLE.withName("elem2"), longLayout.withName("elem3"));
 		VarHandle elemHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
 		VarHandle elemHandle2 = structLayout.varHandle(double.class, PathElement.groupElement("elem2"));
 		VarHandle elemHandle3 = structLayout.varHandle(long.class, PathElement.groupElement("elem3"));

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
@@ -1886,11 +1886,13 @@ public class UpcallMethodHandles {
 
 	public static double addDoubleAndIntDoubleLongFromStruct(double arg1, MemorySegment arg2) {
 		int structElem1 = arg2.get(JAVA_INT, 0);
-		/* The size of [int, double, long] on AIX/PPC 64-bit is 20 bytes without padding by default
-		 * while the same struct is 24 bytes with padding on other platforms.
+		/* The padding in the struct [int, double, long] on AIX/PPC 64-bit is different from
+		 * other platforms as follows:
+		 * 1) there is no padding between int and double.
+		 * 2) there is a 4-byte padding between double and long.
 		 */
 		double structElem2 = (isAixOS) ? arg2.get(JAVA_DOUBLE.withBitAlignment(32), 4) : arg2.get(JAVA_DOUBLE, 8);
-		double structElem3 = (isAixOS) ? arg2.get(JAVA_LONG.withBitAlignment(32), 12) : arg2.get(JAVA_LONG, 16);
+		double structElem3 = arg2.get(JAVA_LONG, 16);
 		double doubleSum = arg1 + structElem1 + structElem2 + structElem3;
 		return doubleSum;
 	}


### PR DESCRIPTION
The PR restores the fixed test code in
addDoubleAndIntDoubleLongFromStruct() for AIX in JD17 & 19
in https://github.com/eclipse-openj9/openj9/pull/16835 which 
was incidentally overwritten by the outdated test code introduced
in https://github.com/eclipse-openj9/openj9/pull/17014/.

Fixes: #17071

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
