### PR TITLE
Add CH Table AOT Feature Flag

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -51,6 +51,7 @@
 #include "runtime/DataCache.hpp"
 #include "env/FrontEnd.hpp"
 #include "infra/Monitor.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/CompilerEnv.hpp"
@@ -1085,6 +1086,8 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hdrInCa
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_ACTIVE_CARD_TABLE_BASE_MISMATCH, "AOT header validation failed: Active Card Table Base feature mismatch.");
    if ((featureFlags & TR_FeatureFlag_ArrayHeaderShape) != (hdrInCache->featureFlags & TR_FeatureFlag_ArrayHeaderShape))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_ARRAY_HEADER_SHAPE_MISMATCH, "AOT header validation failed: Array header shape mismatch.");
+   if ((featureFlags & TR_FeatureFlag_CHTableEnabled) != (hdrInCache->featureFlags & TR_FeatureFlag_CHTableEnabled))
+      defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH, "AOT header validation failed: CH Table mismatch.");
    if ((featureFlags & TR_FeatureFlag_SanityCheckEnd) != (hdrInCache->featureFlags & TR_FeatureFlag_SanityCheckEnd))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_END_SANITY_BIT_MANGLED, "AOT header validation failed: Trailing sanity bit mismatch.");
 
@@ -1419,6 +1422,14 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
 
    if (TR::Options::getCmdLineOptions()->isVariableActiveCardTableBase())
       featureFlags |= TR_FeatureFlag_IsVariableActiveCardTableBase;
+
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+   TR_PersistentCHTable *cht = compInfo->getPersistentInfo()->getPersistentCHTable();
+   if (!TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableCHOpts)
+       && cht && cht->isActive())
+      {
+      featureFlags |= TR_FeatureFlag_CHTableEnabled;
+      }
 
    return featureFlags;
    }

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -80,6 +80,7 @@ typedef enum TR_AOTFeatureFlags
    TR_FeatureFlag_IsVariableHeapBaseForBarrierRange0 = 0x00004000,
    TR_FeatureFlag_IsVariableHeapSizeForBarrierRange0 = 0x00008000,
    TR_FeatureFlag_IsVariableActiveCardTableBase      = 0x00010000,
+   TR_FeatureFlag_CHTableEnabled                     = 0x00020000,
    TR_FeatureFlag_SanityCheckEnd                     = 0x80000000
    } TR_AOTFeatureFlags;
 

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -413,3 +413,11 @@ J9NLS_RELOCATABLE_CODE_ARRAY_HEADER_SHAPE_MISMATCH.system_action=The compiler wi
 J9NLS_RELOCATABLE_CODE_ARRAY_HEADER_SHAPE_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
 J9NLS_RELOCATABLE_CODE_ARRAY_HEADER_SHAPE_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
 # END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH=CH Table mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.explanation=The JVM is not running in the same CH Table configuration as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE


### PR DESCRIPTION
The PR adds a new feature flag to ensure that there isn't a CH Table Opts mismatch. Specifically, if CH Table opts were enabled in the compile run, then it also needs to be enabled in the load run.

Very likely the cause of https://github.com/eclipse-openj9/openj9/issues/17250.