### PR TITLE
Fix the type of _timeOfLastPurge in ClientSessionHT

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -602,7 +602,7 @@ class ClientSessionHT
    private:
    PersistentUnorderedMap<uint64_t, ClientSessionData*> _clientSessionMap;
 
-   uint64_t _timeOfLastPurge;
+   int64_t _timeOfLastPurge;
    TR::CompilationInfo *_compInfo;
    const int64_t TIME_BETWEEN_PURGES; // ms; this defines how often we are willing to scan for old entries to be purged
    const int64_t OLD_AGE;// ms; this defines what an old entry means


### PR DESCRIPTION
This commit fixes the type of _timeOfLastPurge in ClientSessionHT from uint64_t to int64_t.
The field is used to store the return value from j9time_current_time_millis(), whose type is int64_t.