### PR TITLE
Move decReferenceCount out of else block

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -3346,10 +3346,9 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
                   {
                   cg->evaluate(indexChild);
                   }
-               else
-                  {
-                  cg->decReferenceCount(indexChild);
-                  }
+
+               cg->decReferenceCount(indexChild);
+
                faultingInstruction = cg->getImplicitExceptionPoint();
                }
             else


### PR DESCRIPTION
Move a call to decReferenceCount out of an else block because a case existed where the `indexChild` of the `BNDCHKwithSpineCHKEvaluator` node wasn't having its reference count decremented

Closes: #15436