### PR TITLE
Print warning when java.io.tmpDir does not exist

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -286,6 +286,7 @@ public abstract class ClassLoader {
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 		jdk.internal.misc.VM.initLevel(2);
+		System.checkTmpDir();
 		System.initSecurityManager(applicationClassLoader);
 		jdk.internal.misc.VM.initLevel(3);
 		/*[ELSE]*/

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -100,10 +100,12 @@ Java_java_lang_System_initJCLPlatformEncoding(JNIEnv *env, jclass clazz)
  *    1 - platform encoding
  *    2 - file.encoding
  *    3 - os.encoding
+ *    4 - default value of java.io.tmpDir before any -D options
  */
 jstring JNICALL
 Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID)
 {
+	char *envSpace = NULL;
 	const char *sysPropValue = NULL;
 	/* The sysPropValue points to following property which has to be declared at top level. */
 	char property[128] = {0};
@@ -169,11 +171,18 @@ Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass 
 		}
 		break;
 
+	case 4: /* default value of java.io.tmpDir before any -D options */
+		sysPropValue = getTmpDir(env, &envSpace);
+		break;
+
 	default:
 		break;
 	}
 	if (NULL != sysPropValue) {
 		result = (*env)->NewStringUTF(env, sysPropValue);
+	}
+	if (NULL != envSpace) {
+		jclmem_free_memory(env, envSpace);
 	}
 
 	return result;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/16964

I didn't make all the code jdk20+ specific because it looks like there is a backport in https://bugs.openjdk.org/browse/JDK-8290313 so we may be backporting the change to jdk8+ when we get the appropriate OpenJDK levels, after the 2nd quarter releases.