### PR TITLE
Merge started and finished flags into continuation.state

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4373,10 +4373,11 @@ enterContinuation(struct J9VMThread *currentThread, j9object_t continuationObjec
  * @brief Suspends the Continuation runnable.
  *
  * @param currentThread
+ * @param isFinished true if it is last unmount
  * @return BOOLEAN
  */
 BOOLEAN
-yieldContinuation(struct J9VMThread *currentThread);
+yieldContinuation(struct J9VMThread *currentThread, BOOLEAN isFinished);
 
 /**
  * @brief Free the native memory allocated by Continuation.

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -413,8 +413,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="jdk/internal/loader/NativeLibraries$NativeLibraryImpl" name="fromClass" signature="Ljava/lang/Class;" versions="15-"/>
 
 	<fieldref class="jdk/internal/vm/Continuation" name="vmRef" signature="J" cast="struct J9VMContinuation *" versions="19-"/>
-	<fieldref class="jdk/internal/vm/Continuation" name="finished" signature="Z" versions="19-"/>
-	<fieldref class="jdk/internal/vm/Continuation" name="started" signature="Z" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="state" signature="J" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="parent" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="vthread" signature="Ljava/lang/Thread;" versions="19-"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5291,17 +5291,18 @@ ffi_OOM:
 		return rc;
 	}
 
-	/* jdk.internal.vm.Continuation: private static native boolean yieldImpl(); */
+	/* jdk.internal.vm.Continuation: private static native boolean yieldImpl(boolean isFinished); */
 	VMINLINE VM_BytecodeAction
 	yieldContinuationImpl(REGISTER_ARGS_LIST)
 	{
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
+		BOOLEAN isFinished = (0 == *(I_32*)_sp) ? FALSE : TRUE;
 
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 
 		/* store the current Continuation state and swap to carrier thread stack */
-		yieldContinuation(_currentThread);
+		yieldContinuation(_currentThread, isFinished);
 
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		restoreInternalNativeStackFrame(REGISTER_ARGS);

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -301,7 +301,7 @@ static inlMapping mappings[] = {
 #endif /* JAVA_SPEC_VERSION >= 20 */
 #if JAVA_SPEC_VERSION >= 19
 	{ "Java_jdk_internal_vm_Continuation_enterImpl__", J9_BCLOOP_SEND_TARGET_ENTER_CONTINUATION },
-	{ "Java_jdk_internal_vm_Continuation_yieldImpl__", J9_BCLOOP_SEND_TARGET_YIELD_CONTINUATION },
+	{ "Java_jdk_internal_vm_Continuation_yieldImpl__Z", J9_BCLOOP_SEND_TARGET_YIELD_CONTINUATION },
 	{ "Java_jdk_internal_vm_Continuation_isPinnedImpl__", J9_BCLOOP_SEND_TARGET_ISPINNED_CONTINUATION },
 #endif /* JAVA_SPEC_VERSION >= 19 */
 };


### PR DESCRIPTION
Currently there two independent flags started and finished in Continuation Object, the similar bitwise flags also in continuation.state, merge started and finished flags into continuation.state.