### PR TITLE
AArch64: Fix a check in VMCardCheckEvaluator()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1040,7 +1040,7 @@ VMCardCheckEvaluator(
    generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, temp1Reg, dstReg, temp1Reg);
 
    // If we know the object is definitely in heap, then we skip the check.
-   if (!node->isHeapObjectWrtBar())
+   if (!node->chkHeapObjectWrtBar())
       {
       if (comp->getOptions()->isVariableHeapSizeForBarrierRange0() || comp->compileRelocatableCode())
          {


### PR DESCRIPTION
This commit replaces the call to isHeapObjectWrtBar() in VMCardCheckEvaluator() by chkHeapObjectWrtBar().

Fixes: #17617