### PR TITLE
NullRestricted attribute field class checks

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2175,3 +2175,19 @@ J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARAL
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
 # END NON-TRANSLATABLE
+
+# NullRestricted/value/implicit is not translatable
+J9NLS_VM_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS=An instance field with a NullRestricted attribute must be in a value class with an implicit constructor
+# START NON-TRANSLATABLE
+J9NLS_VM_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_VM_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_VM_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# NullRestricted/value/implicit is not translatable
+J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS=A static field with a NullRestricted attribute must be in a value class with an implicit constructor
+# START NON-TRANSLATABLE
+J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
+J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -101,8 +101,6 @@
  * See map in ROMClassBuilder::computeExtraModifiers for
  * available slots.
  */
-#define J9AccImplicitCreateHasDefaultValue 0x10
-#define J9AccImplicitCreateNonAtomic 0x20
 #define J9AccClassIsValueBased 0x40
 #define J9AccClassHiddenOptionNestmate 0x80
 #define J9AccClassHiddenOptionStrong 0x100
@@ -166,5 +164,9 @@
 #else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #define J9StaticFieldRefFlagBits 0x3F
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+
+/* ImplicitCreation attribute flags */
+#define J9AccImplicitCreateHasDefaultValue 0x1
+#define J9AccImplicitCreateNonAtomic 0x2
 
 #endif /*J9JAVAACCESSFLAGS_H */

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -33,6 +33,7 @@
 #include "VMHelpers.hpp"
 #include "AtomicSupport.hpp"
 #include "ObjectMonitor.hpp"
+#include "util_api.h"
 
 extern "C" {
 
@@ -600,6 +601,22 @@ doVerify:
 						bool isStatic = J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry);
 
 						if (isStatic) {
+							U_32 fieldModifiers = entry->field->modifiers;
+							if (J9_ARE_ALL_BITS_SET(fieldModifiers, J9FieldFlagIsNullRestricted)) {
+								J9ROMClass *entryRomClass = entryClazz->romClass;
+								/* A NullRestricted field must be in a value class with an
+								* ImplicitCreation attribute. The attribute must have the ACC_DEFAULT flag set.
+								*/
+								if (J9_ARE_NO_BITS_SET(entryRomClass->modifiers, J9AccValueType)
+									|| J9_ARE_NO_BITS_SET(entryRomClass->optionalFlags, J9_ROMCLASS_OPTINFO_IMPLICITCREATION_ATTRIBUTE)
+									|| J9_ARE_NO_BITS_SET(getImplicitCreationFlags(entryRomClass), J9AccImplicitCreateHasDefaultValue)
+								) {
+									J9UTF8 *romClassName = J9ROMCLASS_CLASSNAME(entryRomClass);
+									setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(romClassName), J9UTF8_DATA(romClassName));
+									goto done;
+								}
+							}
+
 							initializationLock = enterInitializationLock(currentThread, initializationLock);
 							if (J9_OBJECT_MONITOR_ENTER_FAILED(initializationLock)) {
 								goto done;

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeGenerator.java
@@ -42,36 +42,36 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 
 	public static Class<?> generateClassWithTwoImplicitCreationAttributes(String name) throws Throwable {
 		byte[] bytes = generateClass(name, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(0), new ImplicitCreationAttribute(0)});
+			new Attribute[] {new ImplicitCreationAttribute(), new ImplicitCreationAttribute()});
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 
 	public static Class<?> generateNonValueTypeClassWithImplicitCreationAttribute(String name) throws Throwable {
-		byte[] bytes = generateClass(name, ValhallaUtils.ACC_IDENTITY, new Attribute[] {new ImplicitCreationAttribute(0)});
+		byte[] bytes = generateClass(name, ValhallaUtils.ACC_IDENTITY, new Attribute[] {new ImplicitCreationAttribute()});
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 
 	public static Class<?> generateValidClassWithImplicitCreationAttribute(String name) throws Throwable {
 		byte[] bytes = generateClass(name, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(0)});
+			new Attribute[] {new ImplicitCreationAttribute()});
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 
 	public static Class<?> generateFieldWithMultipleNullRestrictedAttributes(String className, String fieldClassName) throws Throwable {
 		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set  */
 		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+			new Attribute[] {new ImplicitCreationAttribute()});
 		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
 
 		/* Generate class with field and multiple NullRestricted attributes */
-		byte[] classBytes = generateClassWithField(className, ValhallaUtils.ACC_IDENTITY,
+		byte[] classBytes = generateIdentityClassWithField(className, 0,
 			"field", fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute(), new NullRestrictedAttribute()});
 		return generator.defineClass(className, classBytes, 0, classBytes.length);
 	}
 
 	public static Class<?> generateNullRestrictedAttributeInPrimitiveField(String className) throws Throwable {
 		/* Generate class with primitive field and a NullRestricted attribute */
-		byte[] classBytes = generateClassWithField(className, ValhallaUtils.ACC_IDENTITY,
+		byte[] classBytes = generateIdentityClassWithField(className, 0,
 			"field", "I", new Attribute[]{new NullRestrictedAttribute()});
 		return generator.defineClass(className, classBytes, 0, classBytes.length);
 	}
@@ -79,11 +79,11 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 	public static Class<?> generateNullRestrictedAttributeInArrayField(String className, String fieldClassName) throws Throwable {
 		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set.  */
 		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+			new Attribute[] {new ImplicitCreationAttribute()});
 		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
 
 		/* Generate class field field that is an array with a NullRestricted attribute */
-		byte[] classBytes = generateClassWithField(className, ValhallaUtils.ACC_IDENTITY,
+		byte[] classBytes = generateIdentityClassWithField(className, 0,
 			"field", "[" + fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute()});
 		return generator.defineClass(className, classBytes, 0, classBytes.length);
 	}
@@ -93,7 +93,7 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 
 		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set.  */
 		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+			new Attribute[] {new ImplicitCreationAttribute()});
 		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
 
 		ClassWriter classWriter = new ClassWriter(0);
@@ -131,7 +131,7 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 
 		/* Generate field class - value class with ImplicitCreation attribute and ACC_DEFAULT flag set.  */
 		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
-			new Attribute[] {new ImplicitCreationAttribute(ValhallaUtils.ACC_DEFAULT)});
+			new Attribute[] {new ImplicitCreationAttribute()});
 		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
 
 		ClassWriter classWriter = new ClassWriter(0);
@@ -155,6 +155,40 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 
 		classWriter.visitEnd();
 		byte[] classBytes = classWriter.toByteArray();
+		return generator.defineClass(className, classBytes, 0, classBytes.length);
+	}
+
+	public static Class<?> generateNullRestrictedAttributeInIdentityClass(boolean isStatic, String className, String fieldClassName) throws Throwable {
+		/* Generate field class - identity class */
+		byte[] fieldClassBytes = generateClass(fieldClassName, ValhallaUtils.ACC_IDENTITY, null);
+		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
+
+		/* Generate class with field that is an identity class with a NullRestricted attribute */
+		byte[] classBytes = generateIdentityClassWithField(className, isStatic ? ACC_STATIC : 0,
+			"field", fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute()});
+		return generator.defineClass(className, classBytes, 0, classBytes.length);
+	}
+
+	public static Class<?> generateNullRestrictedAttributeInValueClassWithoutIC(boolean isStatic, String className, String fieldClassName) throws Throwable {
+		/* Generate field class - value class with no attributes */
+		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE, null);
+		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
+
+		/* Generate class with field that has a NullRestricted attribute */
+		byte[] classBytes = generateIdentityClassWithField(className, isStatic ? ACC_STATIC : 0,
+			"field", fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute()});
+		return generator.defineClass(className, classBytes, 0, classBytes.length);
+	}
+
+	public static Class<?> generateNullRestrictedFieldWhereICHasNoDefaultFlag(boolean isStatic, String className, String fieldClassName) throws Throwable {
+		/* Generate field class - value type with ImplicitCreation attribute, no flags */
+		byte[] fieldClassBytes = generateClass(fieldClassName, ACC_FINAL + ValhallaUtils.ACC_VALUE_TYPE,
+			new Attribute[] {new ImplicitCreationAttribute(0)});
+		Class<?> fieldClass = generator.defineClass(fieldClassName, fieldClassBytes, 0, fieldClassBytes.length);
+
+		/* Generate class with field with NullRestricted attribute */
+		byte[] classBytes = generateIdentityClassWithField(className, isStatic ? ACC_STATIC : 0,
+			"field", fieldClass.descriptorString(), new Attribute[]{new NullRestrictedAttribute()});
 		return generator.defineClass(className, classBytes, 0, classBytes.length);
 	}
 
@@ -212,16 +246,25 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 		return classWriter.toByteArray();
 	}
 
-	public static byte[] generateClassWithField(String name, int classFlags, String fieldName, String fieldDescriptor, Attribute[] fieldAttributes) {
+	public static byte[] generateIdentityClassWithField(String name, int fieldFlags, String fieldName, String fieldDescriptor, Attribute[] fieldAttributes) {
 		ClassWriter classWriter = new ClassWriter(0);
-		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, classFlags, name, null, "java/lang/Object", null);
+		classWriter.visit(ValhallaUtils.CLASS_FILE_MAJOR_VERSION, ValhallaUtils.ACC_IDENTITY, name, null, "java/lang/Object", null);
 
-		FieldVisitor fieldVisitor = classWriter.visitField(0, fieldName, fieldDescriptor, null, null);
+		FieldVisitor fieldVisitor = classWriter.visitField(fieldFlags, fieldName, fieldDescriptor, null, null);
 		if (null != fieldAttributes) {
 			for (Attribute attr : fieldAttributes) {
 				fieldVisitor.visitAttribute(attr);
 			}
 		}
+
+		/* <init> */
+		MethodVisitor mvInit = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		mvInit.visitCode();
+		mvInit.visitVarInsn(ALOAD, 0);
+		mvInit.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+		mvInit.visitInsn(RETURN);
+		mvInit.visitMaxs(1, 1);
+		mvInit.visitEnd();
 
 		classWriter.visitEnd();
 		return classWriter.toByteArray();
@@ -263,6 +306,12 @@ public class ValhallaAttributeGenerator extends ClassLoader {
 
 	final static class ImplicitCreationAttribute extends Attribute {
 		private final int flags;
+
+		public ImplicitCreationAttribute() {
+			super("ImplicitCreation");
+			/* this is the default flag generated by the compiler for the implicit modifier. */
+			this.flags = ValhallaUtils.ACC_DEFAULT;
+		}
 
 		public ImplicitCreationAttribute(int flags) {
 			super("ImplicitCreation");

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -103,6 +103,57 @@ public class ValhallaAttributeTests {
 		ValhallaAttributeGenerator.generateNullRestrictedAttributeInArrayField("TestNullRestrictedNotAllowedInArrayTypeField", "TestNullRestrictedNotAllowedInArrayTypeFieldField");
 	}
 
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Failure for non-static fields should occur during class creation.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*An instance field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testNullRestrictedFieldMustBeInValueClass() throws Throwable {
+		ValhallaAttributeGenerator.generateNullRestrictedAttributeInIdentityClass(false, "TestNullRestrictedFieldMustBeInValueClass", "TestNullRestrictedFieldMustBeInValueClassField");
+	}
+
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Failure for non-static fields should occur during class creation.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*An instance field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testNullRestrictedFieldClassMustHaveImplicitCreation() throws Throwable {
+		ValhallaAttributeGenerator.generateNullRestrictedAttributeInValueClassWithoutIC(false, "TestNullRestrictedFieldClassMustHaveImplicitCreation", "TestNullRestrictedFieldClassMustHaveImplicitCreationField");
+	}
+
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Failure for non-static fields should occur during class creation.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*An instance field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testNullRestrictedFieldWhereImplicitCreationHasNoDefaultFlag() throws Throwable {
+		ValhallaAttributeGenerator.generateNullRestrictedFieldWhereICHasNoDefaultFlag(false, "TestNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlag", "TestNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlagField");
+	}
+
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Static fields should fail during the preparation stage of linking.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testStaticNullRestrictedFieldMustBeInValueClass() throws Throwable {
+		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedAttributeInIdentityClass(true, "TestStaticNullRestrictedFieldMustBeInValueClass", "TestStaticNullRestrictedFieldMustBeInValueClassField");
+		c.newInstance();
+	}
+
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Static fields should fail during the preparation stage of linking.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testStaticNullRestrictedFieldClassMustHaveImplicitCreation() throws Throwable {
+		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedAttributeInValueClassWithoutIC(true, "TestStaticNullRestrictedFieldClassMustHaveImplicitCreation", "TestStaticNullRestrictedFieldClassMustHaveImplicitCreationField");
+		c.newInstance();
+	}
+
+	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
+	 * Static fields should fail during the preparation stage of linking.
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
+	static public void testStaticNullRestrictedFieldWhereImplicitCreationHasNoDefaultFlag() throws Throwable {
+		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedFieldWhereICHasNoDefaultFlag(true, "TestStaticNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlag", "TestStaticNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlagField");
+		c.newInstance();
+	}
+
 	/* Instance field with NullRestricted attribute cannot be set to null. */
 	@Test(expectedExceptions = java.lang.NullPointerException.class)
 	static public void testPutFieldNullToNullRestrictedField() throws Throwable {


### PR DESCRIPTION
- NullRestricted fields must be a value type with an ImplicitCreation attribute that has the ACC_DEFAULT flag set. For non-static fields this should be checked during class creation and for static fields during the preparation stage of linking.
- This pr also adds static NullRestricted fields to the flattenedClassCache to make the described failure possible. Changes to allow non-static NullRestricted fields to be flattened will come in a later pull request.
- Move ImplicitCreation flag declarations because flags are no longer part of extramodifiers, and correct default flag value

Related: https://github.com/eclipse-openj9/openj9/issues/17340