### PR TITLE
Skip methods with JvmtiMountTransition annotation

### DIFF
--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1352,6 +1352,17 @@ suspendAgentBreakpoint(J9VMThread * currentThread, J9JVMTIAgentBreakpoint * agen
 UDATA
 findDecompileInfo(J9VMThread *currentThread, J9VMThread *targetThread, UDATA depth, J9StackWalkState *walkState);
 
+#if JAVA_SPEC_VERSION >= 20
+/**
+ * A helper to iterate through the frames of a thread.
+ * @param[in] currentThread current thread
+ * @param[in] walkState a stack walk state
+ * @return 0 on success and non-zero on failure
+ */
+UDATA
+genericFrameIterator(J9VMThread *currentThread, J9StackWalkState *walkState);
+#endif /* JAVA_SPEC_VERSION >= 20 */
+
 /**
  * A helper to walk a platform thread or virtual thread
  * @param[in] currentThread current thread


### PR DESCRIPTION
Java methods tagged with the JvmtiMountTransition annotation are
involved in transitioning between carrier to virtual threads, and
vice-versa.

These methods are not part of the thread's scope. So, they should be
skipped during introspection by all the relevant JVMTI functions.

This commit covers the remaining JVMTI functions which need to skip
methods tagged with the JvmtiMountTransition annotation.

Fixes: #17520

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>