### PR TITLE
WIP:Handle code cache allocation for low physical memory.

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -29,6 +29,7 @@
 #include "compile/CompilationTypes.hpp"
 #include "control/CompilationPriority.hpp"
 #include "control/ClassHolder.hpp"
+#include "control/CompilationController.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #include "env/CpuUtilization.hpp"
 #include "env/Processors.hpp"
@@ -57,6 +58,7 @@ struct J9SharedClassJavacoreDataDescriptor;
 class CpuUtilization;
 namespace TR { class CompilationInfoPerThread; }
 namespace TR { class CompilationInfoPerThreadBase; }
+namespace TR { typedef OMR::CompilationInfo CompilationInfoConnector; }
 class TR_FilterBST;
 class TR_FrontEnd;
 class TR_HWProfiler;
@@ -331,7 +333,7 @@ class DLTTracking : public J9Method_HT
 namespace TR
 {
 
-class CompilationInfo
+class CompilationInfo : public OMR::CompilationInfoConnector
    {
 public:
    friend class TR::CompilationInfoPerThreadBase;
@@ -1192,15 +1194,6 @@ public:
 
    int32_t calculateCodeSize(TR_MethodMetaData *metaData);
    void increaseUnstoredBytes(U_32 aotBytes, U_32 jitBytes);
-
-   /**
-   * @brief Compute free physical memory taking into account container limits
-   *
-   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered memory couldn't be read
-   * @return                 A value representing the free physicalMemory
-                             or OMRPORT_MEMINFO_NOT_AVAILABLE in case of error
-   */
-   uint64_t computeFreePhysicalMemory(bool &incompleteInfo);
 
    /**
    * @brief Compute free physical memory taking into account container limits and caches it for later use


### PR DESCRIPTION
The fix proposes to handle code cache allocation in environments with low physical memory.
For this we need to check the available physical memory first during the initialization when code cache related values are configured and then another time when the actual allocation happens.
The method `TR::CompilationInfo::computeFreePhysicalMemory(bool &incompleteInfo)` can be reused for this purpose.

1. In `onLoadInternal(` compute the available physical memory and assign code cache value defaults based on this. If the available memory is less than 256 MB then only a percentage (may be 50%) of the available memory is allocated to the code cache total value. There needs to be a lower limit that needs to be set. [Need to consider `_safeReservePhysicalMemoryValue`??]
2. In `OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize` calculate available physical memory and perform new code cache allocation if we have the safe amount returned for the memory.

The corresponding OMR fix is here: #[6986](https://github.com/eclipse/omr/pull/6986)

Fixes: #17011