### PR TITLE
Adding helper functions for crc32 special routines to enable optimizations in AOT

### DIFF
--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -338,43 +338,50 @@ TR::Register *J9::Power::JNILinkage::buildDirectDispatch(TR::Node *callNode)
             deps->getPreConditions()->setDependencyInfo(map.getTargetIndex(TR::RealRegister::gr7), wasteArg, TR::RealRegister::gr7, UsesDependentRegister);
             deps->getPostConditions()->setDependencyInfo(map.getTargetIndex(TR::RealRegister::gr7), wasteArg, TR::RealRegister::gr7, UsesDependentRegister);
             }
+         }
 
-         if (comp()->compileRelocatableCode())
+      if (comp()->compileRelocatableCode())
+         {
+         TR_RuntimeHelper CRChelperId;
+         if (crc32m1)
+            CRChelperId = TR_PPCcrc32_oneByte;
+         else
+            CRChelperId = (targetAddress == (uintptr_t)crc32_vpmsum)? TR_PPCcrc32_vpmsum : TR_PPCcrc32_no_vpmsum;
+
+
+         TR::SymbolReference * specialCRCSymRef = (comp())->getSymRefTab()->findOrCreateRuntimeHelper(CRChelperId,false,false,false);
+         TR::LabelSymbol *specialCRCSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, specialCRCSymRef);
+         TR::Register *gr12Reg = deps->searchPreConditionRegister(TR::RealRegister::gr12);
+
+         if (specialCRCSnippetLabel == NULL)
             {
-
-            TR::SymbolReference * vpmsumSymRef = (comp())->getSymRefTab()->findOrCreateRuntimeHelper(TR_PPCcrc32_vpmsum,false,false,false);
-            TR::LabelSymbol *vpmsumSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, vpmsumSymRef);
-            TR::Register *gr12Reg = deps->searchPreConditionRegister(TR::RealRegister::gr12);
-
-            if (vpmsumSnippetLabel == NULL)
-               {
-               vpmsumSnippetLabel = generateLabelSymbol(cg());
-               cg()->addSnippet(new (cg()->trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, vpmsumSnippetLabel, vpmsumSymRef));
-               }
-
-            callNode->setSymbolReference(vpmsumSymRef);
-            if(comp()->target().isLinux() && comp()->target().is64Bit() && comp()->target().cpu.isLittleEndian())
-               {
-               if (!comp()->getOption(TR_DisableTOC) && !comp()->compilePortableCode())
-                  {
-                  int32_t helperOffset = (callNode->getSymbolReference()->getReferenceNumber() - 1)*sizeof(intptr_t);
-                  generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, gr12Reg,
-                                             TR::MemoryReference::createWithDisplacement(cg(), cg()->getTOCBaseRegister(), helperOffset, TR::Compiler->om.sizeofReferenceAddress()));
-                  }
-                  else
-                  {
-                  loadAddressConstant(cg(), callNode, (int64_t)runtimeHelperValue((TR_RuntimeHelper)vpmsumSymRef->getReferenceNumber()),
-                                      gr12Reg, NULL, false, TR_AbsoluteHelperAddress);
-                  }
-               }
-            else if (comp()->target().isAIX() || (comp()->target().isLinux() && comp()->target().is64Bit()))
-               {
-               generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, gr2Reg,
-                                          TR::MemoryReference::createWithDisplacement(cg(), cg()->getMethodMetaDataRegister(), offsetof(J9VMThread, jitTOC), TR::Compiler->om.sizeofReferenceAddress()));
-               }
-
-               generateDepLabelInstruction(cg(), TR::InstOpCode::bl, callNode, vpmsumSnippetLabel, deps);
+            specialCRCSnippetLabel = generateLabelSymbol(cg());
+            cg()->addSnippet(new (cg()->trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, specialCRCSnippetLabel, specialCRCSymRef));
             }
+
+         callNode->setSymbolReference(specialCRCSymRef);
+         if(comp()->target().isLinux() && comp()->target().is64Bit() && comp()->target().cpu.isLittleEndian())
+            {
+            if (!comp()->getOption(TR_DisableTOC) && !comp()->compilePortableCode())
+               {
+               int32_t helperOffset = (callNode->getSymbolReference()->getReferenceNumber() - 1)*sizeof(intptr_t);
+               generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, gr12Reg,
+                                          TR::MemoryReference::createWithDisplacement(cg(), cg()->getTOCBaseRegister(), helperOffset, TR::Compiler->om.sizeofReferenceAddress()));
+
+               }
+               else
+               {
+               loadAddressConstant(cg(), callNode, (int64_t)runtimeHelperValue((TR_RuntimeHelper)specialCRCSymRef->getReferenceNumber()),
+                                   gr12Reg, NULL, false, TR_AbsoluteHelperAddress);
+               }
+            }
+         else if (comp()->target().isAIX() || (comp()->target().isLinux() && comp()->target().is64Bit()))
+            {
+            generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, gr2Reg,
+                                       TR::MemoryReference::createWithDisplacement(cg(), cg()->getMethodMetaDataRegister(), offsetof(J9VMThread, jitTOC), TR::Compiler->om.sizeofReferenceAddress()));
+            }
+
+            generateDepLabelInstruction(cg(), TR::InstOpCode::bl, callNode, specialCRCSnippetLabel, deps);
          }
       }
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -458,6 +458,8 @@ JIT_HELPER(__forwardQuadWordArrayCopy_vsx);
 JIT_HELPER(__postP10ForwardCopy);
 JIT_HELPER(__postP10GenericCopy);
 JIT_HELPER(crc32_vpmsum);
+JIT_HELPER(crc32_no_vpmsum);
+JIT_HELPER(crc32_oneByte);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
 #if defined(OMR_GC_FULL_POINTERS)
@@ -1391,6 +1393,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_PPCpostP10ForwardCopy,           (void *) __postP10ForwardCopy,           TR_Helper);
    SET(TR_PPCpostP10GenericCopy,           (void *) __postP10GenericCopy,           TR_Helper);
    SET(TR_PPCcrc32_vpmsum,                 (void *) crc32_vpmsum,                   TR_CHelper);
+   SET(TR_PPCcrc32_no_vpmsum,              (void *) crc32_no_vpmsum,                TR_CHelper);
+   SET(TR_PPCcrc32_oneByte,                (void *) crc32_oneByte,                  TR_CHelper);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
 #if defined(OMR_GC_COMPRESSED_POINTERS)


### PR DESCRIPTION
This issue was caused as one of the special crc32 routine was not AOT-enabled. Adding code to enable AOT for all related methods.
Closes: https://github.com/eclipse-openj9/openj9/issues/17444