### PR TITLE
Disable EDO under AOT/JITServer on aarch64

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8762,6 +8762,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_DisableOnDemandLiteralPoolRegister);
 
                options->setOption(TR_DisableIPA);
+#if defined(TR_HOST_ARM64)
+               options->setOption(TR_DisableEDO); // Temporary AOT limitation on aarch64
+#endif /* defined (TR_HOST_ARM64) */
                options->setDisabled(OMR::invariantArgumentPreexistence, true);
                options->setOption(TR_DisableHierarchyInlining);
                options->setOption(TR_DisableKnownObjectTable);

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2679,6 +2679,9 @@ J9::Options::setupJITServerOptions()
       {
       self()->setOption(TR_DisableSamplingJProfiling);
       self()->setOption(TR_DisableProfiling); // JITServer limitation, JIT profiling data is not available to remote compiles yet
+#if defined(TR_HOST_ARM64)
+      self()->setOption(TR_DisableEDO); // Temporary JITServer limitation on aarch64
+#endif /* defined (TR_HOST_ARM64) */
       self()->setOption(TR_DisableMethodIsCold); // Shady heuristic; better to disable to reduce client/server traffic
       self()->setOption(TR_DisableJProfilerThread);
       self()->setOption(TR_EnableJProfiling, false);


### PR DESCRIPTION
EDO is disabled on aarch64 until the problems identified in the linked issue can be resolved.

Fixes: #17535