### PR TITLE
cfdump support for Valhalla preload attribute

### DIFF
--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -64,6 +64,9 @@ DECLARE_UTF8_ATTRIBUTE_NAME(ANNOTATION_DEFAULT, "AnnotationDefault");
 DECLARE_UTF8_ATTRIBUTE_NAME(BOOTSTRAP_METHODS, "BootstrapMethods");
 DECLARE_UTF8_ATTRIBUTE_NAME(RECORD, "Record");
 DECLARE_UTF8_ATTRIBUTE_NAME(PERMITTED_SUBCLASSES, "PermittedSubclasses");
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+DECLARE_UTF8_ATTRIBUTE_NAME(PRELOAD, "Preload");
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if JAVA_SPEC_VERSION >= 11
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_MEMBERS, "NestMembers");
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_HOST, "NestHost");
@@ -110,6 +113,18 @@ ClassFileWriter::analyzeROMClass()
 		}
 	}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (J9_ARE_ALL_BITS_SET(_romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE)) {
+		addEntry((void*) &PRELOAD, 0, CFR_CONSTANT_Utf8);
+
+		U_32 *preloadInfoPtr = getPreloadInfoPtr(_romClass);
+		U_32 numberOfPreloadClasses = *preloadInfoPtr;
+		for (U_32 i = 0; i < numberOfPreloadClasses; i++) {
+			J9UTF8* preloadClassNameUtf8 = preloadClassNameAtIndex(preloadInfoPtr, i);
+			addEntry(preloadClassNameUtf8, 0, CFR_CONSTANT_Utf8);
+		}
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	J9EnclosingObject * enclosingObject = getEnclosingMethodForROMClass(_javaVM, NULL, _romClass);
 	J9UTF8 * genericSignature = getGenericSignatureForROMClass(_javaVM, NULL, _romClass);
 	J9UTF8 * sourceFileName = getSourceFileNameForROMClass(_javaVM, NULL, _romClass);
@@ -1001,6 +1016,11 @@ ClassFileWriter::writeAttributes()
 		attributesCount += 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 11 */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (J9_ARE_ALL_BITS_SET(_romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE)) {
+		attributesCount += 1;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	writeU16(attributesCount);
 
 	if ((0 != _romClass->innerClassCount)
@@ -1168,6 +1188,34 @@ ClassFileWriter::writeAttributes()
 			}
 		}
 	}
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* write Preload attribute */
+	if (J9_ARE_ALL_BITS_SET(_romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE)) {
+		U_32 *preloadInfoPtr = getPreloadInfoPtr(_romClass);
+		/* The first 32 bits of preloadInfoPtr contain the number of preload classes */
+		U_32 numberPreloadClasses = *preloadInfoPtr;
+		writeAttributeHeader((J9UTF8 *) &PRELOAD, sizeof(U_16) + (numberPreloadClasses * sizeof(U_16)));
+		writeU16(numberPreloadClasses);
+
+		for (U_32 i = 0; i < numberPreloadClasses; i++) {
+			J9UTF8* preloadClassNameUtf8 = preloadClassNameAtIndex(preloadInfoPtr, i);
+			/* CONSTANT_Class_info index should be written. Find class entry that references the preload class name in constant pool. */
+			J9HashTableState hashTableState;
+			HashTableEntry * entry = (HashTableEntry *) hashTableStartDo(_cpHashTable, &hashTableState);
+			while (NULL != entry) {
+				if (CFR_CONSTANT_Class == entry->cpType) {
+					J9UTF8* classNameCandidate = (J9UTF8*)entry->address;
+					if (J9UTF8_EQUALS(classNameCandidate, preloadClassNameUtf8)) {
+						writeU16(entry->cpIndex);
+						break;
+					}
+				}
+				entry = (HashTableEntry *) hashTableNextDo(&hashTableState);
+			}
+		}
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 }
 
 void ClassFileWriter::writeRecordAttribute()

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -917,6 +917,19 @@ static void dumpAttribute(J9CfrClassFile* classfile, J9CfrAttribute* attrib, U_3
 			}
 			break;
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		case CFR_ATTRIBUTE_Preload:
+			for(i = 0; i < ((J9CfrAttributePreload*)attrib)->numberOfClasses; i++) {
+				U_16 classIndex = ((J9CfrAttributePreload*)attrib)->classes[i];
+				U_16 nameIndex = classfile->constantPool[classIndex].slot1;
+
+				for(j = 0; j < tabLevel + 1; j++) {
+					j9tty_printf(PORTLIB, "  ");
+				}
+				j9tty_printf(PORTLIB, "Preload class index, name: %i, %i -> %s\n", classIndex, nameIndex, classfile->constantPool[nameIndex].bytes);
+			}
+			break;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		case CFR_ATTRIBUTE_StrippedLineNumberTable:
 		case CFR_ATTRIBUTE_StrippedLocalVariableTable:
 		case CFR_ATTRIBUTE_StrippedLocalVariableTypeTable:

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1357,16 +1357,17 @@ getNumberOfInjectedInterfaces(J9ROMClass *romClass);
  * ROM class parameter references a class with preloaded classes.
  *
  * @param J9ROMClass class
- * @return U_32 number of preload classes in optionalinfo
+ * @return U_32* the first U_32 is the number of classes, followed by that number
+ * of constant pool indices.
  */
 U_32*
-getNumberOfPreloadClassesPtr(J9ROMClass *romClass);
+getPreloadInfoPtr(J9ROMClass *romClass);
 
 /**
  * Find the preload class name constant pool entry at index in the optional data of the ROM class parameter.
  * This method assumes there is at least one preloaded class in the ROM class.
  *
- * @param U_32* the pointer returned by getNumberOfPreloadClassesPtr
+ * @param U_32* the pointer returned by getPreloadInfoPtr
  * @param U_32 class index
  * @return the preload class name at index from ROM class
  */

--- a/runtime/util/optinfo.c
+++ b/runtime/util/optinfo.c
@@ -717,7 +717,7 @@ getNumberOfInjectedInterfaces(J9ROMClass *romClass) {
 }
 
 U_32*
-getNumberOfPreloadClassesPtr(J9ROMClass *romClass)
+getPreloadInfoPtr(J9ROMClass *romClass)
 {
 	U_32 *ptr = getSRPPtr(J9ROMCLASS_OPTIONALINFO(romClass), romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE);
 
@@ -727,10 +727,10 @@ getNumberOfPreloadClassesPtr(J9ROMClass *romClass)
 }
 
 J9UTF8*
-preloadClassNameAtIndex(U_32* preloadClassesCountPtr, U_32 index)
+preloadClassNameAtIndex(U_32* preloadInfoPtr, U_32 index)
 {
 	/* SRPs to Preload name constant pool entries start after the preloadClassesCountPtr */
-	U_32* preloadClassesPtr = preloadClassesCountPtr + 1 + index;
+	U_32* preloadClassesPtr = preloadInfoPtr + 1 + index;
 
 	return NNSRP_PTR_GET(preloadClassesPtr, J9UTF8*);
 }

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -79,6 +79,9 @@ static I_32 dumpPermittedSubclasses(J9PortLibrary *portLib, J9ROMClass *romClass
 #if JAVA_SPEC_VERSION >= 11
 static I_32 dumpNest (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
 #endif /* JAVA_SPEC_VERSION >= 11 */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+static I_32 dumpPreloadClasses (J9PortLibrary *portLib, J9ROMClass *romClass);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 static I_32 dumpSimpleName (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
 static I_32 dumpUTF ( J9UTF8 *utfString, J9PortLibrary *portLib, U_32 flags);
 static I_32 dumpSourceDebugExtension (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
@@ -189,6 +192,10 @@ IDATA j9bcutil_dumpRomClass( J9ROMClass *romClass, J9PortLibrary *portLib, J9Tra
 	/* dump the nest members or nest host, if defined */
 	dumpNest(portLib, romClass, flags);
 #endif /* JAVA_SPEC_VERSION >= 11 */
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	dumpPreloadClasses(portLib, romClass);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	j9tty_printf( PORTLIB, "Fields (%i):\n", romClass->romFieldCount);
 	currentField = romFieldsStartDo(romClass, &state);
@@ -870,6 +877,24 @@ dumpNest(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 	return BCT_ERR_NO_ERROR;
 }
 #endif /* JAVA_SPEC_VERSION >= 11 */
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+static I_32
+dumpPreloadClasses(J9PortLibrary *portLib, J9ROMClass *romClass)
+{
+	PORT_ACCESS_FROM_PORT(portLib);
+	U_32* preloadInfoPtr = getPreloadInfoPtr(romClass);
+	U_32 preloadClassCount = *preloadInfoPtr;
+	U_16 i = 0;
+
+	j9tty_printf(PORTLIB, "Preload classes (%i):\n", preloadClassCount);
+	for (; i < preloadClassCount; i++) {
+		J9UTF8* preloadClassNameUtf8 = preloadClassNameAtIndex(preloadInfoPtr, i);
+		j9tty_printf(PORTLIB, "  %.*s\n", J9UTF8_LENGTH(preloadClassNameUtf8), J9UTF8_DATA(preloadClassNameUtf8));
+	}
+	return BCT_ERR_NO_ERROR;
+}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 static I_32
 dumpSimpleName(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -838,6 +838,36 @@ allSlotsInPermittedSubclassesDo(J9ROMClass* romClass, U_32* permittedSubclassesP
 	callbacks->sectionCallback(romClass, permittedSubclassesPointer, (UDATA)cursor - (UDATA)permittedSubclassesPointer, "permittedSubclassesInfo", userData);
 }
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+static void
+allSlotsInPreloadAttributeDo(J9ROMClass* romClass, U_32* preloadAttributePointer, J9ROMClassWalkCallbacks* callbacks, void* userData)
+{
+	BOOLEAN rangeValid = FALSE;
+	U_32 *cursor = preloadAttributePointer;
+	U_32 preloadAttributeCount = 0;
+
+	rangeValid = callbacks->validateRangeCallback(romClass, cursor, sizeof(U_32), userData);
+	if (FALSE == rangeValid) {
+		return;
+	}
+
+	callbacks->slotCallback(romClass, J9ROM_U32, cursor, "preloadAttributeCount", userData);
+	cursor += 1;
+	preloadAttributeCount = *preloadAttributePointer;
+
+	for (; preloadAttributeCount > 0; preloadAttributeCount--) {
+		rangeValid = callbacks->validateRangeCallback(romClass, cursor, sizeof(U_32), userData);
+		if (FALSE == rangeValid) {
+			return;
+		}
+		callbacks->slotCallback(romClass, J9ROM_UTF8, cursor, "className", userData);
+		cursor += 1;
+	}
+
+	callbacks->sectionCallback(romClass, preloadAttributePointer, (UDATA)cursor - (UDATA)preloadAttributePointer, "preloadAttributeInfo", userData);
+}
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+
 /*
  * See ROMClassWriter::writeOptionalInfo for illustration of the layout.
  */
@@ -932,6 +962,15 @@ allSlotsInOptionalInfoDo(J9ROMClass* romClass, J9ROMClassWalkCallbacks* callback
 		rangeValid = callbacks->validateRangeCallback(romClass, cursor, sizeof(J9SRP), userData);
 		if (rangeValid) {
 			callbacks->slotCallback(romClass, J9ROM_SRP, cursor, "optionalInjectedInterfaces", userData);
+		}
+		cursor++;
+	}
+
+	if (J9_ARE_ANY_BITS_SET(romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE)) {
+		rangeValid = callbacks->validateRangeCallback(romClass, cursor, sizeof(J9SRP), userData);
+		if (rangeValid) {
+			callbacks->slotCallback(romClass, J9ROM_SRP, cursor, "preloadAttributeSRP", userData);
+			allSlotsInPreloadAttributeDo(romClass, SRP_PTR_GET(cursor, U_32*), callbacks, userData);
 		}
 		cursor++;
 	}

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1947,7 +1947,7 @@ loadFlattenableFieldValueClasses(J9VMThread *currentThread, J9ClassLoader *class
 	/* Preload classes marked for preloading */
 	/* Currently classes are preloaded if they are mentioned in the preload attribute or if they are a Q type. In the future (when javac is updated with better support for the preload attribute) the Q type check will be removed. */
 	if (J9_ARE_ALL_BITS_SET(romClass->optionalFlags, J9_ROMCLASS_OPTINFO_PRELOAD_ATTRIBUTE)) {
-		U_32 *numberOfPreloadClassesPtr = getNumberOfPreloadClassesPtr(romClass);
+		U_32 *numberOfPreloadClassesPtr = getPreloadInfoPtr(romClass);
 
 		for (U_32 i = 0; i < *numberOfPreloadClassesPtr; i++) {
 			J9UTF8 *preloadClassNameUtf8 = preloadClassNameAtIndex(numberOfPreloadClassesPtr, i);


### PR DESCRIPTION
Also rename getNumberOfPreloadClassesPtr to getPreloadInfoPtr to clarify behavior.

Related to: https://github.com/eclipse-openj9/openj9/issues/17233

Part of these changes came from the work @ehrenjulzert drafted https://github.com/eclipse-openj9/openj9/pull/17787. I split up the commit to commit the attribute support separately. Thanks Ehren!