### PR TITLE
(v0.38.0-release) CRIU BytecodeInterpreter requires J9VM_OPT_CRIU_SUPPORT

### DIFF
--- a/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterCompressed.cpp
@@ -22,10 +22,10 @@
 
 #include "j9cfg.h"
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT)
 #define DO_HOOKS
 #define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
 #define LOOP_NAME criuBytecodeLoopCompressed
 #define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterCompressed
 #include "BytecodeInterpreter.inc"
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/vm/CRIUBytecodeInterpreterFull.cpp
+++ b/runtime/vm/CRIUBytecodeInterpreterFull.cpp
@@ -22,10 +22,10 @@
 
 #include "j9cfg.h"
 
-#if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT)
 #define DO_HOOKS
 #define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
 #define LOOP_NAME criuBytecodeLoopFull
 #define INTERPRETER_CLASS VM_CRIUBytecodeInterpreterFull
 #include "BytecodeInterpreter.inc"
-#endif /* defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_FULL_POINTERS) && defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
`CRIU` `BytecodeInterpreter` requires `J9VM_OPT_CRIU_SUPPORT`

`CRIUBytecodeInterpreterCompressed.cpp` and `CRIUBytecodeInterpreterFull.cpp` are only compiled if `J9VM_OPT_CRIU_SUPPORT` is defined.

Cherry-Pick
* https://github.com/eclipse-openj9/openj9/pull/17297

Signed-off-by: Jason Feng <fengj@ca.ibm.com>