### PR TITLE
NullRestricted attribute cant be in primitive or array field

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -461,6 +461,15 @@ ClassFileOracle::walkFields()
 				break;
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 			case CFR_ATTRIBUTE_NullRestricted:
+				/* JVMS: There must not be a NullRestricted attribute in the attributes table of a field_info
+				 * structure whose descriptor_index references a primitive type or an array type.*/
+				if (!IS_REF_OR_VAL_SIGNATURE(fieldChar)) {
+					if ('[' == fieldChar) {
+						throwGenericErrorWithCustomMsg(J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD__ID, fieldIndex);
+					} else { /* primitive type*/
+						throwGenericErrorWithCustomMsg(J9NLS_CFR_NO_NULLRESTRICTED_IN_PRIMITIVEFIELD__ID, fieldIndex);
+					}
+				}
 				_fieldsInfo[fieldIndex].isNullRestricted = true;
 				break;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1758,3 +1758,19 @@ J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.explanation=Please consul
 J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_IMPLICITCREATION_ILLEGAL_CLASS_MODIFIERS.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+# NullRestricted is not translatable
+J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD=A field with an array type cannot have a NullRestricted attribute
+# START NON-TRANSLATABLE
+J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# NullRestricted is not translatable
+J9NLS_CFR_NO_NULLRESTRICTED_IN_PRIMITIVEFIELD=A field with a primitive type cannot have a NullRestricted attribute
+# START NON-TRANSLATABLE
+J9NLS_CFR_NO_NULLRESTRICTED_IN_PRIMITIVEFIELD.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_NO_NULLRESTRICTED_IN_PRIMITIVEFIELD.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_NO_NULLRESTRICTED_IN_PRIMITIVEFIELD.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -84,4 +84,22 @@ public class ValhallaAttributeTests {
 	static public void testValueTypeClassWithImplicitCreationAttribute() throws Throwable {
 		ValhallaAttributeGenerator.generateValidClassWithImplicitCreationAttribute("ValueTypeClassWithImplicitCreationAttribute");
 	}
+
+	/* There must be no more than one NullRestricted attribute in the attributes table of a field_info structure */
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*Multiple NullRestricted attributes present.*")
+	static public void testMultipleNullRestrictedAttributes() throws Throwable {
+		ValhallaAttributeGenerator.generateFieldWithMultipleNullRestrictedAttributes("TestMultipleNullRestrictedAttributes", "TestMultipleNullRestrictedAttributesField");
+	}
+
+	/* There must not be a NullRestricted attribute in the attributes table of a field_info structure whose descriptor_index references a primitive type. */
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*A field with a primitive type cannot have a NullRestricted attribute.*")
+	static public void testNullRestrictedNotAllowedInPrimitiveField() throws Throwable {
+		ValhallaAttributeGenerator.generateNullRestrictedAttributeInPrimitiveField("TestNullRestrictedNotAllowedInPrimitiveField");
+	}
+
+	/* There must not be a NullRestricted attribute in the attributes table of a field_info structure whose descriptor_index references an array type */
+	@Test(expectedExceptions = java.lang.ClassFormatError.class, expectedExceptionsMessageRegExp = ".*A field with an array type cannot have a NullRestricted attribute.*")
+	static public void testNullRestrictedNotAllowedInArrayTypeField() throws Throwable {
+		ValhallaAttributeGenerator.generateNullRestrictedAttributeInArrayField("TestNullRestrictedNotAllowedInArrayTypeField", "TestNullRestrictedNotAllowedInArrayTypeFieldField");
+	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -35,4 +35,9 @@ public class ValhallaUtils {
 	static final int ACC_IDENTITY = 0x20;
 	static final int ACC_VALUE_TYPE = 0x040;
 	static final int ACC_PRIMITIVE = 0x800;
+
+	/* ImplicitCreation flags */
+	static final int ACC_DEFAULT = 0x1;
+	static final int ACC_NON_ATOMIC = 0x2;
+
 }


### PR DESCRIPTION
- throw error in vm if there is a NullRestricted attribute in primitive or array field
- verification test for multiple NullRestricted attributes in a field
- verification test for NullRestricted attribute in primitive and array fields

Related to https://github.com/eclipse-openj9/openj9/issues/17340