### PR TITLE
Refactor GC CRIU Routines

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -261,6 +261,5 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	j9gc_prepare_for_checkpoint,
 	j9gc_reinitialize_for_restore,
-	j9gc_reinitializeDefaults
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 };

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -262,7 +262,7 @@ extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThrea
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 extern J9_CFUNC void j9gc_prepare_for_checkpoint(J9VMThread *vmThread);
 extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat);
-extern J9_CFUNC BOOLEAN j9gc_reinitializeDefaults(J9VMThread *vmThread);
+extern J9_CFUNC BOOLEAN gcReinitializeDefaultsForRestore(J9VMThread *vmThread);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /* J9VMFinalizeSupport*/

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -240,8 +240,8 @@ public:
 	void collectorInitialized(MM_RealtimeGC *gc);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	virtual bool expandThreadPool(MM_EnvironmentBase *env) { return true; }
-	virtual void contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount) {};
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env) { return true; }
+	virtual void prepareForCheckpoint(MM_EnvironmentBase *env, uintptr_t newThreadCount) {};
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_Scheduler(MM_EnvironmentBase *env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize) :

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4610,7 +4610,6 @@ typedef struct J9MemoryManagerFunctions {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	void  ( *j9gc_prepare_for_checkpoint)(struct J9VMThread *vmThread) ;
 	BOOLEAN  ( *j9gc_reinitialize_for_restore)(struct J9VMThread *vmThread, const char **nlsMsgFormat) ;
-	BOOLEAN  ( *j9gc_reinitializeDefaults)(struct J9VMThread *vmThread) ;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9MemoryManagerFunctions;
 


### PR DESCRIPTION
Update GC CRIU checkpoint and restore routines based on refactoring done in upstream OMR: https://github.com/eclipse/omr/pull/6947.

- Replace configuration reinitializeGCThreadCountForRestore and adjustGCThreadCountForCheckpoint calls with single reinitializeForRestore call.
- Invoke the dispatcher directly to expand/contract thread pool
- Update the GC thread count in j9gc_reinitializeDefaults 

Depends on https://github.com/eclipse/omr/pull/6947

Signed-off-by: Salman Rana <salman.rana@ibm.com>