### PR TITLE
Recognize @IntrinsicCandidate java.lang.Math.multiplyHigh

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -122,6 +122,7 @@
    java_lang_Math_tanh,
    java_lang_Math_fma_D,
    java_lang_Math_fma_F,
+   java_lang_Math_multiplyHigh,
    java_lang_Object_init,
    java_lang_Object_getClass,
    java_lang_Object_clone,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2254,6 +2254,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Math_tanh,             "tanh",           "(D)D")},
       {x(TR::java_lang_Math_fma_D,            "fma",            "(DDD)D")},
       {x(TR::java_lang_Math_fma_F,            "fma",            "(FFF)F")},
+      {x(TR::java_lang_Math_multiplyHigh,     "multiplyHigh",   "(JJ)J")},
       {  TR::unknownMethod}
       };
 
@@ -4621,6 +4622,7 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
             case TR::java_lang_Math_abs_L:
             case TR::java_lang_Math_abs_F:
             case TR::java_lang_Math_abs_D:
+            case TR::java_lang_Math_multiplyHigh:
             case TR::java_lang_Long_reverseBytes:
             case TR::java_lang_Integer_reverseBytes:
             case TR::java_lang_Short_reverseBytes:

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -67,6 +67,7 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_Math_min_L:
       case TR::java_lang_Math_min_F:
       case TR::java_lang_Math_min_D:
+      case TR::java_lang_Math_multiplyHigh:
       case TR::java_lang_Math_nextAfter_F:
       case TR::java_lang_Math_nextAfter_D:
       case TR::java_lang_Math_pow:

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1117,6 +1117,8 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          case TR::java_lang_Math_max_L:
          case TR::java_lang_Math_min_L:
             return !comp()->getOption(TR_DisableMaxMinOptimization);
+         case TR::java_lang_Math_multiplyHigh:
+            return cg()->getSupportsLMulHigh();
          case TR::java_lang_StringUTF16_toBytes:
             return !comp()->compileRelocatableCode();
          case TR::java_lang_StrictMath_sqrt:
@@ -1240,6 +1242,9 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
             break;
          case TR::java_lang_Math_min_L:
             processIntrinsicFunction(treetop, node, TR::lmin);
+            break;
+         case TR::java_lang_Math_multiplyHigh:
+            processIntrinsicFunction(treetop, node, TR::lmulh);
             break;
          case TR::java_lang_StringUTF16_toBytes:
             process_java_lang_StringUTF16_toBytes(treetop, node);


### PR DESCRIPTION
java.lang.Math.multiplyHigh has been an intrinsic candidate in the Java class library since JDK17. There is a single opcode which implements the functionality of multiplyHigh. This provides an opportunity to simplify calls to multiplyHigh much like other Math methods (abs, min, max, etc).

This commit adds the following:

+ The recognition of java.lang.Math.multiplyHigh as a recognized method.
+ The replacement of calls to java.lang.Math.multiplyHigh with a single lmulh node as part of RecognizedCallTransformer