### PR TITLE
Add support for jdk.tracePinnedThreads system property

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
+++ b/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
@@ -1,0 +1,58 @@
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 21]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package java.lang;
+
+import java.io.PrintStream;
+import java.lang.StackWalker.StackFrame;
+import java.lang.StackWalker.StackFrameImpl;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import static java.lang.StackWalker.Option.*;
+
+/**
+ * Prints the stack trace of Pinned Thread that is attempting to yield.
+ */
+public class PinnedThreadPrinter {
+    private static StackWalker STACKWALKER;
+
+    static {
+        STACKWALKER = StackWalker.getInstance(Set.of(SHOW_REFLECT_FRAMES, RETAIN_CLASS_REFERENCE));
+        STACKWALKER.setGetMontiorFlag();
+    }
+
+    static void printStackTrace(PrintStream out, boolean printAll) {
+        out.println(Thread.currentThread());
+        List<StackFrame> stackFrames = STACKWALKER.walk(s -> s.collect(Collectors.toList()));
+        for (int i = 0; i < stackFrames.size(); i++) {
+            StackFrameImpl sti = (StackFrameImpl)stackFrames.get(i);
+            Object[] monitors = sti.getMonitors();
+
+            if (monitors != null) {
+                out.println("    " + sti.toString() + " <== monitors:" + monitors.length);
+            } else if (sti.isNativeMethod() || (printAll && (sti.getDeclaringClass() != PinnedThreadPrinter.class))) {
+                out.println("    " + sti.toString());
+            }
+        }
+    }
+}

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -59,6 +59,11 @@ public final class StackWalker {
 	private final static int J9_SHOW_REFLECT_FRAMES = 2;
 	private final static int J9_SHOW_HIDDEN_FRAMES = 4;
 
+	/*[IF JAVA_SPEC_VERSION >= 21]*/
+	/* Internal flag for retrieving monitor info for stack frames. */
+	private final static int J9_GET_MONITORS = 0x10;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+
 	final Set<Option> walkerOptions;
 
 	private final int bufferSize;
@@ -96,6 +101,15 @@ public final class StackWalker {
 			flags |= J9_SHOW_HIDDEN_FRAMES;
 		}
 	}
+
+	/*[IF JAVA_SPEC_VERSION >= 21]*/
+	/**
+	 * Set the J9_GET_MONITORS flag.
+	 */
+	protected final void setGetMontiorFlag() {
+		flags |= J9_GET_MONITORS;
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
 	/**
 	 * Factory method to create a StackWalker instance with no options set.
@@ -390,6 +404,9 @@ public final class StackWalker {
 		private Module frameModule;
 		private String methodName;
 		private String methodSignature;
+		/*[IF JAVA_SPEC_VERSION >= 21]*/
+		private Object[] monitors;
+		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 		boolean callerSensitive;
 
 		@Override
@@ -492,6 +509,11 @@ public final class StackWalker {
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
+		/*[IF JAVA_SPEC_VERSION >= 21]*/
+		protected Object[] getMonitors() {
+			return monitors;
+		}
+		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 	}
 
 	static class PermissionSingleton {

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -35,7 +35,12 @@ extern "C" {
 #define SHOW_REFLECT_FRAMES 2
 #define SHOW_HIDDEN_FRAMES 4
 #define FRAME_VALID 8
+#if JAVA_SPEC_VERSION >= 21
+#define GET_MONITORS 0x10
+#define FRAME_FILTER_MASK (RETAIN_CLASS_REFERENCE | SHOW_REFLECT_FRAMES | SHOW_HIDDEN_FRAMES | GET_MONITORS)
+#else /* JAVA_SPEC_VERSION >= 21 */
 #define FRAME_FILTER_MASK (RETAIN_CLASS_REFERENCE | SHOW_REFLECT_FRAMES | SHOW_HIDDEN_FRAMES)
+#endif /* JAVA_SPEC_VERSION >= 21 */
 
 static UDATA stackFrameFilter(J9VMThread * currentThread, J9StackWalkState * walkState);
 
@@ -96,6 +101,32 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 	) {
 		walkState->flags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
 	}
+
+#if JAVA_SPEC_VERSION >= 21
+	J9ObjectMonitorInfo *info = NULL;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	if (J9_ARE_ALL_BITS_SET((UDATA)flags, GET_MONITORS)) {
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		IDATA infoLen = vmFuncs->getOwnedObjectMonitors(vmThread, vmThread, NULL, 0);
+		if (infoLen > 0) {
+			info = (J9ObjectMonitorInfo *)j9mem_allocate_memory(infoLen * sizeof(J9ObjectMonitorInfo), J9MEM_CATEGORY_VM_JCL);
+			if (NULL != info) {
+				IDATA rc = 0;
+				rc = vmFuncs->getOwnedObjectMonitors(vmThread, vmThread, info, infoLen);
+				if (rc >= 0) {
+					walkState->userData3 = info;
+					walkState->userData4 = (void *)infoLen;
+				} else {
+					j9mem_free_memory(info);
+				}
+			} else {
+				vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
+				return NULL;
+			}
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
 	walkState->frameWalkFunction = stackFrameFilter;
 	const char * walkerMethodChars = env->GetStringUTFChars(stackWalkerMethod, NULL);
 	if (NULL == walkerMethodChars) { /* native out of memory exception pending */
@@ -122,6 +153,13 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 	if (NULL != walkerMethodChars) {
 		env->ReleaseStringUTFChars(stackWalkerMethod, walkerMethodChars);
 	}
+
+#if JAVA_SPEC_VERSION >= 21
+	if (NULL != info) {
+		j9mem_free_memory(info);
+	}
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
 	vmThread->stackWalkState = newWalkState.previous;
 
 	return result;
@@ -278,6 +316,39 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 			if (J9ROMMETHOD_IS_CALLER_SENSITIVE(romMethod)) {
 				J9VMJAVALANGSTACKWALKERSTACKFRAMEIMPL_SET_CALLERSENSITIVE(vmThread, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), TRUE);
 			}
+
+#if JAVA_SPEC_VERSION >= 21
+			if (J9_ARE_ALL_BITS_SET(walkState->flags, GET_MONITORS)) {
+				J9ObjectMonitorInfo *monitorInfo = (J9ObjectMonitorInfo *)walkState->userData3;
+				IDATA *monitorCount = (IDATA *)(&walkState->userData4);
+
+				/* Temp fields to find the number of monitors hold by this frame. */
+				J9ObjectMonitorInfo *tempInfo = monitorInfo;
+				U_32 count = 0;
+				/* Use a while loop as there may be more than one lock taken in a stack frame. */
+				while ((0 != *monitorCount) && ((UDATA)tempInfo->depth == walkState->framesWalked)) {
+					count++;
+					tempInfo++;
+					(*monitorCount)--;
+				}
+				if (count > 0) {
+					J9Class *arrayClass = fetchArrayClass(vmThread, J9VMJAVALANGOBJECT(vm));
+					j9object_t monitorArray = mmFuncs->J9AllocateIndexableObject(vmThread, arrayClass, count, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
+					if (NULL == monitorArray) {
+						vmFuncs->setHeapOutOfMemoryError(vmThread);
+						goto _pop_frame;
+					}
+					J9VMJAVALANGSTACKWALKERSTACKFRAMEIMPL_SET_MONITORS(vmThread, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), monitorArray);
+					for (U_32 i = 0; i < count; i++) {
+						J9JAVAARRAYOFOBJECT_STORE(vmThread, monitorArray, i, monitorInfo->object);
+						monitorInfo++;
+					}
+
+					/* Store the updated progress back in userData for the next callback */
+					walkState->userData3 = monitorInfo;
+				}
+			}
+#endif /* JAVA_SPEC_VERSION >= 21 */
 
 _pop_frame:
 			DROP_OBJECT_IN_SPECIAL_FRAME(vmThread);

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -219,6 +219,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodName" signature="Ljava/lang/String;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodSignature" signature="Ljava/lang/String;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="frameModule" signature="Ljava/lang/Module;" versions="9-"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="monitors" signature="[Ljava/lang/Object;" versions="21-"/>
 
 	<!-- Common field references shared between OpenJ9 and OpenJDK Thread. -->
 	<fieldref class="java/lang/Thread" name="contextClassLoader" signature="Ljava/lang/ClassLoader;"/>


### PR DESCRIPTION
- New internal StackWalker flag J9_GET_MONITORS to include monitor entry info
into StackFramesImpl structure.
- New protected getMonitors() API to retrieve monitor entry info.

If the new StackWalker flag is set, the monitor info will be fetched before
parsing each stackframe and monitors will be added to the matching
StackFrameImpl structure's monitors array based on stack depth.
This will be used by PinnedThreadPrinter class to output the stack's acquired
monitors' state.

Fix: #17860 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>