### PR TITLE
Reorder j9javaaccessflags.h and remove unused flags

### DIFF
--- a/debugtools/DDR_VM/data/superset-constants.dat
+++ b/debugtools/DDR_VM/data/superset-constants.dat
@@ -2296,13 +2296,10 @@ C|J9AccClassRAMArray
 C|J9AccClassRAMShapeShift
 C|J9AccClassReferenceMask
 C|J9AccClassReferencePhantom
-C|J9AccClassReferenceShift
 C|J9AccClassReferenceSoft
 C|J9AccClassReferenceWeak
 C|J9AccClassRomToRamMask
 C|J9AccClassUnsafe
-C|J9AccClassUnused200
-C|J9AccClassUnused400
 C|J9AccClassUseBisectionSearch
 C|J9AccEmptyMethod
 C|J9AccEnum
@@ -2310,7 +2307,6 @@ C|J9AccFinal
 C|J9AccForwarderMethod
 C|J9AccGetterMethod
 C|J9AccInterface
-C|J9AccMandated
 C|J9AccMethodCallerSensitive
 C|J9AccMethodFrameIteratorSkip
 C|J9AccMethodHasBackwardBranches

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1173,7 +1173,7 @@ ROMClassBuilder::finishPrepareAndLaydown(
  *                                  + AccImplicitCreateHasDefaultValue
  *                                 + AccImplicitCreateNonAtomic
  *                                + J9AccClassIsValueBased
- *                              + J9AccClassHiddenOptionNestmate
+ *                               + J9AccClassHiddenOptionNestmate
  *
  *                             + J9AccClassHiddenOptionStrong
  *                            + AccSealed

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -30,112 +30,144 @@
 
 /* @ddr_namespace: map_to_type=J9JavaAccessFlags */
 
-/* Constants from J9JavaAccessFlags */
-#define J9AccAbstract 0x400
-#define J9AccAnnotation 0x2000
-#define J9AccBridge 0x40
-
-#define J9AccClassHasIdentity 0x20
-#define J9AccImplicitCreateHasDefaultValue 0x10
-#define J9AccImplicitCreateNonAtomic 0x20
-#define J9AccClassIsValueBased 0x40
-#define J9AccClassHiddenOptionNestmate 0x80
-#define J9AccClassHiddenOptionStrong 0x100
-#define J9AccClassAnnnotionRefersDoubleSlotEntry 0x80000
-#define J9AccClassAnonClass 0x800
-#define J9AccClassArray 0x10000
-#define J9AccClassBytecodesModified 0x100000
-#define J9AccClassCloneable 0x80000000
-#define J9AccClassCompatibilityMask 0x7FFF
-#define J9AccClassDepthMask 0xFFFF
-#define J9AccClassDying 0x8000000
-#define J9AccClassFinalizeNeeded 0x40000000
-#define J9AccClassGCSpecial 0x800000
-#define J9AccClassHasBeenOverridden 0x100000
-#define J9AccClassHasClinit 0x4000000
-#define J9AccClassHasEmptyFinalize 0x200000
-#define J9AccClassIsUnmodifiable 0x400000
-#define J9AccClassHasFinalFields 0x2000000
-#define J9AccClassHasJDBCNatives 0x400000
-#define J9AccClassHasNonStaticNonAbstractMethods 0x8000000
-#define J9AccClassHasVerifyData 0x800000
-#define J9AccClassHotSwappedOut 0x4000000
-#define J9AccClassInnerClass 0x4000
-#define J9AccClassHidden 0x8000
-#define J9AccClassNeedsStaticConstantInit 0x10000
-#define J9AccClassIntermediateDataIsClassfile 0x20000
-#define J9AccClassInternalPrimitiveType 0x20000
-#define J9AccClassIsContended 0x1000000
-#define J9AccClassOwnableSynchronizer 0x200000
-#define J9AccClassContinuation 0x1000000
-#define J9AccClassUnused400 0x400
-#define J9AccClassUnused200 0x200
-#define J9AccClassRAMArray 0x10000
-#define J9AccClassRAMShapeShift 0x10
-#define J9AccClassReferenceMask 0x30000000
-#define J9AccClassReferencePhantom 0x30000000
-#define J9AccClassReferenceShift 0x1C
-#define J9AccClassReferenceSoft 0x20000000
-#define J9AccClassReferenceWeak 0x10000000
-#define J9AccClassRomToRamMask 0xF3000000
-#define J9AccClassUnsafe 0x40000
-#define J9AccClassUseBisectionSearch 0x2000
-#define J9AccEmptyMethod 0x4000
-#define J9AccEnum 0x4000
+/*
+ * Modifiers of ROM classes, fields or methods.
+ * When a given modifier is defined by the JVM specification,
+ * the value is taken from that specification.
+ */
+#define J9AccPublic 0x1
+#define J9AccPrivate 0x2
+#define J9AccProtected 0x4
+#define J9AccStatic 0x8
 #define J9AccFinal 0x10
-#define J9AccForwarderMethod 0x2000
-#define J9AccGetterMethod 0x200
+/* Project Valhalla repurposes 0x20 as ACC_IDENTITY since ACC_SUPER has no effect after Java 8. */
+#define J9AccSuper 0x20
+#define J9AccClassHasIdentity 0x20
+#define J9AccValueType 0x40
 #define J9AccInterface 0x200
-#define J9AccMandated 0x8000
-#define J9AccMethodCallerSensitive 0x100000
-#define J9AccMethodAllowFinalFieldWrites 0x1000000
-#define J9AccMethodFrameIteratorSkip 0x80000
-#define J9AccMethodHasBackwardBranches 0x200000
-#define J9AccMethodHasDebugInfo 0x40000
-#define J9AccMethodHasDefaultAnnotation 0x80000000
+#define J9AccAbstract 0x400
+#define J9AccPrimitiveValueType 0x800
+#define J9AccSynthetic 0x1000
+#define J9AccAnnotation 0x2000
+#define J9AccEnum 0x4000
+#define J9AccClassArray 0x10000
+#define J9AccClassInternalPrimitiveType 0x20000
+/* Masks and helpers */
+#define J9AccClassCompatibilityMask 0x7FFF
+
+/*
+ * Modifiers of ROM methods.
+ * When a given modifier is defined by the JVM specification,
+ * the value is taken from that specification.
+ * See map in ROMClassWriter::writeMethods to confirm available slots.
+ */
+#define J9AccSynchronized 0x20
+#define J9AccBridge 0x40
+#define J9AccVarArgs 0x80
+#define J9AccNative 0x100
+#define J9AccGetterMethod 0x200
+#define J9AccStrict 0x800
+#define J9AccForwarderMethod 0x2000
+#define J9AccEmptyMethod 0x4000
+#define J9AccMethodVTable 0x10000
 #define J9AccMethodHasExceptionInfo 0x20000
-#define J9AccMethodHasExtendedModifiers 0x4000000
-#define J9AccMethodHasGenericSignature 0x2000000
-#define J9AccMethodHasMethodAnnotations 0x20000000
-#define J9AccMethodHasMethodHandleInvokes 0x8000000
-#define J9AccMethodHasMethodParameters 0x800000
-#define J9AccMethodHasParameterAnnotations 0x40000000
-#define J9AccMethodHasStackMap 0x10000000
-#define J9AccMethodHasTypeAnnotations 0x4000000
+#define J9AccMethodHasDebugInfo 0x40000
+#define J9AccMethodFrameIteratorSkip 0x80000
+#define J9AccMethodCallerSensitive 0x100000
+#define J9AccMethodHasBackwardBranches 0x200000
 #define J9AccMethodObjectConstructor 0x400000
+#define J9AccMethodHasMethodParameters 0x800000
+#define J9AccMethodAllowFinalFieldWrites 0x1000000
+#define J9AccMethodHasGenericSignature 0x2000000
+#define J9AccMethodHasExtendedModifiers 0x4000000
+#define J9AccMethodHasMethodHandleInvokes 0x8000000
+#define J9AccMethodHasStackMap 0x10000000
+#define J9AccMethodHasMethodAnnotations 0x20000000
+#define J9AccMethodHasParameterAnnotations 0x40000000
+#define J9AccMethodHasDefaultAnnotation 0x80000000
+/* Masks and helpers */
+#define J9AccMethodReturnMask 0x1C0000
+#define J9AccMethodReturnShift 0x12
+/* Used in HookedByTheJit.cpp */
 #define J9AccMethodReturn0 0x0
 #define J9AccMethodReturn1 0x40000
 #define J9AccMethodReturn2 0x80000
 #define J9AccMethodReturnA 0x140000
 #define J9AccMethodReturnD 0x100000
 #define J9AccMethodReturnF 0xC0000
-#define J9AccMethodReturnMask 0x1C0000
-#define J9AccMethodReturnShift 0x12
-#define J9AccMethodVTable 0x10000
-#define J9AccNative 0x100
-#define J9AccPrivate 0x2
-#define J9AccProtected 0x4
-#define J9AccPublic 0x1
-#define J9AccStatic 0x8
-#define J9AccStrict 0x800
-#define J9AccSuper 0x20
-#define J9AccSynchronized 0x20
-#define J9AccSynthetic 0x1000
-#define J9AccTransient 0x80
-#define J9AccVarArgs 0x80
+/* DDR flags */
+#define J9AccMethodHasTypeAnnotations 0x4000000
+
+/*
+ * Modifiers of ROM fields.
+ * When a given modifier is defined by the JVM specification,
+ * the value is taken from that specification.
+ */
 #define J9AccVolatile 0x40
-#define J9AccValueType 0x40
-#define J9AccRecord 0x400
+#define J9AccTransient 0x80
+
+/* Extra modifiers of ROM classes.
+ * When a given modifier is defined by the JVM specification,
+ * the value is taken from that specification.
+ * See map in ROMClassBuilder::computeExtraModifiers for
+ * available slots.
+ */
+#define J9AccImplicitCreateHasDefaultValue 0x10
+#define J9AccImplicitCreateNonAtomic 0x20
+#define J9AccClassIsValueBased 0x40
+#define J9AccClassHiddenOptionNestmate 0x80
+#define J9AccClassHiddenOptionStrong 0x100
 #define J9AccSealed 0x200
-#define J9AccPrimitiveValueType 0x800
+#define J9AccRecord 0x400
+#define J9AccClassAnonClass 0x800
+#define J9AccClassUseBisectionSearch 0x2000
+#define J9AccClassInnerClass 0x4000
+#define J9AccClassHidden 0x8000
+#define J9AccClassNeedsStaticConstantInit 0x10000
+#define J9AccClassIntermediateDataIsClassfile 0x20000
+#define J9AccClassUnsafe 0x40000
+#define J9AccClassAnnnotionRefersDoubleSlotEntry 0x80000
+#define J9AccClassBytecodesModified 0x100000
+#define J9AccClassHasEmptyFinalize 0x200000
+#define J9AccClassIsUnmodifiable 0x400000
+#define J9AccClassHasVerifyData 0x800000
+#define J9AccClassIsContended 0x1000000
+#define J9AccClassHasFinalFields 0x2000000
+#define J9AccClassHasClinit 0x4000000
+#define J9AccClassHasNonStaticNonAbstractMethods 0x8000000
+#define J9AccClassReferenceWeak 0x10000000
+#define J9AccClassReferenceSoft 0x20000000
+#define J9AccClassReferencePhantom 0x30000000
+#define J9AccClassFinalizeNeeded 0x40000000
+#define J9AccClassCloneable 0x80000000
+
+/* RAM class classDepthAndFlags.
+ * See map in createramclass.cpp:internalCreateRAMClassFromROMClassImpl
+ * for available slots.
+ */
+#define J9AccClassRAMArray 0x10000
+#define J9AccClassHasBeenOverridden 0x100000
+#define J9AccClassOwnableSynchronizer 0x200000
+#define J9AccClassHasJDBCNatives 0x400000
+#define J9AccClassGCSpecial 0x800000
+#define J9AccClassContinuation 0x1000000
+#define J9AccClassHotSwappedOut 0x4000000
+#define J9AccClassDying 0x8000000
+/* Masks and helpers */
+#define J9AccClassDepthMask 0xFFFF
+#define J9AccClassReferenceMask 0x30000000
+#define J9AccClassRomToRamMask 0xF3000000
+#define J9AccClassRAMShapeShift 0x10
+#define J9_JAVA_CLASS_FINALIZER_CHECK_MASK (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)
+#define J9_JAVA_MODIFIERS_SPECIAL_OBJECT (J9AccClassFinalizeNeeded | J9AccClassReferenceMask)
+
+/* static field helpers*/
 #define J9StaticFieldRefBaseType 0x1
 #define J9StaticFieldRefDouble 0x2
 #define J9StaticFieldRefVolatile 0x4
 #define J9StaticFieldRefBoolean 0x8
 #define J9StaticFieldRefPutResolved 0x10
-#define J9StaticFieldRefFinal 0x20
 #define J9StaticFieldRefFlagBits 0x3F
-#define J9_JAVA_CLASS_FINALIZER_CHECK_MASK (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)
-#define J9_JAVA_MODIFIERS_SPECIAL_OBJECT (J9AccClassFinalizeNeeded | J9AccClassReferenceMask)
+#define J9StaticFieldRefFinal 0x20
 
 #endif /*J9JAVAACCESSFLAGS_H */

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -34,58 +34,55 @@
  * Modifiers of ROM classes, fields or methods.
  * When a given modifier is defined by the JVM specification,
  * the value is taken from that specification.
+ *
+ * See map in ROMClassWriter::writeMethods to confirm available slots for methods.
  */
-#define J9AccPublic 0x1
-#define J9AccPrivate 0x2
-#define J9AccProtected 0x4
-#define J9AccStatic 0x8
-#define J9AccFinal 0x10
-/* Project Valhalla repurposes 0x20 as ACC_IDENTITY since ACC_SUPER has no effect after Java 8. */
-#define J9AccSuper 0x20
-#define J9AccClassHasIdentity 0x20
-#define J9AccValueType 0x40
-#define J9AccInterface 0x200
-#define J9AccAbstract 0x400
-#define J9AccPrimitiveValueType 0x800
-#define J9AccSynthetic 0x1000
-#define J9AccAnnotation 0x2000
-#define J9AccEnum 0x4000
-#define J9AccClassArray 0x10000
-#define J9AccClassInternalPrimitiveType 0x20000
+#define J9AccPublic                        0x00000001 /* class method field */
+#define J9AccPrivate                       0x00000002 /* class(nested) method field */
+#define J9AccProtected                     0x00000004 /* class(nested) method field */
+#define J9AccStatic                        0x00000008 /* class(nested) method field */
+#define J9AccFinal                         0x00000010 /* class method field */
+/* Project Valhalla repurposes 0x00000020 as ACC_IDENTITY since ACC_SUPER has no effect after Java 8. */
+#define J9AccSuper                         0x00000020 /* class */
+#define J9AccClassHasIdentity              0x00000020 /* class */
+#define J9AccSynchronized                  0x00000020 /* method */
+#define J9AccValueType                     0x00000040 /* class(Valhalla) */
+#define J9AccBridge                        0x00000040 /* method */
+#define J9AccVolatile                      0x00000040 /* field */
+#define J9AccVarArgs                       0x00000080 /* method */
+#define J9AccTransient                     0x00000080 /* field */
+#define J9AccNative                        0x00000100 /* method */
+#define J9AccInterface                     0x00000200 /* class */
+#define J9AccGetterMethod                  0x00000200 /* method */
+#define J9AccAbstract                      0x00000400 /* class method */
+#define J9AccPrimitiveValueType            0x00000800 /* class(Valhalla) */
+#define J9AccStrict                        0x00000800 /* method */
+#define J9AccSynthetic                     0x00001000 /* class method field */
+#define J9AccAnnotation                    0x00002000 /* class */
+#define J9AccForwarderMethod               0x00002000 /* method */
+#define J9AccEnum                          0x00004000 /* class field */
+#define J9AccEmptyMethod                   0x00004000 /* method */
+/* ACC_MODULE reserves 0x00008000 for classes */
+#define J9AccClassArray                    0x00010000 /* class */
+#define J9AccMethodVTable                  0x00010000 /* method */
+#define J9AccClassInternalPrimitiveType    0x00020000 /* class */
+#define J9AccMethodHasExceptionInfo        0x00020000 /* method */
+#define J9AccMethodHasDebugInfo            0x00040000 /* method */
+#define J9AccMethodFrameIteratorSkip       0x00080000 /* method */
+#define J9AccMethodCallerSensitive         0x00100000 /* method */
+#define J9AccMethodHasBackwardBranches     0x00200000 /* method */
+#define J9AccMethodObjectConstructor       0x00400000 /* method */
+#define J9AccMethodHasMethodParameters     0x00800000 /* method */
+#define J9AccMethodAllowFinalFieldWrites   0x01000000 /* method */
+#define J9AccMethodHasGenericSignature     0x02000000 /* method */
+#define J9AccMethodHasExtendedModifiers    0x04000000 /* method */
+#define J9AccMethodHasMethodHandleInvokes  0x08000000 /* method */
+#define J9AccMethodHasStackMap             0x10000000 /* method */
+#define J9AccMethodHasMethodAnnotations    0x20000000 /* method */
+#define J9AccMethodHasParameterAnnotations 0x40000000 /* method */
+#define J9AccMethodHasDefaultAnnotation    0x80000000 /* method */
 /* Masks and helpers */
 #define J9AccClassCompatibilityMask 0x7FFF
-
-/*
- * Modifiers of ROM methods.
- * When a given modifier is defined by the JVM specification,
- * the value is taken from that specification.
- * See map in ROMClassWriter::writeMethods to confirm available slots.
- */
-#define J9AccSynchronized 0x20
-#define J9AccBridge 0x40
-#define J9AccVarArgs 0x80
-#define J9AccNative 0x100
-#define J9AccGetterMethod 0x200
-#define J9AccStrict 0x800
-#define J9AccForwarderMethod 0x2000
-#define J9AccEmptyMethod 0x4000
-#define J9AccMethodVTable 0x10000
-#define J9AccMethodHasExceptionInfo 0x20000
-#define J9AccMethodHasDebugInfo 0x40000
-#define J9AccMethodFrameIteratorSkip 0x80000
-#define J9AccMethodCallerSensitive 0x100000
-#define J9AccMethodHasBackwardBranches 0x200000
-#define J9AccMethodObjectConstructor 0x400000
-#define J9AccMethodHasMethodParameters 0x800000
-#define J9AccMethodAllowFinalFieldWrites 0x1000000
-#define J9AccMethodHasGenericSignature 0x2000000
-#define J9AccMethodHasExtendedModifiers 0x4000000
-#define J9AccMethodHasMethodHandleInvokes 0x8000000
-#define J9AccMethodHasStackMap 0x10000000
-#define J9AccMethodHasMethodAnnotations 0x20000000
-#define J9AccMethodHasParameterAnnotations 0x40000000
-#define J9AccMethodHasDefaultAnnotation 0x80000000
-/* Masks and helpers */
 #define J9AccMethodReturnMask 0x1C0000
 #define J9AccMethodReturnShift 0x12
 /* Used in HookedByTheJit.cpp */
@@ -97,14 +94,6 @@
 #define J9AccMethodReturnF 0xC0000
 /* DDR flags */
 #define J9AccMethodHasTypeAnnotations 0x4000000
-
-/*
- * Modifiers of ROM fields.
- * When a given modifier is defined by the JVM specification,
- * the value is taken from that specification.
- */
-#define J9AccVolatile 0x40
-#define J9AccTransient 0x80
 
 /* Extra modifiers of ROM classes.
  * When a given modifier is defined by the JVM specification,


### PR DESCRIPTION
- Reorganized these values to be more readable
- Deleted the unused values:
#define J9AccMandated 0x8000
#define J9AccClassReferenceShift 0x1C
#define J9AccClassUnused400 0x400 <-- I don't think these placeholders are really helping anyone
#define J9AccClassUnused200 0x200

Related to https://github.com/eclipse-openj9/openj9/issues/17785