### PR TITLE
Load criu instead of j9 library in init check

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -112,7 +112,7 @@ public final class CRIUSupport {
 		if (!nativeLoaded) {
 			try {
 				AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-					System.loadLibrary("j9criu29"); //$NON-NLS-1$
+					System.loadLibrary("criu"); //$NON-NLS-1$
 					nativeLoaded = true;
 					return null;
 				});


### PR DESCRIPTION
Previously when we were relying on the dynamic linker to load libcriu. Loading libj9criu29 was sufficient to ensure that libcriu existed. However, since we switched to explicit loading libcriu is onl loaded at the time of checkpoint, which means querying if criu support is enabled is not sufficient to determine if the system can actually take a checkpoint.

This PR loads CRIU earlier so that the user has more info before the checkpoint is attempted.