### PR TITLE
Sync JVM init and exit paths

### DIFF
--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -160,7 +160,10 @@ jint JNICALL J9_CreateJavaVM(JavaVM ** p_vm, void ** p_env, J9CreateJavaVMParams
 	env = vm->mainThread;
 
 	/* Success */
+	omrthread_monitor_enter(vm->runtimeFlagsMutex);
 	vm->runtimeFlags |= J9_RUNTIME_INITIALIZED;
+	omrthread_monitor_notify_all(vm->runtimeFlagsMutex);
+	omrthread_monitor_exit(vm->runtimeFlagsMutex);
 	*p_env = (void*) env;
 
 	/* Link the VM into the list */
@@ -345,6 +348,14 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 		 * the other thread shutting down.
 		 */
 		return JNI_ERR;
+	}
+	/* Wait until the JVM has initialized before exiting the JVM. */
+	while (OMR_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_INITIALIZED)) {
+		if (vm->runtimeFlagsMutex != NULL) {
+			omrthread_monitor_wait(vm->runtimeFlagsMutex);
+		} else {
+			omrthread_yield();
+		}
 	}
 	if (vm->runtimeFlagsMutex != NULL) {
 		omrthread_monitor_exit(vm->runtimeFlagsMutex);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -533,6 +533,14 @@ exitJavaVM(J9VMThread * vmThread, IDATA rc)
 		}
 
 		vm->runtimeFlags |= J9_RUNTIME_EXIT_STARTED;
+		/* Wait until the JVM has initialized before exiting the JVM. */
+		while (OMR_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_INITIALIZED)) {
+			if (vm->runtimeFlagsMutex != NULL) {
+				omrthread_monitor_wait(vm->runtimeFlagsMutex);
+			} else {
+				omrthread_yield();
+			}
+		}
 		if(vm->runtimeFlagsMutex != NULL) {
 			omrthread_monitor_exit(vm->runtimeFlagsMutex);
 		}


### PR DESCRIPTION
JVM init path: J9_CreateJavaVM.
JVM exit paths: protectedDestroyJavaVM and exitJavaVM.

A segfault can happen if JVM init and exit paths execute concurrently.
This can happen if a shutdown signal is raised and the shutdown handler
is invoked. JVM shutdown signals are SIGINT, SIGTERM and SIGHUP.

The JVM exit paths wait or spin until the JVM has successfully initialized.

This should prevent clean up (freeing of memory) until the JVM has
successfully initialized, and resolve the associated segfaults.

Internal issue: 148771