### PR TITLE
Add areFlattenableValueTypesEnabled() for JIT

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4956,6 +4956,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *setNestmatesError)(struct J9VMThread *vmThread, struct J9Class *nestMember, struct J9Class *nestHost, IDATA errorCode);
 #endif /* JAVA_SPEC_VERSION >= 11 */
 	BOOLEAN ( *areValueTypesEnabled)(struct J9JavaVM *vm);
+	BOOLEAN ( *areFlattenableValueTypesEnabled)(struct J9JavaVM *vm);
 	J9Class* ( *peekClassHashTable)(struct J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength);
 #if defined(J9VM_OPT_JITSERVER)
 	BOOLEAN ( *isJITServerEnabled )(struct J9JavaVM *vm);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1666,6 +1666,14 @@ BOOLEAN
 areValueTypesEnabled(J9JavaVM *vm);
 
 /**
+ * @brief Queries whether flattenable valueTypes are enable on the JVM
+ * @param vm A handle to the J9JavaVM
+ * @return TRUE if flattenable valueTypes are enabled, FALSE otherwise
+ */
+BOOLEAN
+areFlattenableValueTypesEnabled(J9JavaVM *vm);
+
+/**
  * Checks if args in specified args array have been consumed by the JVM, if not it outputs a warning message
  * and returns FALSE. This function consults the -XXvm:ignoreUnrecognized, -XX:[+|-]IgnoreUnrecognizedVMOptions
  * and -XX:[-|+]IgnoreUnrecognizedXXColonOptions to determine if args are consumed or not.

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -253,6 +253,16 @@ areValueTypesEnabled(J9JavaVM *vm)
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 }
 
+BOOLEAN
+areFlattenableValueTypesEnabled(J9JavaVM *vm)
+{
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+	return TRUE;
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+	return FALSE;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+}
+
 j9object_t*
 getDefaultValueSlotAddress(J9Class* clazz)
 {

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -374,6 +374,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	setNestmatesError,
 #endif /* JAVA_SPEC_VERSION >= 11 */
 	areValueTypesEnabled,
+	areFlattenableValueTypesEnabled,
 	peekClassHashTable,
 #if defined(J9VM_OPT_JITSERVER)
 	isJITServerEnabled,


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/17394 has added new flag 
`J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES` for flattenable value types. 
The value object code is under the existing `J9VM_OPT_VALHALLA_VALUE_TYPES`. 
Add new API `areFlattenableValueTypesEnabled()` for JIT.

issue #17235