### PR TITLE
Provide JITServer implementation for CRIU specific FE queries (0.38.0)

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1351,7 +1351,7 @@ public:
     * \return True if snapshots can be taken, false if no snapshots that will include this
     * body are allowed.
     */
-   bool inSnapshotMode();
+   virtual bool inSnapshotMode();
 
    /**
     * \brief Answers whether checkpoint and restore mode is enabled (but not necessarily
@@ -1359,7 +1359,7 @@ public:
     *
     * \return True if checkpoint and restore mode is enabled, false otherwise.
     */
-   bool isSnapshotModeEnabled();
+   virtual bool isSnapshotModeEnabled();
 
 protected:
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -244,6 +244,8 @@ public:
 #endif
    virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName) override;
    virtual bool isMethodHandleExpectedType(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, TR::KnownObjectTable::Index expectedTypeIndex) override;
+   virtual bool inSnapshotMode() override;
+   virtual bool isSnapshotModeEnabled() override;
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -97,7 +97,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 42;
+   static const uint16_t MINOR_NUMBER = 43;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -190,6 +190,7 @@ const char *messageNames[] =
    "VM_delegatingMethodHandleTarget",
    "VM_getVMTargetOffset",
    "VM_getVMIndexOffset",
+   "VM_inSnapshotMode",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -199,6 +199,7 @@ enum MessageType : uint16_t
    VM_delegatingMethodHandleTarget,
    VM_getVMTargetOffset,
    VM_getVMIndexOffset,
+   VM_inSnapshotMode,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -319,6 +319,12 @@ public:
       TR_AOTHeader _aotHeader;
       TR_OpaqueClassBlock *_JavaLangObject;
       TR_OpaqueClassBlock *_JavaStringObject;
+      // The following three fields refer to CRIU support
+      // Do not protect them with #if defined(J9VM_OPT_CRIU_SUPPORT) because we want JITServer to be
+      // able to handle all clients whether or not they have CRIU support enabled
+      bool _inSnapshotMode;
+      bool _isSnapshotModeEnabled;
+      bool _isNonPortableRestoreMode;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
Two frontend queries that are specific to CRIU, `inSnapshotMode()` and `isSnapshotModeEnabled()` need to be overridden with JITServer specific implementation that fetches the required information from the client.
Three new fields were added to the `ClientSessionData.VMInfo` struct which caches information per client:
      bool _inSnapshotMode;
      bool _isSnapshotModeEnabled;
      bool _isNonPortableRestoreMode;
`_isSnapshotModeEnabled` and `_isNonPortableRestoreMode` can be cached from the very first response of the client, because they get set when the VM is initialized and never change their value.
`_inSnapshotMode` requires special handling: if the client runs in portable restore mode, then this field is always true. If the client runs in non-portable restore mode, then this field starts as true, but after a restore, it transitions to false and it stays false until the end of the JVM. While this field returns 'true', the server must always inquire the client about the value of this field. After it transitions to `false`, the server can cache its value and refrain from asking the client again. For this purpose, a new message type was introduced, `VM_inSnapshotMode` and the `MINOR_NUMBER` of JITServer has been incremented.

Issue: #17117