### PR TITLE
CRIU GC: Flush and Reset Buffers on Reinit

### DIFF
--- a/runtime/gc_base/ContinuationObjectBuffer.hpp
+++ b/runtime/gc_base/ContinuationObjectBuffer.hpp
@@ -51,12 +51,12 @@ public:
 
 private:
 
+protected:
+
 	/**
 	 * Reset a flushed buffer to the empty state.
 	 */
 	void reset();
-
-protected:
 
 	virtual bool initialize(MM_EnvironmentBase *env) = 0;
 	virtual void tearDown(MM_EnvironmentBase *env) = 0;

--- a/runtime/gc_base/OwnableSynchronizerObjectBuffer.hpp
+++ b/runtime/gc_base/OwnableSynchronizerObjectBuffer.hpp
@@ -50,13 +50,13 @@ protected:
 public:
 	
 private:
-	
+
+protected:
+
 	/**
 	 * Reset a flushed buffer to the empty state.
 	 */
 	void reset();
-
-protected:
 
 	virtual bool initialize(MM_EnvironmentBase *env) = 0;
 	virtual void tearDown(MM_EnvironmentBase *env) = 0;

--- a/runtime/gc_base/ReferenceObjectBuffer.hpp
+++ b/runtime/gc_base/ReferenceObjectBuffer.hpp
@@ -50,11 +50,6 @@ public:
 private:
 	
 	/**
-	 * Reset a flushed buffer to the empty state.
-	 */
-	void reset();
-
-	/**
 	 * Determine the type (weak/soft/phantom) of the specified reference object.
 	 * @param object[in] the object to examine
 	 * @return one of J9AccClassReferenceWeak, J9AccClassReferenceSoft or J9AccClassReferencePhantom
@@ -63,6 +58,11 @@ private:
 	
 protected:
 	
+	/**
+	 * Reset a flushed buffer to the empty state.
+	 */
+	void reset();
+
 	virtual bool initialize(MM_EnvironmentBase *env) = 0;
 	virtual void tearDown(MM_EnvironmentBase *env) = 0;
 

--- a/runtime/gc_base/UnfinalizedObjectBuffer.hpp
+++ b/runtime/gc_base/UnfinalizedObjectBuffer.hpp
@@ -50,13 +50,13 @@ protected:
 public:
 	
 private:
+
+protected:
 	
 	/**
 	 * Reset a flushed buffer to the empty state.
 	 */
 	void reset();
-
-protected:
 
 	virtual bool initialize(MM_EnvironmentBase *env) = 0;
 	virtual void tearDown(MM_EnvironmentBase *env) = 0;

--- a/runtime/gc_modron_standard/ContinuationObjectBufferStandard.cpp
+++ b/runtime/gc_modron_standard/ContinuationObjectBufferStandard.cpp
@@ -77,7 +77,7 @@ MM_ContinuationObjectBufferStandard::flushImpl(MM_EnvironmentBase *env)
 
 	list->addAll(env, _head, _tail);
 	_continuationObjectListIndex += 1;
-	if (regionExtension->_maxListIndex == _continuationObjectListIndex) {
+	if (_continuationObjectListIndex >= regionExtension->_maxListIndex) {
 		_continuationObjectListIndex = 0;
 	}
 }
@@ -92,6 +92,12 @@ MM_ContinuationObjectBufferStandard::reinitializeForRestore(MM_EnvironmentBase *
 	Assert_MM_true(extensions->objectListFragmentCount > 0);
 
 	_maxObjectCount = extensions->objectListFragmentCount;
+
+	flush(env);
+
+	/* This reset is necessary to ensure the object counter is reset based on the the new _maxObjectCount value.
+	 * Specifically to handle the case when the buffer was previously emptied and reset based on previous _maxObjectCount. */
+	reset();
 
 	return true;
 }

--- a/runtime/gc_modron_standard/OwnableSynchronizerObjectBufferStandard.cpp
+++ b/runtime/gc_modron_standard/OwnableSynchronizerObjectBufferStandard.cpp
@@ -77,7 +77,7 @@ MM_OwnableSynchronizerObjectBufferStandard::flushImpl(MM_EnvironmentBase *env)
 
 	list->addAll(env, _head, _tail);
 	_ownableSynchronizerObjectListIndex += 1;
-	if (regionExtension->_maxListIndex == _ownableSynchronizerObjectListIndex) {
+	if (_ownableSynchronizerObjectListIndex >= regionExtension->_maxListIndex) {
 		_ownableSynchronizerObjectListIndex = 0;
 	}
 }
@@ -92,6 +92,12 @@ MM_OwnableSynchronizerObjectBufferStandard::reinitializeForRestore(MM_Environmen
 	Assert_MM_true(extensions->objectListFragmentCount > 0);
 
 	_maxObjectCount = extensions->objectListFragmentCount;
+
+	flush(env);
+
+	/* This reset is necessary to ensure the object counter is reset based on the the new _maxObjectCount value.
+	 * Specifically to handle the case when the buffer was previously emptied and reset based on previous _maxObjectCount. */
+	reset();
 
 	return true;
 }

--- a/runtime/gc_modron_standard/ReferenceObjectBufferStandard.cpp
+++ b/runtime/gc_modron_standard/ReferenceObjectBufferStandard.cpp
@@ -75,7 +75,7 @@ MM_ReferenceObjectBufferStandard::flushImpl(MM_EnvironmentBase *env)
 	MM_ReferenceObjectList *list = &regionExtension->_referenceObjectLists[_referenceObjectListIndex];
 	list->addAll(env, _referenceObjectType, _head, _tail);
 	_referenceObjectListIndex += 1;
-	if (regionExtension->_maxListIndex == _referenceObjectListIndex) {
+	if (_referenceObjectListIndex >= regionExtension->_maxListIndex) {
 		_referenceObjectListIndex = 0;
 	}
 }
@@ -90,6 +90,12 @@ MM_ReferenceObjectBufferStandard::reinitializeForRestore(MM_EnvironmentBase *env
 	Assert_MM_true(extensions->objectListFragmentCount > 0);
 
 	_maxObjectCount = extensions->objectListFragmentCount;
+
+	flush(env);
+
+	/* This reset is necessary to ensure the object counter is reset based on the the new _maxObjectCount value.
+	 * Specifically to handle the case when the buffer was previously emptied and reset based on previous _maxObjectCount. */
+	reset();
 
 	return true;
 }

--- a/runtime/gc_modron_standard/UnfinalizedObjectBufferStandard.cpp
+++ b/runtime/gc_modron_standard/UnfinalizedObjectBufferStandard.cpp
@@ -76,7 +76,7 @@ MM_UnfinalizedObjectBufferStandard::flushImpl(MM_EnvironmentBase *env)
 	MM_UnfinalizedObjectList *list = &regionExtension->_unfinalizedObjectLists[_unfinalizedObjectListIndex];
 	list->addAll(env, _head, _tail);
 	_unfinalizedObjectListIndex += 1;
-	if (regionExtension->_maxListIndex == _unfinalizedObjectListIndex) {
+	if (_unfinalizedObjectListIndex >= regionExtension->_maxListIndex) {
 		_unfinalizedObjectListIndex = 0;
 	}
 }
@@ -91,6 +91,12 @@ MM_UnfinalizedObjectBufferStandard::reinitializeForRestore(MM_EnvironmentBase *e
 	Assert_MM_true(extensions->objectListFragmentCount > 0);
 
 	_maxObjectCount = extensions->objectListFragmentCount;
+
+	flush(env);
+
+	/* This reset is necessary to ensure the object counter is reset based on the the new _maxObjectCount value.
+	 * Specifically to handle the case when the buffer was previously emptied and reset based on previous _maxObjectCount. */
+	reset();
 
 	return true;
 }


### PR DESCRIPTION
Address the particular scenario when a buffer is empty and in a reset state during its reinitialization.

Due to the update of _maxObjectCount by reinitializeForRestore, it becomes necessary to reset the buffer once more in order to update the _objectCount. During reset, _objectCount is set to _maxObjectCount (to appear full to force init on next add).

Signed-off-by: Salman Rana <salman.rana@ibm.com>