### PR TITLE
Fix incorrect exception info in BNDCHK evaluator

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2725,6 +2725,46 @@ bool isConditionCodeSetForCompare(TR::Node *node, bool *jumpOnOppositeCondition)
    return false;
    }
 
+void setImplicitNULLCHKExceptionInfo(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT_FATAL(node->hasFoldedImplicitNULLCHK(), "Attempt to set exception info on BNDCHK without implicit NULLCHK");
+
+   TR::Compilation *comp = cg->comp();
+   bool isTraceCG = comp->getOption(TR_TraceCG);
+
+   TR::Instruction *faultingInstruction = cg->getImplicitExceptionPoint();
+   if (faultingInstruction)
+      {
+      // Check and correctly set the implicit exception point
+      //
+      // The compare analyzer may have generated a secondary load to
+      // resolved a compressed pointer and incorrectly set the exception point.
+      // If that is the case, correctly set the exception point on
+      // the comparison that actually throws the null pointer exception.
+      //
+      // The last instruction is a branch, the comparison is before.
+      TR::Instruction *cmpInstruction = cg->getAppendInstruction()->getPrev();
+      TR::InstOpCode::Mnemonic mnemonic = cmpInstruction->getOpCodeValue();
+      bool isComparisonMemForm = mnemonic == TR::InstOpCode::CMP4MemReg ||
+                                 mnemonic == TR::InstOpCode::CMP4RegMem;
+      if (comp->useCompressedPointers() &&
+          faultingInstruction != cmpInstruction &&
+          isComparisonMemForm)
+         {
+         if (isTraceCG)
+            traceMsg(comp,"Faulting instruction (previously %p) updated to %p\n",faultingInstruction,cmpInstruction);
+
+         faultingInstruction = cmpInstruction;
+         cg->setImplicitExceptionPoint(faultingInstruction);
+         }
+
+      faultingInstruction->setNeedsGCMap(0xFF00FFFF);
+      faultingInstruction->setNode(node);
+      }
+
+   if (isTraceCG)
+      traceMsg(comp,"Node %p has foldedimplicitNULLCHK, and a faulting instruction of %p\n",node,faultingInstruction);
+   }
 
 TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -2791,21 +2831,8 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
                                                      instr,
                                                      false
                                                      ));
-
    if (node->hasFoldedImplicitNULLCHK())
-      {
-      TR::Instruction *faultingInstruction = cg->getImplicitExceptionPoint();
-      if (comp->getOption(TR_TraceCG))
-         {
-         traceMsg(comp,"Node %p has foldedimplicitNULLCHK, and a faulting instruction of %p\n",node,faultingInstruction);
-         }
-
-      if (faultingInstruction)
-         {
-         faultingInstruction->setNeedsGCMap(0xFF00FFFF);
-         faultingInstruction->setNode(node);
-         }
-      }
+      setImplicitNULLCHKExceptionInfo(node, cg);
 
    firstChild->setIsNonNegative(true);
    secondChild->setIsNonNegative(true);

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -527,6 +527,33 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>BNDCHKImplicitNullTest</testCaseName>
+		<variations>
+			<variation>-Xjit:count=1000,limit={*C.shouldThrowNullPointerException*},optLevel=noopt,disableAsyncCompilation</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	BNDCHKImplicitNullTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<features>
+			<feature>AOT:nonapplicable</feature>
+		</features>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>BNDCHKSimplifyTest</testCaseName>
 		<variations>
 			<variation>-Xjit:count=100,limit={*checkIndex*},optLevel=scorching,disableAsyncCompilation</variation>

--- a/test/functional/JIT_Test/src/jit/test/tr/BNDCHKImplicitNull/BNDCHKImplicitNullTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/BNDCHKImplicitNull/BNDCHKImplicitNullTest.java
@@ -1,0 +1,30 @@
+package jit.test.tr.BNDCHKImplicitNull;
+
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+
+@Test(groups = { "level.sanity","component.jit" })
+public class BNDCHKImplicitNullTest {
+
+	static class C {
+		private int idx = 1;
+		private double[] arr;
+
+		public void shouldThrowNullPointerException() {
+			for (int i = 0; i < 1; ++i) {
+				double x = arr[idx];
+			}
+		}
+	}
+
+	@Test
+	public void testFoldedImplicitNULLCHK() {
+		C c = new C();
+		for (int i = 0; i < 10000; ++i) {
+			try {
+				c.shouldThrowNullPointerException();
+				AssertJUnit.fail("failed to throw null pointer exception");
+			} catch (NullPointerException ignored) {}
+		}
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -450,6 +450,11 @@
 	   <class name="jit.test.tr.SIMDOpts.SIMDOptTest" />
 	 </classes>
   </test>
+  <test name="BNDCHKImplicitNullTest">
+    <classes>
+      <class name="jit.test.tr.BNDCHKImplicitNull.BNDCHKImplicitNullTest" />
+    </classes>
+  </test>
   <test name="BNDCHKSimplifyTest">
 	 <classes>
 	   <class name="jit.test.tr.BNDCHKSimplify.BNDCHKSimplifyTest" />


### PR DESCRIPTION
When the evaluator for bound check on arrays generates code to decompress pointers, it incorrectly sets the implicit exception point to be the load of the pointer decompression. This causes the garbage to collector to crash because it uses the wrong GC atlas.

This commit correctly handles this case but the implicit exception point on the cmp [mem] [reg] which actually loads the length field of an array.

Issue: #17171