### PR TITLE
Inline IntrinsicCandidate methods

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3866,8 +3866,15 @@ TR_J9VMBase::isForceInline(TR_ResolvedMethod *method)
 bool
 TR_J9VMBase::isDontInline(TR_ResolvedMethod *method)
    {
-   return jitIsMethodTaggedWithDontInline(
-      vmThread(), (J9Method*)method->getPersistentIdentifier());
+   return jitIsMethodTaggedWithDontInline(vmThread(),
+                                          (J9Method*)method->getPersistentIdentifier());
+   }
+
+bool
+TR_J9VMBase::isIntrinsicCandidate(TR_ResolvedMethod *method)
+   {
+   return jitIsMethodTaggedWithIntrinsicCandidate(vmThread(),
+                                                  (J9Method*)method->getPersistentIdentifier());
    }
 
 // Creates a node to initialize the local object flags field

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1056,6 +1056,13 @@ public:
     */
    virtual bool isDontInline(TR_ResolvedMethod *method);
 
+   /**
+    * \brief Determine whether a method is annotated with @IntrinsicCandidate.
+    * \param method method
+    * \return true if a @IntrinsicCandidate annotation is present, false otherwise
+    */
+   virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method);
+
    /*
     * \brief
     *    tell whether it's possible to dereference a field given the field symbol at compile time

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2430,6 +2430,12 @@ TR_J9ServerVM::isForceInline(TR_ResolvedMethod *method)
    }
 
 bool
+TR_J9ServerVM::isIntrinsicCandidate(TR_ResolvedMethod *method)
+   {
+   return static_cast<TR_ResolvedJ9JITServerMethod *>(method)->isIntrinsicCandidate();
+   }
+
+bool
 TR_J9ServerVM::isDontInline(TR_ResolvedMethod *method)
    {
    return static_cast<TR_ResolvedJ9JITServerMethod *>(method)->isDontInline();

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -161,6 +161,7 @@ public:
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass) override;
    virtual bool isStable(J9Class *fieldClass, int cpIndex) override;
    virtual bool isForceInline(TR_ResolvedMethod *method) override;
+   virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method) override;
    virtual bool isDontInline(TR_ResolvedMethod *method) override;
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual void markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart) override;

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -145,7 +145,7 @@ TR_ResolvedJ9JITServerMethod::staticAttributes(TR::Compilation * comp, I_32 cpIn
    return result;
    }
 
-TR_OpaqueClassBlock * 
+TR_OpaqueClassBlock *
 TR_ResolvedJ9JITServerMethod::definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock **fromResolvedJ9Method)
    {
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
@@ -241,7 +241,7 @@ TR_ResolvedJ9JITServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT
 
    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
       {
-      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &classOfStaticCache = getJ9ClassInfo(compInfoPT, _ramClass)._classOfStaticCache;
       auto it = classOfStaticCache.find(cpIndex);
       if (it != classOfStaticCache.end())
@@ -259,7 +259,7 @@ TR_ResolvedJ9JITServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT
       // reacquire monitor and cache, if client returned a valid class
       // if client returned NULL, don't cache, because class might not be fully initialized,
       // so the result may change in the future
-      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &classOfStaticCache = getJ9ClassInfo(compInfoPT, _ramClass)._classOfStaticCache;
       classOfStaticCache.insert({cpIndex, classOfStatic});
       }
@@ -382,7 +382,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Compil
             aotStats = & (((TR_JitPrivateConfig *)_fe->_jitConfig->privateConfig)->aotStats->virtualMethods);
 
          TR_ResolvedJ9JITServerMethodInfo &methodInfo = std::get<3>(recv);
-         
+
          // call constructor without making a new query
          if (createResolvedMethod)
             {
@@ -442,11 +442,11 @@ TR_ResolvedJ9JITServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMethod 
 
    if (cpIndex1 == cpIndex2 && ramMethod() == serverMethod2->ramMethod())
       return true;
-   
+
    int32_t sig1Len = 0, sig2Len = 0;
    char *signature1 = fieldOrStaticSignatureChars(cpIndex1, sig1Len);
    char *signature2 = serverMethod2->fieldOrStaticSignatureChars(cpIndex2, sig2Len);
-   
+
    int32_t name1Len = 0, name2Len = 0;
    char *name1 = fieldOrStaticNameChars(cpIndex1, name1Len);
    char *name2 = serverMethod2->fieldOrStaticNameChars(cpIndex2, name2Len);
@@ -484,13 +484,13 @@ TR_ResolvedJ9JITServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod
 
    if (cpIndex1 == cpIndex2 && ramMethod() == serverMethod2->ramMethod())
       return true;
-   
-   // the client version of this method compares the addresses of values first, which we cannot do on the server. 
-   // skipping that step affects performance, but does not affect correctness. 
+
+   // the client version of this method compares the addresses of values first, which we cannot do on the server.
+   // skipping that step affects performance, but does not affect correctness.
    int32_t sig1Len = 0, sig2Len = 0;
    char *signature1 = fieldOrStaticSignatureChars(cpIndex1, sig1Len);
    char *signature2 = serverMethod2->fieldOrStaticSignatureChars(cpIndex2, sig2Len);
-   
+
    int32_t name1Len = 0, name2Len = 0;
    char *name1 = fieldOrStaticNameChars(cpIndex1, name1Len);
    char *name2 = serverMethod2->fieldOrStaticNameChars(cpIndex2, name2Len);
@@ -517,7 +517,7 @@ TR_ResolvedJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedI
    {
    // Return a persistent attributes cache for regular JIT compilations
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
-   auto &attributesCache = isStatic ? 
+   auto &attributesCache = isStatic ?
       getJ9ClassInfo(compInfoPT, _ramClass)._staticAttributesCache :
       getJ9ClassInfo(compInfoPT, _ramClass)._fieldAttributesCache;
    return attributesCache;
@@ -529,7 +529,7 @@ TR_ResolvedJ9JITServerMethod::getCachedFieldAttributes(int32_t cpIndex, TR_J9Met
    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
       {
       // First, search a global cache
-      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &attributesCache = getAttributesCache(isStatic);
       auto it = attributesCache.find(cpIndex);
       if (it != attributesCache.end())
@@ -563,7 +563,7 @@ TR_ResolvedJ9JITServerMethod::cacheFieldAttributes(int32_t cpIndex, const TR_J9M
    else
       {
       // field is resolved in CP, can cache globally per RAM class.
-      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &attributesCache = getAttributesCache(isStatic);
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
       TR_ASSERT(canCacheFieldAttributes(cpIndex, attributes, isStatic), "new and cached field attributes are not equal");
@@ -608,7 +608,7 @@ TR_ResolvedJ9JITServerMethod::fieldAttributes(TR::Compilation * comp, I_32 cpInd
       {
       TR_ASSERT(validateMethodFieldAttributes(attributes, isStatic, cpIndex, isStore, needAOTValidation), "field attributes from client and cache do not match");
       }
-   
+
    bool result;
    attributes.setMethodFieldAttributesResult(fieldOffset, type, volatileP, isFinal, isPrivate, unresolvedInCP, &result);
    return result;
@@ -705,7 +705,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedSpecialMethod(TR::Compilation * comp, I
    {
    // JITServer TODO: Decide whether the counters should be updated on the server or the client
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-   
+
    auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) _fe->_compInfoPT;
    TR_ResolvedMethod *resolvedMethod = NULL;
    TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *) _ramClass;
@@ -837,7 +837,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedInterfaceMethod(TR::Compilation * comp,
    TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *) _ramClass;
    if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::Interface, clazz, cpIndex, classObject), this, &resolvedMethod))
       return resolvedMethod;
-   
+
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedInterfaceMethodAndMirror_3, getPersistentIdentifier(), classObject, cpIndex, _remoteMirror);
    auto recv = _stream->read<bool, J9Method*, TR_ResolvedJ9JITServerMethodInfo>();
    bool resolved = std::get<0>(recv);
@@ -916,7 +916,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(TR::Compilation
       // check for cache first
       auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) _fe->_compInfoPT;
       TR_ResolvedMethod * resolvedMethod = NULL;
-      if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::ImproperInterface, (TR_OpaqueClassBlock *) _ramClass, cpIndex), this, &resolvedMethod)) 
+      if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::ImproperInterface, (TR_OpaqueClassBlock *) _ramClass, cpIndex), this, &resolvedMethod))
          return resolvedMethod;
 
       // query for resolved method and create its mirror at the same time
@@ -972,7 +972,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(TR::Compilation * comp, T
    TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *) _ramClass;
    TR_ResolvedMethod *resolvedMethod = NULL;
    // If method is already cached, return right away
-   if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::VirtualFromOffset, clazz, virtualCallOffset, classObject), this, &resolvedMethod)) 
+   if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::VirtualFromOffset, clazz, virtualCallOffset, classObject), this, &resolvedMethod))
       return resolvedMethod;
 
    // Remote call finds RAM method at offset and creates a resolved method at the client
@@ -1041,7 +1041,7 @@ TR_ResolvedJ9JITServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)
          strncmp("java/lang/String", comp->signature(), 16) == 0 ||
          strncmp("sun/nio/", comp->signature(), 8) == 0
          );
- 
+
    if (!candidate)
       {
       return false;
@@ -1343,7 +1343,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodMirror(TR_ResolvedJ9JITServerM
    if (!((TR_J9VMBase *) fe)->isAOT_DEPRECATED_DO_NOT_USE())
       resolvedMethod = new (trMemory->trHeapMemory()) TR_ResolvedJ9Method(method, fe, trMemory, owningMethod, vTableSlot);
    else
-      resolvedMethod = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9Method(method, fe, trMemory, owningMethod, vTableSlot); 
+      resolvedMethod = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9Method(method, fe, trMemory, owningMethod, vTableSlot);
    if (!resolvedMethod) throw std::bad_alloc();
 
    packMethodInfo(methodInfo, resolvedMethod, fe);
@@ -1358,7 +1358,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(TR_Resolved
    // Resolved method can be NULL.
    TR_ASSERT(owningMethod, "owning method cannot be NULL");
    TR_ResolvedJ9Method *resolvedMethod = NULL;
-   // The simplest solution would be to call owningMethod->createResolvedMethodFromJ9Method(...) here. 
+   // The simplest solution would be to call owningMethod->createResolvedMethodFromJ9Method(...) here.
    // Thanks to polymorphism, the correct version of the resolved method would be initialized and everything would be simple.
    // However, createResolvedMethodFromJ9Method is declared protected in TR_ResolvedJ9Method, so we can't call it here.
    // Maybe we should make it public, but that would require changing baseline.
@@ -1430,8 +1430,8 @@ TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &m
    J9Class *cpHdr = J9_CLASS_FROM_CP(literals);
 
    J9Method *j9method = resolvedMethod->ramMethod();
-  
-   // fill-in struct fields 
+
+   // fill-in struct fields
    methodInfoStruct.remoteMirror = resolvedMethod;
    methodInfoStruct.literals = literals;
    methodInfoStruct.ramClass = cpHdr;
@@ -1451,6 +1451,7 @@ TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &m
    methodInfoStruct.isLambdaFormGeneratedMethod = static_cast<TR_J9VMBase *>(fe)->isLambdaFormGeneratedMethod(resolvedMethod);
    methodInfoStruct.isForceInline = static_cast<TR_J9VMBase *>(fe)->isForceInline(resolvedMethod);
    methodInfoStruct.isDontInline = static_cast<TR_J9VMBase *>(fe)->isDontInline(resolvedMethod);
+   methodInfoStruct.isIntrinsicCandidate = static_cast<TR_J9VMBase *>(fe)->isIntrinsicCandidate(resolvedMethod);
 
    TR_PersistentJittedBodyInfo *bodyInfo = NULL;
    // Method may not have been compiled
@@ -1475,8 +1476,8 @@ void
 TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
    {
    auto &methodInfoStruct = std::get<0>(methodInfo);
-   
-   
+
+
    _ramMethod = (J9Method *)aMethod;
 
    _remoteMirror = methodInfoStruct.remoteMirror;
@@ -1498,7 +1499,7 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    _isInterpreted = methodInfoStruct.isInterpreted;
    _isJNINative = methodInfoStruct.isJNINative;
    _isMethodInValidLibrary = methodInfoStruct.isMethodInValidLibrary;
-   
+
    TR::RecognizedMethod mandatoryRm = methodInfoStruct.mandatoryRm;
    TR::RecognizedMethod rm = methodInfoStruct.rm;
 
@@ -1509,26 +1510,27 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    _isLambdaFormGeneratedMethod = methodInfoStruct.isLambdaFormGeneratedMethod;
    _isForceInline = methodInfoStruct.isForceInline;
    _isDontInline = methodInfoStruct.isDontInline;
+   _isIntrinsicCandidate = methodInfoStruct.isIntrinsicCandidate;
 
    auto &bodyInfoStr = std::get<1>(methodInfo);
    auto &methodInfoStr = std::get<2>(methodInfo);
 
    _bodyInfo = J9::Recompilation::persistentJittedBodyInfoFromString(bodyInfoStr, methodInfoStr, trMemory);
- 
+
    // initialization from TR_J9Method constructor
    _className = J9ROMCLASS_CLASSNAME(_romClass);
    _name = J9ROMMETHOD_NAME(_romMethod);
    _signature = J9ROMMETHOD_SIGNATURE(_romMethod);
    parseSignature(trMemory);
    _fullSignature = NULL;
-  
+
    setMandatoryRecognizedMethod(mandatoryRm);
    setRecognizedMethod(rm);
 
    JITServerIProfiler *iProfiler = (JITServerIProfiler *) ((TR_J9VMBase *) fe)->getIProfiler();
    const std::string &entryStr = std::get<3>(methodInfo);
    const auto serialEntry = (TR_ContiguousIPMethodHashTableEntry*) &entryStr[0];
-   _iProfilerMethodEntry = (iProfiler && !entryStr.empty()) ? iProfiler->deserializeMethodEntry(serialEntry, trMemory) : NULL; 
+   _iProfilerMethodEntry = (iProfiler && !entryStr.empty()) ? iProfiler->deserializeMethodEntry(serialEntry, trMemory) : NULL;
    }
 
 bool
@@ -1808,7 +1810,7 @@ TR_ResolvedJ9JITServerMethod::validateMethodFieldAttributes(const TR_J9MethodFie
    // because unresolved attribute might have become resolved during the current compilation
    // so validation would fail, but since it does not affect functional correctness,
    // we'll just keep the cached result until the end of the compilation.
-   if (attributes.isUnresolvedInCP()) 
+   if (attributes.isUnresolvedInCP())
       return true;
    if (!isStatic)
       _stream->write(JITServer::MessageType::ResolvedMethod_fieldAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
@@ -2140,7 +2142,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method(TR::Co
    _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, getRemoteMirror(), j9method, cpIndex, vTableSlot);
    auto recv = _stream->read<TR_ResolvedJ9JITServerMethodInfo, bool, bool, bool>();
    auto &methodInfo = std::get<0>(recv);
-   // These parameters are only needed to update AOT stats. 
+   // These parameters are only needed to update AOT stats.
    // Maybe we shouldn't even track them, because another version of this method doesn't.
    bool isRomClassForMethodInSharedCache = std::get<1>(recv);
    bool sameClassLoaders = std::get<2>(recv);
@@ -2239,7 +2241,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::startAddressForInterpreterOfJittedMetho
    return ((J9Method *)getNonPersistentIdentifier())->extra;
    }
 
-TR_OpaqueClassBlock * 
+TR_OpaqueClassBlock *
 TR_ResolvedRelocatableJ9JITServerMethod::definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock **fromResolvedJ9Method)
    {
    TR_OpaqueClassBlock *resolvedClass = TR_ResolvedJ9JITServerMethod::definingClassFromCPFieldRef(comp, cpIndex, isStatic);
@@ -2439,7 +2441,7 @@ bool
 TR_ResolvedRelocatableJ9JITServerMethod::fieldAttributes(TR::Compilation * comp, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-   
+
    // Will search per-resolved method cache and make a remote call if needed, client will call AOT version of the method.
    // We still need to create a validation record, and if it can't be added, change
    // return values appropriately.
@@ -2453,7 +2455,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::fieldAttributes(TR::Compilation * comp,
       _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_fieldAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes>();
       attributes = std::get<0>(recv);
-      
+
       cacheFieldAttributes(cpIndex, attributes, isStatic);
       }
    else
@@ -2497,7 +2499,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::fieldAttributes(TR::Compilation * comp,
    if (!fieldInfoCanBeUsed)
       {
       theFieldIsFromLocalClass = false;
-      // Either couldn't create validation record 
+      // Either couldn't create validation record
       // or AOT instance field resolution is disabled.
       if (volatileP) *volatileP = true;
       if (isFinal) *isFinal = false;
@@ -2535,7 +2537,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes(TR::Compilation * comp
       _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_staticAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes>();
       attributes = std::get<0>(recv);
-      
+
       cacheFieldAttributes(cpIndex, attributes, isStatic);
       }
    else
@@ -2578,7 +2580,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes(TR::Compilation * comp
    if (!fieldInfoCanBeUsed)
       {
       theFieldIsFromLocalClass = false;
-      // Either couldn't create validation record 
+      // Either couldn't create validation record
       // or AOT instance field resolution is disabled.
       if (volatileP) *volatileP = true;
       if (isFinal) *isFinal = false;
@@ -2594,7 +2596,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::getAttributesCache(bool isStatic, bool 
    {
    // Return persistent attributes cache for AOT compilations
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
-   auto &attributesCache = isStatic ? 
+   auto &attributesCache = isStatic ?
       getJ9ClassInfo(compInfoPT, _ramClass)._staticAttributesCacheAOT :
       getJ9ClassInfo(compInfoPT, _ramClass)._fieldAttributesCacheAOT;
    return attributesCache;
@@ -2607,7 +2609,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::validateMethodFieldAttributes(const TR_
    // because unresolved attribute might have become resolved during the current compilation
    // so validation would fail, but since it does not affect functional correctness,
    // we'll just keep the cached result until the end of the compilation.
-   if (attributes.isUnresolvedInCP()) 
+   if (attributes.isUnresolvedInCP())
       return true;
    if (!isStatic)
       _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_fieldAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -54,6 +54,7 @@ TR_ResolvedJ9JITServerMethodInfoStruct
    bool isLambdaFormGeneratedMethod;
    bool isForceInline;
    bool isDontInline;
+   bool isIntrinsicCandidate;
    };
 
 
@@ -219,6 +220,7 @@ public:
    virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic) override;
    bool isForceInline() const { return _isForceInline; }
    bool isDontInline() const { return _isDontInline; }
+   bool isIntrinsicCandidate() const { return _isIntrinsicCandidate; }
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
@@ -258,6 +260,7 @@ private:
    bool _isLambdaFormGeneratedMethod;
    bool _isForceInline;
    bool _isDontInline;
+   bool _isIntrinsicCandidate;
 
    void unpackMethodInfo(TR_OpaqueMethodBlock *aMethod, TR_FrontEnd *fe, TR_Memory *trMemory, uint32_t vTableSlot,
                          TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 49; // ID: C3VbnDEdGq49br7YGAxK
+   static const uint16_t MINOR_NUMBER = 50; // ID: rTTHu2gMya2I5Wwu3nGy
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -431,6 +431,15 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       return true;
       }
 
+   if (calleeMethod->getRecognizedMethod() == TR::unknownMethod &&
+       comp()->fej9()->isIntrinsicCandidate(calleeMethod) &&
+       !comp()->getOption(TR_DisableInliningUnrecognizedIntrinsics))
+      {
+      if (comp()->trace(OMR::inlining))
+         traceMsg(comp(), "@IntrinsicCandidate was specified for %s, in alwaysWorthInlining\n", calleeMethod->signature(comp()->trMemory()));
+      return true;
+      }
+
    return false;
    }
 
@@ -2177,6 +2186,15 @@ TR_J9InlinerPolicy::tryToInline(TR_CallTarget * calltarget, TR_CallStack * callS
             traceMsg(comp(), "@ForceInline was specified for %s, in tryToInline\n", method->signature(comp()->trMemory()));
          return true;
          }
+
+      if (method->getRecognizedMethod() == TR::unknownMethod &&
+          comp()->fej9()->isIntrinsicCandidate(method) &&
+          !comp()->getOption(TR_DisableInliningUnrecognizedIntrinsics))
+         {
+         if (comp()->trace(OMR::inlining))
+            traceMsg(comp(), "@IntrisicCandidate was specified for %s, in tryToInline\n", method->signature(comp()->trMemory()));
+         return true;
+         }
       }
    else
       {
@@ -2443,6 +2461,16 @@ TR_J9InlinerPolicy::callMustBeInlinedInCold(TR_ResolvedMethod *method)
          return true;
          }
       }
+
+   if (method->getRecognizedMethod() == TR::unknownMethod &&
+       comp()->fej9()->isIntrinsicCandidate(method) &&
+       !comp()->getOption(TR_DisableInliningUnrecognizedIntrinsics))
+      {
+      if (comp()->trace(OMR::inlining))
+         traceMsg(comp(), "@IntrinsicCandidate was specified for %s, in callMustBeInlined\n", method->signature(comp()->trMemory()));
+      return true;
+      }
+
 
    return false;
    }


### PR DESCRIPTION
- if method annotated IntrinsicCandidate is not a recognized
  method and, therefore, most likely not treated as an intrinsic
  it's probably beneficial to inline it

- force inlining of methods annotated as IntrinsicCandidate
  unless they are recognized methods

- this inlining can be disabled with -Xjit:disableInliningUnrecognizedIntrinsics


Depends https://github.com/eclipse/omr/pull/7080