### PR TITLE
Use factory method for ExternalRelocations

### DIFF
--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -257,11 +257,15 @@ uint8_t *TR::ARM64CallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(intptr_t *)cursor = (intptr_t)getCallRA();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               NULL,
-                               TR_AbsoluteMethodAddress, cg()),
-                               __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 8;
 
    //induceOSRAtCurrentPC is implemented in the VM, and it knows, by looking at the current PC, what method it needs to
@@ -275,9 +279,16 @@ uint8_t *TR::ARM64CallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             {
             cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
-                                    TR_HCR, cg()),
-                                       __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  (uint8_t *)cursor,
+                  NULL,
+                  (uint8_t *)needsFullSizeRuntimeAssumption,
+                  TR_HCR,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       else
@@ -286,10 +297,16 @@ uint8_t *TR::ARM64CallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             {
             cg()->jitAddPicToPatchOnClassRedefinition((void *)methodSymbol->getMethodAddress(), (void *)cursor);
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
-                                                                                    getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                    TR_MethodObject, cg()),
-                                       __FILE__, __LINE__, callNode);
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)methodSymRef,
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  TR_MethodObject,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               callNode);
             }
          }
       }
@@ -484,12 +501,16 @@ uint8_t *TR::ARM64UnresolvedCallSnippet::emitSnippetBody()
       traceMsg(comp, "</relocatableDataTrampolinesCG>\n");
       }
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               *(uint8_t **)cursor,
-                               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                               TR_Trampolines, cg()),
-                               __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_Trampolines,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 8;
 
    switch (getNode()->getDataType())
@@ -591,23 +612,31 @@ uint8_t *TR::ARM64VirtualUnresolvedSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(intptr_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               NULL,
-                               TR_AbsoluteMethodAddress, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(intptr_t);
 
    // CP
    intptr_t cpAddr = (intptr_t)methodSymRef->getOwningMethod(comp)->constantPool();
    *(intptr_t *)cursor = cpAddr;
    uint8_t *j2iThunkRelocationPoint = cursor;
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               *(uint8_t **)cursor,
-                               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                               TR_Thunks, cg()),
-                               __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_Thunks,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += sizeof(intptr_t);
 
    // CP index
@@ -638,12 +667,16 @@ uint8_t *TR::ARM64VirtualUnresolvedSnippet::emitSnippetBody()
    // data3 = distance in bytes from Constant Pool Pointer to J2I Thunk
    info->data3 = (intptr_t)cursor - (intptr_t)j2iThunkRelocationPoint;
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               j2iThunkRelocationPoint,
-                               (uint8_t *)info,
-                               NULL,
-                               TR_J2IVirtualThunkPointer, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         j2iThunkRelocationPoint,
+         (uint8_t *)info,
+         NULL,
+         TR_J2IVirtualThunkPointer,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += sizeof(intptr_t);
 
@@ -735,11 +768,15 @@ uint8_t *TR::ARM64InterfaceCallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(intptr_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               NULL,
-                               TR_AbsoluteMethodAddress, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(intptr_t);
 
    // CP
@@ -770,12 +807,26 @@ uint8_t *TR::ARM64InterfaceCallSnippet::emitSnippetBody()
    *reinterpret_cast<intptr_t *>(cursor + 3*sizeof(intptr_t)) = reinterpret_cast<intptr_t>(blAddress);
 
    // Register for relocation of the 1st target address
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + sizeof(intptr_t), NULL, TR_AbsoluteMethodAddress, cg()),
-         __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor + sizeof(intptr_t),
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    // Register for relocation of the 2nd target address
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + 3*sizeof(intptr_t), NULL, TR_AbsoluteMethodAddress, cg()),
-         __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor + 3*sizeof(intptr_t),
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += 4*sizeof(intptr_t);
 
@@ -800,12 +851,16 @@ uint8_t *TR::ARM64InterfaceCallSnippet::emitSnippetBody()
       // data3 = distance in bytes from Constant Pool Pointer to J2I Thunk
       info->data3 = reinterpret_cast<intptr_t>(cursor) - reinterpret_cast<intptr_t>(j2iThunkRelocationPoint);
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                                  j2iThunkRelocationPoint,
-                                  reinterpret_cast<uint8_t *>(info),
-                                  NULL,
-                                  TR_J2IVirtualThunkPointer, cg()),
-                                  __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            j2iThunkRelocationPoint,
+            reinterpret_cast<uint8_t *>(info),
+            NULL,
+            TR_J2IVirtualThunkPointer,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
       }
    cursor += sizeof(intptr_t);
 

--- a/runtime/compiler/aarch64/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/ForceRecompilationSnippet.cpp
@@ -69,8 +69,15 @@ TR::ARM64ForceRecompilationSnippet::emitSnippetBody()
 
    // bl distance
    *(uint32_t *)cursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x03ffffff); // imm26
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)induceRecompilationSymRef, TR_HelperAddress, cg()),
-                               __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)induceRecompilationSymRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += ARM64_INSTRUCTION_LENGTH;
 
    if (_restartLabel != NULL)

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -126,11 +126,15 @@ J9::ARM64::CodeGenerator::encodeHelperBranchAndLink(TR::SymbolReference *symRef,
                       "Target address is out of range");
       }
 
-   cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(
-                             cursor,
-                             (uint8_t *)symRef,
-                             TR_HelperAddress, cg),
-                             __FILE__, __LINE__, node);
+   cg->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)symRef,
+         TR_HelperAddress,
+         cg),
+      __FILE__,
+      __LINE__,
+      node);
 
    uintptr_t distance = target - (uintptr_t)cursor;
    return TR::InstOpCode::getOpCodeBinaryEncoding(omitLink ? (TR::InstOpCode::b) : (TR::InstOpCode::bl)) | ((distance >> 2) & 0x3ffffff); /* imm26 */

--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
@@ -99,10 +99,15 @@ J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(intptr_t *)cursor = (intptr_t)getAddressOfDataReference(); // Code Cache RA
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-               cursor,
-               NULL,
-               TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 8;
 
    if (getDataSymbol()->isCallSiteTableEntry())
@@ -120,11 +125,16 @@ J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 8;
 
    *(intptr_t *)cursor = (intptr_t)getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool(); // CP
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-               cursor,
-               *(uint8_t **)cursor,
-               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-               TR_ConstantPool, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 8;
 
    *(int32_t *)cursor = getMemoryReference()->getOffset(); // offset

--- a/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
@@ -54,10 +54,15 @@ uint8_t *TR::ARMHelperCallSnippet::emitSnippetBody()
    *(int32_t *)buffer = 0xea000000 | ((distance >> 2)& 0x00ffffff);
    if (_restartLabel != NULL)
       *(int32_t *)buffer |= 0x01000000;
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                             buffer,
-                             (uint8_t *)getDestination(),
-                             TR_HelperAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)getDestination(),
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    buffer += 4;
 
    gcMap().registerStackMap(buffer, cg());

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -270,10 +270,15 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getCallRA();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-        						 cursor,
-        						 NULL,
-        						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 4;
 
    // Store the method pointer: it is NULL for unresolved
@@ -283,9 +288,16 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
       if (comp->getOption(TR_EnableHCR))
          {
          cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
-                                   TR_HCR, cg()),__FILE__, __LINE__,
-                                   getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               (uint8_t *)cursor,
+               NULL,
+               (uint8_t *)needsFullSizeRuntimeAssumption,
+               TR_HCR,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       }
    else
@@ -293,20 +305,31 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
       *(int32_t *)cursor = (uintptr_t)methodSymbol->getMethodAddress();
       if (comp->getOption(TR_EnableHCR))
          cg()->jitAddPicToPatchOnClassRedefinition((void *)methodSymbol->getMethodAddress(), (void *)cursor);
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
-                                                                                 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                 TR_MethodObject, cg()),
-                                      __FILE__, __LINE__, callNode);
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)methodSymRef,
+               getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+               TR_MethodObject,
+               cg()),
+            __FILE__,
+            __LINE__,
+            callNode);
       /*
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)methodSymRef;
       recordInfo->data2 = (uintptr_t)(getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1);
       recordInfo->data3 = (uintptr_t)fixedSequence1;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                             cursor,
-                             (uint8_t *)recordInfo,
-                             TR_MethodObject, cg()), __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)recordInfo,
+            TR_MethodObject,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
        */
       }
    cursor += TR::Compiler->om.sizeofReferenceAddress();
@@ -377,11 +400,16 @@ uint8_t *TR::ARMUnresolvedCallSnippet::emitSnippetBody()
       traceMsg(comp, "</relocatableDataTrampolinesCG>\n");
       }
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-        						 cursor,
-        						 *(uint8_t **)cursor,
-        						 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-        						 TR_Trampolines, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_Trampolines,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    return cursor+4;
    }
@@ -407,20 +435,30 @@ uint8_t *TR::ARMVirtualUnresolvedSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-        						 cursor,
-        						 NULL,
-        						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 4;
 
    // CP
    *(int32_t *)cursor = (intptr_t)methodSymRef->getOwningMethod(comp)->constantPool();
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                             cursor,
-                             *(uint8_t **)cursor,
-                             getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                             TR_Thunks, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_Thunks,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    cursor += 4;
 
@@ -449,19 +487,29 @@ uint8_t *TR::ARMInterfaceCallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-        						 cursor,
-        						 NULL,
-        						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)methodSymRef->getOwningMethod(cg()->comp())->constantPool();
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                             cursor,
-                             *(uint8_t **)cursor,
-                             getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                             TR_Thunks, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_Thunks,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    cursor += 4;
 

--- a/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
@@ -80,10 +80,15 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)getAddressOfDataReference();   // Code Cache RA
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-               cursor,
-               NULL,
-               TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 4;
 
    if (getDataSymbol()->isCallSiteTableEntry())
@@ -101,11 +106,16 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool();  // CP
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-               cursor,
-               *(uint8_t **)cursor,
-               getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-               TR_ConstantPool, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += 4;
 
    *(int32_t *)cursor = getMemoryReference()->getOffset(); // offset

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2601,11 +2601,16 @@ static void addValidationRecords(TR::CodeGenerator *cg)
 
          TR_ASSERT(siteIndex < (int32_t) cg->comp()->getNumInlinedCallSites(), "did not find AOTClassInfo %p method in inlined site table", *info);
 
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                          (uint8_t *)(intptr_t)siteIndex,
-                                                                          (uint8_t *)(*info),
-                                                                          (*info)->_reloKind, cg),
-                                                                          __FILE__, __LINE__, NULL);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               NULL,
+               (uint8_t *)(intptr_t)siteIndex,
+               (uint8_t *)(*info),
+               (*info)->_reloKind,
+               cg),
+            __FILE__,
+            __LINE__,
+            NULL);
          }
       }
    }
@@ -2621,10 +2626,15 @@ static void addSVMValidationRecords(TR::CodeGenerator *cg)
 
       for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                          (uint8_t *)(*it),
-                                                                          (*it)->_kind, cg),
-                                                                          __FILE__, __LINE__, NULL);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               NULL,
+               (uint8_t *)(*it),
+               (*it)->_kind,
+               cg),
+            __FILE__,
+            __LINE__,
+            NULL);
          }
       }
    }
@@ -2772,18 +2782,28 @@ static void processAOTGuardSites(TR::CodeGenerator *cg, uint32_t inlinedCallSize
          case TR_CheckMethodEnter:
          case TR_CheckMethodExit:
          case TR_HCR:
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
-                                                                             (uint8_t *)(*it)->getDestination(),
-                                                                             type, cg),
-                             __FILE__, __LINE__, NULL);
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  (uint8_t *)(*it)->getLocation(),
+                  (uint8_t *)(*it)->getDestination(),
+                  type,
+                  cg),
+               __FILE__,
+               __LINE__,
+               NULL);
             break;
 
          case TR_Breakpoint:
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
-                                                                             (uint8_t *)(intptr_t)(*it)->getGuard()->getCurrentInlinedSiteIndex(),
-                                                                             (uint8_t *)(*it)->getDestination(),
-                                                                             type, cg),
-                             __FILE__, __LINE__, NULL);
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  (uint8_t *)(*it)->getLocation(),
+                  (uint8_t *)(intptr_t)(*it)->getGuard()->getCurrentInlinedSiteIndex(),
+                  (uint8_t *)(*it)->getDestination(),
+                  type,
+                  cg),
+               __FILE__,
+               __LINE__,
+               NULL);
             break;
 
          case TR_NoRelocation:
@@ -2814,8 +2834,15 @@ static void addInlinedSiteRelocation(TR::CodeGenerator *cg,
    info->data3 = reinterpret_cast<uintptr_t>(receiver);
    info->data4 = reinterpret_cast<uintptr_t>(destinationAddress);
 
-   cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(reloLocation, (uint8_t *)info, reloType, cg),
-                   __FILE__,__LINE__, NULL);
+   cg->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         reloLocation,
+         (uint8_t *)info,
+         reloType,
+         cg),
+      __FILE__,
+      __LINE__,
+      NULL);
    }
 
 static void addInliningTableRelocations(TR::CodeGenerator *cg, uint32_t inlinedCallSize, TR_InlinedSiteHastTableEntry *orderedInlinedSiteListTable)
@@ -2946,10 +2973,25 @@ void J9::CodeGenerator::addProjectSpecializedRelocation(uint8_t *location, uint8
       TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    (target2 == NULL) ?
-         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, kind, self()),
-               generatingFileName, generatingLineNumber, node) :
-         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, target2, kind, self()),
-               generatingFileName, generatingLineNumber, node);
+         self()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               location,
+               target,
+               kind,
+               self()),
+            generatingFileName,
+            generatingLineNumber,
+            node) :
+         self()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               location,
+               target,
+               target2,
+               kind,
+               self()),
+            generatingFileName,
+            generatingLineNumber,
+            node);
    }
 
 void J9::CodeGenerator::addProjectSpecializedRelocation(TR::Instruction *instr, uint8_t *target, uint8_t *target2,
@@ -3000,8 +3042,15 @@ J9::CodeGenerator::jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinit
    if (self()->comp()->compileRelocatableCode())
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)firstInstruction, 0, TR_HCR, self()),
-                                 __FILE__,__LINE__, NULL);
+      self()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)firstInstruction,
+            0,
+            TR_HCR,
+            self()),
+         __FILE__,
+         __LINE__,
+         NULL);
       }
    else
       {

--- a/runtime/compiler/codegen/J9WatchedInstanceFieldSnippet.cpp
+++ b/runtime/compiler/codegen/J9WatchedInstanceFieldSnippet.cpp
@@ -54,14 +54,27 @@ uint8_t *TR::J9WatchedInstanceFieldSnippet::emitSnippetBody()
    if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
       {
       cg()->addExternalRelocation(
-         new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedInstanceFieldData, method), reinterpret_cast<uint8_t *>(instanceFieldData.method), reinterpret_cast<uint8_t *>(TR::SymbolType::typeMethod), TR_SymbolFromManager, cg()),
+         TR::ExternalRelocation::create(
+            cursor + offsetof(J9JITWatchedInstanceFieldData, method),
+            reinterpret_cast<uint8_t *>(instanceFieldData.method),
+            reinterpret_cast<uint8_t *>(TR::SymbolType::typeMethod),
+            TR_SymbolFromManager,
+            cg()),
          __FILE__,
          __LINE__,
          node);
       }
    else
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor  + offsetof(J9JITWatchedInstanceFieldData, method), NULL, TR_RamMethod, cg()), __FILE__, __LINE__, node);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor  + offsetof(J9JITWatchedInstanceFieldData, method),
+            NULL,
+            TR_RamMethod,
+            cg()),
+         __FILE__,
+         __LINE__,
+         node);
       }
    cursor += sizeof(J9JITWatchedInstanceFieldData);
 

--- a/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
+++ b/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
@@ -59,14 +59,27 @@ uint8_t *TR::J9WatchedStaticFieldSnippet::emitSnippetBody()
    if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
       {
       cg()->addExternalRelocation(
-         new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedStaticFieldData, method), reinterpret_cast<uint8_t *>(staticFieldData.method), reinterpret_cast<uint8_t *>(TR::SymbolType::typeMethod), TR_SymbolFromManager, cg()),
+         TR::ExternalRelocation::create(
+            cursor + offsetof(J9JITWatchedStaticFieldData, method),
+            reinterpret_cast<uint8_t *>(staticFieldData.method),
+            reinterpret_cast<uint8_t *>(TR::SymbolType::typeMethod),
+            TR_SymbolFromManager,
+            cg()),
          __FILE__,
          __LINE__,
          node);
       }
    else if (cg()->needClassAndMethodPointerRelocations())
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedStaticFieldData, method), NULL, TR_RamMethod, cg()), __FILE__, __LINE__, node);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor + offsetof(J9JITWatchedStaticFieldData, method),
+            NULL,
+            TR_RamMethod,
+            cg()),
+         __FILE__,
+         __LINE__,
+         node);
       }
 
    bool isResolved = !node->getSymbolReference()->isUnresolved();
@@ -77,7 +90,12 @@ uint8_t *TR::J9WatchedStaticFieldSnippet::emitSnippetBody()
       if (cg()->needRelocationsForStatics())
          {
          cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedStaticFieldData, fieldAddress), reinterpret_cast<uint8_t *>(node->getSymbolReference()), reinterpret_cast<uint8_t *>(node->getInlinedSiteIndex()), TR_DataAddress, cg()),
+            TR::ExternalRelocation::create(
+               cursor + offsetof(J9JITWatchedStaticFieldData, fieldAddress),
+               reinterpret_cast<uint8_t *>(node->getSymbolReference()),
+               reinterpret_cast<uint8_t *>(node->getInlinedSiteIndex()),
+               TR_DataAddress,
+               cg()),
             __FILE__,
             __LINE__,
             node);
@@ -86,12 +104,17 @@ uint8_t *TR::J9WatchedStaticFieldSnippet::emitSnippetBody()
       if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
          {
          cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedStaticFieldData, fieldClass), reinterpret_cast<uint8_t *>(staticFieldData.fieldClass), reinterpret_cast<uint8_t *>(TR::SymbolType::typeClass), TR_SymbolFromManager, cg()),
+            TR::ExternalRelocation::create(
+               cursor + offsetof(J9JITWatchedStaticFieldData, fieldClass),
+               reinterpret_cast<uint8_t *>(staticFieldData.fieldClass),
+               reinterpret_cast<uint8_t *>(TR::SymbolType::typeClass),
+               TR_SymbolFromManager,
+               cg()),
             __FILE__,
             __LINE__,
             node);
          }
-      // relocations for TR_ClassAddress are needed for AOT/AOTaaS compiles and not needed for regular JIT and JITServer compiles. 
+      // relocations for TR_ClassAddress are needed for AOT/AOTaaS compiles and not needed for regular JIT and JITServer compiles.
       // cg->needClassAndMethodPointerRelocations() tells us whether a relocation is needed depending on the type of compile being performed.
       else if (cg()->needClassAndMethodPointerRelocations())
          {
@@ -99,7 +122,12 @@ uint8_t *TR::J9WatchedStaticFieldSnippet::emitSnippetBody()
          // A short-term solution would be to use TR_ClassPointer. However this is hacky because TR_ClassPointer expects an aconst node (so we would have to create a dummy node). The proper solution would be to implement the functionality in the power
          // codegenerator to be able to patch TR_ClassAddress contiguous word.
          cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor + offsetof(J9JITWatchedStaticFieldData, fieldClass), reinterpret_cast<uint8_t *>(node->getSymbolReference()), reinterpret_cast<uint8_t *>(node->getInlinedSiteIndex()), TR_ClassAddress, cg()),
+            TR::ExternalRelocation::create(
+               cursor + offsetof(J9JITWatchedStaticFieldData, fieldClass),
+               reinterpret_cast<uint8_t *>(node->getSymbolReference()),
+               reinterpret_cast<uint8_t *>(node->getInlinedSiteIndex()),
+               TR_ClassAddress,
+               cg()),
             __FILE__,
             __LINE__,
             node);

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -361,8 +361,15 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
    // we use "b" for induceOSR because we want the helper to think that it's been called from the mainline code and not from the snippet.
    int32_t branchInstruction = (glueRef->isOSRInductionHelper()) ? 0x48000000 : 0x48000001;
    *(int32_t *)cursor = branchInstruction | ((helperAddress - (intptr_t)cursor) & 0x03fffffc);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
-      __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)glueRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += PPC_INSTRUCTION_LENGTH;
 
@@ -386,8 +393,15 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
       {
       // Store the code cache RA
       *(intptr_t *)cursor = (intptr_t)getCallRA();
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
-            __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            NULL,
+            TR_AbsoluteMethodAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
 
       cursor += TR::Compiler->om.sizeofReferenceAddress();
       }
@@ -404,9 +418,16 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             {
             cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
-                                                                                         TR_HCR, cg()),__FILE__, __LINE__,
-                                   getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  (uint8_t *)cursor,
+                  NULL,
+                  (uint8_t *)needsFullSizeRuntimeAssumption,
+                  TR_HCR,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       else
@@ -417,15 +438,25 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
 
          if (comp->compileRelocatableCode())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t *)methodSymbol->getMethodAddress(),
-                                                                  (uint8_t *)TR::SymbolType::typeMethod,
-                                                                  TR_SymbolFromManager,
-                                                                  cg()),  __FILE__, __LINE__, getNode());
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t *)methodSymbol->getMethodAddress(),
-                                                                  TR_ResolvedTrampolines,
-                                                                  cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)methodSymbol->getMethodAddress(),
+                  (uint8_t *)TR::SymbolType::typeMethod,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)methodSymbol->getMethodAddress(),
+                  TR_ResolvedTrampolines,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       }
@@ -493,11 +524,16 @@ uint8_t *TR::PPCUnresolvedCallSnippet::emitSnippetBody()
       traceMsg(comp, "</relocatableDataTrampolinesCG>\n");
       }
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
          *(uint8_t **)cursor,
          getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-         TR_Trampolines, cg()),
-         __FILE__, __LINE__, getNode());
+         TR_Trampolines,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
@@ -549,8 +585,15 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
 
    // bl glueRef
    *(int32_t *)cursor = 0x48000001 | ((helperAddress - (intptr_t)cursor) & 0x03fffffc);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
-      __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)glueRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += 4;
 
    /*
@@ -567,8 +610,15 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(intptr_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
-         __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
@@ -609,8 +659,16 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    // data3 = distance in bytes from Constant Pool Pointer to J2I Thunk
    info->data3 = (intptr_t)cursor - (intptr_t)j2iThunkRelocationPoint;
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(j2iThunkRelocationPoint, (uint8_t *)info, NULL, TR_J2IVirtualThunkPointer, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         j2iThunkRelocationPoint,
+         (uint8_t *)info,
+         NULL,
+         TR_J2IVirtualThunkPointer,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += sizeof(intptr_t);
 
@@ -669,8 +727,15 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
 
    // bl glueRef
    *(int32_t *)cursor = 0x48000001 | ((helperAddress - (intptr_t)cursor) & 0x03fffffc);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_HelperAddress, cg()),
-                             __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)glueRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    blAddress = cursor;
    cursor += PPC_INSTRUCTION_LENGTH;
 
@@ -783,12 +848,26 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    *(intptr_t *)(cursor+3*TR::Compiler->om.sizeofReferenceAddress()) = (intptr_t)blAddress;
 
    // Register for relation of the 1st target address
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
-         __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor+TR::Compiler->om.sizeofReferenceAddress(),
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    // Register for relocation of the 2nd target address
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+3*TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
-         __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor+3*TR::Compiler->om.sizeofReferenceAddress(),
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += 4 * TR::Compiler->om.sizeofReferenceAddress();
 
@@ -814,8 +893,16 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
       // data3 = distance in bytes from Constant Pool Pointer to J2I Thunk
       info->data3 = (intptr_t)cursor - (intptr_t)j2iThunkRelocationPoint;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(j2iThunkRelocationPoint, (uint8_t *)info, NULL, TR_J2IVirtualThunkPointer, cg()),
-                               __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            j2iThunkRelocationPoint,
+            (uint8_t *)info,
+            NULL,
+            TR_J2IVirtualThunkPointer,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
       }
    cursor += sizeof(intptr_t);
 

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -129,10 +129,15 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
    // b distance
    *(int32_t *)buffer = 0x48000000 | ((helperAddress - (intptr_t)buffer) & 0x03ffffff);
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)induceRecompilationSymRef,TR_HelperAddress, cg()),
-                          __FILE__,
-                          __LINE__,
-                          getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)induceRecompilationSymRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    buffer += PPC_INSTRUCTION_LENGTH;
 

--- a/runtime/compiler/p/codegen/J9PPCInstruction.cpp
+++ b/runtime/compiler/p/codegen/J9PPCInstruction.cpp
@@ -152,8 +152,15 @@ uint8_t *TR::PPCDepImmSymInstruction::generateBinaryEncoding()
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)getSymbolReference(),TR_HelperAddress, cg()),
-                               __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  TR_HelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       }

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -176,8 +176,15 @@ uint8_t *TR::PPCReadMonitorSnippet::emitSnippetBody()
 
    if (comp->compileRelocatableCode())
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)getMonitorEnterHelper(),TR_HelperAddress, cg()),
-                                __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            buffer,
+            (uint8_t *)getMonitorEnterHelper(),
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    *(int32_t *)buffer |= (helperAddress - (intptr_t)buffer) & 0x03FFFFFC;

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -178,13 +178,16 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(intptr_t *)cursor = (intptr_t)getDataSymbolReference()->getOwningMethod(comp)->constantPool();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,*(uint8_t **)cursor,
-                                                                          getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                          TR_ConstantPool,
-                                                                          cg()),
-                          __FILE__,
-                          __LINE__,
-                          getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
    if (getMemoryReference()->isTOCAccess())

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -60,10 +60,15 @@ uint8_t *TR::PPCRecompilationSnippet::emitSnippetBody()
 
    // bl distance
    *(int32_t *)buffer = 0x48000001 | ((helperAddress - (intptr_t)buffer) & 0x03ffffff);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)countingRecompMethodSymRef,TR_HelperAddress, cg()),
-                          __FILE__,
-                          __LINE__,
-                          getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)countingRecompMethodSymRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    buffer += 4;
 

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
@@ -170,10 +170,15 @@ uint8_t *TR::PPCStackCheckFailureSnippet::emitSnippetBody()
 
    // bl distance
    *(int32_t *)buffer = 0x48000001 | ((helperAddress - (intptr_t)buffer) & 0x03ffffff);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                         (uint8_t *)sofRef,
-                                                         TR_HelperAddress, cg()),
-                        __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)sofRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    buffer += 4;
    returnLocation = buffer;
 

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -842,14 +842,16 @@ TR_HWProfiler::createRecords(TR::Compilation *comp)
       if (!TR::Options::getCmdLineOptions()->getOption(TR_HWProfilerDisableAOT) &&
           fej9->hardwareProfilingInstructionsNeedRelocation())
          {
-         TR::ExternalRelocation *relocation =
-               new (comp->trHeapMemory()) TR::ExternalRelocation(ia,
-                                                                target,
-                                                                target2,
-                                                                relocationTargetKind,
-                                                                cg);
-
-         cg->addExternalRelocation(relocation, __FILE__, __LINE__, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               ia,
+               target,
+               target2,
+               relocationTargetKind,
+               cg),
+            __FILE__,
+            __LINE__,
+            node);
          }
       }
    }

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -90,11 +90,15 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(buffer-1, helperSymRef);
       if (fej9->needRelocationsForHelpers())
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                                                (uint8_t *)helperSymRef,
-                                                                                TR_HelperAddress,
-                                                                                cg()),
-                                   __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               buffer,
+               (uint8_t *)helperSymRef,
+               TR_HelperAddress,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       }
 

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -91,7 +91,7 @@ uint8_t *TR::X86PicDataSnippet::encodeConstantPoolInfo(uint8_t *cursor)
       info->data3 = offsetToJ2IVirtualThunk;
 
       cg()->addExternalRelocation(
-         new (cg()->trHeapMemory()) TR::ExternalRelocation(
+         TR::ExternalRelocation::create(
             cursor,
             (uint8_t *)info,
             NULL,
@@ -104,24 +104,29 @@ uint8_t *TR::X86PicDataSnippet::encodeConstantPoolInfo(uint8_t *cursor)
    else if (_thunkAddress)
       {
       TR_ASSERT(comp->target().is64Bit(), "expecting a 64-bit target for thunk relocations");
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                             *(uint8_t **)cursor,
-                                                                             (uint8_t *)inlinedSiteIndex,
-                                                                             TR_Thunks, cg()),
-                             __FILE__,
-                             __LINE__,
-                             _startOfPicInstruction->getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            *(uint8_t **)cursor,
+            (uint8_t *)inlinedSiteIndex,
+            TR_Thunks,
+            cg()),
+         __FILE__,
+         __LINE__,
+         _startOfPicInstruction->getNode());
       }
    else
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                  (uint8_t *)cpAddr,
-                                                                                   (uint8_t *)inlinedSiteIndex,
-                                                                                   TR_ConstantPool,
-                                                                                   cg()),
-                             __FILE__,
-                             __LINE__,
-                             _startOfPicInstruction->getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)cpAddr,
+            (uint8_t *)inlinedSiteIndex,
+            TR_ConstantPool,
+            cg()),
+         __FILE__,
+         __LINE__,
+         _startOfPicInstruction->getNode());
       }
 
    // DD/DQ cpIndex
@@ -186,11 +191,15 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, _dispatchSymRef);
       *(int32_t *)(++cursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory())
-         TR::ExternalRelocation(cursor,
-                                    (uint8_t *)_dispatchSymRef,
-                                    TR_HelperAddress,
-                                    cg()), __FILE__, __LINE__, _startOfPicInstruction->getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)_dispatchSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         _startOfPicInstruction->getNode());
       cursor += 4;
 
       // Lookup dispatch needs its stack map here.
@@ -362,11 +371,15 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, _dispatchSymRef);
       *(int32_t *)(++cursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory())
-         TR::ExternalRelocation(cursor,
-                                    (uint8_t *)_dispatchSymRef,
-                                    TR_HelperAddress,
-                                    cg()), __FILE__, __LINE__, _startOfPicInstruction->getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)_dispatchSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         _startOfPicInstruction->getNode());
       cursor += 4;
 
       // Populate vtable dispatch needs its stack map here.
@@ -426,11 +439,15 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor, resolveSlotHelperSymRef);
       *(int32_t *)(++picSlotCursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory())
-         TR::ExternalRelocation(picSlotCursor,
-                                    (uint8_t *)resolveSlotHelperSymRef,
-                                    TR_HelperAddress,
-                                    cg()),  __FILE__, __LINE__, _startOfPicInstruction->getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            picSlotCursor,
+            (uint8_t *)resolveSlotHelperSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         _startOfPicInstruction->getNode());
 
          picSlotCursor = (uint8_t *)(picSlotCursor - 1 + sizeofPicSlot);
 
@@ -442,11 +459,15 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
             disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor, populateSlotHelperSymRef);
             *(int32_t *)(++picSlotCursor) = disp32;
 
-            cg()->addExternalRelocation(new (cg()->trHeapMemory())
-               TR::ExternalRelocation(picSlotCursor,
-                                          (uint8_t *)populateSlotHelperSymRef,
-                                          TR_HelperAddress,
-                                          cg()), __FILE__, __LINE__, _startOfPicInstruction->getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  picSlotCursor,
+                  (uint8_t *)populateSlotHelperSymRef,
+                  TR_HelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               _startOfPicInstruction->getNode());
             picSlotCursor = (uint8_t *)(picSlotCursor - 1 + sizeofPicSlot);
             }
       }
@@ -864,11 +885,15 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
       *(int32_t *)(++cursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    (uint8_t *)helperSymRef,
-                                                                                    TR_HelperAddress,
-                                                                                    cg()),
-                                  __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)helperSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       cursor += 4;
 
       if (comp->target().is64Bit())
@@ -894,11 +919,15 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
       *(int32_t *)(++cursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    (uint8_t*)helperSymRef,
-                                                                                    TR_HelperAddress,
-                                                                                    cg()),
-                                  __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t*)helperSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       cursor += 4;
 
       // DW dispatch helper index for the method's return type.
@@ -910,12 +939,16 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       intptr_t cpAddr = (intptr_t)methodSymRef->getOwningMethod(comp)->constantPool();
       *(intptr_t *)cursor = cpAddr;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    *(uint8_t **)cursor,
-                                                                                    getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                    TR_ConstantPool,
-                                                                                    cg()),
-                                  __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            *(uint8_t **)cursor,
+            getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_ConstantPool,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       cursor += sizeof(intptr_t);
 
       // DD cpIndex
@@ -976,12 +1009,16 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                          (uint8_t *)ramMethod,
-                                                                                          (uint8_t *)TR::SymbolType::typeMethod,
-                                                                                          TR_SymbolFromManager,
-                                                                                          cg()),
-                                        __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)ramMethod,
+                  (uint8_t *)TR::SymbolType::typeMethod,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
 
          // HCR in TR::X86CallSnippet::emitSnippetBody register the method address
@@ -1003,11 +1040,15 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, dispatchSymRef);
       *(int32_t *)(++cursor) = disp32;
 
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    (uint8_t *)dispatchSymRef,
-                                                                                    TR_HelperAddress,
-                                                                                    cg()),
-                                  __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)dispatchSymRef,
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       cursor += 4;
       }
 

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -159,13 +159,15 @@ uint8_t *TR::X86CheckFailureSnippet::emitCheckFailureSnippetBody(uint8_t *buffer
       }
 
    *(int32_t *)buffer = (int32_t)(destinationAddress - (intptr_t)(buffer+4));
-   cg()->addExternalRelocation(new (cg()->trHeapMemory())
-      TR::ExternalRelocation(
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
          buffer,
          (uint8_t *)getDestination(),
          TR_HelperAddress,
          cg()),
-      __FILE__, __LINE__, getCheckInstruction()->getNode());
+      __FILE__,
+      __LINE__,
+      getCheckInstruction()->getNode());
 
    buffer += 4;
    uint8_t *checkSite = getCheckInstruction()->getBinaryEncoding();
@@ -303,12 +305,16 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
    //
    *buffer++ = 0x68; // push   imm4
    *(int32_t *)buffer = (int32_t) (intptr_t) getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                                           *(uint8_t **)buffer,
-                                                                           getCheckInstruction()->getNode() ? (uint8_t *)(uintptr_t)getCheckInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                           TR_ConstantPool, cg()),
-                          __FILE__, __LINE__,
-                          getCheckInstruction()->getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         *(uint8_t **)buffer,
+         getCheckInstruction()->getNode() ? (uint8_t *)(uintptr_t)getCheckInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getCheckInstruction()->getNode());
    buffer += 4;
 
    // Call the glue routine
@@ -324,12 +330,15 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(glueAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = (int32_t)(glueAddress - (intptr_t)(buffer+4));
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                         (uint8_t *)glueSymRef,
-                                                         TR_HelperAddress, cg()),
-                          __FILE__,
-                          __LINE__,
-                          getCheckInstruction()->getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)glueSymRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getCheckInstruction()->getNode());
 
    buffer += 4;
 
@@ -351,13 +360,15 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(destinationAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = (int32_t)(destinationAddress - (intptr_t)(buffer+4));
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                         (uint8_t *)getDestination(),
-                                                         TR_HelperAddress,
-                                                         cg()),
-                                                         __FILE__,
-                                                         __LINE__,
-                                                         getCheckInstruction()->getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)getDestination(),
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getCheckInstruction()->getNode());
    buffer += 4;
    uint8_t *checkSite = getCheckInstruction()->getBinaryEncoding();
    *(uint32_t *)buffer = (uint32_t)(buffer - checkSite);

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -58,12 +58,14 @@ uint8_t *TR::X86ForceRecompilationSnippet::emitSnippetBody()
       }
    *(int32_t *)buffer = ((uint8_t*)helperAddress - buffer) - 4;
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory())
-      TR::ExternalRelocation(
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
          buffer,
          (uint8_t *)helper,
          TR_HelperAddress, cg()),
-         __FILE__, __LINE__, getNode());
+      __FILE__,
+      __LINE__,
+      getNode());
 
    buffer += 4;
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -51,12 +51,15 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
        && TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines()
        && _cg->getPicSlotCount())
       {
-      _cg->addExternalRelocation(new (_cg->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                                 (uint8_t *)(uintptr_t)_cg->getPicSlotCount(),
-                                                                                 TR_PicTrampolines, _cg),
-                            __FILE__,
-                            __LINE__,
-                            NULL);
+      _cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            NULL,
+            (uint8_t *)(uintptr_t)_cg->getPicSlotCount(),
+            TR_PicTrampolines,
+            _cg),
+         __FILE__,
+         __LINE__,
+         NULL);
       }
 
    J9::AheadOfTimeCompile::processRelocations();

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -99,10 +99,15 @@ uint8_t *TR::X86RecompilationSnippet::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(helperAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = ((uint8_t*)helperAddress - buffer) - 4;
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
-                                                         (uint8_t *)_destination,
-                                                         TR_HelperAddress, cg()),
-                                                         __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         buffer,
+         (uint8_t *)_destination,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    buffer += 4;
 
    uint8_t *bufferBase = buffer;

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -90,8 +90,15 @@ TR::S390ForceRecompilationSnippet::emitSnippetBody()
 
    *(int32_t *) cursor = (int32_t)((destAddr - (intptr_t)(cursor - 2)) / 2);
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
-                             __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t*) glueRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 
    cursor += sizeof(int32_t);
 
@@ -153,14 +160,28 @@ TR::S390ForceRecompilationDataSnippet::emitSnippetBody()
 
    // Return Address
    *(intptr_t *) cursor = (intptr_t)getRestartLabel()->getCodeLocation();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                             __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += sizeof(intptr_t);
 
    // Start PC
    *(intptr_t *) cursor = (intptr_t)cg()->getCodeStart();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                             __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += sizeof(intptr_t);
 
    return cursor;

--- a/runtime/compiler/z/codegen/J9S390Snippet.cpp
+++ b/runtime/compiler/z/codegen/J9S390Snippet.cpp
@@ -119,8 +119,15 @@ TR::S390HeapAllocSnippet::emitSnippetBody()
    *(int32_t *) buffer = (int32_t)((destAddr - (intptr_t)(buffer - 2)) / 2);
    if (comp->compileRelocatableCode() || comp->isOutOfProcessCompilation())
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer, (uint8_t*) getDestination(), TR_HelperAddress, cg()),
-                                __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            buffer,
+            (uint8_t*) getDestination(),
+            TR_HelperAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    buffer += sizeof(int32_t);

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -291,8 +291,16 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
 
    // address of constant pool
    *(uintptr_t *) cursor = (uintptr_t) getDataSymbolReference()->getOwningMethod(comp)->constantPool();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
-                             __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += sizeof(uintptr_t);
 
    // referencing instruction that needs patching

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -56,19 +56,30 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          {
          TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock*)(*((uintptr_t*)cursor));
          TR_ASSERT_FATAL(clazz, "TR_ClassAddress relocation : cursor = %x, clazz can not be null", cursor);
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                           (uint8_t *)clazz,
-                                                                           (uint8_t *) TR::SymbolType::typeClass,
-                                                                           TR_SymbolFromManager,
-                                                                           cg),
-                                                                        file, line, node);
-
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)clazz,
+               (uint8_t *) TR::SymbolType::typeClass,
+               TR_SymbolFromManager,
+               cg),
+            file,
+            line,
+            node);
          }
       else
          {
          *((uintptr_t*)cursor)=fej9->getPersistentClassPointerFromClassPointer((TR_OpaqueClassBlock*)(*((uintptr_t*)cursor)));
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_ClassAddress, cg),
-                           file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) _symbolReference,
+               (uint8_t *)_inlinedSiteIndex,
+               TR_ClassAddress,
+               cg),
+            file,
+            line,
+            node);
          }
       }
    else if (_reloType==TR_RamMethod)
@@ -78,65 +89,137 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          TR::ResolvedMethodSymbol *methodSym = (TR::ResolvedMethodSymbol*) _symbolReference->getSymbol();
          uint8_t * j9Method = (uint8_t *) (reinterpret_cast<intptr_t>(methodSym->getResolvedMethod()->resolvedMethodAddress()));
          TR_ASSERT_FATAL(j9Method, "TR_RamMethod relocation : cursor = %x, j9Method can not be null", cursor);
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                           j9Method,
-                                                                           (uint8_t *) TR::SymbolType::typeMethod,
-                                                                           TR_SymbolFromManager,
-                                                                           cg),
-                                                                        file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               j9Method,
+               (uint8_t *) TR::SymbolType::typeMethod,
+               TR_SymbolFromManager,
+               cg),
+            file,
+            line,
+            node);
          }
       else
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg), file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_RamMethod,
+               cg),
+            file,
+            line,
+            node);
          }
       }
    else if (_reloType==TR_HelperAddress)
       {
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_HelperAddress, cg),
-                           file, line, node);
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *) _symbolReference,
+            TR_HelperAddress,
+            cg),
+         file,
+         line,
+         node);
       }
    else if (_reloType==TR_AbsoluteHelperAddress)
       {
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_AbsoluteHelperAddress, cg),
-                              file, line, node);
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *) _symbolReference,
+            TR_AbsoluteHelperAddress,
+            cg),
+         file,
+         line,
+         node);
       }
    else if (_reloType==TR_ConstantPool)
       {
       if (comp->target().is64Bit())
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
-                              file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) *((uint64_t*) cursor),
+               (uint8_t *)_inlinedSiteIndex,
+               TR_ConstantPool,
+               cg),
+            file,
+            line,
+            node);
          }
       else
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
-                              file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)(intptr_t) *((uint32_t*) cursor),
+               (uint8_t *)_inlinedSiteIndex,
+               TR_ConstantPool,
+               cg),
+            file,
+            line,
+            node);
          }
       }
    else if (_reloType==TR_MethodObject)
       {
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_MethodObject, cg),
-                              file, line, node);
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *) _symbolReference,
+            (uint8_t *)_inlinedSiteIndex,
+            TR_MethodObject,
+            cg),
+         file,
+         line,
+         node);
       }
    else if (_reloType==TR_DataAddress)
       {
       if (cg->needRelocationsForStatics())
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_DataAddress, cg),
-                              file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) _symbolReference,
+               (uint8_t *)_inlinedSiteIndex,
+               TR_DataAddress,
+               cg),
+            file,
+            line,
+            node);
          }
       }
    else if (_reloType==TR_BodyInfoAddress)
       {
       if (comp->target().is64Bit())
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_BodyInfoAddress, cg),
-                              file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) *((uint64_t*) cursor),
+               TR_BodyInfoAddress,
+               cg),
+            file,
+            line,
+            node);
          }
       else
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_BodyInfoAddress, cg),
-                           file, line, node);
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)(intptr_t) *((uint32_t*) cursor),
+               TR_BodyInfoAddress,
+               cg),
+            file,
+            line,
+            node);
          }
       }
    else if (_reloType==TR_DebugCounter)

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -324,14 +324,28 @@ TR::S390J9CallSnippet::emitSnippetBody()
 
    // Method address
    *(uintptr_t *) cursor = (uintptr_t) glueRef->getMethodAddress();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
-                             __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)glueRef,
+         TR_AbsoluteHelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    // Store the code cache RA
    *(uintptr_t *) cursor = (uintptr_t) getCallRA();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                          __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    //induceOSRAtCurrentPC is implemented in the VM, and it knows, by looking at the current PC, what method it needs to
@@ -349,8 +363,15 @@ TR::S390J9CallSnippet::emitSnippetBody()
             {
             //TODO check what happens when we pass -1 to jitAddPicToPatchOnClassRedefinition an dif it's correct in this case
             cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,
-                                    TR_HCR, cg()),__FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  (uint8_t *)cursor,
+                  NULL,
+                  TR_HCR,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       else
@@ -362,13 +383,17 @@ TR::S390J9CallSnippet::emitSnippetBody()
 
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
-            TR_ASSERT_FATAL(ramMethod, "cursor = %x, ramMehtod can not be null", cursor);
-            cg()->addExternalRelocation( new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                        (uint8_t *)ramMethod,
-                                                                        (uint8_t *)TR::SymbolType::typeMethod,
-                                                                        TR_SymbolFromManager,
-                                                                        cg()),
-                                                                     __FILE__, __LINE__, callNode);
+            TR_ASSERT_FATAL(ramMethod, "cursor = %x, ramMethod can not be null", cursor);
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)ramMethod,
+                  (uint8_t *)TR::SymbolType::typeMethod,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               callNode);
             }
 #if defined(J9VM_OPT_JITSERVER)
          else if (!comp->isOutOfProcessCompilation()) // Since we query this information from the client, remote compilations don't need to add relocation records for TR_MethodObject
@@ -376,8 +401,16 @@ TR::S390J9CallSnippet::emitSnippetBody()
          else
 #endif /* defined(J9VM_OPT_JITSERVER) */
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
-                                    __FILE__, __LINE__, callNode);
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) callNode->getSymbolReference(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  TR_MethodObject,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               callNode);
             }
          }
       }
@@ -661,20 +694,43 @@ TR::S390UnresolvedCallSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-         TR_Trampolines, cg()),
-         __FILE__, __LINE__,getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            *(uint8_t **)cursor,
+            getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_Trampolines,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 #if defined(J9ZOS390)
    else
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
-         __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            *(uint8_t **)cursor,
+            getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_ConstantPool,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 #endif
 #else
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
-      __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         *(uint8_t **)cursor,
+         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         TR_ConstantPool,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
 #endif
 
    cursor += sizeof(uintptr_t);
@@ -739,14 +795,28 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
 
    // Method address
    *(uintptr_t *) cursor = (uintptr_t) glueRef->getMethodAddress();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
-                             __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)glueRef,
+         TR_AbsoluteHelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    // Store the code cache RA
    *(uintptr_t *) cursor = (uintptr_t) getCallRA();
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                             __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    // CP addr
@@ -765,8 +835,15 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
 
    // instruction to be patched
    *(uintptr_t *) cursor = (uintptr_t) (getPatchVftInstruction()->getBinaryEncoding());
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                          __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    // Field used by nestmate private calls
@@ -779,9 +856,16 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
    // No explicit call to `addExternalRelocation` because its relocation info is passed to CP_addr `addExternalRelocation` call.
    *(uintptr_t *) cursor = (uintptr_t) thunkAddress;
    j2iRelocInfo->data3 = (uintptr_t)cursor - cpAddrPosition;    // data3 is the offset of CP_addr to J2I thunk
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t*)cpAddrPosition, (uint8_t*)j2iRelocInfo, NULL,
-                                                                                 TR_J2IVirtualThunkPointer, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         (uint8_t*)cpAddrPosition,
+         (uint8_t*)j2iRelocInfo,
+         NULL,
+         TR_J2IVirtualThunkPointer,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
    cursor += sizeof(uintptr_t);
 
    // Field used by nestmate private calls
@@ -792,8 +876,15 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
                    "Unexpected branch instruction in VirtualUnresolvedSnippet.\n");
 
    *(uintptr_t *) cursor = (uintptr_t) (getIndirectCallInstruction()->getBinaryEncoding() + getIndirectCallInstruction()->getBinaryLength());
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                          __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += sizeof(uintptr_t);
 
@@ -892,8 +983,15 @@ TR::S390InterfaceCallSnippet::emitSnippetBody()
    this->setSnippetDestAddr(destAddr);
 
    *(int32_t *) cursor = (int32_t)((destAddr - (intptr_t)(cursor - 2)) / 2);
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
-            __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t*) glueRef,
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += sizeof(int32_t);
 
    // Set up the code RA to the data snippet.
@@ -1262,8 +1360,15 @@ TR::J9S390InterfaceCallDataSnippet::emitSnippetBody()
    // code cache RA
    TR_ASSERT_FATAL(_codeRA != NULL, "Interface Call Data Constant's code return address not initialized.\n");
    *(uintptr_t *) cursor = (uintptr_t)_codeRA;
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                             __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         NULL,
+         TR_AbsoluteMethodAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
@@ -1296,9 +1401,16 @@ TR::J9S390InterfaceCallDataSnippet::emitSnippetBody()
    *(intptr_t *) cursor = (intptr_t)_thunkAddress;
    j2iRelocInfo->data3 = (uintptr_t)cursor - cpAddrPosition;  // data3 is the offset of CP_addr to J2I thunk
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t*)cpAddrPosition, (uint8_t*)j2iRelocInfo, NULL,
-                                                                                 TR_J2IVirtualThunkPointer, cg()),
-                               __FILE__, __LINE__, callNode);
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         (uint8_t*)cpAddrPosition,
+         (uint8_t*)j2iRelocInfo,
+         NULL,
+         TR_J2IVirtualThunkPointer,
+         cg()),
+      __FILE__,
+      __LINE__,
+      callNode);
 
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
@@ -1321,21 +1433,42 @@ TR::J9S390InterfaceCallDataSnippet::emitSnippetBody()
       // lastCachedSlot
       cursorlastCachedSlot = cursor;
       *(intptr_t *) (cursor) =  snippetStart + getFirstSlotOffset() - (2 * TR::Compiler->om.sizeofReferenceAddress());
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                                __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            NULL,
+            TR_AbsoluteMethodAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
 
       cursor += TR::Compiler->om.sizeofReferenceAddress();
 
       // firstSlot
       *(intptr_t *) (cursor) = snippetStart + getFirstSlotOffset();
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                                __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            NULL,
+            TR_AbsoluteMethodAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
       cursor += TR::Compiler->om.sizeofReferenceAddress();
 
       // lastSlot
       *(intptr_t *) (cursor) =  snippetStart + getLastSlotOffset();
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-                                __FILE__, __LINE__, callNode);
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            NULL,
+            TR_AbsoluteMethodAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         callNode);
       cursor += TR::Compiler->om.sizeofReferenceAddress();
       }
 
@@ -1617,10 +1750,16 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
 
       if (cg()->needClassAndMethodPointerRelocations())
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) callNode->getSymbolReference(),
                callNode  ? (uint8_t *)(intptr_t)callNode->getInlinedSiteIndex() : (uint8_t *)-1,
-                     reloType, cg()),
-                     __FILE__, __LINE__, callNode);
+               reloType,
+               cg()),
+            __FILE__,
+            __LINE__,
+            callNode);
          }
 
       cursor += TR::Compiler->om.sizeofReferenceAddress();
@@ -1632,8 +1771,15 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
        *(intptr_t *) cursor = (intptr_t) (_returnFromJNICallLabel->getCodeLocation());
 
        cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, _returnFromJNICallLabel));
-       cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
-             __FILE__, __LINE__, getNode());
+       cg()->addExternalRelocation(
+          TR::ExternalRelocation::create(
+             cursor,
+             NULL,
+             TR_AbsoluteMethodAddress,
+             cg()),
+          __FILE__,
+          __LINE__,
+          getNode());
 
        cursor += TR::Compiler->om.sizeofReferenceAddress();
        // _savedPC
@@ -1700,12 +1846,14 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
          info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
 
          cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(
+            TR::ExternalRelocation::create(
                cursor,
                reinterpret_cast<uint8_t *>(info),
                reloType,
                cg()),
-            __FILE__, __LINE__, callNode);
+            __FILE__,
+            __LINE__,
+            callNode);
          }
 
       cursor += TR::Compiler->om.sizeofReferenceAddress();


### PR DESCRIPTION
Replace all TR::ExternalRelocation allocations throughout with a factory method.

Take this opportunity to clean up the wildly inconsistent source formatting for all these allocation sites as well.