### PR TITLE
ImplicitCreation atribute tests, value class flag verification

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2632,6 +2632,17 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		case CFR_ATTRIBUTE_ImplicitCreation:
+			/* JVMS: The ImplicitCreation attribute authorizes implicit instance creation of a non-abstract
+			 * value class... There must not be an ImplicitCreation attribute in the attributes table of any
+			 * other ClassFile structure representing a class, interface, or module.
+			 */
+			if (J9_ARE_NO_BITS_SET(classfile->accessFlags, CFR_ACC_VALUE_TYPE)
+			 || J9_ARE_ANY_BITS_SET(classfile->accessFlags, CFR_ACC_INTERFACE | CFR_ACC_ABSTRACT | CFR_ACC_MODULE)
+			) {
+				errorCode = J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS__ID;
+				goto _errorFound;
+				break;
+			}
 			value = ((J9CfrAttributeImplicitCreation*)attrib)->nameIndex;
 			if ((0 == value) || (value >= cpCount)) {
 				errorCode = J9NLS_CFR_ERR_BAD_INDEX__ID;

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1750,3 +1750,11 @@ J9NLS_CFR_ERR_NULLRESTRICTED_ATTRIBUTES_LENGTH_IS_ZERO.explanation=Please consul
 J9NLS_CFR_ERR_NULLRESTRICTED_ATTRIBUTES_LENGTH_IS_ZERO.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_NULLRESTRICTED_ATTRIBUTES_LENGTH_IS_ZERO.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+# ImplicitCreation is not translatable
+J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS=The ImplicitCreation attribute is only allowed in a non-abstract value class
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
@@ -29,14 +29,31 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 	private static ValhallaAttributeGenerator generator = new ValhallaAttributeGenerator();
 
 	public static Class<?> generateClassWithTwoPreloadAttributes(String name, String[] classList1, String[] classList2) throws Throwable {
-		byte[] bytes = generateClass(name, new Attribute[] {
+		byte[] bytes = generateClass(name, ACC_PUBLIC, new Attribute[] {
 			new PreloadAttribute(classList1),
 			new PreloadAttribute(classList2)});
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 
 	public static Class<?> generateClassWithPreloadAttribute(String name, String[] classList) throws Throwable {
-		byte[] bytes = generateClass(name, new Attribute[] {new PreloadAttribute(classList)});
+		byte[] bytes = generateClass(name, ACC_PUBLIC, new Attribute[] {new PreloadAttribute(classList)});
+		return generator.defineClass(name, bytes, 0, bytes.length);
+	}
+
+	public static Class<?> generateClassWithTwoImplicitCreationAttributes(String name) throws Throwable {
+		byte[] bytes = generateClass(name, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
+			new Attribute[] {new ImplicitCreationAttribute(0), new ImplicitCreationAttribute(0)});
+		return generator.defineClass(name, bytes, 0, bytes.length);
+	}
+
+	public static Class<?> generateNonValueTypeClassWithImplicitCreationAttribute(String name) throws Throwable {
+		byte[] bytes = generateClass(name, ACC_PUBLIC, new Attribute[] {new ImplicitCreationAttribute(0)});
+		return generator.defineClass(name, bytes, 0, bytes.length);
+	}
+
+	public static Class<?> generateValidClassWithImplicitCreationAttribute(String name) throws Throwable {
+		byte[] bytes = generateClass(name, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
+			new Attribute[] {new ImplicitCreationAttribute(0)});
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 
@@ -44,18 +61,9 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 		return generator.findLoadedClass(name);
 	}
 
-	public static byte[] generateClass(String name, Attribute[] attributes) {
+	public static byte[] generateClass(String name, int classFlags, Attribute[] attributes) {
 		ClassWriter classWriter = new ClassWriter(0);
-		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC | ACC_FINAL, name, null, "java/lang/Object", null);
-
-		/* Generate base constructor which just calls super.<init>() */
-		MethodVisitor methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-		methodVisitor.visitCode();
-		methodVisitor.visitVarInsn(ALOAD, 0);
-		methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-		methodVisitor.visitInsn(RETURN);
-		methodVisitor.visitMaxs(1, 1);
-		methodVisitor.visitEnd();
+		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, classFlags, name, null, "java/lang/Object", null);
 
 		/* Generate passed in attributes if there are any */
 		if (null != attributes) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -30,7 +30,7 @@ public class ValhallaAttributeTests {
 	class MultiPreloadTest {}
 
 	/* A class may have no more than one Preload attribute. */
-	@Test(expectedExceptions = java.lang.ClassFormatError.class)
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*Multiple Preload attributes.*")
 	static public void testMultiplePreloadAttributes() throws Throwable {
 		String className = MultiPreloadTest.class.getName();
 		ValhallaAttributeGenerator.generateClassWithTwoPreloadAttributes("MultiPreloadAttributes",
@@ -61,5 +61,27 @@ public class ValhallaAttributeTests {
 		ValhallaAttributeGenerator.generateClassWithPreloadAttribute("PreloadValueClassBehavior", new String[]{className});
 		/* Verify that PreloadValueClass is loaded */
 		Assert.assertNotNull(ValhallaAttributeGenerator.findLoadedTestClass(className));
+	}
+
+	/* A class may have no more than one ImplicitCreation attribute. */
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*Multiple ImplicitCreation attributes.*")
+	static public void testMultipleImplicitCreationAttributes() throws Throwable {
+		ValhallaAttributeGenerator.generateClassWithTwoImplicitCreationAttributes("MultiImplicitCreationAttributes");
+	}
+
+	/* There must not be an ImplicitCreation attribute in the attributes table of any other ClassFile structure representing a class, interface, or module.
+	 * In other words any non value class.
+	 */
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*The ImplicitCreation attribute is only allowed in a non-abstract value class.*")
+	static public void testNonValueTypeClassWithImplicitCreationAttribute() throws Throwable {
+		ValhallaAttributeGenerator.generateNonValueTypeClassWithImplicitCreationAttribute("NonValueTypeImplicitCreationAttribute");
+	}
+
+	/* ImplicitCreation smoke test. The attribute doesn't do anything in the vm right now, make sure
+	 * it passes class validation.
+	 */
+	@Test
+	static public void testValueTypeClassWithImplicitCreationAttribute() throws Throwable {
+		ValhallaAttributeGenerator.generateValidClassWithImplicitCreationAttribute("ValueTypeClassWithImplicitCreationAttribute");
 	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -28,4 +28,11 @@ public class ValhallaUtils {
 	 * against BCT_JavaMajorVersionShifted needs to be updated as well.
 	 */
 	static final int CLASS_FILE_MAJOR_VERSION = 66;
+
+	/* workaround till the new ASM is released */
+	static final int ACONST_INIT = 203;
+	static final int WITHFIELD = 204;
+	static final int ACC_IDENTITY = 0x20;
+	static final int ACC_VALUE_TYPE = 0x040;
+	static final int ACC_PRIMITIVE = 0x800;
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -38,13 +38,6 @@ public class ValueTypeGenerator extends ClassLoader {
 	
 	private static boolean DEBUG = false;
 	
-	/* workaround till the new ASM is released */
-	public static final int ACONST_INIT = 203;
-	public static final int WITHFIELD = 204;
-	public static final int ACC_IDENTITY = 0x20;
-	private static final int ACC_VALUE_TYPE = 0x040;
-	private static final int ACC_PRIMITIVE = 0x800;
-	
 	static {
 		generator = new ValueTypeGenerator();
 	}
@@ -218,7 +211,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		if (isRef) {
 			cw.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC + ACC_FINAL + extraClassFlags, className, null, superName, null);
 		} else {
-			cw.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC + ACC_FINAL + ACC_VALUE_TYPE + ACC_PRIMITIVE + extraClassFlags, className, null, superName, null);
+			cw.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE + ValhallaUtils.ACC_PRIMITIVE + extraClassFlags, className, null, superName, null);
 		}
 
 		cw.visitSource(className + ".java", null);
@@ -374,7 +367,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitInsn(DUP);
 		mv.visitMethodInsn(INVOKESPECIAL, className, "<init>", "()V", false);
 		mv.visitLdcInsn(Long.valueOf(123L));
-		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
+		mv.visitFieldInsn(ValhallaUtils.WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(3, 2);
 		mv.visitEnd();
@@ -389,7 +382,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
 		mv.visitLdcInsn(Long.valueOf(123L));
-		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
+		mv.visitFieldInsn(ValhallaUtils.WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(3, 2);
 		mv.visitEnd();
@@ -406,7 +399,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitInsn(DUP);
 		mv.visitMethodInsn(INVOKESPECIAL, className, "<init>", "()V", false);
 		mv.visitLdcInsn(Long.valueOf(123L));
-		mv.visitFieldInsn(WITHFIELD, "NonExistentClass", "longField", "J");
+		mv.visitFieldInsn(ValhallaUtils.WITHFIELD, "NonExistentClass", "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(3, 2);
 		mv.visitEnd();
@@ -447,7 +440,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		boolean doubleDetected = false;
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "makeValue", "(" + makeValueSig + ")" + getSigFromSimpleName(valueName, false), null, null);
 		mv.visitCode();
-		mv.visitTypeInsn(ACONST_INIT, getSigFromSimpleName(valueName, false));
+		mv.visitTypeInsn(ValhallaUtils.ACONST_INIT, getSigFromSimpleName(valueName, false));
 		for (int i = 0, count = 0; i <  fields.length; i++) {
 			String nameAndSig[] = fields[i].split(":");
 			if ((nameAndSig.length < 3) ||  !(nameAndSig[2].equals("static"))) {
@@ -479,7 +472,7 @@ public class ValueTypeGenerator extends ClassLoader {
 					count++;
 					break;
 				}
-				mv.visitFieldInsn(WITHFIELD, valueName, nameAndSig[0], nameAndSig[1]);
+				mv.visitFieldInsn(ValhallaUtils.WITHFIELD, valueName, nameAndSig[0], nameAndSig[1]);
 			}
 		}
 		mv.visitInsn(ARETURN);
@@ -491,7 +484,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	private static void makeValueTypeDefaultValue(ClassWriter cw, String valueName, String makeValueSig, String[] fields, int makeMaxLocal, boolean isRef) {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeValueTypeDefaultValue", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
-		mv.visitTypeInsn(ACONST_INIT, getSigFromSimpleName(valueName, isRef));
+		mv.visitTypeInsn(ValhallaUtils.ACONST_INIT, getSigFromSimpleName(valueName, isRef));
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 0);
 		mv.visitEnd();
@@ -500,7 +493,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	private static void testCheckCastValueTypeOnNonNullType(ClassWriter cw, String className, String[] fields) {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "testCheckCastValueTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
-		mv.visitTypeInsn(ACONST_INIT, getSigFromSimpleName(className, false));
+		mv.visitTypeInsn(ValhallaUtils.ACONST_INIT, getSigFromSimpleName(className, false));
 		mv.visitTypeInsn(CHECKCAST, className);
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 2);
@@ -554,7 +547,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		Label falseLabel = new Label();
 		Label endLabel = new Label();
 		mv.visitJumpInsn(IFEQ, falseLabel);
-		mv.visitTypeInsn(ACONST_INIT, getSigFromSimpleName(valueUsedInCode, false));
+		mv.visitTypeInsn(ValhallaUtils.ACONST_INIT, getSigFromSimpleName(valueUsedInCode, false));
 		mv.visitJumpInsn(GOTO, endLabel);
 		mv.visitLabel(falseLabel);
 		mv.visitFrame(F_SAME, 1, new Object[] {INTEGER}, 0, new Object[]{});
@@ -578,7 +571,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		for (int i = 0; i < valueFields.length; i++) {
 			String[] nameAndSig = valueFields[i].split(":");
 			mv.visitLdcInsn(Integer.valueOf(i+1));
-			mv.visitFieldInsn(WITHFIELD, valueUsedInCode, nameAndSig[0], nameAndSig[1]);
+			mv.visitFieldInsn(ValhallaUtils.WITHFIELD, valueUsedInCode, nameAndSig[0], nameAndSig[1]);
 		}
 		mv.visitJumpInsn(GOTO, endLabel);
 		mv.visitLabel(falseLabel);
@@ -976,7 +969,7 @@ public class ValueTypeGenerator extends ClassLoader {
 			mv.visitVarInsn(ALOAD, 1);
 			break;
 		}
-		mv.visitFieldInsn(WITHFIELD, className, nameAndSigValue[0], nameAndSigValue[1]);
+		mv.visitFieldInsn(ValhallaUtils.WITHFIELD, className, nameAndSigValue[0], nameAndSigValue[1]);
 		mv.visitInsn(ARETURN);
 		int maxStackAndLocals = (doubleDetected ? 3 : 2);
 		mv.visitMaxs(maxStackAndLocals, maxStackAndLocals);


### PR DESCRIPTION
  - class verification check to make sure ImplicitCreation attribute is in a non-abstract value class
  - tests for ImplicitCreation class verification

Related to: https://github.com/eclipse-openj9/openj9/issues/17234