### PR TITLE
Add Unsupported Warning for Hierarchical Scan Ordering with Balanced

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -28,6 +28,7 @@
 
 #include "j9.h"
 #include "j9cfg.h"
+#include "modronnls.h"
 
 #include "ConfigurationIncrementalGenerational.hpp"
 
@@ -277,6 +278,10 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 
 	if (result) {
 		if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_NONE == extensions->scavengerScanOrdering) {
+			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
+		} else if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL == extensions->scavengerScanOrdering) {
+			PORT_ACCESS_FROM_ENVIRONMENT(env);
+			j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN, "balanced");
 			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
 		}
 		extensions->setVLHGC(true);

--- a/runtime/nls/j9gc/j9modron.nls
+++ b/runtime/nls/j9gc/j9modron.nls
@@ -979,3 +979,11 @@ J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN.user_response=Refer to the OpenJ9 docum
 J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN.sample_input_1=4
 
 # END NON-TRANSLATABLE
+
+J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN=Unsupported -Xgc:hierarchicalScanOrdering option with -Xgcpolicy:%s will be ignored.
+# START NON-TRANSLATABLE
+J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN.explanation=-Xgc:hierarchicalScanOrdering is currently only supported with -Xgcpolicy:gencon.
+J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN.system_action=The JVM ignores the -Xgc:hierarchicalScanOrdering option.
+J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN.user_response=Refer to the OpenJ9 documentation for -Xgc:hierarchicalScanOrdering.
+
+# END NON-TRANSLATABLE


### PR DESCRIPTION
Balanced GC policy will throw an "Assert_MM_unimplemented" " assertion when using the option "Xgc:hierarchicalScanOrdering" with "Xgcpolicy:balanced". Instead, output a warning message rather than asserting due to the unsupported option.

Fixes: https://github.com/eclipse-openj9/openj9/issues/17016

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>