### PR TITLE
Call static method VM.getVMArgs() from JNI as a static method

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1372,7 +1372,7 @@ JVM_GetVmArguments(JNIEnv *env)
 					/* exit vm before calling jni method */
 					internalFunctions->internalExitVMToJNI(currentThread);
 
-					result = (jobjectArray)((*env)->CallObjectMethod(env, vmJniClass, mid));
+					result = (jobjectArray)((*env)->CallStaticObjectMethod(env, vmJniClass, mid));
 
 					internalFunctions->internalEnterVMFromJNI(currentThread);
 					internalFunctions->j9jni_deleteLocalRef(env, (jobject)vmJniClass);


### PR DESCRIPTION
Otherwise an error is produced by -Xcheck:jni, which can be triggered by compiling/running on jdk11+ via `java Source.java`.

<JNI GetStaticMethodID: com/sun/tools/javac/launcher/Main.main ([Ljava/lang/String;)V>
JVMJNCK044E JNI error in CallObjectMethod/CallObjectMethodV: Method is static
JVMJNCK077E Error detected in
jdk/internal/misc/VM.getRuntimeArguments()[Ljava/lang/String;