### PR TITLE
Stop exporting functions not needed for Java 21

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -156,7 +156,6 @@ jvm_add_exports(jvm
 	_JVM_GetStackTraceDepth@8
 	_JVM_FillInStackTrace@8
 	_JVM_StartThread@8
-	_JVM_IsThreadAlive@8
 	_JVM_SetThreadPriority@12
 	_JVM_Yield@8
 	_JVM_CurrentThread@8
@@ -389,15 +388,19 @@ endif()
 
 if(NOT JAVA_SPEC_VERSION LESS 19)
 	jvm_add_exports(jvm
-		JVM_LoadZipLibrary
-		JVM_RegisterContinuationMethods
 		JVM_IsContinuationsSupported
 		JVM_IsPreviewEnabled
-		JVM_VirtualThreadMountBegin
-		JVM_VirtualThreadMountEnd
-		JVM_VirtualThreadUnmountBegin
-		JVM_VirtualThreadUnmountEnd
+		JVM_LoadZipLibrary
+		JVM_RegisterContinuationMethods
 	)
+	if(JAVA_SPEC_VERSION LESS 21)
+		jvm_add_exports(jvm
+			JVM_VirtualThreadMountBegin
+			JVM_VirtualThreadMountEnd
+			JVM_VirtualThreadUnmountBegin
+			JVM_VirtualThreadUnmountEnd
+		)
+	endif()
 endif()
 
 if(JAVA_SPEC_VERSION LESS 20)
@@ -413,7 +416,11 @@ else()
 	)
 endif()
 
-if(NOT JAVA_SPEC_VERSION LESS 21)
+if(JAVA_SPEC_VERSION LESS 21)
+	jvm_add_exports(jvm
+		_JVM_IsThreadAlive@8
+	)
+else()
 	jvm_add_exports(jvm
 		JVM_VirtualThreadMount
 		JVM_VirtualThreadUnmount

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1687,7 +1687,7 @@ JVM_IsSupportedJNIVersion(jint version)
 }
 
 
-
+#if JAVA_SPEC_VERSION < 21
 jboolean JNICALL
 JVM_IsThreadAlive(JNIEnv* jniEnv, jobject targetThread)
 {
@@ -1702,7 +1702,7 @@ JVM_IsThreadAlive(JNIEnv* jniEnv, jobject targetThread)
 	/* Assume that a non-null threadRef indicates the thread is alive */
 	return (NULL == vmThread) ? JNI_FALSE : JNI_TRUE;
 }
-
+#endif /* JAVA_SPEC_VERSION < 21 */
 
 
 jobject JNICALL

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -169,7 +169,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_StopThread@12">
 			<exclude-if condition="spec.java20"/>
 		</export>
-		<export name="_JVM_IsThreadAlive@8"/>
+		<export name="_JVM_IsThreadAlive@8">
+			<exclude-if condition="spec.java21"/>
+		</export>
 		<export name="_JVM_SuspendThread@8">
 			<exclude-if condition="spec.java20"/>
 		</export>
@@ -405,13 +407,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_LoadZipLibrary"/>
 
 		<!-- Additions for Java 19 (VirtualThread) -->
-		<export name="JVM_RegisterContinuationMethods"/>
 		<export name="JVM_IsContinuationsSupported"/>
 		<export name="JVM_IsPreviewEnabled"/>
-		<export name="JVM_VirtualThreadMountBegin"/>
-		<export name="JVM_VirtualThreadMountEnd"/>
-		<export name="JVM_VirtualThreadUnmountBegin"/>
-		<export name="JVM_VirtualThreadUnmountEnd"/>
+		<export name="JVM_RegisterContinuationMethods"/>
+		<!-- Removed in Java 21. -->
+		<export name="JVM_VirtualThreadMountBegin">
+			<exclude-if condition="spec.java21"/>
+		</export>
+		<export name="JVM_VirtualThreadMountEnd">
+			<exclude-if condition="spec.java21"/>
+		</export>
+		<export name="JVM_VirtualThreadUnmountBegin">
+			<exclude-if condition="spec.java21"/>
+		</export>
+		<export name="JVM_VirtualThreadUnmountEnd">
+			<exclude-if condition="spec.java21"/>
+		</export>
 	</exports>
 
 	<exports group="jdk20">

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -181,7 +181,8 @@ _X(JVM_IsInterface,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
 _X(JVM_IsInterrupted,JNICALL,true,jboolean,JNIEnv *env, jobject thread, jboolean unknown)
 _X(JVM_IsPrimitiveClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
 _X(JVM_IsSupportedJNIVersion,JNICALL,true,jboolean,jint jniVersion)
-_X(JVM_IsThreadAlive,JNICALL,true,jboolean,JNIEnv *env, jobject targetThread)
+_IF([JAVA_SPEC_VERSION < 21],
+	[_X(JVM_IsThreadAlive,JNICALL,true,jboolean,JNIEnv *env, jobject targetThread)])
 _X(JVM_NewArray,JNICALL,true,jobject,JNIEnv *env, jclass componentType, jint dimension)
 _X(JVM_NewMultiArray,JNICALL,true,jobject,JNIEnv *env, jclass eltClass, jintArray dim)
 _X(JVM_ResolveClass,JNICALL,true,jobject,jint arg0, jint arg1)
@@ -392,13 +393,13 @@ _IF([JAVA_SPEC_VERSION >= 19],
 	[_X(JVM_IsContinuationsSupported, JNICALL, false, void, void)])
 _IF([JAVA_SPEC_VERSION >= 19],
 	[_X(JVM_IsPreviewEnabled, JNICALL, false, void, void)])
-_IF([JAVA_SPEC_VERSION >= 19],
+_IF([(19 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 21)],
 	[_X(JVM_VirtualThreadMountBegin, JNICALL, false, void, JNIEnv *env, jobject thread, jboolean firstMount)])
-_IF([JAVA_SPEC_VERSION >= 19],
+_IF([(19 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 21)],
 	[_X(JVM_VirtualThreadMountEnd, JNICALL, false, void, JNIEnv *env, jobject thread, jboolean firstMount)])
-_IF([JAVA_SPEC_VERSION >= 19],
+_IF([(19 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 21)],
 	[_X(JVM_VirtualThreadUnmountBegin, JNICALL, false, void, JNIEnv *env, jobject thread, jboolean lastUnmount)])
-_IF([JAVA_SPEC_VERSION >= 19],
+_IF([(19 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 21)],
 	[_X(JVM_VirtualThreadUnmountEnd, JNICALL, false, void, JNIEnv *env, jobject thread, jboolean lastUnmount)])
 _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])


### PR DESCRIPTION
These functions are no longer required by Java 21:
  * JVM_IsThreadAlive
  * JVM_VirtualThreadMountBegin
  * JVM_VirtualThreadMountEnd
  * JVM_VirtualThreadUnmountBegin
  * JVM_VirtualThreadUnmountEnd

See https://github.com/eclipse-openj9/openj9/pull/16985#discussion_r1146431459