### PR TITLE
Added the usage of right front end queries and getExistingJittedBodyInfo on Power

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -970,7 +970,7 @@ uint8_t *TR::PPCCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
    if (comp->target().is32Bit() && (((dispatcher&0x80008000) == 0x80008000) || comp->compileRelocatableCode()) )
       codeSize += 4;
 
-   if (comp->compileRelocatableCode())
+   if (fej9->storeOffsetToArgumentsInVirtualIndirectThunks())
       thunk = (uint8_t *)comp->trMemory()->allocateMemory(codeSize, heapAlloc);
    else
       thunk = (uint8_t *)cg->allocateCodeMemory(codeSize, true, false);

--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -41,6 +41,7 @@
 #include "p/codegen/PPCInstruction.hpp"
 #include "p/codegen/PPCRecompilationSnippet.hpp"
 #include "env/CompilerEnv.hpp"
+#include "env/j9method.h"
 
 // Allocate a machine-specific recompilation processor for this compilation
 //
@@ -64,9 +65,8 @@ TR_PPCRecompilation::TR_PPCRecompilation(TR::Compilation * comp)
 
 TR_PersistentMethodInfo *TR_PPCRecompilation::getExistingMethodInfo(TR_ResolvedMethod *method)
    {
-   int8_t *startPC = (int8_t *)method->startAddressForInterpreterOfJittedMethod();
-   TR_PersistentMethodInfo *info = getJittedBodyInfoFromPC(startPC)->getMethodInfo();
-   return(info);
+   TR_PersistentJittedBodyInfo *bodyInfo = (static_cast<TR_ResolvedJ9Method *>(method))->getExistingJittedBodyInfo();
+   return bodyInfo ? bodyInfo->getMethodInfo() : NULL;
    }
 
 TR::Instruction *TR_PPCRecompilation::generatePrePrologue()


### PR DESCRIPTION
This commit updates:
1. `TR::PPCCallSnippet::generateVIThunk` to use the right front end query. 
2. To use `GetExistingMethodInfo` instead of using startPC in `TR_PPCRecompilation::getExistingMethodInfo`

Related PRs for AArch64/z:
1. Use front end query when allocating VI Thunks
https://github.com/eclipse-openj9/openj9/pull/17904 (AArch64)
https://github.com/eclipse-openj9/openj9/pull/6910 (z)
2. Get existing method info from the J9Method instead of startPC
https://github.com/eclipse-openj9/openj9/pull/17915 (AArch64)
https://github.com/eclipse-openj9/openj9/pull/7044 (z)
