### PR TITLE
Fix jvmtiGetStackTrace

### DIFF
--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -62,13 +62,14 @@ jvmtiGetStackTrace(jvmtiEnv* env,
 				currentThread, thread, &targetThread, JVMTI_ERROR_NONE,
 				J9JVMTI_GETVMTHREAD_ERROR_ON_DEAD_THREAD);
 		if (rc == JVMTI_ERROR_NONE) {
-			j9object_t threadObject = (NULL == thread) ? currentThread->threadObject : J9_JNI_UNWRAP_REFERENCE(thread);
+			j9object_t threadObject = NULL;
 #if JAVA_SPEC_VERSION >= 19
 			if (NULL != targetThread)
 #endif /* JAVA_SPEC_VERSION >= 19 */
 			{
 				vmFuncs->haltThreadForInspection(currentThread, targetThread);
 			}
+			threadObject = (NULL == thread) ? currentThread->threadObject : J9_JNI_UNWRAP_REFERENCE(thread);
 			rc = jvmtiInternalGetStackTrace(env, currentThread, targetThread, threadObject, start_depth, (UDATA) max_frame_count, frame_buffer, &rv_count);
 #if JAVA_SPEC_VERSION >= 19
 			if (NULL != targetThread)


### PR DESCRIPTION
`haltThreadForInspection` can release VM access. So, `threadObject` should
be set after `haltThreadForInspection` to stop the GC from relocating it.

Related: #16688