### PR TITLE
Fix inlining when the root method is a customized LambdaForm

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5668,22 +5668,30 @@ void TR_J9InlinerUtil::checkForConstClass(TR_CallTarget *target, TR_LogTracer *t
             }
          }
 
-      if (argument->getOpCode().hasSymbolReference() && (knownObjectClass || argument->getSymbolReference()->hasKnownObjectIndex()))
+      if ((argument->getOpCode().hasSymbolReference() && (knownObjectClass || argument->getSymbolReference()->hasKnownObjectIndex()))
+          || argument->hasKnownObjectIndex())
          {
          if (priorKnowledge < KNOWN_OBJECT)
             {
+            const char *whence = NULL;
             if (knownObjectClass)
                {
-               ecsArgInfo->set(argOrdinal, new (comp->trStackMemory()) TR_PrexArgument(knownObjectIndex, comp));
-               if (tracePrex)
-                  traceMsg(comp, "checkForConstClass: %p: is known object obj%d (knownObjectClass)\n", ecsArgInfo->get(argOrdinal), knownObjectIndex);
+               whence = "constant class";
+               }
+            else if (argument->hasKnownObjectIndex())
+               {
+               knownObjectIndex = argument->getKnownObjectIndex();
+               whence = "node koi";
                }
             else
                {
-               ecsArgInfo->set(argOrdinal, new (comp->trStackMemory()) TR_PrexArgument(argument->getSymbolReference()->getKnownObjectIndex(), comp));
-               if (tracePrex)
-                  traceMsg(comp, "checkForConstClass: %p: is known object obj%d\n", ecsArgInfo->get(argOrdinal), argument->getSymbolReference()->getKnownObjectIndex());
+               knownObjectIndex = argument->getSymbolReference()->getKnownObjectIndex();
+               whence = "symref koi";
                }
+
+            ecsArgInfo->set(argOrdinal, new (comp->trStackMemory()) TR_PrexArgument(knownObjectIndex, comp));
+            if (tracePrex)
+               traceMsg(comp, "checkForConstClass: %p: is known object obj%d (from %s)\n", ecsArgInfo->get(argOrdinal), knownObjectIndex, whence);
             }
          }
 


### PR DESCRIPTION
Each intermediate result in a `LambdaForm` is stored in an auto. Given the final static field load at the beginning of a customized `LambdaForm`, method handle transformer is able to determine a known object for the result of loading final fields from the `MethodHandle`, and it can e.g. refine an `invokeBasic()` call using one into a direct call. It can't add the known object index to the auto that represents the receiver of such a call, since generally an auto can't have a known object index, but it does set the known object index directly on the node.

Until now the only way that inliner has been able to find a known object index for an argument (other than `<javaLangClassFromClass>` of `loadaddr`) has been from the symref, so it would fail to see that the argument is a known object, inhibiting further inlining within the callee. With this change, inliner will now also check to see whether there is a known object index set on the node itself, which allows it to pick up on the result of the analysis from method handle transformer and use it to find more call targets within the callee.