### PR TITLE
CRIU tests add failure condition when a javacore is requested

### DIFF
--- a/test/functional/cmdLineTests/criu/criu.xml
+++ b/test/functional/cmdLineTests/criu/criu.xml
@@ -38,6 +38,7 @@
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
@@ -52,6 +53,7 @@
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image three times">
@@ -67,6 +69,7 @@
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_jitPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitPostRestore.xml
@@ -38,12 +38,14 @@
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
 		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Check Verbose Log">
 		<command>bash $CATSCRIPPATH$ vlog true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xnojit -Xnoaot">
@@ -60,6 +62,7 @@
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
 		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xnoaot">
@@ -76,6 +79,7 @@
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
 		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xjit:exclude={*}">
@@ -92,6 +96,7 @@
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
 		<output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverAcrossCheckpoint.xml
@@ -46,12 +46,14 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Check Connection in Pre-Checkpoint Verbose Log">
 		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="failure">Connected to a server</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Check Connection in Post-Restore Verbose Log">
@@ -59,6 +61,7 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="JITServer not explicitly enabled Post-Restore">
@@ -76,6 +79,7 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
@@ -83,6 +87,7 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 		<output regex="no" type="failure">Connected to a server</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Portable CRIU Mode: JITServer not explicitly enabled Post-Restore">
@@ -100,6 +105,7 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Portable CRIU Mode; JITServer not explicitly enabled Post-Restore: Check no connection in Post-Restore Verbose Log">
@@ -107,6 +113,7 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 		<output regex="no" type="failure">Connected to a server</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
@@ -124,12 +131,14 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint: Check no connection in Pre-Checkpoint Verbose Log">
 		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="success">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="failure">Connected to a server</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
@@ -137,6 +146,7 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Portable CRIU Mode: Enable JITServer specified Pre-Checkpoint but not explicitly enabled Post-Restore">
@@ -154,12 +164,14 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Pre-Checkpoint Verbose Log">
 		<command>bash $CATSCRIPPATH$ preCheckpointVlog false false</command>
 		<output regex="no" type="required">JITServer: JITServer Client Mode.</output>
 		<output regex="no" type="success">Connected to a server</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Portable CRIU Mode; Enable JITServer specified Pre-Checkpoint: Check connection in Post-Restore Verbose Log">
@@ -167,5 +179,6 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
@@ -44,6 +44,7 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Check Verbose Log">
@@ -51,6 +52,7 @@
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xnojit -Xnoaot">
@@ -71,6 +73,7 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xnoaot">
@@ -91,6 +94,7 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 
 	<test id="Test -Xjit:exclude={*}">
@@ -111,5 +115,6 @@
 		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
+++ b/test/functional/cmdLineTests/criu/criu_keepCheckpoint.xml
@@ -38,6 +38,7 @@
     <output type="failure" caseSensitive="yes" regex="no">ERR</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -51,6 +51,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image twice">
@@ -68,6 +69,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
 <!--
@@ -80,6 +82,7 @@
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: System.nanoTime() after CRIU restore:</output>
     <output type="required" caseSensitive="yes" regex="no">Error</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
  -->
 
@@ -97,6 +100,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testSystemNanoTimeJitPostCheckpointCompile">
@@ -113,6 +117,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
@@ -129,6 +134,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testMillisDelayBeforeCheckpointDone">
@@ -145,6 +151,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testDateScheduledBeforeCheckpointDone">
@@ -161,6 +168,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore three times - testDateScheduledAfterCheckpointDone">
@@ -177,6 +185,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create Criu Checkpoint Image once and no restore - TestSingleThreadModeCheckpointException">
@@ -323,6 +332,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Properties test1">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest1 1</command>
@@ -340,6 +350,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Properties test2">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest2 1</command>
@@ -357,6 +368,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Properties test3">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest3 1</command>
@@ -374,6 +386,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Properties test4">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ PropertiesTest4 1</command>
@@ -389,6 +402,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Test setting SecurityManager via -Djava.security.manager">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $OPTION_SET_SECURITYMANAGER$ $MAINCLASS_TEST_SECURITYMANAGER$ setSMCommandOption 1</command>
@@ -402,6 +416,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Test setting SecurityManager programmatically">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_TEST_SECURITYMANAGER$ setSMProgrammatically 1</command>
@@ -415,6 +430,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Envvar test1">
@@ -431,6 +447,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test2">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest2 1</command>
@@ -446,6 +463,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test3">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest3 1</command>
@@ -461,6 +479,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test4">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest4 1</command>
@@ -476,6 +495,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test5">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.16" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest5 1</command>
@@ -494,6 +514,7 @@
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop1=val1</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop2=val2</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop3=val3</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test6">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.16" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest6 1</command>
@@ -512,6 +533,7 @@
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop1=val1</output>
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop2=val2</output>
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop3=val3</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test7">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.16" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest7 1</command>
@@ -530,6 +552,7 @@
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop1=val1</output>
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop2=val2</output>
     <output type="failure" caseSensitive="yes" regex="no">Restore arg: -Dprop3=val3</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test8">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.16" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest8 1</command>
@@ -548,6 +571,7 @@
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop1=val1</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop2=val2</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop3=val3</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test9">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest9 1</command>
@@ -563,6 +587,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test10">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest10 1</command>
@@ -578,6 +603,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test11">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest11 1</command>
@@ -593,6 +619,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test12">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu.16" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest12 1</command>
@@ -611,6 +638,7 @@
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop1=val1</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop2=val2</output>
     <output type="success" caseSensitive="yes" regex="no">Restore arg: -Dprop3=val3</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test13">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest13 1</command>
@@ -627,6 +655,7 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test14">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest14 1</command>
@@ -643,6 +672,7 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test15">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest15 1</command>
@@ -659,6 +689,7 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Envvar test16">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_ENVVAR_TEST$ EnvVarFileTest16 1</command>
@@ -675,6 +706,7 @@
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore trace options test with no trace options specified before checkpoint - 1">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest1 1</command>
@@ -713,6 +745,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore trace options test with no trace options specified before checkpoint - 3">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest3 1</command>
@@ -729,6 +762,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ DumpOptionsTest 1</command>
@@ -745,6 +779,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="criuCheckpoint dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xdump:java:events=criuCheckpoint" $MAINCLASS_OPTIONSFILE_TEST$ criuDumpOptionsTest 1</command>
@@ -761,6 +796,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="criuCheckpoint dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xdump:java:events=criuRestore" $MAINCLASS_OPTIONSFILE_TEST$ criuDumpOptionsTest 1</command>
@@ -777,6 +813,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="criuRestore dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ criuRestoreDumpOptionsTest 1</command>
@@ -793,6 +830,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint and -Xdump:dynamic required">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $XDUMP_DYNAMIC$" $MAINCLASS_OPTIONSFILE_TEST$ dumpOptionsTestRequireDynamic 1</command>
@@ -812,6 +850,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Username test">
@@ -827,5 +866,6 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
@@ -43,6 +43,7 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testThreadSleep">
@@ -60,6 +61,7 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitNotify">
@@ -77,6 +79,7 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedNoNanoSecond">
@@ -94,6 +97,7 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedWithNanoSecond">
@@ -111,5 +115,6 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable_RAS.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable_RAS.xml
@@ -63,6 +63,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore trace options test with -Xtrace before checkpoint - 3">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest3 1</command>
@@ -79,6 +80,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ DumpOptionsTest 1</command>
@@ -95,6 +97,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
   <test id="Restore dump options test with no dump options specified before checkpoint and -Xdump:dynamic required">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $XDUMP_DYNAMIC$" $MAINCLASS_OPTIONSFILE_TEST$ dumpOptionsTestRequireDynamic 1</command>
@@ -114,5 +117,6 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_random.xml
+++ b/test/functional/cmdLineTests/criu/criu_random.xml
@@ -38,6 +38,7 @@
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="First Restore of Criu Checkpoint Image">
@@ -53,6 +54,7 @@
     <output type="failure" caseSensitive="yes" regex="no">Can't open dir cpData: No such file or directory</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
   <test id="Second Restore of Criu Checkpoint Image">
@@ -69,6 +71,7 @@
     <output type="failure" caseSensitive="yes" regex="no">Can't open dir cpData: No such file or directory</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_security.xml
+++ b/test/functional/cmdLineTests/criu/criu_security.xml
@@ -39,6 +39,7 @@
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
 </suite>


### PR DESCRIPTION
CRIU tests add failure condition when a `javacore` is requested

CRIU tests fail if a `javacore` file is requested.

related 
* https://github.com/eclipse-openj9/openj9/pull/17859#issuecomment-1658366404

Signed-off-by: Jason Feng <fengj@ca.ibm.com>