### PR TITLE
Rename TR_InlinedSiteHastTableEntry to TR_InlinedSiteHashTableEntry

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2735,7 +2735,7 @@ static TR_ExternalRelocationTargetKind getReloKindFromGuardSite(TR::CodeGenerato
    return type;
    }
 
-static void processAOTGuardSites(TR::CodeGenerator *cg, uint32_t inlinedCallSize, TR_InlinedSiteHastTableEntry *orderedInlinedSiteListTable)
+static void processAOTGuardSites(TR::CodeGenerator *cg, uint32_t inlinedCallSize, TR_InlinedSiteHashTableEntry *orderedInlinedSiteListTable)
    {
    TR::list<TR_AOTGuardSite*> *aotGuardSites = cg->comp()->getAOTGuardPatchSites();
    for(auto it = aotGuardSites->begin(); it != aotGuardSites->end(); ++it)
@@ -2845,7 +2845,7 @@ static void addInlinedSiteRelocation(TR::CodeGenerator *cg,
       NULL);
    }
 
-static void addInliningTableRelocations(TR::CodeGenerator *cg, uint32_t inlinedCallSize, TR_InlinedSiteHastTableEntry *orderedInlinedSiteListTable)
+static void addInliningTableRelocations(TR::CodeGenerator *cg, uint32_t inlinedCallSize, TR_InlinedSiteHashTableEntry *orderedInlinedSiteListTable)
    {
    // If have inlined calls, now add the relocation records in descending order
    // of inlined site index (at relocation time, the order is reverse)
@@ -2891,11 +2891,11 @@ J9::CodeGenerator::processRelocations()
       uint32_t inlinedCallSize = self()->comp()->getNumInlinedCallSites();
 
       // Create temporary hashtable for ordering AOT guard relocations
-      TR_InlinedSiteHastTableEntry *orderedInlinedSiteListTable = NULL;
+      TR_InlinedSiteHashTableEntry *orderedInlinedSiteListTable = NULL;
       if (inlinedCallSize > 0)
          {
-         orderedInlinedSiteListTable= (TR_InlinedSiteHastTableEntry*)self()->comp()->trMemory()->allocateMemory(sizeof(TR_InlinedSiteHastTableEntry) * inlinedCallSize, heapAlloc);
-         memset(orderedInlinedSiteListTable, 0, sizeof(TR_InlinedSiteHastTableEntry)*inlinedCallSize);
+         orderedInlinedSiteListTable= (TR_InlinedSiteHashTableEntry*)self()->comp()->trMemory()->allocateMemory(sizeof(TR_InlinedSiteHashTableEntry) * inlinedCallSize, heapAlloc);
+         memset(orderedInlinedSiteListTable, 0, sizeof(TR_InlinedSiteHashTableEntry)*inlinedCallSize);
          }
 
       // Traverse list of AOT-specific guards and create relocation records

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -115,11 +115,11 @@ typedef struct TR_InlinedSiteLinkedListEntry
    } TR_InlinedSiteLinkedListEntry;
 
 
-typedef struct TR_InlinedSiteHastTableEntry
+typedef struct TR_InlinedSiteHashTableEntry
    {
    TR_InlinedSiteLinkedListEntry *first;
    TR_InlinedSiteLinkedListEntry *last;
-   } TR_InlinedSiteHastTableEntry;
+   } TR_InlinedSiteHashTableEntry;
 
 
 typedef enum


### PR DESCRIPTION
The identifier "TR_InlinedSiteHastTableEntry" was misspelled, causing confusion
in various parts of the codebase. This commit corrects the typo by renaming the
variable to "TR_InlinedSiteHashTableEntry" consistently throughout the project.

Closes: #17450
Signed-off-by: prajwalbandak <prajwalbandak777@gmail.com>