### PR TITLE
Check flattenable value types and if Q signature is supported

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -520,8 +520,21 @@ static void addEntryForFieldImpl(TR_VMField *field, TR::TypeLayoutBuilder &tlb, 
    uint32_t mergedLength = 0;
    J9UTF8 *signature = J9ROMFIELDSHAPE_SIGNATURE(field->shape);
 
-   if (TR::Compiler->om.areValueTypesEnabled() &&
-       vm->internalVMFunctions->isNameOrSignatureQtype(signature) &&
+   bool isFieldPrimitiveValueType = false;
+
+   if (TR::Compiler->om.areFlattenableValueTypesEnabled())
+      {
+      if (TR::Compiler->om.isQDescriptorForValueTypesSupported())
+         {
+         isFieldPrimitiveValueType = vm->internalVMFunctions->isNameOrSignatureQtype(signature);
+         }
+      else
+         {
+         TR_ASSERT_FATAL(false, "Support for null-restricted types without Q descriptor is to be implemented!!!");
+         }
+      }
+
+   if (isFieldPrimitiveValueType &&
        vm->internalVMFunctions->isFlattenableFieldFlattened(definingClass, field->shape))
       {
       char *prefixForChild = buildTransitiveFieldNames(prefix, prefixLength, field->shape, comp->trMemory()->currentStackRegion(), mergedLength);
@@ -1043,7 +1056,11 @@ J9::ClassEnv::classNameToSignature(const char *name, int32_t &len, TR::Compilati
       {
       len += 2;
       sig = (char *)comp->trMemory()->allocateMemory(len+1, allocKind);
-      if (clazz && TR::Compiler->om.areValueTypesEnabled() && self()->isPrimitiveValueTypeClass(clazz))
+      if (clazz &&
+         TR::Compiler->om.areFlattenableValueTypesEnabled() &&
+         TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
+         self()->isPrimitiveValueTypeClass(clazz)
+         )
          sig[0] = 'Q';
       else
          sig[0] = 'L';

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -122,6 +122,45 @@ J9::ObjectModel::areValueTypesEnabled()
    return javaVM->internalVMFunctions->areValueTypesEnabled(javaVM);
    }
 
+bool
+J9::ObjectModel::areFlattenableValueTypesEnabled()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+      return true;
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+      return false;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   J9JavaVM * javaVM = TR::Compiler->javaVM;
+   return javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM);
+   }
+
+bool
+J9::ObjectModel::isQDescriptorForValueTypesSupported()
+   {
+   // TODO: Implementation is required to determine under which case 'Q' descriptor is removed
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+      return true;
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+      return false;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   J9JavaVM * javaVM = TR::Compiler->javaVM;
+   if (javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM))
+     return true;
+
+   return false;
+   }
 
 bool
 J9::ObjectModel::areValueBasedMonitorChecksEnabled()
@@ -144,13 +183,21 @@ J9::ObjectModel::isValueTypeArrayFlatteningEnabled()
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-	   return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+      return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+      return false;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    J9JavaVM *javaVM = TR::Compiler->javaVM;
-   return J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+
+   if (javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM))
+      return J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING);
+   else
+      return false;
    }
 
 int32_t

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -62,7 +62,19 @@ public:
 
    bool mayRequireSpineChecks();
 
+   /**
+   * @brief Whether or not value object is enabled
+   */
    bool areValueTypesEnabled();
+   /**
+   * @brief Whether or not flattenable value object (aka null restricted) type is enabled
+   */
+   bool areFlattenableValueTypesEnabled();
+   /**
+   * @brief Whether or not `Q` signature is supported
+   */
+   bool isQDescriptorForValueTypesSupported();
+
    /**
    * @brief Whether the check is enabled on monitor object being value based class type
    */

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2532,7 +2532,9 @@ TR_J9VMBase::getClassSignature_DEPRECATED(TR_OpaqueClassBlock * clazz, int32_t &
       sig[i] = '[';
    if (* name != '[')
       {
-      if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
+      if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
+          TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
+          TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
          sig[i++] = 'Q';
       else
          sig[i++] = 'L';
@@ -2565,7 +2567,9 @@ TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock * clazz, TR_Memory * trMemory
       sig[i] = '[';
    if (* name != '[')
       {
-      if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
+      if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
+          TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
+          TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
          sig[i++] = 'Q';
       else
          sig[i++] = 'L';

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9286,7 +9286,7 @@ TR_J9ByteCodeIlGenerator::packReferenceChainOffsets(TR::Node *node, std::vector<
 bool
 TR_ResolvedJ9Method::isFieldQType(int32_t cpIndex)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled() ||
+   if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
 
@@ -9301,7 +9301,7 @@ TR_ResolvedJ9Method::isFieldQType(int32_t cpIndex)
 bool
 TR_ResolvedJ9Method::isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled() ||
+   if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
 
@@ -9309,7 +9309,7 @@ TR_ResolvedJ9Method::isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bo
    J9ROMFieldShape *fieldShape = NULL;
    TR_OpaqueClassBlock *containingClass = definingClassAndFieldShapeFromCPFieldRef(comp, cp(), cpIndex, isStatic, &fieldShape);
 
-   // No lock is required here. Entires in J9Class::flattenedClassCache are only written during classload.
+   // No lock is required here. Entries in J9Class::flattenedClassCache are only written during classload.
    // They are effectively read only when being exposed to the JIT.
    return vmThread->javaVM->internalVMFunctions->isFlattenableFieldFlattened(reinterpret_cast<J9Class *>(containingClass), fieldShape);
    }

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1843,7 +1843,7 @@ TR_ResolvedJ9JITServerMethod::archetypeArgPlaceholderSlot()
 bool
 TR_ResolvedJ9JITServerMethod::isFieldQType(int32_t cpIndex)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled() ||
+   if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
 
@@ -1859,7 +1859,7 @@ TR_ResolvedJ9JITServerMethod::isFieldQType(int32_t cpIndex)
 bool
 TR_ResolvedJ9JITServerMethod::isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled() ||
+   if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -558,11 +558,7 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
 
       if (currNode->getOpCodeValue() == TR::checkcast
           && currNode->getSecondChild()->getOpCodeValue() == TR::loadaddr
-          && currNode->getSecondChild()->getSymbolReference()->isUnresolved()
-          && // check whether the checkcast class is primitive valuetype. Expansion is only needed for checkcast to reference type.
-            (!TR::Compiler->om.areValueTypesEnabled()
-            || !TR::Compiler->cls.isClassRefPrimitiveValueType(comp(), method()->classOfMethod(),
-                                        currNode->getSecondChild()->getSymbolReference()->getCPIndex())))
+          && currNode->getSecondChild()->getSymbolReference()->isUnresolved())
           {
           unresolvedCheckcastTopsNeedingNullGuard.add(currTree);
           }

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1000,7 +1000,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             }
 
          if (!canTransformIdentityArrayElementLoadStoreUseTypeHint &&
-             TR::Compiler->cls.isValueTypeClass(hintComponentClass))
+             TR::Compiler->cls.isPrimitiveValueTypeClass(hintComponentClass))
             {
             if (TR::Compiler->cls.isValueTypeClassFlattened(hintComponentClass))
                {
@@ -1153,7 +1153,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 
             flagsForTransform.set(ValueTypesHelperCallTransform::InsertDebugCounter);
 
-            if (isStoreFlattenableArrayElement && !owningMethodDoesNotContainStoreChecks(this, node))
+            if (isStoreFlattenableArrayElement)
                {
                // Determine whether the value is being copied from the same array that is the target
                // of the array element store.  If so, there's no need for an ArrayStoreCHK or a call
@@ -1173,20 +1173,21 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                   // otherwise, only the ArrayStoreCHK is required.
                   //
                   bool mustFail = false;
-                  if (isArrayStoreCheckNeeded(arrayRefNode, storeValueNode, mustFail, storeClassForCheck, componentClassForCheck))
+                  if (!owningMethodDoesNotContainStoreChecks(this, node) &&
+                     isArrayStoreCheckNeeded(arrayRefNode, storeValueNode, mustFail, storeClassForCheck, componentClassForCheck))
                      {
                      flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreCheck);
                      }
 
-                  if ((isCompTypePrimVT != TR_no) && (storeValueConstraint == NULL || !storeValueConstraint->isNonNullObject()))
+                   //TODO: Require the <nonNullableArrayNullStoreCheck> non-helper if !canSkipNonNullableArrayNullValueChecks(...)
+                   if (canTransformUnflattenedArrayElementLoadStore &&
+                      (isCompTypePrimVT != TR_no) &&
+                      (storeValueConstraint == NULL || !storeValueConstraint->isNonNullObject()))
                      {
                      flagsForTransform.set(ValueTypesHelperCallTransform::RequiresNullValueCheck);
                      }
                   }
-               }
 
-            if (isStoreFlattenableArrayElement)
-               {
                callToTransform =
                      new (trStackMemory()) ArrayElementStoreHelperCallTransform(_curTree, node, flagsForTransform, arrayLength, NULL,
                                                  storeClassForCheck, componentClassForCheck);
@@ -1204,7 +1205,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             TR_OpaqueClassBlock *storeClassForCheck = NULL;
             TR_OpaqueClassBlock *componentClassForCheck = NULL;
 
-            if (isStoreFlattenableArrayElement && !owningMethodDoesNotContainStoreChecks(this, node))
+            if (isStoreFlattenableArrayElement)
                {
                TR::Node *storeValueBaseNode = getStoreValueBaseNode(storeValueNode, symRefTab);
 
@@ -1220,20 +1221,20 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                   // otherwise, only the ArrayStoreCHK is required.
                   //
                   bool mustFail = false;
-                  if (isArrayStoreCheckNeeded(arrayRefNode, storeValueNode, mustFail, storeClassForCheck, componentClassForCheck))
+                  if (!owningMethodDoesNotContainStoreChecks(this, node) &&
+                     isArrayStoreCheckNeeded(arrayRefNode, storeValueNode, mustFail, storeClassForCheck, componentClassForCheck))
                      {
                      flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreCheck);
                      }
 
-                  if (canTransformUnflattenedArrayElementLoadStoreUseTypeHint && (!storeValueConstraint || !storeValueConstraint->isNonNullObject()))
+                  //TODO: Require the <nonNullableArrayNullStoreCheck> non-helper if !canSkipNonNullableArrayNullValueChecks(...)
+                  if (canTransformUnflattenedArrayElementLoadStoreUseTypeHint &&
+                     (!storeValueConstraint || !storeValueConstraint->isNonNullObject()))
                      {
                      flagsForTransform.set(ValueTypesHelperCallTransform::RequiresNullValueCheck);
                      }
                   }
-               }
 
-            if (isStoreFlattenableArrayElement)
-               {
                callToTransform =
                      new (trStackMemory()) ArrayElementStoreHelperCallTransform(_curTree, node, flagsForTransform, arrayLength, typeHintClass, storeClassForCheck, componentClassForCheck);
                }
@@ -2621,7 +2622,8 @@ J9::ValuePropagation::transformUnflattenedArrayElementLoadStoreUseTypeHint(TR_Op
 TR_YesNoMaybe
 J9::ValuePropagation::isArrayElementFlattened(TR::VPConstraint *arrayConstraint)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled())
+   if (!TR::Compiler->om.areValueTypesEnabled() ||
+       !TR::Compiler->om.isValueTypeArrayFlatteningEnabled()) // isValueTypeArrayFlatteningEnabled() checks areFlattenableValueTypesEnabled()
       {
       return TR_no;
       }
@@ -2648,7 +2650,8 @@ J9::ValuePropagation::isArrayElementFlattened(TR::VPConstraint *arrayConstraint)
 TR_YesNoMaybe
 J9::ValuePropagation::isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint)
    {
-   if (!TR::Compiler->om.areValueTypesEnabled())
+   if (!TR::Compiler->om.areValueTypesEnabled() ||
+       !TR::Compiler->om.areFlattenableValueTypesEnabled()) // Only null restricted or primitive value type are flattenable
       {
       return TR_no;
       }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -201,7 +201,9 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
             }
          else
             {
-            if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
+            if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
+                TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
+                TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
                sigStr[0] = 'Q';
             else
                sigStr[0] = 'L';

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -2506,8 +2506,11 @@ public class ValueTypeTests {
 	
 	/*
 	 * Ensure that casting null to a value type class will throw a null pointer exception
+	 * This test is disabled since the latest spec from
+	 * https://cr.openjdk.org/~dlsmith/jep401/jep401-20230519/specs/types-cleanup-jvms.html
+	 * no longer requires null check on the objectref for null restricted value type class
 	 */
-	@Test(priority=1, expectedExceptions=NullPointerException.class)
+	@Test(enabled=false, priority=1, expectedExceptions=NullPointerException.class)
 	static public void testCheckCastValueTypeOnNull() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNull", fields);


### PR DESCRIPTION
- Check `areFlattenableValueTypesEnabled` before checking if element is flattened
- Check if `Q` signature is supported or not before using `Q` signature to determine if the element is a value type
   - This change is intended to lay the foundation to support the two cases: `Q` signature is supported and `Q` signature is not supported. This change does not handle the case where `Q` signature is not supported. At the moment as long as flattenable value types are enabled, `Q` signature is still supported
- Remove special handling on checking primitive value type in `genCheckcast` and disable `testCheckCastValueTypeOnNull` since the latest spec doesn't require special handling on null restricted value types.