### PR TITLE
Remove self() tag in codebase

### DIFF
--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -187,8 +187,8 @@ J9::Z::zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
     * The BASR and NOP padding must stick together and can't have reverse spills in the middle.
     * Hence, splitting the dependencies to avoid spill instructions.
     */
-   TR::RegisterDependencyConditions* callPreDeps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, codeGen);
-   TR::RegisterDependencyConditions* callPostDeps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), codeGen);
+   TR::RegisterDependencyConditions* callPreDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, codeGen);
+   TR::RegisterDependencyConditions* callPostDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), codeGen);
 
    gcPoint = generateRRInstruction(codeGen, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, systemEntryPointRegister, callPreDeps);
    if (isJNIGCPoint)

--- a/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
@@ -268,7 +268,7 @@ TR::Register * J9::Z::CHelperLinkage::buildDirectDispatch(TR::Node * callNode, T
    traceMsg(comp(),"%s: Internal Control Flow in OOL : %s\n",callNode->getOpCode().getName(),isHelperCallWithinICF  ? "true" : "false" );
    for (int i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters; i++)
       {
-      if (!self()->getPreserved(REGNUM(i)) && cg()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Locked)
+      if (!getPreserved(REGNUM(i)) && cg()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Locked)
          {
          RealRegisters.use((TR::RealRegister::RegNum)i);
          }
@@ -282,7 +282,7 @@ TR::Register * J9::Z::CHelperLinkage::buildDirectDispatch(TR::Node * callNode, T
    // TODO For Time Being, it is expected that param number won't increase beyond 3 need to fix this when support for stack is there
    for (int i=0; i< callNode->getNumChildren(); i++)
       {
-      if (i < self()->getNumIntegerArgumentRegisters()-1)
+      if (i < getNumIntegerArgumentRegisters()-1)
          preDeps->addPreCondition(cg()->gprClobberEvaluate(callNode->getChild(i)), getIntegerArgumentRegister(i+1));
       else
          TR_ASSERT(false,"Parameters on Stack not supported yet");
@@ -294,7 +294,7 @@ TR::Register * J9::Z::CHelperLinkage::buildDirectDispatch(TR::Node * callNode, T
    * Following line will use the System linkage's return address register for fast path
    * And for regular dual mode helper, private linkage's return address register
    */
-   TR::RealRegister::RegNum regRANum = isFastPathOnly ? self()->getReturnAddressRegister() : cg()->getReturnAddressRegister();
+   TR::RealRegister::RegNum regRANum = isFastPathOnly ? getReturnAddressRegister() : cg()->getReturnAddressRegister();
    TR::Register *regRA = RealRegisters.use(regRANum);
 #if defined(J9ZOS390)
    TR::Register *DSAPointerReg = NULL;

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -870,7 +870,7 @@ J9::Z::PrivateLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
 void
 J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method)
    {
-   self()->setParameterLinkageRegisterIndex(method, method->getParameterList());
+   setParameterLinkageRegisterIndex(method, method->getParameterList());
    }
 
 void
@@ -882,9 +882,9 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
 
    int32_t paramNum = -1;
    while ((paramCursor != NULL) &&
-          (numIntArgs < self()->getNumIntegerArgumentRegisters() ||
-           numFloatArgs < self()->getNumFloatArgumentRegisters() ||
-           numVectorArgs < self()->getNumVectorArgumentRegisters()))
+          (numIntArgs < getNumIntegerArgumentRegisters() ||
+           numFloatArgs < getNumFloatArgumentRegisters() ||
+           numVectorArgs < getNumVectorArgumentRegisters()))
       {
       int32_t index = -1;
       paramNum++;
@@ -897,14 +897,14 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
          case TR::Int16:
          case TR::Int32:
          case TR::Address:
-            if (numIntArgs < self()->getNumIntegerArgumentRegisters())
+            if (numIntArgs < getNumIntegerArgumentRegisters())
                {
                index = numIntArgs;
                }
             numIntArgs++;
             break;
          case TR::Int64:
-            if(numIntArgs < self()->getNumIntegerArgumentRegisters())
+            if(numIntArgs < getNumIntegerArgumentRegisters())
                {
                index = numIntArgs;
                }
@@ -912,7 +912,7 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
             break;
          case TR::Float:
          case TR::Double:
-            if (numFloatArgs < self()->getNumFloatArgumentRegisters())
+            if (numFloatArgs < getNumFloatArgumentRegisters())
                {
                index = numFloatArgs;
                }
@@ -932,7 +932,7 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
             if (dt.isVector())
                {
                // TODO: special handling for Float?
-               if (numVectorArgs < self()->getNumVectorArgumentRegisters())
+               if (numVectorArgs < getNumVectorArgumentRegisters())
                   {
                   index = numVectorArgs;
                   }
@@ -943,12 +943,12 @@ J9::Z::PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol
       paramCursor->setLinkageRegisterIndex(index);
       paramCursor = paramIterator.getNext();
 
-      if (self()->isFastLinkLinkageType())
+      if (isFastLinkLinkageType())
          {
-         if ((numFloatArgs == 1) || (numIntArgs >= self()->getNumIntegerArgumentRegisters()))
+         if ((numFloatArgs == 1) || (numIntArgs >= getNumIntegerArgumentRegisters()))
             {
             // force fastlink ABI condition of only one float parameter for fastlink parameter and it must be within first slots
-            numFloatArgs = self()->getNumFloatArgumentRegisters();   // no more float args possible now
+            numFloatArgs = getNumFloatArgumentRegisters();   // no more float args possible now
             }
          }
       }
@@ -2521,45 +2521,45 @@ void J9::Z::JNILinkage::releaseVMAccessMask(TR::Node * callNode,
    TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg,
    TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps)
    {
-   TR::LabelSymbol * loopHead = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * longReleaseLabel = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * longReleaseSnippetLabel = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(self()->cg());
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
+   TR::LabelSymbol * loopHead = generateLabelSymbol(cg());
+   TR::LabelSymbol * longReleaseLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol * longReleaseSnippetLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg());
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
    intptr_t aValue = fej9->constReleaseVMAccessMask(); //0xfffffffffffdffdf
    jniCallDataSnippet->setConstReleaseVMAccessMask(aValue);
 
-   generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), callNode, methodAddressReg,
+   generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), callNode, methodAddressReg,
      generateS390MemoryReference(methodMetaDataVirtualRegister,
-       fej9->thisThreadGetPublicFlagsOffset(), self()->cg()));
+       fej9->thisThreadGetPublicFlagsOffset(), cg()));
 
 
-   generateS390LabelInstruction(self()->cg(), TR::InstOpCode::label, callNode, loopHead);
+   generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, loopHead);
    loopHead->setStartInternalControlFlow();
 
 
    aValue = fej9->constReleaseVMAccessOutOfLineMask(); //0x340001
    jniCallDataSnippet->setConstReleaseVMAccessOutOfLineMask(aValue);
 
-   generateRRInstruction(self()->cg(), TR::InstOpCode::getLoadRegOpCode(), callNode, javaLitOffsetReg, methodAddressReg);
-   generateRXInstruction(self()->cg(), TR::InstOpCode::getAndOpCode(), callNode, javaLitOffsetReg,
-        generateS390MemoryReference(jniCallDataSnippet->getBaseRegister(), jniCallDataSnippet->getConstReleaseVMAccessOutOfLineMaskOffset(), self()->cg()));
+   generateRRInstruction(cg(), TR::InstOpCode::getLoadRegOpCode(), callNode, javaLitOffsetReg, methodAddressReg);
+   generateRXInstruction(cg(), TR::InstOpCode::getAndOpCode(), callNode, javaLitOffsetReg,
+        generateS390MemoryReference(jniCallDataSnippet->getBaseRegister(), jniCallDataSnippet->getConstReleaseVMAccessOutOfLineMaskOffset(), cg()));
 
    TR::Instruction * gcPoint = (TR::Instruction *) generateS390BranchInstruction(
-      self()->cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, longReleaseSnippetLabel);
+      cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, longReleaseSnippetLabel);
    gcPoint->setNeedsGCMap(0);
 
-   generateRRInstruction(self()->cg(), TR::InstOpCode::getLoadRegOpCode(), callNode, javaLitOffsetReg, methodAddressReg);
-   generateRXInstruction(self()->cg(), TR::InstOpCode::getAndOpCode(), callNode, javaLitOffsetReg,
-         generateS390MemoryReference(jniCallDataSnippet->getBaseRegister(), jniCallDataSnippet->getConstReleaseVMAccessMaskOffset(), self()->cg()));
-   generateRSInstruction(self()->cg(), TR::InstOpCode::getCmpAndSwapOpCode(), callNode, methodAddressReg, javaLitOffsetReg,
+   generateRRInstruction(cg(), TR::InstOpCode::getLoadRegOpCode(), callNode, javaLitOffsetReg, methodAddressReg);
+   generateRXInstruction(cg(), TR::InstOpCode::getAndOpCode(), callNode, javaLitOffsetReg,
+         generateS390MemoryReference(jniCallDataSnippet->getBaseRegister(), jniCallDataSnippet->getConstReleaseVMAccessMaskOffset(), cg()));
+   generateRSInstruction(cg(), TR::InstOpCode::getCmpAndSwapOpCode(), callNode, methodAddressReg, javaLitOffsetReg,
      generateS390MemoryReference(methodMetaDataVirtualRegister,
-       fej9->thisThreadGetPublicFlagsOffset(), self()->cg()));
+       fej9->thisThreadGetPublicFlagsOffset(), cg()));
 
 
    //get existing post conditions on the registers parameters and create a new post cond for the internal control flow
-   TR::RegisterDependencyConditions * postDeps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(0, 3, self()->cg());
+   TR::RegisterDependencyConditions * postDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(0, 3, cg());
    TR::RealRegister::RegNum realReg;
    int32_t regPos = deps->searchPostConditionRegisterPos(methodMetaDataVirtualRegister);
    if (regPos >= 0)
@@ -2589,13 +2589,13 @@ void J9::Z::JNILinkage::releaseVMAccessMask(TR::Node * callNode,
       postDeps->addPostCondition(javaLitOffsetReg, TR::RealRegister::AssignAny);
 
 
-   generateS390BranchInstruction(self()->cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, loopHead);
+   generateS390BranchInstruction(cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, loopHead);
 
-   generateS390LabelInstruction(self()->cg(), TR::InstOpCode::label, callNode, cFlowRegionEnd, postDeps);
+   generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, cFlowRegionEnd, postDeps);
    cFlowRegionEnd->setEndInternalControlFlow();
 
 
-   self()->cg()->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(self()->cg(), callNode, longReleaseSnippetLabel,
+   cg()->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(cg(), callNode, longReleaseSnippetLabel,
                               comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getJittedMethodSymbol()), cFlowRegionEnd));
    // end of release vm access (spin lock)
    }
@@ -2612,10 +2612,10 @@ void J9::Z::JNILinkage::acquireVMAccessMask(TR::Node * callNode, TR::Register * 
    // If instruction uses literal pool, it must only be to do load, and such instruction's memory reference should be marked MemRefMustNotSpill
    // so that in case of long disp, we will reuse the target reg as a scratch reg
 
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    intptr_t aValue = fej9->constAcquireVMAccessOutOfLineMask();
 
-   TR::Instruction * loadInstr = (TR::Instruction *) genLoadAddressConstant(self()->cg(), callNode, aValue, methodAddressReg, NULL, NULL, javaLitPoolVirtualRegister);
+   TR::Instruction * loadInstr = (TR::Instruction *) genLoadAddressConstant(cg(), callNode, aValue, methodAddressReg, NULL, NULL, javaLitPoolVirtualRegister);
    switch (loadInstr->getKind())
          {
          case TR::Instruction::IsRX:
@@ -2628,20 +2628,20 @@ void J9::Z::JNILinkage::acquireVMAccessMask(TR::Node * callNode, TR::Register * 
               break;
          }
 
-   generateRRInstruction(self()->cg(), TR::InstOpCode::getXORRegOpCode(), callNode, javaLitOffsetReg, javaLitOffsetReg);
+   generateRRInstruction(cg(), TR::InstOpCode::getXORRegOpCode(), callNode, javaLitOffsetReg, javaLitOffsetReg);
 
-   TR::LabelSymbol * longAcquireLabel = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * longAcquireSnippetLabel = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * acquireDoneLabel = generateLabelSymbol(self()->cg());
+   TR::LabelSymbol * longAcquireLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol * longAcquireSnippetLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol * acquireDoneLabel = generateLabelSymbol(cg());
    generateRSInstruction(cg(), TR::InstOpCode::getCmpAndSwapOpCode(), callNode, javaLitOffsetReg, methodAddressReg,
       generateS390MemoryReference(methodMetaDataVirtualRegister,
-         (int32_t)fej9->thisThreadGetPublicFlagsOffset(), self()->cg()));
-   TR::Instruction *gcPoint = (TR::Instruction *) generateS390BranchInstruction(self()->cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, longAcquireSnippetLabel);
+         (int32_t)fej9->thisThreadGetPublicFlagsOffset(), cg()));
+   TR::Instruction *gcPoint = (TR::Instruction *) generateS390BranchInstruction(cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, longAcquireSnippetLabel);
    gcPoint->setNeedsGCMap(0);
 
-   self()->cg()->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(self()->cg(), callNode, longAcquireSnippetLabel,
+   cg()->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(cg(), callNode, longAcquireSnippetLabel,
                               comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getJittedMethodSymbol()), acquireDoneLabel));
-   generateS390LabelInstruction(self()->cg(), TR::InstOpCode::label, callNode, acquireDoneLabel);
+   generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, acquireDoneLabel);
    // end of acquire vm accessa
    }
 
@@ -2676,7 +2676,7 @@ J9::Z::JNILinkage::releaseVMAccessMaskAtomicFree(TR::Node * callNode,
                                                     TR::Register * tempReg1)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
-   TR::CodeGenerator* cg = self()->cg();
+   TR::CodeGenerator* cg = cg();
 
    // Store a 1 into vmthread->inNative
    generateSILInstruction(cg, TR::InstOpCode::getMoveHalfWordImmOpCode(), callNode,
@@ -2699,7 +2699,7 @@ J9::Z::JNILinkage::releaseVMAccessMaskAtomicFree(TR::Node * callNode,
 
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), callNode, tempReg1, J9_PUBLIC_FLAGS_VM_ACCESS, TR::InstOpCode::COND_BNE, longReleaseSnippetLabel, false);
 
-   cg->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(cg,
+   cg->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(cg,
                                                                          callNode, longReleaseSnippetLabel,
                                                                          comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getJittedMethodSymbol()),
                                                                          longReleaseRestartLabel));
@@ -2718,7 +2718,7 @@ J9::Z::JNILinkage::acquireVMAccessMaskAtomicFree(TR::Node * callNode,
                                                     TR::Register * tempReg1)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
-   TR::CodeGenerator* cg = self()->cg();
+   TR::CodeGenerator* cg = cg();
 
    // Zero vmthread->inNative, which is a UDATA field
    generateSS1Instruction(cg, TR::InstOpCode::XC, callNode, TR::Compiler->om.sizeofReferenceAddress() - 1,
@@ -2740,7 +2740,7 @@ J9::Z::JNILinkage::acquireVMAccessMaskAtomicFree(TR::Node * callNode,
 
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), callNode, tempReg1, J9_PUBLIC_FLAGS_VM_ACCESS, TR::InstOpCode::COND_BNE, longAcquireSnippetLabel, false);
 
-   cg->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(cg,
+   cg->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(cg,
                                                                          callNode, longAcquireSnippetLabel,
                                                                          comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getJittedMethodSymbol()),
                                                                          longAcquireRestartLabel));
@@ -2755,18 +2755,18 @@ void J9::Z::JNILinkage::checkException(TR::Node * callNode,
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    // check exception
-   TR::LabelSymbol * exceptionRestartLabel = generateLabelSymbol(self()->cg());
-   TR::LabelSymbol * exceptionSnippetLabel = generateLabelSymbol(self()->cg());
-   generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), callNode, tempReg,
-               new (self()->trHeapMemory()) TR::MemoryReference(methodMetaDataVirtualRegister, fej9->thisThreadGetCurrentExceptionOffset(), self()->cg()));
+   TR::LabelSymbol * exceptionRestartLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol * exceptionSnippetLabel = generateLabelSymbol(cg());
+   generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), callNode, tempReg,
+               new (trHeapMemory()) TR::MemoryReference(methodMetaDataVirtualRegister, fej9->thisThreadGetCurrentExceptionOffset(), cg()));
 
-   TR::Instruction *gcPoint = generateS390CompareAndBranchInstruction(self()->cg(),
+   TR::Instruction *gcPoint = generateS390CompareAndBranchInstruction(cg(),
       TR::InstOpCode::getCmpOpCode(), callNode, tempReg, 0, TR::InstOpCode::COND_BNE, exceptionSnippetLabel, false, true);
    gcPoint->setNeedsGCMap(0);
 
-   self()->cg()->addSnippet(new (self()->trHeapMemory()) TR::S390HelperCallSnippet(self()->cg(), callNode, exceptionSnippetLabel,
+   cg()->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(cg(), callNode, exceptionSnippetLabel,
       comp()->getSymRefTab()->findOrCreateThrowCurrentExceptionSymbolRef(comp()->getJittedMethodSymbol()), exceptionRestartLabel));
-   generateS390LabelInstruction(self()->cg(), TR::InstOpCode::label, callNode, exceptionRestartLabel);
+   generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, exceptionRestartLabel);
    }
 
 void


### PR DESCRIPTION
Removing self() in all the Z linkages as they are not required and help
in code clarity. These changes reflect the conversation found in https://github.com/eclipse-openj9/openj9/issues/7453.

The self() calls should be removed to make the code cleaner and to
not confuse developers into thinking these are extensible classes.

Closes: https://github.com/eclipse-openj9/openj9/issues/7453
Signed-off-by: prajwalbandak [prajwalbandak777@gmail.com](mailto:prajwalbandak777@gmail.com)