### PR TITLE
AArch64: Replace old loadAddressConstant calls to new APIs

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1599,7 +1599,7 @@ static TR::Instruction* buildStaticPICCall(TR::CodeGenerator *cg, TR::Node *call
          }
       else
          {
-         loadAddressConstant(cg, callNode, reinterpret_cast<intptr_t>(profiledClass), tempReg, NULL, true);
+         loadAddressConstant(cg, false, callNode, reinterpret_cast<intptr_t>(profiledClass), tempReg);
          }
       }
    generateCompareInstruction(cg, callNode, vftReg, tempReg, true);

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -107,7 +107,7 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
       TR::Register *biAddrReg = cg->allocateRegister();
       TR::Register *recompCounterReg = cg->allocateRegister();
       intptr_t addr = (intptr_t)(comp->getRecompilationInfo()->getCounterAddress());
-      loadAddressConstant(cg, node, addr, biAddrReg, NULL, false, TR_BodyInfoAddressLoad);
+      loadAddressConstant(cg, cg->needRelocationsForBodyInfoData(), node, addr, biAddrReg, NULL, TR_BodyInfoAddressLoad);
       TR::MemoryReference *loadbiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0);
       TR::MemoryReference *storebiMR = TR::MemoryReference::createWithDisplacement(cg, biAddrReg, 0);
       generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, recompCounterReg, loadbiMR);
@@ -307,9 +307,9 @@ J9::ARM64::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGe
          }
       else
          {
-         // For non-AOT compiles we don't need to use sideEffectRegister here as the class information is available to us at compile time.
+         // For non-AOT (JIT and JITServer) compiles we don't need to use sideEffectRegister here as the class information is available to us at compile time.
          J9Class * fieldClass = static_cast<TR::J9WatchedStaticFieldSnippet *>(dataSnippet)->getFieldClass();
-         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(fieldClass), fieldClassReg);
+         loadAddressConstant(cg, false, node, reinterpret_cast<intptr_t>(fieldClass), fieldClassReg);
          }
       }
    else
@@ -448,7 +448,7 @@ J9::ARM64::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::
       }
    else
       {
-      loadAddressConstant(cg, node, constantPool, resultReg);
+      loadAddressConstant(cg, false, node, constantPool, resultReg);
       }
    loadConstant32(cg, node, symRef->getCPIndex(), cpIndexReg);
 
@@ -844,7 +844,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
       else
          {
          uintptr_t heapBase = comp->getOptions()->getHeapBaseForBarrierRange0();
-         loadAddressConstant(cg, node, heapBase, temp1Reg);
+         loadAddressConstant(cg, false, node, heapBase, temp1Reg);
          }
       generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, temp1Reg, dstReg, temp1Reg);
 
@@ -894,7 +894,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
          else
             {
             uintptr_t activeCardTableBase = comp->getOptions()->getActiveCardTableBase();
-            loadAddressConstant(cg, node, activeCardTableBase, temp2Reg);
+            loadAddressConstant(cg, false, node, activeCardTableBase, temp2Reg);
             }
          generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, temp2Reg, temp2Reg, temp1Reg, TR::SH_LSR, card_size_shift);
          generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, temp1Reg, 1);
@@ -921,7 +921,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
       else
          {
          uintptr_t heapBase = comp->getOptions()->getHeapBaseForBarrierRange0();
-         loadAddressConstant(cg, node, heapBase, temp1Reg);
+         loadAddressConstant(cg, false, node, heapBase, temp1Reg);
          }
       generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, temp1Reg, srcReg, temp1Reg);
 
@@ -1035,7 +1035,7 @@ VMCardCheckEvaluator(
    else
       {
       uintptr_t heapBase = comp->getOptions()->getHeapBaseForBarrierRange0();
-      loadAddressConstant(cg, node, heapBase, temp1Reg);
+      loadAddressConstant(cg, false, node, heapBase, temp1Reg);
       }
    generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, temp1Reg, dstReg, temp1Reg);
 
@@ -1074,7 +1074,7 @@ VMCardCheckEvaluator(
    else
       {
       uintptr_t activeCardTableBase = comp->getOptions()->getActiveCardTableBase();
-      loadAddressConstant(cg, node, activeCardTableBase, temp2Reg);
+      loadAddressConstant(cg, false, node, activeCardTableBase, temp2Reg);
       }
    generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, temp2Reg, temp2Reg, temp1Reg, TR::SH_LSR, card_size_shift);
    generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, temp1Reg, 1);
@@ -1947,7 +1947,7 @@ void genInstanceOfOrCheckCastArbitraryClassTest(TR::Node *node, TR::Register *in
          }
       else
          {
-         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg, NULL, true);
+         loadAddressConstant(cg, false, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg);
          }
       }
    generateCompareInstruction(cg, node, instanceClassReg, arbitraryClassReg, true);
@@ -3185,7 +3185,7 @@ genInitObjectHeader(TR::Node *node, TR::CodeGenerator *cg, TR_OpaqueClassBlock *
          }
       else
          {
-         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(clazz), tempReg1);
+         loadAddressConstant(cg, false, node, reinterpret_cast<intptr_t>(clazz), tempReg1);
          }
       clzReg = tempReg1;
       }
@@ -4136,7 +4136,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *srcReg, TR::R
          }
       else
          {
-         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(objectClass), javaLangObjectClassReg);
+         loadAddressConstant(cg, false, node, reinterpret_cast<intptr_t>(objectClass), javaLangObjectClassReg);
          }
       generateCompareInstruction(cg, node, javaLangObjectClassReg, destComponentClassReg, true);
       instr = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_EQ);
@@ -4190,7 +4190,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *srcReg, TR::R
             }
          else
             {
-            loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(arrayComponentClass), arrayComponentClassReg, NULL, true);
+            loadAddressConstant(cg, false, node, reinterpret_cast<intptr_t>(arrayComponentClass), arrayComponentClassReg);
             }
          }
       generateCompareInstruction(cg, node, arrayComponentClassReg, destComponentClassReg, true);
@@ -4650,7 +4650,7 @@ J9::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *
    generateLogicalShiftRightImmInstruction(cg, node, lengthReg, lengthReg, trailingZeroes(elementSize));
 
    intptr_t *funcdescrptr = (intptr_t *)fej9->getReferenceArrayCopyHelperAddress();
-   loadAddressConstant(cg, node, (intptr_t)funcdescrptr, tmp3Reg, NULL, false, TR_ArrayCopyHelper);
+   loadAddressConstant(cg, cg->needRelocationsForHelpers(), node, (intptr_t)funcdescrptr, tmp3Reg, NULL, TR_ArrayCopyHelper);
 
    // call the C routine
    TR::Instruction *gcPoint = generateRegBranchInstruction(cg, TR::InstOpCode::blr, node, tmp3Reg, deps);
@@ -4756,7 +4756,7 @@ J9::ARM64::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node *node, TR::Code
    TR::addDependency(deps, NULL, TR::RealRegister::x18, TR_GPR, cg);
 
    intptr_t *funcdescrptr = (intptr_t *)fej9->getReferenceArrayCopyHelperAddress();
-   loadAddressConstant(cg, node, (intptr_t)funcdescrptr, tmpReg, NULL, false, TR_ArrayCopyHelper);
+   loadAddressConstant(cg, cg->needRelocationsForHelpers(), node, (intptr_t)funcdescrptr, tmpReg, NULL, TR_ArrayCopyHelper);
 
    // call the C routine
    TR::Instruction *gcPoint = generateRegBranchInstruction(cg, TR::InstOpCode::blr, node, tmpReg, deps);


### PR DESCRIPTION
A new version of `loadAddressConstant` API was added to AArch64 codegen in OMR. This commit updates J9TreeEvaluator.cpp and ARM64PrivateLinkage.cpp to use the new version of the API.