### PR TITLE
Remove JAVA19 pConfig & JAVA21 uses rt-compressed.sunJava21.jar

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -158,37 +158,9 @@
 	</configuration>
 
 	<configuration
-		  label="JAVA19"
-		  outputpath="JAVA19/src"
-		  dependencies="JAVA17"
-		  jdkcompliance="19">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.criu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava19.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="JAVA_SPEC_VERSION=19"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
 		  label="JAVA20"
 		  outputpath="JAVA20/src"
-		  dependencies="JAVA19"
+		  dependencies="JAVA17"
 		  jdkcompliance="19">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
@@ -234,7 +206,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava20.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava21.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=21"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>


### PR DESCRIPTION
Remove `JAVA19` `pConfig` & `JAVA21` uses `rt-compressed.sunJava21.jar`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>
