### PR TITLE
Fix TestThreadMXBean test for jdk21, adding TotalThreadAllocatedBytes

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
@@ -91,6 +91,9 @@ public class TestThreadMXBean {
 		attribs.put("ThreadCpuTimeEnabled", new AttributeData(Boolean.TYPE.getName(), true, true, true));
 		attribs.put("ThreadCpuTimeSupported", new AttributeData(Boolean.TYPE.getName(), true, false, true));
 		attribs.put("TotalStartedThreadCount", new AttributeData(Long.TYPE.getName(), true, false, false));
+		if (VersionCheck.major() >= 21) {
+			attribs.put("TotalThreadAllocatedBytes", new AttributeData(Long.TYPE.getName(), true, false, false));
+		}
 	} // end static initializer
 
 	private ThreadMXBean tb;
@@ -1439,7 +1442,7 @@ public class TestThreadMXBean {
 			numAttributes = 17;
 		} else {
 			numOperations = 20;
-			numAttributes = 18;
+			numAttributes = (VersionCheck.major() >= 21) ? 19 : 18;
 		}
 		MBeanOperationInfo[] operations = mbi.getOperations();
 		AssertJUnit.assertNotNull(operations);


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/17664