### PR TITLE
Allow Reference.refersTo to be inlined under AOT

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1555,8 +1555,6 @@ public:
    virtual bool               sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *);
    virtual bool               isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *);
    virtual bool               classHasBeenExtended(TR_OpaqueClassBlock *);
-   virtual bool               isGetImplInliningSupported();
-   virtual bool               isGetImplAndRefersToInliningSupported();
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
    virtual bool               hasFinalizer(TR_OpaqueClassBlock * classPointer);
    virtual uintptr_t         getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -348,8 +348,6 @@ public:
    virtual bool sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *) override { return false; }
    virtual bool isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *) override { return true; }
    virtual bool classHasBeenExtended(TR_OpaqueClassBlock *) override { return true; }
-   virtual bool isGetImplInliningSupported() override { return false; }
-   virtual bool isGetImplAndRefersToInliningSupported() override { return false; }
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *) override { return NULL; }
    virtual TR::CodeCache * getResolvedTrampoline(TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) override { return 0; }
    virtual intptr_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override { TR_ASSERT_FATAL(0, "methodTrampolineLookup not implemented for AOT");  return 0; }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 46; // ID: qYYkfdldUPTvXZ60POW2
+   static const uint16_t MINOR_NUMBER = 47; // ID: HXF3y37dRYBa2JANYdqS
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
The implementations of `TR_J9SharedCacheVM::isGetImplInliningSupported` and `TR_J9SharedCacheVM::isGetImplAndRefersToInliningSupported` return false unconditionally, preventing inlining of `java/lang/ref/Reference.refersTo` and `java/lang/ref/Reference.getImpl` under AOT compilation.  This change removes the implementations of those methods in `TR_J9SharedCacheVM` to allow inlining to happen under AOT, with an additional test in `TR_J9VM::inlineNativeCall` of whether the 'referent' field's offset could not be retrieved - which can occur under AOT with no symbol validation manager.