### PR TITLE
[FFI/0.38.0] Handling the captured exceptions for the upcall method

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5289,6 +5289,7 @@ typedef struct J9VMThread {
 #if JAVA_SPEC_VERSION >= 16
 	U_64 *ffiArgs;
 	UDATA ffiArgCount;
+	void *jmpBufEnvPtr;
 #endif /* JAVA_SPEC_VERSION >= 16 */
 #if JAVA_SPEC_VERSION >= 19
 	J9VMContinuation *currentContinuation;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -129,6 +129,17 @@ extern void CEEJNIWrapper(J9VMThread *currentThread);
 }
 #endif /* J9VM_PORT_ZOS_CEEHDLRSUPPORT */
 
+#if JAVA_SPEC_VERSION >= 16
+extern "C" {
+extern void
+#if FFI_NATIVE_RAW_API
+ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *function, UDATA *returnStorage, void **values, ffi_raw *values_raw);
+#else /* FFI_NATIVE_RAW_API */
+ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *function, UDATA *returnStorage, void **values);
+#endif /* FFI_NATIVE_RAW_API */
+}
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
 class INTERPRETER_CLASS
 {
 /*
@@ -5141,10 +5152,9 @@ done:
 		VM_VMAccess::inlineExitVMToJNI(_currentThread);
 		VM_VMHelpers::beforeJNICall(_currentThread);
 #if FFI_NATIVE_RAW_API
-		ffi_ptrarray_to_raw(cif, values, values_raw);
-		ffi_raw_call(cif, FFI_FN(function), returnStorage, values_raw);
+		ffiCallWithSetJmpForUpcall(_currentThread, cif, function, returnStorage, values, values_raw);
 #else /* FFI_NATIVE_RAW_API */
-		ffi_call(cif, FFI_FN(function), returnStorage, values);
+		ffiCallWithSetJmpForUpcall(_currentThread, cif, function, returnStorage, values);
 #endif /* FFI_NATIVE_RAW_API */
 		VM_VMHelpers::afterJNICall(_currentThread);
 		VM_VMAccess::inlineEnterVMFromJNI(_currentThread);

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -168,6 +168,7 @@ set(main_sources
 	threadhelp.cpp
 	threadpark.c
 	throwexception.c
+	UpcallExceptionHandler.cpp
 	UpcallThunkMem.cpp
 	UpcallVMHelpers.cpp
 	ValueTypeHelpers.cpp

--- a/runtime/vm/UpcallExceptionHandler.cpp
+++ b/runtime/vm/UpcallExceptionHandler.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ut_j9vm.h"
+#include "vm_internal.h"
+#if JAVA_SPEC_VERSION >= 16
+#include "ffi.h"
+#include <setjmp.h>
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+/**
+ * @brief Save the contents of registers in the call-out for longjmp in
+ * the dispatcher to restore back to this call site whenever an exception
+ * is captured in upcall.
+ *
+ * See the invocation of longjmp in native2InterpJavaUpcallImpl()
+ * at UpcallVMHelpers.cpp for details.
+ *
+ * Note: this is a wrapper for setjmp() as a function calling
+ * setjmp() can never be inlined as captured in compilation.
+ *
+ * @param currentThread[in] The pointer to the current J9VMThread
+ * @param cif[in] The pointer to the ffi_cif structure
+ * @param function[in] The pointer to the native function address
+ * @param returnStorage[in] The pointer to the return value
+ * @param values[in] The pointer to an array of the passed-in arguments
+ * @param values_raw[in] The pointer to the ffi_raw structure for the defined FFI_NATIVE_RAW_API
+ */
+void
+#if FFI_NATIVE_RAW_API
+ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *function, UDATA *returnStorage, void **values, ffi_raw *values_raw)
+#else /* FFI_NATIVE_RAW_API */
+ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *function, UDATA *returnStorage, void **values)
+#endif /* FFI_NATIVE_RAW_API */
+{
+	jmp_buf jmpBufferEnv = {0};
+	void *jmpBufEnvPtr = currentThread->jmpBufEnvPtr;
+
+	/* We only need to restore back to the latest call-out from the dispatcher
+	 * to throw the exception in the case of recursive calls, in which case
+	 * the jump buffer (storing the contents of registers) should be allocated
+	 * every time in downcall.
+	 */
+	currentThread->jmpBufEnvPtr = (void *)&jmpBufferEnv;
+
+	if (!setjmp(jmpBufferEnv)) {
+#if FFI_NATIVE_RAW_API
+		ffi_ptrarray_to_raw(cif, values, values_raw);
+		ffi_raw_call(cif, FFI_FN(function), returnStorage, values_raw);
+#else /* FFI_NATIVE_RAW_API */
+		ffi_call(cif, FFI_FN(function), returnStorage, values);
+#endif /* FFI_NATIVE_RAW_API */
+	}
+	currentThread->jmpBufEnvPtr = jmpBufEnvPtr;
+}
+
+/**
+ * @brief This function serves as a wrapper of longjmp that restore back to
+ * the call site with all registered saved via setjmp whenever an exception
+ * is captured in upcall.
+ *
+ * See the invocation of longjmp in native2InterpJavaUpcallImpl()
+ * at UpcallVMHelpers.cpp for details.
+ *
+ * @param currentThread[in] The pointer to the current J9VMThread
+ */
+void longJumpWrapperForUpall(J9VMThread *currentThread)
+{
+	jmp_buf *jmpBufEnvPtr = (jmp_buf *)(currentThread->jmpBufEnvPtr);
+	Assert_VM_notNull(jmpBufEnvPtr);
+
+#if defined(J9VM_ENV_DATA64) && defined(WIN32)
+	/* longjmp() results in the OS walking the stack on Windows which calls C++ destructor
+	 * that is not required in our code given the builder stack frames aren't walkable
+	 * in our theory. To work around this issue, we have to set the Frame to 0 (undocumented
+	 * in any Windows API) to get it work.
+	 */
+	((struct _JUMP_BUFFER*)jmpBufEnvPtr)->Frame = 0;
+#endif /* defined(J9VM_ENV_DATA64) && defined(WIN32) */
+
+	longjmp(*jmpBufEnvPtr, 1);
+}
+
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -258,6 +258,7 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 #if JAVA_SPEC_VERSION >= 16
 	newThread->ffiArgs = NULL;
 	newThread->ffiArgCount = 0;
+	newThread->jmpBufEnvPtr = NULL;
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 19

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/InvalidUpCallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/InvalidUpCallTests.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep389.upcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import static org.testng.Assert.fail;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.CLinker;
+import static jdk.incubator.foreign.CLinker.*;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.SymbolLookup;
+import jdk.incubator.foreign.ValueLayout;
+
+/**
+ * Test cases for JEP 389: Foreign Linker API (Incubator) for argument/return struct in upcall
+ * which verify the illegal cases specific to the return value.
+ */
+@Test(groups = { "level.sanity" })
+public class InvalidUpCallTests {
+	private static CLinker clinker = CLinker.getInstance();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "An exception is thrown from the upcall method")
+	public void test_throwExceptionFromUpcallMethod() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_INT.withName("elem1"), C_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(int.class, PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(int.class, PathElement.groupElement("elem2"));
+
+		MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class, MemorySegment.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(structLayout, structLayout, structLayout, C_POINTER);
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntStructs_returnStructByUpcallMH").get();
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MethodHandle mh = clinker.downcallHandle(functionSymbol, allocator, mt, fd);
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(UpcallMethodHandles.MH_add2IntStructs_returnStruct_throwException,
+					FunctionDescriptor.of(structLayout, structLayout, structLayout), scope);
+
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 11223344);
+			intHandle2.set(structSegmt1, 55667788);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 99001122);
+			intHandle2.set(structSegmt2, 33445566);
+
+			MemorySegment resultSegmt = (MemorySegment)mh.invokeExact(structSegmt1, structSegmt2, upcallFuncAddr);
+			fail("Failed to throw out IllegalArgumentException from the the upcall method");
+		}
+	}
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
@@ -184,6 +184,7 @@ public class UpcallMethodHandles {
 	public static final MethodHandle MH_addIntAndIntsFromStructWithNestedStructArray;
 	public static final MethodHandle MH_addIntAndIntsFromStructWithNestedStructArray_reverseOrder;
 	public static final MethodHandle MH_add2IntStructs_returnStruct;
+	public static final MethodHandle MH_add2IntStructs_returnStruct_throwException;
 	public static final MethodHandle MH_add2IntStructs_returnStructPointer;
 	public static final MethodHandle MH_add3IntStructs_returnStruct;
 
@@ -382,6 +383,7 @@ public class UpcallMethodHandles {
 			MH_addIntAndIntsFromStructWithNestedStructArray = lookup.findStatic(UpcallMethodHandles.class, "addIntAndIntsFromStructWithNestedStructArray", MT_Int_Int_MemSegmt); //$NON-NLS-1$
 			MH_addIntAndIntsFromStructWithNestedStructArray_reverseOrder = lookup.findStatic(UpcallMethodHandles.class, "addIntAndIntsFromStructWithNestedStructArray_reverseOrder", MT_Int_Int_MemSegmt); //$NON-NLS-1$
 			MH_add2IntStructs_returnStruct = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStruct", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
+			MH_add2IntStructs_returnStruct_throwException = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStruct_throwException", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
 			MH_add2IntStructs_returnStructPointer = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStructPointer", MT_MemAddr_MemAddr_MemSegmt); //$NON-NLS-1$
 			MH_add3IntStructs_returnStruct = lookup.findStatic(UpcallMethodHandles.class, "add3IntStructs_returnStruct", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
 
@@ -1582,6 +1584,10 @@ public class UpcallMethodHandles {
 		intHandle1.set(intStructSegmt, intStruct_Elem1);
 		intHandle2.set(intStructSegmt, intStruct_Elem2);
 		return intStructSegmt;
+	}
+
+	public static MemorySegment add2IntStructs_returnStruct_throwException(MemorySegment arg1, MemorySegment arg2) {
+		throw new IllegalArgumentException("An exception is thrown from the upcall method");
 	}
 
 	public static MemoryAddress add2IntStructs_returnStructPointer(MemoryAddress arg1Addr, MemorySegment arg2) {

--- a/test/functional/Java17andUp/testng_170.xml
+++ b/test/functional/Java17andUp/testng_170.xml
@@ -42,6 +42,7 @@
 	</test>
 	<test name="Jep389Tests_testClinkerFfi_UpCall">
 		<classes>
+			<class name="org.openj9.test.jep389.upcall.InvalidUpCallTests"/>
 			<class name="org.openj9.test.jep389.upcall.MultiUpcallMHTests"/>
 			<class name="org.openj9.test.jep389.upcall.MultiUpcallThrdsMHTests1"/>
 			<class name="org.openj9.test.jep389.upcall.MultiUpcallThrdsMHTests2"/>

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/InvalidUpCallTests.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/InvalidUpCallTests.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.jep424.upcall;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import static org.testng.Assert.fail;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import java.lang.foreign.Addressable;
+import java.lang.foreign.Linker;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import static java.lang.foreign.ValueLayout.*;
+
+/**
+ * Test cases for JEP 424: Foreign Linker API (Preview) for argument/return struct in upcall,
+ * which verify the illegal cases specific to the return value.
+ */
+@Test(groups = { "level.sanity" })
+public class InvalidUpCallTests {
+	private static Linker linker = Linker.nativeLinker();
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "An exception is thrown from the upcall method")
+	public void test_throwExceptionFromUpcallMethod() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_INT.withName("elem1"), JAVA_INT.withName("elem2"));
+		VarHandle intHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle intHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(structLayout, structLayout, structLayout, ADDRESS);
+		Addressable functionSymbol = nativeLibLookup.lookup("add2IntStructs_returnStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (MemorySession session = MemorySession.openConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_add2IntStructs_returnStruct_throwException,
+					FunctionDescriptor.of(structLayout, structLayout, structLayout), session);
+			SegmentAllocator allocator = SegmentAllocator.newNativeArena(session);
+			MemorySegment structSegmt1 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt1, 11223344);
+			intHandle2.set(structSegmt1, 55667788);
+			MemorySegment structSegmt2 = allocator.allocate(structLayout);
+			intHandle1.set(structSegmt2, 99001122);
+			intHandle2.set(structSegmt2, 33445566);
+
+			MemorySegment resultSegmt = (MemorySegment)mh.invoke(allocator, structSegmt1, structSegmt2, upcallFuncAddr);
+			fail("Failed to throw out IllegalArgumentException from the the upcall method");
+		}
+	}
+}

--- a/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java19andUp/src/org/openj9/test/jep424/upcall/UpcallMethodHandles.java
@@ -182,6 +182,7 @@ public class UpcallMethodHandles {
 	public static final MethodHandle MH_addIntAndIntsFromStructWithNestedStructArray;
 	public static final MethodHandle MH_addIntAndIntsFromStructWithNestedStructArray_reverseOrder;
 	public static final MethodHandle MH_add2IntStructs_returnStruct;
+	public static final MethodHandle MH_add2IntStructs_returnStruct_throwException;
 	public static final MethodHandle MH_add2IntStructs_returnStructPointer;
 	public static final MethodHandle MH_add3IntStructs_returnStruct;
 
@@ -380,6 +381,7 @@ public class UpcallMethodHandles {
 			MH_addIntAndIntsFromStructWithNestedStructArray = lookup.findStatic(UpcallMethodHandles.class, "addIntAndIntsFromStructWithNestedStructArray", MT_Int_Int_MemSegmt); //$NON-NLS-1$
 			MH_addIntAndIntsFromStructWithNestedStructArray_reverseOrder = lookup.findStatic(UpcallMethodHandles.class, "addIntAndIntsFromStructWithNestedStructArray_reverseOrder", MT_Int_Int_MemSegmt); //$NON-NLS-1$
 			MH_add2IntStructs_returnStruct = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStruct", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
+			MH_add2IntStructs_returnStruct_throwException = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStruct_throwException", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
 			MH_add2IntStructs_returnStructPointer = lookup.findStatic(UpcallMethodHandles.class, "add2IntStructs_returnStructPointer", MT_Addr_MemAddr_MemSegmt); //$NON-NLS-1$
 			MH_add3IntStructs_returnStruct = lookup.findStatic(UpcallMethodHandles.class, "add3IntStructs_returnStruct", MT_MemSegmt_MemSegmt_MemSegmt); //$NON-NLS-1$
 
@@ -1294,6 +1296,10 @@ public class UpcallMethodHandles {
 		intStructSegmt.set(JAVA_INT, 0, intStruct_Elem1);
 		intStructSegmt.set(JAVA_INT, 4, intStruct_Elem2);
 		return intStructSegmt;
+	}
+
+	public static MemorySegment add2IntStructs_returnStruct_throwException(MemorySegment arg1, MemorySegment arg2) {
+		throw new IllegalArgumentException("An exception is thrown from the upcall method");
 	}
 
 	public static Addressable add2IntStructs_returnStructPointer(MemoryAddress arg1Addr, MemorySegment arg2) {

--- a/test/functional/Java19andUp/testng_190.xml
+++ b/test/functional/Java19andUp/testng_190.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2022, 2022 IBM Corp. and others
+Copyright IBM Corp. and others 2022
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,7 @@
 	</test>
 	<test name="Jep424Tests_testLinkerFfi_UpCall">
 		<classes>
+			<class name="org.openj9.test.jep424.upcall.InvalidUpCallTests"/>
 			<class name="org.openj9.test.jep424.upcall.MultiUpcallMHTests"/>
 			<class name="org.openj9.test.jep424.upcall.MultiUpcallThrdsMHTests1"/>
 			<class name="org.openj9.test.jep424.upcall.MultiUpcallThrdsMHTests2"/>


### PR DESCRIPTION
The change exploits setjmp/longjmp to return back to the
call-out frame by skipping the native function when an
exception triggered by the upcall method is captured in
the dispatcher.

Fixes: #17232

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>