### PR TITLE
AArch64: Override callUsesHelperImplementation function

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -245,3 +245,10 @@ J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMetho
       }
    return false;
    }
+
+bool
+J9::ARM64::CodeGenerator::callUsesHelperImplementation(TR::Symbol *sym)
+   {
+   return sym && (!self()->comp()->getOption(TR_DisableInliningOfNatives) &&
+          sym->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_ComputedCalls_dispatchJ9Method);
+   }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -117,6 +117,8 @@ public:
     * @return true if inlining of the method should be suppressed
     */
    bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
+
+   bool callUsesHelperImplementation(TR::Symbol *sym);
    };
 
 }


### PR DESCRIPTION
This commit adds `callUsesHelperImplementation` query function to AArch64 code generator which overrides OMR's implementation. The function returns true if a Java method call is implemented using an internal runtime helper.[

Depends on https://github.com/eclipse/omr/pull/7077

See https://github.com/eclipse-openj9/openj9/pull/6908 for the reason why this query is needed for JITServer.