### PR TITLE
Remove incorrect TR_ASSERTs related to the reloFlags

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -69,7 +69,6 @@ J9::ARM64::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          uintptr_t gv = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          hcrRecord->setReloFlags(reloTarget, flags);
          hcrRecord->setOffset(reloTarget, gv);
          }

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -124,8 +124,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          uintptr_t inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(symRef->getOwningMethod(comp)->constantPool(), recordInfo->data2);
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(recordInfo->data3));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
-
          moRecord->setInlinedSiteIndex(reloTarget, reinterpret_cast<uintptr_t>(inlinedSiteIndex));
          moRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(symRef->getOwningMethod(comp)->constantPool()));
          moRecord->setReloFlags(reloTarget, flags);
@@ -144,7 +142,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          caRecord->setReloFlags(reloTarget, flags);
          caRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          caRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(constantPool));
@@ -164,7 +161,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          daRecord->setReloFlags(reloTarget, flags);
          daRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          daRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(constantPool));
@@ -178,7 +174,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          TR_RelocationRecordWithOffset *rwoRecord = reinterpret_cast<TR_RelocationRecordWithOffset *>(reloRecord);
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rwoRecord->setReloFlags(reloTarget, flags);
 
          uintptr_t offset = relocation->getTargetAddress()
@@ -194,7 +189,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          TR_RelocationRecord *rRecord = reinterpret_cast<TR_RelocationRecord *>(reloRecord);
 
          uint8_t flags = flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rRecord->setReloFlags(reloTarget, flags);
          }
          break;
@@ -204,7 +198,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          TR_RelocationRecordRamSequence *rsRecord = reinterpret_cast<TR_RelocationRecordRamSequence *>(reloRecord);
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rsRecord->setReloFlags(reloTarget, flags);
 
          // Skip Offset
@@ -219,7 +212,6 @@ J9::ARM::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR::I
          uintptr_t gv = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rwoRecord->setReloFlags(reloTarget, flags);
          rwoRecord->setOffset(reloTarget, gv);
          }

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -549,8 +549,6 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          if (fej9->isMethodTracingEnabled(reinterpret_cast<J9Method *>(method)))
             flags |= methodTracingEnabled;
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
-
          TR_OpaqueClassBlock *inlinedMethodClass = resolvedMethod->containingClass();
          J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedMethodClass));
          uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
@@ -638,7 +636,6 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_OpaqueMethodBlock *method = inlinedMethod->getPersistentIdentifier();
          if (fej9->isMethodTracingEnabled(reinterpret_cast<J9Method *>(method)))
             flags = methodTracingEnabled;
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
 
          // Ugly; this will be cleaned up in a future PR
          uintptr_t cpIndexOrData = 0;
@@ -1260,7 +1257,6 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t offsetOfNameString = fej9->sharedCache()->rememberDebugCounterName(counter->getName());
          uint8_t flags = counterReloData->_seqKind;
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          dcRecord->setReloFlags(reloTarget, flags);
          dcRecord->setInlinedSiteIndex(reloTarget, static_cast<uintptr_t>(counterReloData->_callerIndex));
          dcRecord->setBCIndex(reloTarget, counterReloData->_bytecodeIndex);
@@ -1279,7 +1275,6 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::StaticSymbol *staticSym = tempSR->getSymbol()->getStaticSymbol();
 
          uint8_t flags = (uint8_t) recordInfo->data2;
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          bfRecord->setReloFlags(reloTarget, flags);
 
          TR_PersistentProfileInfo *profileInfo = comp->getRecompilationInfo()->getProfileInfo();

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -85,7 +85,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          caRecord->setReloFlags(reloTarget, flags);
          caRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          caRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(constantPool));
@@ -105,7 +104,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          daRecord->setReloFlags(reloTarget, flags);
          daRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          daRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(constantPool));
@@ -132,7 +130,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          TR_RelocationRecordInformation *recordInfo = (TR_RelocationRecordInformation *) relocation->getTargetAddress();
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(recordInfo->data3));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          maRecord->setReloFlags(reloTarget, flags);
          }
          break;
@@ -145,7 +142,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
          uint8_t *codeLocation = table->getCodeLocation();
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rwoRecord->setReloFlags(reloTarget, flags);
          if (comp->target().is64Bit())
             {
@@ -163,7 +159,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          TR_RelocationRecordWithOffset *rwoRecord = reinterpret_cast<TR_RelocationRecordWithOffset *>(reloRecord);
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rwoRecord->setReloFlags(reloTarget, flags);
          if (comp->target().is64Bit())
             {
@@ -202,7 +197,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
             flags = static_cast<uint8_t>(recordInfo->data3);
             }
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rRecord->setReloFlags(reloTarget, flags);
          }
          break;
@@ -232,7 +226,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
             // Skip Offset
             }
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          rsRecord->setReloFlags(reloTarget, flags);
          }
          break;
@@ -254,7 +247,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          const AOTCacheClassChainRecord *classChainRecord = NULL;
          uintptr_t classChainOffsetInSharedCache = self()->getClassChainOffset(j9class, classChainRecord);
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0, "reloFlags bits overlap cross-platform flags bits");
          acaRecord->setReloFlags(reloTarget, flags);
          acaRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          acaRecord->setClassChainIdentifyingLoaderOffsetInSharedCache(reloTarget, classChainIdentifyingLoaderOffsetInSharedCache,
@@ -282,7 +274,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
             flags = static_cast<uint8_t>(recordInfo->data3);
             }
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          gvRecord->setReloFlags(reloTarget, flags);
          gvRecord->setOffset(reloTarget, gv);
          }
@@ -300,7 +291,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          uint16_t symbolType = (uint16_t)recordInfo->data2;
 
          uint8_t flags = (uint8_t) recordInfo->data3;
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
 
          dsfmRecord->setSymbolID(reloTarget, symbolID);
          dsfmRecord->setSymbolType(reloTarget, static_cast<TR::SymbolType>(symbolType));
@@ -315,7 +305,6 @@ J9::Power::AheadOfTimeCompile::initializePlatformSpecificAOTRelocationHeader(TR:
          uintptr_t gv = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
 
-         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
          hcrRecord->setReloFlags(reloTarget, flags);
          hcrRecord->setOffset(reloTarget, gv);
          }


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/17621 adjusted where the relo flags are set (not to be confused with the flags described by `RELOCATION_CROSS_PLATFORM_FLAGS_MASK`). The `TR_ASSERT_FATAL` in `TR_RelocationRecord::setReloFlags` was updated accordingly, but all the `TR_ASSERT`s sprinkled in the code that initializes the header of the binary relo record was missed.

This PR removes these `TR_ASSERT`s because in addition to be incorrect, they are also redundant; `TR_RelocationRecord::setReloFlags` already has a `TR_ASSERT_FATAL`.

Fixes https://github.com/eclipse-openj9/openj9/issues/17950