### PR TITLE
[FFI/JDK20_Jtreg] Normalize the arguments in the upcall dispatcher

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5968,6 +5968,10 @@ typedef struct J9JavaVM {
 /* The mask for the signature type identifier */
 #define J9_FFI_UPCALL_SIG_TYPE_MASK 0xF
 
+/* The mask for the normalized type identifier */
+#define J9_FFI_UPCALL_BYTE_TYPE_MASK 0xFF
+#define J9_FFI_UPCALL_SHORT_TYPE_MASK 0xFFFF
+
 /* The signature types intended for upcall */
 #define J9_FFI_UPCALL_SIG_TYPE_VOID    0x1
 #define J9_FFI_UPCALL_SIG_TYPE_CHAR    0x2


### PR DESCRIPTION
The changes normalize the arguments less than 32bit in the upcall
dispatcher to ensure the correct value is passed over to the upcall
method and saved upon return.

Fixes: #17128

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
