### PR TITLE
Fix to handle suspend/resume of virtual/carrier threads

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -655,8 +655,8 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 		return 1;
 	}
 
-	/* Stores a non-zero value if the virtual thread is suspended by JVMTI. */
-	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/VirtualThread", "isSuspendedByJVMTI", "I", &vm->isSuspendedByJVMTIOffset)) {
+	/* Stores a non-zero value if the virtual or carrier thread is suspended by JVMTI. */
+	if (0 != vmFuncs->addHiddenInstanceField(vm, "java/lang/Thread", "isSuspendedInternal", "I", &vm->isSuspendedInternalOffset)) {
 		return 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -722,6 +722,16 @@ getThreadState(J9VMThread *currentThread, j9object_t threadObject)
 		if (vmstate & J9VMTHREAD_STATE_SUSPENDED) {
 			state |= JVMTI_THREAD_STATE_SUSPENDED;
 		}
+#if JAVA_SPEC_VERSION >= 19
+		/* Based on the isSuspendedInternal field, set the JVMTI
+		 * thread state to suspended for the corresponding thread.
+		 */
+		if (0 != J9OBJECT_U32_LOAD(currentThread, threadObject, currentThread->javaVM->isSuspendedInternalOffset)) {
+			state |= JVMTI_THREAD_STATE_SUSPENDED;
+		} else {
+			state &= ~JVMTI_THREAD_STATE_SUSPENDED;
+		}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		if (vmstate & J9VMTHREAD_STATE_INTERRUPTED) {
 			state |= JVMTI_THREAD_STATE_INTERRUPTED;
 		}
@@ -784,12 +794,12 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread)
 			currentThread, thread, &targetThread, JVMTI_ERROR_NONE,
 			J9JVMTI_GETVMTHREAD_ERROR_ON_NULL_JTHREAD);
 	if (JVMTI_ERROR_NONE == rc) {
+		j9object_t vThreadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 		if (NULL != targetThread) {
 			vm->internalVMFunctions->haltThreadForInspection(currentThread, targetThread);
 			rc = getThreadState(currentThread, targetThread->carrierThreadObject);
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
 		} else {
-			j9object_t vThreadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 			jint vThreadState = (jint) J9VMJAVALANGVIRTUALTHREAD_STATE(currentThread, vThreadObject);
 			/* The mapping from JVMTI_VTHREAD_STATE_XXX to JVMTI_JAVA_LANG_THREAD_STATE_XXX is based
 			 * on j.l.VirtualThread.threadState().
@@ -817,7 +827,7 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread)
 					rc = JVMTI_JAVA_LANG_THREAD_STATE_RUNNABLE;
 				}
 				vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-				/* Re-fetch object to correctly set the isSuspendedByJVMTI field. */
+				/* Re-fetch object to correctly set the isSuspendedInternal field. */
 				vThreadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 				break;
 			}
@@ -851,9 +861,13 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread)
 				Assert_JVMTI_unreachable();
 				rc = JVMTI_ERROR_INTERNAL;
 			}
-			if (0 != J9OBJECT_U32_LOAD(currentThread, vThreadObject, vm->isSuspendedByJVMTIOffset)) {
-				rc |= JVMTI_THREAD_STATE_SUSPENDED;
-			}
+		}
+		/* Re-fetch object to correctly set the isSuspendedInternal field. */
+		vThreadObject = J9_JNI_UNWRAP_REFERENCE(thread);
+		if (0 != J9OBJECT_U32_LOAD(currentThread, vThreadObject, vm->isSuspendedInternalOffset)) {
+			rc |= JVMTI_THREAD_STATE_SUSPENDED;
+		} else {
+			rc &= ~JVMTI_THREAD_STATE_SUSPENDED;
 		}
 		releaseVMThread(currentThread, targetThread, thread);
 	} else {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5905,7 +5905,7 @@ typedef struct J9JavaVM {
 #if JAVA_SPEC_VERSION >= 19
 	U_64 nextTID;
 	UDATA virtualThreadInspectorCountOffset;
-	UDATA isSuspendedByJVMTIOffset;
+	UDATA isSuspendedInternalOffset;
 	UDATA tlsOffset;
 	j9_tls_finalizer_t tlsFinalizers[J9JVMTI_MAX_TLS_KEYS];
 	omrthread_monitor_t tlsFinalizersMutex;


### PR DESCRIPTION
JVMTI treats a virtual thread and its carrier thread as two separate threads. If JVMTI suspends a virtual thread, then its carrier thread should not be suspended and vice-versa. Similarly, if JVMTI resumes a virtual thread, then its carrier thread should not be resumed and vice-versa.
In OpenJ9, currently, a mounted virtual thread and its carrier thread shared the same J9VMThread. The thread state is derived from the J9VMThread. Due to the sharing of the J9VMThread in the mounted state,if a mounted virtual thread is suspended, then the JVMTI functions will also reflect that its carrier thread is suspended.

Currently, "isSuspendedByJVMTI" is the hidden field that holds the suspend status for the virtual thread only, now it made available for carrier thread too, i.e. the scope has changed from "java/lang/VirtualThread" to "java/lang/Thread" threads Also, it is renamed to "isSuspendedInternal" as this hidden field is not just specific to JVMTI.

The following functions has changed to set/reset and verify "isSuspendedInternal" status for threads:-

1) SUSPEND THREAD:-
suspendhelper.cpp:suspendThread:
jvmtiThread.c:jvmtiSuspendResumeCallBack
thread.cpp:Java_java_lang_Thread_suspendImpl
->In case of suspend the halt flag
(J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND) is set if the thread is mounted, i.e. threadObject == targetThread->threadObject in J9VMThread's publicFlags also the hidden field "isSuspendedInternal" set to a non-zero value for the thread instance in all cases regardless of thread being mounted or unmounted.
->If any of the public flags are already set, then the relevant failure message is assigned.

2) RESUME THREAD:-
jvmtiThread.c:resumeThread:
jvmtiThread.c:jvmtiSuspendResumeCallBack
thread.cpp:Java_java_lang_Thread_resumeImpl
->In case of resume the halt flag
(J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND) is cleared if the thread is mounted, i.e. threadObject == targetThread->threadObject in J9VMThread's publicFlags also the hidden field "isSuspendedInternal" set to a zero value for the thread instance in all cases regardless of thread being mounted or unmounted.
->If any of the public flags are already set, then the relevant failure message is assigned.

3) GETSTATE:-
jvmtiHelpers.c:getThreadState
jvmtiHelpers.c:getVirtualThreadState
->The getThreadState function is changed in such a way that will verify the "isSuspendedInternal" filed to check the thread is suspend or not.

The basic concept behind the new changes:
[mounted + unmounted] set the "isSuspendedInternal" field
[mounted]   the halt flag is only modified if the thread object is
	    stored in targetThread->threadObject
[unmounted] Delay setting the halt flag until the thread mount.

Related: #16689
Signed-off-by: Dipak Bagadiya dipak.bagadiya@ibm.com