### PR TITLE
(v0.38.0-release) CRIU not set J9_EXTENDED_RUNTIME_DEBUG_MODE and enable DO_HOOKS

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -36,7 +36,7 @@
 #include "ut_j9vm.h"
 #include "vm_internal.h"
 #include "jni.h"
-#define FFI_BUILDING /* Needed on Windows to link libffi statically */ 
+#define FFI_BUILDING /* Needed on Windows to link libffi statically */
 #include "ffi.h"
 #include "jitregmap.h"
 #include "j2sever.h"
@@ -74,9 +74,11 @@
 
 #define DO_INTERPRETER_PROFILING
 #if defined(DEBUG_VERSION)
-#define DO_HOOKS
 #define DO_SINGLE_STEP
 #endif /* DEBUG_VERSION */
+#if defined(DEBUG_VERSION) || defined(J9VM_OPT_CRIU_SUPPORT)
+#define DO_HOOKS
+#endif /* defined(DEBUG_VERSION) || defined(J9VM_OPT_CRIU_SUPPORT) */
 
 typedef enum {
 	VM_NO,
@@ -1088,7 +1090,7 @@ obj:
 	{
 		j9object_t instance = NULL;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables)) 
+		if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables))
 #endif
 		{
 			instance = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, &_objectAllocate, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
@@ -2186,7 +2188,7 @@ done:
 			bool enterHooked = J9_EVENT_IS_HOOKED(_vm->hookInterface, J9HOOK_VM_NATIVE_METHOD_ENTER);
 			if (tracing || enterHooked) {
 				UDATA relativeBP = _arg0EA - bp;
-				updateVMStruct(REGISTER_ARGS);		
+				updateVMStruct(REGISTER_ARGS);
 				if (tracing) {
 					UTSI_TRACEMETHODENTER_FROMVM(_vm, _currentThread, _sendMethod, _arg0EA, 0);
 				}
@@ -2916,8 +2918,8 @@ done:
 		if (NULL == arrayClazz) {
 			buildInternalNativeStackFrame(REGISTER_ARGS);
 			updateVMStruct(REGISTER_ARGS);
-			arrayClazz = internalCreateArrayClass(_currentThread, 
-				(J9ROMArrayClass *) J9ROMIMAGEHEADER_FIRSTCLASS(_currentThread->javaVM->arrayROMClasses), 
+			arrayClazz = internalCreateArrayClass(_currentThread,
+				(J9ROMArrayClass *) J9ROMIMAGEHEADER_FIRSTCLASS(_currentThread->javaVM->arrayROMClasses),
 				componentClazz);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			if (VM_VMHelpers::exceptionPending(_currentThread) || (NULL == arrayClazz)) {
@@ -3905,7 +3907,7 @@ done:
 		j9object_t *value = (j9object_t*)_sp;
 		UDATA offset = (UDATA)*(I_64*)(_sp + 1);
 		j9object_t obj = *(j9object_t*)(_sp + 3);
-		
+
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 		VM_UnsafeAPI::putObject(_currentThread, &_objectAccessBarrier, obj, offset, isVolatile, value);
@@ -4983,7 +4985,7 @@ done:
 		return EXECUTE_BYTECODE;
 	}
 
-	/* sun.reflect.Reflection (JDK8) 
+	/* sun.reflect.Reflection (JDK8)
 	 * jdk.internal.reflect.Reflection (JDK11+): private static native int getClassAccessFlags(Class<?> cls);
 	 */
 	VMINLINE VM_BytecodeAction
@@ -5398,7 +5400,7 @@ done:
 				updateVMStruct(REGISTER_ARGS);
 
 				resolvedValue = resolveConstantDynamic(_currentThread, ramConstantPool, index, J9_RESOLVE_FLAG_RUNTIME_RESOLVE);
-		
+
 				VMStructHasBeenUpdated(REGISTER_ARGS);
 				restoreGenericSpecialStackFrame(REGISTER_ARGS);
 
@@ -6921,7 +6923,7 @@ retry:
 				break;
 			case J9DescriptionCpTypeConstantDynamic:
 				if (((J9RAMConstantDynamicRef*)ramCPEntry)->exception == _vm->voidReflectClass->classObject) {
-					/* Void.class placed in the exception slot represents a valid null reference returned from resolution 
+					/* Void.class placed in the exception slot represents a valid null reference returned from resolution
 					 * directly restore the special frame and return the null reference
 					 */
 					restoreGenericSpecialStackFrame(REGISTER_ARGS);
@@ -6948,7 +6950,7 @@ retry:
 resolved:
 		_pc += (1 + parmSize);
 		_sp -= 1;
-		
+
 		if ((J9DescriptionCpTypeConstantDynamic == (romCPEntry->cpType & J9DescriptionCpTypeMask))
 		&& (0 != (romCPEntry->cpType >> J9DescriptionReturnTypeShift))
 		) {
@@ -7370,7 +7372,7 @@ done:
 		UDATA methodIndex = methodIndexAndArgCount >> 8;
 		j9object_t receiver = ((j9object_t*)_sp)[methodIndexAndArgCount & 0xFF];
 		if (J9_UNEXPECTED(NULL == receiver)) {
-			/* Resolution exceptions must be thrown first, so check if methodRef 
+			/* Resolution exceptions must be thrown first, so check if methodRef
 			 * is resolved before throwing NPE on receiver.
 			 */
 			if (methodIndex != J9VTABLE_INITIAL_VIRTUAL_OFFSET) {
@@ -7415,7 +7417,7 @@ done:
 		/* argCount was initialized when we initialized the class (i.e. it is non-volatile), so no memory barrier is required */
 		j9object_t receiver = ((j9object_t*)_sp)[ramMethodRef->methodIndexAndArgCount & 0xFF];
 		if (NULL == receiver) {
-			/* Resolution exceptions must be thrown first, so check if methodRef 
+			/* Resolution exceptions must be thrown first, so check if methodRef
 			 * is resolved before throwing NPE on receiver.
 			 */
 			if (!fromBytecode || ((J9Method *)_vm->initialMethods.initialSpecialMethod != _sendMethod)) {
@@ -8165,7 +8167,7 @@ retry:
 			if (J9_EXPECTED(NULL != arrayClass)) {
 				j9object_t instance = NULL;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-				if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables)) 
+				if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables))
 #endif
 				{
 					instance = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, &_objectAllocate, arrayClass, (U_32) size);
@@ -10120,9 +10122,13 @@ public:
 			goto popFrames; \
 		case FALL_THROUGH: \
 			break;
-#else
+#elif defined(J9VM_OPT_CRIU_SUPPORT) /* defined(DEBUG_VERSION) */
+#define DEBUG_ACTIONS \
+		case REPORT_METHOD_ENTER: \
+			goto methodEnter;
+#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
 #define DEBUG_ACTIONS
-#endif
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if JAVA_SPEC_VERSION >= 16
 #define PERFORM_ACTION_VALUE_TYPE_IMSE \

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3789,7 +3789,6 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			vm->checkpointState.isCheckPointEnabled = TRUE;
 			vm->checkpointState.isCheckPointAllowed = TRUE;
 			vm->portLibrary->finalRestore = FALSE;
-			vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_DEBUG_MODE;
 			j9port_control(J9PORT_CTLDATA_CRIU_SUPPORT_FLAGS, OMRPORT_CRIU_SUPPORT_ENABLED);
 		}
 	}


### PR DESCRIPTION
CRIU doesn't set `J9_EXTENDED_RUNTIME_DEBUG_MODE` by default which was enabled to support `Xtrace` after restore;
Enabled `DO_HOOKS` to include `reportMethodEnter`.

cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/17159

Signed-off-by: Jason Feng <fengj@ca.ibm.com>