### PR TITLE
Allow Object to be modifiable in extended HCR

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -247,11 +247,6 @@ public:
 				&& (isClassAnon() || isClassHidden())
 			) {
 				unmodifiable = true;
-			} else if (NULL == J9VMJAVALANGOBJECT_OR_NULL(_javaVM)) {
-				/* Object is currently only allowed to be redefined in fast HCR */
-				if (areExtensionsEnabled(_javaVM)) {
-					unmodifiable = true;
-				}
 			}
 		}
 		return unmodifiable;


### PR DESCRIPTION
Currently, Object is marked unmodifiable if extended HCR is enabled.
This change allows Object to be modified, but disallows use of the
extensions on Object.

Fixes: #17454

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>