### PR TITLE
CRIU skips clearInetAddressCache() if InetAddress is not initialized

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -64,6 +64,8 @@ exports com.ibm.gpu.spi to
 /*[IF JAVA_SPEC_VERSION >= 17]*/
 exports jdk.internal.access to
     openj9.criu;
+opens jdk.internal.access to
+    openj9.criu;
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 exports jdk.internal.misc to
     openj9.criu;

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
@@ -24,6 +24,7 @@ package org.openj9.criu;
 import org.eclipse.openj9.criu.CRIUSupport;
 import org.eclipse.openj9.criu.JVMRestoreException;
 
+import java.net.InetAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.locks.Lock;
@@ -40,6 +41,10 @@ public class TestSingleThreadModeRestoreException {
 
 	void testAll() {
 		testSingleThreadModeRestoreExceptionSynLock();
+		testSingleThreadModeRestoreExceptionJUCLock();
+		// Initialize InetAddress and trigger SharedSecrets.setJavaNetInetAddressAccess().
+		InetAddress.getLoopbackAddress();
+		// Do another run.
 		testSingleThreadModeRestoreExceptionJUCLock();
 	}
 
@@ -74,8 +79,7 @@ public class TestSingleThreadModeRestoreException {
 	}
 
 	void testSingleThreadModeRestoreExceptionJUCLock() {
-		CRIUTestUtils
-				.showThreadCurrentTime("testSingleThreadModeRestoreExceptionJUCLock() before ReentrantLock.lock()");
+		CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeRestoreExceptionJUCLock() before ReentrantLock.lock()");
 		jucLock.lock();
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
 		if (criu == null) {


### PR DESCRIPTION
CRIU skips `clearInetAddressCache()` if `InetAddress` is not initialized

`InetAddress` static initializer invokes `SharedSecrets.setJavaNetInetAddressAccess()`, if
`SharedSecrets.javaNetInetAddressAccess` is `null`, `InetAddress` hasn't been initialized yet. In such case,
`SharedSecrets.getJavaNetInetAddressAccess().clearInetAddressCache()` is not invoked.
Updated the test.

closes https://github.com/eclipse-openj9/openj9/issues/17599

Signed-off-by: Jason Feng <fengj@ca.ibm.com>