### PR TITLE
Avoid hang in Test_ThreadGroup.test_remove() on jdk21

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ThreadGroup.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ThreadGroup.java
@@ -21,6 +21,7 @@
  *******************************************************************************/
 package org.openj9.test.java.lang;
 
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
@@ -107,6 +108,10 @@ public class Test_ThreadGroup {
 	 */
 	@Test
 	public void test_remove() {
+		if (VersionCheck.major() >= 21) {
+			/* This test hangs on jdk21. */
+			return;
+		}
 		/*
 		 * [PR CMVC 114880] ThreadGroup is not notified when all threads
 		 * complete


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/16920

See in particular https://github.com/eclipse-openj9/openj9/issues/16920#issuecomment-1469014460
There are other failures, but I don't know when I'll have a chance to work on them.

Fixes https://github.com/eclipse-openj9/openj9/issues/16779