### PR TITLE
Throw UnsupportedOperationException in sun.misc.Perf.attach natives

### DIFF
--- a/runtime/jcl/common/sun_misc_Perf.c
+++ b/runtime/jcl/common/sun_misc_Perf.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include "jcl.h"
 #include "jcl_internal.h"
+#include "jclprots.h"
 
 /*
  * This is the minimum implementation of sun.misc.Perf natives to
@@ -40,7 +41,7 @@ Java_sun_misc_Perf_registerNatives(JNIEnv *env, jclass klass)
 jobject JNICALL
 Java_sun_misc_Perf_attach(JNIEnv *env, jobject perf, jstring user, jint lvmid, jint mode)
 {
-	assert(!"Java_sun_misc_Perf_attach unimplemented");
+	throwNewUnsupportedOperationException(env);
 	return NULL;
 }
 
@@ -98,7 +99,7 @@ Java_sun_misc_Perf_highResFrequency(JNIEnv *env, jobject perf)
 jobject JNICALL
 Java_jdk_internal_perf_Perf_attach0(JNIEnv *env, jobject perf, jint lvmid)
 {
-	assert(!"Java_jdk_internal_perf_Perf_attach0 unimplemented");
+	throwNewUnsupportedOperationException(env);
 	return NULL;
 }
 #endif /* JAVA_SPEC_VERSION >= 19 */


### PR DESCRIPTION
Rather than asserting they are unimplemented.

Fixes https://github.com/eclipse-openj9/openj9/issues/17366