### PR TITLE
Fix broken link in Java 8 build instructions

### DIFF
--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -429,7 +429,7 @@ cd /cygdrive/c/temp
 
 - Run the following command:
 ```
-wget http://download.savannah.gnu.org/releases/freetype/freetype-2.5.3.tar.gz
+wget https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.5.3.tar.gz
 ```
 
 - To unpack the Freetype archive, run:


### PR DESCRIPTION
FreeType 2.5.3 has been moved to the `freetype-old` subfolder. Also changed to `https`.

@pshipton @keithc-ca 