### PR TITLE
Remove unwanted spaces in preprocessor directives

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/ORBBase.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/ORBBase.java
@@ -1,6 +1,4 @@
-/*[INCLUDE-IF Sidecar17] */
-package com.ibm.oti.vm;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright IBM Corp. and others 2010
  *
@@ -22,6 +20,7 @@ package com.ibm.oti.vm;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.oti.vm;
 
 import java.util.Map;
 

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/ORBVMHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/ORBVMHelpers.java
@@ -1,5 +1,4 @@
-/*[INCLUDE-IF Sidecar17] */
-package com.ibm.oti.vm;
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright IBM Corp. and others 2010
  *
@@ -21,6 +20,7 @@ package com.ibm.oti.vm;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.oti.vm;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -5412,7 +5412,7 @@ public boolean isNestmateOf(Class<?> that) {
  */
 @CallerSensitive
 public Class<?>[] getNestMembers() throws
-/*[IF JAVA_SPEC_VERSION < 15] */
+/*[IF JAVA_SPEC_VERSION < 15]*/
 LinkageError,
 /*[ENDIF] JAVA_SPEC_VERSION < 15 */
 SecurityException {

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -416,7 +416,7 @@ private ClassLoader(Void staticMethodHolder, String classLoaderName, ClassLoader
 
 /*[IF JAVA_SPEC_VERSION >= 19]*/
 	this.nativelibs = NativeLibraries.newInstance((this == bootstrapClassLoader) ? null : this);
-/*[ELSEIF JAVA_SPEC_VERSION >= 17] */
+/*[ELSEIF JAVA_SPEC_VERSION >= 17]*/
 	this.nativelibs = NativeLibraries.jniNativeLibraries((this == bootstrapClassLoader) ? null : this);
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -97,7 +97,7 @@ final class J9VMInternals {
 	static void threadCompleteInitialization() {
 		/*[PR CMVC 99755] Implement -Djava.system.class.loader option */
 		Thread.currentThread().internalSetContextClassLoader(ClassLoader.getSystemClassLoader());
-		/*[IF JAVA_SPEC_VERSION > 8] */
+		/*[IF JAVA_SPEC_VERSION > 8]*/
 		jdk.internal.misc.VM.initLevel(4);
 		/*[ELSE] JAVA_SPEC_VERSION > 8 */
 		sun.misc.VM.booted();
@@ -106,7 +106,7 @@ final class J9VMInternals {
 		System.startSNMPAgent();
 		/*[ENDIF] Sidecar18-SE-OpenJ9 | (JAVA_SPEC_VERSION > 8) */
 
-		/*[IF JAVA_SPEC_VERSION >= 11] */
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		System.finalizeConsoleEncoding();
 		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	}

--- a/jcl/src/java.base/share/classes/java/lang/Object.java
+++ b/jcl/src/java.base/share/classes/java/lang/Object.java
@@ -22,7 +22,7 @@
  *******************************************************************************/
 package java.lang;
 
-/*[IF JAVA_SPEC_VERSION >= 19] */
+/*[IF JAVA_SPEC_VERSION >= 19]*/
 import jdk.internal.misc.Blocker;
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
@@ -107,9 +107,9 @@ public boolean equals(Object o) {
 	but he can still invoke it. Since this method is empty, the space cost for it
 	is negligible, so we leave it in.
 /*[ENDIF]*/
-/*[IF JAVA_SPEC_VERSION >= 18] */
+/*[IF JAVA_SPEC_VERSION >= 18]*/
 @Deprecated(forRemoval=true, since="9")
-/*[ELSEIF JAVA_SPEC_VERSION >= 9] */
+/*[ELSEIF JAVA_SPEC_VERSION >= 9]*/
 @Deprecated(forRemoval=false, since="9")
 /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 protected void finalize () throws Throwable {
@@ -274,7 +274,7 @@ public final void wait(long time) throws InterruptedException {
  * @see			java.lang.Thread
  */
 public final void wait(long time, int frac) throws InterruptedException {
-/*[IF JAVA_SPEC_VERSION >= 19] */
+/*[IF JAVA_SPEC_VERSION >= 19]*/
 	long blockerRC = Blocker.begin();
 	try {
 		waitImpl(time, frac);

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -62,7 +62,7 @@ import com.ibm.gpu.spi.GPUAssistHolder;
 import com.ibm.jvm.io.ConsolePrintStream;
 /*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | !Sidecar18-SE-OpenJ9 */
 
-/*[IF JAVA_SPEC_VERSION >= 20] */
+/*[IF JAVA_SPEC_VERSION >= 20]*/
 import java.lang.reflect.Field;
 import jdk.internal.util.SystemProps;
 /*[ENDIF] JAVA_SPEC_VERSION >= 20 */
@@ -1152,7 +1152,7 @@ public static void setProperties(Properties p) {
 }
 
 static void checkTmpDir() {
-	/*[IF JAVA_SPEC_VERSION >= 20] */
+	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	String tmpDir = internalGetProperties().getProperty("java.io.tmpdir"); //$NON-NLS-1$
 	if (!defaultTmpDir.equals(tmpDir)) {
 		try {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -513,7 +513,7 @@ public abstract class VarHandle extends VarHandleInternal
 				}
 			}
 		} catch (IllegalAccessException | NoSuchMethodException e) {
-			/* [MSG "K0623", "Unable to create MethodHandle to VarHandle operation."] */
+			/*[MSG "K0623", "Unable to create MethodHandle to VarHandle operation."]*/
 			InternalError error = new InternalError(com.ibm.oti.util.Msg.getString("K0623")); //$NON-NLS-1$
 			error.initCause(e);
 			throw error;
@@ -626,7 +626,7 @@ public abstract class VarHandle extends VarHandleInternal
 				}
 			}
 		} catch (IllegalAccessException | NoSuchMethodException e) {
-			/* [MSG "K0623", "Unable to create MethodHandle to VarHandle operation."] */
+			/*[MSG "K0623", "Unable to create MethodHandle to VarHandle operation."]*/
 			InternalError error = new InternalError(com.ibm.oti.util.Msg.getString("K0623")); //$NON-NLS-1$
 			error.initCause(e);
 			throw error;

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -121,7 +121,7 @@ public class InternalDowncallHandler {
 	 */
 	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	private Set<SegmentScope> memArgScopeSet;
-	/*[ELSEIF JAVA_SPEC_VERSION == 19] */
+	/*[ELSEIF JAVA_SPEC_VERSION == 19]*/
 	private Set<MemorySession> memArgScopeSet;
 	/*[ELSE] JAVA_SPEC_VERSION == 19 */
 	private Set<ResourceScope> memArgScopeSet;

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalUpcallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalUpcallHandler.java
@@ -71,7 +71,7 @@ public final class InternalUpcallHandler {
 	 * @return an internal upcall handler with the thunk address
 	 */
 	public InternalUpcallHandler(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session)
-	/*[ELSEIF JAVA_SPEC_VERSION == 19] */
+	/*[ELSEIF JAVA_SPEC_VERSION == 19]*/
 	/**
 	 * The constructor creates an upcall handler specific to the requested java method
 	 * by generating a native thunk in upcall on a given platform.
@@ -134,7 +134,7 @@ public final class InternalUpcallHandler {
 	 */
 	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	private long getUpcallThunkAddr(MethodHandle target, SegmentScope sessionOrScope)
-	/*[ELSEIF JAVA_SPEC_VERSION == 19] */
+	/*[ELSEIF JAVA_SPEC_VERSION == 19]*/
 	private long getUpcallThunkAddr(MethodHandle target, MemorySession sessionOrScope)
 	/*[ELSE] JAVA_SPEC_VERSION == 19 */
 	private long getUpcallThunkAddr(MethodHandle target, ResourceScope sessionOrScope)

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -432,7 +432,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	 * {@inheritDoc}
 	 */
 	@Override
-	/*[IF JAVA_SPEC_VERSION >= 18] */
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
 	@SuppressWarnings("deprecation")
 	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	public int getObjectPendingFinalizationCount() {

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -74,7 +74,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 	 * 
 	 * @return the number of objects awaiting finalization.
 	 */
-	/*[IF JAVA_SPEC_VERSION >= 18] */
+	/*[IF JAVA_SPEC_VERSION >= 18]*/
 	@Deprecated(forRemoval=false, since="18")
 	/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	public int getObjectPendingFinalizationCount();

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
@@ -72,7 +72,7 @@ public class AttacherDiagnosticsProvider {
 		try {
 			vm = attachProv.attachVirtualMachine(vmid);
 		} catch (AttachNotSupportedException e) {
-			/*[MSG "K0809", "Exception connecting to {0}"] */
+			/*[MSG "K0809", "Exception connecting to {0}"]*/
 			throw new IOException(getString("K0809", vmid)); //$NON-NLS-1$
 		}
 		IPC.logMessage("DiagnosticsProviderImpl attached to ", vmid); //$NON-NLS-1$
@@ -114,7 +114,7 @@ public class AttacherDiagnosticsProvider {
 
 	private void checkAttached() throws IOException {
 		if (null == vm) {
-			/*[MSG "K0544", "Target not attached"] */
+			/*[MSG "K0544", "Target not attached"]*/
 			throw new IOException(getString("K0554")); //$NON-NLS-1$
 		}
 	}

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-/*[IF JAVA_SPEC_VERSION == 8] */
+/*[IF JAVA_SPEC_VERSION == 8]*/
 import sun.misc.Unsafe;
 /*[ELSE]
 import jdk.internal.misc.Unsafe;

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactory.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactory.java
@@ -262,7 +262,7 @@ public interface SharedClassHelperFactory {
 	 *
 	/*[ENDIF]
 	 */
-	/*[IF Sidecar19-SE] */
+	/*[IF Sidecar19-SE]*/
 	@Deprecated(forRemoval=false, since="9")
 	/*[ENDIF]*/
 	public SharedClassHelper findHelperForClassLoader(ClassLoader loader);

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactoryImpl.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactoryImpl.java
@@ -66,11 +66,11 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 	}
 
 	@Override
-	/*[IF Sidecar19-SE] */
+	/*[IF Sidecar19-SE]*/
 	@Deprecated(forRemoval=false, since="9")
 	/*[ENDIF]*/
 	public SharedClassHelper findHelperForClassLoader(ClassLoader loader) {
-		/*[IF Sidecar19-SE] */
+		/*[IF Sidecar19-SE]*/
 		Set<SharedClassHelper> helperSet = findHelpersForClassLoader(loader);
 		int size = helperSet.size();
 		if (1 == size) {
@@ -87,7 +87,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 		/*[ENDIF] Sidecar19-SE */
 	}
 
-	/*[IF Sidecar19-SE] */
+	/*[IF Sidecar19-SE]*/
 	@Override
 	public Set<SharedClassHelper> findHelpersForClassLoader(ClassLoader loader) {
 		Set<SharedClassHelper> helperSet = new HashSet<>();
@@ -109,7 +109,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 
 	@Override
 	public SharedClassTokenHelper getTokenHelper(ClassLoader loader, SharedClassFilter filter)
-	/*[IF !Sidecar19-SE] */
+	/*[IF !Sidecar19-SE]*/
 			throws HelperAlreadyDefinedException
 	/*[ENDIF] !Sidecar19-SE */
 	{
@@ -122,7 +122,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 
 	@Override
 	public SharedClassTokenHelper getTokenHelper(ClassLoader loader)
-	/*[IF !Sidecar19-SE] */
+	/*[IF !Sidecar19-SE]*/
 			throws HelperAlreadyDefinedException
 	/*[ENDIF] !Sidecar19-SE */
 	{
@@ -168,7 +168,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 
 	@Override
 	public SharedClassURLHelper getURLHelper(ClassLoader loader, SharedClassFilter filter)
-	/*[IF !Sidecar19-SE] */
+	/*[IF !Sidecar19-SE]*/
 			throws HelperAlreadyDefinedException
 	/*[ENDIF] !Sidecar19-SE */
 	{
@@ -181,7 +181,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 
 	@Override
 	public SharedClassURLHelper getURLHelper(ClassLoader loader)
-	/*[IF !Sidecar19-SE] */
+	/*[IF !Sidecar19-SE]*/
 			throws HelperAlreadyDefinedException
 	/*[ENDIF] !Sidecar19-SE */
 	{
@@ -253,7 +253,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 			SharedClassURLClasspathHelperImpl result;
 			boolean found = true;
 			if (helper != null) {
-				/*[IF !Sidecar19-SE] */
+				/*[IF !Sidecar19-SE]*/
 				if (helper instanceof SharedClassURLClasspathHelper) {
 					/*[ENDIF] !Sidecar19-SE */
 					result = (SharedClassURLClasspathHelperImpl) helper;
@@ -270,7 +270,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 						/*[MSG "K059e", "A SharedClassURLClasspathHelper already exists for this classloader with a different classpath"]*/
 						throw new HelperAlreadyDefinedException(Msg.getString("K059e")); //$NON-NLS-1$
 					}
-				/*[IF !Sidecar19-SE] */
+				/*[IF !Sidecar19-SE]*/
 				} else {
 					/*[MSG "K059d", "A different type of helper already exists for this classloader"]*/
 					throw new HelperAlreadyDefinedException(Msg.getString("K059d")); //$NON-NLS-1$


### PR DESCRIPTION
(Motivated by https://github.com/eclipse-openj9/openj9/pull/17152#discussion_r1163071253).

* remove space after `]`, e.g. in `/*[IF ...] */`
* remove space before `[`, e.g in `/* [MSG ...]*/`