### PR TITLE
[FFI/Jtreg_JDK21] Store the error codes correctly on Windows

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -23,9 +23,16 @@
 #if !defined(BYTECODEINTERPRETER_HPP_)
 #define BYTECODEINTERPRETER_HPP_
 
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
 #include <errno.h>
-#endif /* JAVA_SPEC_VERSION >= 20 */
+#if defined(WIN32)
+/* Ignore the definition of UDATA as it is defined in <windows.h>. */
+#define UDATA UDATA_win32_
+#include <windows.h>
+#undef UDATA /* This is safe because our UDATA is a typedef rather than a macro. */
+#include <winsock2.h>
+#endif /* defined(WIN32) */
+#endif /* JAVA_SPEC_VERSION >= 21 */
 
 #include "j9.h"
 #include "j9cfg.h"
@@ -5158,12 +5165,10 @@ done:
 			returnStorage = (UDATA *)(UDATA)*(I_64 *)(_sp + 5); /* returnStructMemAddr */
 		}
 
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
 		/* The native memory is allocated at java level to save the execution state after performing the downcall. */
 		returnState = (I_32 *)(UDATA)*(I_64 *)(_sp + 7); /* returnStateMemAddr */
-#endif /* JAVA_SPEC_VERSION >= 20 */
 
-#if JAVA_SPEC_VERSION >= 21
 		/* Set the linker option to the current thread for the trivial downcall. */
 		_currentThread->isInTrivialDownCall = (0 == *(U_32*)(_sp + 9)) ? FALSE : TRUE;
 #endif /* JAVA_SPEC_VERSION >= 21 */
@@ -5278,12 +5283,21 @@ done:
 		recordJNIReturn(REGISTER_ARGS, bp);
 		restoreSpecialStackFrameLeavingArgs(REGISTER_ARGS, bp);
 
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
 		/* Set the execution state after the downcall as required in the linker options. */
 		if (NULL != returnState) {
+			/* The error code layout on Windows in JDK21 is changed to a segment for an array of integers
+			 * which saves the return value of GetLastError(), WSAGetLastError() and errno.
+			 */
+#if defined(WIN32)
+			returnState[0] = GetLastError();
+			returnState[1] = WSAGetLastError();
+			returnState[2] = (I_32)errno;
+#else /* defined(WIN32) */
 			*returnState = (I_32)errno;
+#endif /* defined(WIN32) */
 		}
-#endif /* JAVA_SPEC_VERSION >= 20 */
+#endif /* JAVA_SPEC_VERSION >= 21 */
 		VM_VMHelpers::convertFFIReturnValue(_currentThread, returnType, returnTypeSize, returnStorage);
 		returnDoubleFromINL(REGISTER_ARGS, _currentThread->returnValue, argSlots);
 


### PR DESCRIPTION
The changes follow the latest update for the error code layout in JDK21 at
https://github.com/ibmruntimes/openj9-openjdk-jdk21/blob/openj9/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java to ensure all error code required on Windows
are saved correctly in order in the error code segment.

Fixes: #17873

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>