### PR TITLE
Read-acquire Class Unload Mutex for compilation before checkpoint (0.38)

### DIFF
--- a/runtime/compiler/control/CompileBeforeCheckpoint.cpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.cpp
@@ -111,8 +111,8 @@ TR::CompileBeforeCheckpoint::queueMethodsForCompilationBeforeCheckpoint()
 void
 TR::CompileBeforeCheckpoint::collectAndCompileMethodsBeforeCheckpoint()
    {
-   /* Acquire Class Unload Monitor to prevent class unloading */
-   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection(true);
+   /* Read Acquire Class Unload Monitor to prevent class unloading */
+   TR::ClassUnloadMonitorCriticalSection collectMethodsCriticalSection;
 
    collectMethodsForCompilationBeforeCheckpoint();
    queueMethodsForCompilationBeforeCheckpoint();


### PR DESCRIPTION
Cherry-pick of https://github.com/eclipse-openj9/openj9/pull/17136 and https://github.com/eclipse-openj9/openj9/pull/17143 (squashed into one commit)