### PR TITLE
Implement JEP 451: Prepare to Disallow the Dynamic Loading of Agents

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -24,6 +24,7 @@
 #include "bcverify_api.h"
 #include "j9.h"
 #include "j9cfg.h"
+#include "jvminit.h"
 #include "rommeth.h"
 #include "ut_j9scar.h"
 #include "util_api.h"
@@ -548,10 +549,14 @@ JVM_VirtualThreadHideFrames(JNIEnv *env, jobject vthread, jboolean hide)
 JNIEXPORT jboolean JNICALL
 JVM_PrintWarningAtDynamicAgentLoad()
 {
-	/* A temporary implementation, an actual solution is provided via
-	 * https://github.com/eclipse-openj9/openj9/issues/17500
-	 */
-	return JNI_TRUE;
+	jboolean result = JNI_TRUE;
+	J9JavaVM *vm = BFUjavaVM;
+	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_ALLOW_DYNAMIC_AGENT)
+		&& (0 <= FIND_ARG_IN_VMARGS(EXACT_MATCH, VMOPT_XXENABLEDYNAMICAGENTLOADING, NULL))
+	) {
+		result = JNI_FALSE;
+	}
+	return result;
 }
 
 JNIEXPORT void JNICALL

--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -563,7 +563,7 @@ TraceExit=Trc_JVMTI_issueAgentOnLoadAttach_Exit Overhead=1 Level=1 Noenv Templat
 TraceEvent=Trc_JVMTI_issueAgentOnLoadAttach_close_shared_library Overhead=1 Level=1 Noenv Template="issueAgentOnLoadAttach unloading %s"
 
 TraceEntry=Trc_JVMTI_loadAgentLibraryGeneric_Entry Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric loading library %s"
-TraceExit=Trc_JVMTI_loadAgentLibraryGeneric_Exit Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric successfully loaded library %s"
+TraceExit=Trc_JVMTI_loadAgentLibraryGeneric_Exit Obsolete Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric successfully loaded library %s"
 
 TraceEntry=Trc_JVMTI_loadAgentLibraryOnAttach_Entry Overhead=1 Level=1 Noenv Template="loadAgentLibraryOnAttach loading library %s"
 TraceExit=Trc_JVMTI_loadAgentLibraryOnAttach_Exit Overhead=1 Level=1 Noenv Template="loadAgentLibraryOnAttach loaded library %s, status=%d"
@@ -602,11 +602,11 @@ TraceException=Trc_JVMTI_issueAgentOnLoadAttach_loadFunctionFailed Overhead=1 Le
 TraceEvent=Trc_JVMTI_issueAgentOnLoadAttach_loadFunctionSucceeded Overhead=1 Level=5 Noenv Template="issueAgentOnLoadAttach: Load function %s succeeded"
 
 TraceEvent=Trc_JVMTI_loadAgentLibraryGeneric_loadingAgentAs Overhead=1 Level=5 Noenv Template="loadAgentLibraryGeneric: Loading agent as %s"
-TraceException=Trc_JVMTI_loadAgentLibraryGeneric_execNameNotFound Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: failed obtaining executable name; error code=%d"
-TraceException=Trc_JVMTI_loadAgentLibraryGeneric_failedOpeningAgentLibrary Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed opening agent library %s"
+TraceException=Trc_JVMTI_loadAgentLibraryGeneric_execNameNotFound Obsolete Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: failed obtaining executable name; error code=%d"
+TraceException=Trc_JVMTI_loadAgentLibraryGeneric_failedOpeningAgentLibrary Obsolete Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed opening agent library %s"
 TraceEvent=Trc_JVMTI_loadAgentLibraryGeneric_openedAgentLibrary Overhead=1 Level=5 Noenv Template="loadAgentLibraryGeneric: Opened agent %s (address=%p) %s"
-TraceException=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed1 Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed attaching agent library; load function %s not found"
-TraceException=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed2 Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed attaching agent library; load function failed with error code %zd"
+TraceException=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed1 Obsolete Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed attaching agent library; load function %s not found"
+TraceException=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed2 Obsolete Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric: Failed attaching agent library; load function failed with error code %zd"
 TraceEvent=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachedSuccessfully Overhead=1 Level=5 Noenv Template="loadAgentLibraryGeneric: Attached agent %s successfully"
 
 TraceEvent=Trc_JVMTI_loadAgentLibraryOnAttach_attachingAgentDynamically Overhead=1 Level=5 Noenv Template="loadAgentLibraryOnAttach: Attached agent %s dynamically"
@@ -660,3 +660,8 @@ TraceEntry=Trc_JVMTI_jvmtiHookVirtualThreadMount_Entry Overhead=1 Level=5 Noenv 
 TraceExit=Trc_JVMTI_jvmtiHookVirtualThreadMount_Exit Overhead=1 Level=5 Noenv Template="HookVirtualThreadMount"
 
 TraceEvent=Trc_JVMTI_loadAgentLibraryOnAttach_agentLoadingDisabled Overhead=1 Level=5 Noenv Template="loadAgentLibraryOnAttach: Dynamic agent loading is disabled"
+TraceExit-Exception=Trc_JVMTI_loadAgentLibraryGeneric_execNameNotFound_Exit Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric failed to obtain executable name with error code=%d while loading library %s"
+TraceExit-Exception=Trc_JVMTI_loadAgentLibraryGeneric_failedOpeningAgentLibrary_Exit Overhead==1 Level=1 Noenv Template="loadAgentLibraryGeneric failed to open agent library %s with error message %s"
+TraceExit-Exception=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed1_Exit Overhead==1 Level=1 Noenv Template="loadAgentLibraryGeneric failed attaching agent library %s; load function %s not found"
+TraceExit-Exception=Trc_JVMTI_loadAgentLibraryGeneric_agentAttachFailed2_Exit Overhead==1 Level=1 Noenv Template="loadAgentLibraryGeneric failed attaching agent library %s; load function %s failed with error code=%d"
+TraceExit=Trc_JVMTI_loadAgentLibraryGeneric_succeed_Exit Overhead=1 Level=1 Noenv Template="loadAgentLibraryGeneric successfully loaded library %s and function %s"

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5802,6 +5802,7 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t statisticsMutex;
 	struct J9Statistic* nextStatistic;
 	I_32  (JNICALL *loadAgentLibraryOnAttach)(struct J9JavaVM * vm, const char * library, const char *options, UDATA decorate) ;
+	BOOLEAN (*isAgentLibraryLoaded)(struct J9JavaVM *vm, const char *library);
 	struct J9AttachContext attachContext;
 	UDATA hotSwapCount;
 	UDATA zombieThreadCount;


### PR DESCRIPTION
Implement JEP 451: Prepare to Disallow the Dynamic Loading of Agents

Print warning message when loading an agent via `AttachAPI` `loadAgentLibraryImpl()` if `-XX:+EnableDynamicAgentLoading` is not specified, and the agent wasn't loaded before;
Added `isAgentLibraryLoaded()` to determine if an agent has been loaded already;
Implemented `JVM_PrintWarningAtDynamicAgentLoad()`;
Added `jcmd` command `JVMTI.agent_load` to support openjdk test `test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java`;
Updated a few trace points within `loadAgentLibraryGeneric()`.

This passes [an internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/34281/console) `openjdk` `test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java` w/
* https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/27

related 
* https://github.com/eclipse-openj9/openj9/issues/17500

Signed-off-by: Jason Feng <fengj@ca.ibm.com>