### PR TITLE
Adjust call target weight estimate for callees with const args

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -50,6 +50,8 @@ const float TR_J9EstimateCodeSize::METHOD_INVOKE_ADJUSTMENT_FACTOR = 0.20f;
 // Empirically determined value
 const float TR_J9EstimateCodeSize::CONST_ARG_IN_CALLEE_ADJUSTMENT_FACTOR = 0.75f;
 
+#define DEFAULT_KNOWN_OBJ_WEIGHT 10
+
 /*
 DEFINEs are ugly in general, but putting
    if (tracer)
@@ -420,41 +422,111 @@ TR_J9EstimateCodeSize::adjustEstimateForConstArgs(TR_CallTarget * target, int32_
    if (disableConstArgWeightReduction || !target->_calleeSymbol)
       return false;
 
+   // This for remaining consistent with TR_MultipleCallTargetInliner::applyArgumentHeuristics
+   static const char * envKnownObjWeight = feGetEnv("TR_constClassWeight");
+   int32_t knownObjWeight = envKnownObjWeight ? atoi(envKnownObjWeight) : DEFAULT_KNOWN_OBJ_WEIGHT;
+
+   // The less aggressive adjustment factor, which is just the factor increased by 15% is
+   // intended to be used in cases where we can distinguish different degree of benefit
+   // to be had, with the original factor applied for the more beneficial cases, and the
+   // less aggressive factor being applied for the less beneficial cases.
+
+   float lessAggressiveAdjustmentFactor = factor * 1.15f;
+
    int32_t originalWeight = value;
    TR_LinkHead<TR_ParameterMapping> argMap;
+   TR_PrexArgInfo *prexArgInfo = target->_ecsPrexArgInfo;
    if (((TR_J9InlinerPolicy *)_inliner->getPolicy())->validateArguments(target,argMap))
       {
+      int32_t argIndex = 0;
       for (TR_ParameterMapping* parm = argMap.getFirst(); parm; parm = parm->getNext())
          {
          int32_t interimWeight = value;
          TR::Node * parmNode = parm->_parameterNode;
-         if (parmNode->getSymbolReference())
+         TR::ParameterSymbol * parmSym = parm->_parmSymbol;
+         const char * parmClassName = NULL;
+         int32_t parmClassNameLen = 0;
+         char * argClassName = NULL;
+         TR_PrexArgument * prexArg = NULL;
+         if (prexArgInfo) prexArg = prexArgInfo->get(argIndex++);
+
+         if (parmSym)
+            parmClassName = parmSym->getTypeSignature(parmClassNameLen);
+
+         if (prexArg && prexArg->getClass())
+            argClassName = TR::Compiler->cls.classSignature(comp(), prexArg->getClass(), comp()->trMemory());
+
+         if (parmNode->getOpCode().hasSymbolReference()
+            && parmNode->getSymbolReference()->getSymbol()->isStatic()
+            && parmNode->getSymbolReference()->getSymbol()->castToStaticSymbol()->isConstString())
             {
-            if (parmNode->getSymbolReference()->getSymbol()->isStatic()
-               && parmNode->getSymbolReference()->getSymbol()->castToStaticSymbol()->isConstString())
-               {
-               value *= factor;
-               heuristicTrace(tracer(),"Setting size from %d to %d because arg is constant string.", interimWeight, value);
-               }
-            else if (parmNode->getOpCodeValue() == TR::aload
-                  && parmNode->getSymbolReference()->getSymbol()->isConstObjectRef())
-               {
-               value *= factor;
-               heuristicTrace(tracer(),"Setting size from %d to %d because arg is const object ref.", interimWeight, value);
-               }
-            else if (parmNode->getOpCodeValue() == TR::aloadi
-                  && parmNode->getSymbolReference() == comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef())
-               {
-               value *= factor;
-               heuristicTrace(tracer(),"Setting size from %d to %d because arg is const class ref.", interimWeight, value);
-               }
+            value *= factor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is constant string.", interimWeight, value);
             }
-         if (parmNode->getOpCode().isLoadConst())
+         else if (argClassName
+                 && parmClassName
+                 && strncmp(argClassName, parmClassName, parmClassNameLen) != 0 // arg type needs to be more specific than declared type to benefit from weight adjustment
+                 && strcmp(argClassName, "Ljava/lang/String;") == 0)
+            {
+            value *= lessAggressiveAdjustmentFactor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is a string.", interimWeight, value);
+            }
+         else if (parmNode->getOpCodeValue() == TR::aload
+                 && parmNode->getSymbolReference()
+                 && parmNode->getSymbolReference()->getSymbol()->isConstObjectRef())
+            {
+            value *= factor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is const object ref.", interimWeight, value);
+            }
+         else if (parmNode->getOpCodeValue() == TR::aloadi
+               && parmNode->getOpCode().hasSymbolReference()
+               && parmNode->getSymbolReference() == comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef()
+               && parmNode->getFirstChild()
+               && parmNode->getFirstChild()->getOpCodeValue() == TR::loadaddr
+               && parmNode->getFirstChild()->getSymbol()->isStatic()
+               && !parmNode->getFirstChild()->getSymbolReference()->isUnresolved()
+               && parmNode->getFirstChild()->getSymbol()->isClassObject())
+            {
+            value *= factor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is const class ref.", interimWeight, value);
+            }
+         else if (argClassName
+               && parmClassName
+               && strncmp(argClassName, parmClassName, parmClassNameLen) != 0
+               && strcmp(argClassName, "Ljava/lang/Class;") == 0)
+            {
+            value *= lessAggressiveAdjustmentFactor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is a class ref.", interimWeight, value);
+            }
+         else if (parmNode->getOpCode().isLoadConst())
             {
             value *= factor;
             heuristicTrace(tracer(),"Setting size from %d to %d because arg is load const.", interimWeight, value);
             }
+         else if (argClassName
+               && parmClassName
+               && strncmp(argClassName, parmClassName, parmClassNameLen) != 0
+               && (strcmp(argClassName, "Ljava/lang/Integer;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Long;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Byte;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Double;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Float;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Short;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Boolean;") == 0
+                  || strcmp(argClassName, "Ljava/lang/Character;") == 0))
+            {
+            value *= lessAggressiveAdjustmentFactor;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is boxed primitive type.", interimWeight, value);
+            }
+         if (prexArg && prexArg->hasKnownObjectIndex())
+            {
+            value = knownObjWeight;
+            heuristicTrace(tracer(),"Setting size from %d to %d because arg is known object.", interimWeight, value);
+            break;
+            }
          }
+      value -= (argMap.getSize() * 4);
+      heuristicTrace(tracer(),"Reduced size estimate to %d (subtract num args * 4)", value);
       }
       if (value < originalWeight)
          return true;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -57,6 +57,8 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
     */
    static const float METHOD_INVOKE_ADJUSTMENT_FACTOR;
 
+   static const float CONST_ARG_IN_CALLEE_ADJUSTMENT_FACTOR;
+
    /** \brief
     *     Adjusts the estimated \p value by a \p factor for string compression related methods.
     *  \param method
@@ -92,6 +94,21 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
     *     \endcode
     */
    static bool adjustEstimateForMethodInvoke(TR_ResolvedMethod* method, int32_t& value, float factor);
+
+   /**
+    * \brief
+    *    Adjusts the estimated \p value by \p factor for methods with args that are constant strings,
+    *    const class/object refs or load consts
+    * \param target
+    *    The call target to examine
+    * \param value
+    *    The weight that may be modified if const args exist
+    * \param factor
+    *    The factor multiplier to adjust the \p value
+    * \return
+    *    true if the \p value was lowered using the adjustment factor, otherwise false
+    */
+   bool adjustEstimateForConstArgs(TR_CallTarget * target, int32_t& value, float factor);
 
    static TR::Block *getBlock(TR::Compilation *comp, TR::Block * * blocks, TR_ResolvedMethod *feMethod, int32_t i, TR::CFG & cfg);
 

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -170,6 +170,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
    friend class TR_J9InlinerUtil;
    friend class TR_InlinerBase;
    friend class TR_MultipleCallTargetInliner;
+   friend class TR_J9EstimateCodeSize;
    public:
       TR_J9InlinerPolicy(TR::Compilation *comp);
       virtual bool inlineRecognizedMethod(TR::RecognizedMethod method);


### PR DESCRIPTION
Lowering the estimated weight of callees by the empirically derived factor of 0.75 encourages inlining of callees where further optimizations can be unlocked due to the constant args being passed to the callees. Here are a few examples where this weight reduction can help:
* failed inlining because size estimate for a target is blown up because the callee being considered for inlining is already compiled at a higher opt level than the caller, despite there being possible benefits being unlocked by inlining
* encourage inlining certain methods that may have been just over the size limit for being considered for inlining, despite the constant args providing opportunities for compile-time folding

This size adjustment happens early on during ECS, overcoming the size threshold check during weighCallSite that prevented many callees with constant args from getting inlined.