### PR TITLE
Fix SCC AOT code validation in checkpoint-mode

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1983,6 +1983,20 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       }
 #endif
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be
+    * limited to the same processor features as those used in Portable AOT mode. This
+    * is because, the restore run may not be on the same machine as the one that created
+    * the snapshot; thus the JIT code must be portable.
+    */
+   if (javaVM->internalVMFunctions->isCheckpointAllowed(curThread))
+      {
+      TR::Compiler->target.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
+      if (!J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))
+         TR::Compiler->relocatableTarget.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
+      jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
+      }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
    if (isSharedAOT)
@@ -2079,19 +2093,6 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
          }
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
-
-#if defined(J9VM_OPT_CRIU_SUPPORT)
-   /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be
-    * limited to the same processor features as those used in Portable AOT mode. This
-    * is because, the restore run may not be on the same machine as the one that created
-    * the snapshot; thus the JIT code must be portable.
-    */
-   if (javaVM->internalVMFunctions->isCheckpointAllowed(curThread))
-      {
-      TR::Compiler->target.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
-      jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
-      }
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
    #if defined(TR_TARGET_S390)
       uintptr_t * tocBase = (uintptr_t *)jitConfig->pseudoTOC;


### PR DESCRIPTION
In checkpoint mode we need to downgrade the target processor to allow for portability of not only JIT code but also AOT code. Internally we maintain two separate target processors, `target` for JIT compiled code and `relocatableTarget` for AOT compiled code and SCC validation. In checkpoint mode we downgrade `target` but not `relocatableTarget`, and we do this after validating the SCC.

This patch fixes the problem by downgrading `relocatableTarget` and moving the code to just before SCC validation.

Fixes #17020
Fixes #17082