### PR TITLE
Use a recent OMR acceptance build as bootjdk for AIX and for s390x Linux

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -234,6 +234,8 @@ s390x_linux:
   boot_jdk:
     arch: 's390x'
     os: 'linux'
+    url:
+      20: 'https://openj9-artifactory.osuosl.org/artifactory/ci-openj9/Build_JDK20_s390x_linux_OMR/14/OpenJ9-JDK20-s390x_linux-20230505-063521.tar.gz'
   release:
     all: 'linux-s390x-server-release'
     8: 'linux-s390x-normal-server-release'
@@ -266,6 +268,8 @@ ppc64_aix:
     location: '/opt/bootjdks'
     arch: 'ppc64'
     os: 'aix'
+    url:
+      20: 'https://openj9-artifactory.osuosl.org/artifactory/ci-openj9/Build_JDK20_ppc64_aix_OMR/14/OpenJ9-JDK20-ppc64_aix-20230505-133657.tar.gz'
   release:
     all: 'aix-ppc64-server-release'
     8: 'aix-ppc64-normal-server-release'


### PR DESCRIPTION
No builds are available from Adoptium for these platforms.