### PR TITLE
Correct SPDX license identifiers

### DIFF
--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestResult.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestResult.java
@@ -17,7 +17,7 @@
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 package org.openj9.criu;
 


### PR DESCRIPTION
Correct SPDX license identifiers

Related https://github.com/eclipse-openj9/openj9/pull/17473#discussion_r1212069111

Signed-off-by: Jason Feng <fengj@ca.ibm.com>