### PR TITLE
Correct JDK21 Jep425Tests_testVirtualThread

### DIFF
--- a/test/functional/Java21andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
+++ b/test/functional/Java21andUp/src/org/openj9/test/jep425/VirtualThreadTests.java
@@ -170,7 +170,7 @@ public class VirtualThreadTests {
 		/* The expected frame count is based on test's callstack and OpenJ9's implementation of
 		 * Continuation.yield().
 		 */
-		int expectedFrames = 12;
+		int expectedFrames = 10;
 		String expectedMethodName = "yieldImpl";
 
 		try {
@@ -231,7 +231,7 @@ public class VirtualThreadTests {
 			}
 
 			StackTraceElement[] ste = t.getStackTrace();
-			Assert.assertEquals(ste.length, 4);
+			Assert.assertEquals(ste.length, 3);
 			Assert.assertEquals(ste[0].getClassName(), "org.openj9.test.jep425.VirtualThreadTests");
 
 			testThread2_state = false;


### PR DESCRIPTION
https:
//github.com/ibmruntimes/openj9-openjdk-jdk/commit/1edf1e6ea5b6bcb6a9f2df18d6c98eb4e0a86865 removed the lambda call in VirtualThread.run() method and added @hidden annotation to yieldContinuation(). These changes reduced frame counts of stacktraces in VirtualThreadTests.java.

Fixes https://github.com/eclipse-openj9/openj9/issues/17280