### PR TITLE
Add 31-64 interop support for JVM_ funcs for JDK17+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -377,6 +377,11 @@ if(NOT JAVA_SPEC_VERSION LESS 17)
 		JVM_DumpClassListToFile
 		JVM_DumpDynamicArchive
 	)
+	if(J9VM_ZOS_3164_INTEROPERABILITY)
+		jvm_add_exports(jvm
+			JVM_Invoke31BitJNI_OnXLoad
+		)
+	endif()
 	if(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 		jvm_add_exports(jvm
 			JVM_ValidateJNILibrary

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2328,38 +2328,6 @@ JVM_SuspendThread(jint arg0, jint arg1)
 }
 #endif /* JAVA_SPEC_VERSION < 20 */
 
-/* NOTE this is required by JDK15+ jdk.internal.loader.NativeLibraries.unload().
- */
-#if JAVA_SPEC_VERSION >= 15
-void JNICALL JVM_UnloadLibrary(void *handle)
-#else /* JAVA_SPEC_VERSION >= 15 */
-jobject JNICALL JVM_UnloadLibrary(jint arg0)
-#endif /* JAVA_SPEC_VERSION >= 15 */
-{
-#if JAVA_SPEC_VERSION >= 15
-	Trc_SC_UnloadLibrary_Entry(handle);
-
-#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) && (JAVA_SPEC_VERSION >= 17)
-	{
-		UDATA doSwitching = ((UDATA)handle) & J9_NATIVE_LIBRARY_SWITCH_MASK;
-		handle = (void *)(((UDATA)handle) ^ doSwitching);
-	}
-#endif /* defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) && (JAVA_SPEC_VERSION >= 17) */
-
-#if defined(WIN32)
-	FreeLibrary((HMODULE)handle);
-#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
-	dlclose(handle);
-#else /* defined(WIN32) */
-#error "Please implement J7vmi.c:JVM_UnloadLibrary(void *handle)"
-#endif /* defined(WIN32) */
-#else /* JAVA_SPEC_VERSION >= 15 */
-	assert(!"JVM_UnloadLibrary() stubbed!");
-	return NULL;
-#endif /* JAVA_SPEC_VERSION >= 15 */
-}
-
-
 
 jobject JNICALL
 JVM_Yield(jint arg0, jint arg1)

--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -369,3 +369,9 @@ TraceEvent=Trc_SC_VirtualThread_RootNodeSet Overhead=1 Level=1 Test Template="Vi
 
 TraceEntry=Trc_SC_ValidateJNILibrary_Entry NoEnv Overhead=1 Level=1 Template="JVM_ValidateJNILibrary(name=%s, handle=%p, isStatic=%d)"
 TraceExit=Trc_SC_ValidateJNILibrary_Exit NoEnv Overhead=1 Level=1 Template="JVM_ValidateJNILibrary -- return %p"
+
+TraceExit=Trc_SC_UnloadLibrary_Exit NoEnv Overhead=1 Level=2 Template="JVM_UnloadLibrary()"
+
+// z/OS only
+TraceEntry=Trc_SC_Invoke31BitJNI_OnXLoad_Entry NoEnv Overhead=1 Level=3 Template="JVM_Invoke31BitJNI_OnXLoad(vm=%p, handle=%p, isOnLoad=%d, reserved=%p)"
+TraceExit=Trc_SC_Invoke31BitJNI_OnXLoad_Exit NoEnv Overhead=1 Level=3 Template="JVM_Invoke31BitJNI_OnXLoad -- return %d"

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -394,6 +394,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<!-- Additions for Java 17 (General) -->
 		<export name="JVM_DumpClassListToFile"/>
 		<export name="JVM_DumpDynamicArchive"/>
+		<export name="JVM_Invoke31BitJNI_OnXLoad">
+			<include-if condition="spec.flags.zos_3164_interoperability"/>
+		</export>
 		<export name="JVM_ValidateJNILibrary">
 			<include-if condition="spec.flags.opt_javaOffloadSupport"/>
 		</export>

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -68,6 +68,10 @@
 #include "jitserver_error.h"
 #endif /* J9VM_OPT_JITSERVER */
 
+#if JAVA_SPEC_VERSION < 15
+#include <assert.h>
+#endif /* JAVA_SPEC_VERSION < 15 */
+
 #if defined(AIXPPC)
 #include <procinfo.h>
 #include <sys/types.h>
@@ -3967,6 +3971,13 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 		{
 			UDATA handle = 0;
 			UDATA flags = J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_LAZY_SYMBOL_RESOLUTION) ? J9PORT_SLOPEN_LAZY : 0;
+
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY)
+			if (J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_3164_INTEROPERABILITY)) {
+				flags |= OMRPORT_SLOPEN_ATTEMPT_31BIT_OPEN;
+			}
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) */
+
 			UDATA slOpenResult = j9sl_open_shared_library((char *)libName, &handle, flags);
 
 			Trc_SC_LoadLibrary_OpenShared(libName);
@@ -4004,6 +4015,41 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 	return result;
 }
 
+/* NOTE this is required by JDK15+ jdk.internal.loader.NativeLibraries.unload().
+ */
+#if JAVA_SPEC_VERSION >= 15
+void JNICALL JVM_UnloadLibrary(void *handle)
+#else /* JAVA_SPEC_VERSION >= 15 */
+jobject JNICALL JVM_UnloadLibrary(jint arg0)
+#endif /* JAVA_SPEC_VERSION >= 15 */
+{
+#if JAVA_SPEC_VERSION >= 15
+	Trc_SC_UnloadLibrary_Entry(handle);
+
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) && (JAVA_SPEC_VERSION >= 17)
+	{
+		UDATA doSwitching = ((UDATA)handle) & J9_NATIVE_LIBRARY_SWITCH_MASK;
+		handle = (void *)(((UDATA)handle) ^ doSwitching);
+	}
+#endif /* defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) && (JAVA_SPEC_VERSION >= 17) */
+
+#if defined(WIN32)
+	FreeLibrary((HMODULE)handle);
+#elif defined(J9ZOS390) /* defined(WIN32) */
+	PORT_ACCESS_FROM_JAVAVM(BFUjavaVM);
+	/* Call j9sl_close_shared_library to handle potential 31-bit interoperability handles. */
+	j9sl_close_shared_library((UDATA)handle);
+#elif defined(J9UNIX) /* defined(J9ZOS390) */
+	dlclose(handle);
+#else /* defined(J9UNIX) */
+#error "Please implement jvm.c:JVM_UnloadLibrary(void *handle)"
+#endif /* defined(WIN32) */
+	Trc_SC_UnloadLibrary_Exit();
+#else /* JAVA_SPEC_VERSION >= 15 */
+	assert(!"JVM_UnloadLibrary() stubbed!");
+	return NULL;
+#endif /* JAVA_SPEC_VERSION >= 15 */
+}
 
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) && (JAVA_SPEC_VERSION >= 17)
 /**
@@ -4073,9 +4119,13 @@ JVM_FindLibraryEntry(void* handle, const char *functionName)
 
 #if defined(WIN32)
 	result = GetProcAddress ((HINSTANCE)handle, (LPCSTR)functionName);
-#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
-	result = (void*)dlsym( (void*)handle, (char *)functionName );
-#else /* defined(WIN32) */
+#elif defined(J9ZOS390) /* defined(WIN32) */
+	PORT_ACCESS_FROM_JAVAVM(BFUjavaVM);
+	/* Call j9sl_lookup_name to handle potential 31-bit interoperability targets. */
+	j9sl_lookup_name((UDATA)handle, (char *)functionName, (void *)&result, "");
+#elif defined(J9UNIX) /* defined(J9ZOS390) */
+	result = (void *)dlsym((void *)handle, (char *)functionName);
+#else /* defined(J9UNIX) */
 #error "Please implement jvm.c:JVM_FindLibraryEntry(void* handle, const char *functionName)"
 #endif /* defined(WIN32) */
 
@@ -6465,3 +6515,35 @@ JVM_BeforeHalt()
 {
 	/* To be implemented via https://github.com/eclipse-openj9/openj9/issues/1459 */
 }
+
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
+/*
+ * Utility function used by NativeLibraries to invoke JNI_OnLoad or JNI_OnUnload
+ * functions in 31-bit native interoperability targets. This requires mapping to
+ * the corresponding 31-bit JavaVM object handle, along with invoking CEL4RO31
+ * (via FFI) to the corresponding target function.
+ *
+ * @param vm The JavaVM pointer first parameter for JNI_OnXLoad function
+ * @param handle The target function pointer to invoke - should be a 31-bit interop target
+ * @param isOnLoad TRUE if invoking JNI_OnLoad, FALSE if invoking JNI_OnUnload
+ * @param reserved The reserved second parameter for JNI_OnXLoad function
+ *
+ * @return the return value for JNI_OnLoad, or 0 for JNI_OnUnload
+ */
+jint JNICALL
+JVM_Invoke31BitJNI_OnXLoad(JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved)
+{
+	J9JavaVM *javaVM = (J9JavaVM *)vm;
+	jint result = isOnLoad ? JNI_VERSION_1_1 : 0;
+
+	Trc_SC_Invoke31BitJNI_OnXLoad_Entry(vm, handle, isOnLoad, reserved);
+
+	if (J9_IS_31BIT_INTEROP_TARGET(handle)) {
+		result = javaVM->internalVMFunctions->invoke31BitJNI_OnXLoad(javaVM, handle, isOnLoad, reserved);
+	}
+
+	Trc_SC_Invoke31BitJNI_OnXLoad_Exit(result);
+
+	return result;
+}
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5022,6 +5022,9 @@ typedef struct J9InternalVMFunctions {
 	void (*releaseVThreadInspector)(struct J9VMThread *currentThread, jobject thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	UDATA (*checkArgsConsumed)(struct J9JavaVM * vm, struct J9PortLibrary* portLibrary, struct J9VMInitArgs* j9vm_args);
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
+	I_32 (*invoke31BitJNI_OnXLoad)(struct J9JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved);
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3962,6 +3962,20 @@ UDATA
 initializeNativeLibrary(J9JavaVM * javaVM, J9NativeLibrary* library);
 
 
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
+/**
+ * Invoke JNI_OnLoad/JNI_OnUnload functions in 31-bit interoperability native target library.
+ * @param vm The J9JavaVM pointer passed as first parameter to JNI_OnXLoad function
+ * @param handle The target function pointer to invoke - should be a 31-bit interop target
+ * @param isOnLoad JNI_TRUE if invoking JNI_OnLoad, JNI_FALSE if invoking JNI_OnUnload
+ * @param reserved The reserved second parameter to JNI_OnXLoad function
+ * @return the return value for JNI_OnLoad, or 0 for JNI_OnUnload
+ */
+I_32
+invoke31BitJNI_OnXLoad(J9JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved);
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
+
+
 /* ---------------- vmhook.c ---------------- */
 
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -83,6 +83,8 @@ _X(JVM_GetThreadInterruptEvent,JNICALL,true,void *,void)
 _X(JVM_Halt,JNICALL,true,void,jint exitCode)
 _X(JVM_InitializeSocketLibrary,JNICALL,true,jint,void)
 _X(JVM_InvokeMethod,JNICALL,true,jobject,JNIEnv *env, jobject method, jobject obj, jobjectArray args)
+_IF([defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)],
+	_X(JVM_Invoke31BitJNI_OnXLoad,JNICALL,true,jint,JavaVM *vm,void *handle,jboolean isOnLoad,void *reserved))
 _X(JVM_IsNaN,JNICALL,true,jboolean,jdouble dbl)
 _X(JVM_LatestUserDefinedLoader,JNICALL,true,jobject,JNIEnv *env)
 _X(JVM_Listen,JNICALL,true,jint,jint descriptor, jint count)

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -440,4 +440,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	releaseVThreadInspector,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	checkArgsConsumed,
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
+	invoke31BitJNI_OnXLoad,
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
 };

--- a/runtime/vm/vmbootlib.c
+++ b/runtime/vm/vmbootlib.c
@@ -159,8 +159,8 @@ sendLifecycleEventCallback(struct J9VMThread* vmThread, struct J9NativeLibrary* 
 			if (0 == vmThread->javaVM->javaVM31) {
 				queryJavaVM31(vmThread->javaVM);
 			}
-			args[0]= &ffi_type_sint32;
-			args[1]= &ffi_type_sint32;
+			args[0] = &ffi_type_uint32;
+			args[1] = &ffi_type_uint32;
 			values[0] = (void*)&(vmThread->javaVM->javaVM31);
 			values[1] = (void*)&nullSecondParam;
 
@@ -868,3 +868,52 @@ initializeNativeLibrary(J9JavaVM * javaVM, J9NativeLibrary* library)
 	library->flags = 0;
 	return 0;
 }
+
+
+#if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)
+/*
+ * Utility function used by NativeLibraries to invoke JNI_OnLoad or JNI_OnUnload
+ * functions in 31-bit native interoperability targets. This requires mapping to
+ * the corresponding 31-bit JavaVM object handle, along with invoking CEL4RO31
+ * (via ffi) to the corresponding target function.
+ *
+ * \param vm The J9JavaVM pointer passed as first parameter to JNI_OnXLoad function
+ * \param handle The target function pointer to invoke - should be a 31-bit interop target
+ * \param isOnLoad JNI_TRUE if invoking JNI_OnLoad, JNI_FALSE if invoking JNI_OnUnload
+ * \param reserved The reserved second parameter to JNI_OnXLoad function
+ * \return the return value for JNI_OnLoad, or 0 for JNI_OnUnload
+ */
+I_32
+invoke31BitJNI_OnXLoad(J9JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved)
+{
+	I_32 result = JNI_VERSION_1_1;
+
+	if (J9_IS_31BIT_INTEROP_TARGET(handle)) {
+		ffi_type *args[2];
+		void *values[2];
+		U_32 nullSecondParam = 0;
+		UDATA returnValue = 0;
+		ffi_cif cif;
+
+		if (0 == vm->javaVM31) {
+			queryJavaVM31(vm);
+		}
+		args[0] = &ffi_type_uint32;
+		args[1] = &ffi_type_uint32;
+		values[0] = (void *)&(vm->javaVM31);
+		values[1] = (void *)&nullSecondParam;
+
+		if (isOnLoad) {
+			if (FFI_OK == ffi_prep_cif(&cif, FFI_CEL4RO31, 2, &ffi_type_sint32, args)) {
+				ffi_call(&cif, FFI_FN(handle), &returnValue, values);
+				result = (I_32)(IDATA)returnValue;
+			}
+		} else {
+			if (FFI_OK == ffi_prep_cif(&cif, FFI_CEL4RO31, 2, &ffi_type_void, args)) {
+				ffi_call(&cif, FFI_FN(handle), NULL, values);
+			}
+		}
+	}
+	return result;
+}
+#endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */


### PR DESCRIPTION
- JVM_LoadLibrary / JVM_OnloadLibrary needs to invoke j9sl_open_shared_library and j9sl_close_shared_library respectively to handle potential 31-bit targets.
- OMRPORT_SLOPEN_ATTEMPT_31BIT_OPEN needs to be specified if -XX:+Enable3164Interoperability is specified.
- JVM_FindLibraryEntry needs to invoke j9sl_lookup_name to handle function lookups of 31-bit target.
- Add utility function used by NativeLibraries to invoke JNI_OnLoad or JNI_OnUnload functions in 31-bit native interoperability targets. This requires mapping to the corresponding 31-bit JavaVM object handle, along with invoking CEL4RO31 (via ffi) to the corresponding target function.