### PR TITLE
Enable JITServer post-restore only if explicitly specified

### DIFF
--- a/doc/compiler/control/OptionsPostRestore.md
+++ b/doc/compiler/control/OptionsPostRestore.md
@@ -155,3 +155,16 @@ then specified post-restore, the options processing code will
 invalidate all JIT code in the code cache, as well as prevent further
 AOT compilation (since the AOT method header would have already been
 validated).
+
+### JITServer
+
+The following table outlines when a client JVM will connect to a
+JITServer instance.
+
+||Non-Portable CRIU Pre-Checkpoint|Non-Portable CRIU Post-Restore|Portable CRIU Pre-Checkpoint|Portable CRIU Post-Restore|
+|--|--|--|--|--|
+|No Options Pre-Checkpoint; No Options Post-Restore|:x:|:x:|:x:|:x:|
+|No Options Pre-checkpoint; `-XX:+UseJITServer` Post-Restore|:x:|:white_check_mark:|:x:|:white_check_mark:|
+|`-XX:+UseJITServer` Pre-Checkpoint; No Options Post-Restore|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|`-XX:+UseJITServer` Pre-Checkpoint; `-XX:-UseJITServer` Post-Restore|:x:|:x:|:white_check_mark:|:x:|
+|`-XX:-UseJITServer` Pre-Checkpoint; `-XX:+UseJITServer` Post-Restore|:x:|:x:|:x:|:x:|

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -733,7 +733,19 @@ public:
 
    bool resetStartAndElapsedTime()              { return _resetStartAndElapsedTime;  }
    void setResetStartAndElapsedTime(bool reset) { _resetStartAndElapsedTime = reset; }
+
+#if defined(J9VM_OPT_JITSERVER)
+   bool canPerformRemoteCompilationInCRIUMode()                   { return _canPerformRemoteCompilationInCRIUMode;       }
+   void setCanPerformRemoteCompilationInCRIUMode(bool remoteComp) { _canPerformRemoteCompilationInCRIUMode = remoteComp; }
+
+   bool remoteCompilationRequestedAtBootstrap()                   { return _remoteCompilationRequestedAtBootstrap;       }
+   void setRemoteCompilationRequestedAtBootstrap(bool remoteComp) { _remoteCompilationRequestedAtBootstrap = remoteComp; }
+
+   bool remoteCompilationExplicitlyDisabledAtBootstrap()                   { return _remoteCompilationExplicitlyDisabledAtBootstrap;       }
+   void setRemoteCompilationExplicitlyDisabledAtBootstrap(bool remoteComp) { _remoteCompilationExplicitlyDisabledAtBootstrap = remoteComp; }
 #endif
+
+#endif // #if defined(J9VM_OPT_CRIU_SUPPORT)
 
    TR_PersistentMemory *     persistentMemory() { return _persistentMemory; }
 
@@ -1380,7 +1392,12 @@ private:
    bool _vmMethodTraceEnabled;
    bool _vmExceptionEventsHooked;
    bool _resetStartAndElapsedTime;
+#if defined(J9VM_OPT_JITSERVER)
+   bool _canPerformRemoteCompilationInCRIUMode;
+   bool _remoteCompilationRequestedAtBootstrap;
+   bool _remoteCompilationExplicitlyDisabledAtBootstrap;
 #endif
+#endif // #if defined(J9VM_OPT_CRIU_SUPPORT)
 
    TR::Monitor *_vlogMonitor;
    TR::Monitor *_rtlogMonitor;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2300,26 +2300,35 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxUseJITServerOption, 0);
          int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableUseJITServerOption, 0);
 
-         bool explicitClientMode = xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex;
+         bool useJitServerExplicitlySpecified = xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex;
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+         bool useJitServerExplicitlyDisabled = xxDisableUseJITServerArgIndex > xxUseJITServerArgIndex;
+
          struct J9InternalVMFunctions *ifuncs = vm->internalVMFunctions;
          J9VMThread *currentThread = ifuncs->currentVMThread(vm);
+
          // Enable JITServer client mode if
          // 1) CRIU support is enabled
-         // 2) non-portable restore mode is enabled
-         // 3) client mode is not explicitly disabled
-         // In portable restore mode let the user explicitly decide whether to enable JITServer.
-         bool implicitClientMode = ifuncs->isCRIUSupportEnabled(currentThread) &&
-                                   ifuncs->isNonPortableRestoreMode(currentThread) &&
-                                   (xxUseJITServerArgIndex >= xxDisableUseJITServerArgIndex);
+         // 2) client mode is not explicitly disabled
+         bool implicitClientMode = ifuncs->isCRIUSupportEnabled(currentThread) && !useJitServerExplicitlyDisabled;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
-         if (explicitClientMode
+         if (useJitServerExplicitlySpecified
 #if defined(J9VM_OPT_CRIU_SUPPORT)
              || implicitClientMode
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
          )
             {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+            if (implicitClientMode && useJitServerExplicitlySpecified)
+               {
+               compInfo->setRemoteCompilationRequestedAtBootstrap(true);
+               if (!ifuncs->isNonPortableRestoreMode(currentThread))
+                   compInfo->setCanPerformRemoteCompilationInCRIUMode(true);
+               }
+#endif
+
             J9::PersistentInfo::_remoteCompilationMode = JITServer::CLIENT;
             compInfo->getPersistentInfo()->setSocketTimeout(DEFAULT_JITCLIENT_TIMEOUT);
 
@@ -2355,7 +2364,14 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
                }
             }
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+         else if (useJitServerExplicitlyDisabled)
+            {
+            compInfo->setRemoteCompilationExplicitlyDisabledAtBootstrap(true);
+            }
+#endif // #if defined(J9VM_OPT_CRIU_SUPPORT)
          }
+
       if (!JITServerParseCommonOptions(vm->vmArgsArray, vm, compInfo))
          {
          // Could not parse JITServer options successfully

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -75,6 +75,7 @@
 			<fileset dir="${src}/../" includes="*.xml" />
 			<fileset dir="${src}/../" includes="*.mk" />
 			<fileset dir="${src}/../" includes="*.sh" />
+			<fileset dir="${src}/../../jitserver" includes="jitserverconfig.sh" />
 		</copy>
 	</target>
 

--- a/test/functional/cmdLineTests/criu/criuJitServerScript.sh
+++ b/test/functional/cmdLineTests/criu/criuJitServerScript.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+#
+# Copyright IBM Corp. and others 2023
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+echo "start running script";
+# the expected arguments are:
+# $1 is the TEST_ROOT
+# $2 is the TEST_JDK_BIN
+# $3 is the JVM_OPTIONS
+# $4 is the MAINCLASS
+# $5 is the APP ARGS
+# $6 is the NUM_CHECKPOINT
+# $7 is the KEEP_CHECKPOINT
+
+source $1/jitserverconfig.sh
+
+echo "export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.pthread.rseq=0:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+
+JITSERVER_PORT=$(random_port)
+JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT"
+
+echo "Starting $2/jitserver $JITSERVER_OPTIONS"
+$2/jitserver $JITSERVER_OPTIONS &
+sleep 2
+
+$2/java -XX:+EnableCRIUSupport -XX:JITServerPort=$JITSERVER_PORT $3 -cp "$1/criu.jar" $4 $5 -XX:JITServerPort=$JITSERVER_PORT $6 >testOutput 2>&1;
+
+if [ "$7" != true ]; then
+    NUM_CHECKPOINT=$6
+    for ((i=0; i<$NUM_CHECKPOINT; i++)); do
+        sleep 2;
+        criu restore -D ./cpData --shell-job;
+    done
+fi
+
+cat testOutput;
+
+if  [ "$7" != true ]; then
+    rm -rf testOutput
+    echo "Removed testOutput file"
+fi
+
+echo "Terminating $2/jitserver $JITSERVER_OPTIONS"
+pkill -9 -xf "$2/jitserver $JITSERVER_OPTIONS"
+sleep 2
+
+echo "finished script";

--- a/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Post Restore JIT Option Tests" timeout="300">
+	<variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
+	<variable name="ENABLE_JITSERVER" value="-XX:+UseJITServer" />
+	<variable name="PRE_CRIU_VERBOSE" value="-Xjit:verbose={JITServer},verbose={JITServerConns},vlog=preCheckpointVlog" />
+	<variable name="POST_CRIU_VERBOSE" value="-Xjit:verbose={CheckpointRestore},verbose={JITServer},verbose={JITServerConns},vlog=postRestoreVlog" />
+	<variable name="PORTABLE_CRIU_MODE" value="-XX:-CRIURestoreNonPortableMode" />
+
+	<test id="Generate Verbose Log">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $POST_CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Check Connection in Pre-Checkpoint Verbose Log">
+		<command>cat preCheckpointVlog</command>
+		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
+		<output regex="no" type="failure">Connected to a server</output>
+	</test>
+
+	<test id="Check Connection in Post-Restore Verbose Log">
+		<command>cat postRestoreVlog</command>
+		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">Connected to a server</output>
+	</test>
+
+	<test id="JITServer not explicitly enabled Post-Restore">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
+		<command>cat postRestoreVlog</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="failure">Connected to a server</output>
+	</test>
+
+	<test id="Portable CRIU Mode: JITServer not explicitly enabled Post-Restore">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PORTABLE_CRIU_MODE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Portable CRIU Mode; JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
+		<command>cat postRestoreVlog</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="failure">Connected to a server</output>
+	</test>
+
+	<test id="Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Enable JITServer specified Pre-Checkpoint: Check no connection in Pre-Checkpoint Verbose Log">
+		<command>cat preCheckpointVlog</command>
+		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
+		<output regex="no" type="failure">Connected to a server</output>
+	</test>
+
+	<test id="Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
+		<command>cat postRestoreVlog</command>
+		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">Connected to a server</output>
+	</test>
+
+	<test id="Portable CRIU Mode: Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PORTABLE_CRIU_MODE$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Pre-Checkpoint Verbose Log">
+		<command>cat preCheckpointVlog</command>
+		<output regex="no" type="required">JITServer: JITServer Client Mode.</output>
+		<output regex="no" type="success">Connected to a server</output>
+	</test>
+
+	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
+		<command>cat postRestoreVlog</command>
+		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">Connected to a server</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Post Restore JIT Option Tests" timeout="300">
+	<variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
+	<variable name="ENABLE_JITSERVER" value="-XX:+UseJITServer" />
+	<variable name="CRIU_VERBOSE" value="-Xjit:verbose={CheckpointRestore},verbose={JITServer},verbose={JITServerConns},vlog=vlog" />
+
+	<test id="Generate Verbose Log">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $CRIU_VERBOSE$" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Check Verbose Log">
+		<command>cat vlog</command>
+		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">Connected to a server</output>
+	</test>
+
+	<test id="Test -Xnojit -Xnoaot">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnojit -Xnoaot" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<output type="success" caseSensitive="yes" regex="no">Some or all compiled code in the code cache invalidated post restore.</output>
+		<output type="success" caseSensitive="yes" regex="no">JIT compilation disabled post restore.</output>
+		<output type="success" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore.</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Test -Xnoaot">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnoaot" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<output type="failure" caseSensitive="yes" regex="no">Some or all compiled code in the code cache invalidated post restore.</output>
+		<output type="failure" caseSensitive="yes" regex="no">JIT compilation disabled post restore.</output>
+		<output type="success" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore.</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+
+	<test id="Test -Xjit:exclude={*}">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xjit:exclude={*}" 1 false</command>
+		<output type="success" caseSensitive="no" regex="no">Killed</output>
+		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+		<output type="success" caseSensitive="yes" regex="no">Some or all compiled code in the code cache invalidated post restore.</output>
+		<output type="failure" caseSensitive="yes" regex="no">JIT compilation disabled post restore.</output>
+		<output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore.</output>
+		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -149,6 +149,76 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>cmdLineTester_criu_jitserverAcrossCheckpoint</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>
+			if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
+			then \
+				TR_Options=$(Q)disableSuffixLogs$(Q) \
+				$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+				-DSCRIPPATH=$(TEST_RESROOT)$(D)criuJitServerScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+				-DTEST_JDK_BIN=$(TEST_JDK_BIN) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+				-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_jitserverAcrossCheckpoint.xml$(Q) \
+				-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			else \
+				echo; \
+				echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
+			fi; \
+			$(TEST_STATUS)
+		</command>
+		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_criu_jitserverPostRestore</testCaseName>
+		<variations>
+			<variation>-Xjit</variation>
+			<variation>-Xjit:count=0</variation>
+			<variation>-Xjit:vlog=vlog</variation>
+		</variations>
+		<command>
+			if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
+			then \
+				TR_Options=$(Q)disableSuffixLogs$(Q) \
+				$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+				-DSCRIPPATH=$(TEST_RESROOT)$(D)criuJitServerScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+				-DTEST_JDK_BIN=$(TEST_JDK_BIN) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+				-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_jitserverPostRestore.xml$(Q) \
+				-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			else \
+				echo; \
+				echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
+			fi; \
+			$(TEST_STATUS)
+		</command>
+		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>cmdLineTester_criu_nonPortableRestore_Xtrace_tracepoint</testCaseName>
 		<variations>
 			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>

--- a/test/functional/cmdLineTests/jitserver/build.xml
+++ b/test/functional/cmdLineTests/jitserver/build.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTest_jitserver" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTest_jitserver
+	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jitserver" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml"/>
+			<fileset dir="${src}" includes="*.mk"/>
+			<fileset dir="${src}" includes="*.sh" />
+		</copy>
+	</target>
+
+	<target name="build" depends="buildCmdLineTestTools">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
+++ b/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="jitserverArgumentTesting.xml" timeout="1000">
+	<variable name="ENABLE_JITSERVER" value="-XX:+UseJITServer" />
+	<variable name="DISABLE_JITSERVER" value="-XX:-UseJITServer" />
+	<variable name="JITSERVER_VERBOSE" value="-Xjit:verbose={JITServer},verbose={JITServerConns}" />
+	<variable name="DEFAULT_JITSERVER_OPTIONS" value="-Xjit" />
+
+	<test id="Test default configuration">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSesnsitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+	<test id="Test JITServer disabled">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$DISABLE_JITSERVER$ $JITSERVER_VERBOSE$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+	<test id="Test bad port">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ -XX:JITServerPort=38399" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+	<test id="Test bad hostname">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ -XX:JITServerAddress=bad.address" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+	<test id="Test Metrics">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$" true</command>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="success" caseSensitive="no" regex="no">jitserver_cpu_utilization</output>
+		<output type="success" caseSensitive="no" regex="no">jitserver_available_memory</output>
+		<output type="success" caseSensitive="no" regex="no">jitserver_connected_clients</output>
+		<output type="success" caseSensitive="no" regex="no">jitserver_active_threads</output>
+		<output type="failure" caseSenstive="no" regex="no">Connection refused</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+	<test id="Test Metrics Disabled">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$ -XX:-JITServerMetrics" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$" true</command>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSensitive="no" regex="no">jitserver_cpu_utilization</output>
+		<output type="failure" caseSensitive="no" regex="no">jitserver_available_memory</output>
+		<output type="failure" caseSensitive="no" regex="no">jitserver_connected_clients</output>
+		<output type="failure" caseSensitive="no" regex="no">jitserver_active_threads</output>
+		<output type="success" caseSenstive="no" regex="no">Connection refused</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+	</test>
+
+</suite>

--- a/test/functional/cmdLineTests/jitserver/jitserverScript.sh
+++ b/test/functional/cmdLineTests/jitserver/jitserverScript.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+#
+# Copyright IBM Corp. and others 2023
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+echo "start running script";
+# the expected arguments are:
+# $1 is the TEST_ROOT
+# $2 is the TEST_JDK_BIN
+# $3 is the JITServer Options
+# $4 is the JVM Options
+# %5 is the Metrics
+
+TEST_ROOT=$1
+TEST_JDK_BIN=$2
+JITSERVER_OPTS="$3"
+JVM_OPTS="$4"
+METRICS=$5
+
+source $TEST_ROOT/jitserverconfig.sh
+
+JITSERVER_PORT=$(random_port)
+
+if [ "$METRICS" == true ]; then
+    METRICS_PORT=$(random_port)
+    METRICS_OPTS="-XX:+JITServerMetrics -XX:JITServerMetricsPort=$METRICS_PORT"
+fi
+
+JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT $METRICS_OPTS $JITSERVER_OPTS"
+
+echo "Starting $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
+$TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS &
+JITSERVER_PID=$!
+sleep 2
+
+$TEST_JDK_BIN/java -XX:JITServerPort=$JITSERVER_PORT $JVM_OPTS -version;
+
+if [ "$METRICS" == true ]; then
+    curl http://localhost:$METRICS_PORT/metrics
+fi
+
+echo "Terminating $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
+kill -9 $JITSERVER_PID
+# Running pkill seems to cause a hang...
+#pkill -9 -xf "$TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
+sleep 2
+
+echo "finished script";

--- a/test/functional/cmdLineTests/jitserver/jitserverconfig.sh
+++ b/test/functional/cmdLineTests/jitserver/jitserverconfig.sh
@@ -1,0 +1,41 @@
+# Copyright IBM Corp. and others 2023
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+START_PORT=38400
+END_PORT=60000
+
+DIFF=$(($END_PORT-$START_PORT+1))
+RANDOM=$$
+
+random_port () {
+    RANDOM_PORT=$(($(($RANDOM%$DIFF))+$START_PORT))
+    out=$(lsof -i -P -n | grep LISTEN | grep $RANDOM_PORT)
+    retVal=$?
+
+    while [ $retVal -eq 0 ]
+    do
+        RANDOM_PORT=$(($(($RANDOM%$DIFF))+$START_PORT))
+        out=$(lsof -i -P -n | grep LISTEN | grep $RANDOM_PORT)
+        retVal=$?
+    done
+
+    echo "$RANDOM_PORT"
+}

--- a/test/functional/cmdLineTests/jitserver/playlist.xml
+++ b/test/functional/cmdLineTests/jitserver/playlist.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<include>../variables.mk</include>
+	<test>
+		<testCaseName>testJitserverArguments</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>
+			if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
+			then \
+				TR_Options=$(Q)disableSuffixLogs$(Q) \
+				$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+				-DSCRIPPATH=$(TEST_RESROOT)$(D)jitserverScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+				-DTEST_JDK_BIN=$(TEST_JDK_BIN) \
+				-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)jitserverArgumentTesting.xml$(Q) \
+				-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			else \
+				echo; \
+				echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
+			fi; \
+			$(TEST_STATUS)
+		</command>
+		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+</playlist>


### PR DESCRIPTION
This PR updates the how a JVM Client will connect to a JITServer in the context of CRIU as outlined in the following table; ✅ means the JVM will connect to a JITServer instance and ❌ means it won't.

||Non-Portable CRIU Pre-Checkpoint|Non-Portable CRIU Post-Restore|Portable CRIU Pre-Checkpoint|Portable CRIU Post-Restore|
|--|--|--|--|--|
|No Options Pre-Checkpoint; No Options Post-Restore|:x:|:x:|:x:|:x:|
|No Options Pre-checkpoint; `-XX:+UseJITServer` Post-Restore|:x:|:white_check_mark:|:x:|:white_check_mark:|
|`-XX:+UseJITServer` Pre-Checkpoint; No Options Post-Restore|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
|`-XX:+UseJITServer` Pre-Checkpoint; `-XX:-UseJITServer` Post-Restore|:x:|:x:|:white_check_mark:|:x:|
|`-XX:-UseJITServer` Pre-Checkpoint; `-XX:+UseJITServer` Post-Restore|:x:|:x:|:x:|:x:|

This PR also adds cmdLineTester tests for jitserver, both by itself and in the context of CRIU.