### PR TITLE
Store J9VMThread->scopedValueCache in the Continuation object

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -37,6 +37,13 @@ public class Continuation {
 	private long vmRef; /* J9VMContinuation */
 	protected Thread vthread; /* Parent VirtualThread */
 
+	/* The live thread's scopedValueCache is always kept in J9VMThread->scopedValueCache
+	 * whereas the unmounted thread's scopedValueCache is stored in this field. This
+	 * field is modified in ContinuationHelpers.hpp::swapFieldsWithContinuation. This
+	 * assures a one to one mapping between a java.lang.Thread and scopedValueCache.
+	 */
+	private Object[] scopedValueCache;
+
 	private final ContinuationScope scope;
 	private final Runnable runnable;
 	private Continuation parent;

--- a/runtime/oti/ContinuationHelpers.hpp
+++ b/runtime/oti/ContinuationHelpers.hpp
@@ -51,7 +51,7 @@ protected:
 public:
 
 	static VMINLINE void
-	swapFieldsWithContinuation(J9VMThread *vmThread, J9VMContinuation *continuation, bool swapJ9VMthreadSavedRegisters = true)
+	swapFieldsWithContinuation(J9VMThread *vmThread, J9VMContinuation *continuation, j9object_t continuationObject, bool swapJ9VMthreadSavedRegisters = true)
 	{
 	/* Helper macro to swap fields between the two J9Class structs. */
 #define SWAP_MEMBER(fieldName, fieldType, class1, class2) \
@@ -84,6 +84,10 @@ public:
 		}
 		threadELS->i2jState = tempI2J;
 		SWAP_MEMBER(oldEntryLocalStorage, J9VMEntryLocalStorage*, threadELS, continuation);
+
+		j9object_t scopedValueCache = J9VMJDKINTERNALVMCONTINUATION_SCOPEDVALUECACHE(vmThread, continuationObject);
+		J9VMJDKINTERNALVMCONTINUATION_SET_SCOPEDVALUECACHE(vmThread, continuationObject, vmThread->scopedValueCache);
+		vmThread->scopedValueCache = scopedValueCache;
 	}
 
 	static VMINLINE ContinuationState volatile *

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -413,6 +413,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="jdk/internal/vm/Continuation" name="state" signature="J" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="parent" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 	<fieldref class="jdk/internal/vm/Continuation" name="vthread" signature="Ljava/lang/Thread;" versions="19-"/>
+	<fieldref class="jdk/internal/vm/Continuation" name="scopedValueCache" signature="[Ljava/lang/Object;" versions="19-"/>
 
 	<!-- Field references needed to support Foreign Linker API. -->
 	<fieldref class="openj9/internal/foreign/abi/InternalDowncallHandler" name="cifNativeThunkAddr" signature="J" flags="opt_openjdkFfi" versions="17-"/>

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -233,7 +233,7 @@ enterContinuation(J9VMThread *currentThread, j9object_t continuationObject)
 		currentThread->javaVM->memoryManagerFunctions->preMountContinuation(currentThread, continuationObject);
 	}
 
-	VM_ContinuationHelpers::swapFieldsWithContinuation(currentThread, continuation, started);
+	VM_ContinuationHelpers::swapFieldsWithContinuation(currentThread, continuation, continuationObject, started);
 
 	currentThread->currentContinuation = continuation;
 	/* Reset counters which determine if the current continuation is pinned. */
@@ -285,7 +285,7 @@ yieldContinuation(J9VMThread *currentThread, BOOLEAN isFinished)
 	}
 
 	currentThread->currentContinuation = NULL;
-	VM_ContinuationHelpers::swapFieldsWithContinuation(currentThread, continuation);
+	VM_ContinuationHelpers::swapFieldsWithContinuation(currentThread, continuation, continuationObject);
 
 	/* We need a full fence here to preserve happens-before relationship on PPC and other weakly
 	 * ordered architectures since learning/reservation is turned on by default. Since we have the


### PR DESCRIPTION
When a virtual thread is mounted, the corresponding carrier thread
unmounts and no longer runs. Similarly, when a virtual thread is
unmounted, the corresponding carrier thread mounts and resumes its
operations.

When a virtual thread is mounted, the `scopedValueCache` for the carrier
thread is stored in the `Continuation` object's `scopedValueCache` field.

When a virtual thread is unmounted, the carrier thread's
`scopedValueCache`, which is stored in the `Continuation` object's
`scopedValueCache` field, is swapped with `J9VMThread->scopedValueCache`.

This assures a one to one mapping between a `java.lang.Thread` and
`scopedValueCache`. The live thread's `scopedValueCache` is always kept in
`J9VMThread->scopedValueCache` whereas the unmounted thread's
`scopedValueCache` is stored in the corresponding `Continuation` object's
`scopedValueCache` field.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>