### PR TITLE
Make AOT Compilation generate the same code as JIT Compilation for enter/exit tracing

### DIFF
--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -22,8 +22,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 This document describes at a high level what the various relocation records
 are used for. The exact data stored into the SCC can be found in
-`initializeCommonAOTRelocationHeader` and the various 
-`initializePlatformSpecificAOTRelocationHeader` functions. Similarly, the 
+`initializeCommonAOTRelocationHeader` and the various
+`initializePlatformSpecificAOTRelocationHeader` functions. Similarly, the
 exact type of the API class for each relocation kind can be found in
 `TR_RelocationRecord::create`.
 
@@ -136,3 +136,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_MethodCallAddress`|Relocates the address of a call target. Only used in JitServer (in AOT, all other methods are assumed to be interpreted).|
 |`TR_CatchBlockCounter`|Relocates the address of the catch block counter in the `TR_PersistentMethodInfo` of the method being compiled.|
 |`TR_StartPC`|Relocates the startPC of the method being compiled. Only implemented and used on Power.|
+|`TR_MethodEnterExitHookAddress`|Relocates the address of the method enter or exit hook.|

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1323,6 +1323,22 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_MethodEnterExitHookAddress:
+         {
+         TR_RelocationRecordMethodEnterExitHookAddress *mehaRecord = reinterpret_cast<TR_RelocationRecordMethodEnterExitHookAddress *>(reloRecord);
+
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
+         uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
+
+         TR::Symbol *sym = symRef->getSymbol();
+         TR_ASSERT_FATAL((sym->isEnterEventHookAddress() || sym->isExitEventHookAddress()),
+                         "TR_MethodEnterExitHookAddress: symbol %p is neither enter nor exit hook address\n");
+
+         mehaRecord->setReloFlags(reloTarget, flags);
+         mehaRecord->setIsEnterHookAddr(reloTarget, sym->isEnterEventHookAddress());
+         }
+         break;
+
       default:
          TR_ASSERT(false, "Unknown relo type %d!\n", kind);
          comp->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown relo type %d!\n", kind);
@@ -2247,6 +2263,21 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
                      (uint32_t)icvRecord->sourceClassID(reloTarget),
                      (uint32_t)icvRecord->destClassID(reloTarget),
                      icvRecord->isVisible(reloTarget) ? "true" : "false");
+            }
+         }
+         break;
+
+      case TR_MethodEnterExitHookAddress:
+         {
+         TR_RelocationRecordMethodEnterExitHookAddress *mehaRecord = reinterpret_cast<TR_RelocationRecordMethodEnterExitHookAddress *>(reloRecord);
+
+         self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(
+               self()->comp(),
+               "\n Method Enter/Exit Hook Address: isEnterHookAddr=%s ",
+               mehaRecord->isEnterHookAddr(reloTarget) ? "true" : "false");
             }
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -957,7 +957,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
             "static method cpIndex has special split table flag set");
 
          if ((svmRecord->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) != 0)
-            smfcpRecord->setReloFlags(reloTarget, TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT);
+            smfcpRecord->setReloFlags(reloTarget, staticSpecialMethodFromCpIsSplit);
 
          smfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
          smfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));
@@ -977,7 +977,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
             "special method cpIndex has static split table flag set");
 
          if ((svmRecord->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) != 0)
-            smfcpRecord->setReloFlags(reloTarget, TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT);
+            smfcpRecord->setReloFlags(reloTarget, staticSpecialMethodFromCpIsSplit);
 
          smfcpRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_method));
          smfcpRecord->setDefiningClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_definingClass));

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -264,7 +264,6 @@ J9::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalReloca
    uint8_t *cursor         = relocation->getRelocationData();
    uint8_t targetKind      = relocation->getTargetKind();
    uint16_t sizeOfReloData = relocation->getSizeOfRelocationData();
-   uint8_t wideOffsets     = relocation->needsWideOffsets() ? RELOCATION_TYPE_WIDE_OFFSET : 0;
 
    // Zero-initialize header
    memset(cursor, 0, sizeOfReloData);
@@ -274,7 +273,8 @@ J9::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalReloca
 
    reloRecord->setSize(reloTarget, sizeOfReloData);
    reloRecord->setType(reloTarget, static_cast<TR_RelocationRecordType>(targetKind));
-   reloRecord->setFlag(reloTarget, wideOffsets);
+   if (relocation->needsWideOffsets())
+      reloRecord->setWideOffsets(reloTarget);
 
    if (!self()->initializePlatformSpecificAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind))
       self()->initializeCommonAOTRelocationHeader(relocation, reloTarget, reloRecord, targetKind);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -271,8 +271,8 @@ J9::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalReloca
    TR_RelocationRecord storage;
    TR_RelocationRecord *reloRecord = TR_RelocationRecord::create(&storage, reloRuntime, targetKind, reinterpret_cast<TR_RelocationRecordBinaryTemplate *>(cursor));
 
-   reloRecord->setSize(reloTarget, sizeOfReloData);
    reloRecord->setType(reloTarget, static_cast<TR_RelocationRecordType>(targetKind));
+   reloRecord->setSize(reloTarget, sizeOfReloData);
    if (relocation->needsWideOffsets())
       reloRecord->setWideOffsets(reloTarget);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 48; // ID: D3AHcgts8NbMmvWfHeYV
+   static const uint16_t MINOR_NUMBER = 49; // ID: C3VbnDEdGq49br7YGAxK
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -312,6 +312,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_StartPC:
       case TR_DataAddress:
       case TR_DebugCounter:
+      case TR_MethodEnterExitHookAddress:
          return true;
       }
 

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -121,21 +121,6 @@ typedef struct TR_InlinedSiteHastTableEntry
    TR_InlinedSiteLinkedListEntry *last;
    } TR_InlinedSiteHastTableEntry;
 
-
-typedef enum
-   {
-   inlinedMethodIsStatic = 1,
-   inlinedMethodIsSpecial = 2,
-   inlinedMethodIsVirtual = 3
-   } TR_InlinedMethodKind;
-
-
-typedef enum
-   {
-   needsFullSizeRuntimeAssumption = 1
-   } TR_HCRAssumptionFlags;
-
-
 typedef enum
    {
    noPerfAssumptions = 0,
@@ -144,7 +129,16 @@ typedef enum
    tooManyFailedInlinedAllocRelos = 3
    } TR_FailedPerfAssumptionCode;
 
+typedef enum
+   {
+   inlinedMethodIsStatic            = 0x01,
+   inlinedMethodIsSpecial           = 0x02,
+   inlinedMethodIsVirtual           = 0x04,
 
+   staticSpecialMethodFromCpIsSplit = 0x08,
+
+   needsFullSizeRuntimeAssumption   = 0x10,
+   } TR_RelocationFlags;
 
 /* TR_AOTMethodHeader Versions:
 *     1.0    Java6 GA

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -134,10 +134,9 @@ typedef enum
    inlinedMethodIsStatic            = 0x01,
    inlinedMethodIsSpecial           = 0x02,
    inlinedMethodIsVirtual           = 0x04,
-
    staticSpecialMethodFromCpIsSplit = 0x08,
-
    needsFullSizeRuntimeAssumption   = 0x10,
+   methodTracingEnabled             = 0x20,
    } TR_RelocationFlags;
 
 /* TR_AOTMethodHeader Versions:
@@ -175,8 +174,8 @@ typedef struct TR_AOTMethodHeader {
 
 /* AOT Method flags */
 #define TR_AOTMethodHeader_NeedsRecursiveMethodTrampolineReservation 0x00000001
-#define TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing          0x00000002
-#define TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing           0x00000004
+#define TR_AOTMethodHeader_MethodEnterEventCanBeHooked               0x00000002
+#define TR_AOTMethodHeader_MethodExitEventCanBeHooked                0x00000004
 #define TR_AOTMethodHeader_UsesEnableStringCompressionFolding        0x00000008
 #define TR_AOTMethodHeader_StringCompressionEnabled                  0x00000010
 #define TR_AOTMethodHeader_UsesSymbolValidationManager               0x00000020
@@ -184,8 +183,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_CompressedMethodInCache                   0x00000080
 #define TR_AOTMethodHeader_IsNotCapableOfExceptionHook               0x00000100
 #define TR_AOTMethodHeader_UsesOSR                                   0x00000200
-
-
+#define TR_AOTMethodHeader_MethodTracingEnabled                      0x00000400
 
 
 typedef struct TR_AOTInliningStats

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1593,16 +1593,19 @@ createMethodMetaData(
 
       // Set some flags in the AOTMethodHeader
       //
-      if (!vm->isMethodTracingEnabled(vmMethod->getPersistentIdentifier()) &&
-          !vm->canMethodExitEventBeHooked())
+      if (vm->canMethodEnterEventBeHooked())
          {
-         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing;
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_MethodEnterEventCanBeHooked;
          }
 
-      if (!vm->isMethodTracingEnabled(vmMethod->getPersistentIdentifier()) &&
-          !vm->canMethodEnterEventBeHooked())
+      if (vm->canMethodExitEventBeHooked())
          {
-         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing;
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_MethodExitEventCanBeHooked;
+         }
+
+      if (vm->isMethodTracingEnabled(vmMethod->getNonPersistentIdentifier()))
+         {
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_MethodTracingEnabled;
          }
 
       if (!vm->canExceptionEventBeHooked())

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -942,7 +942,9 @@ TR_RelocationRecord::flags(TR_RelocationTarget *reloTarget)
 void
 TR_RelocationRecord::setReloFlags(TR_RelocationTarget *reloTarget, uint8_t reloFlags)
    {
+   reloFlags <<= RELOCATION_RELOC_FLAGS_SHIFT;
    TR_ASSERT_FATAL((reloFlags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+
    uint8_t crossPlatFlags = flags(reloTarget);
    uint8_t flags = crossPlatFlags | (reloFlags & RELOCATION_RELOC_FLAGS_MASK);
    reloTarget->storeUnsigned8b(flags, (uint8_t *) &_record->_flags);
@@ -951,7 +953,7 @@ TR_RelocationRecord::setReloFlags(TR_RelocationTarget *reloTarget, uint8_t reloF
 uint8_t
 TR_RelocationRecord::reloFlags(TR_RelocationTarget *reloTarget)
    {
-   return reloTarget->loadUnsigned8b((uint8_t *) &_record->_flags) & RELOCATION_RELOC_FLAGS_MASK;
+   return (reloTarget->loadUnsigned8b((uint8_t *) &_record->_flags) & RELOCATION_RELOC_FLAGS_MASK) >> RELOCATION_RELOC_FLAGS_SHIFT;
    }
 
 void

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -81,9 +81,9 @@ struct TR_RelocationRecordBinaryTemplate
    {
    uint8_t type(TR_RelocationTarget *reloTarget);
 
-   uint16_t _size;
    uint8_t _type;
-   uint8_t _flags;
+   uint16_t _size;
+   uint16_t _flags;
    };
 
 struct TR_RelocationRecordHelperAddressBinaryTemplate : public TR_RelocationRecordBinaryTemplate
@@ -929,14 +929,15 @@ TR_RelocationRecord::eipRelative(TR_RelocationTarget *reloTarget)
 void
 TR_RelocationRecord::setFlag(TR_RelocationTarget *reloTarget, uint8_t flag)
    {
-   uint8_t flags = reloTarget->loadUnsigned8b((uint8_t *) &_record->_flags) | (flag & RELOCATION_CROSS_PLATFORM_FLAGS_MASK);
-   reloTarget->storeUnsigned8b(flags, (uint8_t *) &_record->_flags);
+   TR_ASSERT_FATAL((flag >> RELOCATION_RELOC_FLAGS_SHIFT) == 0, "flag %d is larger than %d bits", flag, RELOCATION_RELOC_FLAGS_SHIFT);
+   uint16_t flags = reloTarget->loadUnsigned16b((uint8_t *) &_record->_flags) | (flag & RELOCATION_CROSS_PLATFORM_FLAGS_MASK);
+   reloTarget->storeUnsigned16b(flags, (uint8_t *) &_record->_flags);
    }
 
 uint8_t
 TR_RelocationRecord::flags(TR_RelocationTarget *reloTarget)
    {
-   return reloTarget->loadUnsigned8b((uint8_t *) &_record->_flags) & RELOCATION_CROSS_PLATFORM_FLAGS_MASK;
+   return reloTarget->loadUnsigned16b((uint8_t *) &_record->_flags) & RELOCATION_CROSS_PLATFORM_FLAGS_MASK;
    }
 
 void
@@ -947,13 +948,13 @@ TR_RelocationRecord::setReloFlags(TR_RelocationTarget *reloTarget, uint8_t reloF
 
    uint8_t crossPlatFlags = flags(reloTarget);
    uint8_t flags = crossPlatFlags | (reloFlags & RELOCATION_RELOC_FLAGS_MASK);
-   reloTarget->storeUnsigned8b(flags, (uint8_t *) &_record->_flags);
+   reloTarget->storeUnsigned16b(flags, (uint8_t *) &_record->_flags);
    }
 
 uint8_t
 TR_RelocationRecord::reloFlags(TR_RelocationTarget *reloTarget)
    {
-   return (reloTarget->loadUnsigned8b((uint8_t *) &_record->_flags) & RELOCATION_RELOC_FLAGS_MASK) >> RELOCATION_RELOC_FLAGS_SHIFT;
+   return (reloTarget->loadUnsigned16b((uint8_t *) &_record->_flags) & RELOCATION_RELOC_FLAGS_MASK) >> RELOCATION_RELOC_FLAGS_SHIFT;
    }
 
 void

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -84,56 +84,17 @@ struct TR_RelocationRecordBinaryTemplate
    uint16_t _size;
    uint8_t _type;
    uint8_t _flags;
-
-#if defined(TR_HOST_64BIT)
-   uint32_t _extra;
-#endif
    };
 
-// Generating 32-bit code on a 64-bit machine or vice-versa won't work because the alignment won't
-// be right.  Relying on inheritance in the structures here means padding is automatically inserted
-// at each inheritance boundary: this inserted padding won't match across 32-bit and 64-bit platforms.
-// Making as many fields as possible UDATA should minimize the differences and gives the most freedom
-// in the hierarchy of binary relocation record structures, but the header definitely has an inheritance
-// boundary at offset 4B.
-
-// This struct must be identical to TR_RelocationRecordBinaryTemplate
-// in at least the first three (_size, _type, and _flags) fields
-struct TR_RelocationRecordHelperAddressBinaryTemplate
+struct TR_RelocationRecordHelperAddressBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
-   uint16_t _size;
-   uint8_t _type;
-   uint8_t _flags;
    uint32_t _helperID;
    };
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _size)
-              == offsetof(TR_RelocationRecordHelperAddressBinaryTemplate, _size),
-              "TR_RelocationRecordHelperAddressBinaryTemplate::_size not the same offset as TR_RelocationRecordBinaryTemplate::_size");
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _type)
-              == offsetof(TR_RelocationRecordHelperAddressBinaryTemplate, _type),
-              "TR_RelocationRecordHelperAddressBinaryTemplate::_type not the same offset as TR_RelocationRecordBinaryTemplate::_type");
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _flags)
-              == offsetof(TR_RelocationRecordHelperAddressBinaryTemplate, _flags),
-              "TR_RelocationRecordHelperAddressBinaryTemplate::_flags not the same offset as TR_RelocationRecordBinaryTemplate::_flags");
 
-// This struct must be identical to TR_RelocationRecordBinaryTemplate
-// in at least the first three (_size, _type, and _flags) fields
-struct TR_RelocationRecordPicTrampolineBinaryTemplate
+struct TR_RelocationRecordPicTrampolineBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
-   uint16_t _size;
-   uint8_t _type;
-   uint8_t _flags;
    uint32_t _numTrampolines;
    };
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _size)
-              == offsetof(TR_RelocationRecordPicTrampolineBinaryTemplate, _size),
-              "TR_RelocationRecordPicTrampolineBinaryTemplate::_size not the offset same as TR_RelocationRecordBinaryTemplate::_size");
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _type)
-              == offsetof(TR_RelocationRecordPicTrampolineBinaryTemplate, _type),
-              "TR_RelocationRecordPicTrampolineBinaryTemplate::_type not the offset same as TR_RelocationRecordBinaryTemplate::_type");
-static_assert(offsetof(TR_RelocationRecordBinaryTemplate, _flags)
-              == offsetof(TR_RelocationRecordPicTrampolineBinaryTemplate, _flags),
-              "TR_RelocationRecordPicTrampolineBinaryTemplate::_flags not the offset same as TR_RelocationRecordBinaryTemplate::_flags");
 
 struct TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -4560,7 +4560,7 @@ TR_RelocationRecordValidateStaticMethodFromCP::applyRelocation(TR_RelocationRunt
    uint16_t beholderID = this->beholderID(reloTarget);
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
-   if ((reloFlags(reloTarget) & TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT) != 0)
+   if ((reloFlags(reloTarget) & staticSpecialMethodFromCpIsSplit) != 0)
       cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
@@ -4577,7 +4577,7 @@ TR_RelocationRecordValidateSpecialMethodFromCP::applyRelocation(TR_RelocationRun
    uint16_t beholderID = this->beholderID(reloTarget);
    uint32_t cpIndex = this->cpIndex(reloTarget);
 
-   if ((reloFlags(reloTarget) & TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT) != 0)
+   if ((reloFlags(reloTarget) & staticSpecialMethodFromCpIsSplit) != 0)
       cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateSpecialMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2726,10 +2726,8 @@ TR_RelocationRecordInlinedMethod::inlinedSiteCanBeActivated(TR_RelocationRuntime
       return false;
       }
 
-   if (reloRuntime->fej9()->isAnyMethodTracingEnabled((TR_OpaqueMethodBlock *) currentMethod)
-       || (!reloRuntime->comp()->getOption(TR_FullSpeedDebug)
-           && (reloRuntime->fej9()->canMethodEnterEventBeHooked()
-               || reloRuntime->fej9()->canMethodExitEventBeHooked())))
+   if (reloRuntime->fej9()->isMethodTracingEnabled((TR_OpaqueMethodBlock *)currentMethod)
+       && !(reloFlags(reloTarget) & methodTracingEnabled))
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\tinlinedSiteCanBeActivated: target may need enter/exit tracing so disabling inline site\n");
       return false;
@@ -2788,7 +2786,8 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
          else
             reloPrivateData->_receiverClass = NULL;
 
-         if (reloFlags(reloTarget) != inlinedMethodIsStatic && reloFlags(reloTarget) != inlinedMethodIsSpecial)
+         if (((reloFlags(reloTarget) & inlinedMethodIsStatic) == 0)
+             && ((reloFlags(reloTarget) & inlinedMethodIsSpecial) == 0))
             {
             TR_ResolvedMethod *calleeResolvedMethod = reloRuntime->fej9()->createResolvedMethod(reloRuntime->comp()->trMemory(),
                                                                                                 (TR_OpaqueMethodBlock *)currentMethod,

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -41,9 +41,6 @@ typedef TR_ExternalRelocationTargetKind TR_RelocationRecordType;
 namespace TR { class AheadOfTimeCompile; }
 class AOTCacheClassChainRecord;
 
-
-#define TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT 0x01
-
 class TR_RelocationRecordGroup
    {
    public:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -171,6 +171,11 @@ struct TR_RelocationRecordBreakpointGuardPrivateData
    uint8_t *_destinationAddress;
    };
 
+struct TR_RelocationRecordMethodEnterExitHookAddressPrivateData
+   {
+   bool _isEnterHookAddr;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -189,6 +194,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordBlockFrequencyPrivateData blockFrequency;
    TR_RelocationRecordRecompQueuedFlagPrivateData recompQueuedFlag;
    TR_RelocationRecordBreakpointGuardPrivateData breakpointGuard;
+   TR_RelocationRecordMethodEnterExitHookAddressPrivateData hookAddress;
    };
 
 enum TR_RelocationRecordAction
@@ -1970,6 +1976,24 @@ class TR_RelocationRecordStartPC : public TR_RelocationRecord
       virtual char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
+class TR_RelocationRecordMethodEnterExitHookAddress : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordMethodEnterExitHookAddress() {}
+      TR_RelocationRecordMethodEnterExitHookAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name() { return "TR_RelocationRecordMethodEnterExitHookAddress"; }
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setIsEnterHookAddr(TR_RelocationTarget *reloTarget, bool isEnterHookAddr);
+      bool isEnterHookAddr(TR_RelocationTarget *reloTarget);
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -138,6 +138,9 @@ struct TR_RelocationError
     * @brief The relocation error codes. Low tagging allows quick inference of
     *        the category of an error, and also does not require keeping all the
     *        error codes belonging to a category together.
+    *
+    * @remark When updating this enum, the associated string array
+    *         TR_RelocationRuntime::_reloErrorCodeNames[] should also be updated.
     */
    enum TR_RelocationErrorCode
       {
@@ -190,24 +193,24 @@ struct TR_RelocationError
       isClassVisibleValidationFailure                  = (44 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
       svmValidationFailure                             = (45 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
       wkcValidationFailure                             = (46 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      methodTracingValidationFailure                   = (47 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
 
-      classAddressRelocationFailure                    = (47 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      inlinedMethodRelocationFailure                   = (48 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      symbolFromManagerRelocationFailure               = (49 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      thunkRelocationFailure                           = (50 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      trampolineRelocationFailure                      = (51 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      picTrampolineRelocationFailure                   = (52 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      cacheFullRelocationFailure                       = (53 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      blockFrequencyRelocationFailure                  = (54 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      recompQueuedFlagRelocationFailure                = (55 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      debugCounterRelocationFailure                    = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      directJNICallRelocationFailure                   = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      ramMethodConstRelocationFailure                  = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      catchBlockCounterRelocationFailure               = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      classAddressRelocationFailure                    = (48 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      inlinedMethodRelocationFailure                   = (49 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      symbolFromManagerRelocationFailure               = (50 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      thunkRelocationFailure                           = (51 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      trampolineRelocationFailure                      = (52 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      picTrampolineRelocationFailure                   = (53 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      cacheFullRelocationFailure                       = (54 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      blockFrequencyRelocationFailure                  = (55 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      recompQueuedFlagRelocationFailure                = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      debugCounterRelocationFailure                    = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      directJNICallRelocationFailure                   = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      ramMethodConstRelocationFailure                  = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      catchBlockCounterRelocationFailure               = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      staticDefaultValueInstanceRelocationFailure      = (61 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
 
-      staticDefaultValueInstanceRelocationFailure      = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-
-      maxRelocationError                               = (61 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
+      maxRelocationError                               = (62 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
       };
 
    static uint32_t decode(TR_RelocationErrorCode errorCode) { return static_cast<uint32_t>(errorCode >> RELO_ERRORCODE_SHIFT); }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2146,6 +2146,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_StartPC:
       case TR_DataAddress:
       case TR_DebugCounter:
+      case TR_MethodEnterExitHookAddress:
 #endif
          isOrderedPair = true;
          break;

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -234,6 +234,19 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
                                            node,
                                            counter);
       }
+   else if (_reloType==TR_MethodEnterExitHookAddress)
+      {
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)_symbolReference,
+            NULL,
+            TR_MethodEnterExitHookAddress,
+            cg),
+         file,
+         line,
+         node);
+      }
    else
       {
       TR_ASSERT(0,"relocation type [%d] not handled yet", _reloType);


### PR DESCRIPTION
There are two different types of method enter/exit tracing available:
1. `-Xtrace:print=mt,methods=...`
2. JVMTI method enter/exit hooks

### JIT Implementation
If either of these types of tracing are possible, then the ILGenerator generates IL containing `TR::MethodEnterHook` and/or `TR::MethodExitHook` op codes. Later on in the compilation, `TR_J9VMBase::lowerMethodHook` is invoked on these op codes. 

If `-Xtrace` is specified on a particular method, then the compiler generates a call to the appropriate helper [1]. Otherwise, if the JVM may have to report method enter/exit hooks to a JVMTI agent, then a runtime test is generated [2].

### AOT Implementation
Like the JIT case, if either of these types of tracing are possible, then the ILGenerator generates IL containing `TR::MethodEnterHook` and/or `TR::MethodExitHook` op codes, on which `TR_J9VMBase::lowerMethodHook` is invoked. The difference though is that regardless of the type of tracing, the compiler generates a `TR_MethodEnterExitGuard` [3]. At AOT load time, if either type of tracing is possible, the guard is activated; otherwise, it is left as a NOP.

[1] https://github.com/eclipse-openj9/openj9/blob/45ed10ad1d3e751f1116ba846459d2adfd311c65/runtime/compiler/env/VMJ9.cpp#L2980
[2] https://github.com/eclipse-openj9/openj9/blob/45ed10ad1d3e751f1116ba846459d2adfd311c65/runtime/compiler/env/VMJ9.cpp#L3076
[3] https://github.com/eclipse-openj9/openj9/blob/45ed10ad1d3e751f1116ba846459d2adfd311c65/runtime/compiler/env/VMJ9.cpp#L3000

<hr/>

This PR makes the code generated during an AOT compilation the same as what is generated during a JIT compilation with respect to enter/exit tracing. The main functional difference is that in the existing implementation, if tracing was not enabled on a Load run, if the code had the guard, it would be left as a NOP to not report to the VM whereas in the proposed implementation, it would continue to report to the VM (in the case of `-Xtrace`) or continue to have the runtime test (in the case of the JVMTI callback) thus increasing the path length. However, I don't the added complexity of having a completely different implementation for AOT is justified to prevent this extra path length considering that it will only happen if one generates AOT with the tracing and then removes the option in a subsequent run.

This PR also includes some refactoring to facilitate this change. Specifically:
* Removes the `_extra` field from the binary template
* Moves cross platform relocation flags to the lower nibble
* Upgrades the relocation flags to be 16 bits

The reason for this is to have additional flags in the method header as well as the inlined method relocation records. The method header flags indicate if method tracing is enabled (`-Xtrace`) as well as if method enter/exit events can be hooked (JVMTI). The inlined method relocation records only need a flag to validate if method tracing is enabled; this is because the JVMTI hooks are not method specific and so it suffices to only check the AOT method header; ~in fact a further refactoring could move this flag to the AOT Header (which covers all methods in the SCC)~ - this is likely going to be needed for CRIU to allow methods that both have and don't have tracing support.

Depends on https://github.com/eclipse/omr/pull/7039