### PR TITLE
Read-acquire Class Unload Mutex for compilation before checkpoint

### DIFF
--- a/runtime/compiler/control/CompileBeforeCheckpoint.cpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.cpp
@@ -112,8 +112,8 @@ TR::CompileBeforeCheckpoint::queueMethodsForCompilationBeforeCheckpoint()
 void
 TR::CompileBeforeCheckpoint::collectAndCompileMethodsBeforeCheckpoint()
    {
-   /* Acquire Class Unload Monitor to prevent class unloading */
-   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection(true);
+   /* Read Acquire Class Unload Monitor to prevent class unloading */
+   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection();
 
    collectMethodsForCompilationBeforeCheckpoint();
    queueMethodsForCompilationBeforeCheckpoint();


### PR DESCRIPTION
The following deadlock is possible:

1. Comp thread read-enters class unload mutex
2. Checkpointing thread acquires comp monitor
3. Comp thread blocks trying to acquire comp monitor
4. Checkpointing thread blocks trying to write-enter class unload mutex

The reason the Checkpointing thread acquires the class unload mutex is to prevent class unloading while it collects methods. However, a read-acquire is sufficient for this task.

Therefore, having the Checkpointing thread do a read-acquire will prevent the deadlock since it will not block waiting to enter.