### PR TITLE
CRIU BytecodeInterpreter requires J9VM_OPT_CRIU_SUPPORT

### DIFF
--- a/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
@@ -22,10 +22,10 @@
 
 #include "j9cfg.h"
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT)
 #define DO_HOOKS
 #define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
 #define LOOP_NAME criuBytecodeLoopCompressed
 #define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterCompressed
 #include "BytecodeInterpreter.inc"
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/vm/CRIUBytecodeInterpreterFull.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterFull.cpp
@@ -22,10 +22,10 @@
 
 #include "j9cfg.h"
 
-#if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT)
 #define DO_HOOKS
 #define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
 #define LOOP_NAME criuBytecodeLoopFull
 #define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterFull
 #include "BytecodeInterpreter.inc"
-#endif /* defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_FULL_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
`CRIU` `BytecodeInterpreter` requires `J9VM_OPT_CRIU_SUPPORT`

`CRIUBytecodeInterpreterCompressed.cpp` and `CRIUBytecodeInterpreterFull.cpp` are only compiled if `J9VM_OPT_CRIU_SUPPORT` is defined.

This fixes the compilation error of internal Java 8 UMA `AIX/LinuxPPC` platforms.

[J9 Java [AIX64 Compressed Pointers] 80 Compile](http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=58838390)
```
1586-491 (?) COMPILER LIMIT EXCEEDED: Insufficient virtual storage.
```
[J9 Java [Linux PPC] 80 Compile](http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=58841519)
```
"../include/ffi.h", line 186.27: 1540-0840 (W) The integer literal "9223372036854775807" is out of range.
"../include/ffi.h", line 187.3: 1540-0859 (S) #error directive: "no 64-bit data type supported".
make[2]: *** [CRIUBytecodeInterpreterFull.o] Error 1
```

Passed [a personal build AIX/LinuxPPC and other platforms](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=50121)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>