### PR TITLE
Clean up old JDK version and remove temporary urls

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -66,7 +66,7 @@
  *   ENABLE_SUMMARY_AUTO_REFRESH: Boolean - flag to enable the downstream summary auto-refresh, default: false
  */
 
-CURRENT_RELEASES = ['8', '11', '17', '19', '20', '21', 'next']
+CURRENT_RELEASES = ['8', '11', '17', '20', '21', 'next']
 
 SPECS = ['ppc64_aix' : CURRENT_RELEASES,
          'ppc64le_linux'  : CURRENT_RELEASES,

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -36,10 +36,6 @@ openjdk:
     default:
       repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk17.git'
       branch: 'openj9'
-  18:
-    default:
-      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk18.git'
-      branch: 'openj9'
   20:
     default:
       repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk20.git'
@@ -161,14 +157,13 @@ boot_jdk_default:
       8: '8'
       11: '11'
       17: '17'
-      20: '18'
+      20: '19'
       21: '20'
       next: '20'
     dir_strip:
       all: '1'
     url:
       all: 'https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${os}/${arch}/jdk/openj9/normal/adoptopenjdk?project=jdk'
-      20: 'https://api.adoptium.net/v3/binary/latest/20/ga/${os}/${arch}/jdk/hotspot/normal/eclipse?project=jdk'
 #========================================#
 # CRIU
 #========================================#
@@ -234,8 +229,6 @@ s390x_linux:
   boot_jdk:
     arch: 's390x'
     os: 'linux'
-    url:
-      20: 'https://openj9-artifactory.osuosl.org/artifactory/ci-openj9/Build_JDK20_s390x_linux_OMR/14/OpenJ9-JDK20-s390x_linux-20230505-063521.tar.gz'
   release:
     all: 'linux-s390x-server-release'
     8: 'linux-s390x-normal-server-release'
@@ -268,8 +261,6 @@ ppc64_aix:
     location: '/opt/bootjdks'
     arch: 'ppc64'
     os: 'aix'
-    url:
-      20: 'https://openj9-artifactory.osuosl.org/artifactory/ci-openj9/Build_JDK20_ppc64_aix_OMR/14/OpenJ9-JDK20-ppc64_aix-20230505-133657.tar.gz'
   release:
     all: 'aix-ppc64-server-release'
     8: 'aix-ppc64-normal-server-release'


### PR DESCRIPTION
JDK versions that are no longer supported are removed or substituted from files pertaining to the build environment.

Temporary BootJDK20 URLs are, also, removed since Semeru 20 is now released and all platforms can now use the default parameterized API link.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)