### PR TITLE
Revert "Enable String Compression by default in OpenJ9"

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6461,23 +6461,12 @@ processCompressionOptions(J9JavaVM *vm)
 	argIndex1 = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXCOMPACTSTRINGS, NULL);
 	argIndex2 = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXNOCOMPACTSTRINGS, NULL);
 
-#if JAVA_SPEC_VERSION >= 11
-	/* Default setting */
-	vm->strCompEnabled = TRUE;
-
-	// Default to enable string compression unless there's the option to disable string compression
-	// is explicitly defined.
-	if (argIndex2 > argIndex1) {
-		vm->strCompEnabled = FALSE;
-	}
-#else /* JAVA_SPEC_VERSION >= 11 */
 	/* Default setting */
 	vm->strCompEnabled = FALSE;
 
 	if (argIndex1 > argIndex2) {
 		vm->strCompEnabled = TRUE;
 	}
-#endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
 /**


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#16452

Reverting due to https://github.com/eclipse-openj9/openj9/issues/17598