### PR TITLE
Ignore ScopedMemoryAccess in isCallerClassJavaNio()

### DIFF
--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -218,8 +218,12 @@ isCallerClassJavaNio(J9VMThread *currentThread, J9StackWalkState *walkState)
 		UDATA length = J9UTF8_LENGTH(className);
 		U_8 *data = J9UTF8_DATA(className);
 
-		/* Ignore any methods in Unsafe */
-		if (J9UTF8_LITERAL_EQUALS(data, length, "sun/misc/Unsafe") || J9UTF8_LITERAL_EQUALS(data, length, "jdk/internal/misc/Unsafe")) {
+		/* Ignore any methods in Unsafe, and ScopedMemoryAccess with version 17 and later. */
+		if (J9UTF8_LITERAL_EQUALS(data, length, "sun/misc/Unsafe") || J9UTF8_LITERAL_EQUALS(data, length, "jdk/internal/misc/Unsafe")
+#if JAVA_SPEC_VERSION >= 17
+			|| J9UTF8_LITERAL_EQUALS(data, length, "jdk/internal/misc/ScopedMemoryAccess")
+#endif /* JAVA_SPEC_VERSION >= 17 */
+		) {
 			goto done;
 		}
 		if (length >= 9) {


### PR DESCRIPTION
When handling SIGBUS, or ABEND on z/OS, the stack walk from sigBusHandler() ignores the Unsafe class when looking for a java/nio caller class. From Java 17, Unsafe options are wrapped with ScopedMemoryAccess, which also needs to be ignored.

Internal issue runtimes/openj9-openjdk-jdk17-zos/issues/514

On z/OS, the following test case demonstrates the problem
```
import java.io.File;
import java.io.IOException;
import java.io.RandomAccessFile;
import java.nio.ByteBuffer;
import java.nio.MappedByteBuffer;
import java.nio.channels.FileChannel;


public class TruncateTest {

    static final long INITIAL_FILE_SIZE = 32000L;
    static final long TRUNCATED_FILE_SIZE = 512L;


    public static void main(String [] args) throws IOException, InterruptedException {
	File blah = File.createTempFile("blah", null);
	blah.deleteOnExit();

	final FileChannel fc = new RandomAccessFile(blah, "rw").getChannel();
	fc.position(INITIAL_FILE_SIZE).write(ByteBuffer.wrap("THE END".getBytes()));
	final MappedByteBuffer mbb = fc.map(FileChannel.MapMode.READ_WRITE, 0, fc.size());
	boolean truncated;
	try {
            fc.truncate(TRUNCATED_FILE_SIZE);
            truncated = true;
	} catch (IOException ioe) {
            truncated = false;
	}
        if (truncated) {
            mbb.get((int) TRUNCATED_FILE_SIZE + 1);
	}
        fc.close();
    }
}
```

Without this change you get
```
CEE3250C The system or user abend S028  R=6C000101 was issued.
         From entry point debugBytecodeLoopCompressed at compile unit offset +00000000155EE5C0 at entry offset -00000000001A9030 at address 00000000155EE5C0.
```

With this change you get the expected
```
xception in thread "main" java.lang.InternalError: SIGBUS
	at java.base/jdk.internal.misc.Unsafe.getByte(Native Method)
	at java.base/jdk.internal.misc.ScopedMemoryAccess.getByteInternal(ScopedMemoryAccess.java:482)
	at java.base/jdk.internal.misc.ScopedMemoryAccess.getByte(ScopedMemoryAccess.java:470)
	at java.base/java.nio.DirectByteBuffer.get(DirectByteBuffer.java:337)
	at TruncateTest.main(TruncateTest.java:30)
```