### PR TITLE
CRIU JDK11UpTimeoutAdjustmentTest adjusts for thread starting

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
@@ -79,11 +79,11 @@
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
   </test>
 
-  <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedV1">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedV1" 1 1 false</command>
+  <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedNoNanoSecond">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedNoNanoSecond" 1 1 false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
-    <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedV1</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedNoNanoSecond</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: expected wait time</output>
@@ -96,11 +96,11 @@
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
   </test>
 
-  <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedV2">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedV2" 1 1 false</command>
+  <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedWithNanoSecond">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedWithNanoSecond" 1 1 false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
-    <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedV2</output>
+    <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedWithNanoSecond</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: expected wait time</output>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -86,6 +86,34 @@ public class CRIUTestUtils {
 		}
 	}
 
+	public static CRIUSupport prepareCheckPointJVM(Path path) {
+		CRIUSupport criu = null;
+		if (CRIUSupport.isCRIUSupportEnabled()) {
+			deleteCheckpointDirectory(path);
+			createCheckpointDirectory(path);
+			criu = new CRIUSupport(path);
+		} else {
+			System.err.println("CRIU is not enabled");
+		}
+		return criu;
+	}
+
+	public static void checkPointJVMNoSetup(CRIUSupport criu, Path path, boolean deleteDir) {
+		if (criu != null) {
+			try {
+				showThreadCurrentTime("Performing CRIUSupport.checkpointJVM()");
+				criu.setLeaveRunning(false).setShellJob(true).setFileLocks(true).checkpointJVM();
+			} catch (SystemRestoreException e) {
+				e.printStackTrace();
+			}
+			if (deleteDir) {
+				deleteCheckpointDirectory(path);
+			}
+		} else {
+			System.err.println("CRIU is not enabled");
+		}
+	}
+
 	public static void showThreadCurrentTime(String logStr) {
 		System.out.println(logStr + ", current thread name: " + Thread.currentThread().getName() + ", " + new Date()
 				+ ", System.currentTimeMillis(): " + System.currentTimeMillis() + ", System.nanoTime(): "

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
@@ -42,16 +42,6 @@ import jdk.internal.misc.Unsafe;
 
 public class DeadlockTest {
 
-	static class TestResult {
-		boolean testPassed;
-		volatile int lockStatus;
-
-		TestResult(boolean testPassed, int lockStatus) {
-			this.testPassed = testPassed;
-			this.lockStatus = lockStatus;
-		}
-	}
-
 	public static void main(String[] args) {
 		String test = args[0];
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestResult.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestResult.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.criu;
+
+public class TestResult {
+	boolean testPassed;
+	volatile int lockStatus;
+
+	TestResult(boolean testPassed, int lockStatus) {
+		this.testPassed = testPassed;
+		this.lockStatus = lockStatus;
+	}
+}


### PR DESCRIPTION
Added a checkpoint preparation utility helper to reduce the time gap between checkpoint and the target thread for `park/sleep/wait`; 
Moved `DeadlockTest.TestResult` to a separated class; 
Added TestResult for checkpoint and target threads synchronization; 
Renamed method names for better clarification.

Related 
* https://github.com/eclipse-openj9/openj9/issues/16907

Signed-off-by: Jason Feng <fengj@ca.ibm.com>