### PR TITLE
Fix Intermittent vlog not found CRIU Jitserver test failures

### DIFF
--- a/test/functional/cmdLineTests/criu/criu.xml
+++ b/test/functional/cmdLineTests/criu/criu.xml
@@ -28,7 +28,7 @@
   <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 1 1 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -41,7 +41,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 2 2 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 2 2 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint 1</output>
@@ -55,7 +55,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image three times">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ $JVM_OPTIONS$ $MAINCLASS_SIMPLE$ 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Post-checkpoint 1</output>

--- a/test/functional/cmdLineTests/criu/criuJitServerScript.sh
+++ b/test/functional/cmdLineTests/criu/criuJitServerScript.sh
@@ -31,6 +31,7 @@ echo "start running script";
 # $5 is the APP ARGS
 # $6 is the NUM_CHECKPOINT
 # $7 is the KEEP_CHECKPOINT
+# $8 is the KEEP_TEST_OUTPUT
 
 source $1/jitserverconfig.sh
 
@@ -59,15 +60,17 @@ if [ "$JITSERVER_EXISTS" == 0 ]; then
         NUM_CHECKPOINT=$6
         for ((i=0; i<$NUM_CHECKPOINT; i++)); do
             sleep 2;
-            criu restore -D ./cpData --shell-job;
+            criu restore -D ./cpData --shell-job >criuOutput 2>&1;
         done
     fi
 
-    cat testOutput;
+    cat testOutput criuOutput;
 
     if  [ "$7" != true ]; then
-        rm -rf testOutput
-        echo "Removed testOutput file"
+        if [ "$8" != true ]; then
+            rm -rf testOutput criuOutput
+            echo "Removed test output files"
+        fi
     fi
 
     ps | grep $JITSERVER_PID | grep 'jitserver'

--- a/test/functional/cmdLineTests/criu/criu_jitPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitPostRestore.xml
@@ -28,7 +28,7 @@
 	<variable name="MAINCLASS_OPTIONSFILE_TEST" value="org.openj9.criu.OptionsFileTest" />
 
 	<test id="Generate Verbose Log">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xjit:verbose={CheckpointRestore},vlog=vlog" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xjit:verbose={CheckpointRestore},vlog=vlog" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -41,12 +41,13 @@
 	</test>
 
 	<test id="Check Verbose Log">
-		<command>cat vlog</command>
+		<command>bash $CATSCRIPPATH$ vlog true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
 	<test id="Test -Xnojit -Xnoaot">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xnojit -Xnoaot" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xnojit -Xnoaot" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -62,7 +63,7 @@
 	</test>
 
 	<test id="Test -Xnoaot">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xnoaot" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xnoaot" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -78,7 +79,7 @@
 	</test>
 
 	<test id="Test -Xjit:exclude={*}">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xjit:exclude={*}" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest -Xjit:exclude={*}" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>

--- a/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
@@ -32,7 +32,7 @@
 	<variable name="PORTABLE_CRIU_MODE" value="-XX:-CRIURestoreNonPortableMode" />
 
 	<test id="Generate Verbose Log">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $POST_CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $POST_CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -49,19 +49,20 @@
 	</test>
 
 	<test id="Check Connection in Pre-Checkpoint Verbose Log">
-		<command>cat preCheckpointVlog</command>
+		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="failure">Connected to a server</output>
 	</test>
 
 	<test id="Check Connection in Post-Restore Verbose Log">
-		<command>cat postRestoreVlog</command>
-		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<command>bash $CATSCRIPPATH$ postRestoreVlog true true</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
 	<test id="JITServer not explicitly enabled Post-Restore">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -78,13 +79,14 @@
 	</test>
 
 	<test id="JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
-		<command>cat postRestoreVlog</command>
+		<command>bash $CATSCRIPPATH$ postRestoreVlog true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 		<output regex="no" type="failure">Connected to a server</output>
 	</test>
 
 	<test id="Portable CRIU Mode: JITServer not explicitly enabled Post-Restore">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PORTABLE_CRIU_MODE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $PORTABLE_CRIU_MODE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -101,13 +103,14 @@
 	</test>
 
 	<test id="Portable CRIU Mode; JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
-		<command>cat postRestoreVlog</command>
+		<command>bash $CATSCRIPPATH$ postRestoreVlog true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 		<output regex="no" type="failure">Connected to a server</output>
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -124,19 +127,20 @@
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint: Check no connection in Pre-Checkpoint Verbose Log">
-		<command>cat preCheckpointVlog</command>
+		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="failure">Connected to a server</output>
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
-		<command>cat postRestoreVlog</command>
-		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<command>bash $CATSCRIPPATH$ postRestoreVlog true true</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
 	<test id="Portable CRIU Mode: Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PORTABLE_CRIU_MODE$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$ $ENABLE_JITSERVER$ $PORTABLE_CRIU_MODE$ $PRE_CRIU_VERBOSE$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $POST_CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -153,14 +157,15 @@
 	</test>
 
 	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Pre-Checkpoint Verbose Log">
-		<command>cat preCheckpointVlog</command>
+		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="required">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="success">Connected to a server</output>
 	</test>
 
 	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
-		<command>cat postRestoreVlog</command>
-		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<command>bash $CATSCRIPPATH$ postRestoreVlog true true</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
@@ -30,7 +30,7 @@
 	<variable name="CRIU_VERBOSE" value="-Xjit:verbose={compilePerformance},verbose={CheckpointRestore},verbose={JITServer},verbose={JITServerConns},vlog=vlog" />
 
 	<test id="Generate Verbose Log">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $CRIU_VERBOSE$" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ $CRIU_VERBOSE$" 1 false true</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -47,13 +47,14 @@
 	</test>
 
 	<test id="Check Verbose Log">
-		<command>cat vlog</command>
-		<output regex="no" type="required">CHECKPOINT RESTORE: Ready for restore</output>
+		<command>bash $CATSCRIPPATH$ vlog true true</command>
+		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
+		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
 	<test id="Test -Xnojit -Xnoaot">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnojit -Xnoaot" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnojit -Xnoaot" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -73,7 +74,7 @@
 	</test>
 
 	<test id="Test -Xnoaot">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnoaot" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xnoaot" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -93,7 +94,7 @@
 	</test>
 
 	<test id="Test -Xjit:exclude={*}">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xjit:exclude={*}" 1 false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ "JitOptionsTest $ENABLE_JITSERVER$ -Xjit:exclude={*}" 1 false false</command>
 		<output type="success" caseSensitive="no" regex="no">Killed</output>
 		<output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
 		<output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>

--- a/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
@@ -28,7 +28,7 @@
   <variable name="MAINCLASS_SIMPLE" value="org.openj9.criu.CRIUSimpleTest" />
 
   <test id="Create Criu Checkpoint Image without Restore">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 true</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 true true</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">Post-checkpoint</output>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -39,7 +39,7 @@
   <variable name="XDUMP_DYNAMIC" value="-Xdump:dynamic" />
 
   <test id="Create and Restore Criu Checkpoint Image once">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 1 1 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
@@ -54,7 +54,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 2 2 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SIMPLE$ 2 2 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint 1</output>
@@ -72,7 +72,7 @@
 
 <!--
   <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTime">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTime" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTime" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
@@ -84,7 +84,7 @@
  -->
 
   <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJitPreCheckpointCompile">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPreCheckpointCompile" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPreCheckpointCompile" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
@@ -100,7 +100,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJitPostCheckpointCompile">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPostCheckpointCompile" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testSystemNanoTimeJitPostCheckpointCompile" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">System.nanoTime() before CRIU checkpoint:</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: System.nanoTime() after CRIU restore:</output>
@@ -116,7 +116,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayBeforeCheckpointDone" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayBeforeCheckpointDone" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testMillisDelay</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected MILLIS_DELAY</output>
@@ -132,7 +132,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayAfterCheckpointDone" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testMillisDelayAfterCheckpointDone" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testMillisDelay</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected MILLIS_DELAY</output>
@@ -148,7 +148,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testDateScheduledBeforeCheckpointDone">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledBeforeCheckpointDone" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledBeforeCheckpointDone" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testDateScheduledBeforeCheckpointDone</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected to run after timeMillisScheduledBeforeCheckpointDone</output>
@@ -164,7 +164,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testDateScheduledAfterCheckpointDone">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledAfterCheckpointDone" 3 3 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" "$MAINCLASS_TIMECHANGE$ testDateScheduledAfterCheckpointDone" 3 3 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testDateScheduledAfterCheckpointDone</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected to run after timeMillisScheduledAfterCheckpointDone</output>
@@ -180,7 +180,7 @@
   </test>
 
   <test id="Create Criu Checkpoint Image once and no restore - TestSingleThreadModeCheckpointException">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_CHECKPOINT$ 1 1 true</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_CHECKPOINT$ 1 1 true true</command>
     <output type="success" caseSensitive="yes" regex="no">TestSingleThreadModeCheckpointException: PASSED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="no" regex="no">TestSingleThreadModeCheckpointException: FAILED</output>
@@ -196,7 +196,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image once - TestSingleThreadModeRestoreException">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_RESTORE$ 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_RESTORE$ 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException: Exception thrown when running user post-restore</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
@@ -260,7 +260,7 @@
 -->
 
   <test id="Create and Restore Criu Checkpoint Image once - TestDelayedOperations">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_DELAYEDOPERATIONS$ 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_DELAYEDOPERATIONS$ 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">TestDelayedOperations.testDelayedThreadInterrupt(): PASSED</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>

--- a/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
@@ -30,7 +30,7 @@
   <variable name="TRACECRIU" value="-Xtrace:print={j9criu}" />
 
   <test id="Create CRIU checkpoint image and restore once - testThreadPark">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testThreadPark" 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testThreadPark" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected park time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testThreadPark</output>
@@ -46,7 +46,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testThreadSleep">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testThreadSleep" 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testThreadSleep" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected sleep time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testThreadSleep</output>
@@ -63,7 +63,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitNotify">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitNotify" 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitNotify" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitNotify</output>
@@ -80,7 +80,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedNoNanoSecond">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedNoNanoSecond" 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedNoNanoSecond" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedNoNanoSecond</output>
@@ -97,7 +97,7 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedWithNanoSecond">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedWithNanoSecond" 1 1 false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedWithNanoSecond" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
     <output type="required" caseSensitive="yes" regex="no">Start test name: testObjectWaitTimedWithNanoSecond</output>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -130,6 +130,7 @@
 			TR_Options=$(Q)disableSuffixLogs$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DCATSCRIPPATH=$(TEST_RESROOT)$(D)criuCatVlog.sh \
 			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_jitPostRestore.xml$(Q) \
 			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
@@ -159,6 +160,7 @@
 				TR_Options=$(Q)disableSuffixLogs$(Q) \
 				$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 				-DSCRIPPATH=$(TEST_RESROOT)$(D)criuJitServerScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+				-DCATSCRIPPATH=$(TEST_RESROOT)$(D)criuCatVlog.sh \
 				-DTEST_JDK_BIN=$(TEST_JDK_BIN) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 				-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_jitserverAcrossCheckpoint.xml$(Q) \
 				-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
@@ -196,6 +198,7 @@
 				TR_Options=$(Q)disableSuffixLogs$(Q) \
 				$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 				-DSCRIPPATH=$(TEST_RESROOT)$(D)criuJitServerScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+				-DCATSCRIPPATH=$(TEST_RESROOT)$(D)criuCatVlog.sh \
 				-DTEST_JDK_BIN=$(TEST_JDK_BIN) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 				-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_jitserverPostRestore.xml$(Q) \
 				-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \


### PR DESCRIPTION
Sometimes, a restore can fail in a known way, in which case the test is set to pass; however, this causes subsequent tests that depend on the output of this test to fail. This PR adds a new script to wrap the `cat` commands that test for certain Jitserver characteristics post restore. This wrapper script will check the output of the previous test if the vlog to cat does not exist, and outputs a message that causes the test to pass if the previous test failed in one of the known ways.

This PR also modifies the existing criu scripts to take in an additional parameter to not delete the `testOutput` file if subsequent tests need it.

Fixes https://github.com/eclipse-openj9/openj9/issues/17367