### PR TITLE
Remove unnecessary compatibility constant J9DescriptionCpTypeShift

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
@@ -54,6 +54,8 @@ J9Consts.J9_ITABLE_OFFSET_DIRECT = 0
 J9Consts.J9_ITABLE_OFFSET_TAG_BITS = 0
 J9Consts.J9_ITABLE_OFFSET_VIRTUAL = 0
 
+J9DescriptionBits.J9DescriptionCpBsmIndexMask = 0
+
 J9JavaAccessFlags.J9AccClassIsUnmodifiable = 0
 J9JavaAccessFlags.J9AccRecord = 0
 J9JavaAccessFlags.J9AccSealed = 0
@@ -69,9 +71,6 @@ J9JavaClassFlags.J9ClassRequiresPrePadding = 0
 J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_INJECTED_INTERFACE_INFO = 0
 J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_PERMITTEDSUBCLASSES_ATTRIBUTE = 0
 J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_RECORD_ATTRIBUTE = 0
-
-J9DescriptionBits.J9DescriptionCpBsmIndexMask = 0
-J9DescriptionBits.J9DescriptionCpTypeShift = 0
 
 J9Object.OBJECT_HEADER_LOCK_LEARNING = 0
 J9Object.OBJECT_HEADER_LOCK_LEARNING_RECURSION_OFFSET = 0


### PR DESCRIPTION
It was needlessly added in #15404. Also restore order.