### PR TITLE
Print Dynatrace original_core_pattern in javacore if available

### DIFF
--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -55,6 +55,7 @@ UDATA rasDumpAgentEnabled = (UDATA)-1;
 char* dumpDirectoryPrefix = NULL;
 
 #define MAX_DUMP_OPTS  128
+#define MAX_INTERESTING_LENGTH 255
 
 #if defined(J9ZOS390)
 #if defined(J9VM_ENV_DATA64)
@@ -112,7 +113,7 @@ static void initRasDumpGlobalStorage(J9JavaVM *vm);
 static void freeRasDumpGlobalStorage(J9JavaVM *vm);
 static void hookVmInitialized PROTOTYPE((J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData));
 #if defined(LINUX)
-static void appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName );
+static J9RASSystemInfo *appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName);
 #endif /* defined(LINUX) */
 #ifdef J9ZOS390
 static IDATA processZOSDumpOptions(J9JavaVM *vm, J9RASdumpOption* agentOpts, int optIndex);
@@ -1365,7 +1366,46 @@ initSystemInfo(J9JavaVM *vm)
 			}
 		}
 	}
-	appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_PATTERN, J9RAS_CORE_PATTERN_FILE);
+	{
+		J9RASSystemInfo *corePatternInfo = appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_PATTERN, J9RAS_CORE_PATTERN_FILE);
+		if (NULL != corePatternInfo) {
+			/* A common core_pattern is Dynatrace; for example, |/opt/dynatrace/oneagent/agent/rdp
+			 * This program sends the core to the originally configured
+			 * core_pattern as stored in, for example,
+			 * /opt/dynatrace/oneagent/agent/conf/original_core_pattern
+			 *
+			 * If we find this Dynatrace core_pattern, extract its installation
+			 * directory and then read original_core_pattern relative to that.
+			 */
+			const char *corePattern = (const char *)corePatternInfo->data;
+			if ('|' == corePattern[0]) {
+				static const char search[] = "/oneagent/agent/rdp";
+				static const char replacement[] = "/oneagent/agent/conf/original_core_pattern";
+				const char *dynatracePath = strstr(corePattern, search);
+
+				/* Check if core_pattern includes the Dynatrace agent. */
+				if (NULL != dynatracePath) {
+					char namebuf[MAX_INTERESTING_LENGTH];
+					/* The length of the agent path prefix, minus the pipe character. */
+					size_t prefixLength = dynatracePath - corePattern - 1;
+
+					/* Ensure that the original_core_pattern path will fit in our buffer. */
+					if (prefixLength <= (sizeof(namebuf) - sizeof(replacement))) {
+						/* Copy the prefix starting after the pipe character. */
+						memcpy(namebuf, corePattern + 1, prefixLength);
+
+						/* Append the relative location of original_core_pattern. */
+						memcpy(namebuf + prefixLength, replacement, sizeof(replacement));
+
+						/* Finally, read the file contents, if available/accessible.
+						 * Note that in containers, this file will most likely be invisible.
+						 */
+						appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_ORIGINAL_PATTERN, namebuf);
+					}
+				}
+			}
+		}
+	}
 	appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_USES_PID, J9RAS_CORE_USES_PID_FILE);
 #endif /* defined(LINUX) */
 }
@@ -1407,41 +1447,43 @@ initDumpDirectory(J9JavaVM *vm)
 
 #if defined(LINUX)
 /* Adds a J9RASSystemInfo to the end of the system info list using the key
- * specified as the key and the data from the specified file in /proc if
+ * specified as the key and the first line from the specified file in fileName if
  * it exists.
  *
  * @param[in]	vm			pointer to J9JavaVM
- * @param[out]	key			J9RAS_SYSTEMINFO_ key from rasdump_internal.h
- * @param[in]	procFileName	the file in /proc to read the value from
+ * @param[in]	key			J9RAS_SYSTEMINFO_ key from rasdump_internal.h
+ * @param[in]	fileName	the file in fileName to read the value from
  *
- * @return:
- *	nothing
+ * @return return new J9RASSystemInfo* if success, otherwise NULL
  */
-static void
-appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName )
+static J9RASSystemInfo *
+appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName)
 {
-
+	J9RASSystemInfo *systemInfo = NULL;
 	IDATA fd = -1;
-	J9RAS* rasStruct = vm->j9ras;
+	J9RAS *rasStruct = vm->j9ras;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if( NULL == rasStruct ) {
-		return;
+	if (NULL == rasStruct) {
+		return NULL;
 	}
 
 	fd = j9file_open(fileName, EsOpenRead, 0);
-	if (fd != -1) {
-		/* Files in /proc report length as 0 but we don't expect the contents to be more than 1 line.
-		 * We take the first line or 80 characters that should be enough information to put in javacore */
-		char buf[80];
-		char* read = NULL;
-		read = j9file_read_text(fd, &buf[0], 80);
-		if( read == &buf[0] ) {
-			J9RASSystemInfo* systemInfo;
+	if (-1 != fd) {
+		/* We don't expect the contents to be more than 1 line.
+		 * The first MAX_INTERESTING_LENGTH characters should be enough information.
+		 */
+		char buf[MAX_INTERESTING_LENGTH];
+		char *read = j9file_read_text(fd, buf, sizeof(buf));
+		if (buf == read) {
 			size_t bufLen = 0;
-			/* Make sure the string is only one line and null terminated. */
-			for( bufLen = 0; bufLen < 80; bufLen++) {
-				if( read[bufLen] == '\n') {
+			/* Make sure the string is only one line.
+			 * If the string is longer than the size
+			 * of the buffer, it will be NULL-terminated
+			 * in the memset below.
+			 */
+			for (bufLen = 0; bufLen < sizeof(buf); bufLen++) {
+				if ('\n' == read[bufLen]) {
 					read[bufLen] = '\0';
 					break;
 				}
@@ -1450,17 +1492,19 @@ appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName )
 			 * without having to track whether or not we did an allocation for systemInfo->data.
 			 */
 			systemInfo = (J9RASSystemInfo *) j9mem_allocate_memory(sizeof(J9RASSystemInfo) + bufLen + 1, OMRMEM_CATEGORY_VM);
-			if( systemInfo != NULL ) {
+			if (NULL != systemInfo) {
 				memset(systemInfo, '\0', sizeof(J9RASSystemInfo) + bufLen + 1);
 				systemInfo->key = key;
 				/* Allocated with systemInfo, data is right after systemInfo. */
 				systemInfo->data = &systemInfo[1];
-				memcpy(systemInfo->data, read, bufLen + 1 );
+				memcpy(systemInfo->data, read, bufLen);
 				J9_LINKED_LIST_ADD_LAST(rasStruct->systemInfo, systemInfo);
 			}
 		}
 		j9file_close(fd);
 	}
+
+	return systemInfo;
 }
 #endif /* defined(LINUX) */
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1341,7 +1341,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 		switch (systemInfo->key) {
 		case J9RAS_SYSTEMINFO_SCHED_COMPAT_YIELD:
 			{
-				char *sched_compat_yield = (char *)&systemInfo->data;
+				const char *sched_compat_yield = (const char *)&systemInfo->data;
 				_OutputStream.writeCharacters("2CISYSINFO     " J9RAS_SCHED_COMPAT_YIELD_FILE " = ");
 				_OutputStream.writeVPrintf("%c ", sched_compat_yield[0]);
 				_OutputStream.writeCharacters("\n");
@@ -1350,7 +1350,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 
 		case J9RAS_SYSTEMINFO_HYPERVISOR:
 			{
-				char *hypervisorName = (char *)systemInfo->data;
+				const char *hypervisorName = (const char *)systemInfo->data;
 				_OutputStream.writeCharacters("2CISYSINFO     Hypervisor name = ");
 				_OutputStream.writeCharacters(hypervisorName);
 				_OutputStream.writeCharacters("\n");
@@ -1358,7 +1358,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			break;
 		case J9RAS_SYSTEMINFO_CORE_PATTERN:
 			{
-				char *corepattern = (char *)systemInfo->data;
+				const char *corepattern = (const char *)systemInfo->data;
 				_OutputStream.writeCharacters("2CISYSINFO     " J9RAS_CORE_PATTERN_FILE " = ");
 				_OutputStream.writeCharacters(corepattern);
 				_OutputStream.writeCharacters("\n");
@@ -1366,9 +1366,17 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			break;
 		case J9RAS_SYSTEMINFO_CORE_USES_PID:
 			{
-				char *coreusespid = (char *)systemInfo->data;
+				const char *coreusespid = (const char *)systemInfo->data;
 				_OutputStream.writeCharacters("2CISYSINFO     " J9RAS_CORE_USES_PID_FILE " = ");
 				_OutputStream.writeCharacters(coreusespid);
+				_OutputStream.writeCharacters("\n");
+			}
+			break;
+		case J9RAS_SYSTEMINFO_CORE_ORIGINAL_PATTERN:
+			{
+				const char *coreOriginalPattern = (const char *)systemInfo->data;
+				_OutputStream.writeCharacters("2CISYSINFO     " J9RAS_CORE_ORIGINAL_PATTERN " = ");
+				_OutputStream.writeCharacters(coreOriginalPattern);
 				_OutputStream.writeCharacters("\n");
 			}
 			break;

--- a/runtime/rasdump/rasdump_internal.h
+++ b/runtime/rasdump/rasdump_internal.h
@@ -108,14 +108,16 @@ void rasDumpFlushHooks(J9JavaVM *vm, IDATA stage);
 void setAllocationThreshold(J9VMThread *vmThread, UDATA min, UDATA max);
 
 /* Constants used with the RASDumpSystemInfo structures (linked list off J9RAS.systemInfo) */
-#define J9RAS_SYSTEMINFO_SCHED_COMPAT_YIELD 1
-#define J9RAS_SYSTEMINFO_HYPERVISOR         2
-#define J9RAS_SYSTEMINFO_CORE_PATTERN       3
-#define J9RAS_SYSTEMINFO_CORE_USES_PID      4
+#define J9RAS_SYSTEMINFO_SCHED_COMPAT_YIELD    1
+#define J9RAS_SYSTEMINFO_HYPERVISOR            2
+#define J9RAS_SYSTEMINFO_CORE_PATTERN          3
+#define J9RAS_SYSTEMINFO_CORE_USES_PID         4
+#define J9RAS_SYSTEMINFO_CORE_ORIGINAL_PATTERN 5
 
 #define J9RAS_SCHED_COMPAT_YIELD_FILE "/proc/sys/kernel/sched_compat_yield"
-#define J9RAS_CORE_PATTERN_FILE "/proc/sys/kernel/core_pattern"
-#define J9RAS_CORE_USES_PID_FILE "/proc/sys/kernel/core_uses_pid"
+#define J9RAS_CORE_PATTERN_FILE       "/proc/sys/kernel/core_pattern"
+#define J9RAS_CORE_USES_PID_FILE      "/proc/sys/kernel/core_uses_pid"
+#define J9RAS_CORE_ORIGINAL_PATTERN   ".../oneagent/agent/conf/original_core_pattern"
 
 #if defined(WIN32)
 #define ALT_DIR_SEPARATOR '/'


### PR DESCRIPTION
A very common Linux `kernel.core_pattern` is [`|/opt/dynatrace/oneagent/agent/rdp`](https://www.dynatrace.com/support/help/platform-modules/applications-and-microservices/profiling-and-optimization/crash-analysis#linux-core-dump-handling) installed by the 3rd party monitoring product Dynatrace. When `rdp` is installed, it saves off the previous `kernel.core_pattern` into `/opt/dynatrace/oneagent/agent/conf/original_core_pattern`. When `rdp` handles a core dump, it first processes it internally, and then sends the core dump to the program in `original_core_pattern`.

Therefore, it's very common to see the following in a javacore:

```
2CISYSINFO     /proc/sys/kernel/core_pattern = |/opt/dynatrace/oneagent/agent/rdp
```

However, that doesn't really help understand where the core dump went because the javacore doesn't print `/opt/dynatrace/oneagent/agent/conf/original_core_pattern`. This leads to an extra back-and-forth with a customer.

If it's acceptable for J9 to reference third party file locations, then this PR adds this if available. Example from a local build:

```
2CISYSINFO     /proc/sys/kernel/core_pattern = |/opt/dynatrace/oneagent/agent/rdp
2CISYSINFO     /proc/sys/kernel/core_uses_pid = 1
2CISYSINFO     /opt/dynatrace/oneagent/agent/conf/original_core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h
```

I also increased the amount of characters printed from such files from 80 to 255 as 80 seemed a bit low to me.

@keithc-ca @pshipton 