### PR TITLE
Change API used for computing code cache size in low memory environments (0.40.0)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1637,19 +1637,17 @@ void J9::Options::preProcessCodeCacheIncreaseTotalSize(J9JavaVM *vm, J9JITConfig
       codecachetotalAlreadyParsed = true;
 
       UDATA ccTotalSize = jitConfig->codeCacheTotalKB;
-#if !defined(J9ZTPF)
-      // The z/TPF OS reserves code cache memory differently
-      bool incomplete;
-      uint64_t freePhysicalMemoryB = getCompilationInfo(jitConfig)->computeAndCacheFreePhysicalMemory(incomplete);
-      if (freePhysicalMemoryB != OMRPORT_MEMINFO_NOT_AVAILABLE && !incomplete)
+#if !defined(J9ZTPF)  // The z/TPF OS reserves code cache memory differently
+      uint64_t freePhysicalMemoryB = omrsysinfo_get_addressable_physical_memory();
+      if (freePhysicalMemoryB != 0)
          {
          // If the available memory is less than the default code cache total value
-	 // then use only the user specified percentage(default 25%) of the free memory as code cache total
+         // then use only the user specified percentage(default 25%) of the free memory as code cache total
          uint64_t proposedCodeCacheTotalKB = ((uint64_t)(((double)freePhysicalMemoryB / 100.0) * getCodeCacheMaxPercentageOfAvailableMemory(vm))) >> 10;
          if (proposedCodeCacheTotalKB < jitConfig->codeCacheTotalKB)
             {
             ccTotalSize = static_cast<UDATA>(proposedCodeCacheTotalKB);
-	    _overrideCodecachetotal = true;
+            _overrideCodecachetotal = true;
             }
          }
 #endif


### PR DESCRIPTION
PR #17425 introduced a change for limiting the total size of the Code Cache to no more than 25% of available physical memory. This is done based on the output from the `computeAndCacheFreePhysicalMemory()` function. This function takes into consideration the amount of physical memory installed on the machine and the limits imposed by cgroups, but also looks at how much free physical memory is available (not used by other proceses) at the moment of the call. Thus, if there is a transient and very narrow spike of memory usage by some other process when our JVM starts, the JVM may think that it has very limitted physical memory and allocate a very small code cache repository.
This commit changes the function used for computing physical memory to `omrsysinfo_get_addressable_physical_memory()` which looks at how much physical memory the JVM is allowed to use, rather than at how much physical memory is available.

Cherry-pick of commit https://github.com/eclipse-openj9/openj9/pull/17666/commits/11674ac7fadc9797acab5d22656797a8cf1775a3