### PR TITLE
Tracepoints for the memory usage of memory pools

### DIFF
--- a/runtime/jcl/common/mgmtmemory.c
+++ b/runtime/jcl/common/mgmtmemory.c
@@ -702,9 +702,16 @@ Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificati
 				return;
 			}
 
-			(*env)->CallVoidMethod(env, threadInstance, helperGCID,
-					gcName, gcAction, gcCause,
-					(jlong)gcInfo->index, (jlong)gcInfo->startTime, (jlong)gcInfo->endTime,
+			(*env)->CallVoidMethod(
+					env,
+					threadInstance,
+					helperGCID,
+					gcName,
+					gcAction,
+					gcCause,
+					(jlong)gcInfo->index,
+					(jlong)gcInfo->startTime,
+					(jlong)gcInfo->endTime,
 					initialArray,
 					preUsedArray,
 					preCommittedArray,
@@ -724,7 +731,10 @@ Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificati
 			poolName = poolNames[idx];
 			if (THRESHOLD_EXCEEDED == notification->type) {
 				/* heap usage threshold exceeded */
-				(*env)->CallVoidMethod(env, threadInstance, helperMemID,
+				(*env)->CallVoidMethod(
+						env,
+						threadInstance,
+						helperMemID,
 						poolName,
 						(jlong)pool->initialSize,
 						(jlong)usageThreshold->usedSize,
@@ -738,7 +748,10 @@ Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificati
 				}
 			} else { /* COLLECTION_THRESHOLD_EXCEEDED == notification->type) */
 				/* heap collection usage threshold exceeded */
-				(*env)->CallVoidMethod(env, threadInstance, helperMemID,
+				(*env)->CallVoidMethod(
+						env,
+						threadInstance,
+						helperMemID,
 						poolName,
 						pool->initialSize,
 						(jlong)usageThreshold->usedSize,

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -704,3 +704,6 @@ TraceEntry=Trc_JCL_J9SigUsr2Shutdown_Entry noEnv Overhead=1 Level=1 Template="J9
 TraceExit=Trc_JCL_J9SigUsr2Shutdown_Exit noEnv Overhead=1 Level=1 Template="J9SigUsr2Shutdown"
 
 TraceEvent=Trc_JCL_MXBean_getUptimeImpl Overhead=1 Level=3 Template="RuntimeMXBeanImpl_getUptimeImpl timeNow (%lld) vmStartTime (%lld) criuTimeDeltaMillis (%lld)"
+
+TraceException=Trc_JCL_memoryManagement_verifyMemoryUsageAfterGC_memoryUsageError Test NoEnv Overhead=1 Level=1 Template="JCL: verifyMemoryUsageAfterGC memoryUsageError: GcName=%s, MemoryPool=%s, initialSize=%lld, preUsedSize=%llu, preCommittedSize==%llu, preMaxSize=%lld, postUsedSize=%llu, postCommittedSize==%llu, postMaxSize=%lld"
+TraceEvent=Trc_JCL_memoryManagement_verifyMemoryUsageAfterGC_memoryUsage Test NoEnv Overhead=1 Level=6 Template="JCL: verifyMemoryUsageAfterGC memoryUsage: GcName=%s, MemoryPool=%s, initialSize=%lld, preUsedSize=%llu, preCommittedSize==%llu, preMaxSize=%lld, postUsedSize=%llu, postCommittedSize==%llu, postMaxSize=%lld"


### PR DESCRIPTION
new tracepoints are added for the memory usage of memory pools (both heap memory and nonHeap memory, before GC and after GC) in order to identify/isolate potential inconsistent memory usage case.

- Add level 6 tracepoint to record memory usages for every memory pools at both before GC and after GC.
- Add exception tracepoint for in case the memory pool usages are inconsistent.

related to: https://github.com/eclipse-openj9/openj9/issues/17769

Signed-off-by: Lin Hu <linhu@ca.ibm.com>