### PR TITLE
NullRestricted Valhalla attribute cfdump support

### DIFF
--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -69,6 +69,7 @@ DECLARE_UTF8_ATTRIBUTE_NAME(PRELOAD, "Preload");
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 DECLARE_UTF8_ATTRIBUTE_NAME(IMPLICITCREATION, "ImplicitCreation");
+DECLARE_UTF8_ATTRIBUTE_NAME(NULLRESTRICTED, "NullRestricted");
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #if JAVA_SPEC_VERSION >= 11
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_MEMBERS, "NestMembers");
@@ -434,6 +435,12 @@ ClassFileWriter::analyzeFields()
 				addEntry(value, 0, cpType);
 			}
 		}
+
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		if (J9_ARE_ALL_BITS_SET(fieldShape->modifiers, J9FieldFlagIsNullRestricted)) {
+			addEntry((void *) &NULLRESTRICTED, 0, CFR_CONSTANT_Utf8);
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 		fieldShape = romFieldsNextDo(&fieldWalkState);
 	}
@@ -805,6 +812,11 @@ ClassFileWriter::writeField(J9ROMFieldShape * fieldShape)
 	if (NULL != typeAnnotationsData) {
 		attributesCount += 1;
 	}
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+	if (J9_ARE_ALL_BITS_SET(fieldShape->modifiers, J9FieldFlagIsNullRestricted)) {
+		attributesCount += 1;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 	writeU16(U_16(fieldShape->modifiers & CFR_FIELD_ACCESS_MASK));
 	writeU16(indexForUTF8(name));
@@ -844,6 +856,11 @@ ClassFileWriter::writeField(J9ROMFieldShape * fieldShape)
 	if (NULL != typeAnnotationsData) {
 		writeTypeAnnotationsAttribute(typeAnnotationsData);
 	}
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+	if (J9_ARE_ALL_BITS_SET(fieldShape->modifiers, J9FieldFlagIsNullRestricted)) {
+		writeAttributeHeader((J9UTF8 *) &NULLRESTRICTED, 0);
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 }
 
 void

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -1362,6 +1362,14 @@ static void printField(J9CfrClassFile* classfile, J9CfrField* field)
 	for(i = 0; i < arity; i++)
 		j9tty_printf( PORTLIB, "[]");
 
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+	for(i = 0; i < field->attributesCount; i++) {
+		if (CFR_ATTRIBUTE_NullRestricted == field->attributes[i]->tag) {
+			j9tty_printf(PORTLIB, "!");
+		}
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+
 	j9tty_printf( PORTLIB, " %s;\n", classfile->constantPool[field->nameIndex].bytes);
 
 	return;


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/17340

### Test Class
I compiled this using https://github.com/openjdk/valhalla/tree/lw5
```
class Test {
        static FieldTest! ft;
}
value class FieldTest {
        public implicit FieldTest();
}
```
### Classfilewriter.cpp changes
```
$~/openj9builds/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/vm/runtime/cfdump -t Test.class
Wrote 267 bytes to output file Test.j9class
$ ~/openj9builds/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/vm/runtime/cfdump Test.j9class 
class Test extends java.lang.Object
{
    static FieldTest! ft;
    void <init>();
}
```

### Main.c changes:
```
~/openj9builds/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/vm/runtime/cfdump -d Test.class

…
Fields (1):
  Name: 9 -> ft
  Signature: 10 -> LFieldTest;
  Access Flags: 0x8 ( 
  access: default static )
  Attributes (1):
    NullRestricted:
…
```