### PR TITLE
Initialize JITServer SSL context post CRIU restore

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1283,6 +1283,7 @@ public:
    void  addJITServerSslCert(const std::string &cert) { _sslCerts.push_back(cert); }
    const std::string &getJITServerSslRootCerts() const { return _sslRootCerts; }
    void  setJITServerSslRootCerts(const std::string &cert) { _sslRootCerts = cert; }
+   void  freeClientSslCertificates() { _sslRootCerts.clear(); }
    const PersistentVector<std::string> &getJITServerMetricsSslKeys() const { return _metricsSslKeys; }
    void  addJITServerMetricsSslKey(const std::string &key) { _metricsSslKeys.push_back(key); }
    const PersistentVector<std::string> &getJITServerMetricsSslCerts() const { return _metricsSslCerts; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2935,6 +2935,18 @@ void TR::CompilationInfo::prepareForCheckpoint()
    if (!suspendCompThreadsForCheckpoint(vmThread))
       return;
 
+#if defined(J9VM_OPT_JITSERVER)
+   // If this is a JITServer client that has an SSL context, free that context now
+   if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+      {
+      if (JITServer::CommunicationStream::useSSL())
+         {
+         freeClientSslCertificates();
+         JITServer::ClientStream::freeSSLContext();
+         }
+      }
+#endif
+
    setReadyForCheckpointRestore();
    }
 

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -66,6 +66,7 @@ public:
        Returns 0 if successful;; Otherwise, returns -1.
    */
    static int static_init(TR::CompilationInfo *compInfo);
+   static void freeSSLContext();
 
    explicit ClientStream(TR::PersistentInfo *info);
    virtual ~ClientStream()


### PR DESCRIPTION
When encryption is enabled for a JITServer client post CRIU restore, the client needs to update its SSL configuration with the newly provided certificate. This is done in `ClientStream::static_init()` function which needs to be called during `processOptionsPostRestore()`.

Moreover, if SSL encryption was specified pre-checkpoint, the hook that gets executed, `TR::CompilationInfo::prepareForCheckpoint()`, will delete the existing SSL context and any existing certificate.

Issue: #17786