### PR TITLE
Prepare MM_Scheduler for OMR Base Class Changes

### DIFF
--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -763,6 +763,19 @@ void MM_Scheduler::yieldFromGC(MM_EnvironmentRealtime *env, bool distanceChecked
 }
 
 void
+MM_Scheduler::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
+{
+	uintptr_t activeThreads = recomputeActiveThreadCountForTask(env, task, newThreadCount);
+	task->mainSetup(env);
+	prepareThreadsForTask(env, task, activeThreads);
+	acceptTask(env);
+	task->run(env);
+	completeTask(env);
+	cleanupAfterTask(env);
+	task->mainCleanup(env);
+}
+
+void
 MM_Scheduler::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount)
 {
 	omrthread_monitor_enter(_workerThreadMutex);

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -244,6 +244,8 @@ public:
 	virtual void prepareForCheckpoint(MM_EnvironmentBase *env, uintptr_t newThreadCount) {};
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+	virtual void run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount = UDATA_MAX);
+
 	MM_Scheduler(MM_EnvironmentBase *env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize) :
 		MM_ParallelDispatcher(env, handler, handler_arg, defaultOSStackSize),
 		_mutatorStartTimeInNanos(J9CONST64(0)),


### PR DESCRIPTION
Intermediate changes required to  commit upstream OMR changes to base class MM_ParallelDispatcher.

see https://github.com/eclipse/omr/pull/6954

Signed-off-by: Salman Rana <salman.rana@ibm.com>       