### PR TITLE
zOS AttachAPI doesn't use FileLockWatchdogTask for CommonControlFiles

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright IBM Corp. and others 2009
  *
@@ -150,7 +150,7 @@ public abstract class CommonDirectory {
 			}
 		}
 		if (null != controllerLockCopy) { /* first entry */
-			controllerLockCopy.lockFile(true, callSite + "_obtainControllerLock"); //$NON-NLS-1$
+			controllerLockCopy.lockFile(true, callSite + "_obtainControllerLock", IPC.useFileLockWatchdog); //$NON-NLS-1$
 		}
 	}
 
@@ -166,7 +166,7 @@ public abstract class CommonDirectory {
 			++controllerLockCount; /* optimistically assume we enter the lock */
 			if (1 == controllerLockCount) { /* first time in */
 				try {
-					controllerLockEntered = getControllerLock().lockFile(false, callSite + "_tryObtainControllerLock"); //$NON-NLS-1$
+					controllerLockEntered = getControllerLock().lockFile(false, callSite + "_tryObtainControllerLock", IPC.useFileLockWatchdog); //$NON-NLS-1$
 					if (!controllerLockEntered) { /* lock failed, so revert */
 						--controllerLockCount;
 					}
@@ -205,7 +205,7 @@ public abstract class CommonDirectory {
 	 */
 	 
 	public static void obtainAttachLock(String callSite) throws IOException {
-		getAttachLock().lockFile(true, callSite + "_obtainAttachLock"); //$NON-NLS-1$
+		getAttachLock().lockFile(true, callSite + "_obtainAttachLock", IPC.useFileLockWatchdog); //$NON-NLS-1$
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java
@@ -133,8 +133,8 @@ final class WaitLoop extends Thread {
 		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("checkReplyAndCreateAttachment iteration "+ AttachHandler.notificationCount+" waitForNotification obtainLock"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		/* the sync file is missing. */
-		if (!AttachHandler.mainHandler.syncFileLock.lockFile(true, "WaitLoop.checkReplyAndCreateAttachment")) { //$NON-NLS-1$ 
+		/* the sync file is missing, use FileLockWatchdogTask for non-CommonControlFile */
+		if (!AttachHandler.mainHandler.syncFileLock.lockFile(true, "WaitLoop.checkReplyAndCreateAttachment", true)) { //$NON-NLS-1$
 			TargetDirectory.createMySyncFile();
 			/* don't bother locking this since the attacher will not have locked it. */
 		} else {

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -349,7 +349,8 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 					IPC.logMessage("lockAllAttachNotificationSyncFiles locking targetLocks[", vmdIndex, "] ", attachSyncFile); //$NON-NLS-1$ //$NON-NLS-2$
 					targetLocks[vmdIndex] = new FileLock(attachSyncFile, TargetDirectory.SYNC_FILE_PERMISSIONS);
 					try {
-						targetLocks[vmdIndex].lockFile(true, "OpenJ9VirtualMachine.lockAllAttachNotificationSyncFiles"); //$NON-NLS-1$
+						/* use FileLockWatchdogTask for non-CommonControlFile */
+						targetLocks[vmdIndex].lockFile(true, "OpenJ9VirtualMachine.lockAllAttachNotificationSyncFiles", true); //$NON-NLS-1$
 					} catch (IOException e) {
 						targetLocks[vmdIndex] = null;
 						IPC.logMessage("lockAllAttachNotificationSyncFiles locking targetLocks[", vmdIndex, "] ", "already locked"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
@@ -42,7 +42,7 @@ public class NativeFileLock extends GenericFileLock {
 		nflConstructor.setAccessible(true);
 		fileLockObject = nflConstructor.newInstance(lockFile.getAbsolutePath(), Integer.valueOf(mode));
 		lockFileMethod = nativeFileLock.getDeclaredMethod("lockFile",
-				boolean.class, String.class);
+				boolean.class, String.class, boolean.class);
 		lockFileMethod.setAccessible(true);
 		unlockFileMethod = nativeFileLock.getDeclaredMethod("unlockFile", String.class);
 		unlockFileMethod.setAccessible(true);
@@ -53,7 +53,8 @@ public class NativeFileLock extends GenericFileLock {
 	public boolean lockFile(boolean blocking) throws Exception {
 		Boolean result = Boolean.valueOf(true);
 		TestFileLocking.logger.debug("lockfile blocking =" + blocking);
-		result = (Boolean) lockFileMethod.invoke(fileLockObject, Boolean.valueOf(blocking), "NativeFileLock.lockFile()");
+		// The test has no different user involved, always locks file with FileLockWatchdogTask.
+		result = (Boolean) lockFileMethod.invoke(fileLockObject, Boolean.valueOf(blocking), "NativeFileLock.lockFile()", true);
 		return result.booleanValue();
 	}
 


### PR DESCRIPTION
Added a system property `com.ibm.tools.attach.disableFileLockWatchdog`;
Setting `-Dcom.ibm.tools.attach.useFileLockWatchdog=[true|false]` takes precedence, if no such system property is specified, always set false on `z/OS`, defaults to true on non-z/OS platforms.

Related [RTC 148596](https://jazz103.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/148596)
This fixes the zOS usage w/ multiple JVMs running under different user IDs.
Since this issue wasn't seen on other platforms, it is intended to not introduce behaviour differences for non zOS systems unless `-Dcom.ibm.tools.attach.useFileLockWatchdog=false` is specified.
I think this option can be an internal undocumented unless there is actual usage.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>