### PR TITLE
CRIU init() invokes setupJNIFieldIDsAndCRIUAPI()

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -91,6 +91,7 @@ public final class CRIUSupport {
 			boolean unprivileged,
 			String optionsFile,
 			String envFile);
+	private static native boolean setupJNIFieldIDsAndCRIUAPI();
 
 	private static native String[] getRestoreSystemProperites();
 
@@ -113,9 +114,11 @@ public final class CRIUSupport {
 			try {
 				AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 					System.loadLibrary("j9criu29"); //$NON-NLS-1$
-					nativeLoaded = true;
 					return null;
 				});
+				if (setupJNIFieldIDsAndCRIUAPI()) {
+					nativeLoaded = true;
+				}
 			} catch (UnsatisfiedLinkError e) {
 				errorMsg = e.getMessage();
 				Properties internalProperties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();

--- a/runtime/criusupport/criusupport.hpp
+++ b/runtime/criusupport/criusupport.hpp
@@ -34,6 +34,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass u
 jobject JNICALL
 Java_org_eclipse_openj9_criu_CRIUSupport_getRestoreSystemProperites(JNIEnv *env, jclass unused);
 
+jboolean JNICALL
+Java_org_eclipse_openj9_criu_CRIUSupport_setupJNIFieldIDsAndCRIUAPI(JNIEnv *env, jclass unused);
 } /* extern "C" */
 
 #endif

--- a/runtime/criusupport/exports.cmake
+++ b/runtime/criusupport/exports.cmake
@@ -24,5 +24,6 @@ if(J9VM_OPT_CRIU_SUPPORT)
 	omr_add_exports(j9criu
 		Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl
 		Java_org_eclipse_openj9_criu_CRIUSupport_getRestoreSystemProperites;
+		Java_org_eclipse_openj9_criu_CRIUSupport_setupJNIFieldIDsAndCRIUAPI;
 	)
 endif()

--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -45,3 +45,8 @@ TraceEvent=Trc_CRIU_after_checkpoint Overhead=1 Level=2 Template="After checkpoi
 TraceEvent=Trc_CRIU_restoreArg Overhead=1 Level=5 Test Template="Restore arg: %s"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_checkIfSafeToCheckpointBlockedVer2 Overhead=1 Level=2 Template="Checkpoint blocked because thread=%p is in method=%p due to delay code %zu"
 TraceEvent=Trc_CRIU_checkpointJVMImpl_checkpointWithActiveCLinit Overhead=1 Level=2 Template="Taking a checkpoint with active clinit"
+
+TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_null_init Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() criuSystemRestoreExceptionInit(%p) criuJVMRestoreExceptionInit(%p) criuSystemCheckpointExceptionInit(%p) criuJVMCheckpointExceptionInit(%p)"
+TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_null_exception_class Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() criuJVMCheckpointExceptionClass(%p) criuSystemCheckpointExceptionClass(%p) criuJVMRestoreExceptionClass(%p) criuSystemRestoreExceptionClass(%p)"
+TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_load_criu_failure Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() The JVM attempted to load libcriu.so but was unable to: %zi"
+TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_not_find_criu_methods Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() The JVM could not find critical criu functions in libcriu.so: %zi"

--- a/runtime/criusupport/uma/criusupport_exports.xml
+++ b/runtime/criusupport/uma/criusupport_exports.xml
@@ -22,4 +22,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <exports group="criusupport">
 	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl" />
 	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_getRestoreSystemProperites" />
+	<export name="Java_org_eclipse_openj9_criu_CRIUSupport_setupJNIFieldIDsAndCRIUAPI" />
 </exports>


### PR DESCRIPTION
CRIU `init()` invokes `setupJNIFieldIDsAndCRIUAPI()`

Added a native `CRIUSupport.setupJNIFieldIDsAndCRIUAPI()`;
If there is a problem loading `j9criu29` library and associated methods, the `criu.SystemCheckpointException` is thrown.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>