### PR TITLE
Avoid redundant loads and stores in Escape Analysis

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -58,9 +58,9 @@ template <class T> class TR_Array;
 typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
 typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
 
-typedef TR::typed_allocator<std::pair<TR::Node* const, std::pair<TR_BitVector *, NodeDeque*> >, TR::Region&> CallLoadMapAllocator;
+typedef TR::typed_allocator<std::pair<TR::Node* const, std::pair<TR_BitVector *, TR_BitVector*> >, TR::Region&> CallLoadMapAllocator;
 typedef std::less<TR::Node *> CallLoadMapComparator;
-typedef std::map<TR::Node *, std::pair<TR_BitVector *, NodeDeque *>, CallLoadMapComparator, CallLoadMapAllocator> CallLoadMap;
+typedef std::map<TR::Node *, std::pair<TR_BitVector *, TR_BitVector *>, CallLoadMapComparator, CallLoadMapAllocator> CallLoadMap;
 
 typedef TR::typed_allocator<std::pair<TR::Node *const, int32_t>, TR::Region&> RemainingUseCountMapAllocator;
 typedef std::less<TR::Node *> RemainingUseCountMapComparator;

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -715,6 +715,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    TR_BitVector              *_notOptimizableLocalStringObjectsValueNumbers;
    TR_BitVector              *_blocksWithFlushOnEntry;
    TR_BitVector              *_visitedNodes;
+   TR_BitVector              *_initializedHeapifiedTemps;
 
    CallLoadMap               *_callsToProtect;
 

--- a/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
@@ -86,7 +86,7 @@ void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *
 
    TR_BitVector symRefsToLoad(0, _comp->trMemory()->currentStackRegion(), growable);
 
-   // Gather all live autos and pending pushes at this point for inlined methods in _loads
+   // Gather all live autos and pending pushes at this point for inlined methods in symRefsToLoad.
    // This ensures objects that EA can stack allocate will be heapified if OSR is induced
    while (inlinedIndex > -1)
       {

--- a/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
@@ -30,20 +30,21 @@
 
 TR_EscapeAnalysisTools::TR_EscapeAnalysisTools(TR::Compilation *comp)
   {
-  _loads = NULL;
   _comp = comp;
   }
 
-void TR_EscapeAnalysisTools::insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, NodeDeque *loads)
+void TR_EscapeAnalysisTools::insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, TR_BitVector &symRefsToLoad)
    {
-   //TR::Node *fakePrepare = TR::Node::createWithSymRef(node, TR::call, loads->size(), _comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_prepareForOSR, false, false, true));
-   TR::Node *fakePrepare = TR::Node::createEAEscapeHelperCall(node, loads->size());
+   TR::Node *fakePrepare = TR::Node::createEAEscapeHelperCall(node, symRefsToLoad.elementCount());
    int idx = 0;
-   for (auto itr = loads->begin(), end = loads->end(); itr != end; ++itr)
-       {
-       (*itr)->setByteCodeInfo(node->getByteCodeInfo());
-       fakePrepare->setAndIncChild(idx++, *itr);
-       }
+   TR_BitVectorIterator symRefIt(symRefsToLoad);
+
+   while (symRefIt.hasMoreElements())
+      {
+      TR::SymbolReference *symRef = _comp->getSymRefTab()->getSymRef(symRefIt.getNextElement());
+      fakePrepare->setAndIncChild(idx++, TR::Node::createWithSymRef(node, TR::aload, 0, symRef));
+      }
+
    dumpOptDetails(_comp, " Adding fake prepare n%dn to OSR induction block_%d\n", fakePrepare->getGlobalIndex(), block->getNumber());
    block->getLastRealTreeTop()->insertBefore(
       TR::TreeTop::create(_comp, TR::Node::create(node, TR::treetop, 1, fakePrepare)));
@@ -51,11 +52,6 @@ void TR_EscapeAnalysisTools::insertFakeEscapeForLoads(TR::Block *block, TR::Node
 
 void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *induceCall)
    {
-   if (_loads == NULL)
-      _loads = new (_comp->trMemory()->currentStackRegion()) NodeDeque(NodeDequeAllocator(_comp->trMemory()->currentStackRegion()));
-   else
-      _loads->clear();
-
    TR_ByteCodeInfo &bci = induceCall->getByteCodeInfo();
 
    int32_t inlinedIndex = bci.getCallerIndex();
@@ -88,6 +84,8 @@ void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *
       _comp->getOSRCompilationData()->printMap(induceDefiningMap);
       }
 
+   TR_BitVector symRefsToLoad(0, _comp->trMemory()->currentStackRegion(), growable);
+
    // Gather all live autos and pending pushes at this point for inlined methods in _loads
    // This ensures objects that EA can stack allocate will be heapified if OSR is induced
    while (inlinedIndex > -1)
@@ -95,7 +93,7 @@ void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *
       TR::ResolvedMethodSymbol *rms = _comp->getInlinedResolvedMethodSymbol(inlinedIndex);
       TR_ASSERT_FATAL(rms, "Unknown resolved method during escapetools");
       TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(inlinedIndex, rms);
-      processAutosAndPendingPushes(rms, induceDefiningMap, methodData, byteCodeIndex);
+      processAutosAndPendingPushes(rms, induceDefiningMap, methodData, byteCodeIndex, symRefsToLoad);
       byteCodeIndex = _comp->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getByteCodeIndex();
       inlinedIndex = _comp->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getCallerIndex();
       }
@@ -103,18 +101,18 @@ void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *
    // handle the outermost method
       {
       TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(-1, _comp->getMethodSymbol());
-      processAutosAndPendingPushes(_comp->getMethodSymbol(), induceDefiningMap, methodData, byteCodeIndex);
+      processAutosAndPendingPushes(_comp->getMethodSymbol(), induceDefiningMap, methodData, byteCodeIndex, symRefsToLoad);
       }
-   insertFakeEscapeForLoads(block, induceCall, _loads);
+   insertFakeEscapeForLoads(block, induceCall, symRefsToLoad);
    }
 
-void TR_EscapeAnalysisTools::processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, DefiningMap *induceDefiningMap, TR_OSRMethodData *methodData, int32_t byteCodeIndex)
+void TR_EscapeAnalysisTools::processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, DefiningMap *induceDefiningMap, TR_OSRMethodData *methodData, int32_t byteCodeIndex, TR_BitVector &symRefsToLoad)
    {
-   processSymbolReferences(rms->getAutoSymRefs(), induceDefiningMap, methodData->getLiveRangeInfo(byteCodeIndex));
-   processSymbolReferences(rms->getPendingPushSymRefs(), induceDefiningMap, methodData->getPendingPushLivenessInfo(byteCodeIndex));
+   processSymbolReferences(rms->getAutoSymRefs(), induceDefiningMap, methodData->getLiveRangeInfo(byteCodeIndex), symRefsToLoad);
+   processSymbolReferences(rms->getPendingPushSymRefs(), induceDefiningMap, methodData->getPendingPushLivenessInfo(byteCodeIndex), symRefsToLoad);
    }
 
-void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, DefiningMap *induceDefiningMap, TR_BitVector *deadSymRefs)
+void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, DefiningMap *induceDefiningMap, TR_BitVector *deadSymRefs, TR_BitVector &symRefsToLoad)
    {
    for (int i = 0; symbolReferences && i < symbolReferences->size(); i++)
       {
@@ -125,6 +123,8 @@ void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolRef
          TR::Symbol *p = symRef->getSymbol();
          if ((p->isAuto() || p->isParm()) && p->getDataType() == TR::Address)
             {
+            int32_t symRefNum = symRef->getReferenceNumber();
+
             // If no DefiningMap is available for the current sym ref, or the
             // DefiningMap is empty, simply use the sym ref on the
             // eaEscapeHelper if it's live.  Otherwise, walk through the
@@ -132,17 +132,18 @@ void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolRef
             // whose definitions map to the sym ref from the OSR
             // liveness data that we're currently looking at.
             if (!induceDefiningMap
-                || induceDefiningMap->find(symRef->getReferenceNumber()) == induceDefiningMap->end())
+                || induceDefiningMap->find(symRefNum) == induceDefiningMap->end())
                {
-               if (deadSymRefs == NULL || !deadSymRefs->isSet(symRef->getReferenceNumber()))
+               if (deadSymRefs == NULL || !deadSymRefs->isSet(symRefNum))
                   {
-                  _loads->push_back(TR::Node::createWithSymRef(TR::aload, 0, symRef));
+                  symRefsToLoad.set(symRefNum);
                   }
                }
             else
                {
                TR_BitVector *definingSyms = (*induceDefiningMap)[symRef->getReferenceNumber()];
                TR_BitVectorIterator definingSymsIt(*definingSyms);
+
                while (definingSymsIt.hasMoreElements())
                   {
                   int32_t definingSymRefNum = definingSymsIt.getNextElement();
@@ -152,7 +153,7 @@ void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolRef
                   if ((definingSym->isAuto() || definingSym->isParm())
                       && (deadSymRefs == NULL || !deadSymRefs->isSet(definingSymRefNum)))
                      {
-                     _loads->push_back(TR::Node::createWithSymRef(TR::aload, 0, definingSymRef));
+                     symRefsToLoad.set(symRefNum);
                      }
                   }
                }

--- a/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
@@ -31,9 +31,6 @@
 
 namespace TR { class Block; class Node; }
 
-//typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
-//typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
-
 class TR_EscapeAnalysisTools
    {
    public:
@@ -54,24 +51,17 @@ class TR_EscapeAnalysisTools
    void insertFakeEscapeForOSR(TR::Block *block, TR::Node *induceCall);
 
 
-   void insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, NodeDeque *loads);
-   //static bool isFakeEscape(TR::Node *node) { return node->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR;}
+   void insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, TR_BitVector &symRefsToLoad);
    static bool isFakeEscape(TR::Node *node) { return node->isEAEscapeHelperCall(); }
    private:
    TR::Compilation *_comp;
 
    /**
-    * Used by \ref insertFakePrepareForOSR to gather \c aloads of autos and
-    * pending pushes.
-    */
-   NodeDeque *_loads;
-
-   /**
     * Gather live autos and pending pushes at the point of a call to the OSR
     * induction helper in the context of an inlined method or the outermost
-    * method.  Create an \c aload reference to each such auto or pending push.
+    * method.
     *
-    * \c aloads are gathered in \ref _loads.
+    * The symbol reference numbers are gathered in \ref symRefsToLoad.
     *
     * \param[in] rms The method whose live autos and pending pushes are to be
     *                processed
@@ -83,14 +73,16 @@ class TR_EscapeAnalysisTools
     *                relevant method
     * \param[in] byteCodeIndex The bytecode index at this point inside the
     *                relevant method
+    * \param[inout] symRefsToLoad A \ref TR_BitVector of the symbol reference
+    *                numbers of live autos and pending pushes
     */
-   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, DefiningMap *induceDefiningMap, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
+   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, DefiningMap *induceDefiningMap, TR_OSRMethodData *methodData, int32_t byteCodeIndex, TR_BitVector &symRefsToLoad);
 
    /**
-    * Create \c aload references to each live symbol reference among those
-    * listed in the \c symbolReferences argument.
+    * Gather the set of live symbol reference among those listed in the
+    * \c symbolReferences argument.
     *
-    * \c aloads are gathered in \ref _loads.
+    * The symbol reference numbers are gathered in \ref symRefsToLoad.
     *
     * \param[in] symbolReferences \ref TR_Array<> of symbol references for
     *               autos or pending pushes
@@ -101,9 +93,10 @@ class TR_EscapeAnalysisTools
     * \param[in] deadSymRefs Liveness info for \c symbolReferences - a
     *               \ref TR_BitVector of symbols that are not live at the
     *               relevant point
+    * \param[inout] symRefsToLoad A \ref TR_BitVector of the symbol reference
+    *                numbers of live autos and pending pushes
     */
-   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, DefiningMap *induceDefiningMap, TR_BitVector *deadSymRefs);
+   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, DefiningMap *induceDefiningMap, TR_BitVector *deadSymRefs, TR_BitVector &symRefsToLoad);
    };
 
 #endif
-


### PR DESCRIPTION
When Escape Analysis generates fake calls to `<eaEscapeHelper>` for OSR induction points or to guard calls that it has peeked when HCR is enabled, it passes loads of live locals and pending push temporaries on the `<eaEscapeHelper>` calls.  However, in the process of generating those loads, it doesn't check for duplicates, so there might be many redundant loads.  This change uses a `TR_BitVector` to track which locals and pending push temporaries need to be loaded for a call to `<eaEscapeHelper>` to avoid redundant loads.

Further, when Escape Analysis generates heapification code for an object, it will add a store at the method entry to zero initialized any temporary variable that might hold a reference to that heapified object.  However, it does that at each heapification point, so it might generate several zero initialization stores for any particular temporary variable at the method entry.  This change tracks which locals have been initialized on method entry, either in this pass of Escape Analysis or for some other reason - possibly by an earlier pass of Escape Analysis - and skips initializing them.

All these redundant loads and stores bloat the IL temporarily, and can increase the number of uses and defs to the point that it might prevent subsequent optimizations from calculating use/def information.