### PR TITLE
(0.40) Exclude cmdLineTester_CryptoTest in FIPS mode

### DIFF
--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -38,6 +38,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<features>
+			<feature>FIPS:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
@@ -59,6 +62,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<features>
+			<feature>FIPS:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>11+</version>
 		</versions>


### PR DESCRIPTION
Excluded cmdLineTester_CryptoTest in FIPS mode, as per the conversation found in issue #16902.
This is a backport of PR #17533

Signed-off-by: Paritosh Kumar [paritkum@in.ibm.com](mailto:paritkum@in.ibm.com)