### PR TITLE
Correct SPDX license identifier

### DIFF
--- a/runtime/gc_glue_java/HeapRegionDescriptorStandardExtension.hpp
+++ b/runtime/gc_glue_java/HeapRegionDescriptorStandardExtension.hpp
@@ -17,7 +17,7 @@
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
 #ifndef HEAPREGIONDESCRIPTORSTANDARDEXTENSION_HPP_


### PR DESCRIPTION
SPDX license identifier has been merged in old format by mistake. This PR corrects it