### PR TITLE
JITServer: Flush ICache after constructing invokeExactJ2IThunk

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -753,6 +753,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             compInfoPT->getCompilation()->failCompilation<TR::CodeCacheError>("Failed to allocate space in the code cache");
 
          void *thunkAddress = reinterpret_cast<void *>(thunkStart);
+         compInfoPT->reloRuntime()->reloTarget()->flushCache(reinterpret_cast<uint8_t *>(thunkAddress), serializedThunk.size());
          fe->setInvokeExactJ2IThunk(thunkAddress, comp);
          client->write(response, JITServer::Void());
          }


### PR DESCRIPTION
This commit updates JITClientCompilationThread to flush icache after copying instructions to code cache when handling `VM_setInvokeExactJ2IThunk` messages.
I and @knn-k have been investigating an intermittent crash with jitserver client VM on AArch64 Linux. The issue seems to be resolved with this change.