### PR TITLE
Don't inline StringLatin1.inflate when array lets can be generated

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -99,7 +99,8 @@ J9::Z::CodeGenerator::initialize()
       cg->setSupportsInlineStringHashCode();
       }
 
-   if (cg->getSupportsVectorRegisters() && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z14))
+   if (cg->getSupportsVectorRegisters() && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z14) &&
+       !TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsInlineStringLatin1Inflate();
       }


### PR DESCRIPTION
When balanced GC policy is in effect, array lets can be generated. The codegen optimization where we inline StringLatin1.inflate is not compatible in such a scenario. Therefore, this PR disables that optimization when arraylets can be generated. 