### PR TITLE
[FFI/Jtreg_JDK21] Validate the alignment of the pointer address

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -478,10 +478,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<!-- Static method references needed to support Foreign Linker API. -->
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="upcallLinkCallerMethod" signature="(Ljava/lang/Class;Ljava/lang/invoke/MethodType;)Ljava/lang/Object;" versions="17-"/>
-	<staticmethodref class="openj9/internal/foreign/abi/UpcallMHMetaData" name="getNativeArgRetAddrOfPtr" signature="(Ljdk/incubator/foreign/MemoryAddress;)J" flags="opt_openjdkFfi" versions="17"/>
-	<staticmethodref class="openj9/internal/foreign/abi/UpcallMHMetaData" name="getNativeArgRetSegmentOfPtr" signature="(Ljava/lang/foreign/MemorySegment;)J" flags="opt_openjdkFfi" versions="20-"/>
-	<staticmethodref class="openj9/internal/foreign/abi/UpcallMHMetaData" name="getNativeArgRetSegment" signature="(Ljdk/incubator/foreign/MemorySegment;)J" flags="opt_openjdkFfi" versions="17"/>
-	<staticmethodref class="openj9/internal/foreign/abi/UpcallMHMetaData" name="getNativeArgRetSegment" signature="(Ljava/lang/foreign/MemorySegment;)J" flags="opt_openjdkFfi" versions="20-"/>
 
 	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZZ)Z" versions="15-18"/>
 	<staticmethodref class="jdk/internal/loader/NativeLibraries" name="load" signature="(Ljdk/internal/loader/NativeLibraries$NativeLibraryImpl;Ljava/lang/String;ZZ)Z" versions="19-"/>

--- a/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_UpCallMHMetaData.cpp
+++ b/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_UpCallMHMetaData.cpp
@@ -40,18 +40,7 @@ OutOfLineINL_openj9_internal_foreign_abi_UpcallMHMetaData_resolveUpcallDataInfo(
 	J9ConstantPool *jclConstantPool = (J9ConstantPool *)vm->jclConstantPool;
 	J9ROMClass * jclROMClass = jclConstantPool->ramClass->romClass;
 	U_32 * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(jclROMClass);
-#if JAVA_SPEC_VERSION >= 20
-	const int cpEntryNum = 10;
-#else /* JAVA_SPEC_VERSION >= 20 */
-	const int cpEntryNum = 12;
-#endif /* JAVA_SPEC_VERSION >= 20 */
-	U_16 cpIndex[cpEntryNum] = {
-#if JAVA_SPEC_VERSION >= 20
-			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_GETNATIVEARGRETSEGMENTOFPTR,
-#else /* JAVA_SPEC_VERSION >= 20 */
-			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_GETNATIVEARGRETADDROFPTR,
-#endif /* JAVA_SPEC_VERSION >= 20 */
-			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_GETNATIVEARGRETSEGMENT,
+	static const U_16 cpIndex[] = {
 			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_CALLEEMH,
 			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_CALLEETYPE,
 			J9VMCONSTANTPOOL_OPENJ9INTERNALFOREIGNABIUPCALLMHMETADATA_INVOKECACHE,
@@ -65,16 +54,15 @@ OutOfLineINL_openj9_internal_foreign_abi_UpcallMHMetaData_resolveUpcallDataInfo(
 			J9VMCONSTANTPOOL_JDKINTERNALFOREIGNNATIVEMEMORYSEGMENTIMPL_LENGTH,
 			J9VMCONSTANTPOOL_JDKINTERNALFOREIGNNATIVEMEMORYSEGMENTIMPL_SCOPE
 			};
+	const size_t cpEntryNum = sizeof(cpIndex) / sizeof(cpIndex[0]);
 
 	VM_OutOfLineINL_Helpers::buildInternalNativeStackFrame(currentThread, method);
-	for (int i = 0; i < cpEntryNum; i++) {
+	for (size_t i = 0; i < cpEntryNum; i++) {
 		UDATA offset = cpIndex[i];
 		UDATA cpType = J9_CP_TYPE(cpShapeDescription, offset);
 		UDATA resolveFlags = J9_RESOLVE_FLAG_NO_THROW_ON_FAIL | J9_RESOLVE_FLAG_JCL_CONSTANT_POOL;
 
-		if (J9CPTYPE_STATIC_METHOD == cpType) {
-			resolveStaticMethodRef(currentThread, jclConstantPool, offset, resolveFlags);
-		} else if (J9CPTYPE_FIELD == cpType) {
+		if (J9CPTYPE_FIELD == cpType) {
 			J9RAMFieldRef *cpFieldRef = ((J9RAMFieldRef*)jclConstantPool) + offset;
 			UDATA const flags = cpFieldRef->flags;
 			UDATA const valueOffset = cpFieldRef->valueOffset;


### PR DESCRIPTION
The changes validate the pointer address against
the alignment value of its target layout introduced
in JDK21 if exists to ensure the pointer segment
with the valid alignment & size is passed-in or
returned during the downcall/upcall.

Note:
The changes aim to unify the validation methods in
java shared by downcall & upcall with MH filters,
in which case there is no need to do call-ins to
capture the exceptions/invalid cases in the dispatcher.
Thus, it is easy to extend the validation in java
without modifying the code in the dispatcher. 

Fixes: #17686

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
