### PR TITLE
Don't reload j9thr from the wrong location

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5602,7 +5602,7 @@ typedef struct J9JavaVM {
 	UDATA  ( *aotFindAndInitializeMethodEntryPoint)(struct J9JavaVM *javaVM, struct J9ConstantPool *ramCP, struct J9Method *method, struct J9JXEDescription *jxeDescription) ;
 	UDATA  ( *aotInitializeJxeEntryPoint)(struct J9JavaVM *javaVM, struct J9JXEDescription *description, UDATA beforeBootstrap) ;
 	void  ( *freeAotRuntimeInfo)(struct J9JavaVM *javaVM, void * aotRuntimeInfo) ;
-	UDATA aotDllHandle;
+	UDATA threadDllHandle;
 	struct J9ROMImageHeader* arrayROMClasses;
 	struct J9BytecodeVerificationData* bytecodeVerificationData;
 	char* jclDLLName;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -53,6 +53,7 @@ extern "C" {
 
 typedef struct J9CreateJavaVMParams {
 	UDATA j2seVersion;
+	UDATA threadDllHandle;
 	char* j2seRootDirectory;
 	char* j9libvmDirectory;
 	struct J9VMInitArgs* vm_args;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1110,6 +1110,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 
 	vm->internalVMLabels = (J9InternalVMLabels*)-1001;
 	vm->cInterpreter = J9_BUILDER_SYMBOL(cInterpreter);
+	vm->threadDllHandle = createParams->threadDllHandle;
 
 #if JAVA_SPEC_VERSION >= 19
 	/* tid 1 will be use by main thread, first usable tid starts at 2 */
@@ -2881,6 +2882,10 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			) {
 				startVMRuntimeStateListener(vm);
 			}
+			break;
+
+		case INTERPRETER_SHUTDOWN:
+			vm->threadDllHandle = 0;
 			break;
 	}
 	return returnVal;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/17198

Tested in an [internal build](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=49893) and also manually tested it fixes the immediate problem of loading j9thr from the wrong location. This [extended test](http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=58492775) should start passing with this change.