### PR TITLE
Prevent a divide by zero in computeThreadCpuUtilOverLastNns()

### DIFF
--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -316,7 +316,6 @@ int32_t CpuSelfThreadUtilization::computeThreadCpuUtilOverLastNns(int64_t validI
       int64_t totalCPU = _cpuTimeDuringLastInterval;
       int64_t totalTime = _lastIntervalLength;
 
-     
       // The interval between crtTimeNs and lastIntervalEndNs is not accounted for; if this interval
       // is larger than the measurement period the thread might have gone to sleep and not
       // had a chance to update its CPU utilization. Blindly assume a 0% duty cycle
@@ -334,6 +333,8 @@ int32_t CpuSelfThreadUtilization::computeThreadCpuUtilOverLastNns(int64_t validI
             totalTime += _secondLastIntervalLength;
             }
          }
+      if (totalTime == 0)
+         return -1; // A race condition can defeat our attempts to avoid DivByZero, so we need to check here and bailout rather then cause an exception
       return  (int32_t)(100 * totalCPU / totalTime);
       }
    }


### PR DESCRIPTION
The computeThreadCpuUtilOverLastNns() method can cause an integer divide by zero when a race condition occurs between the sampler thread and a compiler thread. This fix will return -1 (error) when the divisor is 0.