### PR TITLE
Update aarch64_linux build docker image to support building openssl 3

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -345,7 +345,7 @@ aarch64_linux:
     11: 'linux-aarch64-normal-server-release'
   node_labels:
     build: 'ci.role.build && hw.arch.aarch64 && sw.tool.docker'
-    docker_image: 'adoptopenjdk/centos7_build_image@sha256:8ce0a5c8607e92aeb6aa6c5dd81643b47842e00adfdbde2730fb5f5237064d1a'
+    docker_image: 'adoptopenjdk/centos7_build_image@sha256:14254361f71a38b80d7f405c9de762fda780060589c070411b2c205b6ee26974'
   build_env:
     vars:
       all: 'CC=/usr/local/gcc10/bin/gcc-10.3 CXX=/usr/local/gcc10/bin/g++-10.3'


### PR DESCRIPTION
Related to
https://github.com/adoptium/infrastructure/pull/3014
https://github.com/adoptium/infrastructure/issues/3083

This was tested with openssl 3.0.9 in https://github.com/eclipse-openj9/openj9/pull/14900