### PR TITLE
[FFI/Jtreg_JDK21] Sign extend the negative byte/short for upcall

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5995,10 +5995,6 @@ typedef struct J9JavaVM {
 /* The mask for the signature type identifier */
 #define J9_FFI_UPCALL_SIG_TYPE_MASK 0xF
 
-/* The mask for the normalized type identifier */
-#define J9_FFI_UPCALL_BYTE_TYPE_MASK 0xFF
-#define J9_FFI_UPCALL_SHORT_TYPE_MASK 0xFFFF
-
 /* The signature types intended for upcall */
 #define J9_FFI_UPCALL_SIG_TYPE_VOID    0x1
 #define J9_FFI_UPCALL_SIG_TYPE_CHAR    0x2

--- a/runtime/tests/clinkerffi/CMakeLists.txt
+++ b/runtime/tests/clinkerffi/CMakeLists.txt
@@ -405,6 +405,8 @@ omr_add_exports(clinkerffitests
 	addLongIntOfStructsFromVaListByUpcallMH
 	addFloatDoubleOfStructsFromVaListByUpcallMH
 	addDoubleFloatOfStructsFromVaListByUpcallMH
+	addNegBytesFromStructByUpcallMH
+	addNegShortsFromStructByUpcallMH
 )
 
 install(

--- a/runtime/tests/clinkerffi/module.xml
+++ b/runtime/tests/clinkerffi/module.xml
@@ -396,6 +396,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="addLongIntOfStructsFromVaListByUpcallMH"/>
 		<export name="addFloatDoubleOfStructsFromVaListByUpcallMH"/>
 		<export name="addDoubleFloatOfStructsFromVaListByUpcallMH"/>
+		<export name="addNegBytesFromStructByUpcallMH"/>
+		<export name="addNegShortsFromStructByUpcallMH"/>
 	</exports>
 
 	<artifact type="shared" name="clinkerffitests" appendrelease="false">

--- a/runtime/tests/clinkerffi/upcall.c
+++ b/runtime/tests/clinkerffi/upcall.c
@@ -2866,3 +2866,33 @@ validateReturnNullAddrByUpcallMH(stru_Int_Int *arg1, stru_Int_Int arg2, stru_Int
 	(*upcallMH)(arg1, arg2);
 	return arg1;
 }
+
+/**
+ * Add negative bytes from a struct by invoking an upcall method.
+ *
+ * @param arg1 a negative byte
+ * @param arg2 a struct with two negative bytes
+ * @param upcallMH the function pointer to the upcall method
+ * @return the sum
+ */
+char
+addNegBytesFromStructByUpcallMH(char arg1, stru_Byte_Byte arg2, char (*upcallMH)(char, stru_Byte_Byte, char, char))
+{
+	char byteSum = (*upcallMH)(arg1, arg2, arg2.elem1, arg2.elem2);
+	return byteSum;
+}
+
+/**
+ * Add negative shorts from a struct by invoking an upcall method.
+ *
+ * @param arg1 a negative short
+ * @param arg2 a struct with two negative shorts
+ * @param upcallMH the function pointer to the upcall method
+ * @return the sum
+ */
+short
+addNegShortsFromStructByUpcallMH(short arg1, stru_Short_Short arg2, short (*upcallMH)(short, stru_Short_Short, short, short))
+{
+	short shortSum = (*upcallMH)(arg1, arg2, arg2.elem1, arg2.elem2);
+	return shortSum;
+}

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
@@ -3068,4 +3068,52 @@ public class UpcallMHWithStructTests {
 			Assert.assertEquals((double)doubleHandle3.get(resultSegmt), 88.579D, 0.001D);
 		}
 	}
+
+	@Test
+	public void test_addNegBytesFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"), C_CHAR.withName("elem2"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+
+		MethodType mt = MethodType.methodType(byte.class, byte.class, MemorySegment.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_CHAR, C_CHAR, structLayout, C_POINTER);
+		Addressable functionSymbol = nativeLibLookup.lookup("addNegBytesFromStructByUpcallMH").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(UpcallMethodHandles.MH_addNegBytesFromStruct,
+					FunctionDescriptor.of(C_CHAR, C_CHAR, structLayout, C_CHAR, C_CHAR), scope);
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt, (byte)-8);
+			byteHandle2.set(structSegmt, (byte)-9);
+
+			byte result = (byte)mh.invoke((byte)-6, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (byte)-40);
+		}
+	}
+
+	@Test
+	public void test_addNegShortsFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"), C_SHORT.withName("elem2"));
+		VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+
+		MethodType mt = MethodType.methodType(short.class, short.class, MemorySegment.class, MemoryAddress.class);
+		FunctionDescriptor fd = FunctionDescriptor.of(C_SHORT, C_SHORT, structLayout, C_POINTER);
+		Addressable functionSymbol = nativeLibLookup.lookup("addNegShortsFromStructByUpcallMH").get();
+		MethodHandle mh = clinker.downcallHandle(functionSymbol, mt, fd);
+
+		try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+			MemoryAddress upcallFuncAddr = clinker.upcallStub(UpcallMethodHandles.MH_addNegShortsFromStruct,
+					FunctionDescriptor.of(C_SHORT, C_SHORT, structLayout, C_SHORT, C_SHORT), scope);
+			SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
+			MemorySegment structSegmt = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt, (short)-888);
+			shortHandle2.set(structSegmt, (short)-999);
+
+			short result = (short)mh.invoke((short)-777, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (short)-4551);
+		}
+	}
 }

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
@@ -21,6 +21,8 @@
  *******************************************************************************/
 package org.openj9.test.jep389.upcall;
 
+import org.testng.Assert;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -274,6 +276,9 @@ public class UpcallMethodHandles {
 	public static final MethodHandle MH_return254BytesFromStruct;
 	public static final MethodHandle MH_return4KBytesFromStruct;
 
+	public static final MethodHandle MH_addNegBytesFromStruct;
+	public static final MethodHandle MH_addNegShortsFromStruct;
+
 	private static CLinker clinker = CLinker.getInstance();
 
 	static {
@@ -482,6 +487,9 @@ public class UpcallMethodHandles {
 			MH_addDoubleAndIntDoubleLongFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addDoubleAndIntDoubleLongFromStruct", MT_Double_Double_MemSegmt); //$NON-NLS-1$
 			MH_return254BytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return254BytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
 			MH_return4KBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return4KBytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
+
+			MH_addNegBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegBytesFromStruct", MT_Byte_Byte_MemSegmt.appendParameterTypes(byte.class, byte.class)); //$NON-NLS-1$
+			MH_addNegShortsFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegShortsFromStruct", MT_Short_Short_MemSegmt.appendParameterTypes(short.class, short.class)); //$NON-NLS-1$
 
 		} catch (IllegalAccessException | NoSuchMethodException e) {
 			throw new InternalError(e);
@@ -2520,5 +2528,39 @@ public class UpcallMethodHandles {
 			MemoryAccess.setByteAtOffset(byteArrStruSegment, i, (byte)i);
 		}
 		return byteArrStruSegment;
+	}
+
+	public static byte addNegBytesFromStruct(byte arg1, MemorySegment arg2, byte arg3, byte arg4) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_CHAR.withName("elem1"), C_CHAR.withName("elem2"));
+		VarHandle byteHandle1 = structLayout.varHandle(byte.class, PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(byte.class, PathElement.groupElement("elem2"));
+		byte arg2_elem1 = (byte)byteHandle1.get(arg2);
+		byte arg2_elem2 = (byte)byteHandle2.get(arg2);
+
+		Assert.assertEquals((byte)-6, ((Byte)arg1).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg2_elem1).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg2_elem2).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg3).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg4).byteValue());
+
+		byte byteSum = (byte)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return byteSum;
+	}
+
+	public static short addNegShortsFromStruct(short arg1,  MemorySegment arg2, short arg3, short arg4) {
+		GroupLayout structLayout = MemoryLayout.structLayout(C_SHORT.withName("elem1"), C_SHORT.withName("elem2"));
+		VarHandle shortHandle1 = structLayout.varHandle(short.class, PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(short.class, PathElement.groupElement("elem2"));
+		short arg2_elem1 = (short)shortHandle1.get(arg2);
+		short arg2_elem2 = (short)shortHandle2.get(arg2);
+
+		Assert.assertEquals((short)-777, ((Short)arg1).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg2_elem1).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg2_elem2).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg3).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg4).shortValue());
+
+		short shortSum = (short)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return shortSum;
 	}
 }

--- a/test/functional/Java20andUp/src/org/openj9/test/jep434/upcall/UpcallMHWithStructTests.java
+++ b/test/functional/Java20andUp/src/org/openj9/test/jep434/upcall/UpcallMHWithStructTests.java
@@ -2899,4 +2899,50 @@ public class UpcallMHWithStructTests {
 			Assert.assertEquals((double)doubleHandle3.get(resultSegmt), 88.579D, 0.001D);
 		}
 	}
+
+	@Test
+	public void test_addNegBytesFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_BYTE.withName("elem1"), JAVA_BYTE.withName("elem2"));
+		VarHandle byteHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, structLayout, ADDRESS);
+		MemorySegment functionSymbol = nativeLibLookup.find("addNegBytesFromStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (Arena arena = Arena.openConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_addNegBytesFromStruct,
+					FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, structLayout, JAVA_BYTE, JAVA_BYTE), arena.scope());
+			SegmentAllocator allocator = SegmentAllocator.nativeAllocator(arena.scope());
+			MemorySegment structSegmt = allocator.allocate(structLayout);
+			byteHandle1.set(structSegmt, (byte)-8);
+			byteHandle2.set(structSegmt, (byte)-9);
+
+			byte result = (byte)mh.invoke((byte)-6, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (byte)-40);
+		}
+	}
+
+	@Test
+	public void test_addNegShortsFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_SHORT.withName("elem1"), JAVA_SHORT.withName("elem2"));
+		VarHandle shortHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, structLayout, ADDRESS);
+		MemorySegment functionSymbol = nativeLibLookup.find("addNegShortsFromStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (Arena arena = Arena.openConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_addNegShortsFromStruct,
+					FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, structLayout, JAVA_SHORT, JAVA_SHORT), arena.scope());
+			SegmentAllocator allocator = SegmentAllocator.nativeAllocator(arena.scope());
+			MemorySegment structSegmt = allocator.allocate(structLayout);
+			shortHandle1.set(structSegmt, (short)-888);
+			shortHandle2.set(structSegmt, (short)-999);
+
+			short result = (short)mh.invoke((short)-777, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (short)-4551);
+		}
+	}
 }

--- a/test/functional/Java20andUp/src/org/openj9/test/jep434/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java20andUp/src/org/openj9/test/jep434/upcall/UpcallMethodHandles.java
@@ -21,6 +21,8 @@
  *******************************************************************************/
 package org.openj9.test.jep434.upcall;
 
+import org.testng.Assert;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -271,6 +273,9 @@ public class UpcallMethodHandles {
 	public static final MethodHandle MH_return254BytesFromStruct;
 	public static final MethodHandle MH_return4KBytesFromStruct;
 
+	public static final MethodHandle MH_addNegBytesFromStruct;
+	public static final MethodHandle MH_addNegShortsFromStruct;
+
 	private static Linker linker = Linker.nativeLinker();
 
 	static {
@@ -480,6 +485,9 @@ public class UpcallMethodHandles {
 			MH_addDoubleAndIntDoubleLongFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addDoubleAndIntDoubleLongFromStruct", MT_Double_Double_MemSegmt); //$NON-NLS-1$
 			MH_return254BytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return254BytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
 			MH_return4KBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return4KBytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
+
+			MH_addNegBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegBytesFromStruct", MT_Byte_Byte_MemSegmt.appendParameterTypes(byte.class, byte.class)); //$NON-NLS-1$
+			MH_addNegShortsFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegShortsFromStruct", MT_Short_Short_MemSegmt.appendParameterTypes(short.class, short.class)); //$NON-NLS-1$
 
 		} catch (IllegalAccessException | NoSuchMethodException e) {
 			throw new InternalError(e);
@@ -2032,5 +2040,33 @@ public class UpcallMethodHandles {
 			byteArrStruSegment.set(JAVA_BYTE, i, (byte)i);
 		}
 		return byteArrStruSegment;
+	}
+
+	public static byte addNegBytesFromStruct(byte arg1, MemorySegment arg2, byte arg3, byte arg4) {
+		byte arg2_elem1 = arg2.get(JAVA_BYTE, 0);
+		byte arg2_elem2 = arg2.get(JAVA_BYTE, 1);
+
+		Assert.assertEquals((byte)-6, ((Byte)arg1).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg2_elem1).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg2_elem2).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg3).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg4).byteValue());
+
+		byte byteSum = (byte)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return byteSum;
+	}
+
+	public static short addNegShortsFromStruct(short arg1,  MemorySegment arg2, short arg3, short arg4) {
+		short arg2_elem1 = arg2.get(JAVA_SHORT, 0);
+		short arg2_elem2 = arg2.get(JAVA_SHORT, 2);
+
+		Assert.assertEquals((short)-777, ((Short)arg1).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg2_elem1).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg2_elem2).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg3).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg4).shortValue());
+
+		short shortSum = (short)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return shortSum;
 	}
 }

--- a/test/functional/Java21andUp/src/org/openj9/test/jep442/upcall/UpcallMHWithStructTests.java
+++ b/test/functional/Java21andUp/src/org/openj9/test/jep442/upcall/UpcallMHWithStructTests.java
@@ -2738,4 +2738,48 @@ public class UpcallMHWithStructTests {
 			Assert.assertEquals((double)doubleHandle3.get(resultSegmt), 88.579D, 0.001D);
 		}
 	}
+
+	@Test
+	public void test_addNegBytesFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_BYTE.withName("elem1"), JAVA_BYTE.withName("elem2"));
+		VarHandle byteHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle byteHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, structLayout, ADDRESS);
+		MemorySegment functionSymbol = nativeLibLookup.find("addNegBytesFromStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_addNegBytesFromStruct,
+					FunctionDescriptor.of(JAVA_BYTE, JAVA_BYTE, structLayout, JAVA_BYTE, JAVA_BYTE), arena);
+			MemorySegment structSegmt = arena.allocate(structLayout);
+			byteHandle1.set(structSegmt, (byte)-8);
+			byteHandle2.set(structSegmt, (byte)-9);
+
+			byte result = (byte)mh.invoke((byte)-6, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (byte)-40);
+		}
+	}
+
+	@Test
+	public void test_addNegShortsFromStructByUpcallMH() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_SHORT.withName("elem1"), JAVA_SHORT.withName("elem2"));
+		VarHandle shortHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));
+		VarHandle shortHandle2 = structLayout.varHandle(PathElement.groupElement("elem2"));
+
+		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, structLayout, ADDRESS);
+		MemorySegment functionSymbol = nativeLibLookup.find("addNegShortsFromStructByUpcallMH").get();
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_addNegShortsFromStruct,
+					FunctionDescriptor.of(JAVA_SHORT, JAVA_SHORT, structLayout, JAVA_SHORT, JAVA_SHORT), arena);
+			MemorySegment structSegmt = arena.allocate(structLayout);
+			shortHandle1.set(structSegmt, (short)-888);
+			shortHandle2.set(structSegmt, (short)-999);
+
+			short result = (short)mh.invoke((short)-777, structSegmt, upcallFuncAddr);
+			Assert.assertEquals(result, (short)-4551);
+		}
+	}
 }

--- a/test/functional/Java21andUp/src/org/openj9/test/jep442/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java21andUp/src/org/openj9/test/jep442/upcall/UpcallMethodHandles.java
@@ -21,6 +21,8 @@
  *******************************************************************************/
 package org.openj9.test.jep442.upcall;
 
+import org.testng.Assert;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -269,6 +271,9 @@ public class UpcallMethodHandles {
 	public static final MethodHandle MH_return254BytesFromStruct;
 	public static final MethodHandle MH_return4KBytesFromStruct;
 
+	public static final MethodHandle MH_addNegBytesFromStruct;
+	public static final MethodHandle MH_addNegShortsFromStruct;
+
 	private static Linker linker = Linker.nativeLinker();
 
 	static {
@@ -478,6 +483,9 @@ public class UpcallMethodHandles {
 			MH_addDoubleAndIntDoubleLongFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addDoubleAndIntDoubleLongFromStruct", MT_Double_Double_MemSegmt); //$NON-NLS-1$
 			MH_return254BytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return254BytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
 			MH_return4KBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "return4KBytesFromStruct", MT_MemSegmt); //$NON-NLS-1$
+
+			MH_addNegBytesFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegBytesFromStruct", MT_Byte_Byte_MemSegmt.appendParameterTypes(byte.class, byte.class)); //$NON-NLS-1$
+			MH_addNegShortsFromStruct = lookup.findStatic(UpcallMethodHandles.class, "addNegShortsFromStruct", MT_Short_Short_MemSegmt.appendParameterTypes(short.class, short.class)); //$NON-NLS-1$
 
 		} catch (IllegalAccessException | NoSuchMethodException e) {
 			throw new InternalError(e);
@@ -2030,5 +2038,33 @@ public class UpcallMethodHandles {
 			byteArrStruSegment.set(JAVA_BYTE, i, (byte)i);
 		}
 		return byteArrStruSegment;
+	}
+
+	public static byte addNegBytesFromStruct(byte arg1, MemorySegment arg2, byte arg3, byte arg4) {
+		byte arg2_elem1 = arg2.get(JAVA_BYTE, 0);
+		byte arg2_elem2 = arg2.get(JAVA_BYTE, 1);
+
+		Assert.assertEquals((byte)-6, ((Byte)arg1).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg2_elem1).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg2_elem2).byteValue());
+		Assert.assertEquals((byte)-8, ((Byte)arg3).byteValue());
+		Assert.assertEquals((byte)-9, ((Byte)arg4).byteValue());
+
+		byte byteSum = (byte)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return byteSum;
+	}
+
+	public static short addNegShortsFromStruct(short arg1,  MemorySegment arg2, short arg3, short arg4) {
+		short arg2_elem1 = arg2.get(JAVA_SHORT, 0);
+		short arg2_elem2 = arg2.get(JAVA_SHORT, 2);
+
+		Assert.assertEquals((short)-777, ((Short)arg1).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg2_elem1).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg2_elem2).shortValue());
+		Assert.assertEquals((short)-888, ((Short)arg3).shortValue());
+		Assert.assertEquals((short)-999, ((Short)arg4).shortValue());
+
+		short shortSum = (short)(arg1 + arg2_elem1 + arg2_elem2 + arg3 + arg4);
+		return shortSum;
 	}
 }


### PR DESCRIPTION
The changes perform the sign extension operation
on the negative byte/short value to guarantee
the negative value to be accessed correctly
during the upcall.

Fixes: #17779

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>