### PR TITLE
CRIU restore clears InetAddress.cache

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -61,11 +61,15 @@ uses com.ibm.gpu.spi.GPUAssist.Provider;
 exports com.ibm.gpu.spi to
     openj9.gpu;
 /*[IF CRIU_SUPPORT]*/
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+exports jdk.internal.access to
+    openj9.criu;
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+exports jdk.internal.misc to
+    openj9.criu;
 exports openj9.internal.criu to
     openj9.criu;
 exports openj9.internal.criu.security to
-    openj9.criu;
-exports jdk.internal.misc to
     openj9.criu;
 opens jdk.internal.misc to
     openj9.criu;


### PR DESCRIPTION
CRIU restore clears `InetAddress.cache`

A post-restore hook `clearInetAddressCache()` is added to clear `InetAddress.cache`.

This change prevents JVM DNS cache before checkpoint which might cause DNS resolution timeout after the CRIU image is restored at a different environment.
Related
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/604

Signed-off-by: Jason Feng <fengj@ca.ibm.com>