### PR TITLE
Remove Access.fastUUID for Java 22+

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -236,7 +236,7 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava21.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="JAVA_SPEC_VERSION=21"/>
+		<parameter name="macro:define" value="JAVA_SPEC_VERSION=22"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -253,9 +253,11 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION < 10 */
 
+/*[IF JAVA_SPEC_VERSION < 22]*/
 	public String fastUUID(long param1, long param2) {
 		return Long.fastUUID(param1, param2);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 22 */
 
 	public Package definePackage(ClassLoader classLoader, String name, Module module) {
 		if (null == classLoader) {


### PR DESCRIPTION
Removed upstream by
  * [8310502: Optimization for j.l.Long.fastUUID()](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/c1abd257beed29f0c05e20de4bce32b8216a7d65)

This requires a correction to `JAVA_SPEC_VERSION` for `JAVA22` in `jpp_configuration.xml`.

See acceptance build failures: https://openj9-jenkins.osuosl.org/job/Pipeline-OpenJDK-Acceptance/489/