### PR TITLE
Enable value types escape analysis

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -595,7 +595,7 @@ J9::Compilation::canAllocateInlineOnStack(TR::Node* node, TR_OpaqueClassBlock* &
    if (self()->compileRelocatableCode())
       return -1;
 
-   if (node->getOpCodeValue() == TR::New)
+   if (node->getOpCodeValue() == TR::New || node->getOpCodeValue() == TR::newvalue)
       {
       J9Class* clazz = self()->fej9vm()->getClassForAllocationInlining(self(), node->getFirstChild()->getSymbolReference());
 
@@ -651,7 +651,7 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
 
    const bool areValueTypesEnabled = TR::Compiler->om.areValueTypesEnabled();
 
-   if (node->getOpCodeValue() == TR::New)
+   if (node->getOpCodeValue() == TR::New || node->getOpCodeValue() == TR::newvalue)
       {
 
       classRef    = node->getFirstChild();

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -8323,6 +8323,29 @@ static void printSymRefList(TR_ScratchList<TR::SymbolReference> *list, TR::Compi
 void Candidate::print()
    {
    traceMsg(comp(), "   Node = %p, contiguous = %d, local = %d\n", _node, isContiguousAllocation(), isLocalAllocation());
+   if (_flags.getValue() != 0)
+      {
+
+#define PRINT_FLAG_IF(comp, cond, text) do { if (cond) traceMsg(comp, text " "); } while (false)
+#define PRINT_FLAG(comp, query, text) PRINT_FLAG_IF(comp, query(), text)
+
+      traceMsg(comp(), "   Flags = {");
+      PRINT_FLAG(comp(), isLocalAllocation, "LocalAllocation");
+      PRINT_FLAG(comp(), mustBeContiguousAllocation, "MustBeContiguous");
+      PRINT_FLAG(comp(), isExplicitlyInitialized, "ExplicitlyInitialized");
+      PRINT_FLAG(comp(), objectIsReferenced, "ObjectIsReferenced");
+      PRINT_FLAG(comp(), fillsInStackTrace, "FillsInStackTrace");
+      PRINT_FLAG(comp(), usesStackTrace, "UsesStackTrace");
+      PRINT_FLAG(comp(), isInsideALoop, "InsideALoop");
+      PRINT_FLAG(comp(), isInAColdBlock, "InAColdBlock");
+      PRINT_FLAG(comp(), isProfileOnly, "ProfileOnly");
+      PRINT_FLAG(comp(), callsStringCopyConstructor, "CallsStringCopy");
+      PRINT_FLAG(comp(), forceLocalAllocation, "ForceLocalAllocation");
+      traceMsg(comp(), "}\n");
+
+#undef PRINT_FLAG_IF
+#undef PRINT_FLAG
+      }
    traceMsg(comp(), "   Value numbers = {");
    for (uint32_t j = 0; j <_valueNumbers->size(); j++)
       traceMsg(comp(), " %d", _valueNumbers->element(j));

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2913,6 +2913,21 @@ bool TR_EscapeAnalysis::checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR
                      }
                   }
                }
+            // Another special case when it is certain that the rhs of the def is not a candidate allocation from a prior iteration
+            // In this case we are loading a value through a call to jitLoadFlattenableArrayElement.  Such a value must be something
+            // that has already escaped and has nothing to do with the candidate allocation
+            //
+            else if (firstChild->getOpCode().isCall()
+                     && ((firstChild->getSymbolReference()->getReferenceNumber() == TR_ldFlattenableArrayElement)
+                         || comp()->getSymRefTab()->isNonHelper(firstChild->getSymbolReference(),
+                                                                TR::SymbolReferenceTable::loadFlattenableArrayElementNonHelperSymbol)))
+               {
+               if (trace())
+                  {
+                  traceMsg(comp(), "         rhs is harmless for defNode2 [%p] - call to jitLoadFlattenableArrayElement\n", defNode2);
+                  }
+               rhsIsHarmless = true;
+               }
             }
 
          if (!rhsIsHarmless)

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -49,6 +49,7 @@
 #include "env/ObjectModel.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
+#include "env/TypeLayout.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "il/AliasSetInterface.hpp"
@@ -118,6 +119,7 @@ static bool blockIsInLoop(TR::Block *block)
 TR_EscapeAnalysis::TR_EscapeAnalysis(TR::OptimizationManager *manager)
    : TR::Optimization(manager),
      _newObjectNoZeroInitSymRef(NULL),
+     _newValueSymRef(NULL),
      _newArrayNoZeroInitSymRef(NULL),
      _dependentAllocations(manager->comp()->trMemory()),
      _inlineCallSites(manager->comp()->trMemory()),
@@ -125,8 +127,11 @@ TR_EscapeAnalysis::TR_EscapeAnalysis(TR::OptimizationManager *manager)
      _devirtualizedCallSites(manager->comp()->trMemory()),
      _aNewArrayNoZeroInitSymRef(NULL)
    {
+   static char *disableValueTypeEASupport = feGetEnv("TR_DisableValueTypeEA");
+   _disableValueTypeStackAllocation = (disableValueTypeEASupport != NULL);
 
    _newObjectNoZeroInitSymRef = comp()->getSymRefTab()->findOrCreateNewObjectNoZeroInitSymbolRef(0);
+   _newValueSymRef = comp()->getSymRefTab()->findOrCreateNewValueSymbolRef(0);
    _newArrayNoZeroInitSymRef  = comp()->getSymRefTab()->findOrCreateNewArrayNoZeroInitSymbolRef(0);
    _aNewArrayNoZeroInitSymRef = comp()->getSymRefTab()->findOrCreateANewArrayNoZeroInitSymbolRef(0);
    _maxPassNumber = 0;
@@ -175,6 +180,11 @@ bool TR_EscapeAnalysis::isImmutableObject(TR::Node *node)
    if (disableImmutableObjectHandling)
       {
       return false;
+      }
+
+   if (node->getOpCodeValue() == TR::newvalue)
+      {
+      return true;
       }
 
    if (node->getOpCodeValue() != TR::New)
@@ -502,7 +512,7 @@ static TR_YesNoMaybe candidateHasField(Candidate *candidate, TR::Node *fieldNode
    int32_t fieldSize = fieldNode->getSize();
 
    int32_t minHeaderSize, maxHeaderSize;
-   if (candidate->_origKind == TR::New)
+   if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
       {
       minHeaderSize = maxHeaderSize = comp->fej9()->getObjectHeaderSizeInBytes();
       }
@@ -1016,7 +1026,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
       {
       next = candidate->getNext();
 
-      if (candidate->_kind == TR::New)
+      if (candidate->_kind == TR::New || candidate->_kind == TR::newvalue)
          {
          static bool doEAOpt = feGetEnv("TR_DisableEAOpt") ? false : true;
          if (!doEAOpt &&
@@ -1070,6 +1080,14 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
                traceMsg(comp(), "   Make [%p] non-local because we can't have locking when candidate escapes in cold blocks\n", candidate->_node);
             }
 
+         // TODO:  Add support for cold block heapification of value types
+         if (candidate->_kind == TR::newvalue && candidate->isLocalAllocation() && candidate->escapesInColdBlocks())
+            {
+            candidate->setLocalAllocation(false);
+            if (trace())
+               traceMsg(comp(), "   Make [%p] non-local because cold block heapification of value types is not yet available\n", candidate->_node);
+            }
+
          // Primitive value type fields of objects created with a NEW bytecode must be initialized
          // with their default values.  EA is not yet set up to perform such iniitialization
          // if the value type's own fields have not been inlined into the class that
@@ -1097,8 +1115,11 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
          switch (candidate->_kind)
             {
             case TR::New:
+            case TR::newvalue:
                if (comp()->fej9()->getReferenceSlotsInClass(comp(), (TR_OpaqueClassBlock *)candidate->_node->getFirstChild()->getSymbol()->getStaticSymbol()->getStaticAddress()))
+                  {
                   objectHasReferenceFields = true;
+                  }
                break;
             case TR::anewarray:
                objectHasReferenceFields = true;
@@ -1567,6 +1588,9 @@ void TR_EscapeAnalysis::findCandidates()
          continue;
          }
 
+      // TODO-VALUETYPE:  If java.lang.Integer is ever made into a value type class, will
+      //                  need to do TR::newvalue for dememoization instead
+      //
       TR::SymbolReference *dememoizedMethodSymRef = NULL;
       TR::TreeTop         *dememoizedConstructorCall = NULL;
       if (!comp()->fej9()->callTargetsNeedRelocations() && node->getOpCodeValue() == TR::acall
@@ -1611,14 +1635,26 @@ void TR_EscapeAnalysis::findCandidates()
 
 
       if (node->getOpCodeValue() != TR::New &&
+          node->getOpCodeValue() != TR::newvalue &&
           node->getOpCodeValue() != TR::newarray &&
           node->getOpCodeValue() != TR::anewarray)
+         {
          continue;
+         }
+
+      if (_disableValueTypeStackAllocation && (node->getOpCodeValue() == TR::newvalue))
+         {
+         if (trace())
+            {
+            traceMsg(comp(), "Reject candidate %s n%dn [%p] because value type stack allocation is disabled\n", node->getOpCode().getName(), node->getGlobalIndex(), node);
+            }
+         continue;
+         }
 
       static char *noEscapeArrays = feGetEnv("TR_NOESCAPEARRAY");
       if (noEscapeArrays)
          {
-         if (node->getOpCodeValue() != TR::New)
+         if (node->getOpCodeValue() != TR::New && node->getOpCodeValue() != TR::newvalue)
             continue;
          }
 
@@ -1640,8 +1676,15 @@ void TR_EscapeAnalysis::findCandidates()
             traceMsg(comp(), "Found [%p] new %s\n", node,
                      className ? className : "<Missing class name>");
             }
+         else if (node->getOpCodeValue() == TR::newvalue)
+            {
+            const char *className = getClassName(node->getFirstChild());
+            traceMsg(comp(), "Found [%p] newvalue of type %s\n", node, className ? className : "<Missing value type class name>");
+            }
          else if (node->getOpCodeValue() == TR::newarray)
+            {
             traceMsg(comp(), "Found [%p] newarray of type %d\n", node, node->getSecondChild()->getInt());
+            }
          else
             {
             const char *className = getClassName(node->getSecondChild());
@@ -1687,6 +1730,7 @@ void TR_EscapeAnalysis::findCandidates()
       if (candidate->isLocalAllocation())
          {
          if (node->getSymbolReference() == _newObjectNoZeroInitSymRef ||
+             node->getSymbolReference() == _newValueSymRef ||
              node->getSymbolReference() == _newArrayNoZeroInitSymRef ||
              node->getSymbolReference() == _aNewArrayNoZeroInitSymRef)
             {
@@ -1721,7 +1765,7 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
       // it immediately. If the class is unresolved, we don't know so we have to
       // assume the worst.
       //
-      if (node->getOpCodeValue() == TR::New)
+      if (node->getOpCodeValue() == TR::New || node->getOpCodeValue() == TR::newvalue)
          {
          TR::Node *classNode = node->getFirstChild();
          if (classNode->getOpCodeValue() != TR::loadaddr)
@@ -1774,7 +1818,7 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
 
    if (comp()->cg()->getSupportsStackAllocationOfArraylets())
       {
-      if (node->getOpCodeValue() != TR::New)
+      if (node->getOpCodeValue() != TR::New && node->getOpCodeValue() != TR::newvalue)
          {
          if (trace())
             traceMsg(comp(), "   Node [%p] failed: arraylet\n", node);
@@ -1822,11 +1866,12 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
                numElementsNode = node->getFirstChild();
                break;
             case TR::New:
+            case TR::newvalue:
             case TR::multianewarray:
                // Can't do anything with these yet
                break;
             default:
-            	break;
+                break;
             }
 
          TR::Recompilation *recomp        = comp()->getRecompilationInfo();
@@ -1846,7 +1891,8 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
             return NULL;
             }
          }
-      else if (node->getOpCodeValue() == TR::New && classInfo)
+      else if ((node->getOpCodeValue() == TR::New || node->getOpCodeValue() == TR::newvalue)
+               && classInfo)
          size = 0;
       else
          return NULL;
@@ -1881,6 +1927,13 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
 
    Candidate *result = NULL;
    result = new (trStackMemory()) Candidate(node, _curTree, _curBlock, size, classInfo, comp());
+
+   // TODO:  Value types must be contiguous for now.  Allow for non-contiguous stack allocation.
+   if (node->getOpCodeValue() == TR::newvalue)
+      {
+      result->setMustBeContiguousAllocation();
+      }
+
    result->setProfileOnly(profileOnly);
    return result;
    }
@@ -1894,7 +1947,7 @@ bool TR_EscapeAnalysis::isEscapePointCold(Candidate *candidate, TR::Node *node)
        (_inColdBlock ||
         (candidate->isInsideALoop() &&
          (candidate->_block->getFrequency() > 4*_curBlock->getFrequency()))) &&
-       (candidate->_origKind == TR::New))
+       (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue))
       return true;
 
    return false;
@@ -2153,7 +2206,7 @@ void TR_EscapeAnalysis::checkDefsAndUses()
                   }
                }
             default:
-            	break;
+                break;
             }
          }
       }
@@ -3237,7 +3290,11 @@ void TR_EscapeAnalysis::forceEscape(TR::Node *node, TR::Node *reason, bool force
                //candidate->setLocalAllocation(false);
                }
             else
+               {
+               if (trace())
+                  traceMsg(comp(), "  Marking immutable candidate [%p] as referenced in forceEscape to allow for non-contiguous allocation, but compensating for escape at [%p]\n", candidate->_node, reason);
                candidate->setObjectIsReferenced();
+               }
             }
          else
             {
@@ -3561,6 +3618,8 @@ bool TR_EscapeAnalysis::checkIfEscapePointIsCold(Candidate *candidate, TR::Node 
       if (canStoreToHeap)
          {
          candidate->setObjectIsReferenced();
+         if (trace())
+            traceMsg(comp(), "  Marking candidate [%p] as referenced in checkIfEscapePointIsCold - escape point [%p]\n", candidate->_node, node);
 
          if (!isImmutableObject(candidate) && (_parms || !node->getOpCode().isReturn()))
             {
@@ -3629,7 +3688,6 @@ static void checkForDifferentSymRefs(Candidate *candidate, int32_t i, TR::Symbol
                   memorizedSymRef->getReferenceNumber(), memorizedSymRef->getName(comp->getDebug()),
                   symRef->getName(comp->getDebug()));
                }
-            //(*candidate->_fields)[i]._isPresentInAllocatedClass=false;
             candidate->setLocalAllocation(false);
             }
          }
@@ -3776,7 +3834,7 @@ void TR_EscapeAnalysis::referencedField(TR::Node *base, TR::Node *field, bool is
             }
 
          int32_t fieldOffset = symRef->getOffset();
-         if (candidate->_origKind == TR::New)
+         if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
             {
             fieldOffset = symRef->getOffset();
             }
@@ -4295,6 +4353,19 @@ void TR_EscapeAnalysis::checkEscapeViaNonCall(TR::Node *node, TR::NodeChecklist&
       return;
       }
 
+   if (node->getOpCodeValue() == TR::newvalue)
+      {
+      // Except for the class address - child operand zero - the
+      // operands of a TR::newvalue should be considered to escape
+      // through that operation.
+      //
+      for (int i = 1; i < node->getNumChildren(); i++)
+         {
+         forceEscape(node->getChild(i), node);
+         }
+      return;
+      }
+
    if (node->getOpCode().hasSymbolReference() &&
          (node->getSymbolReference()->getSymbol() == comp()->getSymRefTab()->findGenericIntShadowSymbol() ||
           node->getSymbol()->isUnsafeShadowSymbol() ||
@@ -4391,9 +4462,9 @@ void TR_EscapeAnalysis::checkEscapeViaNonCall(TR::Node *node, TR::NodeChecklist&
                        stringCopyOwningMethod ||
                       _notOptimizableLocalStringObjectsValueNumbers->get(_valueNumberInfo->getValueNumber(resolvedBaseObject))) &&
                      _notOptimizableLocalObjectsValueNumbers->get(_valueNumberInfo->getValueNumber(resolvedBaseObject)))))
-               {
+                  {
                   forceEscape(node->getSecondChild(), node);
-               }
+                  }
                else
                   {
                   seenStoreToLocalObject = true;
@@ -4472,8 +4543,8 @@ void TR_EscapeAnalysis::checkEscapeViaNonCall(TR::Node *node, TR::NodeChecklist&
 
             // PR 93460
             if (node->getSymbolReference()->getSymbol()->isAuto() &&
-				node->getSymbol()->castToAutoSymbol()->isPinningArrayPointer())
-            	restrictCandidates(node->getFirstChild(), node, MakeContiguous);
+                node->getSymbol()->castToAutoSymbol()->isPinningArrayPointer())
+                restrictCandidates(node->getFirstChild(), node, MakeContiguous);
 
             // Handle escapes via store into a parameter for a called method
             // (this is conservative, but hopefully it doesn't happen too often)
@@ -4818,7 +4889,8 @@ void TR_EscapeAnalysis::checkEscapeViaCall(TR::Node *node, TR::NodeChecklist& vi
             {
             if (!candidate->isNonThisArgToCall(_sniffDepth) &&
                 node->getOpCode().isIndirect() &&
-                ((candidate->_node->getOpCodeValue() == TR::New)) &&
+                ((candidate->_node->getOpCodeValue() == TR::New)
+                 || (candidate->_node->getOpCodeValue() == TR::newvalue)) &&
                 (thisVN > -1) &&
                 usesValueNumber(candidate, thisVN))
                {
@@ -5380,7 +5452,9 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
       valueNumber = _valueNumberInfo->getValueNumber(child);
       for (candidate = _candidates.getFirst(); candidate; candidate = candidate->getNext())
          {
-         if (comp()->generateArraylets() && (candidate->_kind != TR::New))
+         if (comp()->generateArraylets()
+             && (candidate->_kind != TR::New)
+             && (candidate->_kind != TR::newvalue))
             continue;
 
          bool usesValueNum = usesValueNumber(candidate, valueNumber);
@@ -5450,7 +5524,7 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
          if (candidate->isLocalAllocation() && usesValueNum)
             {
             int32_t fieldOffset = node->getSymbolReference()->getOffset();
-            if (candidate->_origKind == TR::New)
+            if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
                {
                TR::SymbolReference *symRef = node->getSymbolReference();
                fieldOffset = symRef->getOffset();
@@ -5556,7 +5630,7 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
                   // Uh, why are we re-calculating the fieldOffset?  Didn't we just do that above?
                   //
                   int32_t fieldOffset = node->getSymbolReference()->getOffset();
-                  if (candidate->_origKind == TR::New)
+                  if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
                      {
                      TR::SymbolReference *symRef = node->getSymbolReference();
                      fieldOffset = symRef->getOffset();
@@ -5712,9 +5786,10 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
             _invalidateUseDefInfo = true;
          node->removeAllChildren();
          TR::Node::recreate(node, TR::iconst);
-         if (candidate->_node->getOpCodeValue() == TR::New)
+         if (candidate->_node->getOpCodeValue() == TR::New
+             || candidate->_node->getOpCodeValue() == TR::newvalue)
             {
-            // Dead code: can't ever execute an arraylength on a TR_New
+            // Dead code: can't ever execute an arraylength on a TR::New or TR::newvalue
             //see ArrayLest.test_getLTR::java_lang_ObjectI for an example
             node->setInt(0xdeadc0de);
             }
@@ -6088,7 +6163,7 @@ bool TR_EscapeAnalysis::fixupFieldAccessForContiguousAllocation(TR::Node *node, 
       }
 
    int32_t fieldOffset = node->getSymbolReference()->getOffset();
-   if (candidate->_origKind == TR::New)
+   if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
       fieldOffset = symRef->getOffset();
@@ -6184,8 +6259,9 @@ TR::Node *TR_EscapeAnalysis::createConst(TR::Compilation *comp, TR::Node *node, 
 bool TR_EscapeAnalysis::fixupFieldAccessForNonContiguousAllocation(TR::Node *node, Candidate *candidate, TR::Node *parent)
    {
    int32_t i;
-   int32_t fieldOffset = (candidate->_origKind == TR::New) ?
-      comp()->fej9()->getObjectHeaderSizeInBytes() : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
+   int32_t fieldOffset = (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
+                            ? comp()->fej9()->getObjectHeaderSizeInBytes()
+                            : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
    TR::DataType fieldType = TR::NoType; // or array element type
 
    // If this is a store to the generic int shadow, it is zero-initializing the
@@ -6208,7 +6284,7 @@ bool TR_EscapeAnalysis::fixupFieldAccessForNonContiguousAllocation(TR::Node *nod
       return true;
       }
 
-   if (candidate->_origKind == TR::New)
+   if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
       fieldOffset = symRef->getOffset();
@@ -6467,7 +6543,7 @@ void TR_EscapeAnalysis::makeLocalObject(Candidate *candidate)
    // Change the "new" node into a load address of a local object/array
    //
    int32_t *referenceSlots = NULL;
-   if (candidate->_kind == TR::New)
+   if (candidate->_kind == TR::New || candidate->_kind == TR::newvalue)
       {
       symRef = getSymRefTab()->createLocalObject(candidate->_size, comp()->getMethodSymbol(), allocationNode->getFirstChild()->getSymbolReference());
 
@@ -6527,7 +6603,7 @@ void TR_EscapeAnalysis::makeLocalObject(Candidate *candidate)
    TR::Node *nodeToUseInInit = allocationNode->duplicateTree();
    TR::TreeTop *insertionPoint = comp()->getStartTree();
 
-   if (candidate->_kind == TR::New)
+   if (candidate->_kind == TR::New || candidate->_kind == TR::newvalue)
       comp()->fej9()->initializeLocalObjectHeader(comp(), nodeToUseInInit, insertionPoint);
    else
       comp()->fej9()->initializeLocalArrayHeader(comp(), nodeToUseInInit, insertionPoint);
@@ -6619,7 +6695,8 @@ void TR_EscapeAnalysis::avoidStringCopyAllocation(Candidate *candidate)
  */
 bool TR_EscapeAnalysis::tryToZeroInitializeUsingArrayset(Candidate* candidate, TR::TreeTop* precedingTreeTop)
    {
-   if (cg()->getSupportsArraySet())
+   // TODO-VALUETYPE:  Investigate whether arrayset can be used for newvalue
+   if (cg()->getSupportsArraySet() && candidate->_kind != TR::newvalue)
       {
       int32_t candidateHeaderSizeInBytes = candidate->_origKind == TR::New ? comp()->fej9()->getObjectHeaderSizeInBytes() : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 
@@ -6663,7 +6740,8 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
    if (comp()->suppressAllocationInlining())
       return;
 
-   if (comp()->generateArraylets() && candidate->_kind != TR::New)
+   if (comp()->generateArraylets() && candidate->_kind != TR::New
+       && candidate->_kind != TR::newvalue)
       return;
 
    dumpOptDetails(comp(), "%sMaking %s node [%p] into a local object of size %d\n",OPT_DETAILS, candidate->_node->getOpCode().getName(), candidate->_node, candidate->_size);
@@ -6674,12 +6752,73 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
       }
 
    if (candidate->escapesInColdBlocks())
+      {
       candidate->_originalAllocationNode = candidate->_node->duplicateTree();
+      }
 
    bool skipZeroInit = false;
-   if ((candidate->_node->getOpCodeValue() != TR::New) &&
+   TR::ILOpCodes       originalAllocationOpCode = candidate->_node->getOpCodeValue();
+
+   if ((originalAllocationOpCode != TR::New) && (originalAllocationOpCode != TR::newvalue) &&
        candidate->_node->canSkipZeroInitialization())
       skipZeroInit = true;
+
+   if (candidate->isExplicitlyInitialized() && (originalAllocationOpCode == TR::newvalue))
+      {
+      // TODO:  Can this code be commoned up with code in lowerNewValue?
+      //
+      TR_OpaqueClassBlock *valueClass = static_cast<TR_OpaqueClassBlock *>(candidate->_node->getFirstChild()->getSymbol()->getStaticSymbol()->getStaticAddress());
+      const TR::TypeLayout* typeLayout = comp()->typeLayout(valueClass);
+
+      TR::TreeTop *fieldValueTreeTopCursor = candidate->_treeTop->getPrevTreeTop();
+      TR::TreeTop *fieldStoreTreeTopCursor = candidate->_treeTop;
+
+      for (int i = 1; i < candidate->_node->getNumChildren(); i++)
+         {
+         TR::Node *fieldValueNode = candidate->_node->getChild(i);
+         TR::Node *ttNode = TR::Node::create(TR::treetop, 1);
+         ttNode->setAndIncChild(0, fieldValueNode);
+
+         fieldValueTreeTopCursor = TR::TreeTop::create(comp(), fieldValueTreeTopCursor, ttNode);
+
+         // generate store to the field
+         const TR::TypeLayoutEntry& fieldEntry = typeLayout->entry(i - 1);
+         TR::SymbolReference* symref = comp()->getSymRefTab()->findOrFabricateShadowSymbol(valueClass,
+                                                                          fieldEntry._datatype,
+                                                                          fieldEntry._offset,
+                                                                          fieldEntry._isVolatile,
+                                                                          fieldEntry._isPrivate,
+                                                                          fieldEntry._isFinal,
+                                                                          fieldEntry._fieldname,
+                                                                          fieldEntry._typeSignature
+                                                                          );
+
+         const TR::ILOpCodes storeOpCode = (fieldValueNode->getDataType() != TR::Address)
+                                              ? comp()->il.opCodeForIndirectStore(fieldValueNode->getDataType())
+                                              : comp()->il.opCodeForIndirectWriteBarrier(fieldValueNode->getDataType());
+         TR::Node *storeNode;
+
+         if (fieldValueNode->getDataType() == TR::Address)
+            {
+            storeNode = TR::Node::createWithSymRef(storeOpCode, 3, 3, candidate->_node, fieldValueNode, candidate->_node, symref);
+            }
+         else
+            {
+            storeNode = TR::Node::createWithSymRef(storeOpCode, 2, 2, candidate->_node, fieldValueNode, symref);
+            }
+
+         // if storing a ref, make sure it is compressed
+         if (comp()->useCompressedPointers() && fieldValueNode->getDataType() == TR::Address)
+            {
+            TR::Node *compressNode = TR::Node::createCompressedRefsAnchor(storeNode);
+            fieldStoreTreeTopCursor = TR::TreeTop::create(comp(), fieldStoreTreeTopCursor, compressNode);
+            }
+         else
+            {
+            fieldStoreTreeTopCursor = TR::TreeTop::create(comp(), fieldStoreTreeTopCursor, storeNode);
+            }
+         }
+      }
 
    makeLocalObject(candidate);
 
@@ -6692,63 +6831,66 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
 
    if (candidate->isExplicitlyInitialized())
       {
-      // Find all the explicit zero-initializations and see if any of the
-      // generic int shadows can be replaced by real field references.
-#if LOCAL_OBJECTS_COLLECTABLE
-      // Any zero-initializations for collectable fields are removed.
-      // These fields must be zero-initialized at the start of the method
-      // instead of at the point of allocation, since liveness is not easily
-      // predictable for these objects.
-#endif
-      //
-      for (initTree = candidate->_treeTop->getNextTreeTop(); initTree; initTree = next)
+      if (originalAllocationOpCode != TR::newvalue)
          {
-         next = initTree->getNextTreeTop();
-         node = initTree->getNode();
-         if (node->getOpCodeValue() != TR::istorei ||
-             node->getSymbol() != getSymRefTab()->findGenericIntShadowSymbol() ||
-             node->getFirstChild() != candidate->_node)
-            break;
-
-         int32_t zeroInitOffset = node->getSymbolReference()->getOffset();
-
-         // If this is a zero-initialization for a collectable field, remove
-         // it since the initialization will be done at the start of the
-         // method.  Don't do this for allocations that are inside loops, since
-         // for these allocations the initialization must happen every time
-         // round the loop.
+         // Find all the explicit zero-initializations and see if any of the
+         // generic int shadows can be replaced by real field references.
+#if LOCAL_OBJECTS_COLLECTABLE
+         // Any zero-initializations for collectable fields are removed.
+         // These fields must be zero-initialized at the start of the method
+         // instead of at the point of allocation, since liveness is not easily
+         // predictable for these objects.
+#endif
          //
-         if (referenceSlots && !candidate->isInsideALoop())
+         for (initTree = candidate->_treeTop->getNextTreeTop(); initTree; initTree = next)
             {
-            for (j = 0; referenceSlots[j]; j++)
-               {
-               ////if (zeroInitOffset == referenceSlots[j]*_cg->sizeOfJavaPointer())
-               if (zeroInitOffset == referenceSlots[j]*TR::Compiler->om.sizeofReferenceField())
-                  {
-                  TR::TransformUtil::removeTree(comp(), initTree);
-                  break;
-                  }
-               }
-            if (referenceSlots[j])
-               continue;
-            }
+            next = initTree->getNextTreeTop();
+            node = initTree->getNode();
+            if (node->getOpCodeValue() != TR::istorei ||
+                node->getSymbol() != getSymRefTab()->findGenericIntShadowSymbol() ||
+                node->getFirstChild() != candidate->_node)
+               break;
 
-         if (candidate->_fields && candidate->_origKind == TR::New)
-            {
-            for (i = candidate->_fields->size()-1; i >= 0; i--)
+            int32_t zeroInitOffset = node->getSymbolReference()->getOffset();
+
+            // If this is a zero-initialization for a collectable field, remove
+            // it since the initialization will be done at the start of the
+            // method.  Don't do this for allocations that are inside loops, since
+            // for these allocations the initialization must happen every time
+            // round the loop.
+            //
+            if (referenceSlots && !candidate->isInsideALoop())
                {
-               FieldInfo &field = candidate->_fields->element(i);
-               offset = field._offset;
-               if (field._symRef &&
-                   offset == node->getSymbolReference()->getOffset())
+               for (j = 0; referenceSlots[j]; j++)
                   {
-                  node->getSecondChild()->recursivelyDecReferenceCount();
-                  sym = field._symRef->getSymbol();
-                  TR::DataType type = sym->getDataType();
-                  node->setAndIncChild(1, createConst(comp(), node, type, 0));
-                  node->setSymbolReference(field._symRef);
-                  TR::Node::recreate(node, comp()->il.opCodeForIndirectStore(type));
-                  break;
+                  ////if (zeroInitOffset == referenceSlots[j]*_cg->sizeOfJavaPointer())
+                  if (zeroInitOffset == referenceSlots[j]*TR::Compiler->om.sizeofReferenceField())
+                     {
+                     TR::TransformUtil::removeTree(comp(), initTree);
+                     break;
+                     }
+                  }
+               if (referenceSlots[j])
+                  continue;
+               }
+
+            if (candidate->_fields && (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue))
+               {
+               for (i = candidate->_fields->size()-1; i >= 0; i--)
+                  {
+                  FieldInfo &field = candidate->_fields->element(i);
+                  offset = field._offset;
+                  if (field._symRef &&
+                      offset == node->getSymbolReference()->getOffset())
+                     {
+                     node->getSecondChild()->recursivelyDecReferenceCount();
+                     sym = field._symRef->getSymbol();
+                     TR::DataType type = sym->getDataType();
+                     node->setAndIncChild(1, createConst(comp(), node, type, 0));
+                     node->setSymbolReference(field._symRef);
+                     TR::Node::recreate(node, comp()->il.opCodeForIndirectStore(type));
+                     break;
+                     }
                   }
                }
             }
@@ -6778,9 +6920,9 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
             }
          }
 
-      int32_t headerSize = (candidate->_kind == TR::New) ?
-         comp()->fej9()->getObjectHeaderSizeInBytes() :
-         TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
+      int32_t headerSize = (candidate->_kind == TR::New || candidate->_kind == TR::newvalue)
+                              ? comp()->fej9()->getObjectHeaderSizeInBytes()
+                              : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
       int32_t refSlotIndex = 0;
       // Changes for new 64-bit object model
       i = headerSize;
@@ -6799,7 +6941,7 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
 
          // See if the slot can be initialized using a field reference
          //
-         if (candidate->_fields && candidate->_origKind == TR::New)
+         if (candidate->_fields && (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue))
             {
             for (j = candidate->_fields->size()-1; j >= 0; j--)
                {
@@ -6823,8 +6965,10 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
          // Since we don't know the type, we have to initialize only a 4byte slot.
          //
          node = TR::Node::create(allocationNode, TR::iconst, 0);
-         node = TR::Node::createWithSymRef(TR::istorei, 2, 2, allocationNode, node, (candidate->_origKind == TR::New)
-                                           ? getSymRefTab()->findOrCreateGenericIntNonArrayShadowSymbolReference(i) : getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(i));
+         node = TR::Node::createWithSymRef(TR::istorei, 2, 2, allocationNode, node,
+                                (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
+                                      ? getSymRefTab()->findOrCreateGenericIntNonArrayShadowSymbolReference(i)
+                                      : getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(i));
          initTree = TR::TreeTop::create(comp(), initTree, node);
          i += intIncrVal;
          }
@@ -6866,7 +7010,7 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
                }
             }
 
-         if (candidate->_fields && candidate->_origKind == TR::New)
+         if (candidate->_fields && (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue))
             {
             for (j = candidate->_fields->size()-1; j >= 0; j--)
                {
@@ -6891,9 +7035,10 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
          //
          node = TR::Node::aconst(allocationNode, 0);
          //symRef = getSymRefTab()->findOrCreateGenericIntShadowSymbolReference(offset);
-         TR::Node *storeNode = TR::Node::createWithSymRef(TR::astorei, 2, 2,baseNode,node, (candidate->_origKind == TR::New) ?
-                                                          getSymRefTab()->findOrCreateGenericIntNonArrayShadowSymbolReference(offset) :
-                                                          getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(offset));
+         TR::Node *storeNode = TR::Node::createWithSymRef(TR::astorei, 2, 2,baseNode,node,
+                                            (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
+                                               ? getSymRefTab()->findOrCreateGenericIntNonArrayShadowSymbolReference(offset)
+                                               : getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(offset));
          if (comp()->useCompressedPointers())
             initTree = TR::TreeTop::create(comp(), initTree, TR::Node::createCompressedRefsAnchor(storeNode));
          else
@@ -6907,7 +7052,7 @@ void TR_EscapeAnalysis::makeNonContiguousLocalAllocation(Candidate *candidate)
    if (comp()->suppressAllocationInlining())
       return;
 
-   if (comp()->generateArraylets() && (candidate->_kind != TR::New))
+   if (comp()->generateArraylets() && (candidate->_kind != TR::New) && (candidate->_kind != TR::newvalue))
       return;
 
    if (candidate->objectIsReferenced())
@@ -6970,7 +7115,7 @@ void TR_EscapeAnalysis::makeNonContiguousLocalAllocation(Candidate *candidate)
    //
    if (candidate->objectIsReferenced())
       {
-      if (candidate->_kind != TR::New)
+      if ((candidate->_kind != TR::New) && (candidate->_kind != TR::newvalue))
          {
          candidate->_origSize = candidate->_size;
          candidate->_origKind = candidate->_kind;
@@ -6993,6 +7138,7 @@ void TR_EscapeAnalysis::makeNonContiguousLocalAllocation(Candidate *candidate)
          }
       else
          {
+         TR_ASSERT_FATAL(candidate->_kind != TR::newvalue, "Don't know how to handle TR::newvalue here");
          // Change the node so that it allocates a java/lang/Object object
          //
          TR::ResolvedMethodSymbol *owningMethodSymbol = candidate->_node->getSymbolReference()->getOwningMethodSymbol(comp());
@@ -7087,7 +7233,7 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
       heapAllocation->getFirstChild()->setHeapificationAlloc(true);
 
       if (trace())
-         traceMsg(comp(), "heapifying %p b1 %d b2 %d\n", candidate->_node, candidate->isContiguousAllocation(), candidate->_dememoizedMethodSymRef);
+         traceMsg(comp(), "heapifying %p:  isContiguousAllocation == %d; _dememoizedMethodSymRef %d; new heapAllocation treetop %p\n", candidate->_node, candidate->isContiguousAllocation(), candidate->_dememoizedMethodSymRef, heapAllocation);
 
       if (!candidate->isContiguousAllocation() && _dememoizedAllocs.find(candidate->_node))
          {
@@ -7102,6 +7248,8 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
                {
                FieldInfo &field = candidate->_fields->element(j);
                fieldSize = field._size;
+
+               // TODO-VALUETYPE:  Need to handle dememoized Integer.valueOf if Integer becomes a value type
                if (field._symRef &&
                    field._symRef->getSymbol()->isAuto() &&
                    (candidate->_origKind == TR::New))
@@ -7178,7 +7326,7 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
 
       // Copy all the slots, using field symbol references where possible.
       //
-      int32_t headerSize = (candidate->_origKind == TR::New) ?
+      int32_t headerSize = ((candidate->_origKind == TR::New) || (candidate->_origKind == TR::newvalue)) ?
          comp()->fej9()->getObjectHeaderSizeInBytes() :
          TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
       int32_t i;
@@ -7206,7 +7354,7 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
                if (field._offset == i &&
                    field._symRef &&
                    (candidate->isContiguousAllocation() || field._symRef->getSymbol()->isAuto()) &&
-                   candidate->_origKind == TR::New)
+                   (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue))
                   {
                   TR::DataType type = field._symRef->getSymbol()->getDataType();
 
@@ -7270,7 +7418,7 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
 //          else
 //             {
             TR::SymbolReference *intShadow;
-            if (candidate->_origKind == TR::New)
+            if (candidate->_origKind == TR::New || candidate->_origKind == TR::newvalue)
                intShadow = getSymRefTab()->findOrCreateGenericIntNonArrayShadowSymbolReference(i);
             else
                intShadow = getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(i);
@@ -7330,9 +7478,9 @@ void TR_EscapeAnalysis::heapifyForColdBlocks(Candidate *candidate)
             //
             TR::TreeTop *coldBlockTree = escapeTree;
 
-            int32_t headerSize = (candidate->_origKind == TR::New) ?
-               comp()->fej9()->getObjectHeaderSizeInBytes() :
-               TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
+            int32_t headerSize = ((candidate->_origKind == TR::New) || (candidate->_origKind == TR::newvalue))
+                                 ? comp()->fej9()->getObjectHeaderSizeInBytes()
+                                 : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
             int32_t size = candidate->_origSize;
             // Changes for new 64-bit object model
             // instead of _cg->sizeOfJavaPointer(), increment by field size
@@ -9057,6 +9205,7 @@ int32_t TR_LocalFlushElimination::perform()
 
          if ((node->getOpCodeValue() == TR::treetop) &&
              ((node->getFirstChild()->getOpCodeValue() == TR::New) ||
+              (node->getFirstChild()->getOpCodeValue() == TR::newvalue) ||
               (node->getFirstChild()->getOpCodeValue() == TR::newarray) ||
               (node->getFirstChild()->getOpCodeValue() == TR::anewarray)))
             {

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -502,6 +502,14 @@ class TR_EscapeAnalysis : public TR::Optimization
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();
 
+   /**
+    * Indicates whether stack allocation of \c newvalue operations may be
+    * performed.  If the value is set to \c true, \c newvalue operations
+    * will not be considered as candidates for stack allocation; otherwise,
+    * they will be considered as candidates.
+    */
+   bool                       _disableValueTypeStackAllocation;
+
    protected:
 
    enum restrictionType { MakeNonLocal, MakeContiguous, MakeObjectReferenced };
@@ -703,6 +711,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    bool findCallSiteFixed(TR::TreeTop * virtualCallSite);
 
    TR::SymbolReference        *_newObjectNoZeroInitSymRef;
+   TR::SymbolReference        *_newValueSymRef;
    TR::SymbolReference        *_newArrayNoZeroInitSymRef;
    TR::SymbolReference        *_aNewArrayNoZeroInitSymRef;
    TR_UseDefInfo             *_useDefInfo;
@@ -844,12 +853,3 @@ class TR_MonitorStructureChecker
 
 #endif
 #endif
-
-
-
-
-
-
-
-
-

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -647,6 +647,7 @@ class TR_EscapeAnalysis : public TR::Optimization
 
    void     makeContiguousLocalAllocation(Candidate *candidate);
    void     makeNonContiguousLocalAllocation(Candidate *candidate);
+   void     makeNewValueLocalAllocation(Candidate *candidate);
    void     heapifyForColdBlocks(Candidate *candidate);
 
    /**

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -119,7 +119,8 @@ struct FieldInfo
    TR_ScratchList<TR::SymbolReference> *_badFieldSymrefs;
    char                                  _vectorElem;
 
-   void                rememberFieldSymRef(TR::Node *node, int32_t fieldOffset, Candidate *candidate, TR_EscapeAnalysis *ea);
+   void                rememberFieldSymRef(TR::Node *node, Candidate *candidate, TR_EscapeAnalysis *ea);
+   void                rememberFieldSymRef(TR::SymbolReference *symRef, TR_EscapeAnalysis *ea);
    bool                symRefIsForFieldInAllocatedClass(TR::SymbolReference *symRef);
    bool                hasBadFieldSymRef();
    TR::SymbolReference *fieldSymRef(); // Any arbitrary good field symref
@@ -133,6 +134,7 @@ class Candidate : public TR_Link<Candidate>
       : _kind(node->getOpCodeValue()), _node(node), _treeTop(treeTop), _origKind(node->getOpCodeValue()), _stringCopyNode(NULL), _stringCopyCallTree(NULL),
         _block(block),
         _class(classInfo),
+        _origClass(classInfo),
         _size(size), _fieldSize(0), _valueNumbers(0), _fields(0), _origSize(size),
         _initializedWords(0),
         _maxInlineDepth(0), _inlineBytecodeSize(0), _seenFieldStore(false), _seenSelfStore(false), _seenStoreToLocalObject(false), _seenArrayCopy(false), _argToCall(false), _usedInNonColdBlock(false), _lockedInNonColdBlock(false),_isImmutable(false),
@@ -248,6 +250,8 @@ class Candidate : public TR_Link<Candidate>
          }
       }
 
+     FieldInfo & findOrSetFieldInfo(TR::Node *fieldRefNode, TR::SymbolReference *symRef, int32_t fieldOffset, int32_t fieldSize, TR::DataType fieldStoreType, TR_EscapeAnalysis *ea);
+
      void print();
 
      TR::ILOpCodes            _kind;
@@ -259,6 +263,7 @@ class Candidate : public TR_Link<Candidate>
      TR_Array<FieldInfo>    *_fields;
      TR_BitVector           *_initializedWords;
      void                   *_class;
+     void                   *_origClass;
      TR::Node                *_originalAllocationNode;
      TR::Compilation *        _comp;
      TR_Memory *             _trMemory;
@@ -797,6 +802,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    friend class TR_FlowSensitiveEscapeAnalysis;
    friend class TR_LocalFlushElimination;
    friend struct FieldInfo;
+   friend class Candidate;
    };
 
 //class Candidate;

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -208,4 +208,84 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>ValueTypeOptTests</testCaseName>
+		<variations>
+			<variation>-Xint</variation>
+			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeOptTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>NullRestrictedTypeOptTests</testCaseName>
+		<variations>
+			<variation>-Xint</variation>
+			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
+			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NullRestrictedTypeOptTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
@@ -1,0 +1,346 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.test.lworld;
+
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeClass;
+
+
+@Test(groups = { "level.sanity" })
+public class NullRestrictedTypeOptTests {
+
+	// A primitive (null-restricted) value class
+	public primitive static class PrimPair {
+		public final int x, y;
+
+		public PrimPair(int x, int y) {
+			this.x = x; this.y = y;
+		}
+
+		public PrimPair(PrimPair p) {
+			this.x = p.x; this.y = p.y;
+		}
+	}
+
+	public static class EscapeException extends RuntimeException {
+		public Object escapingObject;
+
+		public EscapeException(Object o) {
+			escapingObject = o;
+		}
+	}
+
+	public static int result = 0;
+	public static PrimPair[] parr = new PrimPair[] { new PrimPair(3, 4), new PrimPair(0, 0), new PrimPair(0, 0) };
+
+	@Test(priority=1)
+	static public void testEAOpportunity1() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			for (int j = 0; j < 100; j++) {
+				evalTestEA1a(j);
+			}
+			assertEquals(result, 500);
+
+			result = 0;
+			evalTestEA1b();
+			assertEquals(result, 500);
+		}
+	}
+
+	static private void evalTestEA1a(int iter) {
+		// Test situation where EA could apply to value p1,
+		// but might have to allocate contiguously
+		PrimPair p1 = new PrimPair(1, 2);
+		PrimPair p2 = parr[0];
+
+		PrimPair p3;
+		PrimPair p4;
+
+		if (iter % 2 == 0) {
+			p3 = p2;
+			p4 = p1;
+		} else {
+			p3 = p1;
+			p4 = p2;
+		}
+		result += p3.x + p4.y;
+	}
+
+	static private void evalTestEA1b() {
+		for (int j = 0; j < 100; j++) {
+			// Test situation where EA could apply to value p1,
+			// but might have to allocate contiguously
+			PrimPair p1 = new PrimPair(1, 2);
+			PrimPair p2 = parr[0];
+
+			PrimPair p3;
+			PrimPair p4;
+
+			if (j % 2 == 0) {
+				p3 = p2;
+				p4 = p1;
+			} else {
+				p3 = p1;
+				p4 = p2;
+			}
+			result += p3.x + p4.y;
+		}
+	}
+
+	public static PrimPair testEA2Field = new PrimPair(0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity2() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			evalTestEA2(-1);  // No escape
+			assertEquals(result, 200);
+			assertEquals(testEA2Field, new PrimPair(0,0));
+		}
+		evalTestEA2(99);  // Escape for index 99
+		assertEquals(testEA2Field, new PrimPair(2,1));
+		evalTestEA2(98);  // Escape for index 98
+		assertEquals(testEA2Field, new PrimPair(1,2));
+	}
+
+	static private void evalTestEA2(int escapePoint) {
+		int x = 1; int y = 2;
+		int[] nextVal = {0, 2, 1};
+
+		for (int i = 0; i < 100; i++) {
+			PrimPair p1 = new PrimPair(x, y);
+			int updatex = nextVal[x];
+			int updatey = nextVal[y];
+			x = updatex;
+			y = updatey;
+			if (p1.x*p1.y != 2 || escapePoint == i) testEA2Field = p1;  // Value might escape
+
+			result += x*y;
+		}
+	}
+
+	@Test(priority=1)
+	static public void testEAOpportunity3() throws Throwable {
+		for (int i = 0; i < 1000; i++) {
+			result = 0;
+			evalTestEA3();
+			assertEquals(result, 1000);
+		}
+	}
+
+	static private void evalTestEA3() {
+		for (int i = 0; i < 100; i++) {
+			// Test potential stack allocation of array of value type
+			PrimPair[] arr = new PrimPair[] {new PrimPair(1, 2), new PrimPair(3, 4)};
+			for (int j = 0; j < arr.length; j++) {
+				PrimPair val = arr[j%arr.length];
+				result += val.x + val.y;
+			}
+		}
+	}
+
+	// A primitive (null-restricted) value class with primitive value class fields
+	public primitive static class NestedPrimPair {
+		public final PrimPair p1;
+		public final PrimPair p2;
+
+		public NestedPrimPair(int i, int j, int m, int n) {
+			this.p1 = new PrimPair(i, j);
+			this.p2 = new PrimPair(m, n);
+		}
+
+		public NestedPrimPair(PrimPair p1, PrimPair p2) {
+			this.p1 = new PrimPair(p1);
+			this.p2 = new PrimPair(p2);
+		}
+	}
+
+	// An array whose component type is a primitive (null-restricted) value class
+	public static NestedPrimPair[] nestedprimarr = new NestedPrimPair[] { new NestedPrimPair(11, 12, 13, 14) };
+
+	@Test(priority=1)
+	static public void testEAOpportunity4() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			for (int j = 0; j < 100; j++) {
+				evalTestEA4a(j);
+			}
+			assertEquals(result, 1500);
+
+			result = 0;
+			evalTestEA4b();
+			assertEquals(result, 1500);
+		}
+	}
+
+	static private void evalTestEA4a(int iter) {
+		// Test situation where EA could apply to value p1,
+		// but might have to allocate contiguously
+		NestedPrimPair p1 = new NestedPrimPair(1, 2, 3, 4);
+		NestedPrimPair p2 = nestedprimarr[0];
+
+		NestedPrimPair p3;
+		NestedPrimPair p4;
+
+		if (iter % 2 == 0) {
+			p3 = p2;
+			p4 = p1;
+		} else {
+			p3 = p1;
+			p4 = p2;
+		}
+		result += p3.p1.x + p4.p2.y;
+	}
+
+	static private void evalTestEA4b() {
+		for (int j = 0; j < 100; j++) {
+			// Test situation where EA could apply to value p1,
+			// but might have to allocate contiguously.  Also,
+			// extra challenges for stack allocation in a loop
+			NestedPrimPair p1 = new NestedPrimPair(1, 2, 3, 4);
+			NestedPrimPair p2 = nestedprimarr[0];
+
+			NestedPrimPair p3;
+			NestedPrimPair p4;
+
+			if (j % 2 == 0) {
+				p3 = p1;
+				p4 = p2;
+			} else {
+				p3 = p2;
+				p4 = p1;
+			}
+
+			result += p3.p1.x + p4.p2.y;
+		}
+	}
+
+	public static NestedPrimPair testEA5Field = new NestedPrimPair(0,0,0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity5() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			evalTestEA5();
+			assertEquals(result, 2400);
+			assertEquals(testEA5Field, new NestedPrimPair(0,0,0,0));
+		}
+	}
+
+	static private void evalTestEA5() {
+		int x = 1; int y = 2; int z = 3; int w = 4;
+
+		for (int i = 0; i < 100; i++) {
+			NestedPrimPair p = new NestedPrimPair(x, y, z, w);
+			int updatex = (x-y)*(x-y);
+			int updatey = y*(y-x);
+			int updatez = (z-w)*(z-w)*z;
+			int updatew = w*(w-z);
+			x = updatex;
+			y = updatey;
+			z = updatez;
+			w = updatew;
+			if (p.p1.x*p.p1.y+p.p2.x*p.p2.y != 14) testEA5Field = p;  // Looks like value might escape (but never actually does)
+
+			result += x*y*z*w;
+		}
+	}
+
+	@Test(priority=1)
+	static public void testEAOpportunity6() throws Throwable {
+		for (int i = 0; i < 1000; i++) {
+			result = 0;
+			evalTestEA6();
+			assertEquals(result, 1800);
+		}
+	}
+
+	static private void evalTestEA6() {
+		for (int i = 0; i < 100; i++) {
+			// Test potential stack allocation of array of value type
+			NestedPrimPair[] arr = new NestedPrimPair[] {new NestedPrimPair(1, 2, 3, 4), new NestedPrimPair(5, 6, 7, 8)};
+			for (int j = 0; j < arr.length; j++) {
+				NestedPrimPair val = arr[j%arr.length];
+				result += val.p1.x + val.p2.y;
+			}
+		}
+	}
+
+	public static int sval7 = 0;
+	public static PrimPair escape7 = new PrimPair(0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity7() throws Throwable {
+		result = 0;
+		for (int i = 0; i < 100000; i++) {
+			evalTestEA7(i*sval7);
+		}
+		assertEquals(result, 500000);
+		assertEquals(escape7, new PrimPair(0,0));
+
+		evalTestEA7(sval7+99);
+		assertEquals(result, 500000);
+		assertEquals(escape7, new PrimPair(1,2));
+	}
+
+	static private void evalTestEA7(int i) {
+		// Test cold block escape for nested value object
+		PrimPair p = new PrimPair(1, 2);
+
+		try {
+			result += p.x + parr[i].y;
+		} catch (ArrayIndexOutOfBoundsException aioobe) {
+			escape7 = p;
+		}
+	}
+
+	public static int sval8 = 0;
+	public static NestedPrimPair escape8 = new NestedPrimPair(0,0,0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity8() throws Throwable {
+		result = 0;
+		for (int i = 0; i < 100000; i++) {
+			evalTestEA8(i*sval8);
+		}
+		assertEquals(result, 1500000);
+		assertEquals(escape8, new NestedPrimPair(0,0,0,0));
+
+		evalTestEA8(sval8+99);
+		assertEquals(result, 1500000);
+		assertEquals(escape8, new NestedPrimPair(1,2,3,4));
+	}
+
+	static private void evalTestEA8(int i) {
+		// Test cold block escape for nested primitive value objects
+		NestedPrimPair p = new NestedPrimPair(1, 2, 3, 4);
+
+		try {
+			result += p.p1.x + nestedprimarr[i].p2.y;
+		} catch (ArrayIndexOutOfBoundsException aioobe) {
+			escape8 = p;
+		}
+	}
+}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeOptTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeOptTests.java
@@ -1,0 +1,351 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.test.lworld;
+
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeClass;
+
+
+@Test(groups = { "level.sanity" })
+public class ValueTypeOptTests {
+	// An ordinary (non-null-restricted) value class
+	public static value class Pair {
+		public final int x, y;
+
+		public Pair(int x, int y) {
+			this.x = x; this.y = y;
+		}
+
+		public Pair(Pair p) {
+			this.x = p.x; this.y = p.y;
+		}
+	}
+
+	public static class EscapeException extends RuntimeException {
+		public Object escapingObject;
+
+		public EscapeException(Object o) {
+			escapingObject = o;
+		}
+	}
+
+	public static int result = 0;
+	public static Pair[] arr = new Pair[] { new Pair(3, 4) };
+
+	@Test(priority=1)
+	static public void testEAOpportunity1() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			for (int j = 0; j < 100; j++) {
+				evalTestEA1a(j);
+			}
+			assertEquals(result, 500);
+
+			result = 0;
+			evalTestEA1b();
+			assertEquals(result, 500);
+		}
+	}
+
+	static private void evalTestEA1a(int iter) {
+		// Test situation where EA could apply to value p1,
+		// but might have to allocate contiguously
+		Pair p1 = new Pair(1, 2);
+		Pair p2 = arr[0];
+
+		Pair p3;
+		Pair p4;
+
+		if (iter % 2 == 0) {
+			p3 = p1;
+			p4 = p2;
+		} else {
+			p3 = p2;
+			p4 = p1;
+		}
+
+
+		if (result >= 0) {
+			result += p3.x + p4.y;
+		}
+	}
+
+	static private void evalTestEA1b() {
+		for (int j = 0; j < 100; j++) {
+			// Test situation where EA could apply to value p1,
+			// but might have to allocate contiguously.  Also,
+			// extra challenges for stack allocation in a loop
+			Pair p1 = new Pair(1, 2);
+			Pair p2 = arr[0];
+
+			Pair p3;
+			Pair p4;
+
+			if (j % 2 == 0) {
+				p3 = p1;
+				p4 = p2;
+			} else {
+				p3 = p2;
+				p4 = p1;
+			}
+
+
+			if (result >= 0) {
+				result += p3.x + p4.y;
+			}
+		}
+	}
+
+	@Test(priority=1)
+	static public void testEAOpportunity2() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			evalTestEA2(-1);  // No escape
+			assertEquals(result, 200);
+			assertEquals(testEA2Field, new Pair(0,0));
+		}
+		evalTestEA2(99);  // Escape for index 99
+		assertEquals(testEA2Field, new Pair(2,1));
+		evalTestEA2(98);  // Escape for index 98
+		assertEquals(testEA2Field, new Pair(1,2));
+	}
+
+	public static Pair testEA2Field = new Pair(0,0);
+
+	static private void evalTestEA2(int escapePoint) {
+		int x = 1; int y = 2;
+		int[] nextVal = {0, 2, 1};
+
+		for (int i = 0; i < 100; i++) {
+			Pair p1 = new Pair(x, y);
+			int updatex = nextVal[x];
+			int updatey = nextVal[y];
+			x = updatex;
+			y = updatey;
+			if (p1.x*p1.y != 2 || escapePoint == i) testEA2Field = p1;  // Value might escape
+
+			result += x*y;
+		}
+	}
+
+	@Test(priority=1)
+	static public void testEAOpportunity3() throws Throwable {
+		for (int i = 0; i < 1000; i++) {
+			result = 0;
+			evalTestEA3();
+			assertEquals(result, 1000);
+		}
+	}
+
+	static private void evalTestEA3() {
+		for (int i = 0; i < 100; i++) {
+			// Test potential stack allocation of array of value type
+			Pair[] arr = new Pair[] {new Pair(1, 2), new Pair(3, 4)};
+			for (int j = 0; j < arr.length; j++) {
+				Pair val = arr[j%arr.length];
+				result += val.x + val.y;
+			}
+		}
+	}
+
+	public static value class NestedPair {
+		public final Pair p1;
+		public final Pair p2;
+
+		public NestedPair(int i, int j, int m, int n) {
+			this.p1 = new Pair(i, j);
+			this.p2 = new Pair(m, n);
+		}
+
+		public NestedPair(Pair p1, Pair p2) {
+			this.p1 = new Pair(p1);
+			this.p2 = new Pair(p2);
+		}
+	}
+
+	public static NestedPair[] nestedarr = new NestedPair[] { new NestedPair(7, 8, 9, 10) };
+
+	@Test(priority=1)
+	static public void testEAOpportunity4() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			for (int j = 0; j < 100; j++) {
+				evalTestEA4a(j);
+			}
+			assertEquals(result, 1100);
+
+			result = 0;
+			evalTestEA4b();
+			assertEquals(result, 1100);
+		}
+	}
+
+	static private void evalTestEA4a(int iter) {
+		// Test situation where EA could apply to value p1,
+		// but might have to allocate contiguously
+		NestedPair p1 = new NestedPair(1, 2, 3, 4);
+		NestedPair p2 = nestedarr[0];
+
+		NestedPair p3;
+		NestedPair p4;
+
+		if (iter % 2 == 0) {
+			p3 = p2;
+			p4 = p1;
+		} else {
+			p3 = p1;
+			p4 = p2;
+		}
+		result += p3.p1.x + p4.p2.y;
+	}
+
+	static private void evalTestEA4b() {
+		for (int j = 0; j < 100; j++) {
+			// Test situation where EA could apply to value p1,
+			// but might have to allocate contiguously.  Also,
+			// extra challenges for stack allocation in a loop
+			NestedPair p1 = new NestedPair(1, 2, 3, 4);
+			NestedPair p2 = nestedarr[0];
+
+			NestedPair p3;
+			NestedPair p4;
+
+			if (j % 2 == 0) {
+				p3 = p1;
+				p4 = p2;
+			} else {
+				p3 = p2;
+				p4 = p1;
+			}
+
+			result += p3.p1.x + p4.p2.y;
+		}
+	}
+	@Test(priority=1)
+	static public void testEAOpportunity5() throws Throwable {
+		for (int i = 0; i < 10000; i++) {
+			result = 0;
+			evalTestEA5();
+			assertEquals(result, 2400);
+			assertEquals(testEA5Field, new NestedPair(0,0,0,0));
+		}
+	}
+
+	public static NestedPair testEA5Field = new NestedPair(0,0,0,0);
+
+	static private void evalTestEA5() {
+		int x = 1; int y = 2; int z = 3; int w = 4;
+
+		for (int i = 0; i < 100; i++) {
+			NestedPair p = new NestedPair(x, y, z, w);
+			int updatex = (x-y)*(x-y);
+			int updatey = y*(y-x);
+			int updatez = (z-w)*(z-w)*z;
+			int updatew = w*(w-z);
+			x = updatex;
+			y = updatey;
+			z = updatez;
+			w = updatew;
+			if (p.p1.x*p.p1.y*p.p2.x*p.p2.y != 24) testEA5Field = p;  // Looks like value might escape (but never actually does)
+
+			result += x*y*z*w;
+		}
+	}
+
+	@Test(priority=1)
+	static public void testEAOpportunity6() throws Throwable {
+		for (int i = 0; i < 1000; i++) {
+			result = 0;
+			evalTestEA6();
+			assertEquals(result, 1800);
+		}
+	}
+
+	static private void evalTestEA6() {
+		for (int i = 0; i < 100; i++) {
+			// Test potential stack allocation of array of value type
+			NestedPair[] arr = new NestedPair[] {new NestedPair(1, 2, 3, 4), new NestedPair(5, 6, 7, 8)};
+			for (int j = 0; j < arr.length; j++) {
+				NestedPair val = arr[j%arr.length];
+				result += val.p1.x + val.p2.y;
+			}
+		}
+	}
+
+	public static int sval7 = 0;
+	public static Pair escape7 = new Pair(0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity7() throws Throwable {
+		result = 0;
+		for (int i = 0; i < 100000; i++) {
+			evalTestEA7(i*sval7);
+		}
+		assertEquals(result, 500000);
+		assertEquals(escape7, new Pair(0,0));
+
+		evalTestEA7(sval7+99);
+		assertEquals(result, 500000);
+		assertEquals(escape7, new Pair(1,2));
+	}
+
+	static private void evalTestEA7(int i) {
+		// Test cold block escape for value object
+		Pair p = new Pair(1, 2);
+
+		try {
+			result += p.x + arr[i].y;
+		} catch (ArrayIndexOutOfBoundsException aioobe) {
+			escape7 = p;
+		}
+	}
+
+	public static int sval8 = 0;
+	public static NestedPair escape8 = new NestedPair(0,0,0,0);
+
+	@Test(priority=1)
+	static public void testEAOpportunity8() throws Throwable {
+		result = 0;
+		for (int i = 0; i < 100000; i++) {
+			evalTestEA8(i*sval8);
+		}
+		assertEquals(result, 1100000);
+		assertEquals(escape8, new NestedPair(0,0,0,0));
+
+		evalTestEA8(sval8+99);
+		assertEquals(result, 1100000);
+		assertEquals(escape8, new NestedPair(1,2,3,4));
+	}
+
+	static private void evalTestEA8(int i) {
+		// Test cold block escape for nested value objects
+		NestedPair p = new NestedPair(1, 2, 3, 4);
+
+		try {
+			result += p.p1.x + nestedarr[i].p2.y;
+		} catch (ArrayIndexOutOfBoundsException aioobe) {
+			escape8 = p;
+		}
+	}
+}

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -40,4 +40,14 @@
 			<class name="org.openj9.test.lworld.ValueTypeUnsafeTests"/>
 		</classes>
 	</test>
+	<test name="ValueTypeOptTests">
+		<classes>
+			<class name="org.openj9.test.lworld.ValueTypeOptTests"/>
+		</classes>
+	</test>
+	<test name="NullRestrictedTypeOptTests">
+		<classes>
+			<class name="org.openj9.test.lworld.NullRestrictedTypeOptTests"/>
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
These changes enable support for stack allocation of instances of value type classes in escape analysis.  The changes are staged through a sequence of commits to aid in reviewing:

1. Commit 16d4e5ec4ac4d9bc390ebb2c8fb2229de283abb2 adds support for contiguous stack allocation of instances of value type classes
2. Commit 075335a1a65d53146590de54071cd3a6c6c91e14 adds support for non-contiguous stack allocation of instances of value type classes
3. Commit c2951330f46ea107e6d401e1154d51d3bedfeeef adds support for cold block heapification of instances of value type classes
4. Commit 404cd86f5cd9c6c651c3eee86b608cf104c7df86 adds special "harmless" recognition of array element load operations through calls to helper or non-helper methods
5. Commit 453a61a077717d12b4463a984cb1e872b4db8c66 adds some unit tests of escape analysis of value type instances
6. Commit 9e727ec12d64b65b38afe223fec21ab4615810dc is a minor tracing improvement

This pull request is currently marked as a draft pull request as it depends on a downstream OMR pull request.  However, I am not expecting to make any further changes to this pull request, except as might be required to address review comments, of course.

Depends:  eclipse/omr#7031