### PR TITLE
Remove empty parentheses when constructing TR::ClassUnloadMonitorCriticalSection object

### DIFF
--- a/runtime/compiler/control/CompileBeforeCheckpoint.cpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.cpp
@@ -113,7 +113,7 @@ void
 TR::CompileBeforeCheckpoint::collectAndCompileMethodsBeforeCheckpoint()
    {
    /* Read Acquire Class Unload Monitor to prevent class unloading */
-   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection();
+   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection;
 
    collectMethodsForCompilationBeforeCheckpoint();
    queueMethodsForCompilationBeforeCheckpoint();


### PR DESCRIPTION
Fixes build break described in https://github.com/eclipse-openj9/openj9/pull/17136#issuecomment-1502471086