### PR TITLE
Improve linkToVirtual() and linkToInterface() dispatch

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -321,8 +321,10 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/armnathelp.m4
+++ b/runtime/codert_vm/armnathelp.m4
@@ -299,8 +299,10 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -369,8 +369,10 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/riscvnathelp.m4
+++ b/runtime/codert_vm/riscvnathelp.m4
@@ -292,8 +292,10 @@ OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -419,8 +419,10 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -344,8 +344,10 @@ OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
 OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
 OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitResolveFlattenableField,3)
-FAST_PATH_ONLY_HELPER(jitLookupDynamicInterfaceMethod,3)
-OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,3)
+
+ifdef({ASM_J9VM_OPT_OPENJDK_METHODHANDLE},{
+OLD_DUAL_MODE_HELPER(jitLookupDynamicPublicInterfaceMethod,2)
+}) dnl ASM_J9VM_OPT_OPENJDK_METHODHANDLE
 
 dnl Trap handlers
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -860,6 +860,28 @@ J9::SymbolReferenceTable::findOrFabricateShadowSymbol(
    return symRef;
    }
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrFabricateMemberNameVmTargetShadow()
+   {
+   bool isVolatile = false;
+   bool isPrivate = false;
+   bool isFinal = true;
+   TR::SymbolReference *symRef = self()->findOrFabricateShadowSymbol(
+      comp()->getMethodSymbol(),
+      TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
+      TR::Address,
+      comp()->fej9()->getVMTargetOffset(),
+      isVolatile,
+      isPrivate,
+      isFinal,
+      "java/lang/invoke/MemberName.vmtarget J");
+
+   symRef->getSymbol()->setNotCollected();
+   return symRef;
+   }
+#endif
+
 TR::SymbolReference *
 J9::SymbolReferenceTable::findFlattenedArrayElementFieldShadow(
    ResolvedFieldShadowKey key,

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -307,13 +307,6 @@ J9::SymbolReferenceTable::findOrCreateStoreFlattenableArrayElementSymbolRef(TR::
 
 
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateLookupDynamicInterfaceMethodSymbolRef()
-   {
-   return findOrCreateRuntimeHelper(TR_jitLookupDynamicInterfaceMethod, false, false, true);
-   }
-
-
-TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef()
    {
    return findOrCreateRuntimeHelper(TR_jitLookupDynamicPublicInterfaceMethod, false, true, true);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -201,6 +201,11 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     */
    TR::SymbolReference * findOrFabricateShadowSymbol(TR_OpaqueClassBlock *containingClass, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal,  const char *name, const char *signature);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   /// Find or fabricate the shadow symref for MemberName.vmtarget
+   TR::SymbolReference * findOrFabricateMemberNameVmTargetShadow();
+#endif
+
    /** \brief
     *     Returns an array shadow symbol reference fabricated for the field of a flattened array element.
     *

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -159,16 +159,13 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    // This helper walks the iTables to find the VFT offset for an interface
    // method that is not known until runtime (and therefore does not have an
-   // IPIC data snippet). The parameters are the receiver class, interface
-   // class, and iTable index (though in the trees they must appear as
-   // children in the opposite order), and the return value is the VFT offset.
+   // IPIC data snippet). The parameters are the receiver class and MemberName
+   // (though in the trees they must appear as children in the opposite order),
+   // and the return value is the VFT offset.
    //
    // The given receiver class must implement the given interface class.
+   // IllegalAccessError is thrown if the dispatched callee is not public.
    //
-   TR::SymbolReference * findOrCreateLookupDynamicInterfaceMethodSymbolRef();
-
-   // This helper is a variant of jitLookupDynamicInterfaceMethod that requires
-   // the dispatched callee to be public, otherwise throwing IllegalAccessError.
    TR::SymbolReference * findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef();
 
    TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1135,10 +1135,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->isLambdaFormGeneratedMethod(std::get<0>(recv)));
          }
          break;
-      case MessageType::VM_vTableOrITableIndexFromMemberName:
+      case MessageType::VM_getMemberNameMethodInfo:
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
-         client->write(response, fe->vTableOrITableIndexFromMemberName(comp, std::get<0>(recv)));
+         TR_J9VMBase::MemberNameMethodInfo info = {};
+         uintptr_t ok = fe->getMemberNameMethodInfo(comp, std::get<0>(recv), &info);
+         client->write(response, ok, info.vmtarget, info.vmindex, info.clazz, info.refKind);
          }
          break;
       case MessageType::VM_delegatingMethodHandleTarget:

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -875,30 +875,28 @@ public:
     *    VM access is not required
     */
    virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+
+   /// A summary of the method dispatch information in a MemberName.
+   struct MemberNameMethodInfo
+      {
+      TR_OpaqueMethodBlock *vmtarget; ///< the target J9Method
+      uintptr_t vmindex; ///< the interpreter vtable offset, itable index, or -1
+      TR_OpaqueClassBlock *clazz; ///< the relevant subtype of the defining class of vmtarget
+      int32_t refKind; ///< one of the MH_REF_* constants (JVMS table 5.4.3.5-A)
+      };
+
    /*
-    * \brief
-    *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
-    *    Caller must acquire VM access
+    * \brief Summarize a MemberName representing a method or constructor.
+    *
+    * \param comp the compilation object
+    * \param objIndex the known object index of the MemberName object
+    * \param[out] out filled on success, zeroed on failure
+    * \return true on success, false on error (e.g. not a MemberName)
     */
-   virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName);
-   /*
-    * \brief
-    *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
-    *    VM access is not required
-    */
-   virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
-   /*
-    * \brief
-    *    Return vtable or itable index of a method represented by MemberName
-    *    Caller must acquire VM access
-    */
-   virtual uintptr_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
-   /*
-    * \brief
-    *    Return vtable or itable index of a method represented by MemberName
-    *    VM access is not required
-    */
-   virtual uintptr_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual bool getMemberNameMethodInfo(
+      TR::Compilation* comp,
+      TR::KnownObjectTable::Index objIndex,
+      MemberNameMethodInfo *out);
 
    /**
     * \brief

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -238,10 +238,7 @@ public:
    virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray) override;
    virtual bool isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray) override;
 
-   virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName) override;
-   virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
-   virtual uintptr_t vTableOrITableIndexFromMemberName(uintptr_t memberName) override;
-   virtual uintptr_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual bool getMemberNameMethodInfo(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex, MemberNameMethodInfo *out) override;
    virtual TR::KnownObjectTable::Index delegatingMethodHandleTargetHelper( TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass) override;
    virtual UDATA getVMTargetOffset() override;
    virtual UDATA getVMIndexOffset() override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 50; // ID: rTTHu2gMya2I5Wwu3nGy
+   static const uint16_t MINOR_NUMBER = 51; // ID: cGK/z3DilpnVN85FsPsD
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -179,7 +179,7 @@ const char *messageNames[] =
    "VM_targetMethodFromInvokeCacheArrayMemberNameObj",
    "VM_refineInvokeCacheElementSymRefWithKnownObjectIndex",
    "VM_isLambdaFormGeneratedMethod",
-   "VM_vTableOrITableIndexFromMemberName",
+   "VM_getMemberNameMethodInfo",
    "VM_isMethodHandleExpectedType",
    "VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex",
    "VM_isStable",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -188,7 +188,7 @@ enum MessageType : uint16_t
    VM_targetMethodFromInvokeCacheArrayMemberNameObj,
    VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
    VM_isLambdaFormGeneratedMethod,
-   VM_vTableOrITableIndexFromMemberName,
+   VM_getMemberNameMethodInfo,
    VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex,
    VM_isMethodHandleExpectedType,
    VM_isStable,

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -344,7 +344,12 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       /*
        * \brief refine invokestatic callee method based on operands when possible
        */
-      void refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&callee, TR::KnownObjectTable::Index & mcsIndex, TR::KnownObjectTable::Index & mhIndex, bool & isIndirectCall);
+      void refineResolvedCalleeForInvokestatic(
+         TR_ResolvedMethod *&callee,
+         TR::KnownObjectTable::Index & mcsIndex,
+         TR::KnownObjectTable::Index & mhIndex,
+         bool & isIndirectCall,
+         TR_OpaqueClassBlock *&receiverClass);
       /*
        * \brief refine invokevirtual callee method based on operands when possible
        */

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -795,15 +795,7 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_invoke
                                                                                                 "java/lang/invoke/LambdaForm.vmentry Ljava/lang/invoke/MemberName;");
    TR::Node * memberNameNode = TR::Node::createWithSymRef(node, comp()->il.opCodeForIndirectLoad(TR::Address), 1, lambdaFormNode, memberNameSymRef);
    // load from membername.vmTarget, which is the J9Method
-   TR::SymbolReference * vmTargetSymRef = comp()->getSymRefTab()->findOrFabricateShadowSymbol(comp()->getMethodSymbol(),
-                                                                                                TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
-                                                                                                TR::Address,
-                                                                                                fej9->getVMTargetOffset(),
-                                                                                                false,
-                                                                                                false,
-                                                                                                true,
-                                                                                                "java/lang/invoke/MemberName.vmtarget J");
-   vmTargetSymRef->getSymbol()->setNotCollected();
+   TR::SymbolReference * vmTargetSymRef = comp()->getSymRefTab()->findOrFabricateMemberNameVmTargetShadow();
    TR::Node * vmTargetNode = TR::Node::createWithSymRef(node, TR::aloadi, 1, memberNameNode, vmTargetSymRef);
    processVMInternalNativeFunction(treetop, node, vmTargetNode, argsList, inlCallNode);
    }
@@ -826,15 +818,7 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
       }
    // load from membername.vmTarget, which is the J9Method
    TR::Node* mnNode = TR::Node::createLoad(node, argsList->back());
-   TR::SymbolReference * vmTargetSymRef = comp()->getSymRefTab()->findOrFabricateShadowSymbol(comp()->getMethodSymbol(),
-                                                                                                TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
-                                                                                                TR::Address,
-                                                                                                fej9->getVMTargetOffset(),
-                                                                                                false,
-                                                                                                false,
-                                                                                                true,
-                                                                                                "java/lang/invoke/MemberName.vmtarget J");
-   vmTargetSymRef->getSymbol()->setNotCollected();
+   TR::SymbolReference * vmTargetSymRef = comp()->getSymRefTab()->findOrFabricateMemberNameVmTargetShadow();
    TR::Node * vmTargetNode = TR::Node::createWithSymRef(node, TR::aloadi, 1, mnNode, vmTargetSymRef);
    vmTargetNode->setIsNonNull(true);
    argsList->pop_back(); // MemberName is not required when dispatching directly to the jitted method address
@@ -1085,17 +1069,7 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
    const bool vmtargetIsPrivate = false; // could be true? It's a hidden field
    const bool vmtargetIsFinal = true;
    TR::SymbolReference * vmtargetSymRef =
-      comp()->getSymRefTab()->findOrFabricateShadowSymbol(
-         comp()->getMethodSymbol(),
-         TR::Symbol::Java_lang_invoke_MemberName_vmtarget,
-         TR::Address,
-         fej9->getVMTargetOffset(),
-         vmtargetIsVolatile,
-         vmtargetIsPrivate,
-         vmtargetIsFinal,
-         "java/lang/invoke/MemberName.vmtarget J");
-
-   vmtargetSymRef->getSymbol()->setNotCollected();
+      comp()->getSymRefTab()->findOrFabricateMemberNameVmTargetShadow();
 
    TR::Node * vmTargetNode = TR::Node::createWithSymRef(
       node, TR::aloadi, 1, TR::Node::createLoad(node, mnSymRef), vmtargetSymRef);

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -662,8 +662,9 @@ JIT_HELPER(_jitResolveConstantDynamic);
 JIT_HELPER(_nativeStaticHelper);
 JIT_HELPER(_interpreterStaticSpecialCallGlue);
 JIT_HELPER(jitLookupInterfaceMethod);
-JIT_HELPER(jitLookupDynamicInterfaceMethod);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 JIT_HELPER(jitLookupDynamicPublicInterfaceMethod);
+#endif
 JIT_HELPER(jitMethodIsNative);
 JIT_HELPER(jitMethodIsSync);
 JIT_HELPER(jitPreJNICallOffloadCheck);
@@ -1086,8 +1087,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_multiANewArray,             (void *)jitAMultiNewArray, TR_Helper);
    SET(TR_aThrow,                     (void *)jitThrowException, TR_Helper);
 
-   SET(TR_jitLookupDynamicInterfaceMethod, (void *)jitLookupDynamicInterfaceMethod, TR_Helper);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    SET(TR_jitLookupDynamicPublicInterfaceMethod, (void *)jitLookupDynamicPublicInterfaceMethod, TR_Helper);
+#endif
 
    SET(TR_nullCheck,                  (void *)jitThrowNullPointerException,          TR_Helper);
    SET(TR_methodTypeCheck,            (void *)jitThrowWrongMethodTypeException,      TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -77,8 +77,9 @@ JIT_HELPER(jitInduceOSRAtCurrentPCAndRecompile);  // asm calling-convention help
 JIT_HELPER(jitInstanceOf);  // asm calling-convention helper
 JIT_HELPER(jitInterpretNewInstanceMethod);  // asm calling-convention helper
 JIT_HELPER(jitLookupInterfaceMethod);  // asm calling-convention helper
-JIT_HELPER(jitLookupDynamicInterfaceMethod);  // asm calling-convention helper
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 JIT_HELPER(jitLookupDynamicPublicInterfaceMethod);  // asm calling-convention helper
+#endif
 JIT_HELPER(jitMethodIsNative);  // asm calling-convention helper
 JIT_HELPER(jitMethodIsSync);  // asm calling-convention helper
 JIT_HELPER(jitMethodMonitorEntry);  // asm calling-convention helper

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -316,6 +316,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_JIT_FREE_SYSTEM_STACK_POINTER)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_JIT_FREE_SYSTEM_STACK_POINTER", 1) |
 #endif /* J9VM_JIT_FREE_SYSTEM_STACK_POINTER */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_OPT_OPENJDK_METHODHANDLE", 1) |
+#endif /* J9VM_OPT_OPENJDK_METHODHANDLE */
 #if defined(J9VM_PORT_ZOS_CEEHDLRSUPPORT)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_PORT_ZOS_CEEHDLRSUPPORT", 1) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_ceehdlrGPRBase", offsetof(J9VMEntryLocalStorage, ceehdlrGPRBase)) |
@@ -579,9 +582,10 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitInstanceOf", offsetof(J9JITConfig, old_fast_jitInstanceOf)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupInterfaceMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitLookupInterfaceMethod", offsetof(J9JITConfig, old_slow_jitLookupInterfaceMethod)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupDynamicInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupDynamicInterfaceMethod)) |
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLookupDynamicPublicInterfaceMethod", offsetof(J9JITConfig, old_fast_jitLookupDynamicPublicInterfaceMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitLookupDynamicPublicInterfaceMethod", offsetof(J9JITConfig, old_slow_jitLookupDynamicPublicInterfaceMethod)) |
+#endif /* J9VM_OPT_OPENJDK_METHODHANDLE */
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodIsNative", offsetof(J9JITConfig, old_fast_jitMethodIsNative)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodIsSync", offsetof(J9JITConfig, old_fast_jitMethodIsSync)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitMethodMonitorEntry", offsetof(J9JITConfig, old_fast_jitMethodMonitorEntry)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2279,6 +2279,9 @@ typedef struct J9ROMMethodHandleRef {
 #define MN_FLATTENED		0x00400000
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
+#define MN_REFERENCE_KIND_SHIFT	24
+#define MN_REFERENCE_KIND_MASK	0xF		/* (flag >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK */
+
 typedef struct J9ROMMethodRef {
 	U_32 classRefCPIndex;
 	J9SRP nameAndSignature;
@@ -3846,9 +3849,10 @@ typedef struct J9JITConfig {
 	void *old_fast_jitInstanceOf;
 	void *old_fast_jitLookupInterfaceMethod;
 	void *old_slow_jitLookupInterfaceMethod;
-	void *old_fast_jitLookupDynamicInterfaceMethod;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	void *old_fast_jitLookupDynamicPublicInterfaceMethod;
 	void *old_slow_jitLookupDynamicPublicInterfaceMethod;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	void *old_fast_jitMethodIsNative;
 	void *old_fast_jitMethodIsSync;
 	void *old_fast_jitMethodMonitorEntry;


### PR DESCRIPTION
- Remove the direct- and non-interface virtual-dispatch cases from `linkToInterface()` in the VM. They used to be needed, but they've been dead since 425a1f1da08ea74683e85e4492a4a60c44bc8544.

- Implement a recognized call transformation for `linkToInterface()`. The generated IL need only handle actual itable-based dispatch, and it does not introduce any control flow in the IL. This avoids doing a J2I transition whenever the callee is compiled.

- Change `jitLookupDynamicPublicInterfaceMethod` (now used in the above-mentioned transformation) to take the `MemberName` instead of the interface class and iTable index. There's no need to generate IL to find them, since the helper can do that on its own. Cases where they are constant might get slightly slower, but the right way to improve those cases will be to refine and possibly inline `linkToInterface()`.

- Remove the direct-dispatch case from `linkToVirtual()` in the VM and in the IL generated by recognized call transformer. That case used to be needed, but like the removed `linkToInterface()` cases, it has been dead since 425a1f1da08ea74683e85e4492a4a60c44bc8544.

- Remove the interface-dispatch case from `linkToVirtual()` in the VM and in the IL generated by recognized call transformer. `MemberName.vmindex` is no longer a pointer to the `J9JNIMethodID`, but is now instead the vTable offset for `invokevirtual`, the iTable index for `invokeinterface`, and -1 for `invokespecial` and `invokestatic`. The interface dispatch case in `linkToVirtual()` used to occur whenever `vmtarget` was inherited from an interface. Now `MemberName` resolution/initialization detects that scenario and sets `vmindex` to the correct vTable offset for `clazz` so that `linkToVirtual()` can dispatch the call the same way as any other. Note that in combination with the previous point, this means that the `linkToVirtual()` recognized call transformation no longer introduces control flow into the IL.

- Refine `linkToVirtual()` calls in inliner and method handle transformer even when `vmtarget` has been inherited from an interface. Virtual calls to such methods can occur naturally in the bytecode, and the compiler is able to deal with them.

- Delete `jitLookupDynamicInterfaceMethod`, since it's no longer used.