### PR TITLE
Create prex arg info from callee symbol for array-typed parameters

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5718,7 +5718,7 @@ TR_PrexArgInfo* TR_PrexArgInfo::buildPrexArgInfoForMethodSymbol(TR::ResolvedMeth
       int32_t len = 0;
       const char *sig = p->getTypeSignature(len);
 
-      if (*sig == 'L' || *sig == 'Q')
+      if (*sig == 'L' || *sig == 'Q' || *sig == '[')
          {
          TR_OpaqueClassBlock *clazz = (index == 0 && !methodSymbol->isStatic()) ? feMethod->containingClass() :  comp->fe()->getClassFromSignature(sig, len, feMethod);
          if (clazz)


### PR DESCRIPTION
If this type info is missing, `validateAndPropagateArgsFromCalleeSymbol()` can give up, in which case we can fail to inline even trivial methods due to what appears to be a type incompatibility.

In particular, this would cause the actual array access to fail to be inlined for array getter (and probably also setter) MethodHandles.