### PR TITLE
Add Preload and ImplicitCreation attributes

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -230,6 +230,8 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 	_hasNonStaticSynchronizedMethod(false),
 	_hasNonStaticFields(false),
 	_hasNonEmptyConstructor(false),
+	_preloadAttribute(NULL),
+	_implicitCreation(NULL),
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	_recordComponentCount(0),
 	_permittedSubclassesAttribute(NULL),
@@ -604,6 +606,20 @@ ClassFileOracle::walkAttributes()
 			}
 			break;
 		}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		case CFR_ATTRIBUTE_Preload: {
+			_preloadAttribute = (J9CfrAttributePreload *)attrib;
+			for (U_16 numberOfClasses = 0; numberOfClasses < _preloadAttribute->numberOfClasses; numberOfClasses++) {
+				U_16 classCpIndex = _preloadAttribute->classes[numberOfClasses];
+				markClassAsReferenced(classCpIndex);
+			}
+			break;
+		}
+		case CFR_ATTRIBUTE_ImplicitCreation: {
+			_implicitCreation = (J9CfrAttributeImplicitCreation *)attrib;
+			break;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestMembers:
 			/* ignore CFR_ATTRIBUTE_NestMembers for hidden classes, as the nest members never know the name of hidden classes */

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -46,6 +46,9 @@
  * */
 #define UTF8_INDEX_FROM_CLASS_INDEX(cp, cpIndex)  ((U_16)((cpIndex == 0)? 0 : cp[cpIndex].slot1))
 
+#define IMPLICIT_CREATION_FLAGS_DEFAULT 1
+#define IMPLICIT_CREATION_FLAGS_NON_ATOMIC 2
+
 class BufferManager;
 class ConstantPoolMap;
 class ROMClassCreationContext;
@@ -1017,6 +1020,21 @@ class RecordComponentIterator
 	bool needsIdentityFlag() const { return _isIdentityFlagNeeded; }
 	bool hasIdentityFlagSet() const { return _hasIdentityFlagSet; }
 	bool isValueType() const { return _isValueType; }
+	bool hasImplicitCreation() const { return NULL != _implicitCreation; }
+	U_16 getImplicitCreationFlags() const { return hasImplicitCreation() ? _implicitCreation->implicitCreationFlags : 0; }
+	bool isImplicitCreationHasDefaultValue() const { return J9_ARE_ALL_BITS_SET(getImplicitCreationFlags(), IMPLICIT_CREATION_FLAGS_DEFAULT); }
+	bool isImplicitCreationNonAtomic() const { return J9_ARE_ALL_BITS_SET(getImplicitCreationFlags(), IMPLICIT_CREATION_FLAGS_NON_ATOMIC); }
+	bool hasPreloadClasses() const { return NULL != _preloadAttribute; }
+	U_16 getPreloadClassCount() const { return  hasPreloadClasses() ? _preloadAttribute->numberOfClasses : 0; }
+
+	U_16 getPreloadClassNameAtIndex(U_16 index) const {
+		U_16 result = 0;
+		if (hasPreloadClasses()) {
+			U_16 classCpIndex = _preloadAttribute->classes[index];
+			result = _classFile->constantPool[classCpIndex].slot1;
+		}
+		return result;
+	}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 	U_16 getPermittedSubclassesClassNameAtIndex(U_16 index) const {
@@ -1146,6 +1164,10 @@ private:
 	J9CfrAttributeInnerClasses *_innerClasses;
 	J9CfrAttributeBootstrapMethods *_bootstrapMethodsAttribute;
 	J9CfrAttributePermittedSubclasses *_permittedSubclassesAttribute;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	J9CfrAttributeImplicitCreation *_implicitCreation;
+	J9CfrAttributePreload *_preloadAttribute;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if JAVA_SPEC_VERSION >= 11
 	J9CfrAttributeNestMembers *_nestMembers;
 #endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1170,8 +1170,8 @@ ROMClassBuilder::finishPrepareAndLaydown(
  *                                     + UNUSED
  *                                    + UNUSED
  *
- *                                  + UNUSED
- *                                 + UNUSED
+ *                                  + AccImplicitCreateHasDefaultValue
+ *                                 + AccImplicitCreateNonAtomic
  *                                + J9AccClassIsValueBased
  *                              + J9AccClassHiddenOptionNestmate
  *
@@ -1337,6 +1337,15 @@ ROMClassBuilder::computeExtraModifiers(ClassFileOracle *classFileOracle, ROMClas
 		modifiers |= J9AccSealed;
 	}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (classFileOracle->isImplicitCreationNonAtomic()) {
+		modifiers |= J9AccImplicitCreateNonAtomic;
+	}
+	if (classFileOracle->isImplicitCreationHasDefaultValue()) {
+		modifiers |= J9AccImplicitCreateHasDefaultValue;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	return modifiers;
 }
 
@@ -1380,6 +1389,9 @@ ROMClassBuilder::computeOptionalFlags(ClassFileOracle *classFileOracle, ROMClass
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	if (_interfaceInjectionInfo.numOfInterfaces > 0) {
 		optionalFlags |= J9_ROMCLASS_OPTINFO_INJECTED_INTERFACE_INFO;
+	}
+	if (classFileOracle->hasPreloadClasses()) {
+		optionalFlags |= J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE;
 	}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	return optionalFlags;

--- a/runtime/bcutil/ROMClassWriter.hpp
+++ b/runtime/bcutil/ROMClassWriter.hpp
@@ -154,6 +154,7 @@ private:
 	void writePermittedSubclasses(Cursor *cursor, bool markAndCountOnly);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	void writeInjectedInterfaces(Cursor *cursor, bool markAndCountOnly);
+	void writePreload(Cursor *cursor, bool markAndCountOnly);
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 	BufferManager *_bufferManager;
@@ -193,6 +194,7 @@ private:
 	UDATA _permittedSubclassesInfoSRPKey;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	UDATA _injectedInterfaceInfoSRPKey;
+	UDATA _preloadInfoSRPKey;
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 };
 

--- a/runtime/bcutil/attrlookup.gperf
+++ b/runtime/bcutil/attrlookup.gperf
@@ -72,3 +72,5 @@ NestMembers, CFR_ATTRIBUTE_NestMembers, CFR_ATTRIBUTE_NestMembers
 NestHost, CFR_ATTRIBUTE_NestHost, CFR_ATTRIBUTE_NestHost
 Record, CFR_ATTRIBUTE_Record, CFR_ATTRIBUTE_Record
 PermittedSubclasses, CFR_ATTRIBUTE_PermittedSubclasses, CFR_ATTRIBUTE_PermittedSubclasses
+ImplicitCreation, CFR_ATTRIBUTE_ImplicitCreation, CFR_ATTRIBUTE_ImplicitCreation
+Preload, CFR_ATTRIBUTE_Preload, CFR_ATTRIBUTE_Preload

--- a/runtime/bcutil/attrlookup.h
+++ b/runtime/bcutil/attrlookup.h
@@ -59,7 +59,7 @@ struct AttribType
 	U_8 strippedAttribCode;
 };
 
-#define TOTAL_KEYWORDS 28
+#define TOTAL_KEYWORDS 30
 #define MIN_WORD_LENGTH 4
 #define MAX_WORD_LENGTH 36
 #define MIN_HASH_VALUE 4
@@ -88,8 +88,8 @@ attributeHash (register const char *str, register unsigned int len)
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
-      51, 31, 51, 51, 51, 15, 51, 51, 51, 51,
-       0,  0, 51, 51, 51, 51, 15,  0, 51, 51,
+      51, 31, 51, 51, 51, 15, 51, 51, 51,  5,
+       0,  0, 51, 51,  0, 51, 15,  0, 51, 51,
       25,  0, 51, 51, 51, 51, 51, 51, 51, 51,
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
       51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
@@ -121,6 +121,8 @@ lookupKnownAttribute (register const char *str, register unsigned int len)
     {
 #line 47 "attrlookup.gperf"
       {"Code", CFR_ATTRIBUTE_Code, CFR_ATTRIBUTE_Code},
+#line 76 "attrlookup.gperf"
+      {"Preload", CFR_ATTRIBUTE_Preload, CFR_ATTRIBUTE_Preload},
 #line 49 "attrlookup.gperf"
       {"Synthetic", CFR_ATTRIBUTE_Synthetic, CFR_ATTRIBUTE_Synthetic},
 #line 53 "attrlookup.gperf"
@@ -139,6 +141,8 @@ lookupKnownAttribute (register const char *str, register unsigned int len)
       {"LocalVariableTable", CFR_ATTRIBUTE_LocalVariableTable, CFR_ATTRIBUTE_StrippedLocalVariableTable},
 #line 62 "attrlookup.gperf"
       {"SourceDebugExtension", CFR_ATTRIBUTE_SourceDebugExtension, CFR_ATTRIBUTE_StrippedSourceDebugExtension},
+#line 75 "attrlookup.gperf"
+      {"ImplicitCreation", CFR_ATTRIBUTE_ImplicitCreation, CFR_ATTRIBUTE_ImplicitCreation},
 #line 63 "attrlookup.gperf"
       {"LocalVariableTypeTable", CFR_ATTRIBUTE_LocalVariableTypeTable, CFR_ATTRIBUTE_StrippedLocalVariableTypeTable},
 #line 48 "attrlookup.gperf"
@@ -179,10 +183,10 @@ lookupKnownAttribute (register const char *str, register unsigned int len)
 
   static const signed char lookup[] =
     {
-      -1, -1, -1, -1,  0, -1, -1, -1, -1,  1,  2, -1,  3,  4,
-      -1,  5,  6,  7,  8, -1,  9, -1, 10, 11, 12, 13, -1, 14,
-      15, 16, 17, 18, -1, -1, 19, 20, 21, 22, -1, 23, -1, 24,
-      25, -1, -1, -1, -1, 26, -1, -1, 27
+      -1, -1, -1, -1,  0, -1, -1,  1, -1,  2,  3, -1,  4,  5,
+      -1,  6,  7,  8,  9, -1, 10, 11, 12, 13, 14, 15, -1, 16,
+      17, 18, 19, 20, -1, -1, 21, 22, 23, 24, -1, 25, -1, 26,
+      27, -1, -1, -1, -1, 28, -1, -1, 29
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1694,3 +1694,43 @@ J9NLS_CFR_ERR_INVALID_CLASS_FLAGS_ON_VNEW.explanation=Please consult the Java Vi
 J9NLS_CFR_ERR_INVALID_CLASS_FLAGS_ON_VNEW.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_INVALID_CLASS_FLAGS_ON_VNEW.user_response=Contact the provider of the class file for a corrected version.
 # END NON-TRANSLATABLE
+
+# Preload is not translatable
+J9NLS_CFR_ERR_MULTIPLE_PRELOAD_ATTRIBUTES=Multiple Preload attributes
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_MULTIPLE_PRELOAD_ATTRIBUTES.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_MULTIPLE_PRELOAD_ATTRIBUTES.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_MULTIPLE_PRELOAD_ATTRIBUTES.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Preload is not translatable
+J9NLS_CFR_ERR_PRELOAD_NAME_NOT_UTF8=Preload name must be a string
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_PRELOAD_NAME_NOT_UTF8.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_PRELOAD_NAME_NOT_UTF8.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_PRELOAD_NAME_NOT_UTF8.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Preload is not translatable
+J9NLS_CFR_ERR_PRELOAD_CLASS_ENTRY_NOT_CLASS_TYPE=Preload class entry is not a class type
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_PRELOAD_CLASS_ENTRY_NOT_CLASS_TYPE.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_PRELOAD_CLASS_ENTRY_NOT_CLASS_TYPE.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_PRELOAD_CLASS_ENTRY_NOT_CLASS_TYPE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# ImplicitCreation is not translatable
+J9NLS_CFR_ERR_MULTIPLE_IMPLICITCREATION_ATTRIBUTES=Multiple ImplicitCreation attributes
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_MULTIPLE_IMPLICITCREATION_ATTRIBUTES.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_MULTIPLE_IMPLICITCREATION_ATTRIBUTES.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_MULTIPLE_IMPLICITCREATION_ATTRIBUTES.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# ImplicitCreation is not translatable
+J9NLS_CFR_ERR_IMPLICITCREATION_NAME_NOT_UTF8=ImplicitCreation name must be a string
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_IMPLICITCREATION_NAME_NOT_UTF8.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_IMPLICITCREATION_NAME_NOT_UTF8.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_IMPLICITCREATION_NAME_NOT_UTF8.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -241,6 +241,8 @@ typedef struct J9CfrAttribute {
 #define CFR_ATTRIBUTE_NestHost 26
 #define CFR_ATTRIBUTE_Record 27
 #define CFR_ATTRIBUTE_PermittedSubclasses 28
+#define CFR_ATTRIBUTE_Preload 29
+#define CFR_ATTRIBUTE_ImplicitCreation 30
 #define CFR_ATTRIBUTE_StrippedLocalVariableTypeTable  122
 #define CFR_ATTRIBUTE_StrippedSourceDebugExtension  123
 #define CFR_ATTRIBUTE_StrippedInnerClasses  124
@@ -530,6 +532,26 @@ typedef struct J9CfrAttributePermittedSubclasses {
     U_16 numberOfClasses;
     U_16* classes;
 } J9CfrAttributePermittedSubclasses;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+typedef struct J9CfrAttributePreload {
+    U_8 tag;
+    U_16 nameIndex;
+    U_32 length;
+    UDATA romAddress;
+    U_16 numberOfClasses;
+    U_16* classes;
+} J9CfrAttributePreload;
+
+typedef struct J9CfrAttributeImplicitCreation {
+    U_8 tag;
+    U_16 nameIndex;
+    U_32 length;
+    UDATA romAddress;
+    U_16 implicitCreationFlags;
+} J9CfrAttributeImplicitCreation;
+
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 /* @ddr_namespace: map_to_type=J9CfrConstantPoolInfo */
 

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -36,6 +36,8 @@
 #define J9AccBridge 0x40
 
 #define J9AccClassHasIdentity 0x20
+#define J9AccImplicitCreateHasDefaultValue 0x10
+#define J9AccImplicitCreateNonAtomic 0x20
 #define J9AccClassIsValueBased 0x40
 #define J9AccClassHiddenOptionNestmate 0x80
 #define J9AccClassHiddenOptionStrong 0x100

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -75,6 +75,8 @@
 #define J9ROMCLASS_IS_RECORD(romClass)			(_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccRecord) && J9ROMCLASS_IS_FINAL(romClass) && !J9ROMCLASS_IS_ABSTRACT(romClass))
 #define J9ROMCLASS_IS_SEALED(romClass)			_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccSealed)
 #define J9ROMCLASS_IS_VALUEBASED(romClass)			_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassIsValueBased)
+#define J9ROMCLASS_ALLOWS_NON_ATOMIC_CREATION(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccImplicitCreateNonAtomic)
+#define J9ROMCLASS_HAS_DEFAULT(romClass)		_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccImplicitCreateHasDefaultValue)
 
 /* 
  * Note that resolvefield ignores this flag if the cache line size cannot be determined.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -88,6 +88,7 @@
 #define J9ClassEnsureHashed 0x100000
 #define J9ClassHasOffloadAllowSubtasksNatives 0x200000
 #define J9ClassIsPrimitiveValueType 0x400000
+#define J9ClassAllowsNonAtomicCreation 0x800000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 
@@ -257,6 +258,9 @@
 #define J9_ROMCLASS_OPTINFO_RECORD_ATTRIBUTE 0x800000
 #define J9_ROMCLASS_OPTINFO_PERMITTEDSUBCLASSES_ATTRIBUTE 0x1000000
 #define J9_ROMCLASS_OPTINFO_INJECTED_INTERFACE_INFO 0x2000000
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE 0x4000000
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 /* Constants for checkVisibility return results */
 #define J9_VISIBILITY_ALLOWED 1

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1351,6 +1351,27 @@ permittedSubclassesNameAtIndex(U_32* permittedSubclassesCountPtr, U_32 index);
  */
 U_32
 getNumberOfInjectedInterfaces(J9ROMClass *romClass);
+
+/**
+ * Retrieves number of preload classes in this class. Assumes that
+ * ROM class parameter references a class with preloaded classes.
+ *
+ * @param J9ROMClass class
+ * @return U_32 number of preload classes in optionalinfo
+ */
+U_32*
+getNumberOfPreloadClassesPtr(J9ROMClass *romClass);
+
+/**
+ * Find the preload class name constant pool entry at index in the optional data of the ROM class parameter.
+ * This method assumes there is at least one preloaded class in the ROM class.
+ *
+ * @param U_32* the pointer returned by getNumberOfPreloadClassesPtr
+ * @param U_32 class index
+ * @return the preload class name at index from ROM class
+ */
+J9UTF8*
+preloadClassNameAtIndex(U_32* permittedSubclassesCountPtr, U_32 index);
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2676,7 +2676,7 @@ findJ9ClassInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, U_8
  * @param flattenedClassCache[in]	A table of flattened instance field types
  * @param nameAndSignature[in]		The name and signature of field to look for
  *
- * @return index if found 0 otherwise
+ * @return index if found, UDATA_MAX otherwise
  */
 UDATA
 findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature);

--- a/runtime/util/optinfo.c
+++ b/runtime/util/optinfo.c
@@ -715,6 +715,25 @@ getNumberOfInjectedInterfaces(J9ROMClass *romClass) {
 
 	return *SRP_PTR_GET(ptr, U_32*);
 }
+
+U_32*
+getNumberOfPreloadClassesPtr(J9ROMClass *romClass)
+{
+	U_32 *ptr = getSRPPtr(J9ROMCLASS_OPTIONALINFO(romClass), romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE);
+
+	Assert_VMUtil_true(ptr != NULL);
+
+	return SRP_PTR_GET(ptr, U_32*);
+}
+
+J9UTF8*
+preloadClassNameAtIndex(U_32* preloadClassesCountPtr, U_32 index)
+{
+	/* SRPs to Preload name constant pool entries start after the preloadClassesCountPtr */
+	U_32* preloadClassesPtr = preloadClassesCountPtr + 1 + index;
+
+	return NNSRP_PTR_GET(preloadClassesPtr, J9UTF8*);
+}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 BOOLEAN


### PR DESCRIPTION
- Add attributes to attribute hash table (attrlookup.gperf)
- Read attributes from classfile (cfreader.c)
- Store attributes in ClassFileOracle object (ClassFileOracle.cpp)
- Set new flags in ROMClass (ROMClassBuilder.cpp)
- Allow new attributes to be serialized (ROMClassWriter.cpp)
- Preload classes marked for preloading (createramclass.cpp)

For issues #17233 and #17234