### PR TITLE
Add support for jdk.tracePinnedThreads system property

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
+++ b/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
@@ -1,0 +1,58 @@
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 21]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package java.lang;
+
+import java.io.PrintStream;
+import java.lang.StackWalker.StackFrame;
+import java.lang.StackWalker.StackFrameImpl;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import static java.lang.StackWalker.Option.*;
+
+/**
+ * Prints the stack trace of Pinned Thread that is attempting to yield.
+ */
+final class PinnedThreadPrinter {
+	private static final StackWalker STACKWALKER;
+
+	static {
+		STACKWALKER = StackWalker.getInstance(Set.of(SHOW_REFLECT_FRAMES, RETAIN_CLASS_REFERENCE));
+		STACKWALKER.setGetMonitorsFlag();
+	}
+
+	static void printStackTrace(PrintStream out, boolean printAll) {
+		out.println(Thread.currentThread());
+		List<StackFrame> stackFrames = STACKWALKER.walk(s -> s.collect(Collectors.toList()));
+		for (int i = 0; i < stackFrames.size(); i++) {
+			StackFrameImpl sti = (StackFrameImpl)stackFrames.get(i);
+			Object[] monitors = sti.getMonitors();
+
+			if (monitors != null) {
+				out.println("    " + sti.toString() + " <== monitors:" + monitors.length);
+			} else if (sti.isNativeMethod() || (printAll && (sti.getDeclaringClass() != PinnedThreadPrinter.class))) {
+				out.println("    " + sti.toString());
+			}
+		}
+	}
+}

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -219,6 +219,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodName" signature="Ljava/lang/String;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodSignature" signature="Ljava/lang/String;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="frameModule" signature="Ljava/lang/Module;" versions="9-"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="monitors" signature="[Ljava/lang/Object;" versions="21-"/>
 
 	<!-- Common field references shared between OpenJ9 and OpenJDK Thread. -->
 	<fieldref class="java/lang/Thread" name="contextClassLoader" signature="Ljava/lang/ClassLoader;"/>


### PR DESCRIPTION
- New internal StackWalker flag J9_GET_MONITORS to include monitor entry info into StackFramesImpl structure.
- New protected getMonitors() API to retrieve monitor entry info.
- Fix StackWalker class keyword ordering

If the new StackWalker flag is set, the monitor info will be fetched before parsing each stackframe and monitors will be added to the matching StackFrameImpl structure's monitors array based on stack depth. This will be used by PinnedThreadPrinter class to output the stack's acquired monitors' state.