### PR TITLE
Fix JPP for CRIU_SUPPORT

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -196,9 +196,9 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 * @return	true if the Reference was successfully
 	 *			enqueued, false otherwise.
 	 */
-	/* [IF CRIU_SUPPORT] */
+	/*[IF CRIU_SUPPORT]*/
 	@NotCheckpointSafe
-	/* [ENDIF] CRIU_SUPPORT */
+	/*[ENDIF] CRIU_SUPPORT */
 	boolean enqueueImpl() {
 		final ReferenceQueue tempQueue;
 		boolean result;


### PR DESCRIPTION
Fix `JPP` for `CRIU_SUPPORT`

Fix [JDK8 compilation failure](http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=65550217) 
```
/tmp/bld_55732/pConfig/pConfig_SIDECAR18-SE/src/java/lang/ref/Reference.java:119: error: cannot find symbol
	@NotCheckpointSafe
	 ^
  symbol:   class NotCheckpointSafe
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>