### PR TITLE
CRIU triggers javacore dump in case of blocking operation disallowed

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -856,6 +856,8 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 			currentExceptionClass = vm->checkpointState.criuJVMCheckpointExceptionClass;
 			systemReturnCode = vm->checkpointState.maxRetryForNotCheckpointSafe;
 			nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_JCL_CRIU_MAX_RETRY_FOR_NOTCHECKPOINTSAFE_REACHED, NULL);
+			omr_error_t rc = vm->j9rasDumpFunctions->triggerOneOffDump(vm, (char*)"java", (char*)"org.eclipse.openj9.criu.CRIUSupport.checkpointJVMImpl", NULL, 0);
+			Trc_CRIU_checkpointJVMImpl_triggerOneOffJavaDump(currentThread, rc);
 			goto closeWorkDirFD;
 		} else {
 			Trc_CRIU_checkpointJVMImpl_checkpointWithActiveCLinit(currentThread);

--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -50,3 +50,5 @@ TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_null_init Overhead=1 Level=1 
 TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_null_exception_class Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() criuJVMCheckpointExceptionClass(%p) criuSystemCheckpointExceptionClass(%p) criuJVMRestoreExceptionClass(%p) criuSystemRestoreExceptionClass(%p)"
 TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_load_criu_failure Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() The JVM attempted to load libcriu.so but was unable to: %zi"
 TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_not_find_criu_methods Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() The JVM could not find critical criu functions in libcriu.so: %zi"
+
+TraceException=Trc_CRIU_checkpointJVMImpl_triggerOneOffJavaDump Overhead=1 Level=1 Template="checkpointJVMImpl triggerOneOffDump() returns %d"

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -927,3 +927,4 @@ TraceExit=Trc_VM_allocateThunkHeap_Exit NoEnv Overhead=1 Level=3 Template="Exit 
 TraceEvent=Trc_VM_allocateThunkHeap_allocate_thunk_heap_node_failed NoEnv Overhead=1 Level=3 Template="allocateThunkHeap - Failed to allocate memory for the thunk heap node"
 
 TraceExit=Trc_VM_criu_initHooks_Exit Overhead=1 Level=5 Template="initializeCriuHooks - checkpointState.hookRecords (%p), classIterationRestoreHookRecords (%p), delayedLockingOperationsRecords (%p)"
+TraceException=Trc_VM_criu_setSingleThreadModeJVMCRIUException_triggerOneOffJavaDump Overhead=1 Level=1 Template="setCRIUSingleThreadModeJVMCRIUException triggerOneOffDump() returns %d"

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -217,6 +217,7 @@
 
   <test id="Create and Restore Criu Checkpoint Image once - CheckpointDeadlock">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ CheckpointDeadlock 1</command>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="failure" caseSensitive="no" regex="no">Killed</output>
@@ -233,6 +234,7 @@
 
   <test id="Create and Restore Criu Checkpoint Image once - NotCheckpointSafeDeadlock">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+ThrowOnDelayedCheckpointOperation -Xtrace:print=j9criu.17 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ NotCheckpointSafeDeadlock 1</command>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
     <output type="required" caseSensitive="yes" regex="no">Checkpoint blocked because thread</output>
@@ -251,6 +253,7 @@
 <!--
   <test id="Create and Restore Criu Checkpoint Image once - MethodTypeDeadlockTest">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+ThrowOnDelayedCheckpointOperation -Xtrace:print=j9criu.17 -fix-add-opens java.base/jdk.internal.misc=ALL-UNNAMED  -fix-add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ MethodTypeDeadlockTest 1</command>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
@@ -269,6 +272,7 @@
 -->
   <test id="Create and Restore Criu Checkpoint Image once - clinitTest">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+ThrowOnDelayedCheckpointOperation -Xdump:system:events=user -Xtrace:print=j9criu.17 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ ClinitTest 1</command>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
@@ -287,6 +291,7 @@
 
   <test id="Create and Restore Criu Checkpoint Image once - clinitTest2">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:-ThrowOnDelayedCheckpointOperation -Xdump:system:events=user -Xtrace:print=j9criu.17 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_DEADLOCK_TEST$ ClinitTest 1</command>
+    <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>


### PR DESCRIPTION
CRIU triggers `javacore` dump in case of blocking operation disallowed

Blocking operation is not allowed in CRIU single thread mode, JVM throws `JVMCheckpointException` or `JVMRestoreException`, in addition, triggers a `javacore` dump which could be used to identify application code causing
the blocking.

Additional note about the `char*` cast invoking `triggerOneOffDump()`:
`triggerOneOffDump()` has a few other usages in `c` files; no `cast` is required.
`c++` compilation failed due to `error: ISO C++ forbids converting a string constant to 'char*' [-Werror=write-strings]`.
Refactoring triggerOneOffDump() parameters require changes in a few other methods including OMR helpers:
* https://github.com/eclipse-openj9/openj9/issues/17858


Signed-off-by: Jason Feng <fengj@ca.ibm.com>