### PR TITLE
Set CurrentThread sym ref in defaultMethodDefAliases

### DIFF
--- a/runtime/compiler/compile/J9AliasBuilder.cpp
+++ b/runtime/compiler/compile/J9AliasBuilder.cpp
@@ -203,6 +203,13 @@ J9::AliasBuilder::createAliasInfo()
 
    defaultMethodDefAliases() |= self()->tenantDataMetaSymRefs();
 
+   TR::SymbolReference *currentThreadSymRef = symRefTab()->element(TR::SymbolReferenceTable::currentThreadSymbol);
+   if (currentThreadSymRef && !comp()->fej9()->isJ9VMThreadCurrentThreadImmutable())
+      {
+      // "CurrentThread" could be modified by any method calls
+      defaultMethodDefAliases().set(currentThreadSymRef->getReferenceNumber());
+      }
+
    defaultMethodDefAliasesWithoutImmutable().init(symRefTab()->getNumSymRefs(), comp()->trMemory(), heapAlloc, growable);
    defaultMethodDefAliasesWithoutUserField().init(symRefTab()->getNumSymRefs(), comp()->trMemory(), heapAlloc, growable);
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1360,10 +1360,6 @@ J9::SymbolReferenceTable::findOrCreateCurrentThreadSymbolRef()
          {
          sym->setImmutableField();
          }
-      else
-         {
-         sym->setVolatile();
-         }
       element(currentThreadSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), currentThreadSymbol, sym);
       element(currentThreadSymbol)->setOffset(fej9->thisThreadGetCurrentThreadOffset());
       }


### PR DESCRIPTION
For JDK19 and up, `CurrentThread` could be modified by any method calls. Set `CurrentThread` sym ref in `defaultMethodDefAliases`. 

Also removed `setVolatile` on `CurrentThread` symbol which is not needed. 