### PR TITLE
CRIU BytecodeInterpreter enables DO_HOOKS

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -537,12 +537,20 @@ CLANG_CXXFLAGS+=-std=c++0x -D_CRT_SUPPRESS_RESTRICT -DVS12AndHigher
 	CLANG_CXXFLAGS+=-D_M_X64
 </#if>
 endif
-# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, CRIUBytecodeInterpreterFull.cpp, CRIUBytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 BytecodeInterpreterFull$(UMA_DOT_O):BytecodeInterpreterFull.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
 BytecodeInterpreterCompressed$(UMA_DOT_O):BytecodeInterpreterCompressed.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+
+ifneq ($(J9VM_OPT_CRIU_SUPPORT),)
+CRIUBytecodeInterpreterFull$(UMA_DOT_O):CRIUBytecodeInterpreterFull.cpp
+	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+
+CRIUBytecodeInterpreterCompressed$(UMA_DOT_O):CRIUBytecodeInterpreterCompressed.cpp
+	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+endif
 
 DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
@@ -574,7 +582,7 @@ SharedService$(UMA_DOT_O):SharedService.c
 
 <#if uma.spec.processor.ppc>
 ifndef USE_PPC_GCC
-# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, CRIUBytecodeInterpreterFull.cpp, CRIUBytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 FLAGS_TO_REMOVE += -O3
 NEW_OPTIMIZATION_FLAG=-O2 -qdebug=lincomm:ptranl:tfbagg
 <#if uma.spec.type.linux>
@@ -588,6 +596,14 @@ BytecodeInterpreterFull$(UMA_DOT_O):BytecodeInterpreterFull.cpp
 
 BytecodeInterpreterCompressed$(UMA_DOT_O):BytecodeInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+
+ifneq ($(J9VM_OPT_CRIU_SUPPORT),)
+CRIUBytecodeInterpreterFull$(UMA_DOT_O):CRIUBytecodeInterpreterFull.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+
+CRIUBytecodeInterpreterCompressed$(UMA_DOT_O):CRIUBytecodeInterpreterCompressed.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+endif
 
 DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -526,13 +526,21 @@ bcverify$(UMA_DOT_O) : bcverify.c
 
 ifdef USE_PPC_GCC
 
-# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, CRIUBytecodeInterpreterFull.cpp, CRIUBytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 
 BytecodeInterpreterFull$(UMA_DOT_O) : BytecodeInterpreterFull.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
 
 BytecodeInterpreterCompressed$(UMA_DOT_O) : BytecodeInterpreterCompressed.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+
+ifneq ($(J9VM_OPT_CRIU_SUPPORT),)
+CRIUBytecodeInterpreterFull$(UMA_DOT_O) : CRIUBytecodeInterpreterFull.cpp
+	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+
+CRIUBytecodeInterpreterCompressed$(UMA_DOT_O) : CRIUBytecodeInterpreterCompressed.cpp
+	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+endif
 
 DebugBytecodeInterpreterFull$(UMA_DOT_O) : DebugBytecodeInterpreterFull.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -79,11 +79,9 @@
 
 #define DO_INTERPRETER_PROFILING
 #if defined(DEBUG_VERSION)
+#define DO_HOOKS
 #define DO_SINGLE_STEP
 #endif /* DEBUG_VERSION */
-#if defined(DEBUG_VERSION) || defined(J9VM_OPT_CRIU_SUPPORT)
-#define DO_HOOKS
-#endif /* defined(DEBUG_VERSION) || defined(J9VM_OPT_CRIU_SUPPORT) */
 
 typedef enum {
 	VM_NO,
@@ -10165,13 +10163,13 @@ public:
 			goto popFrames; \
 		case FALL_THROUGH: \
 			break;
-#elif defined(J9VM_OPT_CRIU_SUPPORT) /* defined(DEBUG_VERSION) */
+#elif defined(DO_HOOKS) /* defined(DEBUG_VERSION) */
 #define DEBUG_ACTIONS \
 		case REPORT_METHOD_ENTER: \
 			goto methodEnter;
-#else /* defined(J9VM_OPT_CRIU_SUPPORT) */
+#else /* defined(DO_HOOKS) */
 #define DEBUG_ACTIONS
-#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+#endif /* defined(DEBUG_VERSION) */
 
 #if JAVA_SPEC_VERSION >= 16
 #define PERFORM_ACTION_VALUE_TYPE_IMSE \

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -207,6 +207,13 @@ set(interpreter_sources
 	DebugBytecodeInterpreterFull.cpp
 )
 
+if(J9VM_OPT_CRIU_SUPPORT)
+	list(APPEND interpreter_sources
+		CRIUBytecodeInterpreterCompressed.cpp
+		CRIUBytecodeInterpreterFull.cpp
+	)
+endif()
+
 if(J9VM_OPT_METHOD_HANDLE)
 	list(APPEND interpreter_sources
 		MHInterpreterCompressed.cpp

--- a/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#define DO_HOOKS
+#define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
+#define LOOP_NAME criuBytecodeLoopCompressed
+#define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterCompressed
+#include "BytecodeInterpreter.inc"
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */

--- a/runtime/vm/CRIUBytecodeInterpreterFull.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterFull.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(OMR_GC_FULL_POINTERS)
+#define DO_HOOKS
+#define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
+#define LOOP_NAME criuBytecodeLoopFull
+#define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterFull
+#include "BytecodeInterpreter.inc"
+#endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -330,13 +330,19 @@ J9_DECLARE_CONSTANT_UTF8(j9_dispatch, "dispatch");
 /* The appropriate bytecodeLoop is selected based on interpreter mode */
 #if defined(OMR_GC_FULL_POINTERS)
 UDATA bytecodeLoopFull(J9VMThread *currentThread);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+UDATA criuBytecodeLoopFull(J9VMThread *currentThread);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 UDATA debugBytecodeLoopFull(J9VMThread *currentThread);
-#endif /* OMR_GC_FULL_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 UDATA bytecodeLoopCompressed(J9VMThread *currentThread);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+UDATA criuBytecodeLoopCompressed(J9VMThread *currentThread);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 UDATA debugBytecodeLoopCompressed(J9VMThread *currentThread);
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 #if (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME))
 static BOOLEAN isGCPolicyMetronome(J9JavaVM *javaVM);
@@ -2843,28 +2849,41 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			if (0 != initializeExclusiveAccess(vm)) {
 				goto _error;
 			}
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
+#endif /* defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH) */
 			TRIGGER_J9HOOK_VM_ABOUT_TO_BOOTSTRAP(vm->hookInterface, vm->mainThread);
 			/* At this point, the decision about which interpreter to use has been made */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+			if (vm->checkpointState.isCheckPointAllowed) {
+				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+					vm->bytecodeLoop = criuBytecodeLoopCompressed;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
+				} else {
+#if defined(OMR_GC_FULL_POINTERS)
+					vm->bytecodeLoop = criuBytecodeLoopFull;
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+				}
+			} else
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_DEBUG_MODE)) {
 				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 					vm->bytecodeLoop = debugBytecodeLoopCompressed;
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 				} else {
 #if defined(OMR_GC_FULL_POINTERS)
 					vm->bytecodeLoop = debugBytecodeLoopFull;
-#endif /* OMR_GC_FULL_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
 				}
 			} else {
 				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 					vm->bytecodeLoop = bytecodeLoopCompressed;
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 				} else {
 #if defined(OMR_GC_FULL_POINTERS)
 					vm->bytecodeLoop = bytecodeLoopFull;
-#endif /* OMR_GC_FULL_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
 				}
 			}
 			break;


### PR DESCRIPTION
`CRIU` `BytecodeInterpreter` enables `DO_HOOKS`

`criuBytecodeLoopCompressed`/`criuBytecodeLoopFull` are used when `CRIU` is enabled.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>