### PR TITLE
Move freeContinuation to yieldContinuation

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -428,9 +428,6 @@ JVM_VirtualThreadUnmountEnd(JNIEnv *env, jobject thread, jboolean lastUnmount)
 
 	if (lastUnmount) {
 		vmFuncs->freeTLS(currentThread, threadObj);
-		/* CleanupContinuation */
-		j9object_t contObj = (j9object_t)J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObj);
-		vmFuncs->freeContinuation(currentThread, contObj);
 	}
 
 	/* Allow thread to be inspected again. */

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -252,7 +252,10 @@ yieldContinuation(J9VMThread *currentThread, BOOLEAN isFinished)
 	 * missed due to the continuation still is stated as mounted(we don't scan any mounted continuation, it should be scanned during root scanning via J9VMThread->currentContinuation).
 	 * so calling postUnmountContinuation() after resetContinuationCarrierID() to avoid the missing scan case.
 	 */
-	if (!isFinished) {
+	if (isFinished) {
+		/* Cleanup the native structure allocated */
+		freeContinuation(currentThread, continuationObject);
+	} else {
 		/* Notify GC of Continuation stack swap */
 		currentThread->javaVM->memoryManagerFunctions->postUnmountContinuation(currentThread, continuationObject);
 	}


### PR DESCRIPTION
Continuation cleanup have been moved to the last yield location to support future optimization on skipping JVMTI operation.

Depends on https://github.com/eclipse-openj9/openj9/issues/17058