### PR TITLE
Update 0.38.0 release note

### DIFF
--- a/doc/release-notes/0.38/0.38.md
+++ b/doc/release-notes/0.38/0.38.md
@@ -56,6 +56,15 @@ The following table covers notable changes in v0.38.0. Further information about
 <td valign="top">The Visual Studio redistributable files included with the build are updated to match.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16532">#16532</a></td>
+<td valign="top">Support for running OpenJDK 8 and OpenJDK 11 on CentOS 6.10 is deprecated and might be removed in a future release.</td>
+<td valign="top">OpenJDK 8 and 11 (CentOS 6.10)</td>
+<td valign="top">OpenJ9 no longer tests OpenJDK 11 on CentOS 6.10 after 0.36.1 release and might stop testing OpenJDK 8 in the future.</td>
+</tr>
+
+
+
 
 
 </tbody>


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9/issues/16788

Updated the document with support for running OpenJDK 8 and OpenJDK 11 on CentOS 6.10 is deprecated

[skip ci]
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>