### PR TITLE
Revert "Restore @Override annotation for Access.getLoaderNameID()"

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -697,7 +697,6 @@ final class Access implements JavaLangAccess {
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
 /*[IF (JAVA_SPEC_VERSION >= 11) & (JAVA_SPEC_VERSION != 20)]*/
-	@Override
 	public String getLoaderNameID(ClassLoader loader) {
 		StringBuilder buffer = new StringBuilder();
 		String name = loader.getName();


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#17341