### PR TITLE
CRIU skips j9sysinfo_get_username()/getpwuid() if isCheckPointAllowed

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -395,9 +395,10 @@ typedef struct J9PortLibrary {
 	int64_t nanoTimeMonotonicClockDelta;
 	/* Invoking j9sysinfo_get_username()/getpwuid() with SSSD enabled can cause checkpoint failure.
 	 * It is safe to call those methods if checkpoint is disallowed after a final restore.
+	 * This is equivalent to isCheckpointAllowed(), just for portlibrary access.
 	 * https://github.com/eclipse-openj9/openj9/issues/15800
 	 */
-	BOOLEAN finalRestore;
+	BOOLEAN isCheckPointAllowed;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } J9PortLibrary;
 

--- a/runtime/port/sysvipc/j9sharedhelper.c
+++ b/runtime/port/sysvipc/j9sharedhelper.c
@@ -236,10 +236,10 @@ cleanSharedMemorySegments(struct J9PortLibrary* portLibrary)
 
 	Trc_PRT_shared_cleanSharedMemorySegments_entry();
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	/* finalRestore is equivalent to !isCheckpointAllowed().
+	/* isCheckPointAllowed is equivalent to isCheckpointAllowed().
 	 * https://github.com/eclipse-openj9/openj9/issues/15800
 	 */
-	if (portLibrary->finalRestore)
+	if (!portLibrary->isCheckPointAllowed)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	{
 		result = omrsysinfo_get_username(processOwner, OUTPUTBUFSIZE);

--- a/runtime/port/sysvipc/j9shmem.c
+++ b/runtime/port/sysvipc/j9shmem.c
@@ -1293,10 +1293,10 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 			if (NULL == homeDir) {
 				struct passwd *pwent = NULL;
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-				/* finalRestore is equivalent to !isCheckpointAllowed().
+				/* isCheckPointAllowed is equivalent to isCheckpointAllowed().
 				 * https://github.com/eclipse-openj9/openj9/issues/15800
 				 */
-				if (!portLibrary->finalRestore) {
+				if (portLibrary->isCheckPointAllowed) {
 					Trc_PRT_j9shmem_getDir_tryHomeDirFailed_notFinalRestore();
 				} else
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -89,7 +89,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 	if (vm->checkpointState.isNonPortableRestoreMode) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		vm->checkpointState.isCheckPointAllowed = FALSE;
-		vm->portLibrary->finalRestore = TRUE;
+		vm->portLibrary->isCheckPointAllowed = FALSE;
 		j9port_control(J9PORT_CTLDATA_CRIU_SUPPORT_FLAGS, OMRPORT_CRIU_SUPPORT_ENABLED | J9OMRPORT_CRIU_SUPPORT_FINAL_RESTORE);
 	}
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3819,7 +3819,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			PORT_ACCESS_FROM_JAVAVM(vm);
 			vm->checkpointState.isCheckPointEnabled = TRUE;
 			vm->checkpointState.isCheckPointAllowed = TRUE;
-			vm->portLibrary->finalRestore = FALSE;
+			vm->portLibrary->isCheckPointAllowed = TRUE;
 			j9port_control(J9PORT_CTLDATA_CRIU_SUPPORT_FLAGS, OMRPORT_CRIU_SUPPORT_ENABLED);
 		}
 	}


### PR DESCRIPTION
CRIU skips `j9sysinfo_get_username()`/`getpwuid()` if `isCheckPointAllowed` 

`portLibrary->finalRestore` was `false` by default when `CRIU` is not enabled, this skips `j9sysinfo_get_username()`/`getpwuid()` unnecessarily for `non-criu` applications.
Now `portLibrary->isCheckPointAllowed` is equivalent to `vmFuncs->isCheckpointAllowed()` which is true if `CRIU` is enabled and `javaVM->checkpointState.isCheckPointAllowed` is `true` as well.

closes https://github.com/eclipse-openj9/openj9/issues/17471

FYI @hangshao0 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>