### PR TITLE
Restore @Override annotation for Access.getLoaderNameID()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -710,7 +710,8 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
 
-/*[IF (JAVA_SPEC_VERSION >= 11) & (JAVA_SPEC_VERSION != 20)]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
+	@Override
 	public String getLoaderNameID(ClassLoader loader) {
 		StringBuilder buffer = new StringBuilder();
 		String name = loader.getName();
@@ -727,7 +728,7 @@ final class Access implements JavaLangAccess {
 
 		return buffer.toString();
 	}
-/*[ENDIF] (JAVA_SPEC_VERSION >= 11) & (JAVA_SPEC_VERSION != 20) */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF INLINE-TYPES]*/
 	@Override


### PR DESCRIPTION
Removed special case for 20 since 20 is no longer supported.

Obsoletes https://github.com/eclipse-openj9/openj9/pull/17362