### PR TITLE
Abort compilations for exceptions during invokedynamic resolution

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1098,6 +1098,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->targetMethodFromMethodHandle(comp, std::get<0>(recv)));
          }
          break;
+      case MessageType::VM_isInvokeCacheEntryAnArray:
+         {
+         auto recv = client->getRecvData<uintptr_t *>();
+         client->write(response, fe->isInvokeCacheEntryAnArray(std::get<0>(recv)));
+         }
       case MessageType::VM_getKnotIndexOfInvokeCacheArrayAppendixElement:
          {
          auto recv = client->getRecvData<uintptr_t *>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4863,6 +4863,13 @@ TR_J9VMBase::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownO
    return (uintptr_t)-1;
    }
 
+bool
+TR_J9VMBase::isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray)
+   {
+   TR::VMAccessCriticalSection vmAccess(this);
+   return VM_VMHelpers::objectIsArray(getCurrentVMThread(), (j9object_t) *invokeCacheArray);
+   }
+
 TR::KnownObjectTable::Index
 TR_J9VMBase::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -899,6 +899,17 @@ public:
     *    VM access is not required
     */
    virtual uintptr_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+
+   /**
+    * \brief
+    *    invokedynamic resolution can either result in a valid entry in the corresponding CallSite table slot if successful,
+    *    or an exception object otherwise. The entry is considered valid when the object in the slot is an array type.
+    *    This helper must be used before trying to access elements of an invokeCacheArray corresponding to an invokedynamic bytecode
+    * \param invokeCacheArray the invokeCacheArray address
+    * \return true if entry is an array type; false otherwise
+    */
+   virtual bool isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray);
+
    /*
     * \brief
     *    Create and return a resolved method from member name index of an invoke cache array.

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2228,6 +2228,17 @@ TR_J9ServerVM::targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObje
    return NULL;
    }
 
+bool
+TR_J9ServerVM::isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray)
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(
+      JITServer::MessageType::VM_isInvokeCacheEntryAnArray,
+      invokeCacheArray
+      );
+   return std::get<0>(stream->read<bool>());
+   }
+
 TR::KnownObjectTable::Index
 TR_J9ServerVM::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -235,6 +235,7 @@ public:
    virtual TR_ResolvedMethod *targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray) override;
    virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray) override;
    virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray) override;
+   virtual bool isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray) override;
 
    virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName) override;
    virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6605,6 +6605,16 @@ TR_ResolvedJ9Method::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callS
       {
       TR_OpaqueMethodBlock * targetJ9MethodBlock = NULL;
       uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
+      // invokedynamic resolution can either result in a valid entry in the corresponding CallSite table slot if successful,
+      // or an exception object otherwise. The CallSite table entry is a two-element array containing the MemberName
+      // and appendix objects necessary for constructing a resolved invokedynamic adapter method call.
+      // The exception object would not be an array type object, and therefore it is sufficient to check if
+      // the entry obtained from the CallSite table is an array instance to determine if the resolution was successful.
+      if (!fej9()->isInvokeCacheEntryAnArray(invokeCacheArray))
+         {
+         comp->failCompilation<TR::CompilationException>("Invalid CallSite table entry for invokedynamic");
+         }
+
          {
          TR::VMAccessCriticalSection getResolvedDynamicMethod(fej9());
          targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayMemberNameIndex)); // this will not work in AOT or JITServer

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 47; // ID: HXF3y37dRYBa2JANYdqS
+   static const uint16_t MINOR_NUMBER = 48; // ID: D3AHcgts8NbMmvWfHeYV
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -187,6 +187,7 @@ const char *messageNames[] =
    "VM_getVMTargetOffset",
    "VM_getVMIndexOffset",
    "VM_inSnapshotMode",
+   "VM_isInvokeCacheEntryAnArray",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -196,6 +196,7 @@ enum MessageType : uint16_t
    VM_getVMTargetOffset,
    VM_getVMIndexOffset,
    VM_inSnapshotMode,
+   VM_isInvokeCacheEntryAnArray,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1256,6 +1256,12 @@ InterpreterEmulator::visitInvokedynamic()
          || comp()->compileRelocatableCode()
       ) return; // do nothing if unresolved, is AOT compilation
    uintptr_t * invokeCacheArray = (uintptr_t *) owningMethod->callSiteTableEntryAddress(callSiteIndex);
+   // CallSite table entry is expected to be an array object upon successful resolution, but this is not
+   // the case when an exception occurs during the invokedynamic resolution, in which case an exception
+   // object is placed in the slot instead.
+   if (!comp()->fej9()->isInvokeCacheEntryAnArray(invokeCacheArray))
+      return;
+
    updateKnotAndCreateCallSiteUsingInvokeCacheArray(owningMethod, invokeCacheArray, -1);
 #else
    bool isInterface = false;


### PR DESCRIPTION
Invokedynamic call resolution can either result in a valid entry
in the CallSite table if successful, or an exception object
otherwise. The call site table entry is a two element array
containing the MemberName and appendix objects necessary for
constructing a resolved invokedynamic call. The exception object
would not be an array type object, and therefore it is sufficient
to check if the entry obtained from the CallSite table is an array
instance to determine if the resolution was successful.

This changeset handles the cases when we have an invalid entry
in the CallSite table that results in either failed inlining or
failed compilation, depending on whether the invokedynamic is part
of the inlining candidate or the root method, respectively.

Issue: #16965