### PR TITLE
Enable EDO during AOT compilation

### DIFF
--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -134,4 +134,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_SymbolFromManager`|Relocates a pointer materialized by using its SVM ID.|
 |`TR_DiscontiguousSymbolFromManager`|Relocates a discontiguous pointer materialized by using its SVM ID.|
 |`TR_MethodCallAddress`|Relocates the address of a call target. Only used in JitServer (in AOT, all other methods are assumed to be interpreted).|
-
+|`TR_CatchBlockCounter`|Relocates the address of the catch block counter in the `TR_PersistentMethodInfo` of the method being compiled.|

--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -135,3 +135,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_DiscontiguousSymbolFromManager`|Relocates a discontiguous pointer materialized by using its SVM ID.|
 |`TR_MethodCallAddress`|Relocates the address of a call target. Only used in JitServer (in AOT, all other methods are assumed to be interpreted).|
 |`TR_CatchBlockCounter`|Relocates the address of the catch block counter in the `TR_PersistentMethodInfo` of the method being compiled.|
+|`TR_StartPC`|Relocates the startPC of the method being compiled. Only implemented and used on Power.|

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -107,7 +107,7 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
       TR::Register *biAddrReg = cg->allocateRegister();
       TR::Register *recompCounterReg = cg->allocateRegister();
       intptr_t addr = (intptr_t)(comp->getRecompilationInfo()->getCounterAddress());
-      loadAddressConstant(cg, node, addr, biAddrReg);
+      loadAddressConstant(cg, node, addr, biAddrReg, NULL, false, TR_BodyInfoAddressLoad);
       TR::MemoryReference *loadbiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0);
       TR::MemoryReference *storebiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0);
       generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, recompCounterReg, loadbiMR);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -336,6 +336,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
       case TR_BodyInfoAddressLoad:
       case TR_RecompQueuedFlag:
       case TR_CatchBlockCounter:
+      case TR_StartPC:
          {
          // Nothing to do
          }
@@ -1418,6 +1419,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
       case TR_BodyInfoAddressLoad:
       case TR_RecompQueuedFlag:
       case TR_CatchBlockCounter:
+      case TR_StartPC:
          {
          self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
          }

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -335,6 +335,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
       case TR_ArrayCopyToc:
       case TR_BodyInfoAddressLoad:
       case TR_RecompQueuedFlag:
+      case TR_CatchBlockCounter:
          {
          // Nothing to do
          }
@@ -1416,6 +1417,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
       case TR_ArrayCopyToc:
       case TR_BodyInfoAddressLoad:
       case TR_RecompQueuedFlag:
+      case TR_CatchBlockCounter:
          {
          self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
          }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4887,6 +4887,12 @@ J9::CodeGenerator::needRelocationsForCurrentMethodPC()
    }
 
 bool
+J9::CodeGenerator::needRelocationsForCurrentMethodStartPC()
+   {
+   return self()->fej9()->needRelocationsForCurrentMethodStartPC();
+   }
+
+bool
 J9::CodeGenerator::needRelocationsForHelpers()
    {
    return self()->fej9()->needRelocationsForHelpers();

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -183,6 +183,7 @@ public:
    bool needRelocationsForStatics();
    bool needRelocationsForHelpers();
    bool needRelocationsForCurrentMethodPC();
+   bool needRelocationsForCurrentMethodStartPC();
 #if defined(J9VM_OPT_JITSERVER)
    bool needRelocationsForBodyInfoData();
    bool needRelocationsForPersistentInfoData();

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8762,7 +8762,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_DisableOnDemandLiteralPoolRegister);
 
                options->setOption(TR_DisableIPA);
-               options->setOption(TR_DisableEDO);
                options->setDisabled(OMR::invariantArgumentPreexistence, true);
                options->setOption(TR_DisableHierarchyInlining);
                options->setOption(TR_DisableKnownObjectTable);

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2679,7 +2679,6 @@ J9::Options::setupJITServerOptions()
       {
       self()->setOption(TR_DisableSamplingJProfiling);
       self()->setOption(TR_DisableProfiling); // JITServer limitation, JIT profiling data is not available to remote compiles yet
-      self()->setOption(TR_DisableEDO); // JITServer limitation, EDO counters are not relocatable yet
       self()->setOption(TR_DisableMethodIsCold); // Shady heuristic; better to disable to reduce client/server traffic
       self()->setOption(TR_DisableJProfilerThread);
       self()->setOption(TR_EnableJProfiling, false);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -285,6 +285,7 @@ public:
    virtual bool needClassAndMethodPointerRelocations() { return false; }
    virtual bool needRelocationsForStatics() { return false; }
    virtual bool needRelocationsForCurrentMethodPC() { return false; }
+   virtual bool needRelocationsForCurrentMethodStartPC() { return false; }
    virtual bool needRelocationsForBodyInfoData() { return false; }
    virtual bool needRelocationsForPersistentInfoData() { return false; }
    virtual bool needRelocationsForLookupEvaluationData() { return false; }
@@ -1497,6 +1498,7 @@ public:
    virtual bool               supportsFastNanoTime()                          { return false; }
    virtual bool               needRelocationsForStatics()                     { return true; }
    virtual bool               needRelocationsForCurrentMethodPC()             { return true; }
+   virtual bool               needRelocationsForCurrentMethodStartPC()        { return true; }
    virtual bool               needRelocationsForLookupEvaluationData()        { return true; }
    virtual bool               needRelocationsForBodyInfoData()                { return true; }
    virtual bool               needRelocationsForPersistentInfoData()          { return true; }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -54,7 +54,8 @@ public:
    virtual bool needRelocationsForBodyInfoData() override                { return true; }
    virtual bool needRelocationsForPersistentInfoData() override          { return true; }
    virtual bool needRelocationsForLookupEvaluationData() override        { return true; }
-   virtual bool needRelocationsForCurrentMethodPC() override                     { return true; }
+   virtual bool needRelocationsForCurrentMethodPC() override             { return true; }
+   virtual bool needRelocationsForCurrentMethodStartPC() override        { return true; }
    virtual bool isPortableSCCEnabled() override;
    virtual void markHotField(TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool) override { return; }
    virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT) override;
@@ -289,6 +290,7 @@ public:
    virtual bool       supportsFastNanoTime() override                          { return false; }
    virtual bool       needRelocationsForStatics() override                     { return true; }
    virtual bool       needRelocationsForCurrentMethodPC() override             { return true; }
+   virtual bool       needRelocationsForCurrentMethodStartPC() override        { return true; }
    virtual bool       needRelocationsForLookupEvaluationData() override        { return true; }
    virtual bool       needRelocationsForBodyInfoData() override                { return true; }
    virtual bool       needRelocationsForPersistentInfoData() override          { return true; }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 44; // ID: EMimrZgcKwDZhSWK3DD5
+   static const uint16_t MINOR_NUMBER = 45; // ID: xE92Epd5mxpOTwnwiRt7
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/CatchBlockProfiler.cpp
+++ b/runtime/compiler/optimizer/CatchBlockProfiler.cpp
@@ -23,6 +23,7 @@
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Recompilation.hpp"
 #include "il/Block.hpp"
+#include "il/SymbolReference.hpp"
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
 #include "optimizer/CatchBlockProfiler.hpp"
@@ -65,6 +66,8 @@ int32_t TR::CatchBlockProfiler::perform()
                {
                uint32_t *catchBlockCounterAddress = recompilation->getMethodInfo()->getCatchBlockCounterAddress();
                _catchBlockCounterSymRef = comp()->getSymRefTab()->createKnownStaticDataSymbolRef(catchBlockCounterAddress, TR::Int32);
+               _catchBlockCounterSymRef->getSymbol()->setIsCatchBlockCounter();
+               _catchBlockCounterSymRef->getSymbol()->setNotDataAddress();
                }
             TR::TreeTop *profilingTree = TR::TreeTop::createIncTree(comp(), b->getEntry()->getNode(), _catchBlockCounterSymRef, 1, b->getEntry());
             profilingTree->getNode()->setIsProfilingCode();

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -47,6 +47,10 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
    TR::SymbolReference  *induceRecompilationSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinduceRecompilation);
    intptr_t startPC = (intptr_t)((uint8_t*)cg()->getCodeStart());
+   // The relo runtime expects this kind of address to be zero in a relocatable binary, since it uses
+   // |= to update the address chunks. See TR_PPC64RelocationTarget::storeAddressSequence.
+   intptr_t startPCRegValue = cg()->needRelocationsForCurrentMethodStartPC() &&
+                              !cg()->canEmitDataForExternallyRelocatableInstructions() ? 0 : startPC;
 
    getSnippetLabel()->setCodeLocation(buffer);
 
@@ -57,12 +61,14 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
 
    if (cg()->comp()->target().is64Bit())
       {
+      uint8_t *firstInstruction = buffer;
+
       // put jit entry point address in startPCReg
       uint32_t hhval, hlval, lhval, llval;
-      hhval = startPC >> 48 & 0xffff;
-      hlval = (startPC >>32) & 0xffff;
-      lhval = (startPC >>16) & 0xffff;
-      llval = startPC & 0xffff;
+      hhval = startPCRegValue >> 48 & 0xffff;
+      hlval = (startPCRegValue >>32) & 0xffff;
+      lhval = (startPCRegValue >>16) & 0xffff;
+      llval = startPCRegValue & 0xffff;
 
       opcode.setOpCodeValue(TR::InstOpCode::lis);
       buffer = opcode.copyBinaryToBuffer(buffer);
@@ -100,22 +106,57 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
       startPCReg->setRegisterFieldRS((uint32_t *)buffer);
       *(uint32_t *)buffer |= llval;
       buffer += PPC_INSTRUCTION_LENGTH;
+
+      if (cg()->needRelocationsForCurrentMethodStartPC())
+         {
+         TR::Relocation *startPCRelo = new (cg()->trHeapMemory()) TR::ExternalRelocation(firstInstruction,
+                                                                                        NULL,
+                                                                                        (uint8_t *)fixedSequence1,
+                                                                                        TR_StartPC,
+                                                                                        cg());
+         cg()->addExternalRelocation(startPCRelo,
+                                     __FILE__,
+                                     __LINE__,
+                                     getNode());
+         }
       }
    else
       {
+      uint8_t *firstInstruction = buffer;
+
       // put jit entry point address in startPCReg
       opcode.setOpCodeValue(TR::InstOpCode::lis);
       buffer = opcode.copyBinaryToBuffer(buffer);
       startPCReg->setRegisterFieldRS((uint32_t *)buffer);
-      *(uint32_t *)buffer |= (uint32_t) (startPC >> 16 & 0xffff);
+      *(uint32_t *)buffer |= (uint32_t) (startPCRegValue >> 16 & 0xffff);
       buffer += PPC_INSTRUCTION_LENGTH;
+
+      uint8_t *secondInstruction = buffer;
 
       opcode.setOpCodeValue(TR::InstOpCode::ori);
       buffer = opcode.copyBinaryToBuffer(buffer);
       startPCReg->setRegisterFieldRT((uint32_t *)buffer);
       startPCReg->setRegisterFieldRA((uint32_t *)buffer);
-      *(uint32_t *)buffer |= (uint32_t) (startPC & 0xffff);
+      *(uint32_t *)buffer |= (uint32_t) (startPCRegValue & 0xffff);
       buffer += PPC_INSTRUCTION_LENGTH;
+
+      if (cg()->needRelocationsForCurrentMethodStartPC())
+         {
+         TR_RelocationRecordInformation *recordInfo =
+            (TR_RelocationRecordInformation *)cg()->comp()->trMemory()->allocateMemory(sizeof(TR_RelocationRecordInformation), heapAlloc);
+         recordInfo->data1 = (uintptr_t)NULL;
+         recordInfo->data3 = orderedPairSequence2;
+         TR::Relocation *startPCRelo = new (cg()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(firstInstruction,
+                                                                                                         secondInstruction,
+                                                                                                         (uint8_t *)recordInfo,
+                                                                                                         TR_StartPC,
+                                                                                                         cg());
+         cg()->addExternalRelocation(startPCRelo,
+                                     __FILE__,
+                                     __LINE__,
+                                     getNode());
+         }
+
       }
 
    intptr_t helperAddress = (intptr_t)induceRecompilationSymRef->getMethodAddress();

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -186,6 +186,7 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
       case TR_ArrayCopyToc:
       case TR_BodyInfoAddressLoad:
       case TR_CatchBlockCounter:
+      case TR_StartPC:
       case TR_RecompQueuedFlag:
          {
          TR_RelocationRecord *rRecord = reinterpret_cast<TR_RelocationRecord *>(reloRecord);

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -185,6 +185,7 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
       case TR_ArrayCopyHelper:
       case TR_ArrayCopyToc:
       case TR_BodyInfoAddressLoad:
+      case TR_CatchBlockCounter:
       case TR_RecompQueuedFlag:
          {
          TR_RelocationRecord *rRecord = reinterpret_cast<TR_RelocationRecord *>(reloRecord);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11960,7 +11960,7 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
       TR::Register *biAddrReg = cg->allocateRegister();
       TR::Register *recompCounterReg = cg->allocateRegister();
       intptr_t addr = (intptr_t) (comp->getRecompilationInfo()->getCounterAddress());
-      TR::Instruction *cursor = loadAddressConstant(cg, comp->compileRelocatableCode(), node, addr, biAddrReg);
+      TR::Instruction *cursor = loadAddressConstant(cg, cg->needRelocationsForBodyInfoData(), node, addr, biAddrReg, NULL, false, TR_BodyInfoAddressLoad);
       TR::MemoryReference *loadbiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0, TR::Compiler->om.sizeofReferenceAddress());
       TR::MemoryReference *storebiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0, TR::Compiler->om.sizeofReferenceAddress());
       cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, recompCounterReg, loadbiMR);

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -308,6 +308,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_GlobalValue:
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
+      case TR_CatchBlockCounter:
       case TR_DataAddress:
       case TR_DebugCounter:
          return true;

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -309,6 +309,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
       case TR_CatchBlockCounter:
+      case TR_StartPC:
       case TR_DataAddress:
       case TR_DebugCounter:
          return true;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1964,5 +1964,18 @@ class TR_RelocationRecordCatchBlockCounter : public TR_RelocationRecord
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
 
+class TR_RelocationRecordStartPC : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordStartPC() {}
+      TR_RelocationRecordStartPC(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name();
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
 #endif   // RELOCATION_RECORD_INCL
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1951,5 +1951,18 @@ class TR_RelocationRecordValidateIsClassVisible : public TR_RelocationRecord
       bool isVisible(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordCatchBlockCounter : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordCatchBlockCounter() {}
+      TR_RelocationRecordCatchBlockCounter(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name();
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
 #endif   // RELOCATION_RECORD_INCL
 

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -203,10 +203,11 @@ struct TR_RelocationError
       debugCounterRelocationFailure                    = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
       directJNICallRelocationFailure                   = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
       ramMethodConstRelocationFailure                  = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      catchBlockCounterRelocationFailure               = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
 
-      staticDefaultValueInstanceRelocationFailure      = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      staticDefaultValueInstanceRelocationFailure      = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
 
-      maxRelocationError                               = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
+      maxRelocationError                               = (61 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
       };
 
    static uint32_t decode(TR_RelocationErrorCode errorCode) { return static_cast<uint32_t>(errorCode >> RELO_ERRORCODE_SHIFT); }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2142,6 +2142,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_GlobalValue:
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
+      case TR_CatchBlockCounter:
       case TR_DataAddress:
       case TR_DebugCounter:
 #endif

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2143,6 +2143,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
       case TR_CatchBlockCounter:
+      case TR_StartPC:
       case TR_DataAddress:
       case TR_DebugCounter:
 #endif

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11337,14 +11337,15 @@ VMgenerateCatchBlockBBStartPrologue(
    TR::Block *block = node->getBlock();
    if (fej9->shouldPerformEDO(block, comp))
       {
+      TR_ASSERT_FATAL(cg->comp()->getRecompilationInfo(), "Recompilation info should be available");
+
       TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
       TR::LabelSymbol *restartLabel = generateLabelSymbol(cg);
 
-      generateMemInstruction(TR::InstOpCode::DEC4Mem, node, generateX86MemoryReference((intptr_t)comp->getRecompilationInfo()->getCounterAddress(), cg), cg);
+      generateMemInstruction(TR::InstOpCode::DEC4Mem, node, generateX86MemoryReference(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
       generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
       generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, cg);
       cg->addSnippet(new (cg->trHeapMemory()) TR::X86ForceRecompilationSnippet(cg, node, restartLabel, snippetLabel));
-      TR_ASSERT_FATAL(cg->comp()->getRecompilationInfo(), "Recompilation info should be available");
       cg->comp()->getRecompilationInfo()->getJittedBodyInfo()->setHasEdoSnippet();
       }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -13231,7 +13231,15 @@ VMgenerateCatchBlockBBStartPrologue(
       TR::Register * biAddrReg = cg->allocateRegister();
 
       // Load address of counter into biAddrReg
-      genLoadAddressConstant(cg, node, (uintptr_t) comp->getRecompilationInfo()->getCounterAddress(), biAddrReg);
+      if (cg->needRelocationsForBodyInfoData())
+         {
+         generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, biAddrReg,
+                                      (uintptr_t)comp->getRecompilationInfo()->getCounterAddress(), TR_BodyInfoAddress);
+         }
+      else
+         {
+         genLoadAddressConstant(cg, node, (uintptr_t) comp->getRecompilationInfo()->getCounterAddress(), biAddrReg);
+         }
 
       // Counter is 32-bit, so only use 32-bit opcodes
       TR::MemoryReference * recompMR = generateS390MemoryReference(biAddrReg, 0, cg);


### PR DESCRIPTION
This PR is based on #17217, which caused build failures on aarch64_mac and x86-64_windows. I added an `#include "il/SymbolReference.hpp"` line to `CatchBlockCounter.cpp` and this now appears to compile successfully on those platforms.

Attn @mpirvu.