### PR TITLE
Put select system property names and values in allocated memory

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1400,7 +1400,7 @@ typedef struct J9RAS {
 	UDATA pid;
 	UDATA tid;
 	char* serviceLevel;
-	const char *productName;
+	char *productName;
 	struct J9RASSystemInfo* systemInfo;
 	I_64 startTimeMillis;
 	I_64 startTimeNanos;


### PR DESCRIPTION
Improve `!coreinfo` command to continue despite encountering faults trying to read information from the core file.

Fixes: #17397.