### PR TITLE
Expand bytecode offset variables to 32bit

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -134,7 +134,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool isShortRunningMethod(int32_t callerIndex);
 
-   int32_t getDltBcIndex() { return (uint32_t)_dltBcIndex;}
+   int32_t getDltBcIndex() { return _dltBcIndex;}
    void setDltBcIndex(int32_t ix) { _dltBcIndex=ix;}
 
    int32_t *getDltSlotDescription() { return _dltSlotDescription;}
@@ -431,7 +431,7 @@ private:
 
    bool _needsClassLookahead;
 
-   uint16_t _dltBcIndex;
+   int32_t _dltBcIndex;
 
    int32_t * _dltSlotDescription;
 

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -853,8 +853,7 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
       flags[end + 1].set(InterpreterEmulator::BytecodePropertyFlag::bbStart);
       flags[handler].set(InterpreterEmulator::BytecodePropertyFlag::bbStart);
 
-      tryCatchInfo[i].initialize((uint16_t) start, (uint16_t) end,
-            (uint16_t) handler, (uint32_t) type);
+      tryCatchInfo[i].initialize(start, end, handler, (uint32_t) type);
       }
 
       calltarget->_cfg = new (cfgRegion) TR::CFG(comp(), calltarget->_calleeSymbol, cfgRegion);


### PR DESCRIPTION
A user experienced a compile time crash in setHandlerInfoWithOutBCInfo() because a bytecode index to a catch handler is above the 2^16th limit that normally applies for Java methods. This limit can be exceeded in rare cases after the JVM expands the method size on load. A good example of this would be when the VM inlines a "jsr" bytecode. Because the handler index is larger then 2^16th the offset is truncated when it is placed into the 16bit integer that we were using to record the offset. This fix will expand the size of variables used to hold bytecode offsets to be 32bits. This change also prevents a negative array index in genExceptionHandlers() when a try region starts at bytecode index 0.