### PR TITLE
Add stronger guarantees to System.gc()

### DIFF
--- a/runtime/jcl/common/java_lang_ref_Finalizer.c
+++ b/runtime/jcl/common/java_lang_ref_Finalizer.c
@@ -40,4 +40,8 @@ Java_java_lang_ref_Finalizer_runFinalizationImpl(JNIEnv *env, jclass recv)
 	vmFuncs->internalReleaseVMAccess(currentThread);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	mmFuncs->runFinalization(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+	vmFuncs->internalAcquireVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 }


### PR DESCRIPTION
The JCL code expects that when System.GC() is called a GC occurs and finalizable objects are finalized. Historically, J9 has never provided this guarantee. We have often had to modify tests to ensure a GC is triggered at the appropriate time. Increasingly, we are finding that more and more tests rely on this behaviour, and most importantly, core JCL code now relies on this behaviour. This PR ensures that a call to System.gc() triggers a GC and runs finalization.