### PR TITLE
Do not send SVM map to JITServer clients

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3181,7 +3181,6 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
    CHTableCommitData chTableData;
    std::vector<TR_OpaqueClassBlock *> classesThatShouldNotBeNewlyExtended;
    std::string logFileStr;
-   std::string svmValueToSymbolStr;
    std::vector<TR_ResolvedJ9Method *> resolvedMirrorMethodsPersistIPInfo;
    TR_OptimizationPlan modifiedOptPlan;
    std::vector<SerializedRuntimeAssumption> serializedRuntimeAssumptions;
@@ -3221,7 +3220,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
       if (JITServer::MessageType::compilationCode == response)
          {
          auto recv = client->getRecvData<
-            std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>, std::string, std::string,
+            std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>, std::string,
             std::vector<TR_ResolvedJ9Method*>, TR_OptimizationPlan, std::vector<SerializedRuntimeAssumption>,
             JITServer::ServerMemoryState, JITServer::ServerActiveThreadsState, std::vector<TR_OpaqueMethodBlock *>
          >();
@@ -3231,13 +3230,12 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          chTableData = std::get<2>(recv);
          classesThatShouldNotBeNewlyExtended = std::get<3>(recv);
          logFileStr = std::get<4>(recv);
-         svmValueToSymbolStr = std::get<5>(recv);
-         resolvedMirrorMethodsPersistIPInfo = std::get<6>(recv);
-         modifiedOptPlan = std::get<7>(recv);
-         serializedRuntimeAssumptions = std::get<8>(recv);
-         JITServer::ServerMemoryState nextMemoryState = std::get<9>(recv);
-         JITServer::ServerActiveThreadsState nextActiveThreadState = std::get<10>(recv);
-         methodsRequiringTrampolines = std::get<11>(recv);
+         resolvedMirrorMethodsPersistIPInfo = std::get<5>(recv);
+         modifiedOptPlan = std::get<6>(recv);
+         serializedRuntimeAssumptions = std::get<7>(recv);
+         JITServer::ServerMemoryState nextMemoryState = std::get<8>(recv);
+         JITServer::ServerActiveThreadsState nextActiveThreadState = std::get<9>(recv);
+         methodsRequiringTrampolines = std::get<10>(recv);
 
          updateCompThreadActivationPolicy(compInfoPT, nextMemoryState, nextActiveThreadState);
 
@@ -3468,8 +3466,6 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
             // Compilation is done, now we need client to validate all of the records accumulated by the server,
             // so need to exit heuristic region.
             compiler->exitHeuristicRegion();
-            // Populate symbol to id map
-            compiler->getSymbolValidationManager()->deserializeValueToSymbolMap(svmValueToSymbolStr);
             }
 
          TR_ASSERT(codeCacheStr.size(), "must have code cache");

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -146,12 +146,6 @@ outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp)
    // Pack log file to send to client
    std::string logFileStr = TR::Options::packLogFile(comp->getOutFile());
 
-   std::string svmValueToSymbolStr;
-   if (comp->getOption(TR_UseSymbolValidationManager))
-      {
-      svmValueToSymbolStr = comp->getSymbolValidationManager()->serializeValueToSymbolMap();
-      }
-
    // Send runtime assumptions created during compilation to the client
    std::vector<SerializedRuntimeAssumption> serializedRuntimeAssumptions;
    if (comp->getSerializedRuntimeAssumptions().size() > 0)
@@ -182,7 +176,7 @@ outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp)
    entry->_stream->finishCompilation(
       codeCacheStr, dataCacheStr, chTableData,
       std::vector<TR_OpaqueClassBlock*>(classesThatShouldNotBeNewlyExtended->begin(), classesThatShouldNotBeNewlyExtended->end()),
-      logFileStr, svmValueToSymbolStr,
+      logFileStr,
       resolvedMirrorMethodsPersistIPInfo
          ? std::vector<TR_ResolvedJ9Method*>(resolvedMirrorMethodsPersistIPInfo->begin(), resolvedMirrorMethodsPersistIPInfo->end())
          : std::vector<TR_ResolvedJ9Method*>(),

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 45; // ID: xE92Epd5mxpOTwnwiRt7
+   static const uint16_t MINOR_NUMBER = 46; // ID: qYYkfdldUPTvXZ60POW2
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1617,41 +1617,6 @@ static void printClass(TR_OpaqueClassBlock *clazz)
       }
    }
 
-#if defined(J9VM_OPT_JITSERVER)
-std::string
-TR::SymbolValidationManager::serializeValueToSymbolMap()
-   {
-   int32_t entrySize = sizeof(ValueToSymbolMap::key_type) + sizeof(ValueToSymbolMap::mapped_type);
-   std::string valueToSymbolStr(entrySize * _valueToSymbolMap.size(), '\0');
-   uint16_t idx = 0;
-   for (auto it : _valueToSymbolMap)
-      {
-      ValueToSymbolMap::key_type symbol = it.first;
-      ValueToSymbolMap::mapped_type id = it.second;
-      memcpy(&valueToSymbolStr[idx * entrySize], &symbol, sizeof(symbol));
-      memcpy(&valueToSymbolStr[idx * entrySize + sizeof(symbol)], &id, sizeof(id));
-      ++idx;
-      }
-   return valueToSymbolStr;
-   }
-
-void
-TR::SymbolValidationManager::deserializeValueToSymbolMap(const std::string &valueToSymbolStr)
-   {
-   _valueToSymbolMap.clear();
-
-   int32_t entrySize = sizeof(ValueToSymbolMap::key_type) + sizeof(ValueToSymbolMap::mapped_type);
-   int32_t numEntries = valueToSymbolStr.length() / entrySize;
-   for (int32_t idx = 0; idx < numEntries; idx++)
-      {
-      ValueToSymbolMap::key_type symbol;
-      memcpy(&symbol, &valueToSymbolStr[idx * entrySize], sizeof(symbol));
-      ValueToSymbolMap::mapped_type id = (uint16_t) valueToSymbolStr[idx * entrySize + sizeof(symbol)];
-      _valueToSymbolMap.insert(std::make_pair(symbol, id));
-      }
-   }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-
 namespace // file-local
    {
    class LexicalOrder

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -862,8 +862,6 @@ public:
    static int getSystemClassesNotWorthRememberingCount();
 
 #if defined(J9VM_OPT_JITSERVER)
-   std::string serializeValueToSymbolMap();
-   void deserializeValueToSymbolMap(const std::string &valueToSymbolStr);
    static void populateSystemClassesNotWorthRemembering(ClientSessionData *clientData);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 


### PR DESCRIPTION
The _valueToSymbolMap generated at the JITServer itself is not useful to clients. It is used in the creation of relocation records during code generation and is unused afterward, including during method relocation.