### PR TITLE
JDK22 removes JavaLangAccess.fastUUID()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -236,7 +236,7 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava21.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="JAVA_SPEC_VERSION=21"/>
+		<parameter name="macro:define" value="JAVA_SPEC_VERSION=22"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -253,9 +253,11 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION < 10 */
 
+/*[IF JAVA_SPEC_VERSION < 22]*/
 	public String fastUUID(long param1, long param2) {
 		return Long.fastUUID(param1, param2);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 22 */
 
 	public Package definePackage(ClassLoader classLoader, String name, Module module) {
 		if (null == classLoader) {


### PR DESCRIPTION
`JDK22` removes `JavaLangAccess.fastUUID()`

Updated `JAVA22` `JAVA_SPEC_VERSION=22`.

closes https://github.com/eclipse-openj9/openj9/issues/17721

Signed-off-by: Jason Feng <fengj@ca.ibm.com>