### PR TITLE
Add getNanoTimeTemp() to OpenJ9

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -50,7 +50,8 @@
 extern void TEMPORARY_initJ9X86TreeEvaluatorTable(TR::CodeGenerator *cg);
 
 J9::X86::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
-      J9::CodeGenerator(comp),
+   J9::CodeGenerator(comp),
+   _nanoTimeTemp(NULL),
    _stackFramePaddingSizeInBytes(0)
    {
    /**
@@ -190,6 +191,23 @@ TR::Recompilation *
 J9::X86::CodeGenerator::allocateRecompilationInfo()
    {
    return TR_X86Recompilation::allocate(self()->comp());
+   }
+
+TR::SymbolReference *
+J9::X86::CodeGenerator::getNanoTimeTemp()
+   {
+   if (_nanoTimeTemp == NULL)
+      {
+      TR::AutomaticSymbol *sym;
+#if defined(LINUX) || defined(OSX)
+      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
+#else
+      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,8);
+#endif
+      self()->comp()->getMethodSymbol()->addAutomatic(sym);
+      _nanoTimeTemp = new (self()->trHeapMemory()) TR::SymbolReference(self()->comp()->getSymRefTab(), sym);
+      }
+   return _nanoTimeTemp;
    }
 
 void

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -46,6 +46,8 @@ public:
 
    TR::Recompilation *allocateRecompilationInfo();
 
+   TR::SymbolReference *getNanoTimeTemp();
+
    void beginInstructionSelection();
 
    void endInstructionSelection();
@@ -101,6 +103,9 @@ public:
 
    // See J9::CodeGenerator::guaranteesResolvedVirtualDispatchForSVM
    bool guaranteesResolvedVirtualDispatchForSVM() { return true; }
+
+private:
+   TR::SymbolReference *_nanoTimeTemp;
    };
 
 }


### PR DESCRIPTION
Add getNanoTimeTemp() to OpenJ9 as the first step of migrating it out of OMR

Issue: [omr #5133](https://github.com/eclipse/omr/issues/5133)