### PR TITLE
Fix sequence after frame pop query

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1818,13 +1818,7 @@ throwStackOverflow:
 			}
 #if defined(DEBUG_VERSION)
 			if (J9_CHECK_ASYNC_POP_FRAMES == action) {
-				UDATA executeAsyncCheck = FALSE;
-				updateVMStruct(REGISTER_ARGS);
-				ALWAYS_TRIGGER_J9HOOK_VM_POP_FRAMES_INTERRUPT(_vm->hookInterface, _currentThread, executeAsyncCheck);
-				VMStructHasBeenUpdated(REGISTER_ARGS);
-				if (executeAsyncCheck) {
-					rc = GOTO_ASYNC_CHECK;
-				}
+				rc = GOTO_ASYNC_CHECK;
 				goto done;
 			}
 #endif


### PR DESCRIPTION
The existing code fails to remove the generic special frame if triggering the frame pop hook doesnt require us to run the async check.