### PR TITLE
Disable inlining of intrinsics

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2667,6 +2667,9 @@ J9::Options::fePreProcess(void * base)
    self()->setOption(TR_EnableSymbolValidationManager);
 #endif
 
+   // Forcing inlining of unrecognized intrinsics needs more performance investigation
+   self()->setOption(TR_DisableInliningUnrecognizedIntrinsics);
+
    return true;
    }
 


### PR DESCRIPTION
- https://github.com/eclipse-openj9/openj9/pull/17222 seems to cause a slowdown
- disable for further performance investigation