### PR TITLE
Permit JITServer AOT cache methods compiled with SVM to be immediately relocated at the client

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11948,14 +11948,6 @@ TR::CompilationInfo::replenishInvocationCount(J9Method *method, TR::Compilation 
    if ((methodVMExtra == 1) || (methodVMExtra == J9_JIT_QUEUED_FOR_COMPILATION))
       {
       int32_t count;
-#if defined(J9VM_OPT_JITSERVER)
-      // Even if the option to disable AOT relocation delay was specified, we need to delay relocation of deserialized
-      // AOT methods using SVM received from the JITServer AOT cache until the next interpreted invocation. Such methods
-      // cannot be immediately relocated in the current implementation; see CompilationInfo::canRelocateMethod().
-      if (comp->isDeserializedAOTMethodUsingSVM() && comp->getOption(TR_DisableDelayRelocationForAOTCompilations))
-         count = 0;
-      else
-#endif /* defined(J9VM_OPT_JITSERVER) */
       // We want to use high counts unless the user specified counts on the command line
       // or used useLowerMethodCounts (or -Xquickstart)
       if (TR::Options::getCountsAreProvidedByUser() || (TR::Options::startupTimeMatters() == TR_yes))
@@ -13164,16 +13156,7 @@ TR::CompilationInfo::canRelocateMethod(TR::Compilation *comp)
       return false;
 
 #if defined(J9VM_OPT_JITSERVER)
-   // Delay relocation if this is a deserialized AOT method using SVM received from the JITServer AOT cache.
-   // Such methods cannot be immediately relocated in the current implementation. An immediate AOT+SVM load
-   // uses the ID-symbol mapping created during compilation. This mapping is missing when the client receives
-   // a serialized AOT method from the server, and trying to load the deserialized method immediately
-   // triggers fatal assertions in SVM validation in certain cases. As a workaround, we delay the AOT load
-   // until the next interpreted invocation of the method; see CompilationInfo::replenishInvocationCounter().
-   //
-   //TODO: Avoid the overhead of rescheduling this compilation request by handling the deserialized AOT load as if
-   //      the method came from the local SCC, rather than as if it was freshly AOT-compiled at the JITServer.
-   if (comp->isDeserializedAOTMethodUsingSVM())
+   if (comp->isDeserializedAOTMethod() && comp->getPersistentInfo()->getJITServerAOTCacheDelayMethodRelocation())
       return false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -370,7 +370,9 @@ char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOp
    "-XX:JITServerAOTCacheDir=",           // = 65
    "-XX:JITServerAOTCacheName=",          // = 66
    "-XX:codecachetotalMaxRAMPercentage=", // = 67
-   // TR_NumExternalOptions                  = 68
+   "-XX:+JITServerAOTCacheDelayMethodRelocation", // = 68
+   "-XX:-JITServerAOTCacheDelayMethodRelocation", // = 69
+   // TR_NumExternalOptions                  = 70
    };
 
 //************************************************************************
@@ -2406,6 +2408,20 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
                char *name = NULL;
                GET_OPTION_VALUE(xxJITServerAOTCacheNameArgIndex, '=', &name);
                compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
+               }
+
+            const char *xxJITServerAOTCacheDelayMethodRelocation =
+               J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusJITServerAOTCacheDelayMethodRelocation];
+            const char *xxDisableJITServerAOTCacheDelayMethodRelocation =
+               J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusJITServerAOTCacheDelayMethodRelocation];
+            int32_t xxJITServerAOTCacheDelayMethodRelocationArgIndex =
+               FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerAOTCacheDelayMethodRelocation, 0);
+            int32_t xxDisableJITServerAOTCacheDelayMethodRelocationArgIndex =
+               FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerAOTCacheDelayMethodRelocation, 0);
+
+            if (xxJITServerAOTCacheDelayMethodRelocationArgIndex > xxDisableJITServerAOTCacheDelayMethodRelocationArgIndex)
+               {
+               compInfo->getPersistentInfo()->setJITServerAOTCacheDelayMethodRelocation(true);
                }
             }
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -121,7 +121,9 @@ enum ExternalOptions
    XXJITServerAOTCacheDirOption                = 65,
    XXJITServerAOTCacheNameOption               = 66,
    XXcodecachetotalMaxRAMPercentage            = 67,
-   TR_NumExternalOptions                       = 68
+   XXplusJITServerAOTCacheDelayMethodRelocation  = 68,
+   XXminusJITServerAOTCacheDelayMethodRelocation = 69,
+   TR_NumExternalOptions                         = 70
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -169,6 +169,8 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::XXminusJITServerAOTCachePersistenceOption:
          case J9::ExternalOptions::XXJITServerAOTCacheDirOption:
          case J9::ExternalOptions::XXcodecachetotalMaxRAMPercentage:
+         case J9::ExternalOptions::XXplusJITServerAOTCacheDelayMethodRelocation:
+         case J9::ExternalOptions::XXminusJITServerAOTCacheDelayMethodRelocation:
             {
             // do nothing, consume them to prevent errors
             FIND_AND_CONSUME_RESTORE_ARG(OPTIONAL_LIST_MATCH, optString, 0);

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -171,6 +171,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerAOTCacheName("default"),
          _JITServerUseAOTCachePersistence(false),
          _JITServerAOTCacheDir(),
+         _JITServerAOTCacheDelayMethodRelocation(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -363,6 +364,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerUseAOTCachePersistence(bool use) { _JITServerUseAOTCachePersistence = use; }
    const std::string &getJITServerAOTCacheDir() const { return _JITServerAOTCacheDir; }
    void setJITServerAOTCacheDir(const char *dir) { _JITServerAOTCacheDir = dir; }
+   bool getJITServerAOTCacheDelayMethodRelocation() const { return _JITServerAOTCacheDelayMethodRelocation; }
+   void setJITServerAOTCacheDelayMethodRelocation(bool b) { _JITServerAOTCacheDelayMethodRelocation = b; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -460,6 +463,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    std::string _JITServerAOTCacheName; // Name of the server AOT cache that this client is using
    bool        _JITServerUseAOTCachePersistence; // Whether to persist the JITServer AOT caches at the server
    std::string _JITServerAOTCacheDir;  // Directory where the JITServer persistent AOT caches are located
+   bool        _JITServerAOTCacheDelayMethodRelocation; // At the client, whether to delay deserialized method relocation or not
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5970,6 +5970,7 @@ TR_J9VMBase::revertToInterpreted(TR_OpaqueMethodBlock * method)
 int32_t *
 TR_J9VMBase::getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, bool isVettedForAOT)
    {
+   TR_ASSERT_FATAL(!comp->compileRelocatableCode() || comp->reloRuntime()->isRelocating(), "Function cannot be called during AOT method compilation");
    if (!TR_J9VMBase::staticStringEnableCompressionFieldAddr) // Not yet cached
       {
       int32_t *enableCompressionFieldAddr = NULL;
@@ -5979,7 +5980,9 @@ TR_J9VMBase::getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, boo
          TR_PersistentClassInfo * classInfo = (comp->getPersistentInfo()->getPersistentCHTable() == NULL) ?
             NULL :
             comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(stringClass, comp, isVettedForAOT);
-         if (classInfo && classInfo->isInitialized())
+         // Since this method should only be called during relocation (and not compilation), we pass false to isInitialized
+         // here so that a relo record is not created for this query.
+         if (classInfo && classInfo->isInitialized(false))
             {
             enableCompressionFieldAddr = (int32_t *)getStaticFieldAddress(stringClass,
                (unsigned char *)"COMPACT_STRINGS", 15, (unsigned char *)"Z", 1);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -213,6 +213,7 @@ TR_RelocationRuntime::TR_RelocationRuntime(J9JITConfig *jitCfg)
       }
 
       _isLoading = false;
+      _isRelocating = false;
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
       _numValidations = 0;
@@ -262,6 +263,8 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
    _options = options;
    TR_ASSERT(_options, "Options were not correctly initialized.");
    _reloLogger->setupOptions(_options);
+
+   TR_RelocationRuntime::IsRelocating startRelocating(this);
 
    uint8_t *tempCodeStart, *tempDataStart;
    uint8_t *oldDataStart, *oldCodeStart, *newCodeStart;


### PR DESCRIPTION
AOT methods compiled with SVM and received by the client from a JITServer AOT cache are now able to be relocated immediately.  Under the current defaults (if we detect that the current JVM is a JITServer client and the JITServer AOT cache deserializer is active) such methods will now always be relocated immediately. Formerly, such methods would always be stored in the local shared class cache and their count would be set to 0 so that they could be loaded from the local SCC on a subsequent invocation. This was done to avoid a particular assert documented in [this comment](https://github.com/eclipse-openj9/openj9/issues/17392#issue-1706225020) and alluded to in comments in the code that have been removed by these patches.

Such methods can be relocated immediately now because the relevant frontend query `getStringClassEnableCompressionFieldAddr` has been changed so that the `classInfo->isInitialized` query it performs no longer requests that a `TR_ValidateClassInfoIsInitialized` be generated. Since the `getStringClassEnableCompressionFieldAddr` query is only ever called during relocation, we should never need to generate a `TR_ValidateClassInfoIsInitialized` relocation record for that `classInfo->isInitialized` invocation.

Indeed, the way `getStringClassEnableCompressionFieldAddr` is implemented (its result is cached) means that it doesn't make sense to run that query while we are compiling an AOT method. To enforce that requirement, the `_isLoading` property of the relocation runtime is now set and reset consistently, so an assert can be added to `getStringClassEnableCompressionFieldAddr` to the effect that it should only be run when the method being compiled is non-AOT or when the method is being actively relocated.

A new option pair `-XX:[+|-]JITServerAOTCacheDelayMethodRelocation` is now available. When this is enabled, every method served from the JITServer AOT cache will have its relocation delayed.

Fixes: #17392