### PR TITLE
Expand default local storage of remote AOT methods

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2969,7 +2969,7 @@ remoteCompilationEnd(J9VMThread *vmThread, TR::Compilation *comp, TR_ResolvedMet
          }
 #endif /* J9VM_INTERP_AOT_RUNTIME_SUPPORT */
 
-      if (shouldStoreRemoteAOTMethods)
+      if (!compInfo->getPersistentInfo()->getJITServerUseAOTCache() || shouldStoreRemoteAOTMethods)
          {
          J9ROMMethod *romMethod = comp->fej9()->getROMMethodFromRAMMethod(method);
          TR::CompilationInfo::storeAOTInSharedCache(


### PR DESCRIPTION
Remotely-compiled AOT methods will now be stored in the local SCC by default if the JITServer AOT cache is not being used. This avoids failures in certain tests that implicitly assume that such methods will be stored in the local SCC.