### PR TITLE
Fix JITServer AOT SCC layer trace template

### DIFF
--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -3002,5 +3002,5 @@ TraceExit=Trc_SHR_OSC_Mmap_syncUpdates_badmsync1 NoEnv Overhead=1 Level=1 Templa
 TraceEvent=Trc_SHR_TMI_LocalCheckTimestamp_Timestamps Overhead=1 Level=6 Template="TMI localCheckTimestamp: timestamp checked, current is %lld, test is %lld"
 
 TraceEvent=Trc_SHR_VMInitStages_Event_UsingJITServerAOTCacheLayer Overhead=1 Level=1 Template="The shared cache is using a temporary top layer for the JITServer AOT cache"
-TraceEvent=Trc_SHR_OSC_Mmap_startup_jitserverlayergooddelete NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: deleteCacheFile succeeded for cache path name = %s, file handle %d"
-TraceException=Trc_SHR_OSC_Mmap_startup_jitserverlayerbaddelete NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: deleteCacheFile failed for cache path name = %s, file handle %d"
+TraceEvent=Trc_SHR_OSC_Mmap_startup_jitserverlayergooddelete NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: deleteCacheFile succeeded for cache path name = %s, file handle %zd"
+TraceException=Trc_SHR_OSC_Mmap_startup_jitserverlayerbaddelete NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: deleteCacheFile failed for cache path name = %s, file handle %zd"


### PR DESCRIPTION
As mentioned in https://github.com/eclipse-openj9/openj9/pull/17945#discussion_r1305637158, the template parameter here should be `%zd` and not `%d`.

Attn @mpirvu @keithc-ca.