### PR TITLE
Add/update java.specification.maintenance.version

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -628,11 +628,18 @@ initializeSystemProperties(J9JavaVM * vm)
 #endif /* JAVA_SPEC_VERSION < 12 */
 
 #if JAVA_SPEC_VERSION == 8
-	rc = addSystemProperty(vm, "java.specification.maintenance.version", "4", 0);
+#define JAVA_SPEC_MAINTENANCE_VERSION "5"
+#elif JAVA_SPEC_VERSION == 11 /* JAVA_SPEC_VERSION == 8 */
+#define JAVA_SPEC_MAINTENANCE_VERSION "2"
+#endif /* JAVA_SPEC_VERSION == 8 */
+
+#if defined(JAVA_SPEC_MAINTENANCE_VERSION)
+	rc = addSystemProperty(vm, "java.specification.maintenance.version", JAVA_SPEC_MAINTENANCE_VERSION, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto fail;
 	}
-#endif /* JAVA_SPEC_VERSION == 8 */
+#undef JAVA_SPEC_MAINTENANCE_VERSION
+#endif /* defined(JAVA_SPEC_MAINTENANCE_VERSION) */
 
 	rc = addSystemProperty(vm, "java.vm.vendor", JAVA_VM_VENDOR, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {


### PR DESCRIPTION
Java 8:
* changed upstream in jdk8u382-b02
* [8303028: Update system property for Java SE specification maintenance version](https://github.com/ibmruntimes/openj9-openjdk-jdk8/commit/d18bd3f730c88281f30852ba49c6074b512cafee)

Java 11:
* [8285497: Add system property for Java SE specification maintenance version](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/530f958c7b5947fad3f7e2d6192fee2d235bdd14)