### PR TITLE
Stop failing compilations due to final Object invokeinterface

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -418,18 +418,7 @@ TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateInterfaceMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
    owningMethodSymbol->setMayHaveInlineableCall(true);
-
-   TR::SymbolReference * symRef = findOrCreateMethodSymbol(owningMethodSymbol->getResolvedMethodIndex(), cpIndex, 0, TR::MethodSymbol::Interface);
-
-   // javasoft.sqe.tests.vm.instr.invokeinterface.invokeinterface019.invokeinterface01910m1.invokeinterface01910m1
-   // has an invoke interface on a final method in object.
-   //
-   if (symRef->getSymbol()->castToMethodSymbol()->getMethod()->isFinalInObject())
-      {
-      comp()->failCompilation<TR::CompilationException>("Method symbol reference is final in object");
-      }
-
-   return symRef;
+   return findOrCreateMethodSymbol(owningMethodSymbol->getResolvedMethodIndex(), cpIndex, 0, TR::MethodSymbol::Interface);
    }
 
 


### PR DESCRIPTION
The `invokeinterface` bytecode instruction can call methods of `Object`, including those declared final, which the VM leaves out of vtables in order to save space. Those methods must therefore be special-cased and dispatched directly.

Historically PicBuilder had no support for this special-case direct dispatch, and so it was not possible for the JIT compiler to generate code for an unresolved `invokeinterface` instruction if its constant pool entry could later resolve to a final method of `Object`. To prevent that situation, the compiler took advantage of the fact that `Object`'s final methods are known in advance, and it's possible to predict precisely whether resolution will find one just by looking at the name and signature of the callee. So whenever the name and signature matched those of a final method of `Object`, the JIT compiler would refuse to generate IL for the method containing the call, failing the compilation or at least refusing to inline. As such, any method containing such an `invokeinterface` instruction could only run in the interpreter, but that was generally not a performance problem because javac would always generate `invokevirtual` for calls to methods of `Object`.

But now (for some reason) starting in Java 18, javac generates `invokeinterface` for calls to methods of `Object` when the type of the receiver expression is an interface.

Separately, with nestmates (starting in Java 9), interfaces were allowed to define private instance methods, and javac started to implement calls to private methods with `invokevirtual` or `invokeinterface` (as appropriate based on the receiver type). Private methods are also omitted from vtables, so in order to support nestmates, PicBuilder was modified to handle methods that must be dispatched directly (#2673), including final methods of `Object`. As a result, failing compilation / IL generation has not been necessary for some time.

This commit simply allows compilation to proceed, preventing methods from getting stuck in the interpreter. Note that (except possibly in AOT) this only affects methods in which the `invokeinterface` instruction of interest is unresolved at compile time. In the resolved case, the JIT compiler already notices the callee and treats the call as direct.