### PR TITLE
Support JNI_VERSION_21 for jdk21+

### DIFF
--- a/runtime/include/jni.h.m4
+++ b/runtime/include/jni.h.m4
@@ -57,6 +57,7 @@ ifelse(eval(JAVA_SPEC_VERSION >=  9), 1, `#define JNI_VERSION_9   0x00090000', `
 ifelse(eval(JAVA_SPEC_VERSION >= 10), 1, `#define JNI_VERSION_10  0x000A0000', `dnl')
 ifelse(eval(JAVA_SPEC_VERSION >= 19), 1, `#define JNI_VERSION_19  0x00130000', `dnl')
 ifelse(eval(JAVA_SPEC_VERSION >= 20), 1, `#define JNI_VERSION_20  0x00140000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 21), 1, `#define JNI_VERSION_21  0x00150000', `dnl')
 
 #define JVMEXT_VERSION_1_1 0x7E010001
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1676,6 +1676,9 @@ JVM_IsSupportedJNIVersion(jint version)
 #if JAVA_SPEC_VERSION >= 20
 	case JNI_VERSION_20:
 #endif /* JAVA_SPEC_VERSION >= 20 */
+#if JAVA_SPEC_VERSION >= 21
+	case JNI_VERSION_21:
+#endif /* JAVA_SPEC_VERSION >= 21 */
 		return JNI_TRUE;
 
 	default:

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2543,6 +2543,9 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 20
 	case JNI_VERSION_20:
 #endif /* JAVA_SPEC_VERSION >= 20 */
+#if JAVA_SPEC_VERSION >= 21
+	case JNI_VERSION_21:
+#endif /* JAVA_SPEC_VERSION >= 21 */
 		return JNI_OK;
 	}
 

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -935,6 +935,9 @@ JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 20
 		case JNI_VERSION_20:
 #endif /* JAVA_SPEC_VERSION >= 20 */
+#if JAVA_SPEC_VERSION >= 21
+		case JNI_VERSION_21:
+#endif /* JAVA_SPEC_VERSION >= 21 */
 			return JNI_OK;
 		default:
 			break;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -430,7 +430,9 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
+	return JNI_VERSION_21;
+#elif JAVA_SPEC_VERSION >= 20
 	return JNI_VERSION_20;
 #elif JAVA_SPEC_VERSION >= 19
 	return JNI_VERSION_19;
@@ -438,7 +440,7 @@ getVersion(JNIEnv *env)
 	return JNI_VERSION_10;
 #else /* JAVA_SPEC_VERSION >= 10 */
 	return JNI_VERSION_1_8;
-#endif /* JAVA_SPEC_VERSION >= 19 */
+#endif /* JAVA_SPEC_VERSION >= 21 */
 }
 
 jsize JNICALL

--- a/runtime/vm/jvminitcommon.c
+++ b/runtime/vm/jvminitcommon.c
@@ -152,6 +152,9 @@ jniVersionIsValid(UDATA jniVersion)
 #if JAVA_SPEC_VERSION >= 20
 	case JNI_VERSION_20:
 #endif /* JAVA_SPEC_VERSION >= 20 */
+#if JAVA_SPEC_VERSION >= 21
+	case JNI_VERSION_21:
+#endif /* JAVA_SPEC_VERSION >= 21 */
 		return JNI_TRUE;
 	default:
 		return JNI_FALSE;


### PR DESCRIPTION
Added upstream in
* [8304919: Implementation of Virtual Threads](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/1edf1e6ea5b6bcb6a9f2df18d6c98eb4e0a86865)