### PR TITLE
Rework RegionExtenstion/Object List Initialization 

### DIFF
--- a/runtime/gc_base/ContinuationObjectList.cpp
+++ b/runtime/gc_base/ContinuationObjectList.cpp
@@ -45,6 +45,38 @@ MM_ContinuationObjectList::MM_ContinuationObjectList()
 	_typeId = __FUNCTION__;
 }
 
+MM_ContinuationObjectList *
+MM_ContinuationObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+{
+	MM_ContinuationObjectList *continuationObjectLists;
+
+	continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate(sizeof(MM_ContinuationObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	if (NULL != continuationObjectLists) {
+		new(continuationObjectLists) MM_ContinuationObjectList[arrayElements]();
+
+		for (uintptr_t index = 0; index < arrayElements; index++) {
+			continuationObjectLists[index].initialize(env);
+		}
+	}
+
+	return continuationObjectLists;
+}
+
+bool
+MM_ContinuationObjectList::initialize(MM_EnvironmentBase *env)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+
+	setNextList(extensions->getContinuationObjectLists());
+	setPreviousList(NULL);
+	if (NULL != extensions->getContinuationObjectLists()) {
+		extensions->getContinuationObjectLists()->setPreviousList(this);
+	}
+	extensions->setContinuationObjectLists(this);
+
+	return true;
+}
+
 void
 MM_ContinuationObjectList::addAll(MM_EnvironmentBase* env, j9object_t head, j9object_t tail)
 {

--- a/runtime/gc_base/ContinuationObjectList.hpp
+++ b/runtime/gc_base/ContinuationObjectList.hpp
@@ -54,6 +54,17 @@ private:
 protected:
 public:
 	/**
+	 * Allocate and initialize an array of MM_ContinuationObjectList instances, resembling the functionality of operator new[].
+	 *
+	 * @param env the current thread
+	 * @param arrayElements the number of lists to create
+	 *
+	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
+	 */
+	static MM_ContinuationObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	bool initialize(MM_EnvironmentBase *env);
+
+	/**
 	 * Add the specified linked list of objects to the buffer.
 	 * The objects are expected to be in a NULL terminated linked
 	 * list, starting from head and end at tail.

--- a/runtime/gc_base/OwnableSynchronizerObjectList.cpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectList.cpp
@@ -45,6 +45,38 @@ MM_OwnableSynchronizerObjectList::MM_OwnableSynchronizerObjectList()
 	_typeId = __FUNCTION__;
 }
 
+MM_OwnableSynchronizerObjectList *
+MM_OwnableSynchronizerObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+{
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectLists;
+
+	ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate(sizeof(MM_OwnableSynchronizerObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	if (NULL != ownableSynchronizerObjectLists) {
+		new(ownableSynchronizerObjectLists) MM_OwnableSynchronizerObjectList[arrayElements]();
+
+		for (uintptr_t index = 0; index < arrayElements; index++) {
+			ownableSynchronizerObjectLists[index].initialize(env);
+		}
+	}
+
+	return ownableSynchronizerObjectLists;
+}
+
+bool
+MM_OwnableSynchronizerObjectList::initialize(MM_EnvironmentBase *env)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+
+	setNextList(extensions->getOwnableSynchronizerObjectLists());
+	setPreviousList(NULL);
+	if (NULL != extensions->getOwnableSynchronizerObjectLists()) {
+		extensions->getOwnableSynchronizerObjectLists()->setPreviousList(this);
+	}
+	extensions->setOwnableSynchronizerObjectLists(this);
+
+	return true;
+}
+
 void 
 MM_OwnableSynchronizerObjectList::addAll(MM_EnvironmentBase* env, j9object_t head, j9object_t tail)
 {

--- a/runtime/gc_base/OwnableSynchronizerObjectList.hpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectList.hpp
@@ -55,6 +55,17 @@ private:
 protected:
 public:
 	/**
+	 * Allocate and initialize an array of MM_OwnableSynchronizerObjectList instances, resembling the functionality of operator new[].
+	 *
+	 * @param env the current thread
+	 * @param arrayElements the number of lists to create
+	 *
+	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
+	 */
+	static MM_OwnableSynchronizerObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	bool initialize(MM_EnvironmentBase *env);
+
+	/**
 	 * Add the specified linked list of objects to the buffer.
 	 * The objects are expected to be in a NULL terminated linked
 	 * list, starting from head and end at tail.

--- a/runtime/gc_base/ReferenceObjectList.cpp
+++ b/runtime/gc_base/ReferenceObjectList.cpp
@@ -44,6 +44,23 @@ MM_ReferenceObjectList::MM_ReferenceObjectList()
 	_typeId = __FUNCTION__;
 }
 
+MM_ReferenceObjectList *
+MM_ReferenceObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+{
+	MM_ReferenceObjectList *referenceObjectLists;
+
+	referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate(sizeof(MM_ReferenceObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	if (NULL != referenceObjectLists) {
+		new(referenceObjectLists) MM_ReferenceObjectList[arrayElements]();
+
+		for (uintptr_t index = 0; index < arrayElements; index++) {
+			referenceObjectLists[index].initialize(env);
+		}
+	}
+
+	return referenceObjectLists;
+}
+
 void 
 MM_ReferenceObjectList::addAll(MM_EnvironmentBase* env, UDATA referenceObjectType, j9object_t head, j9object_t tail)
 {

--- a/runtime/gc_base/ReferenceObjectList.hpp
+++ b/runtime/gc_base/ReferenceObjectList.hpp
@@ -52,6 +52,17 @@ private:
 protected:
 public:
 	/**
+	 * Allocate and initialize an array of MM_ReferenceObjectList instances, resembling the functionality of operator new[].
+	 *
+	 * @param env the current thread
+	 * @param arrayElements the number of lists to create
+	 *
+	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
+	 */
+	static MM_ReferenceObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	bool initialize(MM_EnvironmentBase *env) { return true; }
+
+	/**
 	 * Add the specified linked list of objects to the buffer.
 	 * The objects are expected to be in a NULL terminated linked
 	 * list, starting from head and end at tail.

--- a/runtime/gc_base/UnfinalizedObjectList.cpp
+++ b/runtime/gc_base/UnfinalizedObjectList.cpp
@@ -42,6 +42,38 @@ MM_UnfinalizedObjectList::MM_UnfinalizedObjectList()
 	_typeId = __FUNCTION__;
 }
 
+MM_UnfinalizedObjectList *
+MM_UnfinalizedObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+{
+	MM_UnfinalizedObjectList *unfinalizedObjectLists;
+
+	unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate(sizeof(MM_UnfinalizedObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	if (NULL != unfinalizedObjectLists) {
+		new(unfinalizedObjectLists) MM_UnfinalizedObjectList[arrayElements]();
+
+		for (uintptr_t index = 0; index < arrayElements; index++) {
+			unfinalizedObjectLists[index].initialize(env);
+		}
+	}
+
+	return unfinalizedObjectLists;
+}
+
+bool
+MM_UnfinalizedObjectList::initialize(MM_EnvironmentBase *env)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+
+	setNextList(extensions->unfinalizedObjectLists);
+	setPreviousList(NULL);
+	if (NULL != extensions->unfinalizedObjectLists) {
+		extensions->unfinalizedObjectLists->setPreviousList(this);
+	}
+	extensions->unfinalizedObjectLists = this;
+
+	return true;
+}
+
 void 
 MM_UnfinalizedObjectList::addAll(MM_EnvironmentBase* env, j9object_t head, j9object_t tail)
 {

--- a/runtime/gc_base/UnfinalizedObjectList.hpp
+++ b/runtime/gc_base/UnfinalizedObjectList.hpp
@@ -51,6 +51,17 @@ private:
 protected:
 public:
 	/**
+	 * Allocate and initialize an array of MM_UnfinalizedObjectList instances, resembling the functionality of operator new[].
+	 *
+	 * @param env the current thread
+	 * @param arrayElements the number of lists to create
+	 *
+	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
+	 */
+	static MM_UnfinalizedObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	bool initialize(MM_EnvironmentBase *env);
+
+	/**
 	 * Add the specified linked list of objects to the buffer.
 	 * The objects are expected to be in a NULL terminated linked
 	 * list, starting from head and end at tail.

--- a/runtime/gc_glue_java/HeapRegionDescriptorStandardExtension.hpp
+++ b/runtime/gc_glue_java/HeapRegionDescriptorStandardExtension.hpp
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef HEAPREGIONDESCRIPTORSTANDARDEXTENSION_HPP_
+#define HEAPREGIONDESCRIPTORSTANDARDEXTENSION_HPP_
+
+#include "EnvironmentBase.hpp"
+
+#include "OwnableSynchronizerObjectList.hpp"
+#include "ContinuationObjectList.hpp"
+#include "ReferenceObjectList.hpp"
+#include "UnfinalizedObjectList.hpp"
+
+class MM_HeapRegionDescriptorStandardExtension : public MM_BaseNonVirtual
+{
+/*
+ * Member data and types
+ */
+private:
+protected:
+public:
+	uintptr_t _maxListIndex; /**< Max index for _*ObjectLists[index] */
+	MM_UnfinalizedObjectList *_unfinalizedObjectLists; /**< An array of lists of unfinalized objects in this region */
+	MM_OwnableSynchronizerObjectList *_ownableSynchronizerObjectLists; /**< An array of lists of ownable synchronizer objects in this region */
+	MM_ContinuationObjectList *_continuationObjectLists; /**< An array of lists of continuation objects in this region */
+	MM_ReferenceObjectList *_referenceObjectLists; /**< An array of lists of reference objects (i.e. weak/soft/phantom) in this region */
+
+/*
+ * Member functions
+ */
+private:
+protected:
+public:
+	static MM_HeapRegionDescriptorStandardExtension *
+	newInstance(MM_EnvironmentBase *env, uintptr_t listCount)
+	{
+		MM_HeapRegionDescriptorStandardExtension *heapRegionDescriptorStandardExtension = NULL;
+
+		heapRegionDescriptorStandardExtension = (MM_HeapRegionDescriptorStandardExtension *)env->getForge()->allocate(sizeof(MM_HeapRegionDescriptorStandardExtension), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+		if (NULL != heapRegionDescriptorStandardExtension) {
+			new(heapRegionDescriptorStandardExtension) MM_HeapRegionDescriptorStandardExtension(listCount);
+			if (!heapRegionDescriptorStandardExtension->initialize(env)) {
+				heapRegionDescriptorStandardExtension->kill(env);
+				heapRegionDescriptorStandardExtension = NULL;
+			}
+		}
+		return heapRegionDescriptorStandardExtension;
+	}
+
+	bool
+	initialize(MM_EnvironmentBase *env)
+	{
+		if (NULL == (_unfinalizedObjectLists = MM_UnfinalizedObjectList::newInstanceArray(env, _maxListIndex))) {
+			return false;
+		}
+
+		if (NULL == (_ownableSynchronizerObjectLists = MM_OwnableSynchronizerObjectList::newInstanceArray(env, _maxListIndex))) {
+			return false;
+		}
+
+		if (NULL == (_continuationObjectLists = MM_ContinuationObjectList::newInstanceArray(env, _maxListIndex))) {
+			return false;
+		}
+
+		if (NULL == (_referenceObjectLists = MM_ReferenceObjectList::newInstanceArray(env, _maxListIndex))) {
+			return false;
+		}
+
+		return true;
+	}
+
+	void
+	kill(MM_EnvironmentBase *env)
+	{
+		tearDown(env);
+		env->getForge()->free(this);
+	}
+
+	void
+	tearDown(MM_EnvironmentBase *env)
+	{
+		if (NULL != _unfinalizedObjectLists) {
+			env->getForge()->free(_unfinalizedObjectLists);
+			_unfinalizedObjectLists = NULL;
+		}
+
+		if (NULL != _ownableSynchronizerObjectLists) {
+			env->getForge()->free(_ownableSynchronizerObjectLists);
+			_ownableSynchronizerObjectLists = NULL;
+		}
+
+		if (NULL != _continuationObjectLists) {
+			env->getForge()->free(_continuationObjectLists);
+			_continuationObjectLists = NULL;
+		}
+
+		if (NULL != _referenceObjectLists) {
+			env->getForge()->free(_referenceObjectLists);
+			_referenceObjectLists = NULL;
+		}
+	}
+
+	MM_HeapRegionDescriptorStandardExtension(uintptr_t listCount) :
+		MM_BaseNonVirtual()
+		, _maxListIndex(listCount)
+		, _unfinalizedObjectLists(NULL)
+		, _ownableSynchronizerObjectLists(NULL)
+		, _continuationObjectLists(NULL)
+		, _referenceObjectLists(NULL)
+	{
+		_typeId = __FUNCTION__;
+	}
+};
+
+#endif /* HEAPREGIONDESCRIPTORSTANDARDEXTENSION_HPP_ */


### PR DESCRIPTION
Move allocation and init of object lists from high level Config Delegate to the each individual list class.

Signed-off-by: Salman Rana <salman.rana@ibm.com>