### PR TITLE
(0.37.0)Relocate state of Continuation from native structure to Object

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -41,6 +41,11 @@ public class Continuation {
 	private Continuation parent;
 	private boolean started;
 	private boolean finished;
+	/* it's a bit-wise struct of CarrierThread ID and continuation flags(includes started and finished flag)
+	 * low 8 bits are reserved for flags and the rest are the carrier thread ID.
+	 * the state should not be directly accessed from Java
+	 */
+	private volatile long state;
 
 	private static JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5021,9 +5021,12 @@ typedef struct J9JITGPRSpillArea {
 #endif /* J9VM_ARCH_X86 */
 } J9JITGPRSpillArea;
 
-#if JAVA_SPEC_VERSION >= 19
+/* it's a bit-wise struct of CarrierThread ID and continuation flags
+ * low 8 bits are reserved for flags and the rest are the carrier thread ID.
+ */
 typedef uintptr_t ContinuationState;
 
+#if JAVA_SPEC_VERSION >= 19
 typedef struct J9VMContinuation {
 	UDATA* arg0EA;
 	UDATA* bytecodes;
@@ -5038,10 +5041,6 @@ typedef struct J9VMContinuation {
 	struct J9JITGPRSpillArea jitGPRs;
 	struct J9I2JState i2jState;
 	struct J9VMEntryLocalStorage* oldEntryLocalStorage;
-	/* it's a bit-wise struct of CarrierThread ID and continuation flags
-	 * low 8 bits are reserved for flags and the rest are the carrier thread ID.
-	 */
-	volatile ContinuationState state;
 	UDATA dropFlags;
 } J9VMContinuation;
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -415,6 +415,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="jdk/internal/vm/Continuation" name="vmRef" signature="J" cast="struct J9VMContinuation *" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="finished" signature="Z" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="started" signature="Z" versions="19-"/>
+	<fieldref class="jdk/internal/vm/Continuation" name="state" signature="J" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="parent" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="vthread" signature="Ljava/lang/Thread;" versions="19-"/>
 


### PR DESCRIPTION
The state of Continuation is mainly used for synchronizing continuation mounting/unmount and continuation scanning, in order to prevent potential timing hole to view/update the state around new/delete the native structure, the state is relocated from native structure to continuation Object.

accessing the state from native methods via vmconstantpool.

fix: https://github.com/eclipse-openj9/openj9/issues/17058

backport: https://github.com/eclipse-openj9/openj9/pull/17081