### PR TITLE
Skip methods with JvmtiMountTransition annotation in findDecompileInfo

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.JvmtiMountTransition;
 
 /**
  * Continuation class performing the mount/unmount operation for VirtualThread
@@ -277,7 +278,9 @@ public class Continuation {
 	}
 
 	/* Continuation Native APIs */
+	@JvmtiMountTransition
 	private native boolean enterImpl();
-	private static native boolean yieldImpl(boolean isFinished);
 
+	@JvmtiMountTransition
+	private static native boolean yieldImpl(boolean isFinished);
 }


### PR DESCRIPTION
Java methods tagged with the JvmtiMountTransition annotation are
involved in transitioning between carrier to virtual threads, and
vice-versa.

These methods are not part of the thread's scope. So, they are skipped
during introspection by the following JVMTI functions:
- ForceEarlyReturn
- NotifyFramePop
- Local Variable (GetOrSetLocal)

This PR allows us to match the RI in `jvmti/vthread/MethodExitTest`.

Related #17490

Closes #17758