### PR TITLE
CRIU tests require only one Pre-checkpoint message

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -183,8 +183,7 @@
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_CHECKPOINT$ 1 1 true true</command>
     <output type="success" caseSensitive="yes" regex="no">testSingleThreadModeCheckpointExceptionJUCLock: PASSED</output>
     <output type="success" caseSensitive="yes" regex="no">testSingleThreadModeCheckpointExceptionSynMonitor: PASSED</output>
-    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint JUC LOCK</output>
-    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint synchronization</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="no" regex="no">testSingleThreadModeCheckpointExceptionJUCLock: FAILED</output>
     <output type="failure" caseSensitive="no" regex="no">testSingleThreadModeCheckpointExceptionSynMonitor: FAILED</output>
     <output type="failure" caseSensitive="no" regex="no">Killed</output>
@@ -202,8 +201,7 @@
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_RESTORE$ 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">testSingleThreadModeRestoreExceptionJUCLock: PASSED</output>
     <output type="success" caseSensitive="yes" regex="no">testSingleThreadModeRestoreExceptionSynLock: PASSED</output>
-    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint JUC LOCK</output>
-    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint synchronization</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="no" regex="no">testSingleThreadModeRestoreExceptionJUCLock: FAILED</output>
     <output type="failure" caseSensitive="no" regex="no">testSingleThreadModeRestoreExceptionSynLock: FAILED</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
@@ -58,7 +58,7 @@ public class TestSingleThreadModeCheckpointException {
 				});
 
 				try {
-					System.out.println("Pre-checkpoint JUC LOCK");
+					System.out.println("Pre-checkpoint");
 					CRIUTestUtils.checkPointJVMNoSetup(criu, CRIUTestUtils.imagePath, false);
 				} catch (JVMCheckpointException jvmce) {
 					result = true;
@@ -111,7 +111,7 @@ public class TestSingleThreadModeCheckpointException {
 				});
 
 				try {
-					System.out.println("Pre-checkpoint synchronization");
+					System.out.println("Pre-checkpoint");
 					CRIUTestUtils.checkPointJVMNoSetup(criu, CRIUTestUtils.imagePath, false);
 				} catch (JVMCheckpointException jvmce) {
 					result = true;

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
@@ -58,7 +58,7 @@ public class TestSingleThreadModeRestoreException {
 				});
 
 				try {
-					System.out.println("Pre-checkpoint JUC LOCK");
+					System.out.println("Pre-checkpoint");
 					CRIUTestUtils.checkPointJVMNoSetup(criu, CRIUTestUtils.imagePath, false);
 				} catch (JVMRestoreException jvmre) {
 					result = true;
@@ -115,7 +115,7 @@ public class TestSingleThreadModeRestoreException {
 				});
 
 				try {
-					System.out.println("Pre-checkpoint synchronization");
+					System.out.println("Pre-checkpoint");
 					CRIUTestUtils.checkPointJVMNoSetup(criu, CRIUTestUtils.imagePath, false);
 				} catch (JVMRestoreException jvmre) {
 					result = true;


### PR DESCRIPTION
`CRIU` tests require only one `Pre-checkpoint` message

The messages after a checkpoint can't be required due to the known intermittent CRIU checkpoint errors.

close https://github.com/eclipse-openj9/openj9/issues/17657

Signed-off-by: Jason Feng <fengj@ca.ibm.com>