### PR TITLE
Enable JITServer tests on AArch64 Linux

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -775,7 +775,7 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -170,7 +170,7 @@
 			fi; \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,bits.64</platformRequirements>
 		<features>
 			<feature>CRIU:required</feature>
 			<feature>JITAAS:nonapplicable</feature>
@@ -208,7 +208,7 @@
 			fi; \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,bits.64</platformRequirements>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>

--- a/test/functional/cmdLineTests/jitserver/playlist.xml
+++ b/test/functional/cmdLineTests/jitserver/playlist.xml
@@ -42,7 +42,7 @@
 			fi; \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
This commit enables JITServer tests on AArch64 Linux.