### PR TITLE
Ensure flags stored to raw relo record is 16 bits

### DIFF
--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -137,6 +137,14 @@ typedef enum
    staticSpecialMethodFromCpIsSplit = 0x08,
    needsFullSizeRuntimeAssumption   = 0x10,
    methodTracingEnabled             = 0x20,
+
+   // Relo Flags cannot be more than 12 bits
+   // unless the _flags field of the
+   // TR_RelocationRecordBinaryTemplate
+   // is appropriately updated. This is because
+   // the lowest 4 bits are used for the (poorly
+   // named) Cross Platform Flags.
+   highestBit                       = 0x800,
    } TR_RelocationFlags;
 
 /* TR_AOTMethodHeader Versions:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -290,6 +290,9 @@ class TR_RelocationRecord
       TR_RelocationRecordPrivateData _privateData;
 
       static uint32_t _relocationRecordHeaderSizeTable[TR_NumExternalRelocationKinds];
+
+   private:
+      void updateFlags(TR_RelocationTarget *reloTarget, uint16_t flagsToSet);
    };
 
 // No class that derives from TR_RelocationRecord should define any state: all state variables should be declared


### PR DESCRIPTION
The `_flags` field of the `TR_RelocationRecordBinaryTemplate` struct is 16 bits wide. This was to ensure that the relocation infrastructure could store more than 4 bits of Relocation Flags (the other 4 bits are reserved for the Cross Platform Flags).

The code in `TR_RelocationRecord::setReloFlags` did some validation to ensure that the bits did not overlap; however, it did so using a uint8_t which could lose some bits due to a shift. This PR fixes this by ensuring a `uint16_t` is used.

This PR also changes how the flags are set; existing flags in the raw relocation record are now preserved.