### PR TITLE
Add -XX:continuationCache option

### DIFF
--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -316,12 +316,12 @@ standardInit(J9JavaVM *vm, char *dllName)
 
 		{
 			PORT_ACCESS_FROM_JAVAVM(vm);
-			vm->continuationArraySize = (U_32)j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
-			vm->globalContinuationCacheArray = (J9VMContinuation**)j9mem_allocate_memory(sizeof(J9VMContinuation*) * vm->continuationArraySize, J9MEM_CATEGORY_VM);
-			if (NULL == vm->globalContinuationCacheArray) {
+			UDATA cacheSize = sizeof(J9VMContinuation*) * vm->continuationT2Size;
+			vm->continuationT2Cache = (J9VMContinuation**)j9mem_allocate_memory(cacheSize, J9MEM_CATEGORY_VM);
+			if (NULL == vm->continuationT2Cache) {
 				goto _fail;
 			}
-			memset(vm->globalContinuationCacheArray, 0, sizeof(J9VMContinuation*) * vm->continuationArraySize);
+			memset(vm->continuationT2Cache, 0, cacheSize);
 		}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #endif /* !J9VM_IVE_RAW_BUILD */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5375,7 +5375,7 @@ typedef struct J9VMThread {
 	UDATA callOutCount;
 	j9object_t carrierThreadObject;
 	j9object_t scopedValueCache;
-	J9VMContinuation *cachedContinuation;
+	J9VMContinuation **continuationT1Cache;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 } J9VMThread;
 
@@ -5921,8 +5921,9 @@ typedef struct J9JavaVM {
 	struct J9Pool *tlsPool;
 	omrthread_monitor_t tlsPoolMutex;
 	jobject vthreadGroup;
-	J9VMContinuation **globalContinuationCacheArray;
-	U_32 continuationArraySize;
+	J9VMContinuation **continuationT2Cache;
+	U_32 continuationT1Size;
+	U_32 continuationT2Size;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	omrthread_monitor_t delayedLockingOperationsMutex;

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -544,6 +544,8 @@ enum INIT_STAGE {
 #define VMOPT_XXDYNAMICHEAPIFICATION "-XX:+DynamicHeapification"
 #define VMOPT_XXNODYNAMICHEAPIFICATION "-XX:-DynamicHeapification"
 
+#define VMOPT_XXCONTINUATIONCACHE "-XX:ContinuationCache:"
+
 #define MAPOPT_AGENTLIB_JDWP_EQUALS "-agentlib:jdwp="
 #define MAPOPT_XRUNJDWP "-Xrunjdwp:"
 

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -237,9 +237,13 @@ deallocateVMThread(J9VMThread * vmThread, UDATA decrementZombieCount, UDATA send
 	}
 
 	/* Cleanup Continuation cache */
-	if (NULL != vmThread->cachedContinuation) {
-		vm->internalVMFunctions->recycleContinuation(vm, NULL, vmThread->cachedContinuation, TRUE);
-		vmThread->cachedContinuation = NULL;
+	if (NULL != vmThread->continuationT1Cache) {
+		for (U_32 i = 0; i < vm->continuationT1Size; i++) {
+			if (NULL != vmThread->continuationT1Cache[i]) {
+				vm->internalVMFunctions->recycleContinuation(vm, NULL, vmThread->continuationT1Cache[i], TRUE);
+			}
+		}
+		j9mem_free_memory(vmThread->continuationT1Cache);
 	}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 


### PR DESCRIPTION
Allow manual setting of Continuation Tier 1/2 cache size.

This change also increases the default T2 size by 2.

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>