### PR TITLE
Update the default mode for adding to the continuation list

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -386,7 +386,7 @@ public:
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
 		, continuationListOption(enable_continuation_list)
-		, timingAddContinuationInList(onStarted)
+		, timingAddContinuationInList(onCreated)
 	{
 		_typeId = __FUNCTION__;
 	}


### PR DESCRIPTION
Related: #17554

Currently, the default mode is “onStarted”. This adds the continuation
to the list only when the VirtualThread (or the Continuation) starts.

The “onCreated” mode adds to the list as soon as the VirtualThread
(or the Continuation) object is created. This mode is needed if JVMTI
is used. So, the default is changed to “onCreated” until we can
dynamically determine that JVMTI won’t be used.

With “onStarted” as default, the following failures started to occur
last week:
- #17784
- #17791 (intermittent)
- #17782 (intermittent)