### PR TITLE
Handle code cache alloction for low memory

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -120,7 +120,8 @@ enum ExternalOptions
    XXminusJITServerAOTCachePersistenceOption   = 64,
    XXJITServerAOTCacheDirOption                = 65,
    XXJITServerAOTCacheNameOption               = 66,
-   TR_NumExternalOptions                       = 67
+   XXcodecachetotalMaxRAMPercentage            = 67,
+   TR_NumExternalOptions                       = 68
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
@@ -287,7 +288,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static int32_t _numCodeCachesToCreateAtStartup;
    static int32_t getNumCodeCachesToCreateAtStartup() { return _numCodeCachesToCreateAtStartup; }
-
+   static bool _overrideCodecachetotal;
    static int32_t _dataCacheQuantumSize;
    static int32_t _dataCacheMinQuanta;
    static int32_t getDataCacheQuantumSize() { return _dataCacheQuantumSize; }

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -168,6 +168,7 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::XXplusJITServerAOTCachePersistenceOption:
          case J9::ExternalOptions::XXminusJITServerAOTCachePersistenceOption:
          case J9::ExternalOptions::XXJITServerAOTCacheDirOption:
+         case J9::ExternalOptions::XXcodecachetotalMaxRAMPercentage:
             {
             // do nothing, consume them to prevent errors
             FIND_AND_CONSUME_RESTORE_ARG(OPTIONAL_LIST_MATCH, optString, 0);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1374,6 +1374,16 @@ onLoadInternal(
 
    TR::CodeCacheConfig &codeCacheConfig = codeCacheManager->codeCacheConfig();
 
+   if (TR::Options::_overrideCodecachetotal && TR::Options::isAnyVerboseOptionSet(TR_VerbosePerformance,TR_VerboseCodeCache))
+      {
+      // Code cache total value defaults were overridden due to low memory available
+      bool incomplete;
+      uint64_t freePhysicalMemoryB = getCompilationInfo(jitConfig)->computeFreePhysicalMemory(incomplete);
+      if (freePhysicalMemoryB != OMRPORT_MEMINFO_NOT_AVAILABLE)
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "Available freePhysicalMemory=%llu MB, allocating code cache total size=%lu MB", freePhysicalMemoryB >> 20, jitConfig->codeCacheTotalKB >> 10);
+      else
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "Allocating code cache total=%llu MB due to low available memory", jitConfig->codeCacheTotalKB >> 10);
+      }
    // Do not allow code caches smaller than 128KB
    if (jitConfig->codeCacheKB < 128)
       jitConfig->codeCacheKB = 128;

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -421,3 +421,12 @@ J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.system_action=The compiler will not gen
 J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
 J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
 # END NON-TRANSLATABLE
+
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE=Value '%1$s%2$f' must be between 1.0 and 100.0; using default percentage '%3$d' instead.
+# START NON-TRANSLATABLE
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.explanation=The specified option is not within the permitted range.
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.system_action=The default percentage value will be used instead.
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.user_response=Correct the option.
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.sample_input_1=-XX:codecachetotalMaxRAMPercentage=
+J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.sample_input_2=25
+# END NON-TRANSLATABLE


### PR DESCRIPTION
The fix proposes to handle code cache allocation in environments with low physical memory.
For this we need to check the available physical memory first during the initialization when code cache related values are configured and then another time when the actual allocation happens.
The method `TR::CompilationInfo::computeFreePhysicalMemory(bool &incompleteInfo)` can be reused for this purpose.

1. Provide a user option to set `codetotalPercentage=` which will be percentage of available memory to be used for code cache if the available free memory is less than 512MB. The percentage defaults is set to 50% so that we leave enough for the JVM.

2. In `OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize `calculate available physical memory and perform new code cache allocation if we have the safe amount returned for the memory.[Need to consider `_safeReservePhysicalMemoryValue`??]