### PR TITLE
Improve MethodHandle direct dispatch J2I-prevention transformations

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5212,3 +5212,21 @@ J9::CodeGenerator::isProfiledClassAndCallSiteCompatible(TR_OpaqueClassBlock *pro
       }
    return false;
    }
+
+bool
+J9::CodeGenerator::enableJitDispatchJ9Method()
+   {
+   static const bool disable = feGetEnv("TR_disableJitDispatchJ9Method") != NULL;
+   return !disable
+      && self()->supportsNonHelper(TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol);
+   }
+
+bool
+J9::CodeGenerator::stressJitDispatchJ9MethodJ2I()
+   {
+   if (!self()->enableJitDispatchJ9Method())
+      return false;
+
+   static const bool stress = feGetEnv("TR_stressJitDispatchJ9MethodJ2I") != NULL;
+   return stress;
+   }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -633,6 +633,12 @@ public:
    */
    void setSavesNonVolatileGPRsForGC() {_j9Flags.set(SavesNonVolatileGPRsForGC); }
 
+   /// Determine whether \c jitDispatchJ9Method is (supported and) enabled.
+   bool enableJitDispatchJ9Method();
+
+   /// Determine whether to stress the J2I path for \c jitDispatchJ9Method.
+   bool stressJitDispatchJ9MethodJ2I();
+
 private:
 
    enum // Flags

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -314,6 +314,30 @@ J9::SymbolReferenceTable::findOrCreateLookupDynamicPublicInterfaceMethodSymbolRe
 
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateDispatchJ9MethodSymbolRef()
+   {
+   TR_ASSERT_FATAL(comp()->cg()->enableJitDispatchJ9Method(), "not enabled");
+
+   TR::SymbolReference *symRef = element(jitDispatchJ9MethodSymbol);
+   if (symRef == NULL)
+      {
+      TR::MethodSymbol *sym = TR::MethodSymbol::create(trHeapMemory(), TR_None);
+      sym->setHelper();
+      sym->setIsInlinedByCG();
+      sym->setLinkage(TR_Private);
+      TR::SymbolReference *symRef = new (trHeapMemory()) TR::SymbolReference(
+         self(), jitDispatchJ9MethodSymbol, sym);
+
+      symRef->setCanGCandReturn();
+      symRef->setCanGCandExcept();
+      element(jitDispatchJ9MethodSymbol) = symRef;
+      }
+
+   return element(jitDispatchJ9MethodSymbol);
+   }
+
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateFloatSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
    void * dataAddress = owningMethodSymbol->getResolvedMethod()->floatConstant(cpIndex);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -168,6 +168,13 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    //
    TR::SymbolReference * findOrCreateLookupDynamicPublicInterfaceMethodSymbolRef();
 
+   // "Non-helper" that takes the callee J9Method as an extra (first) argument.
+   //
+   // This uses JIT private linkage with a small tweak so that the call will
+   // match the expected linkage for the actual callee.
+   //
+   TR::SymbolReference * findOrCreateDispatchJ9MethodSymbolRef();
+
    TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);
    TR::SymbolReference * findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, char* name = NULL);
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2543,3 +2543,12 @@ J9::Node::canGCandReturn(TR::Compilation *comp)
       }
    return OMR::NodeConnector::canGCandReturn();
    }
+
+bool
+J9::Node::isJitDispatchJ9MethodCall(TR::Compilation *comp)
+   {
+   return self()->getOpCode().isCallDirect()
+      && comp->getSymRefTab()->isNonHelper(
+            self()->getSymbolReference(),
+            TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol);
+   }

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -367,6 +367,7 @@ public:
    void setSharedMemory(bool v);
 
    bool isArrayCopyCall();
+   bool isJitDispatchJ9MethodCall(TR::Compilation *comp);
 
    /**
     * Node flag functions end

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -324,9 +324,8 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::flushArguments(
 
    int32_t numGPArgs = 0;
    int32_t numFPArgs = 0;
-   int32_t argSize   = argAreaSize(callNode);
-   int32_t offset    = argSize;
-   bool    needFlush = false;
+   int32_t offset = argAreaSize(callNode);
+   bool needFlush = false;
 
    // account for the return address in thunks and snippets.
    if (isReturnAddressOnStack)
@@ -341,7 +340,11 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::flushArguments(
 
    const uint8_t slotSize = DOUBLE_SIZED_ARGS? 8 : 4;
 
-   for (int i = callNode->getFirstArgumentIndex(); i < callNode->getNumChildren(); i++)
+   int firstArgIndex = callNode->getFirstArgumentIndex();
+   if (callNode->isJitDispatchJ9MethodCall(cg()->comp()))
+      firstArgIndex++; // skip the J9Method
+
+   for (int i = firstArgIndex; i < callNode->getNumChildren(); i++)
       {
       TR::DataType type = callNode->getChild(i)->getType();
       dt = type.getDataType();
@@ -793,6 +796,10 @@ int32_t J9::X86::AMD64::PrivateLinkage::argAreaSize(TR::Node *callNode)
    int32_t  i;
    int32_t  result  = 0;
    int32_t  firstArgument   = callNode->getFirstArgumentIndex();
+
+   if (callNode->isJitDispatchJ9MethodCall(comp()))
+      firstArgument++; // skip the J9Method
+
    int32_t  lastArgument    = callNode->getNumChildren() - 1;
    for (i=firstArgument; i <= lastArgument; i++)
       {
@@ -809,7 +816,10 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildArgs(TR::Node                      
    TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
    bool passArgsOnStack;
    bool rightToLeft = methodSymbol && methodSymbol->isHelper()
-      && !methodSymRef->isOSRInductionHelper(); //we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
+      && !methodSymRef->isOSRInductionHelper()  //we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
+      // <jitDispatchJ9Method> receives arguments in the same order as the actual callee
+      && !callNode->isJitDispatchJ9MethodCall(comp());
+
    if (callNode->getOpCode().isIndirect())
       {
       if (methodSymbol->isVirtual() &&
@@ -884,6 +894,8 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node        
    int                        numDupedArgRegs = 0;
    TR::Register               *dupedArgRegs[NUM_INTEGER_LINKAGE_REGS + NUM_FLOAT_LINKAGE_REGS];
 
+   bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp());
+
    // Even though the parameters will be passed on the stack, create dummy linkage registers
    // to ensure that if the call were to be made using the linkage registers (e.g., in a guarded
    // devirtual snippet if it was overridden) then the registers would be available at this
@@ -943,6 +955,7 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node        
       TR::DataType             type      = child->getType();
       TR::RealRegister::RegNum  rregIndex = noReg;
       TR::DataType            dt        = type.getDataType();
+      bool reserveStackSlotForArg = true;
 
       switch (dt)
          {
@@ -977,6 +990,14 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node        
                   	break;
                   }
                }
+
+            if (rregIndex == noReg && isJitDispatchJ9Method && i == firstArgument)
+               {
+               rregIndex = getProperties().getJ9MethodArgumentRegister();
+               numSpecialArgs++;
+               reserveStackSlotForArg = false;
+               }
+
             if (rregIndex == noReg)
                {
                rregIndex =
@@ -1035,28 +1056,31 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node        
          dependencies->addPreCondition(preCondReg, rregIndex, cg());
          }
 
-      offset += child->getRoundedSize() * ((DOUBLE_SIZED_ARGS && dt != TR::Address) ? 2 : 1);
-
-      if ((rregIndex == noReg) || (rregIndex != noReg && createDummyLinkageRegisters))
+      if (reserveStackSlotForArg)
          {
-         if (vreg)
-            generateMemRegInstruction(
-               TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)),
-               child,
-               generateX86MemoryReference(stackPointer, parmAreaSize-offset, cg()),
-               vreg,
-               cg()
-               );
-         else
+         offset += child->getRoundedSize() * ((DOUBLE_SIZED_ARGS && dt != TR::Address) ? 2 : 1);
+
+         if ((rregIndex == noReg) || (rregIndex != noReg && createDummyLinkageRegisters))
             {
-            int32_t konst = child->getInt();
-            generateMemImmInstruction(
-               TR::InstOpCode::S8MemImm4,
-               child,
-               generateX86MemoryReference(stackPointer, parmAreaSize-offset, cg()),
-               konst,
-               cg()
-               );
+            if (vreg)
+               generateMemRegInstruction(
+                  TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)),
+                  child,
+                  generateX86MemoryReference(stackPointer, parmAreaSize-offset, cg()),
+                  vreg,
+                  cg()
+                  );
+            else
+               {
+               int32_t konst = child->getInt();
+               generateMemImmInstruction(
+                  TR::InstOpCode::S8MemImm4,
+                  child,
+                  generateX86MemoryReference(stackPointer, parmAreaSize-offset, cg()),
+                  konst,
+                  cg()
+                  );
+               }
             }
          }
 

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -804,15 +804,19 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
    {
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase*         fej9         = (TR_J9VMBase *)(cg()->fe());
+   TR::SymbolReferenceTable *srTab   = cg()->symRefTab();
    TR::SymbolReference* methodSymRef = _realMethodSymbolReference ? _realMethodSymbolReference : getNode()->getSymbolReference();
    TR::MethodSymbol*    methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
    uint8_t*             cursor       = cg()->getBinaryBufferCursor();
 
    bool needToSetCodeLocation = true;
    bool isJitInduceOSRCall    = false;
+   bool isJitDispatchJ9Method = false;
 
    if (methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper())
       isJitInduceOSRCall = true;
+   else if (getNode()->isJitDispatchJ9MethodCall(comp))
+      isJitDispatchJ9Method = true;
 
    if (comp->target().is64Bit())
       {
@@ -823,8 +827,9 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       cursor = linkage->storeArguments(getNode(), cursor, false, NULL);
       needToSetCodeLocation = false;
 
-      if (cg()->hasCodeCacheSwitched() &&
-          (methodSymRef->getReferenceNumber()>=TR_AMD64numRuntimeHelpers))
+      if (cg()->hasCodeCacheSwitched()
+          && methodSymRef->getReferenceNumber() >= TR_AMD64numRuntimeHelpers
+          && !isJitDispatchJ9Method)
          {
          fej9->reserveTrampolineIfNecessary(comp, methodSymRef, true);
          }
@@ -875,7 +880,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       TR_RuntimeHelper resolutionHelper = methodSymbol->isStatic() ?
          TR_X86interpreterUnresolvedStaticGlue : TR_X86interpreterUnresolvedSpecialGlue;
 
-      TR::SymbolReference *helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(resolutionHelper);
+      TR::SymbolReference *helperSymRef = srTab->findOrCreateRuntimeHelper(resolutionHelper);
 
       *cursor = 0xe8;    // CALL
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
@@ -909,7 +914,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       // JMP interpreterStaticAndSpecialGlue
       //
-      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
+      helperSymRef = srTab->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
       *cursor = 0xe9;    // JMP
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, helperSymRef);
@@ -977,7 +982,11 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       //SD: for jitInduceOSR we don't need to set the RAM method (the method that the VM needs to start executing)
       //because VM is going to figure what method to execute by looking up the jitPC in the GC map and finding
       //the desired invoke bytecode.
-      if (!isJitInduceOSRCall)
+      //
+      // For <jitDispatchJ9Method>, the method is passed in at runtime.
+      // Private linkage has already put it into the correct register.
+      //
+      if (!isJitInduceOSRCall && !isJitDispatchJ9Method)
          {
 #if defined(J9VM_OPT_JITSERVER)
          intptr_t ramMethod = comp->isOutOfProcessCompilation() && !methodSymbol->isInterpreted() ?
@@ -1029,9 +1038,27 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       //
       *cursor = 0xe9;
 
-      TR::SymbolReference *dispatchSymRef = isJitInduceOSRCall
-         ? methodSymRef
-         : cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
+      TR::SymbolReference *dispatchSymRef = NULL;
+      if (isJitInduceOSRCall)
+         {
+         dispatchSymRef = methodSymRef;
+         }
+      else
+         {
+         // For <jitDispatchJ9Method>, jump directly to j2iTransition instead
+         // of using the interpreter glue. Most of the time the glue would also
+         // go to j2iTransition, but first it would check to see if the callee
+         // is compiled, and if so, it would patch the call to target the JIT
+         // body instead of this call snippet, which is incorrect if the callee
+         // varies at runtime. Testing for a JIT body is redundant anyway
+         // because <jitDispatchJ9Method> has already just done that, and there
+         // wasn't one.
+         TR_RuntimeHelper helper = isJitDispatchJ9Method
+            ? TR_j2iTransition
+            : TR_X86interpreterStaticAndSpecialGlue;
+
+         dispatchSymRef = srTab->findOrCreateRuntimeHelper(helper);
+         }
 
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, dispatchSymRef);
       *(int32_t *)(++cursor) = disp32;

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -811,12 +811,8 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
    bool needToSetCodeLocation = true;
    bool isJitInduceOSRCall    = false;
 
-   if (comp->target().is64Bit() &&
-       methodSymbol->isHelper() &&
-       methodSymRef->isOSRInductionHelper())
-      {
+   if (methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper())
       isJitInduceOSRCall = true;
-      }
 
    if (comp->target().is64Bit())
       {
@@ -1033,9 +1029,9 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       //
       *cursor = 0xe9;
 
-      TR::SymbolReference* dispatchSymRef =
-          methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper() ? methodSymRef :
-                                                                             cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
+      TR::SymbolReference *dispatchSymRef = isJitInduceOSRCall
+         ? methodSymRef
+         : cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor, dispatchSymRef);
       *(int32_t *)(++cursor) = disp32;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -498,3 +498,15 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
 
    TR_ASSERT(newCache->isReserved(), "New CodeCache is not reserved");
    }
+
+bool
+J9::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+   {
+   if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol
+       && self()->comp()->target().is64Bit())
+      {
+      return true;
+      }
+
+   return J9::CodeGenerator::supportsNonHelper(symbol);
+   }

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -98,6 +98,9 @@ public:
     */
    bool canEmitBreakOnDFSet();
 
+   // See OMR::CodeGenerator::supportsNonHelper
+   bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
+
    // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
    bool guaranteesResolvedDirectDispatchForSVM() { return true; }
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1108,7 +1108,7 @@ J9::X86::PrivateLinkage::buildDirectDispatch(
    startLabel->setStartInternalControlFlow();
    doneLabel->setEndInternalControlFlow();
 
-   buildDirectCall(callNode->getSymbolReference(), site);
+   buildDirectCall(callNode->getSymbolReference(), site, doneLabel);
 
    // Construct postconditions
    //
@@ -1898,7 +1898,10 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    return returnRegister;
    }
 
-void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, TR::X86CallSite &site)
+void J9::X86::PrivateLinkage::buildDirectCall(
+   TR::SymbolReference *methodSymRef,
+   TR::X86CallSite &site,
+   TR::LabelSymbol *doneLabel)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
    TR::MethodSymbol   *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
@@ -1906,8 +1909,14 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
    TR::Node           *callNode     = site.getCallNode();
    TR_AtomicRegion   *callSiteAtomicRegions = TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions;
 
-   if (comp()->target().is64Bit() && methodSymRef->getReferenceNumber()>=TR_AMD64numRuntimeHelpers)
+   bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp());
+
+   if (comp()->target().is64Bit()
+       && methodSymRef->getReferenceNumber() >= TR_AMD64numRuntimeHelpers
+       && !isJitDispatchJ9Method)
+      {
       fej9->reserveTrampolineIfNecessary(comp(), methodSymRef, false);
+      }
 
 #if defined(J9VM_OPT_JITSERVER)
    // JITServer Workaround: Further transmute dispatchJ9Method symbols to appear as a runtime helper, this will cause OMR to
@@ -1970,6 +1979,86 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
       // Nop is necessary due to confusion when resolving shared slots at a transition
       if (methodSymRef->isOSRInductionHelper())
          generatePaddingInstruction(1, callNode, cg());
+      }
+   else if (isJitDispatchJ9Method)
+      {
+      // This should occur only on 64-bit because it's generated only for
+      // OpenJDK MethodHandles, which are not yet in use in Java 8, with Java 8
+      // being the last version to support 32-bit. This shouldn't necessarily
+      // be too hard to implement on 32-bit, but it is left unimplemented for
+      // now because we can't exercise it anyway until we start to get OpenJDK
+      // MethodHandles working on Java 8.
+      TR_ASSERT_FATAL(comp()->target().is64Bit(), "jitDispatchJ9Method on 32-bit");
+
+      TR::LabelSymbol *interpreterCallLabel = generateLabelSymbol(cg());
+
+      TR::Register *scratchReg = cg()->allocateRegister();
+      site.addPostCondition(
+         scratchReg, getProperties().getVTableIndexArgumentRegister());
+
+      // This will be assigned to getJ9MethodArgumentRegister().
+      TR::Register *j9mReg = callNode->getChild(0)->getRegister();
+
+      int32_t extraOffset = (int32_t)offsetof(J9Method, extra);
+      generateRegMemInstruction(
+         TR::InstOpCode::LRegMem(),
+         callNode,
+         scratchReg,
+         generateX86MemoryReference(j9mReg, extraOffset, cg()),
+         cg());
+
+      // The test/jnz sequence assumes that J9_STARTPC_NOT_TRANSLATED is a
+      // single bit in the low byte.
+      static_assert(0 < J9_STARTPC_NOT_TRANSLATED, "negative J9_STARTPC_NOT_TRANSLATED");
+      static_assert(J9_STARTPC_NOT_TRANSLATED < 256, "large J9_STARTPC_NOT_TRANSLATED");
+      static_assert(
+         (J9_STARTPC_NOT_TRANSLATED & (J9_STARTPC_NOT_TRANSLATED - 1)) == 0,
+         "non-power-of-two J9_STARTPC_NOT_TRANSLATED");
+
+      generateRegImmInstruction(
+         TR::InstOpCode::TEST1RegImm1, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED, cg());
+
+      TR::InstOpCode::Mnemonic oolBranchOp = TR::InstOpCode::JNE4;
+      if (cg()->stressJitDispatchJ9MethodJ2I())
+         oolBranchOp = TR::InstOpCode::JMP4; // go to J2I path unconditionally
+
+      generateLabelInstruction(oolBranchOp, callNode, interpreterCallLabel, cg());
+
+      // The method is compiled - call through register to JIT entry point
+      generateRegMemInstruction(
+         TR::InstOpCode::L4RegMem,
+         callNode,
+         j9mReg, // can reuse because the actual J9Method isn't needed anymore
+         generateX86MemoryReference(scratchReg, -4, cg()),
+         cg());
+
+      generateRegImmInstruction(
+         TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
+
+      generateRegRegInstruction(
+         TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
+
+      callInstr = generateRegInstruction(
+         TR::InstOpCode::CALLReg, callNode, scratchReg, cg());
+
+      // But if the method is interpreted, call through a call snippet instead.
+      // The snippet will store arguments to the stack and do a J2I transition.
+      TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
+      TR::SymbolReference *labelSymRef = new (trHeapMemory()) TR::SymbolReference(
+         comp()->getSymRefTab(), snippetLabel);
+
+      TR_OutlinedInstructionsGenerator og(interpreterCallLabel, callNode, cg());
+      TR::Instruction *interpreterCallInstr =
+         generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, 0, labelSymRef, cg());
+      interpreterCallInstr->setNeedsGCMap(site.getPreservedRegisterMask());
+      generateLabelInstruction(TR::InstOpCode::JMP4, callNode, doneLabel, cg());
+      og.endOutlinedInstructionSequence();
+
+      TR::Snippet *snippet = new (trHeapMemory()) TR::X86CallSnippet(
+         cg(), callNode, snippetLabel, false);
+
+      cg()->addSnippet(snippet);
+      cg()->stopUsingRegister(scratchReg);
       }
    else
       {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -253,7 +253,11 @@ class PrivateLinkage : public J9::PrivateLinkage
    //
    // doneLabel (always provided) is placed at the end of the call sequence by the caller of these functions.
    //
-   virtual void buildDirectCall(TR::SymbolReference *methodSymRef, TR::X86CallSite &site); // NOTE: the methodSymRef being called is not necessarily site.getSymbolReference()
+   virtual void buildDirectCall(
+      TR::SymbolReference *methodSymRef, // NOTE: the methodSymRef being called is not necessarily site.getSymbolReference()
+      TR::X86CallSite &site,
+      TR::LabelSymbol *doneLabel = NULL); // doneLabel is used only for jitDispatchJ9Method
+
    virtual void buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)=0;
    virtual void buildInterfaceCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk);
 


### PR DESCRIPTION
...by avoiding breaking the block containing the original call. There isn't much opportunity to optimize the inline logic anyway, so it's better to keep the IL neater.

On code generators that support doing so (initially just x86-64), calls to `linkToStatic`, `linkToSpecial`, and `invokeBasic` that have not been refined are now changed in-place into calls to a new JIT non-helper `<jitDispatchJ9Method>`, which takes the callee `J9Method` as an additional (first) argument. It has JIT private linkage, but the extra argument is treated specially so that the other arguments are passed in exactly the way expected by (any JIT-compiled body for) the actual callee. The code generator generates a sequence that determines whether the callee is compiled and jumps to the JIT entry point if it is. Otherwise, it jumps out of line to do a J2I transition.

If the environment variable `TR_stressJitDispatchJ9MethodJ2I` is set, then the back end generates an unconditional jump to the J2I path, exercising it even when the callee is compiled.

----

There is one additional commit to get rid of the `mov edi, <imm>` instruction in the call snippet when calling an OSR induction helper on x86-32, mostly for consistency.

----

This depends on eclipse/omr#7090