### PR TITLE
AArch64: Fix the flag to enable trace of PICs

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1473,8 +1473,8 @@ static bool getProfiledCallSiteInfo(TR::CodeGenerator *cg, TR::Node *callNode, u
          }
       return false;
       }
-   static const bool tracePIC = (feGetEnv("TR_TracePIC") != NULL) && comp->getOption(TR_TraceCG);
-   if (tracePIC)
+   static const bool tracePIC = (feGetEnv("TR_TracePIC") != NULL);
+   if (tracePIC && comp->getOption(TR_TraceCG))
       {
       traceMsg(comp, "Value profile info for callNode %p in %s\n", callNode, comp->signature());
       info->getProfiler()->dumpInfo(comp->getOutFile());


### PR DESCRIPTION
Fix the initialization code of static `tracePIC` flag so that the flag is enabled even if `TR_TraceCG` is not set when the environment variable `TR_TracePIC` is checked.