### PR TITLE
AArch64: Fix thunk generation to support JITServer

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1862,8 +1862,8 @@ void J9::ARM64::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
          default:
             if (fej9->needsInvokeExactJ2IThunk(callNode, comp()))
                {
-               comp()->getPersistentInfo()->getInvokeExactJ2IThunkTable()->addThunk(
-                  TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(callNode, argSize, cg(), methodSymbol->getMethod()->signatureChars()), fej9);
+               TR_MHJ2IThunk *thunk = TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(callNode, argSize, cg(), methodSymbol->getMethod()->signatureChars());
+               fej9->setInvokeExactJ2IThunk(thunk, comp());
                }
             break;
          }

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -1056,7 +1056,8 @@ TR_MHJ2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callN
 
    omrthread_jit_write_protect_disable();
 
-   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
+   TR::SymbolReference *dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(helper);
+   dispatcher = reinterpret_cast<intptr_t>(cg->fej9()->getInvokeExactThunkHelperAddress(comp, dispatcherSymbol, callNode->getDataType()));
 
    buffer = flushArgumentsToStack(buffer, callNode, argSize, cg);
 


### PR DESCRIPTION
This commit updates `TR::ARM64CallSnippet::generateInvokeExactJ2IThunk` to get thunk helper address through front end so that it can obtain correct values in remote compilation mode.
This commit also updates `J9::ARM64::PrivateLinkage::buildVirtualDispatch` to add the thunk to the table through front end so that it can update the client side thunk table.