### PR TITLE
Do not create class unload PIC site assumption if not required

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -5462,7 +5462,9 @@ TR_RelocationRecordSymbolFromManager::activatePointer(TR_RelocationRuntime *relo
       clazz = (TR_OpaqueClassBlock *)J9_CLASS_FROM_METHOD((J9Method *)(reloPrivateData->_symbol));
       }
 
-   if (needsUnloadAssumptions(symbolType))
+   TR::Compilation *comp = reloRuntime->comp();
+   if (needsUnloadAssumptions(symbolType) &&
+       comp->fej9()->isUnloadAssumptionRequired(clazz, comp->getCurrentMethod()))
       {
       SVM_ASSERT(clazz != NULL, "clazz must exist to add Unload Assumptions!");
       reloTarget->addPICtoPatchPtrOnClassUnload(clazz, reloLocation);
@@ -5470,8 +5472,8 @@ TR_RelocationRecordSymbolFromManager::activatePointer(TR_RelocationRuntime *relo
    if (needsRedefinitionAssumption(reloRuntime, reloLocation, clazz, symbolType))
       {
       SVM_ASSERT(clazz != NULL, "clazz must exist to add Redefinition Assumptions!");
-      createClassRedefinitionPicSite((void *)reloPrivateData->_symbol, (void *) reloLocation, sizeof(uintptr_t), false, reloRuntime->comp()->getMetadataAssumptionList());
-      reloRuntime->comp()->setHasClassRedefinitionAssumptions();
+      createClassRedefinitionPicSite((void *)reloPrivateData->_symbol, (void *) reloLocation, sizeof(uintptr_t), false, comp->getMetadataAssumptionList());
+      comp->setHasClassRedefinitionAssumptions();
       }
    }
 


### PR DESCRIPTION
The issue is `TR_RelocationRecordSymbolFromManager::activatePointer` creates `TR_UnloadedClassPicSite` for a J9Method in the pre-prologue of the current method body. The class of the J9Method is the same as the class of the current method body. In this case, the class unload assumption is not needed because once the class is unloaded, no code will ever reach the J9Method in the pre-prologue.

Fixes: #17734