### PR TITLE
Return an unmodifiableList from RuntimeMXBean.getInputArguments()

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
@@ -24,6 +24,7 @@ package com.ibm.java.lang.management.internal;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,7 +209,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 	@Override
 	public final List<String> getInputArguments() {
 		checkMonitorPermission();
-		return ManagementUtils.convertStringArrayToList(VM.getVMArgs());
+		return Collections.unmodifiableList(ManagementUtils.convertStringArrayToList(VM.getVMArgs()));
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/17691