### PR TITLE
Restore OpenJ9DiagnosticsMXBean registration call in ManagementUtils

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -724,7 +724,7 @@ public final class ManagementUtils {
 		private static final String OPENJ9_DIAGNOSTICS_MXBEAN_NAME = "openj9.lang.management:type=OpenJ9Diagnostics"; //$NON-NLS-1$
 
 		static void registerAll() {
-			// register standard singleton beans
+			// Register standard singleton beans for JDK8.
 			create(ManagementFactory.CLASS_LOADING_MXBEAN_NAME, ClassLoadingMXBeanImpl.getInstance())
 				.addInterface(java.lang.management.ClassLoadingMXBean.class)
 				.validateAndRegister();
@@ -757,7 +757,7 @@ public final class ManagementUtils {
 				.addInterface(java.lang.management.ThreadMXBean.class)
 				.validateAndRegister();
 
-			// register OpenJ9-specific singleton beans
+			// Register OpenJ9-specific singleton beans for JDK8.
 			create(GUEST_OPERATING_SYSTEM_MXBEAN_NAME, com.ibm.virtualization.management.internal.GuestOS.getInstance())
 				.addInterface(com.ibm.virtualization.management.GuestOSMXBean.class)
 				.validateAndRegister();
@@ -770,12 +770,16 @@ public final class ManagementUtils {
 				.addInterface(com.ibm.lang.management.JvmCpuMonitorMXBean.class)
 				.validateAndRegister();
 
-			// register standard optional beans
+			create(OPENJ9_DIAGNOSTICS_MXBEAN_NAME, openj9.lang.management.internal.OpenJ9DiagnosticsMXBeanImpl.getInstance())
+				.addInterface(openj9.lang.management.OpenJ9DiagnosticsMXBean.class)
+				.validateAndRegister();
+
+			// Register standard optional beans for JDK8.
 			create(ManagementFactory.COMPILATION_MXBEAN_NAME, CompilationMXBeanImpl.getInstance())
 				.addInterface(java.lang.management.CompilationMXBean.class)
 				.validateAndRegister();
 
-			// register beans with zero or more instances
+			// Register beans with zero or more instances for JDK8.
 			create(BUFFERPOOL_MXBEAN_DOMAIN_TYPE, BufferPoolMXBeanImpl.getBufferPoolMXBeans())
 				.addInterface(java.lang.management.BufferPoolMXBean.class)
 				.validateAndRegister();
@@ -788,7 +792,7 @@ public final class ManagementUtils {
 				.validateAndRegister();
 
 			create(ManagementFactory.MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE,
-					// exclude garbage collector beans handled above
+					// Exclude garbage collector beans handled above.
 					excluding(ExtendedMemoryMXBeanImpl.getInstance().getMemoryManagerMXBeans(false), java.lang.management.GarbageCollectorMXBean.class))
 				.addInterface(java.lang.management.MemoryManagerMXBean.class)
 				.validateAndRegister();


### PR DESCRIPTION
The registration call was removed in eclipse-openj9#17709 due to a false
assumption. It has been added back since it is still required.

Refs:
- https://github.com/eclipse-openj9/openj9/pull/17709#discussion_r1246811609
- https://github.com/eclipse-openj9/openj9/pull/17709#discussion_r1247964717