### PR TITLE
Fix array constructor for Object Lists

### DIFF
--- a/runtime/gc_base/ContinuationObjectList.cpp
+++ b/runtime/gc_base/ContinuationObjectList.cpp
@@ -52,9 +52,8 @@ MM_ContinuationObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t a
 
 	continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate(sizeof(MM_ContinuationObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != continuationObjectLists) {
-		new(continuationObjectLists) MM_ContinuationObjectList[arrayElements]();
-
 		for (uintptr_t index = 0; index < arrayElements; index++) {
+			new(&continuationObjectLists[index]) MM_ContinuationObjectList();
 			continuationObjectLists[index].initialize(env);
 		}
 	}

--- a/runtime/gc_base/OwnableSynchronizerObjectList.cpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectList.cpp
@@ -52,9 +52,8 @@ MM_OwnableSynchronizerObjectList::newInstanceArray(MM_EnvironmentBase *env, uint
 
 	ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate(sizeof(MM_OwnableSynchronizerObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != ownableSynchronizerObjectLists) {
-		new(ownableSynchronizerObjectLists) MM_OwnableSynchronizerObjectList[arrayElements]();
-
 		for (uintptr_t index = 0; index < arrayElements; index++) {
+			new(&ownableSynchronizerObjectLists[index]) MM_OwnableSynchronizerObjectList();
 			ownableSynchronizerObjectLists[index].initialize(env);
 		}
 	}

--- a/runtime/gc_base/ReferenceObjectList.cpp
+++ b/runtime/gc_base/ReferenceObjectList.cpp
@@ -51,9 +51,8 @@ MM_ReferenceObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arra
 
 	referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate(sizeof(MM_ReferenceObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != referenceObjectLists) {
-		new(referenceObjectLists) MM_ReferenceObjectList[arrayElements]();
-
 		for (uintptr_t index = 0; index < arrayElements; index++) {
+			new(&referenceObjectLists[index]) MM_ReferenceObjectList();
 			referenceObjectLists[index].initialize(env);
 		}
 	}

--- a/runtime/gc_base/UnfinalizedObjectList.cpp
+++ b/runtime/gc_base/UnfinalizedObjectList.cpp
@@ -49,9 +49,8 @@ MM_UnfinalizedObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t ar
 
 	unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate(sizeof(MM_UnfinalizedObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != unfinalizedObjectLists) {
-		new(unfinalizedObjectLists) MM_UnfinalizedObjectList[arrayElements]();
-
 		for (uintptr_t index = 0; index < arrayElements; index++) {
+			new(&unfinalizedObjectLists[index]) MM_UnfinalizedObjectList();
 			unfinalizedObjectLists[index].initialize(env);
 		}
 	}


### PR DESCRIPTION
`new[]()` not supported on older compilers. Instead, just calling
`new()` in a loop for every element of the array.