### PR TITLE
(0.40) Update OpenSSL to the 1.1.1 July 19 CVE level

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -133,7 +133,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1u'
+  extra_getsource_options: '--openssl-version=OpenSSL_1_1_1u+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Includes fix for CVE-2023-3446.

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/17828 for 0.40