### PR TITLE
Handle code cache allocation when available memory becomes low

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1045,6 +1045,9 @@ public:
    bool              isInShutdownMode() {return _isInShutdownMode;}
    void              setIsInShutdownMode() {_isInShutdownMode = true;}
 
+   bool              isSwapMemoryDisabled() {return _isSwapMemoryDisabled;}
+   void              setIsSwapMemoryDisabled(bool b) {_isSwapMemoryDisabled = b;}
+
    TR_LinkHead0<TR_ClassHolder> *getListOfClassesToCompile() { return &_classesToCompileList; }
    int32_t getCompilationLag();
    int32_t getCompilationLagUnlocked() { return getCompilationLag(); } // will go away
@@ -1485,6 +1488,7 @@ private:
    bool                   _traceCompiling;
 #endif
    bool                   _isInShutdownMode;
+   bool                   _isSwapMemoryDisabled;
    int32_t                _numCompThreads; // Number of usable compilation threads that does not include the diagnostic thread
    int32_t                _numDiagnosticThreads;
    int32_t                _numAllocatedCompThreads; // Number of allocated compilation threads that does not include the diagnostic thread

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1378,7 +1378,7 @@ onLoadInternal(
       {
       // Code cache total value defaults were overridden due to low memory available
       bool incomplete;
-      uint64_t freePhysicalMemoryB = getCompilationInfo(jitConfig)->computeFreePhysicalMemory(incomplete);
+      uint64_t freePhysicalMemoryB = getCompilationInfo(jitConfig)->computeAndCacheFreePhysicalMemory(incomplete);
       if (freePhysicalMemoryB != OMRPORT_MEMINFO_NOT_AVAILABLE)
          TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "Available freePhysicalMemory=%llu MB, allocating code cache total size=%lu MB", freePhysicalMemoryB >> 20, jitConfig->codeCacheTotalKB >> 10);
       else

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -34,6 +34,7 @@
 #include "infra/Monitor.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
+#include "control/CompilationRuntime.hpp"
 #include "env/FrontEnd.hpp"
 #include "env/ut_j9jit.h"
 #include "infra/CriticalSection.hpp"
@@ -74,6 +75,37 @@ J9::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCod
    _javaVM = _jitConfig->javaVM;
 
    return self()->OMR::CodeCacheManager::initialize(useConsolidatedCache, numberOfCodeCachesToCreateAtStartup);
+   }
+
+bool
+J9::CodeCacheManager::isSufficientPhysicalMemoryAvailableForAllocation(size_t requestedCodeCacheSize)
+   {
+   TR::CodeCacheConfig &config = self()->codeCacheConfig();
+   TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
+   bool incomplete;
+   // If swap memory is not available then no need to do further check
+   if (!compInfo->isSwapMemoryDisabled())
+      {
+      return true;
+      }
+
+   // Read the amount of free physical memory currently, bypassing the caching mechanism
+   uint64_t freePhysicalMemoryB = compInfo->computeAndCacheFreePhysicalMemory(incomplete, 0);
+   // Avoid consuming the last drop of physical memory for JIT; leave some for emergency situations
+   uint64_t safeMemReserve = (uint64_t)TR::Options::getSafeReservePhysicalMemoryValue();
+   uint64_t desiredMemory = requestedCodeCacheSize + safeMemReserve;
+
+   if (!incomplete && freePhysicalMemoryB < desiredMemory)
+      {
+      if (config.verboseCodeCache() || config.verbosePerformance())
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "Warning: low physical memory detected during code cache allocation, requestedCodeCacheSize=%zu, freePhysicalMemory=%zu, safeMemReserve=%zu",
+                                       requestedCodeCacheSize, (size_t)freePhysicalMemoryB, (size_t)safeMemReserve);
+      return false;
+      }
+   else
+      {
+      return true;
+      }
    }
 
 void
@@ -296,6 +328,10 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    // For virtual allocations the size must always be a multiple of the page size
    codeCacheSizeToAllocate = (codeCacheSizeToAllocate + (vmemParams.pageSize-1)) & (~(vmemParams.pageSize-1));
    vmemParams.byteAmount = codeCacheSizeToAllocate;
+
+   // Fail code cache allocation, if the available physical memory is low
+   if (!self()->isSufficientPhysicalMemoryAvailableForAllocation(codeCacheSizeToAllocate))
+      return 0;
 
    void *defaultEndAddress = vmemParams.endAddress;
 

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -70,6 +70,7 @@ public:
 
    TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
 
+   bool isSufficientPhysicalMemoryAvailableForAllocation(size_t requestedCodeCacheSize);
    void addCodeCache(TR::CodeCache *codeCache);
 
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,


### PR DESCRIPTION
When running in low memory environment like containers with limited memory, code cache allocation needs to consider the available free memory before allocating new cache. A new check to confirm safe memory limits before carving new code cache.

- [ ] OMR change:Handle code cache allocation for low physical memory [[7036](https://github.com/eclipse/omr/pull/7036)]