### PR TITLE
Fix compile error due to unused variable

### DIFF
--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -567,6 +567,7 @@ done:
 		return value;
 	}
 
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	/**
 	 * Copies an array of non-primitive objects
 	 * Handles flattened and non-flattened cases
@@ -661,6 +662,7 @@ done:
 
 		return 0;
 	}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 };
 


### PR DESCRIPTION
See https://openj9-jenkins.osuosl.org/job/Build_JDK8_x86-64_linux_OpenJDK8/59/:
```
 In file included from /home/jenkins/workspace/Build_JDK8_x86-64_linux_OpenJDK8/openj9/runtime/vm/ValueTypeHelpers.cpp:23:0:
23:24:52  /home/jenkins/workspace/Build_JDK8_x86-64_linux_OpenJDK8/openj9/runtime/vm/ValueTypeHelpers.hpp: In static member function 'static I_32 VM_ValueTypeHelpers::copyFlattenableArray(J9VMThread*, MM_ObjectAccessBarrierAPI, MM_ObjectAllocationAPI, j9object_t, j9object_t, I_32, I_32, I_32)':
23:24:52  /home/jenkins/workspace/Build_JDK8_x86-64_linux_OpenJDK8/openj9/runtime/vm/ValueTypeHelpers.hpp:596:12: error: unused variable 'destComponentClass' [-Werror=unused-variable]
23:24:52     J9Class *destComponentClass = ((J9ArrayClass *)destClazz)->componentType;
23:24:52              ^~~~~~~~~~~~~~~~~~
```