### PR TITLE
Insert branch around re performing store for awrtbar

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -7183,19 +7183,10 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
 
    // Store for case where we have a NULL ptr detected at runtime and
    // branches around the wrtbar
-   //
-   // For the non-NULL case we chose to simply exec the ST twice as this is
-   // cheaper than branching around the a single ST inst.
-   //
+
    if (!sourceChild->isNonNull() && (doWrtBar || doCrdMrk))
       {
-      // As we could hit a gc when doing the gencon wrtbar, we have to not
-      // re-do the ST.  We must branch around the second store.
-      //
-      if (doWrtBar)
-         {
-         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
-         }
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::label, node, simpleStoreLabel);
 


### PR DESCRIPTION
In case of balanced GC policy, we generated code for awrtbar where in case of Non-NULL object stored into array object, it will re performing storing to avoid branching around which may have been cheaper. This re performing storing in the same object field twice for awrtbarrier somehow causing issue in unit test for PingPong using virtual threads where we end up with incorrect state in the array of ForkJoinTask causing one of the producer or consumer thread to be in waiting state. Change in this commit inserts the branch around the second store where we would jump to in case on runtime we encounter the null object store which can bypass costly write barrier checks.

Fixes: https://github.com/eclipse-openj9/openj9/issues/17255