### PR TITLE
NullRestricted: putstatic and putfield throw NPE on null assignment

### DIFF
--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -150,13 +150,21 @@
 #define J9_JAVA_CLASS_FINALIZER_CHECK_MASK (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer | J9AccClassContinuation)
 #define J9_JAVA_MODIFIERS_SPECIAL_OBJECT (J9AccClassFinalizeNeeded | J9AccClassReferenceMask)
 
-/* static field helpers*/
+/* static field flags (classAndFlags) */
 #define J9StaticFieldRefBaseType 0x1
 #define J9StaticFieldRefDouble 0x2
 #define J9StaticFieldRefVolatile 0x4
 #define J9StaticFieldRefBoolean 0x8
 #define J9StaticFieldRefPutResolved 0x10
-#define J9StaticFieldRefFlagBits 0x3F
 #define J9StaticFieldRefFinal 0x20
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+#define J9StaticFieldIsNullRestricted 0x40
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+/* flag mask for classAndFlags*/
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+#define J9StaticFieldRefFlagBits 0x7F
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+#define J9StaticFieldRefFlagBits 0x3F
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 #endif /*J9JAVAACCESSFLAGS_H */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7286,6 +7286,16 @@ done:
 		}
 #endif
 		{
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+			/* NullRestricted field cannot be set to null. */
+			if (J9_ARE_ALL_BITS_SET(classAndFlags, J9StaticFieldIsNullRestricted)) {
+				j9object_t valueref = *(j9object_t*)_sp;
+				if (NULL == valueref) {
+					rc = THROW_NPE;
+					goto done;
+				}
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			J9Class *fieldClass = (J9Class*)(classAndFlags & ~(UDATA)J9StaticFieldRefFlagBits);
 			bool isVolatile = (0 != (classAndFlags & J9StaticFieldRefVolatile));
 			if (classAndFlags & J9StaticFieldRefBaseType) {
@@ -7482,6 +7492,14 @@ done:
 					goto done;
 				}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+				/* NullRestricted field cannot be set to null. */
+				if (J9_ARE_ALL_BITS_SET(flags, J9FieldFlagIsNullRestricted)) {
+					j9object_t valueref = *(j9object_t*)_sp;
+					if (NULL == valueref) {
+						rc = THROW_NPE;
+						goto done;
+					}
+				}
 				if (flags & J9FieldFlagFlattened) {
 					VM_ValueTypeHelpers::putFlattenableField(_currentThread, _objectAccessBarrier, ramFieldRef, objectref, *(j9object_t*)_sp);
 				} else

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -851,6 +851,11 @@ illegalAccess:
 				if (0 != (resolveFlags & J9_RESOLVE_FLAG_FIELD_SETTER)) {
 					localClassAndFlagsData |= J9StaticFieldRefPutResolved;
 				}
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+				if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagIsNullRestricted)) {
+					localClassAndFlagsData |= J9StaticFieldIsNullRestricted;
+				}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				/* Swap the class address bits and the flag bits. */
 				ramCPEntry->flagsAndClass = J9FLAGSANDCLASS_FROM_CLASSANDFLAGS(localClassAndFlagsData);
 				/* Set the high bit in valueOffset to ensure that a resolved static field ref is always interpreted as an unresolved instance fieldref. */

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
@@ -87,6 +87,77 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 			"field", "[" + fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute()});
 		return generator.defineClass(className, classBytes, 0, classBytes.length);
 	}
+
+	public static Class<?> generateStaticNullRestrictedFieldAssignedToNull(String className, String fieldClassName) {
+		String fieldName = "field";
+
+		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set.  */
+		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
+			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
+
+		ClassWriter classWriter = new ClassWriter(0);
+		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC + ValhallaUtils.ACC_IDENTITY, className, null, "java/lang/Object", null);
+
+		/* static field of previously generated field class with NullRestrictd attribute */
+		FieldVisitor fieldVisitor = classWriter.visitField(ACC_PUBLIC + ACC_STATIC, fieldName, fieldClass.descriptorString(), null, null);
+		fieldVisitor.visitAttribute(new NullRestrictedAttribute());
+
+		/* assign field to null in <clinit> */
+		MethodVisitor mvClinit = classWriter.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+		mvClinit.visitCode();
+		mvClinit.visitInsn(ACONST_NULL);
+		mvClinit.visitFieldInsn(PUTSTATIC, className, fieldName, fieldClass.descriptorString());
+		mvClinit.visitInsn(RETURN);
+		mvClinit.visitMaxs(1, 0);
+		mvClinit.visitEnd();
+
+		/* <init> */
+		MethodVisitor mvInit = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		mvInit.visitCode();
+		mvInit.visitVarInsn(ALOAD, 0);
+		mvInit.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+		mvInit.visitInsn(RETURN);
+		mvInit.visitMaxs(1, 1);
+		mvInit.visitEnd();
+
+		classWriter.visitEnd();
+		byte[] classBytes = classWriter.toByteArray();
+		return generator.defineClass(className, classBytes, 0, classBytes.length);
+	}
+
+	public static Class<?> generateInstanceNullRestrictedFieldAssignedToNull(String className, String fieldClassName) {
+		String fieldName = "field";
+
+		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set.  */
+		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
+			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
+
+		ClassWriter classWriter = new ClassWriter(0);
+		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ACC_PUBLIC + ValhallaUtils.ACC_IDENTITY, className, null, "java/lang/Object", null);
+
+		/* instance field of previously generated field class with NullRestrictd attribute */
+		FieldVisitor fieldVisitor = classWriter.visitField(ACC_PUBLIC, fieldName, fieldClass.descriptorString(), null, null);
+		fieldVisitor.visitAttribute(new NullRestrictedAttribute());
+
+		/* assign field to null in <init> */
+		MethodVisitor mvInit = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		mvInit.visitCode();
+		mvInit.visitVarInsn(ALOAD, 0);
+		mvInit.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+		mvInit.visitVarInsn(ALOAD, 0);
+		mvInit.visitInsn(ACONST_NULL);
+		mvInit.visitFieldInsn(PUTFIELD, className, fieldName, fieldClass.descriptorString());
+		mvInit.visitInsn(RETURN);
+		mvInit.visitMaxs(2, 1);
+		mvInit.visitEnd();
+
+		classWriter.visitEnd();
+		byte[] classBytes = classWriter.toByteArray();
+		return generator.defineClass(className, classBytes, 0, classBytes.length);
+	}
+
 	public static Class<?> findLoadedTestClass(String name) {
 		return generator.findLoadedClass(name);
 	}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -102,4 +102,31 @@ public class ValhallaAttributeTests {
 	static public void testNullRestrictedNotAllowedInArrayTypeField() throws Throwable {
 		ValhallaAttributeGenerator.generateNullRestrictedAttributeInArrayField("TestNullRestrictedNotAllowedInArrayTypeField", "TestNullRestrictedNotAllowedInArrayTypeFieldField");
 	}
+
+	/* Instance field with NullRestricted attribute cannot be set to null. */
+	@Test(expectedExceptions = java.lang.NullPointerException.class)
+	static public void testNullRestrictedInstanceFieldCannotBeAssignedNull() throws Throwable {
+		Class<?> c = ValhallaAttributeGenerator.generateInstanceNullRestrictedFieldAssignedToNull("TestNullRestrictedInstanceFieldCannotBeAssignedNull", "TestNullRestrictedInstanceFieldCannotBeAssignedNullField");
+		c.newInstance();
+	}
+
+	/* Static field with NullRestricted attribute cannot be set to null.
+	 * putstatic should throw NPE if field with NullRestricted attribute is assigned null.
+	 * JVMS 5.5 says if putstatic casuses a class to initialize and fails with an exception
+	 * it should be wrapped in ExceptionInInitializerError.
+	 * Since value fields are implicitly final this will always be the case.
+	 */
+	@Test
+	static public void testNullRestrictedStaticFieldCannotBeAssignedNull() throws Throwable {
+		try {
+			Class<?> c = ValhallaAttributeGenerator.generateStaticNullRestrictedFieldAssignedToNull("testNullRestrictedStaticFieldCannotBeAssignedNull", "testNullRestrictedStaticFieldCannotBeAssignedNullField");
+			c.newInstance();
+		} catch(java.lang.ExceptionInInitializerError e) {
+			if (e.getCause() instanceof NullPointerException) {
+				return; /* pass */
+			}
+			throw e;
+		}
+		Assert.fail("Test expected a NullPointerException wrapped in ExceptionInInitializerError.");
+	}
 }


### PR DESCRIPTION
- putstatic and putfield throw NullPointerException if a field is being set to null that has a NullRestricted attribute
- tests for putfield and putstatic

Related: https://github.com/eclipse-openj9/openj9/issues/17340