### PR TITLE
Recognize new Class methods for Valhalla prototype support in Value Propagation

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -58,6 +58,9 @@
    java_lang_Class_newInstancePrototype,
    java_lang_Class_isArray,
    java_lang_Class_isPrimitive,
+   java_lang_Class_isValue,
+   java_lang_Class_isPrimitiveClass,
+   java_lang_Class_isIdentity,
    java_lang_Class_getComponentType,
    java_lang_Class_getModifiersImpl,
    java_lang_Class_getSuperclass,
@@ -1125,9 +1128,11 @@
    java_lang_J9VMInternals_getInstanceDescriptionFromJ9Class64,
    java_lang_J9VMInternals_getDescriptionWordFromPtr64,
    java_lang_J9VMInternals_getSuperclass,
+   java_lang_J9VMInternals_primitiveClone,
+
    java_lang_J9VMInternals_identityHashCode,
    java_lang_J9VMInternals_fastIdentityHashCode,
-   java_lang_J9VMInternals_primitiveClone,
+   java_lang_J9VMInternals_valueHashCode,
 
    java_util_GregorianCalendar_computeFields,
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2868,6 +2868,12 @@ TR_J9VMBase::testIsClassPrimitiveValueType(TR::Node *j9ClassRefNode)
    }
 
 TR::Node *
+TR_J9VMBase::testIsClassIdentityType(TR::Node *j9ClassRefNode)
+   {
+   return testAreSomeClassFlagsSet(j9ClassRefNode, J9ClassHasIdentity);
+   }
+
+TR::Node *
 TR_J9VMBase::checkSomeArrayCompClassFlags(TR::Node *arrayBaseAddressNode, TR::ILOpCodes ifCmpOp, uint32_t flagsToTest)
    {
    TR::SymbolReference *vftSymRef = TR::comp()->getSymRefTab()->findOrCreateVftSymbolRef();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1207,6 +1207,15 @@ public:
    TR::Node * testIsClassPrimitiveValueType(TR::Node *j9ClassRefNode);
 
    /**
+    * \brief Load class flags field of the specified class and test whether the hasIdentity
+    *        flag is set.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return \ref TR::Node that evaluates to a non-zero integer if the class is an identity type,
+    *         or zero otherwise
+    */
+   TR::Node * testIsClassIdentityType(TR::Node *j9ClassRefNode);
+
+   /**
     * \brief Test whether any of the specified flags is set on the array's component class
     * \param arrayBaseAddressNode A node representing a reference to the array base address
     * \param ifCmpOp If comparison opCode such as ificmpeq or ificmpne

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2080,6 +2080,9 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Class_newInstance,          "newInstance",          "()Ljava/lang/Object;")},
       {x(TR::java_lang_Class_isArray,              "isArray",              "()Z")},
       {x(TR::java_lang_Class_isPrimitive,          "isPrimitive",          "()Z")},
+      {x(TR::java_lang_Class_isValue,              "isValue",              "()Z")},
+      {x(TR::java_lang_Class_isPrimitiveClass,     "isPrimitiveClass",     "()Z")},
+      {x(TR::java_lang_Class_isIdentity,           "isIdentity",           "()Z")},
       {x(TR::java_lang_Class_getComponentType,     "getComponentType",     "()Ljava/lang/Class;")},
       {x(TR::java_lang_Class_getModifiersImpl,     "getModifiersImpl",     "()I")},
       {x(TR::java_lang_Class_isAssignableFrom,     "isAssignableFrom",     "(Ljava/lang/Class;)Z")},
@@ -3365,6 +3368,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_J9VMInternals_getSuperclass,                       "getSuperclass", "(Ljava/lang/Class;)Ljava/lang/Class;")},
       {x(TR::java_lang_J9VMInternals_identityHashCode,                    "identityHashCode", "(Ljava/lang/Object;)I")},
       {x(TR::java_lang_J9VMInternals_fastIdentityHashCode,                "fastIdentityHashCode", "(Ljava/lang/Object;)I")},
+      {x(TR::java_lang_J9VMInternals_valueHashCode,                       "valueHashCode", "(Ljava/lang/Object;)I")},
       {x(TR::java_lang_J9VMInternals_primitiveClone,                      "primitiveClone", "(Ljava/lang/Object;)Ljava/lang/Object;")},
       {  TR::unknownMethod}
       };

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1552,6 +1552,10 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
          bool classChildGlobal;
          TR::VPConstraint *classChildConstraint = getConstraint(classChild, classChildGlobal);
 
+         // If the class is known for a call to Class.isValue, Class.isPrimitiveClass or
+         // Class.isIdentity, fold it at compile-time.  Otherwise, inline a test of the
+         // class flags
+         //
          if (classChildConstraint
              && classChildConstraint->isJavaLangClassObject() == TR_yes
              && classChildConstraint->isNonNullObject()
@@ -1566,6 +1570,67 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, queryResult, classChildGlobal, true, false);
             TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
             }
+         else if (classChildConstraint
+                  && classChildConstraint->isJavaLangClassObject() == TR_yes
+                  && classChildConstraint->isNonNullObject())
+            {
+            // Consider two cases:
+            //
+            // (i)  The operand is an instance of java.lang.Class indirectly loaded through a vft.  In that case,
+            //      we can work with the vft directly
+            // (ii) The operand is definitely a non-null instance of java.lang.Class.  In that case, load the
+            //      J9Class from the java.lang.Class by way of <classFromJavaLangClass>
+            //
+            // The result of Class.isValueType(), Class.isPrimitiveValueType() or Class.isIdentity() can then
+            // be determined by checking the corresponding bit in the classFlags field.
+            TR::SymbolReference *symRef = classChild->getOpCode().hasSymbolReference() ? classChild->getSymbolReference() : NULL;
+            TR::Node *classOperand = NULL;
+
+            if ((symRef != NULL) && (symRef == comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef()))
+               {
+               classOperand = classChild->getFirstChild();
+               }
+            else
+               {
+               classOperand = TR::Node::createWithSymRef(TR::aloadi, 1, 1, classChild,
+                                                      comp()->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef());
+               }
+
+            TR::Node *testFlagsNode = NULL;
+            TR::ILOpCodes testFlagsCompareOp;
+
+            switch (rm)
+               {
+               case TR::java_lang_Class_isValue:
+                  {
+                  testFlagsNode = comp()->fej9()->testIsClassValueType(classOperand);
+                  break;
+                  }
+               case TR::java_lang_Class_isPrimitiveClass:
+                  {
+                  testFlagsNode = comp()->fej9()->testIsClassPrimitiveValueType(classOperand);
+                  break;
+                  }
+               case TR::java_lang_Class_isIdentity:
+                  {
+                  testFlagsNode = comp()->fej9()->testIsClassIdentityType(classOperand);
+                  break;
+                  }
+               default:
+                  {
+                  TR_ASSERT_FATAL(false, "%s:  How did we get here?\n", __FUNCTION__);
+                  break;
+                  }
+               }
+
+            // The testIsClass*Type methods will produce IL whose result is zero if the specified
+            // flags(s) are not set, and non-zero if any of the specified flag(s) are set;
+            // compare the result to zero to force the result to be zero or one.
+            //
+            TR::Node *inlineFlagsTest = TR::Node::create(node, TR::icmpne, 2, testFlagsNode, TR::Node::iconst(node, 0));
+            transformCallToNodeDelayedTransformations(_curTree, inlineFlagsTest, false);
+            }
+
          break;
          }
       case TR::java_lang_Class_getComponentType:


### PR DESCRIPTION
This change adds support to `constrainRecognizedMethod` in Value Propagation to recognize the `isIdentity`, `isPrimitiveClass` and `isValue` methods in `java.lang.Class` for Valhalla prototype support.  If the class is known at compile-time, the result of the call can be determined at compile-time; otherwise, the appropriate bit of the classFlags field of the J9Class can be tested in generated inline IL.