### PR TITLE
Remove unnecessary assertion at OSCachesysv.cpp:1211

### DIFF
--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1208,7 +1208,6 @@ SH_OSCachesysv::acquireWriteLock(UDATA lockID)
 			OSC_ERR_TRACE1(J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX, myerror);
 #endif /* !defined(WIN32) */
 			Trc_SHR_OSC_enterMutex_Exit3(myerror);
-			Trc_SHR_Assert_ShouldNeverHappen();
 			return -1;
 		}
 	}


### PR DESCRIPTION
It is possible that the semaphore is removed from the system by another
process and the JVM could reach this assertion. On z/OS, this assertion
leads the JVM to exit on core dumps, which is undesirable. The design
is to ignore the startup error of default SCC and continue without using
the SCC. The assertion message is:

```
j9shr.2038          Exit       <OSCache enterMutex failed - j9shsem_wait
failed with error = -328433
j9shr.1009   *   ** ASSERTION FAILED **
at /openj9/runtime/shared_common/OSCachesysv.cpp:1211: ((0 ))
```