### PR TITLE
(0.37) Refactor VirtualThread synchronization design

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -34,6 +34,7 @@ import jdk.internal.misc.Unsafe;
  */
 public class Continuation {
 	private long vmRef; /* J9VMContinuation */
+	protected Thread vthread; /* Parent VirtualThread */
 
 	private final ContinuationScope scope;
 	private final Runnable runnable;

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -34,7 +34,9 @@
 #include "mmhook.h"
 #include "mmomrhook.h"
 #include "vmaccess.h"
+#if JAVA_SPEC_VERSION >= 19
 #include "HeapIteratorAPI.h"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 #include "codegen/CodeGenerator.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"
@@ -6460,6 +6462,7 @@ static UDATA jitReleaseCodeStackWalkFrame(J9VMThread *vmThread, J9StackWalkState
    return J9_STACKWALK_KEEP_ITERATING;
    }
 
+#if JAVA_SPEC_VERSION >= 19
 static jvmtiIterationControl jitWalkContinuationCallBack(J9VMThread *vmThread, J9MM_IterateObjectDescriptor *object, void *userData)
    {
    J9InternalVMFunctions *vmFuncs = vmThread->javaVM->internalVMFunctions;
@@ -6498,6 +6501,7 @@ static jvmtiIterationControl jitResetContinuationFlag(J9VMThread *vmThread, J9MM
 
    return JVMTI_ITERATION_CONTINUE;
    }
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFunctionPtr condYield = NULL)
    {

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -6557,6 +6557,7 @@ static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFu
 
       do
          {
+         vm->memoryManagerFunctions->j9gc_flush_nonAllocationCaches_for_walk(vm);
          jvmtiIterationControl rc = vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(vmThread, PORTLIB, 0, jitWalkContinuationCallBack, (void*)condYield);
          if (JVMTI_ITERATION_ABORT == rc)
             yieldHappened = true;

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -356,7 +356,7 @@ public:
 		, minimumFreeSizeForSurvivor(DEFAULT_SURVIVOR_MINIMUM_FREESIZE)
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
-		, continuationListOption(verify_continuation_list)
+		, continuationListOption(enable_continuation_list)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -246,6 +246,31 @@ JVM_IsPreviewEnabled(void)
 	return isPreviewEnabled;
 }
 
+static void
+enterVThreadTransitionCritical(J9VMThread *currentThread, jobject thread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	MM_ObjectAccessBarrierAPI objectAccessBarrier = MM_ObjectAccessBarrierAPI(currentThread);
+	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+
+	while(!objectAccessBarrier.inlineMixedObjectCompareAndSwapU64(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, 0, (U_64)-1)) {
+		/* Thread is being inspected or unmounted, wait. */
+		vmFuncs->internalExitVMToJNI(currentThread);
+		VM_AtomicSupport::yieldCPU();
+		/* After wait, the thread may suspend here. */
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+	}
+}
+
+static void
+exitVThreadTransitionCritical(J9VMThread *currentThread, j9object_t vthread)
+{
+	Assert_SC_true(-1 == J9OBJECT_I64_LOAD(currentThread, vthread, currentThread->javaVM->virtualThreadInspectorCountOffset));
+	J9OBJECT_I64_STORE(currentThread, vthread, currentThread->javaVM->virtualThreadInspectorCountOffset, 0);
+}
+
 JNIEXPORT void JNICALL
 JVM_VirtualThreadMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 {
@@ -256,13 +281,12 @@ JVM_VirtualThreadMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 	Trc_SC_VirtualThreadMountBegin_Entry(currentThread, thread, firstMount);
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-	f_monitorEnter(vm->liveVirtualThreadListMutex);
 	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
-
 	Assert_SC_true(IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObj));
 
 	if (TrcEnabled_Trc_SC_VirtualThread_Info) {
 		j9object_t continuationObj = J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObj);
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObj);
 		Trc_SC_VirtualThread_Info(
 				currentThread,
 				threadObj,
@@ -270,30 +294,11 @@ JVM_VirtualThreadMountBegin(JNIEnv *env, jobject thread, jboolean firstMount)
 				J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset),
 				J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(currentThread, threadObj),
 				continuationObj,
-				J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObj));
+				continuation);
 	}
 
-	while (vm->inspectingLiveVirtualThreadList
-	|| (0 != J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset))
-	) {
-		/* Thread is being inspected or unmounted, wait. */
-		vmFuncs->internalExitVMToJNI(currentThread);
-		f_monitorWait(vm->liveVirtualThreadListMutex);
-		/* Release the monitor before suspending. */
-		f_monitorExit(vm->liveVirtualThreadListMutex);
-		/* After wait, the thread may suspend here. */
-		vmFuncs->internalEnterVMFromJNI(currentThread);
-		/* Acquire the monitor after resuming from suspend. */
-		f_monitorEnter(vm->liveVirtualThreadListMutex);
-		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
-	}
+	enterVThreadTransitionCritical(currentThread, thread);
 
-	/* Prevent inspectors from inspecting this thread during stack swap and mount by locking from notifyJvmtiMountBegin
-	 * to notifyJvmtiMountEnd. See getVMThread() in jvmtiHelpers.c.
-	 */
-	J9OBJECT_I64_STORE(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, -1);
-
-	f_monitorExit(vm->liveVirtualThreadListMutex);
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 	Trc_SC_VirtualThreadMountBegin_Exit(currentThread, thread, firstMount);
@@ -328,71 +333,13 @@ JVM_VirtualThreadMountEnd(JNIEnv *env, jobject thread, jboolean firstMount)
 				J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObj));
 	}
 
-	/* On some occassions, J9AllocateObject acquires exclusive VM access. It is invoked without acquiring
-	 * liveVirtualThreadListMutex to prevent a deadlock.
-	 */
-	if (NULL == vm->liveVirtualThreadList) {
-		Assert_SC_true(firstMount);
-		J9Class *virtualThreadClass = J9OBJECT_CLAZZ(currentThread, J9_JNI_UNWRAP_REFERENCE(thread));
-		J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
-
-		/* Allocate empty virtual thread and create a global reference to it as root for the linked list.
-		 * This prevents the root reference from becoming stale if the GC moves the object.
-		 */
-		rootVirtualThread = mmFuncs->J9AllocateObject(currentThread, virtualThreadClass, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
-		if (NULL == rootVirtualThread) {
-			vmFuncs->setHeapOutOfMemoryError(currentThread);
-			goto release1;
-		}
-
-		/* Re-fetch as the memory allocation above may have moved the object. */
-		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
-
-		J9VMJAVALANGVIRTUALTHREAD_SET_STATE(currentThread, rootVirtualThread, J9VM_VIRTUALTHREAD_ROOT_NODE_STATE);
-	}
-
-	f_monitorEnter(vm->liveVirtualThreadListMutex);
+	/* Allow thread to be inspected again. */
+	exitVThreadTransitionCritical(currentThread, threadObj);
 
 	if (firstMount) {
-		if (NULL == vm->liveVirtualThreadList) {
-			Assert_SC_true(NULL != rootVirtualThread);
-
-			jobject globalRef = vmFuncs->j9jni_createGlobalRef((JNIEnv *)currentThread, rootVirtualThread, JNI_FALSE);
-			if (NULL == globalRef) {
-				vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
-				goto release2;
-			}
-
-			Trc_SC_VirtualThread_RootNodeSet(currentThread, globalRef);
-			vm->liveVirtualThreadList = (j9object_t *)globalRef;
-			/* Set linkNext/linkPrevious to itself. */
-			J9OBJECT_OBJECT_STORE(currentThread, rootVirtualThread, vm->virtualThreadLinkNextOffset, rootVirtualThread);
-			J9OBJECT_OBJECT_STORE(currentThread, rootVirtualThread, vm->virtualThreadLinkPreviousOffset, rootVirtualThread);
-		}
-
-		if (NULL != vm->liveVirtualThreadList) {
-			j9object_t threadPrev = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset);
-			j9object_t threadNext = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkNextOffset);
-
-			/* Non-null previous and next elements in the list suggest that the thread has
-			 * already been added to the list. Only add to the list if the previous and
-			 * next elements in the list are null.
-			 */
-			Assert_SC_true((NULL == threadPrev) && (NULL == threadNext));
-			j9object_t root = *(vm->liveVirtualThreadList);
-			j9object_t rootPrev = J9OBJECT_OBJECT_LOAD(currentThread, root, vm->virtualThreadLinkPreviousOffset);
-
-			/* Add thread to the end of the list. */
-			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkNextOffset, root);
-			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset, rootPrev);
-			J9OBJECT_OBJECT_STORE(currentThread, rootPrev, vm->virtualThreadLinkNextOffset, threadObj);
-			J9OBJECT_OBJECT_STORE(currentThread, root, vm->virtualThreadLinkPreviousOffset, threadObj);
-		}
+		TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_STARTED(vm->hookInterface, currentThread);
 	}
-
-	/* Allow thread to be inspected again. */
-	Assert_SC_true(-1 == J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset));
-	J9OBJECT_I64_STORE(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, 0);
+	TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_MOUNT(vm->hookInterface, currentThread);
 
 	/* If isSuspendedByJVMTI is non-zero, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND is set
 	 * in currentThread->publicFlags while resetting isSuspendedByJVMTI to zero. During
@@ -403,19 +350,6 @@ JVM_VirtualThreadMountEnd(JNIEnv *env, jobject thread, jboolean firstMount)
 		vmFuncs->setHaltFlag(currentThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 	}
 
-	f_monitorNotifyAll(vm->liveVirtualThreadListMutex);
-
-	/* J9Hooks can be run since no errors were encountered. */
-	runJ9Hooks = TRUE;
-release2:
-	f_monitorExit(vm->liveVirtualThreadListMutex);
-release1:
-	if (runJ9Hooks) {
-		if (firstMount) {
-			TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_STARTED(vm->hookInterface, currentThread);
-		}
-		TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_MOUNT(vm->hookInterface, currentThread);
-	}
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 	Trc_SC_VirtualThreadMountEnd_Exit(currentThread, thread, firstMount);
@@ -431,7 +365,6 @@ JVM_VirtualThreadUnmountBegin(JNIEnv *env, jobject thread, jboolean lastUnmount)
 	Trc_SC_VirtualThreadUnmountBegin_Entry(currentThread, thread, lastUnmount);
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-	f_monitorEnter(vm->liveVirtualThreadListMutex);
 	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 
 	Assert_SC_true(IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObj));
@@ -448,51 +381,18 @@ JVM_VirtualThreadUnmountBegin(JNIEnv *env, jobject thread, jboolean lastUnmount)
 				J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObj));
 	}
 
-	while (vm->inspectingLiveVirtualThreadList
-	|| (0 != J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset))
-	) {
-		/* Thread is being inspected, wait. */
-		vmFuncs->internalExitVMToJNI(currentThread);
-		f_monitorWait(vm->liveVirtualThreadListMutex);
-		/* Release the monitor before suspending. */
-		f_monitorExit(vm->liveVirtualThreadListMutex);
-		/* After wait, the thread may suspend here. */
-		vmFuncs->internalEnterVMFromJNI(currentThread);
-		/* Acquire the monitor after resuming from suspend. */
-		f_monitorEnter(vm->liveVirtualThreadListMutex);
-		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
-	}
-
-	/* Prevent inspectors from inspecting this thread during stack swap and unmount by locking from notifyJvmtiUnmountBegin
-	 * to notifyJvmtiUnmountEnd. See getVMThread() in jvmtiHelpers.c.
-	 */
-	J9OBJECT_I64_STORE(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, -1);
-
-	if (lastUnmount) {
-		if (NULL != vm->liveVirtualThreadList) {
-			j9object_t threadPrev = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset);
-			j9object_t threadNext = J9OBJECT_OBJECT_LOAD(currentThread, threadObj, vm->virtualThreadLinkNextOffset);
-
-			/* Non-null previous and next elements in the list suggest that the thread has
-			 * been added to the list. Only remove from the list if the previous and next
-			 * elements in the list are non-null.
-			 */
-			Assert_SC_true((NULL != threadPrev) && (NULL != threadNext));
-			/* Remove thread from the list. The root will never be removed. */
-			J9OBJECT_OBJECT_STORE(currentThread, threadPrev, vm->virtualThreadLinkNextOffset, threadNext);
-			J9OBJECT_OBJECT_STORE(currentThread, threadNext, vm->virtualThreadLinkPreviousOffset, threadPrev);
-
-			/* Reset previous and next fields in the thread object to null. */
-			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkNextOffset, NULL);
-			J9OBJECT_OBJECT_STORE(currentThread, threadObj, vm->virtualThreadLinkPreviousOffset, NULL);
-		}
-	}
-
-	f_monitorExit(vm->liveVirtualThreadListMutex);
-
 	TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_UNMOUNT(vm->hookInterface, currentThread);
 	if (lastUnmount) {
 		TRIGGER_J9HOOK_VM_VIRTUAL_THREAD_END(vm->hookInterface, currentThread);
+	}
+
+	enterVThreadTransitionCritical(currentThread, thread);
+	if (lastUnmount) {
+		/* Re-fetch reference as enterVThreadTransitionCritical may release VMAccess. */
+		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
+		j9object_t continuationObj = J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObj);
+		/* Add reverse link from Continuation object to VirtualThread object, this let JVMTI code */
+		J9VMJDKINTERNALVMCONTINUATION_SET_VTHREAD(currentThread, continuationObj, NULL);
 	}
 	vmFuncs->internalExitVMToJNI(currentThread);
 
@@ -509,7 +409,6 @@ JVM_VirtualThreadUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
 	Trc_SC_VirtualThreadUnmountEnd_Entry(currentThread, thread, lastUnmount);
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-	f_monitorEnter(vm->liveVirtualThreadListMutex);
 	j9object_t threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 
 	Assert_SC_true(IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObj));
@@ -534,11 +433,8 @@ JVM_VirtualThreadUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
 	}
 
 	/* Allow thread to be inspected again. */
-	Assert_SC_true(-1 == J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset));
-	J9OBJECT_I64_STORE(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, 0);
-	f_monitorNotifyAll(vm->liveVirtualThreadListMutex);
+	exitVThreadTransitionCritical(currentThread, threadObj);
 
-	f_monitorExit(vm->liveVirtualThreadListMutex);
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 	Trc_SC_VirtualThreadUnmountEnd_Exit(currentThread, thread, lastUnmount);

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -650,16 +650,6 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 		return 1;
 	}
 
-	/* Points to the next VirtualThread in the liveVirtualThreadList. */
-	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkNext", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkNextOffset)) {
-		return 1;
-	}
-
-	/* Points to the previous VirtualThread in the liveVirtualThreadList. */
-	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "linkPrevious", "Ljava/lang/VirtualThread;", &vm->virtualThreadLinkPreviousOffset)) {
-		return 1;
-	}
-
 	/* Counter to track if the virtual thread is being inspected by JVMTI. */
 	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "inspectorCount", "J", &vm->virtualThreadInspectorCountOffset)) {
 		return 1;

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -339,17 +339,18 @@ Java_java_lang_Thread_getStackTraceImpl(JNIEnv *env, jobject rcv)
 #if JAVA_SPEC_VERSION >= 19
 	BOOLEAN releaseInspector = FALSE;
 	if (IS_JAVA_LANG_VIRTUALTHREAD(currentThread, receiverObject)) {
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		j9object_t carrierThread = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(currentThread, receiverObject);
-		I_64 vthreadInspectorCount = J9OBJECT_I64_LOAD(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset);
-
-		/* Ensure virtual thread is mounted and not during transition. */
-		if ((NULL != carrierThread) && (vthreadInspectorCount >= 0)) {
-			J9OBJECT_I64_STORE(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset, vthreadInspectorCount + 1);
-			releaseInspector = TRUE;
+		/* Do not spin when acquiring access, if acquire failed, return NULL.
+		 * The caller of getStackTraceImpl will handle if should retry or get stack using unmounted path.
+		 */
+		if (!vmFuncs->acquireVThreadInspector(currentThread, rcv, FALSE)) {
+			goto done;
 		}
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
-		if (!releaseInspector) {
+		j9object_t carrierThread = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(currentThread, receiverObject);
+		/* Ensure virtual thread is mounted and not during transition. */
+		if (NULL != carrierThread) {
+			releaseInspector = TRUE;
+		} else {
+			vmFuncs->releaseVThreadInspector(currentThread, rcv);
 			goto done;
 		}
 		/* Gets targetThread from the carrierThread object. */
@@ -370,16 +371,7 @@ Java_java_lang_Thread_getStackTraceImpl(JNIEnv *env, jobject rcv)
 	if (releaseInspector) {
 		receiverObject = J9_JNI_UNWRAP_REFERENCE(rcv);
 		/* Release the virtual thread (allow it to die) now that we are no longer inspecting it. */
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		I_64 vthreadInspectorCount = J9OBJECT_I64_LOAD(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset);
-		Assert_JCL_true(vthreadInspectorCount > 0);
-		vthreadInspectorCount -= 1;
-		J9OBJECT_I64_STORE(currentThread, receiverObject, vm->virtualThreadInspectorCountOffset, vthreadInspectorCount);
-
-		if (!vm->inspectingLiveVirtualThreadList && (0 == vthreadInspectorCount)) {
-			omrthread_monitor_notify_all(vm->liveVirtualThreadListMutex);
-		}
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+		vmFuncs->releaseVThreadInspector(currentThread, rcv);
 	}
 done:
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -36,6 +36,19 @@ static jvmtiError resumeThread(J9VMThread *currentThread, jthread thread);
 static UDATA wrappedAgentThreadStart(J9PortLibrary *portLib, void *entryArg);
 static void ownedMonitorIterator(J9VMThread *currentThread, J9StackWalkState *walkState, j9object_t *slot, const void *stackLocation);
 
+#if JAVA_SPEC_VERSION >= 19
+#include "HeapIteratorAPI.h"
+
+typedef struct jvmtiVThreadCallBackData {
+	const jthread *except_list;
+	jint except_count;
+	BOOLEAN is_suspend;
+	BOOLEAN suspend_current_thread;
+} jvmtiVThreadCallBackData;
+
+static jvmtiIterationControl jvmtiSuspendResumeCallBack(J9VMThread *vmThread, J9MM_IterateObjectDescriptor *object, void *userData);
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 jvmtiError JNICALL
 jvmtiGetThreadState(jvmtiEnv *env,
 	jthread thread,
@@ -1289,6 +1302,58 @@ done:
 }
 
 #if JAVA_SPEC_VERSION >= 19
+static jvmtiIterationControl
+jvmtiSuspendResumeCallBack(J9VMThread *vmThread, J9MM_IterateObjectDescriptor *object, void *userData)
+{
+	j9object_t vthread = J9VMJDKINTERNALVMCONTINUATION_VTHREAD(vmThread, object->object);
+	if (NULL != vthread) {
+		jvmtiVThreadCallBackData *data = (jvmtiVThreadCallBackData*)userData;
+		BOOLEAN is_excepted = FALSE;
+		for (jint i = 0; i < data->except_count; ++i) {
+			if (vthread == J9_JNI_UNWRAP_REFERENCE(data->except_list[i])) {
+				is_excepted = TRUE;
+				break;
+			}
+		}
+		if (!is_excepted) {
+			J9JavaVM *vm = vmThread->javaVM;
+			J9VMThread *targetThread = NULL;
+			j9object_t carrierThread = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(vmThread, vthread);
+			if (NULL != carrierThread) {
+				targetThread = J9VMJAVALANGTHREAD_THREADREF(vmThread, carrierThread);
+				Assert_JVMTI_notNull(targetThread);
+			}
+			if (data->is_suspend) {
+				if (NULL != targetThread) {
+					if (OMR_ARE_NO_BITS_SET(targetThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND | J9_PUBLIC_FLAGS_STOPPED)) {
+						setHaltFlag(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
+						Trc_JVMTI_threadSuspended(targetThread);
+					}
+				} else {
+					/* NULL carrier thread imply the virtual threadis unmounted. */
+					if (0 == J9OBJECT_U32_LOAD(vmThread, vthread, vm->isSuspendedByJVMTIOffset)) {
+						J9OBJECT_U32_STORE(vmThread, vthread, vm->isSuspendedByJVMTIOffset, 1);
+					}
+				}
+			} else {
+				/* Resume the virtual thread. */
+				if (NULL != targetThread) {
+					if (OMR_ARE_ANY_BITS_SET(targetThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND)) {
+						clearHaltFlag(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
+						Trc_JVMTI_threadResumed(targetThread);
+					}
+				} else {
+					/* targetThread is NULL only for virtual threads. */
+					if (0 != J9OBJECT_U32_LOAD(currentThread, vthread, vm->isSuspendedByJVMTIOffset)) {
+						J9OBJECT_U32_STORE(currentThread, vthread, vm->isSuspendedByJVMTIOffset, 0);
+					}
+				}
+			}
+		}
+	}
+	return JVMTI_ITERATION_CONTINUE;
+}
+
 jvmtiError JNICALL
 jvmtiSuspendAllVirtualThreads(jvmtiEnv *env,
 	jint except_count,
@@ -1303,8 +1368,9 @@ jvmtiSuspendAllVirtualThreads(jvmtiEnv *env,
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (JVMTI_ERROR_NONE == rc) {
 		jint i = 0;
-		BOOLEAN currentThreadEverSuspended = FALSE;
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		jvmtiVThreadCallBackData data = {except_list, except_count, TRUE, FALSE};
 
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 
@@ -1327,47 +1393,12 @@ jvmtiSuspendAllVirtualThreads(jvmtiEnv *env,
 		}
 
 		/* Walk all virtual threads. */
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		while (vm->inspectingLiveVirtualThreadList) {
-			/* Virtual thread list is being inspected, wait. */
-			vmFuncs->internalExitVMToJNI(currentThread);
-			omrthread_monitor_wait(vm->liveVirtualThreadListMutex);
-			vmFuncs->internalEnterVMFromJNI(currentThread);
-		}
-		vm->inspectingLiveVirtualThreadList = TRUE;
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
-		if (NULL != vm->liveVirtualThreadList) {
-			j9object_t root = *(vm->liveVirtualThreadList);
-			/* Skip the root, which is a dummy virtual thread and global ref. */
-			j9object_t walkVirtualThread = J9OBJECT_OBJECT_LOAD(currentThread, root, vm->virtualThreadLinkNextOffset);
-			do {
-				BOOLEAN suspend = TRUE;
-				for (i = 0; i < except_count; ++i) {
-					if (walkVirtualThread == J9_JNI_UNWRAP_REFERENCE(except_list[i])) {
-						suspend = FALSE;
-						break;
-					}
-				}
-				if (suspend) {
-					BOOLEAN currentThreadSuspended = FALSE;
-					JNIEnv *jniEnv = (JNIEnv *)currentThread;
-					jobject virtualThreadRef = vmFuncs->j9jni_createLocalRef(jniEnv, walkVirtualThread);
-					/* Ignore errors if the virtual thread is already suspended. */
-					suspendThread(currentThread, (jthread)virtualThreadRef, FALSE, &currentThreadSuspended);
-					walkVirtualThread = J9_JNI_UNWRAP_REFERENCE(virtualThreadRef);
-					vmFuncs->j9jni_deleteLocalRef(jniEnv, virtualThreadRef);
-					currentThreadEverSuspended |= currentThreadSuspended;
-				}
-				walkVirtualThread = J9OBJECT_OBJECT_LOAD(currentThread, walkVirtualThread, vm->virtualThreadLinkNextOffset);
-			} while (root != walkVirtualThread);
-		}
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		vm->inspectingLiveVirtualThreadList = FALSE;
-		omrthread_monitor_notify_all(vm->liveVirtualThreadListMutex);
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+		vmFuncs->acquireExclusiveVMAccess(currentThread);
+		vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(currentThread, PORTLIB, 0, jvmtiSuspendResumeCallBack, (void*)&data);
+		vmFuncs->releaseExclusiveVMAccess(currentThread);
 
 		/* If the current thread appeared in the list (and was marked as suspended), block now until the thread is resumed. */
-		if (currentThreadEverSuspended) {
+		if (data.suspend_current_thread) {
 			vmFuncs->internalExitVMToJNI(currentThread);
 			setHaltFlag(currentThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 			vmFuncs->internalEnterVMFromJNI(currentThread);
@@ -1394,6 +1425,8 @@ jvmtiResumeAllVirtualThreads(jvmtiEnv *env,
 	if (rc == JVMTI_ERROR_NONE) {
 		jint i = 0;
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		jvmtiVThreadCallBackData data = {except_list, except_count, FALSE, FALSE};
 
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 
@@ -1416,38 +1449,9 @@ jvmtiResumeAllVirtualThreads(jvmtiEnv *env,
 		}
 
 		/* Walk all virtual threads. */
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		while (vm->inspectingLiveVirtualThreadList) {
-			/* Virtual thread list is being inspected, wait. */
-			vmFuncs->internalExitVMToJNI(currentThread);
-			omrthread_monitor_wait(vm->liveVirtualThreadListMutex);
-			vmFuncs->internalEnterVMFromJNI(currentThread);
-		}
-		vm->inspectingLiveVirtualThreadList = TRUE;
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
-		if (NULL != vm->liveVirtualThreadList) {
-			j9object_t root = *(vm->liveVirtualThreadList);
-			/* Skip the root, which is a dummy virtual thread and global ref. */
-			j9object_t walkVirtualThread = J9OBJECT_OBJECT_LOAD(currentThread, root, vm->virtualThreadLinkNextOffset);
-			do {
-				BOOLEAN resume = TRUE;
-				for (i = 0; i < except_count; ++i) {
-					if (walkVirtualThread == J9_JNI_UNWRAP_REFERENCE(except_list[i])) {
-						resume = FALSE;
-						break;
-					}
-				}
-				if (resume) {
-					/* Ignore errors if the virtual thread is already resumed. */
-					resumeThread(currentThread, (jthread)&walkVirtualThread);
-				}
-				walkVirtualThread = J9OBJECT_OBJECT_LOAD(currentThread, walkVirtualThread, vm->virtualThreadLinkNextOffset);
-			} while (root != walkVirtualThread);
-		}
-		omrthread_monitor_enter(vm->liveVirtualThreadListMutex);
-		vm->inspectingLiveVirtualThreadList = FALSE;
-		omrthread_monitor_notify_all(vm->liveVirtualThreadListMutex);
-		omrthread_monitor_exit(vm->liveVirtualThreadListMutex);
+		vmFuncs->acquireExclusiveVMAccess(currentThread);
+		vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(currentThread, PORTLIB, 0, jvmtiSuspendResumeCallBack, (void*)&data);
+		vmFuncs->releaseExclusiveVMAccess(currentThread);
 done:
 		vmFuncs->internalExitVMToJNI(currentThread);
 	}

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -1394,6 +1394,7 @@ jvmtiSuspendAllVirtualThreads(jvmtiEnv *env,
 
 		/* Walk all virtual threads. */
 		vmFuncs->acquireExclusiveVMAccess(currentThread);
+		vm->memoryManagerFunctions->j9gc_flush_nonAllocationCaches_for_walk(vm);
 		vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(currentThread, PORTLIB, 0, jvmtiSuspendResumeCallBack, (void*)&data);
 		vmFuncs->releaseExclusiveVMAccess(currentThread);
 
@@ -1450,6 +1451,7 @@ jvmtiResumeAllVirtualThreads(jvmtiEnv *env,
 
 		/* Walk all virtual threads. */
 		vmFuncs->acquireExclusiveVMAccess(currentThread);
+		vm->memoryManagerFunctions->j9gc_flush_nonAllocationCaches_for_walk(vm);
 		vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(currentThread, PORTLIB, 0, jvmtiSuspendResumeCallBack, (void*)&data);
 		vmFuncs->releaseExclusiveVMAccess(currentThread);
 done:

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2251,7 +2251,6 @@ exit:
 			}
 		}
 	}
-
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 	static VMINLINE void

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4946,6 +4946,8 @@ typedef struct J9InternalVMFunctions {
 	void (*freeTLS)(struct J9VMThread *currentThread, j9object_t threadObj);
 	UDATA (*walkContinuationStackFrames)(struct J9VMThread *currentThread, struct J9VMContinuation *continuation, J9StackWalkState *walkState);
 	UDATA (*walkAllStackFrames)(struct J9VMThread *currentThread, J9StackWalkState *walkState);
+	BOOLEAN (*acquireVThreadInspector)(struct J9VMThread *currentThread, jobject thread, BOOLEAN spin);
+	void (*releaseVThreadInspector)(struct J9VMThread *currentThread, jobject thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9InternalVMFunctions;
 
@@ -5818,11 +5820,6 @@ typedef struct J9JavaVM {
 	struct J9HashTable* ensureHashedClasses;
 #if JAVA_SPEC_VERSION >= 19
 	U_64 nextTID;
-	j9object_t *liveVirtualThreadList;
-	omrthread_monitor_t liveVirtualThreadListMutex;
-	volatile BOOLEAN inspectingLiveVirtualThreadList;
-	UDATA virtualThreadLinkNextOffset;
-	UDATA virtualThreadLinkPreviousOffset;
 	UDATA virtualThreadInspectorCountOffset;
 	UDATA isSuspendedByJVMTIOffset;
 	UDATA tlsOffset;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4376,6 +4376,26 @@ walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continu
  */
 UDATA
 walkAllStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState);
+
+/**
+ * @brief Acquire inspector access on VirtualThread, block until access is acquired.
+ *
+ * @param currentThread
+ * @param thread target VirtualThread to acquire the inspector on
+ * @param spin call should spin until sucessfully acquired access
+ * @return TRUE on success, FALSE on failure
+ */
+BOOLEAN
+acquireVThreadInspector(J9VMThread *currentThread, jobject thread, BOOLEAN spin);
+
+/**
+ * @brief Release the inspector acquired from VirtualThread.
+ *
+ * @param currentThread
+ * @param thread target VirtualThread to release the inspector on
+ */
+void
+releaseVThreadInspector(J9VMThread *currentThread, jobject thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 /* ---------------- hookableAsync.c ---------------- */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -416,6 +416,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="jdk/internal/vm/Continuation" name="finished" signature="Z" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="started" signature="Z" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="parent" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
+	<fieldref class="jdk/internal/vm/Continuation" name="vthread" signature="Ljava/lang/Thread;" versions="19-"/>
 
 	<!-- Field references needed to support Foreign Linker API. -->
 	<fieldref class="openj9/internal/foreign/abi/InternalDowncallHandler" name="cifNativeThunkAddr" signature="J" flags="opt_openjdkFfi" versions="16-"/>

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -372,6 +372,7 @@ walkAllStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 
 	/* Walk all live continuation stacks using the GC Continuation object iterator */
 	PORT_ACCESS_FROM_VMC(currentThread);
+	vm->memoryManagerFunctions->j9gc_flush_nonAllocationCaches_for_walk(vm);
 	vm->memoryManagerFunctions->j9mm_iterate_all_continuation_objects(
 									currentThread,
 									PORTLIB,

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -261,7 +261,7 @@ freeContinuation(J9VMThread *currentThread, j9object_t continuationObject)
 			currentStack = previous;
 		} while (NULL != currentStack);
 
-		Assert_VM_true(VM_VMHelpers::isFinished(continuation->state));
+		Assert_VM_true(!VM_VMHelpers::isConcurrentlyScanned(continuation->state) && (NULL == VM_VMHelpers::getCarrierThread(continuation->state)));
 
 		/* Free the J9VMContinuation struct */
 		j9mem_free_memory(continuation);

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -433,5 +433,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	freeTLS,
 	walkContinuationStackFrames,
 	walkAllStackFrames,
+	acquireVThreadInspector,
+	releaseVThreadInspector,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 };

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -92,7 +92,6 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 
 #if JAVA_SPEC_VERSION >= 19
 		/* Held when adding or removing a virtual thread from the list at virtual thread start or terminate. */
-		omrthread_monitor_init_with_name(&vm->liveVirtualThreadListMutex, 0, "Live virtual thread list mutex") ||
 		omrthread_monitor_init_with_name(&vm->tlsFinalizersMutex, 0, "TLS finalizers mutex") ||
 		omrthread_monitor_init_with_name(&vm->tlsPoolMutex, 0, "TLS pool mutex") ||
 #endif /* JAVA_SPEC_VERSION >= 19 */
@@ -197,10 +196,6 @@ void terminateVMThreading(J9JavaVM *vm)
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 19
-	if (NULL != vm->liveVirtualThreadListMutex) {
-		omrthread_monitor_destroy(vm->liveVirtualThreadListMutex);
-		vm->liveVirtualThreadListMutex = NULL;
-	}
 	if (NULL != vm->tlsFinalizersMutex) {
 		omrthread_monitor_destroy(vm->tlsFinalizersMutex);
 		vm->tlsFinalizersMutex = NULL;


### PR DESCRIPTION
Removes use of liveVirtualThreadList/liveVirtualThreadListMutex in the VM and rely on GC's Continuation list.
This design uses an atomic based RW lock with busy waiting for vthread access during mounted/unmount transition.
Global access in JVMTI is a slow path and done through Exclusive VM Access which doesn't require additional locking.

mutual dependency:
https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/87

Port of #16855 and #17086