### PR TITLE
Minor javadoc fixes

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUDumpPermission.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUDumpPermission.java
@@ -26,13 +26,13 @@ import java.security.BasicPermission;
 
 /**
  * The permission class for operations on the org.eclipse.openj9.criu.CRIUSupport class.
- * Allowing code access to this permission will allow applications to trigger 
- * CRIU dumps
- * 
- * A dump file will be a complete image of the applications memory. Code with read
+ * Allowing code access to this permission will allow applications to trigger
+ * CRIU dumps.
+ *
+ * A dump file will be a complete image of the application's memory. Code with read
  * access to dump files produced by org.eclipse.openj9.criu.CRIUSupport should be considered as having
  * access to any information that was within the application at the time the dump
- * was taken. 
+ * was taken.
  */
 public class CRIUDumpPermission extends BasicPermission {
 
@@ -42,7 +42,7 @@ public class CRIUDumpPermission extends BasicPermission {
 	private static final long serialVersionUID = -8218410156654287322L;
 
 	/**
-	 * Creates CRIUDumpPermission
+	 * Creates CRIUDumpPermission.
 	 */
 	public CRIUDumpPermission() {
 		super("CRIUDumpPermission"); //$NON-NLS-1$


### PR DESCRIPTION
Trailing whitespace noted in generated javadoc; see eclipse-openj9/openj9-docs#1082.

Also fix punctuation in a few places.