### PR TITLE
GC CRIU: Reinit HeapRegionDescriptorExtensions (Region Obj Lists)

### DIFF
--- a/runtime/gc_base/ContinuationObjectList.cpp
+++ b/runtime/gc_base/ContinuationObjectList.cpp
@@ -46,13 +46,22 @@ MM_ContinuationObjectList::MM_ContinuationObjectList()
 }
 
 MM_ContinuationObjectList *
-MM_ContinuationObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+MM_ContinuationObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_ContinuationObjectList *listsToCopy, uintptr_t arrayElementsToCopy)
 {
-	MM_ContinuationObjectList *continuationObjectLists;
+	MM_ContinuationObjectList *continuationObjectLists = NULL;
 
-	continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate(sizeof(MM_ContinuationObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate(sizeof(MM_ContinuationObjectList) * arrayElementsTotal,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != continuationObjectLists) {
-		for (uintptr_t index = 0; index < arrayElements; index++) {
+		Assert_MM_true(arrayElementsTotal >= arrayElementsToCopy);
+		/* Check whether a new array instance in being created from an existing array. If so, copy over the elements first. */
+		if (arrayElementsToCopy > 0) {
+			for (uintptr_t index = 0; index < arrayElementsToCopy; index++) {
+				continuationObjectLists[index] = listsToCopy[index];
+				continuationObjectLists[index].initialize(env);
+			}
+		}
+
+		for (uintptr_t index = arrayElementsToCopy; index < arrayElementsTotal; index++) {
 			new(&continuationObjectLists[index]) MM_ContinuationObjectList();
 			continuationObjectLists[index].initialize(env);
 		}

--- a/runtime/gc_base/ContinuationObjectList.hpp
+++ b/runtime/gc_base/ContinuationObjectList.hpp
@@ -57,11 +57,13 @@ public:
 	 * Allocate and initialize an array of MM_ContinuationObjectList instances, resembling the functionality of operator new[].
 	 *
 	 * @param env the current thread
-	 * @param arrayElements the number of lists to create
+	 * @param arrayElementsTotal the number of lists to create
+	 * @param listsToCopy existing MM_ContinuationObjectList array to use to construct a new array of lists
+	 * @param arrayElementsToCopy the size of the list array to be copied
 	 *
 	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
 	 */
-	static MM_ContinuationObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	static MM_ContinuationObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_ContinuationObjectList *listsToCopy, uintptr_t arrayElementsToCopy);
 	bool initialize(MM_EnvironmentBase *env);
 
 	/**

--- a/runtime/gc_base/OwnableSynchronizerObjectList.cpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectList.cpp
@@ -46,13 +46,22 @@ MM_OwnableSynchronizerObjectList::MM_OwnableSynchronizerObjectList()
 }
 
 MM_OwnableSynchronizerObjectList *
-MM_OwnableSynchronizerObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+MM_OwnableSynchronizerObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_OwnableSynchronizerObjectList *listsToCopy, uintptr_t arrayElementsToCopy)
 {
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectLists = NULL;
 
-	ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate(sizeof(MM_OwnableSynchronizerObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate(sizeof(MM_OwnableSynchronizerObjectList) * arrayElementsTotal,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != ownableSynchronizerObjectLists) {
-		for (uintptr_t index = 0; index < arrayElements; index++) {
+		Assert_MM_true(arrayElementsTotal >= arrayElementsToCopy);
+		/* Check whether a new array instance in being created from an existing array. If so, copy over the elements first. */
+		if (arrayElementsToCopy > 0) {
+			for (uintptr_t index = 0; index < arrayElementsToCopy; index++) {
+				ownableSynchronizerObjectLists[index] = listsToCopy[index];
+				ownableSynchronizerObjectLists[index].initialize(env);
+			}
+		}
+
+		for (uintptr_t index = arrayElementsToCopy; index < arrayElementsTotal; index++) {
 			new(&ownableSynchronizerObjectLists[index]) MM_OwnableSynchronizerObjectList();
 			ownableSynchronizerObjectLists[index].initialize(env);
 		}

--- a/runtime/gc_base/OwnableSynchronizerObjectList.hpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectList.hpp
@@ -58,11 +58,13 @@ public:
 	 * Allocate and initialize an array of MM_OwnableSynchronizerObjectList instances, resembling the functionality of operator new[].
 	 *
 	 * @param env the current thread
-	 * @param arrayElements the number of lists to create
+	 * @param arrayElementsTotal the number of lists to create
+	 * @param listsToCopy existing MM_OwnableSynchronizerObjectList array to use to construct a new array of lists
+	 * @param arrayElementsToCopy the size of the list array to be copied
 	 *
 	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
 	 */
-	static MM_OwnableSynchronizerObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	static MM_OwnableSynchronizerObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_OwnableSynchronizerObjectList *listsToCopy, uintptr_t arrayElementsToCopy);
 	bool initialize(MM_EnvironmentBase *env);
 
 	/**

--- a/runtime/gc_base/ReferenceObjectList.cpp
+++ b/runtime/gc_base/ReferenceObjectList.cpp
@@ -45,13 +45,22 @@ MM_ReferenceObjectList::MM_ReferenceObjectList()
 }
 
 MM_ReferenceObjectList *
-MM_ReferenceObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+MM_ReferenceObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_ReferenceObjectList *listsToCopy, uintptr_t arrayElementsToCopy)
 {
-	MM_ReferenceObjectList *referenceObjectLists;
+	MM_ReferenceObjectList *referenceObjectLists = NULL;
 
-	referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate(sizeof(MM_ReferenceObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate(sizeof(MM_ReferenceObjectList) * arrayElementsTotal,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != referenceObjectLists) {
-		for (uintptr_t index = 0; index < arrayElements; index++) {
+		Assert_MM_true(arrayElementsTotal >= arrayElementsToCopy);
+		/* Check whether a new array instance in being created from an existing array. If so, copy over the elements first. */
+		if (arrayElementsToCopy > 0) {
+			for (uintptr_t index = 0; index < arrayElementsToCopy; index++) {
+				referenceObjectLists[index] = listsToCopy[index];
+				referenceObjectLists[index].initialize(env);
+			}
+		}
+
+		for (uintptr_t index = arrayElementsToCopy; index < arrayElementsTotal; index++) {
 			new(&referenceObjectLists[index]) MM_ReferenceObjectList();
 			referenceObjectLists[index].initialize(env);
 		}

--- a/runtime/gc_base/ReferenceObjectList.hpp
+++ b/runtime/gc_base/ReferenceObjectList.hpp
@@ -55,11 +55,13 @@ public:
 	 * Allocate and initialize an array of MM_ReferenceObjectList instances, resembling the functionality of operator new[].
 	 *
 	 * @param env the current thread
-	 * @param arrayElements the number of lists to create
+	 * @param arrayElementsTotal the number of lists to create
+	 * @param listsToCopy existing MM_ReferenceObjectList array to use to construct a new array of lists
+	 * @param arrayElementsToCopy the size of the list array to be copied
 	 *
 	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
 	 */
-	static MM_ReferenceObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	static MM_ReferenceObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_ReferenceObjectList *listsToCopy, uintptr_t arrayElementsToCopy);
 	bool initialize(MM_EnvironmentBase *env) { return true; }
 
 	/**

--- a/runtime/gc_base/UnfinalizedObjectList.cpp
+++ b/runtime/gc_base/UnfinalizedObjectList.cpp
@@ -43,13 +43,22 @@ MM_UnfinalizedObjectList::MM_UnfinalizedObjectList()
 }
 
 MM_UnfinalizedObjectList *
-MM_UnfinalizedObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements)
+MM_UnfinalizedObjectList::newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_UnfinalizedObjectList *listsToCopy, uintptr_t arrayElementsToCopy)
 {
-	MM_UnfinalizedObjectList *unfinalizedObjectLists;
+	MM_UnfinalizedObjectList *unfinalizedObjectLists = NULL;
 
-	unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate(sizeof(MM_UnfinalizedObjectList) * arrayElements,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate(sizeof(MM_UnfinalizedObjectList) * arrayElementsTotal,  MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL != unfinalizedObjectLists) {
-		for (uintptr_t index = 0; index < arrayElements; index++) {
+		Assert_MM_true(arrayElementsTotal >= arrayElementsToCopy);
+		/* Check whether a new array instance in being created from an existing array. If so, copy over the elements first. */
+		if (arrayElementsToCopy > 0) {
+			for (uintptr_t index = 0; index < arrayElementsToCopy; index++) {
+				unfinalizedObjectLists[index] = listsToCopy[index];
+				unfinalizedObjectLists[index].initialize(env);
+			}
+		}
+
+		for (uintptr_t index = arrayElementsToCopy; index < arrayElementsTotal; index++) {
 			new(&unfinalizedObjectLists[index]) MM_UnfinalizedObjectList();
 			unfinalizedObjectLists[index].initialize(env);
 		}

--- a/runtime/gc_base/UnfinalizedObjectList.hpp
+++ b/runtime/gc_base/UnfinalizedObjectList.hpp
@@ -54,11 +54,13 @@ public:
 	 * Allocate and initialize an array of MM_UnfinalizedObjectList instances, resembling the functionality of operator new[].
 	 *
 	 * @param env the current thread
-	 * @param arrayElements the number of lists to create
+	 * @param arrayElementsTotal the number of lists to create
+	 * @param listsToCopy existing MM_UnfinalizedObjectList array to use to construct a new array of lists
+	 * @param arrayElementsToCopy the size of the list array to be copied
 	 *
 	 * @return a pointer to the first list in the array, or NULL if we failed to allocate/init the array
 	 */
-	static MM_UnfinalizedObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElements);
+	static MM_UnfinalizedObjectList *newInstanceArray(MM_EnvironmentBase *env, uintptr_t arrayElementsTotal, MM_UnfinalizedObjectList *listsToCopy, uintptr_t arrayElementsToCopy);
 	bool initialize(MM_EnvironmentBase *env);
 
 	/**


### PR DESCRIPTION
HeapRegionDescriptorExtensions contain multiple array of obj lists which are inited at startup based on the startup thread count. These must be reinitialized during restore (CRIU) according to the new GC thread
count. Specifically, when the thread count is increased, it is necessary to divide the region object lists. This is required to improve parallelism with GC threads and ultimately improve GC performance for the restore environment. For background, see https://github.com/eclipse/omr/issues/6888 (Compensate for Thread Count Change).

Signed-off-by: Salman Rana <salman.rana@ibm.com>