### PR TITLE
Remove unused counters

### DIFF
--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -1580,7 +1580,6 @@ wrap_primitiveFieldCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData, IDATA
 	J9ROMFieldShape * field;
 	jvmtiError rc;
 	jvmtiIterationControl visitRc = JVMTI_ITERATION_ABORT;
-	jint fieldIndex = 0;
 	UDATA const objectHeaderSize = J9JAVAVM_OBJECT_HEADER_SIZE(vm);
 
 	/* Check if the referee was already visited and had its primitive fields callback issued. Duplicate SUN behavior
@@ -1727,8 +1726,6 @@ wrap_primitiveFieldCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData, IDATA
 
 
 nextField:
-		fieldIndex++;
-
 		/* Go look at the next field */
 		field = vm->internalVMFunctions->fullTraversalFieldOffsetsNextDo(&state);
 	}

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -625,7 +625,6 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 	char persistentCacheDir[J9SH_MAXPATH];
 	char nonpersistentCacheDir[J9SH_MAXPATH];
 	char* nameWithVGen = NULL;
-	IDATA cntr = 0;
 	J9Pool* incompatibleList = NULL;
 	SH_OSCache_Info tempInfo;
 	SH_OSCache_Info* newElement = NULL;
@@ -760,7 +759,6 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 											goto done;
 										}
 										memcpy(newElement, anElement, sizeof(SH_OSCache_Info));
-										++cntr;
 									} while ((anElement = (SH_OSCache_Info*)pool_nextDo(&poolState)) != NULL);
 								}
 							}
@@ -789,7 +787,6 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 					memcpy(newElement, &tempInfo, sizeof(SH_OSCache_Info));
 				}
 			}
-			++cntr;
 		}
 		
 		if (NULL != lowerLayerList) {


### PR DESCRIPTION
These unused counters are causing compiler errors in the latest version of XCode. 

Related to https://github.com/eclipse-openj9/openj9/issues/17493