### PR TITLE
Minimize continuation Object size in continuation list

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -253,6 +253,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9mm_iterate_all_continuation_objects,
 	ownableSynchronizerObjectCreated,
 	continuationObjectCreated,
+	continuationObjectStarted,
+	continuationObjectFinished,
 	j9gc_notifyGCOfClassReplacement,
 	j9gc_get_jit_string_dedup_policy,
 	j9gc_stringHashFn,

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -204,6 +204,11 @@ public:
 	};
 	ContinuationListOption continuationListOption;
 
+	enum TimingAddContinuationInList {
+		onCreated = 0,
+		onStarted = 1,
+	};
+	TimingAddContinuationInList timingAddContinuationInList;
 protected:
 private:
 protected:
@@ -381,6 +386,7 @@ public:
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
 		, continuationListOption(enable_continuation_list)
+		, timingAddContinuationInList(onStarted)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -274,6 +274,8 @@ extern J9_CFUNC void* finalizeForcedClassLoaderUnload(J9VMThread *vmThread);
 
 extern J9_CFUNC UDATA ownableSynchronizerObjectCreated(J9VMThread *vmThread, j9object_t object);
 extern J9_CFUNC UDATA continuationObjectCreated(J9VMThread *vmThread, j9object_t object);
+extern J9_CFUNC UDATA continuationObjectStarted(J9VMThread *vmThread, j9object_t object);
+extern J9_CFUNC UDATA continuationObjectFinished(J9VMThread *vmThread, j9object_t object);
 
 extern J9_CFUNC void j9gc_notifyGCOfClassReplacement(J9VMThread *vmThread, J9Class *originalClass, J9Class *replacementClass, UDATA isFastHCR);
 

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -33,6 +33,8 @@
 #include "j9cfg.h"
 #include "modronapicore.hpp"
 
+class MM_EnvironmentBase;
+
 extern "C" {
 /* define constant memory pool name and garbage collector name here -- the name should not be over 31 characters */
 #define J9_GC_MANAGEMENT_POOL_NAME_HEAP_OLD				"Java heap"
@@ -102,6 +104,9 @@ J9HookInterface** j9gc_get_private_hook_interface(J9JavaVM *javaVM);
 UDATA ownableSynchronizerObjectCreated(J9VMThread *vmThread, j9object_t object);
 
 UDATA continuationObjectCreated(J9VMThread *vmThread, j9object_t object);
+UDATA continuationObjectStarted(J9VMThread *vmThread, j9object_t object);
+UDATA continuationObjectFinished(J9VMThread *vmThread, j9object_t object);
+void addContinuationObjectInList(MM_EnvironmentBase *env, j9object_t object);
 void preMountContinuation(J9VMThread *vmThread, j9object_t object);
 void postUnmountContinuation(J9VMThread *vmThread, j9object_t object);
 

--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -24,6 +24,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
+#include "ModronAssertions.h"
 
 #if defined(J9VM_GC_FINALIZATION)
 #include "CollectorLanguageInterfaceImpl.hpp"
@@ -42,13 +43,15 @@
 #include "ModronAssertions.h"
 #include "OwnableSynchronizerObjectBuffer.hpp"
 #include "ContinuationObjectBuffer.hpp"
-#include "VMHelpers.hpp"
 #include "ParallelDispatcher.hpp"
 #include "ReferenceObjectBuffer.hpp"
 #include "ReferenceStats.hpp"
 #include "RootScanner.hpp"
 #include "StackSlotValidator.hpp"
 #include "UnfinalizedObjectBuffer.hpp"
+#if JAVA_SPEC_VERSION >= 19
+#include "ContinuationHelpers.hpp"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 void
 MM_MarkingSchemeRootClearer::doSlot(omrobjectptr_t *slotPtr)
@@ -308,6 +311,7 @@ MM_MarkingSchemeRootClearer::scanOwnableSynchronizerObjects(MM_EnvironmentBase *
 void
 MM_MarkingSchemeRootClearer::scanContinuationObjects(MM_EnvironmentBase *env)
 {
+#if JAVA_SPEC_VERSION >= 19
 	if (_markingDelegate->shouldScanContinuationObjects()) {
 		/* allow the marking scheme to handle this */
 		reportScanningStarted(RootScannerEntity_ContinuationObjects);
@@ -325,7 +329,7 @@ MM_MarkingSchemeRootClearer::scanContinuationObjects(MM_EnvironmentBase *env)
 						while (NULL != object) {
 							gcEnv->_markJavaStats._continuationCandidates += 1;
 							omrobjectptr_t next = _extensions->accessBarrier->getContinuationLink(object);
-							if (_markingScheme->isMarked(object)) {
+							if (_markingScheme->isMarked(object) && !VM_ContinuationHelpers::isFinished(*VM_ContinuationHelpers::getContinuationStateAddress((J9VMThread *)env->getLanguageVMThread() , object))) {
 								/* object was already marked. */
 								gcEnv->_continuationObjectBuffer->add(env, object);
 							} else {
@@ -344,6 +348,7 @@ MM_MarkingSchemeRootClearer::scanContinuationObjects(MM_EnvironmentBase *env)
 		gcEnv->_continuationObjectBuffer->flush(env);
 		reportScanningEnded(RootScannerEntity_ContinuationObjects);
 	}
+#endif /* JAVA_SPEC_VERSION >= 19 */
 }
 
 void

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -41,7 +41,9 @@
 #include "UnfinalizedObjectList.hpp"
 #include "ContinuationObjectBuffer.hpp"
 #include "ContinuationObjectList.hpp"
-#include "VMHelpers.hpp"
+#if JAVA_SPEC_VERSION >= 19
+#include "ContinuationHelpers.hpp"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 #include "ScavengerRootClearer.hpp"
 
@@ -221,6 +223,7 @@ MM_ScavengerRootClearer::scavengeUnfinalizedObjects(MM_EnvironmentStandard *env)
 void
 MM_ScavengerRootClearer::scavengeContinuationObjects(MM_EnvironmentStandard *env)
 {
+#if JAVA_SPEC_VERSION >= 19
 	MM_HeapRegionDescriptorStandard *region = NULL;
 	GC_HeapRegionIteratorStandard regionIterator(_extensions->heapRegionManager);
 	GC_Environment *gcEnv = env->getGCEnvironment();
@@ -238,13 +241,15 @@ MM_ScavengerRootClearer::scavengeContinuationObjects(MM_EnvironmentStandard *env
 							gcEnv->_scavengerJavaStats._continuationCandidates += 1;
 
 							MM_ForwardedHeader forwardedHeader(object, compressed);
-							if (!forwardedHeader.isForwardedPointer()) {
-								Assert_GC_true_with_message2(env, _scavenger->isObjectInEvacuateMemory(object), "Continuation object  %p should be a dead object, forwardedHeader=%p\n", object, &forwardedHeader);
-								gcEnv->_scavengerJavaStats._continuationCleared += 1;
-								_extensions->releaseNativesForContinuationObject(env, object);
-							} else {
-								omrobjectptr_t forwardedPtr = forwardedHeader.getForwardedObject();
+							omrobjectptr_t forwardedPtr = object;
+							if (forwardedHeader.isForwardedPointer()) {
+								forwardedPtr = forwardedHeader.getForwardedObject();
 								Assert_GC_true_with_message(env, NULL != forwardedPtr, "Continuation object  %p should be forwarded\n", object);
+							}
+							if (!forwardedHeader.isForwardedPointer() || VM_ContinuationHelpers::isFinished(*VM_ContinuationHelpers::getContinuationStateAddress((J9VMThread *)env->getLanguageVMThread() , forwardedPtr))) {
+								gcEnv->_scavengerJavaStats._continuationCleared += 1;
+								_extensions->releaseNativesForContinuationObject(env, forwardedPtr);
+							} else {
 								gcEnv->_continuationObjectBuffer->add(env, forwardedPtr);
 							}
 							object = next;
@@ -257,6 +262,7 @@ MM_ScavengerRootClearer::scavengeContinuationObjects(MM_EnvironmentStandard *env
 
 	/* restore everything to a flushed state before exiting */
 	gcEnv->_continuationObjectBuffer->flush(env);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 }
 
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1547,6 +1547,15 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "AddContinuationInListOnStarted")) {
+			extensions->timingAddContinuationInList = MM_GCExtensions::onStarted;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "AddContinuationInListOnCreated")) {
+			extensions->timingAddContinuationInList = MM_GCExtensions::onCreated;
+			continue;
+		}
 		/* Couldn't find a match for arguments */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_UNKNOWN, error_scan);
 		returnValue = JNI_EINVAL;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -64,7 +64,6 @@
 #include "FinalizableReferenceBuffer.hpp"
 #include "ContinuationObjectBuffer.hpp"
 #include "ContinuationObjectList.hpp"
-#include "VMHelpers.hpp"
 #include "FinalizeListManager.hpp"
 #include "ForwardedHeader.hpp"
 #include "GlobalAllocationManager.hpp"
@@ -102,6 +101,9 @@
 #include "SurvivorMemoryIterator.hpp"
 #include "WorkPacketsIterator.hpp"
 #include "WorkPacketsVLHGC.hpp"
+#if JAVA_SPEC_VERSION >= 19
+#include "ContinuationHelpers.hpp"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 #define INITIAL_FREE_HISTORY_WEIGHT ((float)0.8)
 #define TENURE_BYTES_HISTORY_WEIGHT ((float)0.8)
@@ -2002,7 +2004,7 @@ MM_CopyForwardScheme::copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *
 			newCacheAlloc = (void *)((uintptr_t)destinationObjectPtr + objectReserveSizeInBytes);
 
 			/* Try to swap the forwarding pointer to the destination copy array into the source object */
-			J9Object* originalDestinationObjectPtr = destinationObjectPtr;
+			J9Object *originalDestinationObjectPtr = destinationObjectPtr;
 			destinationObjectPtr = forwardedHeader->setForwardedObject(destinationObjectPtr);
 			Assert_MM_true(NULL != destinationObjectPtr);
 			if (destinationObjectPtr == originalDestinationObjectPtr) {
@@ -2087,7 +2089,7 @@ MM_CopyForwardScheme::copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *
 
 #if defined(J9VM_GC_LEAF_BITS)
 void
-MM_CopyForwardScheme::copyLeafChildren(MM_EnvironmentVLHGC* env, MM_AllocationContextTarok *reservingContext, J9Object* objectPtr)
+MM_CopyForwardScheme::copyLeafChildren(MM_EnvironmentVLHGC* env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr)
 {
 	J9Class *clazz = J9GC_J9OBJECT_CLAZZ(objectPtr, env);
 	if (GC_ObjectModel::SCAN_MIXED_OBJECT == _extensions->objectModel.getScanType(clazz)) {
@@ -2292,7 +2294,7 @@ MM_CopyForwardScheme::scanOwnableSynchronizerObjectSlots(MM_EnvironmentVLHGC *en
 }
 
 void
-MM_CopyForwardScheme::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, J9StackWalkState *walkState, const void *stackLocation)
+MM_CopyForwardScheme::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation)
 {
 	if (isHeapObject(*slotPtr)) {
 		/* heap object - validate and copyforward */
@@ -3035,7 +3037,7 @@ MM_CopyForwardScheme::scanPointerArrayObjectSlots(MM_EnvironmentVLHGC *env, MM_A
 		/* make sure we only record stats for the object once -- note that this means we might
 		 * attribute the scanning cost to the wrong thread, but that's not really important
 		 */
-		updateScanStats(env, (J9Object*)arrayPtr, reason);
+		updateScanStats(env, (J9Object *)arrayPtr, reason);
 	}
 	
 	scanPointerArrayObjectSlotsSplit(env, reservingContext, arrayPtr, index, currentSplitUnitOnly);
@@ -3476,7 +3478,7 @@ MM_CopyForwardScheme::scanUnfinalizedObjects(MM_EnvironmentVLHGC *env)
 					 * 2. it was copied by this thread.
 					 */
 					MM_ForwardedHeader forwardedHeader(pointer, _extensions->compressObjectReferences());
-					J9Object* forwardedPtr = forwardedHeader.getForwardedObject();
+					J9Object *forwardedPtr = forwardedHeader.getForwardedObject();
 					if (NULL == forwardedPtr) {
 						if (_markMap->isBitSet(pointer)) {
 							forwardedPtr = pointer;
@@ -3496,7 +3498,7 @@ MM_CopyForwardScheme::scanUnfinalizedObjects(MM_EnvironmentVLHGC *env)
 						}
 					}
 
-					J9Object* next = _extensions->accessBarrier->getFinalizeLink(forwardedPtr);
+					J9Object *next = _extensions->accessBarrier->getFinalizeLink(forwardedPtr);
 					if (finalizable) {
 						/* object was not previously marked -- it is now finalizable so push it to the local buffer */
 						env->_copyForwardStats._unfinalizedEnqueued += 1;
@@ -3526,6 +3528,7 @@ MM_CopyForwardScheme::scanUnfinalizedObjects(MM_EnvironmentVLHGC *env)
 void
 MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 {
+#if JAVA_SPEC_VERSION >= 19
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	while (NULL != (region = regionIterator.nextRegion())) {
@@ -3542,14 +3545,14 @@ MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 					 * 2. it was copied by this thread.
 					 */
 					MM_ForwardedHeader forwardedHeader(pointer, _extensions->compressObjectReferences());
-					J9Object* forwardedPtr = forwardedHeader.getForwardedObject();
-					if (NULL == forwardedPtr) {
+					J9Object *forwardedPtr = forwardedHeader.getForwardedObject();
+					if ((NULL == forwardedPtr) || VM_ContinuationHelpers::isFinished(*VM_ContinuationHelpers::getContinuationStateAddress((J9VMThread *)env->getLanguageVMThread() , forwardedPtr))) {
 						if (_markMap->isBitSet(pointer)) {
 							forwardedPtr = pointer;
 						}
 					}
 
-					J9Object* next = _extensions->accessBarrier->getContinuationLink(pointer);
+					J9Object *next = _extensions->accessBarrier->getContinuationLink(pointer);
 					if (NULL == forwardedPtr) {
 						/* object was not previously marked, clean up */
 						env->_copyForwardStats._continuationCleared += 1;
@@ -3565,6 +3568,7 @@ MM_CopyForwardScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 
 	/* restore everything to a flushed state before exiting */
 	env->getGCEnvironment()->_continuationObjectBuffer->flush(env);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 }
 
 void
@@ -3728,7 +3732,7 @@ MM_CopyForwardScheme::updateOrDeleteObjectsFromExternalCycle(MM_EnvironmentVLHGC
 								Assert_MM_true(!_markMap->isBitSet(forwardedObject));
 								deletedCount += 1;
 								slotIterator.resetSplitTagIndexForObject(object, PACKET_INVALID_OBJECT);
-								*slot = (J9Object*)PACKET_INVALID_OBJECT;
+								*slot = (J9Object *)PACKET_INVALID_OBJECT;
 							}
 						}
 					}
@@ -4722,7 +4726,7 @@ void
 MM_CopyForwardScheme::verifyReferenceObjectSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr)
 {
 	fj9object_t referentToken = J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr);
-	J9Object* referentPtr = _extensions->accessBarrier->convertPointerFromToken(referentToken);
+	J9Object *referentPtr = _extensions->accessBarrier->convertPointerFromToken(referentToken);
 	if (!_abortInProgress && !isObjectInNoEvacuationRegions(env, referentPtr) && verifyIsPointerInEvacute(env, referentPtr)) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
 		j9tty_printf(PORTLIB, "RefMixed referent slot points to evacuate!  srcObj %p dstObj %p\n", objectPtr, referentPtr);
@@ -5174,7 +5178,7 @@ MM_CopyForwardScheme::scanPhantomReferenceObjects(MM_EnvironmentVLHGC *env)
 }
 
 void
-MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC* region, J9Object* headOfList, MM_ReferenceStats *referenceStats)
+MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, J9Object *headOfList, MM_ReferenceStats *referenceStats)
 {
 	/* no list can possibly contain more reference objects than there are bytes in a region. */
 	const UDATA maxObjects = _regionManager->getRegionSize();
@@ -5182,7 +5186,7 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 	GC_FinalizableReferenceBuffer buffer(_extensions);
 	bool const compressed = env->compressObjectReferences();
 
-	J9Object* referenceObj = headOfList;
+	J9Object *referenceObj = headOfList;
 	while (NULL != referenceObj) {
 		Assert_MM_true(isLiveObject(referenceObj));
 
@@ -5192,7 +5196,7 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 		Assert_MM_true(region->isAddressInRegion(referenceObj));
 		Assert_MM_true(objectsVisited < maxObjects);
 
-		J9Object* nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
+		J9Object *nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
 
 		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		J9Object *referent = referentSlotObject.readReferenceFromSlot();
@@ -5265,15 +5269,15 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 }
 
 void
-MM_CopyForwardScheme::rememberReferenceList(MM_EnvironmentVLHGC *env, J9Object* headOfList)
+MM_CopyForwardScheme::rememberReferenceList(MM_EnvironmentVLHGC *env, J9Object *headOfList)
 {
 	Assert_MM_true((NULL == headOfList) || (NULL != env->_cycleState->_externalCycleState));
 	/* If phantom reference processing has already started this list will never be processed */
 	Assert_MM_true(0 == _phantomReferenceRegionsToProcess);
 
-	J9Object* referenceObj = headOfList;
+	J9Object *referenceObj = headOfList;
 	while (NULL != referenceObj) {
-		J9Object* next = _extensions->accessBarrier->getReferenceLink(referenceObj);
+		J9Object *next = _extensions->accessBarrier->getReferenceLink(referenceObj);
 		I_32 referenceState = J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj);
 		switch (referenceState) {
 		case  GC_ObjectModel::REF_STATE_INITIAL:
@@ -5332,7 +5336,7 @@ MM_CopyForwardScheme::rememberAndResetReferenceLists(MM_EnvironmentVLHGC *env, M
 
 	if (0 == (referenceObjectOptions & MM_CycleState::references_clear_weak)) {
 		referenceObjectList->startWeakReferenceProcessing();
-		J9Object* headOfList = referenceObjectList->getPriorWeakList();
+		J9Object *headOfList = referenceObjectList->getPriorWeakList();
 		if (NULL != headOfList) {
 			Trc_MM_CopyForwardScheme_rememberAndResetReferenceLists_rememberWeak(env->getLanguageVMThread(), region, headOfList);
 			rememberReferenceList(env, headOfList);
@@ -5341,7 +5345,7 @@ MM_CopyForwardScheme::rememberAndResetReferenceLists(MM_EnvironmentVLHGC *env, M
 
 	if (0 == (referenceObjectOptions & MM_CycleState::references_clear_soft)) {
 		referenceObjectList->startSoftReferenceProcessing();
-		J9Object* headOfList = referenceObjectList->getPriorSoftList();
+		J9Object *headOfList = referenceObjectList->getPriorSoftList();
 		if (NULL != headOfList) {
 			Trc_MM_CopyForwardScheme_rememberAndResetReferenceLists_rememberSoft(env->getLanguageVMThread(), region, headOfList);
 			rememberReferenceList(env, headOfList);
@@ -5350,7 +5354,7 @@ MM_CopyForwardScheme::rememberAndResetReferenceLists(MM_EnvironmentVLHGC *env, M
 
 	if (0 == (referenceObjectOptions & MM_CycleState::references_clear_phantom)) {
 		referenceObjectList->startPhantomReferenceProcessing();
-		J9Object* headOfList = referenceObjectList->getPriorPhantomList();
+		J9Object *headOfList = referenceObjectList->getPriorPhantomList();
 		if (NULL != headOfList) {
 			Trc_MM_CopyForwardScheme_rememberAndResetReferenceLists_rememberPhantom(env->getLanguageVMThread(), region, headOfList);
 			rememberReferenceList(env, headOfList);
@@ -5400,7 +5404,7 @@ MM_CopyForwardScheme::scanFinalizableObjects(MM_EnvironmentVLHGC *env)
 					next = _extensions->accessBarrier->getReferenceLink(referenceObject);
 
 					MM_AllocationContextTarok *reservingContext = getContextForHeapAddress(referenceObject);
-					J9Object* copyObject = copy(env, reservingContext, &forwardedHeader);
+					J9Object *copyObject = copy(env, reservingContext, &forwardedHeader);
 					if ( (NULL == copyObject) || (referenceObject == copyObject) ) {
 						referenceBuffer.add(env, referenceObject);
 					} else {
@@ -5441,7 +5445,7 @@ MM_CopyForwardScheme::scanFinalizableList(MM_EnvironmentVLHGC *env, j9object_t h
 				next = _extensions->accessBarrier->getFinalizeLink(headObject);
 
 				MM_AllocationContextTarok *reservingContext = getContextForHeapAddress(headObject);
-				J9Object* copyObject = copy(env, reservingContext, &forwardedHeader);
+				J9Object *copyObject = copy(env, reservingContext, &forwardedHeader);
 				if ( (NULL == copyObject) || (headObject == copyObject) ) {
 					objectBuffer.add(env, headObject);
 				} else {

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -50,7 +50,6 @@
 #endif /* J9VM_GC_FINALIZATION*/
 #include "ContinuationObjectBuffer.hpp"
 #include "ContinuationObjectList.hpp"
-#include "VMHelpers.hpp"
 #include "GCExtensions.hpp"
 #include "GlobalCollectionCardCleaner.hpp"
 #include "GlobalCollectionNoScanCardCleaner.hpp"
@@ -88,6 +87,9 @@
 #include "WorkPacketsIterator.hpp"
 #include "WorkPacketsVLHGC.hpp"
 #include "WorkStack.hpp"
+#if JAVA_SPEC_VERSION >= 19
+#include "ContinuationHelpers.hpp"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 void
 MM_ParallelGlobalMarkTask::mainSetup(MM_EnvironmentBase *env)
@@ -1099,6 +1101,7 @@ MM_GlobalMarkingScheme::scanOwnableSynchronizerObjects(MM_EnvironmentVLHGC *env)
 void
 MM_GlobalMarkingScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 {
+#if JAVA_SPEC_VERSION >= 19
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
 	while (NULL != (region = regionIterator.nextRegion())) {
@@ -1112,7 +1115,7 @@ MM_GlobalMarkingScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 
 						/* read the next link before we add it to the buffer */
 						J9Object* next = _extensions->accessBarrier->getContinuationLink(object);
-						if (isMarked(object)) {
+						if (isMarked(object) && !VM_ContinuationHelpers::isFinished(*VM_ContinuationHelpers::getContinuationStateAddress((J9VMThread *)env->getLanguageVMThread() , object))) {
 							env->getGCEnvironment()->_continuationObjectBuffer->add(env, object);
 						} else {
 							env->_markVLHGCStats._continuationCleared += 1;
@@ -1126,6 +1129,7 @@ MM_GlobalMarkingScheme::scanContinuationObjects(MM_EnvironmentVLHGC *env)
 	}
 	/* restore everything to a flushed state before exiting */
 	env->getGCEnvironment()->_continuationObjectBuffer->flush(env);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 }
 
 /**

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4604,6 +4604,8 @@ typedef struct J9MemoryManagerFunctions {
 	jvmtiIterationControl  ( *j9mm_iterate_all_continuation_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;
 	UDATA ( *ownableSynchronizerObjectCreated)(struct J9VMThread *vmThread, j9object_t object) ;
 	UDATA ( *continuationObjectCreated)(struct J9VMThread *vmThread, j9object_t object) ;
+	UDATA ( *continuationObjectStarted)(struct J9VMThread *vmThread, j9object_t object) ;
+	UDATA ( *continuationObjectFinished)(struct J9VMThread *vmThread, j9object_t object) ;
 
 	void  ( *j9gc_notifyGCOfClassReplacement)(struct J9VMThread *vmThread, J9Class *originalClass, J9Class *replacementClass, UDATA isFastHCR) ;
 	I_32  ( *j9gc_get_jit_string_dedup_policy)(struct J9JavaVM *javaVM) ;

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -216,6 +216,8 @@ enterContinuation(J9VMThread *currentThread, j9object_t continuationObject)
 			/* Directly return result if the create code failed, exception is already set. */
 			return result;
 		}
+		currentThread->javaVM->memoryManagerFunctions->continuationObjectStarted(currentThread, continuationObject);
+
 		continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, continuationObject);
 	}
 	Assert_VM_notNull(continuation);


### PR DESCRIPTION
Currently GC maintain the global continuation lists contain all of
 "live" continuation Object for releasing native resource(exceptional
 case), jvmti retrieving all continuation and JIT code cache reclaim
 processing.
keep less items in the list would reduce time to refresh/iterate the list.
 - new Java Option -XXgc:AddContinuationInListOnFirstMount (default, would not add unstarted continuation in the list) and -XXgc:AddContinuationInListOnCreated.
 - remove not only "dead" but also finished continuation during refreshing list.