### PR TITLE
Flush SCC modification from CML utility to file on disk on z/OS

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -330,6 +330,18 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 				if (nonfatal) {
 					return J9VMDLLMAIN_OK;
 				} else {
+#if defined(J9ZOS390)
+					if ((J9VMDLLMAIN_SILENT_EXIT_VM == rc)
+						&& J9_ARE_ALL_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE)
+						&& J9_ARE_NO_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_READONLY)
+					) {
+						/**
+						 * Call j9shr_guaranteed_exit() to ensure any modification to the cache is flushed to the file on disk.
+						 * For utility option printStats and its variants, J9SHR_RUNTIMEFLAG_ENABLE_READONLY is always set.
+						 */
+						j9shr_guaranteed_exit(vm, FALSE);
+					}
+#endif /* defined(J9ZOS390) */
 					return rc;
 				}
 			}

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
@@ -443,6 +443,53 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
+	<test id="Test 14-a: Create a shared cache explicitly with sub-option persistent" timeout="600" runPath=".">
+		<!-- On z/OS, the default cache type is non-persistent. Use sub-option persistent to test the non-default cache type.-->
+		<command>$JAVA_EXE$ $currentMode$,persistent -Xscmx16m -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+
+		<output type="failure" caseSensitive="no" regex="no">error</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 14-b: adjust the softmx bytes to 10m" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,persistent,adjustsoftmx=10m</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">The softmx bytes is set to 10485760</output>
+
+		<output type="failure" caseSensitive="yes" regex="no">error</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 14-c: check the cache statistics for the softmx value" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,persistent,printStats</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">softmx bytes\s+= 10485760</output>
+
+		<output type="failure" caseSensitive="no" regex="no">error</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 14-d : Cleanup" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,persistent,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+
+		<output type="failure" caseSensitive="no" regex="no">error</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
 	<test id="End : Cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
1. Add call of j9shr_guaranteed_exit() if j9shr_init() returns J9VMDLLMAIN_SILENT_EXIT_VM on z/OS for persistent cache.
2. Add testing code.

Fixes #17628