### PR TITLE
Check if prev test failed when checking vlog

### DIFF
--- a/test/functional/cmdLineTests/criu/criuCatVlog.sh
+++ b/test/functional/cmdLineTests/criu/criuCatVlog.sh
@@ -48,12 +48,12 @@ else
         echo ""
 
         cat_prev_output
-
-        $(grep -q "Thread pid mismatch\|do not match expected\|Unable to create a thread:" testOutput criuOutput)
-        if [ $? -eq 0 ]; then
-            echo "CAT VLOG FORCE PASS"
-        fi
     fi
+fi
+
+$(grep -q "Thread pid mismatch\|do not match expected\|Unable to create a thread:" testOutput criuOutput)
+if [ $? -eq 0 ]; then
+    echo "CAT VLOG FORCE PASS"
 fi
 
 if [ "$3" == true ]; then


### PR DESCRIPTION
Check if the previous test failed when checking the vlog regardless of whether the vlog exists or not; if a vlog is specified pre-checkpoint then it will exist post-restore even if the restore fails for one of the known reasons.

Fixes https://github.com/eclipse-openj9/openj9/issues/17729