### PR TITLE
Update Split List Forced Flag + Revert CRIU Thread Count Reinit

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3050,8 +3050,7 @@ BOOLEAN
 gcReinitializeDefaultsForRestore(J9VMThread* vmThread)
 {
 	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(vmThread);
-	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
-	J9JavaVM* vm = vmThread->javaVM;
+	J9JavaVM *vm = vmThread->javaVM;
 	bool result = true;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -3063,20 +3062,11 @@ gcReinitializeDefaultsForRestore(J9VMThread* vmThread)
 		result = false;
 	}
 
-	/* Init of thread count will only occur if it is not enforced by gcParseReconfigurableArguments. */
-	extensions->configuration->initializeGCThreadCount(env);
-
-	/* If the thread count is being forced, check its validity and display a warning message if it is invalid, then mark it as invalid (see comment below). */
+	/* If the thread count is being forced, check its validity and display a warning message if it is invalid, then mark it as invalid. */
 	if (extensions->gcThreadCountForced && (extensions->gcThreadCount < extensions->dispatcher->threadCountMaximum())) {
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN, (UDATA)extensions->dispatcher->threadCountMaximum());
 		extensions->gcThreadCountForced = false;
 	}
-
-	/* Currently, threads don't shutdown during restore, so ensure thread count doesn't fall below
-	 * the checkpoint thread count. This adjustment can be removed in the future when dispatcher
-	 * thread shutdown is sufficiently tested at restore.
-	 */
-	extensions->gcThreadCount = OMR_MAX(extensions->dispatcher->threadCountMaximum(), extensions->gcThreadCount);
 
 	return result;
 }

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -37,6 +37,7 @@
 
 #include "mmparse.h"
 
+#include "Configuration.hpp"
 #include "GCExtensions.hpp"
 #if defined(J9VM_GC_REALTIME)
 #include "Scheduler.hpp"
@@ -641,6 +642,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
+			extensions->configuration->_packetListSplitForced = true;
 			continue;
 		}
 		
@@ -655,6 +657,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
+			extensions->configuration->_cacheListSplitForced = true;
 			continue;
 		}
 #endif /* J9VM_GC_MODRON_SCAVENGER */
@@ -698,6 +701,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				break;
 			}
 			extensions->enableHybridMemoryPool = true;
+			extensions->configuration->_splitFreeListAmountForced = true;
 			continue;
 		}
 
@@ -712,6 +716,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
+			extensions->configuration->_splitFreeListAmountForced = true;
 			continue;
 		}
 


### PR DESCRIPTION
- Set list split forced flags during cmdline parsing, now required by upstream GC params init API.
- Revert GC thread count init behaviour: recompute the default thread count when the explicit thread count is invalid.

Signed-off-by: Salman Rana <salman.rana@ibm.com>