### PR TITLE
Fix GC crash when running portable code on PWR10 CPUs

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -623,6 +623,16 @@ public:
     */
    bool guaranteesResolvedVirtualDispatchForSVM() { return false; } // safe default
 
+   /** \brief
+   *    Determines if this method is saving all Non Volatile registers for the GC
+   */
+   bool getSavesNonVolatileGPRsForGC() { return _j9Flags.testAny(SavesNonVolatileGPRsForGC); }
+
+   /** \brief
+   *    Set the flag specifying that this method is saving all Non Volatile registers for the GC
+   */
+   void setSavesNonVolatileGPRsForGC() {_j9Flags.set(SavesNonVolatileGPRsForGC); }
+
 private:
 
    enum // Flags
@@ -638,6 +648,7 @@ private:
       SupportsIntegerStringSize                           = 0x00000100,
       SupportsIntegerToChars                              = 0x00000200,
       SupportsInlineEncodeASCII                           = 0x00000400,
+      SavesNonVolatileGPRsForGC                           = 0x00000800,
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -231,6 +231,7 @@ TR::Register *J9::Power::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       {
       // We need to kill all the non-volatiles so that they'll be in a stack frame in case
       // gc needs to find them.
+      cg()->setSavesNonVolatileGPRsForGC();
       if (comp()->target().is64Bit())
          {
          if (comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))


### PR DESCRIPTION
When running portable code (CRIU or PortableAOT) on PWR10 CPUs and a method needs to save all non-volatile registers so that GC has access to them (i.e. methods with a Direct-to-JNI call-out) this issue can occur. 1) The portable code will be compiled for PWR8 and therefor does not save R16 since it is dedicated to the PTOC and therefore can never contain a collectible obj ref. 2) A method lower on the stack could have been compiled for PWR10 and used R16 to hold a collectible obj ref. Now if a GC cycle occurs while executing in the JNI code, the GC will retrieve the saved non-volatile registers from the frame of the portable code method (R17-R31). Then it walks the stack looking for collectible references. When it encounters a frame for a PWR10 compiled method that has marked R16 as collectible it will look at its register set and try to access R16. Since the portable code did not save R16 it gets a null reference and crashes.

This fix will force portable code that saves all non-volatile registers for the GC to save and restore R16 even when the target CPU is less then PWR10. In this way, should the portable code be executed on a PWR10 CPU, it will have saved R16 in case some frame down the stack from the portable code's frame uses R16 to hold a collectible obj reference.