### PR TITLE
Update LinearDumpTests.testInvalidClassFile() and enable CFdumptest

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -148,12 +148,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>CFdumptest</testCaseName>
-		<disables>
-			<disable>
-				<comment>excluded OpenJ9 tests</comment>
-			</disable>
-		</disables>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)junit4.jar$(Q) \
 	junit.textui.TestRunner com.ibm.j9.cfdump.tests.CfdumpTestSuite; \
 	$(TEST_STATUS)</command>

--- a/test/functional/VM_Test/src/com/ibm/j9/cfdump/tests/lineardump/LinearDumpTests.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/cfdump/tests/lineardump/LinearDumpTests.java
@@ -104,7 +104,6 @@ public class LinearDumpTests extends LinearDumpTestCase {
 			String[] stringsToFind = new String[] {
 					"Invalid class file:",
 					"Recommended action: throw java.lang.ClassFormatError",
-					"bad magic number"
 			};
 
 			for (String line; (line = in.readLine()) != null && numFound != stringsToFind.length;) {


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/10917

Tested jdk8 all platforms in https://openj9-jenkins.osuosl.org/job/Grinder/2675/ which passed.