### PR TITLE
Remove unnecessary idiom recognition assertions

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -38,6 +38,7 @@
 #include "infra/HashTab.hpp"
 #include "infra/Link.hpp"
 #include "infra/List.hpp"
+#include "infra/String.hpp"
 #include "infra/TRlist.hpp"
 #include "optimizer/LoopCanonicalizer.hpp"
 #include "optimizer/OptimizationManager.hpp"
@@ -1469,6 +1470,9 @@ class TR_CISCTransformer : public TR_LoopTransformer
    TR_RegionStructure *getCurrentLoop() { return _loopStructure; }
    void setCurrentLoop(TR_RegionStructure *loop) { _loopStructure = loop; }
 
+   void countFail(const char *fmt, ...) TR_PRINTF_FORMAT_ATTR(2, 3);
+   void countUnhandledOpcode(const char *where, uint32_t opcode);
+
 private:
    List<TR::Block> _bblistPred;
    List<TR::Block> _bblistBody;
@@ -1510,6 +1514,8 @@ private:
    uint8_t *_DE;        // just for working
    bool _isGenerateI2L;
    bool _showMesssagesStdout;
+
+   TR::StringBuf _countFailBuf;
    };
 
 #endif

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -2245,8 +2245,11 @@ CISCTransform2NestedArrayFindBytes(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -3625,8 +3628,11 @@ CISCTransform2TROTArray(TR_CISCTransformer *trans)
    List<TR_CISCNode> *P2T = trans->getP2T();
    TR::Compilation *comp = trans->comp();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -5035,8 +5041,11 @@ CISCTransform2TRTOArray(TR_CISCTransformer *trans)
    List<TR_CISCNode> *P2T = trans->getP2T();
    TR::Compilation *comp = trans->comp();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -5832,8 +5841,11 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
    bool isDecrement = trans->isMEMCPYDec();
    const bool disptrace = DISPTRACE(trans);
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -6347,8 +6359,11 @@ CISCTransform2ArrayCopyB2CorC2B(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -6703,8 +6718,11 @@ CISCTransform2ArrayCopyB2CBndchk(TR_CISCTransformer *trans)
    List<TR_CISCNode> *P2T = trans->getP2T();
    TR::Compilation *comp = trans->comp();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -6919,8 +6937,11 @@ CISCTransform2ArrayCopyC2BMixed(TR_CISCTransformer *trans)
    List<TR_CISCNode> *P2T = trans->getP2T();
    TR::Compilation *comp = trans->comp();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -7249,8 +7270,11 @@ CISCTransform2ArrayCopyC2BIf2(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -7533,8 +7557,11 @@ CISCTransform2ArrayCopyB2I(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -8010,8 +8037,11 @@ CISCTransform2ArraySet(TR_CISCTransformer *trans)
    TR::Compilation *comp = trans->comp();
    bool ctrl = trans->isGenerateI2L();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -8678,8 +8708,11 @@ CISCTransform2MixedArraySet(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -10270,8 +10303,11 @@ CISCTransform2BitOpMem(TR_CISCTransformer *trans)
    TR::Compilation *comp = trans->comp();
    bool ctrl = trans->isGenerateI2L();
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -10805,8 +10841,11 @@ CISCTransform2CountDecimalDigit(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find
@@ -11114,8 +11153,11 @@ CISCTransform2LongToStringDigit(TR_CISCTransformer *trans)
 
    TR_ASSERT(trans->getP()->getVersionLength() == 0, "Versioning code is not implemented yet");
 
-   TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
-   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
+   if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1))
+      {
+      trans->countFail("%s/nonemptyAfterInsertionIdiomList", __FUNCTION__);
+      return false;
+      }
 
    trans->findFirstNode(&trTreeTop, &trNode, &block);
    if (!block) return false;    // cannot find


### PR DESCRIPTION
There are uses of `TR_ASSERT()` in idiom recognition that check for cases that are not necessarily impossible and that are handled conservatively in builds where `TR_ASSERT()` is not checked. Assertions are not a good way to detect and report these cases, since assertion failure is not likely to be due to a bug.

This commit removes a number of these assertions. Now the conservative logic will apply in all builds. When it does, a static debug counter will be incremented, and (when tracing idiom recognition) a message will be printed to the log.

Anyone who wants to look for transformations that have been prevented due to incomplete support for a particular case can use the new static debug counters.

Additionally, use `dumpOptDetails()` to trace when a transformer fails. In that case it's misleading to leave the log showing only the message from `performTransformation()`.

Fixes #17819