### PR TITLE
Replace j9time_current_time_millis() with j9time_hires_clock() in gc

### DIFF
--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -395,7 +395,7 @@ MM_ParallelScrubCardTableTask::shouldYieldFromTask(MM_EnvironmentBase *env)
 {
 	if (!_timeLimitWasHit) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
-		I_64 currentTime = j9time_current_time_millis();
+		U_64 currentTime = j9time_hires_clock();
 						
 		if (currentTime >= _timeThreshold) {
 			_timeLimitWasHit = true;

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
@@ -190,7 +190,7 @@ class MM_ParallelScrubCardTableTask : public MM_ParallelTask
 private:
 	MM_CycleState * const _cycleState; /**< Current cycle state information */
 	bool _timeLimitWasHit;	/**< true if any requests to check the time came in after we had hit our time threshold */
-	const I_64 _timeThreshold;	/**< The millisecond which represents the end of this increment */
+	const U_64 _timeThreshold;	/**< The ticks which represents the end of this increment */
 	
 public:
 
@@ -216,7 +216,7 @@ public:
 	 */
 	MM_ParallelScrubCardTableTask(MM_EnvironmentBase *env,
 			MM_ParallelDispatcher *dispatcher, 
-			I_64 timeThreshold,
+			U_64 timeThreshold,
 			MM_CycleState *cycleState) :
 		MM_ParallelTask(env, dispatcher)
 		,_cycleState(cycleState)

--- a/runtime/gc_vlhgc/GlobalMarkDelegate.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkDelegate.hpp
@@ -106,10 +106,10 @@ public:
 	 * Execute one step of incremental Mark.
 	 * 
 	 * @param env[in] The thread which called driveGlobalCollectMainThread
-	 * @param markIncrementEndTime[in] end of time interval scheduled for step (as observed by current_time_millis)
+	 * @param markIncrementEndTime[in] end of time interval scheduled for step (as observed by time_hires_clock in ticks)
 	 * @return true if last step of incremental Mark has been executed
 	 */
-	bool performMarkIncremental(MM_EnvironmentVLHGC *env, I_64 markIncrementEndTime);
+	bool performMarkIncremental(MM_EnvironmentVLHGC *env, U_64 markIncrementEndTime);
 
 	/**
 	 * Execute one step of concurrent GMP Mark.
@@ -158,10 +158,10 @@ private:
 
 	/**
 	 *	Mark operation - Initialization.
-	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in system milliseconds
+	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in ticks
 	 *	@return True if the operation reached timeThreshold before it completed the operation 
 	 */
-	bool markInit(MM_EnvironmentVLHGC *env, I_64 timeThreshold);
+	bool markInit(MM_EnvironmentVLHGC *env, U_64 timeThreshold);
 
 	/**
 	 *	Mark operation - Marking Roots.
@@ -170,17 +170,17 @@ private:
 
 	/**
 	 *	Mark operation - Scan work packets.
-	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in system milliseconds 
+	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in ticks
 	 *	@return True if the operation reached timeThreshold before it completed the operation 
 	 */
-	bool markScan(MM_EnvironmentVLHGC *env, I_64 timeThreshold);
+	bool markScan(MM_EnvironmentVLHGC *env, U_64 timeThreshold);
 
 	/**
 	 *	Mark operation - Use any remaining increment time to scrub the card table.
-	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in system milliseconds 
+	 *	@param timeThreshold[in] The scheduled end time by which the operation is expected to end, expressed in ticks
 	 *	@return True if the operation reached timeThreshold before it completed the operation 
 	 */
-	bool markScrubCardTable(MM_EnvironmentVLHGC *env, I_64 timeThreshold);
+	bool markScrubCardTable(MM_EnvironmentVLHGC *env, U_64 timeThreshold);
 
 	/**
 	 *	Mark operation - Complete.

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -222,7 +222,7 @@ MM_ParallelGlobalMarkTask::shouldYieldFromTask(MM_EnvironmentBase *env)
 {
 	if (!_timeLimitWasHit) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
-		I_64 currentTime = j9time_current_time_millis();
+		U_64 currentTime = j9time_hires_clock();
 						
 		if (currentTime >= _timeThreshold) {
 			_timeLimitWasHit = true;

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -78,7 +78,7 @@ private:
 	MM_GlobalMarkingScheme *_markingScheme;
 	const MarkAction _action; /**< specify which action Mark Setup to do*/
 	bool _timeLimitWasHit;	/**< true if any requests to check the time came in after we had hit our time threshold */
-	const I_64 _timeThreshold;	/**< The millisecond which represents the end of this increment */
+	const U_64 _timeThreshold;	/**< The ticks which represents the end of this increment */
 	MM_CycleState *_cycleState; /**< Current cycle state information */
 	
 public:
@@ -111,7 +111,7 @@ public:
 			MM_ParallelDispatcher *dispatcher, 
 			MM_GlobalMarkingScheme *markingScheme, 
 			MarkAction action,
-			I_64 timeThreshold,
+			U_64 timeThreshold,
 			MM_CycleState *cycleState) :
 		MM_ParallelTask(env, dispatcher)
 		,_markingScheme(markingScheme)
@@ -167,7 +167,7 @@ public:
 			UDATA bytesToScan,
 			volatile bool *forceExit,
 			MM_CycleState *cycleState) :
-		MM_ParallelGlobalMarkTask(env, dispatcher, markingScheme, action, I_64_MAX, cycleState)
+		MM_ParallelGlobalMarkTask(env, dispatcher, markingScheme, action, U_64_MAX, cycleState)
 		, _bytesToScan(bytesToScan)
 		, _bytesScanned(0)
 		, _didReturnEarly(false)

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -425,7 +425,7 @@ MM_IncrementalGenerationalGC::globalMarkPhase(MM_EnvironmentVLHGC *env, bool inc
 
 	if (incrementalMark) {
 		reportGMPMarkStart(env);
-		I_64 endTime = j9time_current_time_millis() + _schedulingDelegate.currentGlobalMarkIncrementTimeMillis(env);
+		U_64 endTime = j9time_hires_clock() + _schedulingDelegate.currentGlobalMarkIncrementTimeMillis(env) * j9time_hires_frequency() / 1000;
 		if (env->_cycleState->_markDelegateState == MM_CycleState::state_mark_idle) {
 			_globalMarkDelegate.performMarkSetInitialState(env);
 		}


### PR DESCRIPTION
The j9time_current_time_millis() uses UNIX gettimeofday() function, and is therefore non-monotonic and error-prone.
We turn to use monotonic j9time_hires_clock() function call.

Issue: #17706