### PR TITLE
Never validate class names provided via privileged API for jdk21+

### DIFF
--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -108,8 +108,10 @@ Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclas
 	if (J9_ARE_ALL_BITS_SET(flags, CLASSOPTION_FLAG_HIDDEN)) {
 		options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE);
 	} else {
+#if JAVA_SPEC_VERSION < 21
 		/* Validate the name for a normal (non-hidden) class. */
 		validateName = TRUE;
+#endif /* JAVA_SPEC_VERSION < 21 */
 	}
 	if (J9_ARE_ALL_BITS_SET(flags, CLASSOPTION_FLAG_NESTMATE)) {
 		options |= J9_FINDCLASS_FLAG_CLASS_OPTION_NESTMATE;


### PR DESCRIPTION
`ClassLoader.defineClassImpl1()` is only accessible to privileged code that is either in the `java.lang` package or that has access to `JavaLangAccess`, so we cannot subject the class name to the normal validation rules, otherwise in jdk21 since

[8304846: Provide a shared utility to dump generated classes defined via Lookup API](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/7dc79c2c1838708db518e4fec8ef40d8a2e629d2)

defining a class like 'java/lang/invoke/BoundMethodHandle$Species_LL' fails
```
java.lang.InternalError
	at java.base/java.lang.ClassLoader.defineClassInternal(ClassLoader.java:509)
	at java.base/java.lang.Access.defineClass(Access.java:347)
	at java.base/java.lang.invoke.MethodHandles$Lookup$ClassDefiner.defineClass(MethodHandles.java:2512)
	at java.base/java.lang.invoke.MethodHandles$Lookup$ClassDefiner.defineClass(MethodHandles.java:2487)
	at java.base/java.lang.invoke.ClassSpecializer$Factory.generateConcreteSpeciesCode(ClassSpecializer.java:580)
	at java.base/java.lang.invoke.ClassSpecializer$Factory.loadSpecies(ClassSpecializer.java:497)
	at java.base/java.lang.invoke.ClassSpecializer.findSpecies(ClassSpecializer.java:200)
	at java.base/java.lang.invoke.BoundMethodHandle$SpeciesData.extendWith(BoundMethodHandle.java:360)
```

Fixes: #17121.