### PR TITLE
Collect *.pdb files to help diagnose omr_ddrgen failures

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -528,7 +528,10 @@ def archive_diagnostics(javaVersionJdkImageDir = null) {
     findCrashDataCmd += " -o -name 'jitdump.*.dmp'"
     findCrashDataCmd += " -o -name 'Snap.*.trc'"
 
-    if (SPEC.contains('zos')) {
+    if (SPEC.contains('win')) {
+        // collect *.pdb files to help diagnose omr_ddrgen failures
+        findCrashDataCmd += " -o -name '*.pdb'"
+    } else if (SPEC.contains('zos')) {
         def logContent = currentBuild.rawBuild.getLog()
         // search for each occurrence of IEATDUMP success for DSN=
         def matches = logContent =~ /IEATDUMP success for DSN=.*/


### PR DESCRIPTION
We've seen a number of unexplained failures building on Windows: A recent example is https://openj9-jenkins.osuosl.org/job/Pipeline_Build_Test_JDK21_x86-64_windows/101/ which needed to be restarted (twice). The intent of this change is to collect `*.pdb` files when a build fails so it that problem recurs, we'll have some data to examine in support of a resolution.