### PR TITLE
Remove JVM_IsThreadAlive() for Java 17

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -369,6 +369,7 @@ if(JAVA_SPEC_VERSION LESS 17)
 		_JVM_DTraceIsProbeEnabled@8
 		_JVM_DTraceIsSupported@4
 		_JVM_GetInterfaceVersion@0
+		_JVM_IsThreadAlive@8
 	)
 endif()
 
@@ -426,11 +427,7 @@ else()
 	)
 endif()
 
-if(JAVA_SPEC_VERSION LESS 21)
-	jvm_add_exports(jvm
-		_JVM_IsThreadAlive@8
-	)
-else()
+if(NOT JAVA_SPEC_VERSION LESS 21)
 	jvm_add_exports(jvm
 		JVM_IsForeignLinkerSupported
 		JVM_PrintWarningAtDynamicAgentLoad

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1687,7 +1687,7 @@ JVM_IsSupportedJNIVersion(jint version)
 }
 
 
-#if JAVA_SPEC_VERSION < 21
+#if JAVA_SPEC_VERSION < 17
 jboolean JNICALL
 JVM_IsThreadAlive(JNIEnv* jniEnv, jobject targetThread)
 {
@@ -1702,7 +1702,7 @@ JVM_IsThreadAlive(JNIEnv* jniEnv, jobject targetThread)
 	/* Assume that a non-null threadRef indicates the thread is alive */
 	return (NULL == vmThread) ? JNI_FALSE : JNI_TRUE;
 }
-#endif /* JAVA_SPEC_VERSION < 21 */
+#endif /* JAVA_SPEC_VERSION < 17 */
 
 
 jobject JNICALL

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -170,7 +170,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<exclude-if condition="spec.java20"/>
 		</export>
 		<export name="_JVM_IsThreadAlive@8">
-			<exclude-if condition="spec.java21"/>
+			<exclude-if condition="spec.java17"/>
 		</export>
 		<export name="_JVM_SuspendThread@8">
 			<exclude-if condition="spec.java20"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -185,7 +185,7 @@ _X(JVM_IsInterface,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
 _X(JVM_IsInterrupted,JNICALL,true,jboolean,JNIEnv *env, jobject thread, jboolean unknown)
 _X(JVM_IsPrimitiveClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
 _X(JVM_IsSupportedJNIVersion,JNICALL,true,jboolean,jint jniVersion)
-_IF([JAVA_SPEC_VERSION < 21],
+_IF([JAVA_SPEC_VERSION < 17],
 	[_X(JVM_IsThreadAlive,JNICALL,true,jboolean,JNIEnv *env, jobject targetThread)])
 _X(JVM_NewArray,JNICALL,true,jobject,JNIEnv *env, jclass componentType, jint dimension)
 _X(JVM_NewMultiArray,JNICALL,true,jobject,JNIEnv *env, jclass eltClass, jintArray dim)


### PR DESCRIPTION
Need was removed upstream by
* [8305425: Thread.isAlive0 doesn't need to call into the VM](https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/a0a6232914bea1b4fe2233b67a1b874481c1b8c0)