### PR TITLE
Follow moved destObject in copyFlattenableArray

### DIFF
--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -616,7 +616,9 @@ done:
 				*/
 				if ((NULL == copyObject) && J9_IS_J9CLASS_FLATTENED(srcClazz)) {
 					VM_VMHelpers::pushObjectInSpecialFrame(currentThread, srcObject);
+					VM_VMHelpers::pushObjectInSpecialFrame(currentThread, destObject);
 					copyObject = loadFlattenableArrayElement(currentThread, objectAccessBarrier, objectAllocate, srcObject, srcIndex, false);
+					destObject = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
 					srcObject = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
 				}
 
@@ -639,7 +641,9 @@ done:
 				*/
 				if ((NULL == copyObject) && J9_IS_J9CLASS_FLATTENED(srcClazz)) {
 					VM_VMHelpers::pushObjectInSpecialFrame(currentThread, srcObject);
+					VM_VMHelpers::pushObjectInSpecialFrame(currentThread, destObject);
 					copyObject = loadFlattenableArrayElement(currentThread, objectAccessBarrier, objectAllocate, srcObject, srcIndex, false);
+					destObject = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
 					srcObject = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
 				}
 


### PR DESCRIPTION
When calling loadFlattenableArrayElement it is possible that destObject gets moved by the GC. We can get the new, correct address by pushing and popping destObject in a special frame.

Fixes #17675