### PR TITLE
Fix several mis-spellings of 'starting'

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3204,7 +3204,7 @@ bool TR_MultipleCallTargetInliner::inlineCallTargets(TR::ResolvedMethodSymbol *c
          if ((uint32_t)(estimatedNumberOfNodes*factor) > _nodeCountThreshold)
             {
             callTargetToChop = calltarget;
-            debugTrace(tracer(),"estimate nodes exceeds _nodeCountThreshold, chopped off targets staring from %p, lastTargetToInline %p\n", callTargetToChop, prev);
+            debugTrace(tracer(),"estimate nodes exceeds _nodeCountThreshold, chopped off targets starting from %p, lastTargetToInline %p\n", callTargetToChop, prev);
             break;
             }
          }

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -779,7 +779,7 @@ TR::TreeTop *TR_StringPeepholes::detectSubMulSetScalePattern(TR::TreeTop *tt, TR
    bool foundPattern = false;
 
    if (trace())
-      traceMsg(comp(), "Looking for subtract multiply setscale pattern in block %d, staring at tt: %p, node: %p\n", firstTree->getEnclosingBlock()->getNumber(), firstTree, firstTree->getNode());
+      traceMsg(comp(), "Looking for subtract multiply setscale pattern in block %d, starting at tt: %p, node: %p\n", firstTree->getEnclosingBlock()->getNumber(), firstTree, firstTree->getNode());
 
    for (; !foundPattern && tt != exit; tt = tt->getNextRealTreeTop())
       {

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -668,7 +668,7 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 	while ((rc == -1) && (j9error_last_error_number() == J9PORT_ERROR_FILE_LOCK_EDEADLK)) {
 		if (++loopCount > 1) {
 			/* We time the loop so it doesn't loop forever. Try the lock algorithm below
-			 * once before staring the timer. */
+			 * once before starting the timer. */
 			if (startLoopTime == 0) {
 				startLoopTime = j9time_nano_time();
 			} else if (loopCount > 2) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
@@ -610,7 +610,7 @@ public class TestOpenJ9DiagnosticsMXBean {
 		remoteServer = builder.start();
 
 		lock.waitForEvent("child started");
-		logger.info("Staring remote server finished");
+		logger.info("Starting remote server finished");
 	} 
 
 	/**

--- a/test/functional/JLM_Tests/src/org/openj9/test/management/JvmCpuMonitorMXBeanTest.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/management/JvmCpuMonitorMXBeanTest.java
@@ -463,7 +463,7 @@ public class JvmCpuMonitorMXBeanTest {
 		}
 
 		lock.waitForEvent("child started");
-		logger.debug("staring remoteServet finished");
+		logger.debug("starting remoteServer finished");
 	}
 
 	/**


### PR DESCRIPTION
Noticed one instance in [test log](https://openj9-jenkins.osuosl.org/job/Test_openjdk20_j9_extended.functional_ppc64_aix_Personal_testList_0/1/consoleFull) for https://github.com/ibmruntimes/openj9-openjdk-jdk20/pull/57.