### PR TITLE
Support HotSpotDiagnosticMXBean in OpenJ9 JDK21+

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -770,10 +770,6 @@ public final class ManagementUtils {
 				.addInterface(com.ibm.lang.management.JvmCpuMonitorMXBean.class)
 				.validateAndRegister();
 
-			create(OPENJ9_DIAGNOSTICS_MXBEAN_NAME, openj9.lang.management.internal.OpenJ9DiagnosticsMXBeanImpl.getInstance())
-				.addInterface(openj9.lang.management.OpenJ9DiagnosticsMXBean.class)
-				.validateAndRegister();
-
 			// register standard optional beans
 			create(ManagementFactory.COMPILATION_MXBEAN_NAME, CompilationMXBeanImpl.getInstance())
 				.addInterface(java.lang.management.CompilationMXBean.class)

--- a/jcl/src/java.management/share/classes/sun/management/LazyCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/LazyCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/MappedMXBeanType.java
+++ b/jcl/src/java.management/share/classes/sun/management/MappedMXBeanType.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/MemoryNotifInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryNotifInfoCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/MemoryUsageCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryUsageCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/StackTraceElementCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/StackTraceElementCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/java.management/share/classes/sun/management/ThreadInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/ThreadInfoCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -35,6 +35,11 @@ import com.ibm.virtualization.management.internal.HypervisorMXBeanImpl;
 import openj9.lang.management.OpenJ9DiagnosticsMXBean;
 import openj9.lang.management.internal.OpenJ9DiagnosticsMXBeanImpl;
 
+/*[IF JAVA_SPEC_VERSION >= 21]*/
+import com.sun.management.internal.ExtendedHotSpotDiagnostic;
+import com.sun.management.HotSpotDiagnosticMXBean;
+/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+
 /**
  * This class implements the service-provider interface to make OpenJ9-specific
  * MXBeans available. These beans are either in addition to the basic set or
@@ -100,6 +105,12 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 				.addInterface(OpenJ9DiagnosticsMXBean.class)
 				.register(allComponents);
 		}
+
+		/*[IF JAVA_SPEC_VERSION >= 21]*/
+		ComponentBuilder.create("com.sun.management:type=HotSpotDiagnostic", ExtendedHotSpotDiagnostic.getInstance()) //$NON-NLS-1$
+			.addInterface(HotSpotDiagnosticMXBean.class)
+			.register(allComponents);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
 		// register beans with zero or more instances
 

--- a/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/ExtendedHotSpotDiagnostic.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/ExtendedHotSpotDiagnostic.java
@@ -1,0 +1,96 @@
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 21]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+package com.sun.management.internal;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Collections;
+import com.sun.management.VMOption;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.internal.HotSpotDiagnostic;
+
+/**
+ * Runtime type for {@link com.sun.management.HotSpotDiagnosticMXBean}.
+ */
+public class ExtendedHotSpotDiagnostic extends HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
+
+	private static final HotSpotDiagnosticMXBean instance = new ExtendedHotSpotDiagnostic();
+
+	/**
+	 * Singleton accessor method.
+	 *
+	 * @return the <code>HotSpotDiagnostic</code> singleton.
+	 */
+	public static HotSpotDiagnosticMXBean getInstance() {
+		return instance;
+	}
+
+	/**
+	 * Constructor intentionally private to prevent instantiation by others.
+	 */
+	private ExtendedHotSpotDiagnostic() {
+		super();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void dumpHeap(String outputFile, boolean live) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<VMOption> getDiagnosticOptions() {
+		return Collections.emptyList();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public VMOption getVMOption(String name) {
+		if (name == null) {
+			throw new NullPointerException("A non-null name is required");
+		}
+		throw new IllegalArgumentException("OpenJ9 doesn't support the API i.e. the VM option might exist, but OpenJ9 can't retrieve it");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setVMOption(String name, String value) {
+		if (name == null) {
+			throw new NullPointerException("A non-null name is required");
+		}
+		if (value == null) {
+			throw new NullPointerException("A non-null value is required");
+		}
+		throw new IllegalArgumentException("OpenJ9 doesn't support the API i.e. the VM option might exist, but OpenJ9 can't set it");
+	}
+}

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/VMOptionCompositeData.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/VMOptionCompositeData.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION <= 20)]*/
 
 /*******************************************************************************
  * Copyright IBM Corp. and others 2017


### PR DESCRIPTION
This will allow us to enable a JTReg test for Structured Concurrency.

JTReg test: StructuredTaskScope/StructuredThreadDumpTest

Related: #17634