### PR TITLE
(v0.40.0-release) CRIU tests pass if the original thread IDs can't be acquired

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -208,6 +208,8 @@
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
@@ -238,6 +240,8 @@
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->


### PR DESCRIPTION
CRIU tests pass if the original thread IDs can't be acquired

Added missing success conditions:
```
    <output type="success" caseSensitive="yes" regex="no">Thread pid
mismatch</output>
    <output type="success" caseSensitive="yes" regex="no">do not match
expected</output>
```

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/17695

This is a test-only change which could help 0.40.0 milestone 2 build triage.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>