### PR TITLE
Adjust arguments to Unsafe array operations while offheap is enabled

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -831,11 +831,13 @@ TR_J9InlinerPolicy::createAnchorNodesForUnsafeGetPut(TR::TreeTop* treeTop,
 
       TR::Node* node = treeTop->getNode();
       TR::TreeTop *compRefTT =
-         TR::TreeTop::create(comp(), genCompressedRefs(isUnsafeGet ? node->getFirstChild() : node,
-                                                       false));
+         TR::TreeTop::create(comp(), genCompressedRefs(isUnsafeGet?node->getFirstChild():node,
+                                                      false));
+
       TR::TreeTop *prevTT = treeTop->getPrevTreeTop();
-      prevTT->join(compRefTT);
+      if (prevTT != NULL) prevTT->join(compRefTT);
       compRefTT->join(isUnsafeGet ? treeTop : treeTop->getNextTreeTop());
+
       }
    }
 
@@ -1664,22 +1666,66 @@ TR_J9InlinerPolicy::createUnsafeCASCallDiamond( TR::TreeTop *callNodeTreeTop, TR
    // Codegens have a fast path for the compare and swaps, but cannot deal with the case where the offset value passed in to a the CAS is low tagged
    // (A low tagged offset value means the object being passed in is a java/lang/Class object, and we want a static field)
 
+   // Regarding which checks/diamonds get generated, there are three possible cases:
+   // 1.) Only the low tagged check is generated. This will occur either when gencon GC policy is being used, or under 
+   //     balanced GC policy with offheap allocation enabled if the object being operated on is known NOT to be an array 
+   //     at compile time.
+   // 2.) No checks are generated. This will occur under balanced GC policy with offheap allocation enabled if the object
+   //     being operated on is known to be an array at compile time (since if the object is an array, it can't also be a 
+   //     java/lang/Class object).
+   // 3.) Both the array and low tagged checks are generated. This will occur under balanced GC policy with offheap allocation
+   //     enabled if the type of the object being operated on is unknown at compile time.
+
    // This method assumes the offset node is of type long, and is the second child of the unsafe call.
    TR_InlinerDelimiter delimiter(tracer(),"createUnsafeCASCallDiamond");
    debugTrace(tracer(),"Transforming unsafe callNode = %p",callNode);
+
+   int length;
+   const char *objTypeSig = callNode->getChild(1)->getSymbolReference() ? callNode->getChild(1)->getSymbolReference()->getTypeSignature(length) : NULL;
+
+   // There are three cases where we cannot be sure of the Object type at compile time:
+   // 1.) Object type info is unknown/inaccessible
+   // 2.) Object type is known at compile time to be java/lang/Object
+   // 3.) Object type is known at compile time to be some interface classes (e.g.: java/lang/Cloneable, java/io/Serializable)
+   bool objTypeUnknown;
+
+   if (objTypeSig == NULL)
+      {
+      objTypeUnknown = true;
+      }
+   else
+      {
+      TR_OpaqueClassBlock *objClass = comp()->fe()->getClassFromSignature(objTypeSig, length, callNode->getChild(1)->getSymbolReference()->getOwningMethod(comp()));
+      bool isParameter = callNode->getChild(1)->getSymbolReference()->getSymbol()->isParm();
+
+      objTypeUnknown = objClass == NULL || objClass == comp()->getObjectClassPointer() || TR::Compiler->cls.isInterfaceClass(comp(), objClass) || isParameter;
+      }
+
+   //only generate array test in case (3)
+   bool arrayTestNeeded = TR::Compiler->om.isOffHeapAllocationEnabled() && comp()->target().is64Bit() && objTypeUnknown;
+
+   //only generate separate array access block in cases (2) or (3)
+   bool arrayBlockNeeded = TR::Compiler->om.isOffHeapAllocationEnabled() && comp()->target().is64Bit() &&
+                           (arrayTestNeeded || objTypeSig[0] == '[');
 
    createTempsForUnsafeCall(callNodeTreeTop, callNode);
 
    TR::Node *offsetNode = callNode->getChild(2);
 
-   TR::TreeTop *compareTree = genClassCheckForUnsafeGetPut(offsetNode, /* branchIfLowTagged */ false);
+   TR::TreeTop *compareTree;
+
+   //do not generate low tagged test in case (2)
+   if (!arrayTestNeeded && arrayBlockNeeded)
+      compareTree = NULL;
+   else
+      compareTree = genClassCheckForUnsafeGetPut(offsetNode, /* branchIfLowTagged */ false );
 
    TR::TreeTop *isArrayTreeTop = NULL;
    TR::TreeTop *arrayAccessTreeTop = NULL;
    TR::TreeTop *nonArrayAccessTreeTop = NULL;
 
 #if defined (J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
-   if (TR::Compiler->om.isOffHeapAllocationEnabled())
+   if (arrayTestNeeded)
    {
       //create arrayCHK treetop
 
@@ -1701,8 +1747,10 @@ TR_J9InlinerPolicy::createUnsafeCASCallDiamond( TR::TreeTop *callNodeTreeTop, TR
       TR::Node *isArrayNode = TR::Node::createif(TR::ificmpne, andNode, TR::Node::create(TR::iconst, 0), NULL);
 
       isArrayTreeTop = TR::TreeTop::create(comp(), isArrayNode, NULL, NULL);
+   }
 
-
+   if (arrayBlockNeeded)
+   {
       //create array access treetop
       //adjust arguments if object is array and offheap is being used by changing
       //object base address (second child) to dataAddr
@@ -1735,21 +1783,27 @@ TR_J9InlinerPolicy::createUnsafeCASCallDiamond( TR::TreeTop *callNodeTreeTop, TR
       if (isArrayTreeTop)
          nonArrayAccessTreeTop = TR::TreeTop::create(comp(),callNodeTreeTop->getNode()->duplicateTree());
    }
-#endif /* TR_TARGET_64BIT */
+#endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
 
-   // genClassCheck generates a ifcmpne offset&mask 1, meaning if it is NOT
-   // lowtagged (ie offset&mask == 0), the branch will be taken
-   TR::TreeTop *branchTargetTree = TR::TreeTop::create(comp(),callNodeTreeTop->getNode()->duplicateTree());
-   branchTargetTree->getNode()->getFirstChild()->setIsSafeForCGToFastPathUnsafeCall(true);
+   TR::TreeTop *branchTargetTree;
+   TR::TreeTop *fallThroughTree;
 
-   TR::TreeTop *fallThroughTree = TR::TreeTop::create(comp(),callNodeTreeTop->getNode()->duplicateTree());
+   //only generate if and else trees for low tagged check in cases (1) and (3)
+   if (compareTree != NULL)
+   {
+      // genClassCheck generates a ifcmpne offset&mask 1, meaning if it is NOT
+      // lowtagged (ie offset&mask == 0), the branch will be taken
+      branchTargetTree = TR::TreeTop::create(comp(),callNodeTreeTop->getNode()->duplicateTree());
+      branchTargetTree->getNode()->getFirstChild()->setIsSafeForCGToFastPathUnsafeCall(true);
+
+      fallThroughTree = TR::TreeTop::create(comp(),callNodeTreeTop->getNode()->duplicateTree());
 
 
-   branchTargetTree->getNode()->getFirstChild()->setVisitCount(_inliner->getVisitCount());
-   fallThroughTree->getNode()->getFirstChild()->setVisitCount(_inliner->getVisitCount());
+      branchTargetTree->getNode()->getFirstChild()->setVisitCount(_inliner->getVisitCount());
+      fallThroughTree->getNode()->getFirstChild()->setVisitCount(_inliner->getVisitCount());
 
-
-   debugTrace(tracer(),"branchTargetTree = %p fallThroughTree = %p",branchTargetTree->getNode(),fallThroughTree->getNode());
+      debugTrace(tracer(),"branchTargetTree = %p fallThroughTree = %p",branchTargetTree->getNode(),fallThroughTree->getNode());
+   }
 
 
    // the call itself may be commoned, so we need to create a temp for the callnode itself
@@ -1768,33 +1822,43 @@ TR_J9InlinerPolicy::createUnsafeCASCallDiamond( TR::TreeTop *callNodeTreeTop, TR
 
    TR::Block *callBlock = callNodeTreeTop->getEnclosingBlock();
 
-   if (isArrayTreeTop != NULL) //offheap case: array check generated
+   if (arrayTestNeeded) //in case (3), we generate the array test diamond, followed by the low tagged check test
    {
       callBlock->createConditionalBlocksBeforeTree(callNodeTreeTop, isArrayTreeTop, arrayAccessTreeTop, nonArrayAccessTreeTop, comp()->getFlowGraph(), false, false);
       nonArrayAccessTreeTop->getEnclosingBlock()->createConditionalBlocksBeforeTree(nonArrayAccessTreeTop, compareTree, branchTargetTree, fallThroughTree, comp()->getFlowGraph(), false, false);
    }
-   else //default case (gencon): no array check generated
+   else if (arrayBlockNeeded) //in case (2), no branching is needed: we simply need to replace the original CAS call with the modified array access block 
+   {
+      callNodeTreeTop->insertAfter(arrayAccessTreeTop);
+      callNodeTreeTop->getPrevTreeTop()->join(callNodeTreeTop->getNextTreeTop());
+      callBlock->split(arrayAccessTreeTop->getNextTreeTop(), comp()->getFlowGraph(), true);
+      callBlock->split(arrayAccessTreeTop, comp()->getFlowGraph(), true);
+   }
+   else if (compareTree != NULL) //in case (1), we only generate the low tagged check diamond 
       callBlock->createConditionalBlocksBeforeTree(callNodeTreeTop, compareTree, branchTargetTree, fallThroughTree, comp()->getFlowGraph(), false, false);
 
-   // the original call will be deleted by createConditionalBlocksBeforeTree, but if the refcount was > 1, we need to insert stores.
 
+   // the original call will be deleted by createConditionalBlocksBeforeTree, but if the refcount was > 1, we need to insert stores.
    if (newSymbolReference)
       {
-      TR::Node *branchTargetStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1, branchTargetTree->getNode()->getFirstChild(), newSymbolReference);
-      TR::TreeTop *branchTargetStoreTree = TR::TreeTop::create(comp(), branchTargetStoreNode);
+      if (compareTree != NULL) //case (1) and (3) only
+      {
+         TR::Node *branchTargetStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1, branchTargetTree->getNode()->getFirstChild(), newSymbolReference);
+         TR::TreeTop *branchTargetStoreTree = TR::TreeTop::create(comp(), branchTargetStoreNode);
 
-      branchTargetTree->insertAfter(branchTargetStoreTree);
+         branchTargetTree->insertAfter(branchTargetStoreTree);
 
-      debugTrace(tracer(),"Inserted store tree %p for branch target (taken) side of the diamond",branchTargetStoreNode);
+         debugTrace(tracer(),"Inserted store tree %p for branch target (taken) side of the diamond", branchTargetStoreNode);
 
-      TR::Node *fallThroughStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1, fallThroughTree->getNode()->getFirstChild(), newSymbolReference);
-      TR::TreeTop *fallThroughStoreTree = TR::TreeTop::create(comp(), fallThroughStoreNode);
+         TR::Node *fallThroughStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1, fallThroughTree->getNode()->getFirstChild(), newSymbolReference);
+         TR::TreeTop *fallThroughStoreTree = TR::TreeTop::create(comp(), fallThroughStoreNode);
 
-      fallThroughTree->insertAfter(fallThroughStoreTree);
+         fallThroughTree->insertAfter(fallThroughStoreTree);
 
-      debugTrace(tracer(),"Inserted store tree %p for fall-through side of the diamond",fallThroughStoreNode);
+         debugTrace(tracer(),"Inserted store tree %p for fall-through side of the diamond", fallThroughStoreNode);
+      }
 
-      if (arrayAccessTreeTop != NULL)
+      if (arrayAccessTreeTop != NULL) //case (1) only
          {
          TR::Node *arrayAccessStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1, arrayAccessTreeTop->getNode()->getFirstChild(), newSymbolReference);
          TR::TreeTop *arrayAccessStoreTree = TR::TreeTop::create(comp(), arrayAccessStoreNode);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -998,7 +998,7 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
 
    if (typeTestsNeeded && arrayBlockNeeded) // CASE (1)
       {
-      indirectAccessBlock = beforeCallBlock->getNextBlock();
+      directAccessBlock = beforeCallBlock->getNextBlock();
 
       if (directAccessWithConversionTreeTop)
          {
@@ -1036,7 +1036,7 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
       indirectAccessBlock->append(indirectAccessTreeTop);
       indirectAccessBlock->append(
             TR::TreeTop::create(comp(),
-                                TR::Node::create(directAccessTreeTop->getNode(),
+                                TR::Node::create(indirectAccessTreeTop->getNode(),
                                                  TR::Goto, 0, joinBlock->getEntry())));
 
       arrayDirectAccessBlock->getExit()->insertTreeTopsAfterMe(indirectAccessBlock->getEntry(),

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -305,6 +305,10 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
        * \param indirectAccessTreeTop A pointer to a \ref TR::TreeTop for the IL
        *           needed to perform a more "indirect" reference loading or storing a
        *           static field value for the \c Unsafe method call
+       * \param directAccessWithConversionTreeTop A pointer to a \ref TR::TreeTop for
+       *           the IL needed to perform a nearly "direct" reference loading or 
+       *           storing a value for the \c Unsafe method call, with a conversion
+       *           for one or two byte values
        * \param needNullCheck A \bool value indicating whether a \ref TR::NULLCHK
        *           needs to be generated for the value of \c unsafeAddress
        * \param isUnsafeGet A \bool value indicating whether the call represents an
@@ -313,14 +317,19 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
        * \param conversionNeeded Indicates whether the call reprents an \c Unsafe
        *           method call involving any of Java \c char, \c short, \c byte or
        *           \c boolean.
+       * \param arrayBlockNeeded Indicates whether a separate access block needs to be
+       *           generated to handle the case where the \c Object is an array
+       * \param typeTestsNeeded Indicates whether any type tests for \c Object need to
+       *           be generated (i.e.: if the type of the \c Object is unknown)
        * \param orderedCallNode Indicates whether the call represents an \c Unsafe
        *           ordered method
        */
       void genCodeForUnsafeGetPut(TR::Node* unsafeAddress, TR::Node *unsafeOffset, TR::DataType type, TR::TreeTop* callNodeTreeTop,
                                   TR::TreeTop* prevTreeTop, TR::SymbolReference* newSymbolReferenceForAddress,
                                   TR::TreeTop* directAccessTreeTop, TR::TreeTop* arraydirectAccessTreeTop,
-                                  TR::TreeTop* indirectAccessTreeTop, bool needNullCheck, bool isUnsafeGet,
-                                  bool conversionNeeded, TR::Node* orderedCallNode);
+                                  TR::TreeTop* indirectAccessTreeTop, TR::TreeTop* directAccessWithConversionTreeTop,
+                                  bool needNullCheck, bool isUnsafeGet, bool conversionNeeded, 
+                                  bool arrayBlockNeeded, bool typeTestsNeeded, TR::Node* orderedCallNode);
       virtual bool callMustBeInlined(TR_CallTarget *calltarget);
       virtual bool callMustBeInlinedInCold(TR_ResolvedMethod *method);
       bool mustBeInlinedEvenInDebug(TR_ResolvedMethod * calleeMethod, TR::TreeTop *callNodeTreeTop);

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -306,7 +306,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
        *           needed to perform a more "indirect" reference loading or storing a
        *           static field value for the \c Unsafe method call
        * \param directAccessWithConversionTreeTop A pointer to a \ref TR::TreeTop for
-       *           the IL needed to perform a nearly "direct" reference loading or 
+       *           the IL needed to perform a nearly "direct" reference loading or
        *           storing a value for the \c Unsafe method call, with a conversion
        *           for one or two byte values
        * \param needNullCheck A \bool value indicating whether a \ref TR::NULLCHK
@@ -328,7 +328,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
                                   TR::TreeTop* prevTreeTop, TR::SymbolReference* newSymbolReferenceForAddress,
                                   TR::TreeTop* directAccessTreeTop, TR::TreeTop* arraydirectAccessTreeTop,
                                   TR::TreeTop* indirectAccessTreeTop, TR::TreeTop* directAccessWithConversionTreeTop,
-                                  bool needNullCheck, bool isUnsafeGet, bool conversionNeeded, 
+                                  bool needNullCheck, bool isUnsafeGet, bool conversionNeeded,
                                   bool arrayBlockNeeded, bool typeTestsNeeded, TR::Node* orderedCallNode);
       virtual bool callMustBeInlined(TR_CallTarget *calltarget);
       virtual bool callMustBeInlinedInCold(TR_ResolvedMethod *method);


### PR DESCRIPTION
In this contribution, the following adjustments have been made to the arguments that are passed in to Unsafe.get(), Unsafe.put(), and Unsafe.compareAndSwap() when offheap/balanced GC policy is in use:

- The dataAddr pointer is loaded and passed in as the base address of the object being operated on
- ~The array header size is subtracted from the offset~ 
_no longer necessary due to this change_: https://github.com/eclipse-openj9/openj9/pull/19326/

This is to account for the differing array shape under offheap/balanced GC policy as opposed to the default (gencon).

In addition, as a performance improvement for both the offheap and gencon cases, when the object type is known at compile time, we can eliminate unnecessary lowtag, class, and array checks that are currently performed at runtime for the following cases:

-  Object is known to be an array at compile time
- Object type is known to be non-array, non-class, non-java/lang/Object at compile time

Depends on https://github.com/eclipse-openj9/openj9/pull/18303