### PR TITLE
Change Attachment.loadAgentLibrary() to a static method

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
@@ -366,11 +366,11 @@ final class Attachment extends Thread implements Response {
 	 *            add prefixes and suffixes to the library name.
 	 * @return null if successful, diagnostic string if error
 	 */
-	String loadAgentLibrary(String agentLibrary, String options,
+	static String loadAgentLibrary(String agentLibrary, String options,
 			boolean decorate) {
 		IPC.logMessage("loadAgentLibrary " + agentLibrary + ':' + options + " decorate=" + decorate); //$NON-NLS-1$ //$NON-NLS-2$
 		ClassLoader loader = java.lang.ClassLoader.getSystemClassLoader();
-		int status = loadAgentLibraryImpl(loader ,agentLibrary,  options, decorate);
+		int status = loadAgentLibraryImpl(true, loader, agentLibrary,  options, decorate);
 		if (0 != status) {
 			if (-1 == status) {
 				return Response.EXCEPTION_AGENT_LOAD_EXCEPTION + ' '
@@ -384,16 +384,18 @@ final class Attachment extends Thread implements Response {
 	}
 
 	/**
-	 * 
+	 * @param agentLibrary
+	 *            a dummy arg to ensure that current native method has the ClassLoader instance
+	 *            as it's second argument required by jnimisc.cpp:getCurrentClassLoader()
 	 * @param agentLibrary
 	 *            name of the agent library
 	 * @param options
 	 *            arguments to the library's Agent_OnAttach function
 	 * @param decorate
-	 *            add prefixes and suffixes to the library name.
+	 *            add prefixes and suffixes to the library name
 	 * @return 0 if all went well
 	 */
-	private native int loadAgentLibraryImpl(ClassLoader loader,String agentLibrary,
+	private static native int loadAgentLibraryImpl(boolean dummy, ClassLoader loader,String agentLibrary,
 			String options, boolean decorate);
 
 	private int getPortNumber() {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4841,7 +4841,7 @@ done:
 		return rc;
 	}
 
-	/* openj9.internal.tools.attach.target.Attachment: private native int loadAgentLibraryImpl(ClassLoader loader, String agentLibrary, String options, boolean decorate); */
+	/* openj9.internal.tools.attach.target.Attachment: private static native int loadAgentLibraryImpl(boolean dummy, ClassLoader loader, String agentLibrary, String options, boolean decorate); */
 	VMINLINE VM_BytecodeAction
 	inlAttachmentLoadAgentLibraryImpl(REGISTER_ARGS_LIST)
 	{


### PR DESCRIPTION
Change `Attachment.loadAgentLibrary()` to a public static method

Added a dummy arg for the native loadAgentLibraryImpl() to ensure that the current native method has the ClassLoader instance as its second argument required by `jnimisc.cpp:getCurrentClassLoader()`.

related to
* https://github.com/eclipse-openj9/openj9/issues/17500

Signed-off-by: Jason Feng <fengj@ca.ibm.com>