### PR TITLE
Make J9VMDllLoadInfo::fatalErrorStr 'const'

### DIFF
--- a/runtime/bcutil/bcutil.c
+++ b/runtime/bcutil/bcutil.c
@@ -137,14 +137,14 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				rc = initJImageIntf(&jimageIntf, vm, PORTLIB);
 				if (J9JIMAGE_NO_ERROR != rc) {
-					loadInfo->fatalErrorStr = "failed to initialize JImage interface";
+					vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "failed to initialize JImage interface", FALSE);
 					returnVal = J9VMDLLMAIN_FAILED;
 					break;
 				}
 			}
 			translationBuffers = j9bcutil_allocTranslationBuffers(vm->portLibrary);
 			if (translationBuffers == NULL) {
-				loadInfo->fatalErrorStr = "j9bcutil_allocTranslationBuffers failed";
+				vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "j9bcutil_allocTranslationBuffers failed", FALSE);
 				returnVal = J9VMDLLMAIN_FAILED;
 				break;
 			}
@@ -165,7 +165,7 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			if (omrthread_monitor_init_with_name(&vm->mapMemoryBufferMutex, 0, "global mapMemoryBuffer mutex")
 			|| (vm->mapMemoryResultsBuffer == NULL)
 			) {
-				loadInfo->fatalErrorStr = "initial global mapMemoryBuffer or mapMemoryBufferMutex allocation failed";
+				vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "initial global mapMemoryBuffer or mapMemoryBufferMutex allocation failed", FALSE);
 				returnVal = J9VMDLLMAIN_FAILED;
 			}
 			vm->mapMemoryBuffer = vm->mapMemoryResultsBuffer + MAP_MEMORY_RESULTS_BUFFER_SIZE;
@@ -173,7 +173,7 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 
 		case AGENTS_STARTED :
 			break;
-			
+
 		case JCL_INITIALIZED :
 			break;
 

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -68,7 +68,7 @@ static IDATA initializeCompilerArgs(J9JavaVM* vm,
    char* xCommandLineOptions = NULL;
 
    char *VMOPT_WITH_COLON;
-   char *fatalErrorStr;
+   const char *fatalErrorStr = NULL;
    if (isXjit)
       {
       VMOPT_WITH_COLON = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xjitcolon];
@@ -178,7 +178,7 @@ static IDATA initializeCompilerArgs(J9JavaVM* vm,
       /* If sizeOfOption is 0 then there have been no arguments for (potentially multiple) -Xjit: / -Xaot: */
       else
          {
-         loadInfo->fatalErrorStr = fatalErrorStr;
+         vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, fatalErrorStr, FALSE);
          return J9VMDLLMAIN_FAILED;
          }
       }
@@ -198,7 +198,7 @@ static IDATA initializeCompilerArgs(J9JavaVM* vm,
       if (!* xCommandLineOptions)
          {
          j9mem_free_memory(xCommandLineOptions);
-         loadInfo->fatalErrorStr = fatalErrorStr;
+         vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, fatalErrorStr, FALSE);
          return J9VMDLLMAIN_FAILED;
          }
       }
@@ -454,7 +454,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
                if (!jitConfig)
                   {
-                  loadInfo->fatalErrorStr = "cannot initialize JIT: no jitconfig";
+                  vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot initialize JIT: no jitconfig", FALSE);
                   return J9VMDLLMAIN_FAILED;
                   }
 
@@ -493,7 +493,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             _abort:
             freeJITConfig(jitConfig);
             if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-               loadInfo->fatalErrorStr = "cannot initialize JIT";
+               vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot initialize JIT", FALSE);
             return J9VMDLLMAIN_FAILED;
             }
          break;
@@ -590,7 +590,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                // cannot free JIT config because shutdown stage expects it to exist
                vm->runtimeFlags &= ~J9_RUNTIME_JIT_ACTIVE;
                if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-                  loadInfo->fatalErrorStr = "cannot initialize JIT";
+                  vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot initialize JIT", FALSE);
                return J9VMDLLMAIN_FAILED;
                }
 
@@ -649,8 +649,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
                if ((curThread->currentException != NULL) || (curThread->threadObject == NULL))
                   {
-                  if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-                     loadInfo->fatalErrorStr = "cannot create the jit Thread object";
+                  if ((NULL == loadInfo->fatalErrorStr) || ('\0' == loadInfo->fatalErrorStr[0]))
+                     vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot create the jit Thread object", FALSE);
                   return J9VMDLLMAIN_FAILED;
                   }
 
@@ -675,8 +675,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                   );
                if ((curThread->currentException != NULL) || (curThread->threadObject == NULL))
                   {
-                  if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-                     loadInfo->fatalErrorStr = "cannot create the jit Sampler Thread object";
+                  if ((NULL == loadInfo->fatalErrorStr) || ('\0' == loadInfo->fatalErrorStr[0]))
+                     vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot create the jit Sampler Thread object", FALSE);
                   return J9VMDLLMAIN_FAILED;
                   }
                compInfo->setSamplingThreadLifetimeState(TR::CompilationInfo::SAMPLE_THR_INITIALIZED);
@@ -701,8 +701,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                       iProfilerThread);
                   if ((curThread->currentException != NULL) || (curThread->threadObject == NULL))
                      {
-                     if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-                        loadInfo->fatalErrorStr = "cannot create the iProfiler Thread object";
+                     if ((NULL == loadInfo->fatalErrorStr) || ('\0' == loadInfo->fatalErrorStr[0]))
+                        vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot create the iProfiler Thread object", FALSE);
                      return J9VMDLLMAIN_FAILED;
                      }
                   TRIGGER_J9HOOK_VM_THREAD_STARTED(vm->hookInterface, curThread, iProfilerThread);
@@ -722,8 +722,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                       jProfilerThread);
                   if ((curThread->currentException != NULL) || (curThread->threadObject == NULL))
                      {
-                     if (!loadInfo->fatalErrorStr || strlen(loadInfo->fatalErrorStr)==0)
-                        loadInfo->fatalErrorStr = "cannot create the jProfiler Thread object";
+                     if ((NULL == loadInfo->fatalErrorStr) || ('\0' == loadInfo->fatalErrorStr[0]))
+                        vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "cannot create the jProfiler Thread object", FALSE);
                      return J9VMDLLMAIN_FAILED;
                      }
                   TRIGGER_J9HOOK_VM_THREAD_STARTED(vm->hookInterface, curThread, jProfilerThread);

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -350,14 +350,17 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 			const char* qualifier = NULL;
 			qualifiedSize(&size, &qualifier);
 
-			char *format = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_LOW_MEMORY_RESERVE_SIZE_REQUESTED, "Failed to instantiate compressed references metadata.  %zu%s requested");
+			const char *format = j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_LOW_MEMORY_RESERVE_SIZE_REQUESTED,
+				"Failed to instantiate compressed references metadata; %zu%s requested");
 			UDATA formatLength = strlen(format) + 32; /* 2^64 is 20 digits, so have a few extra */
 
-			loadInfo->fatalErrorStr = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
-			if (loadInfo->fatalErrorStr) {
-				j9str_printf(PORTLIB, loadInfo->fatalErrorStr, formatLength, format, size, qualifier);
-				loadInfo->loadFlags |= FREE_ERROR_STRING; /* indicates that buffer should be freed later */
+			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
+			if (NULL != buffer) {
+				j9str_printf(PORTLIB, buffer, formatLength, format, size, qualifier);
 			}
+			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			break;
 		}
 
@@ -369,14 +372,17 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 			const char* qualifier = NULL;
 			qualifiedSize(&size, &qualifier);
 
-			char *format = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_HEAP_SIZE_REQUESTED, "Failed to instantiate heap.  %zu%s requested");
+			const char *format = j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_HEAP_SIZE_REQUESTED,
+				"Failed to instantiate heap; %zu%s requested");
 			UDATA formatLength = strlen(format) + 32; /* 2^64 is 20 digits, so have a few extra */
 
-			loadInfo->fatalErrorStr = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
-			if (loadInfo->fatalErrorStr) {
-				j9str_printf(PORTLIB, loadInfo->fatalErrorStr, formatLength, format, size, qualifier);
-				loadInfo->loadFlags |= FREE_ERROR_STRING; /* indicates that buffer should be freed later */
+			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
+			if (NULL != buffer) {
+				j9str_printf(PORTLIB, buffer, formatLength, format, size, qualifier);
 			}
+			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			break;
 		}
 
@@ -392,14 +398,17 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 			const char* pageSizeQualifier = NULL;
 			qualifiedSize(&pageSize, &pageSizeQualifier);
 
-			char *format = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_OPTIONS_XLP_PAGE_NOT_AVAILABLE_STRICT, "Unable to satisfy heap size %zu%s with page size %zu%s. Heap size can be specified with -Xmx");
+			const char *format = j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_OPTIONS_XLP_PAGE_NOT_AVAILABLE_STRICT,
+				"Unable to satisfy heap size %zu%s with page size %zu%s. Heap size can be specified with -Xmx");
 			UDATA formatLength = strlen(format) + 32; /* 2^64 is 20 digits, so have a few extra */
 
-			loadInfo->fatalErrorStr = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
-			if (loadInfo->fatalErrorStr) {
-				j9str_printf(PORTLIB, loadInfo->fatalErrorStr, formatLength, format, heapSize, heapSizeQualifier, pageSize, pageSizeQualifier);
-				loadInfo->loadFlags |= FREE_ERROR_STRING; /* indicates that buffer should be freed later */
+			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
+			if (NULL != buffer) {
+				j9str_printf(PORTLIB, buffer, formatLength, format, heapSize, heapSizeQualifier, pageSize, pageSizeQualifier);
 			}
+			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			extensions->largePageFailedToSatisfy = true;
 			break;
 		}
@@ -413,7 +422,10 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 		/* Handle split heap failures cases */
 		if (NULL != splitFailure) {
-			const char *format = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_SPLIT_HEAP, "Failed to instantiate split heap: %s (new size %zu%s, old size %zu%s)");
+			const char *format = j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_SPLIT_HEAP,
+				"Failed to instantiate split heap: %s (new size %zu%s, old size %zu%s)");
 			UDATA oldSpaceSize = extensions->oldSpaceSize;
 			const char* oldQualifier = NULL;
 			qualifiedSize(&oldSpaceSize, &oldQualifier);
@@ -422,16 +434,23 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 			qualifiedSize(&newSpaceSize, &newQualifier);
 			UDATA formatLength = j9str_printf(PORTLIB, NULL, 0, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
 
-			loadInfo->fatalErrorStr = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
-			if (loadInfo->fatalErrorStr) {
-				j9str_printf(PORTLIB, loadInfo->fatalErrorStr, formatLength, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
-				loadInfo->loadFlags |= FREE_ERROR_STRING; /* indicates that buffer should be freed later */
+			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
+			if (NULL != buffer) {
+				j9str_printf(PORTLIB, buffer, formatLength, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
 			}
+			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 		}
 
 		/* failed to generate error string - use default */
-		if(NULL == loadInfo->fatalErrorStr) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_HEAP, "Failed to instantiate heap.");
+		if (NULL == loadInfo->fatalErrorStr) {
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INSTANTIATE_HEAP,
+					"Failed to instantiate heap."),
+				FALSE);
 		}
 
 		goto error_no_memory;
@@ -439,7 +458,14 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 	extensions->dispatcher = extensions->configuration->createParallelDispatcher(&env, (omrsig_handler_fn)vm->internalVMFunctions->structuredSignalHandlerVM, vm, vm->defaultOSStackSize);
 	if (NULL == extensions->dispatcher) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_TASK_DISPATCHER, "Failed to instantiate task dispatcher.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_TASK_DISPATCHER,
+				"Failed to instantiate task dispatcher."),
+			FALSE);
 		goto error_no_memory;
 	}
 
@@ -452,7 +478,14 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 		if(MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_METRONOME_DOES_NOT_SUPPORT_4BIT_SHIFT == extensions->heapInitializationFailureReason) {
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, displayXmxOrMaxRAMPercentage(memoryParameterTable));
 		}
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_GLOBAL_GARBAGE_COLLECTOR, "Failed to instantiate global garbage collector.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INSTANTIATE_GLOBAL_GARBAGE_COLLECTOR,
+				"Failed to instantiate global garbage collector."),
+			FALSE);
 		goto error_no_memory;
 	}
 	/* Mark this collector as a global collector so that we will check for excessive gc after it collects */
@@ -477,7 +510,14 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 	/* Initialize statistic locks */
 	if (omrthread_monitor_init_with_name(&extensions->gcStatsMutex, 0, "MM_GCExtensions::gcStats")) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_MUTEX, "Failed to initialize mutex for GC statistics.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE_MUTEX,
+				"Failed to initialize mutex for GC statistics."),
+			FALSE);
 		goto error_no_memory;
 	}
 
@@ -516,13 +556,27 @@ gcInitializeHeapStructures(J9JavaVM *vm)
 
 	/* For now, number of segments to default in pool */
 	if ((vm->memorySegments = vm->internalVMFunctions->allocateMemorySegmentList(vm, 10, OMRMEM_CATEGORY_VM)) == NULL) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_ALLOCATE_VM_MEMORY_SEGMENTS, "Failed to allocate VM memory segments.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_ALLOCATE_VM_MEMORY_SEGMENTS,
+				"Failed to allocate VM memory segments."),
+			FALSE);
 		goto error;
 	}
 
 	/* For now, number of segments to default in pool */
 	if ((vm->classMemorySegments = vm->internalVMFunctions->allocateMemorySegmentListWithFlags(vm, 10, MEMORY_SEGMENT_LIST_FLAG_SORT, J9MEM_CATEGORY_CLASSES)) == NULL) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_ALLOCATE_VM_CLASS_MEMORY_SEGMENTS, "Failed to allocate VM class memory segments.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_ALLOCATE_VM_CLASS_MEMORY_SEGMENTS,
+				"Failed to allocate VM class memory segments."),
+			FALSE);
 		goto error;
 	}
 
@@ -531,7 +585,14 @@ gcInitializeHeapStructures(J9JavaVM *vm)
 	/* Create and initialize the default memory space */
 	defaultMemorySpace = internalAllocateMemorySpaceWithMaximum(vm, extensions->initialMemorySize, extensions->minNewSpaceSize, extensions->newSpaceSize, extensions->maxNewSpaceSize, extensions->minOldSpaceSize, extensions->oldSpaceSize, extensions->maxOldSpaceSize, extensions->maxSizeDefaultMemorySpace, 0, MEMORY_TYPE_DISCARDABLE);
 	if (defaultMemorySpace == NULL) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_ALLOCATE_DEFAULT_MEMORY_SPACE, "Failed to allocate default memory space.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_ALLOCATE_DEFAULT_MEMORY_SPACE,
+				"Failed to allocate default memory space."),
+			FALSE);
 		goto error;
 	}
 
@@ -539,7 +600,14 @@ gcInitializeHeapStructures(J9JavaVM *vm)
 
 #if defined(J9VM_GC_FINALIZATION)
 		if(!(extensions->finalizeListManager = GC_FinalizeListManager::newInstance(&env))) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_FINALIZER_MANAGEMENT, "Failed to initialize finalizer management.");
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INITIALIZE_FINALIZER_MANAGEMENT,
+					"Failed to initialize finalizer management."),
+				FALSE);
 			goto error;
 		}
 #endif /* J9VM_GC_FINALIZATION */
@@ -2855,7 +2923,14 @@ gcInitializeDefaults(J9JavaVM* vm)
 
 	memoryParameterTable = (IDATA *)j9mem_allocate_memory(tableSize, OMRMEM_CATEGORY_MM);
 	if (!memoryParameterTable) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY, "Failed to initialize, out of memory.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY,
+				"Failed to initialize, out of memory."),
+			FALSE);
 		goto error;
 	}
 	memset(memoryParameterTable, -1, tableSize);
@@ -2866,7 +2941,14 @@ gcInitializeDefaults(J9JavaVM* vm)
 	//gcOmrInitializeDefaults(vm->omrVM);
 	extensions = MM_GCExtensions::newInstance(&env);
 	if (NULL == extensions) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY, "Failed to initialize, out of memory.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY,
+				"Failed to initialize, out of memory."),
+			FALSE);
 		goto error;
 	}
 	extensions->setOmrVM(vm->omrVM);
@@ -2891,7 +2973,14 @@ gcInitializeDefaults(J9JavaVM* vm)
 	initializeVerboseFunctionTableWithDummies(&extensions->verboseFunctionTable);
 
 	if (JNI_OK != gcParseCommandLineAndInitializeWithValues(vm, memoryParameterTable)) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE, "Failed to initialize, parsing command line.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE,
+				"Failed to initialize, parsing command line."),
+			FALSE);
 		goto error;
 	}
 
@@ -2912,7 +3001,14 @@ gcInitializeDefaults(J9JavaVM* vm)
 
 		vm->realtimeSizeClasses = (J9VMGCSizeClasses *)j9mem_allocate_memory(realtimeSizeClassesAllocationSize, OMRMEM_CATEGORY_VM);
 		if (NULL == vm->realtimeSizeClasses) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY, "Failed to initialize, out of memory.");
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INITIALIZE_OUT_OF_MEMORY,
+					"Failed to initialize, out of memory."),
+				FALSE);
 			goto error;
 		}
 	}
@@ -2963,14 +3059,28 @@ gcInitializeDefaults(J9JavaVM* vm)
 	extensions->indexableObjectModel.setIsIndexableDataAddrPresent(vm);
 #endif /* defined(J9VM_ENV_DATA64) */
 	if (NULL == extensions->configuration) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE, "Failed to initialize.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE,
+				"Failed to initialize."),
+			FALSE);
 		goto error;
 	}
 
 	extensions->trackMutatorThreadCategory = J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_REDUCE_CPU_MONITOR_OVERHEAD);
 
 	if (!gcParseTGCCommandLine(vm)) {
-		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE, "Failed to initialize, parsing command line.");
+		vm->internalVMFunctions->setErrorJ9dll(
+			PORTLIB,
+			loadInfo,
+			j9nls_lookup_message(
+				J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+				J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE,
+				"Failed to initialize, parsing command line."),
+			FALSE);
 		goto error;
 	}
 
@@ -2983,19 +3093,40 @@ gcInitializeDefaults(J9JavaVM* vm)
 	while (true) {
 		/* Verify Xmx and Xmdx before using the Xmdx value to calculate further values */
 		if (JNI_OK != gcInitializeXmxXmdxVerification(vm, memoryParameterTable, flatConfiguration, minimumVMSize, NULL, NULL)) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE, "Failed to initialize.");
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INITIALIZE,
+					"Failed to initialize."),
+				FALSE);
 			goto error;
 		}
 
 		/* Calculate memory parameters based on Xmx/Xmdx */
 		if (JNI_OK != gcInitializeCalculatedValues(vm, memoryParameterTable)) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE, "Failed to initialize.");
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INITIALIZE,
+					"Failed to initialize."),
+				FALSE);
 			goto error;
 		}
 
 		/* Verify all memory parameters */
 		if (JNI_OK != gcInitializeVerification(vm, memoryParameterTable, flatConfiguration)) {
-			loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE, "Failed to initialize.");
+			vm->internalVMFunctions->setErrorJ9dll(
+				PORTLIB,
+				loadInfo,
+				j9nls_lookup_message(
+					J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
+					J9NLS_GC_FAILED_TO_INITIALIZE,
+					"Failed to initialize."),
+				FALSE);
 			goto error;
 		}
 
@@ -3015,12 +3146,8 @@ gcInitializeDefaults(J9JavaVM* vm)
 			goto error;
 		}
 
-		/* We are going to try again -- free any buffer we already have from j9gc_initialize_heap */
-		if  ((loadInfo->loadFlags & FREE_ERROR_STRING) && (NULL != loadInfo->fatalErrorStr)) {
-			j9mem_free_memory(loadInfo->fatalErrorStr);
-			loadInfo->loadFlags &= ~FREE_ERROR_STRING;
-		}
-		loadInfo->fatalErrorStr = NULL;
+		/* We are going to try again -- free any buffer we already have from j9gc_initialize_heap. */
+		vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, NULL, FALSE);
 	}
 
 	/* initialize largeObjectAllocationProfilingVeryLargeObjectThreshold, largeObjectAllocationProfilingVeryLargeObjectSizeClass and freeMemoryProfileMaxSizeClasses for non segregated memoryPool case */

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -106,10 +106,10 @@ const U_64 jclConfig = J9CONST64(0x7363617237306200);		/* 'scar70b' */
 
 jint scarInit(J9JavaVM *vm);
 jint scarPreconfigure(J9JavaVM *vm);
-static UDATA addBFUSystemProperties(J9JavaVM* vm);
+static UDATA addBFUSystemProperties(J9JavaVM *vm);
 static IDATA addVMSpecificDirectories(J9JavaVM *vm, UDATA *cursor, char *subdirName);
 static IDATA loadClasslibPropertiesFile(J9JavaVM *vm, UDATA *cursor);
-static void setFatalErrorStringInDLLTableEntry(J9JavaVM* vm, char *errorString);
+static void setFatalErrorStringInDLLTableEntry(J9JavaVM *vm, const char *errorString);
 
 jint
 JNICALL JVM_OnLoad(JavaVM * jvm, char *options, void *reserved)
@@ -124,7 +124,7 @@ JNICALL JVM_OnLoad(JavaVM * jvm, char *options, void *reserved)
  * @return J9SYSPROP_ERROR_NONE on success, or a J9SYSPROP_ERROR_* value on failure.
  */
 static UDATA
-addBFUSystemProperties(J9JavaVM* vm)
+addBFUSystemProperties(J9JavaVM *vm)
 {
 	int fontPathSize = 0;
 	char* fontPathBuffer = "";
@@ -250,7 +250,7 @@ addBFUSystemProperties(J9JavaVM* vm)
 
 
 jint
-scarInit(J9JavaVM * vm)
+scarInit(J9JavaVM *vm)
 {
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	UDATA handle = 0;
@@ -320,7 +320,7 @@ scarInit(J9JavaVM * vm)
 
 
 IDATA
-J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
+J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	IDATA returnVal = J9VMDLLMAIN_OK;
@@ -419,23 +419,24 @@ J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 
 /**
  * Helper function which looks up the entry for this DLL
- * in the VM's table and sets the fatalErrorString specified
+ * in the VM's table and sets the error string specified
  * if the entry is found.
  *
  * @param[in] vm			A pointer to the Java VM
  * @param[in] errorString	The error string to set in the VM's dll entry
  */
 static void
-setFatalErrorStringInDLLTableEntry(J9JavaVM* vm, char *errorString)
+setFatalErrorStringInDLLTableEntry(J9JavaVM *vm, const char *errorString)
 {
 	J9VMDllLoadInfo *loadInfo = FIND_DLL_TABLE_ENTRY(J9_DLL_NAME);
 	if (NULL != loadInfo) {
-		loadInfo->fatalErrorStr = errorString;
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, errorString, FALSE);
 	}
 }
 
 jint
-scarPreconfigure(J9JavaVM * vm)
+scarPreconfigure(J9JavaVM *vm)
 {
 	/* There are a fixed number of entries in jclBootstrapClassPath, ensure that you don't exceed the maximum number */
 	UDATA i = 0;
@@ -575,7 +576,7 @@ loadClasslibPropertiesFile(J9JavaVM *vm, UDATA *cursor)
 }
 
 static IDATA
-addVMSpecificDirectories(J9JavaVM *vm, UDATA *cursor, char * subdirName)
+addVMSpecificDirectories(J9JavaVM *vm, UDATA *cursor, char *subdirName)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	int javaHomePathLength = (int)strlen((char*)vm->javaHome);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -875,7 +875,7 @@ typedef struct J9VMDllLoadInfo {
 	U_32 completedBits;
 	UDATA descriptor;
 	IDATA  ( *j9vmdllmain)(struct J9JavaVM *vm, IDATA stage, void *reserved) ;
-	char* fatalErrorStr;
+	const char* fatalErrorStr;
 	void* reserved;
 } J9VMDllLoadInfo;
 
@@ -4778,6 +4778,7 @@ typedef struct J9InternalVMFunctions {
 	IDATA  ( *optionValueOperations)(J9PortLibrary *portLibrary, struct J9VMInitArgs* j9vm_args, IDATA element, IDATA action, char** valuesBuffer, UDATA bufSize, char delim, char separator, void* reserved) ;
 	void  ( *dumpStackTrace)(struct J9VMThread *currentThread) ;
 	UDATA  ( *loadJ9DLL)(struct J9JavaVM * vm, struct J9VMDllLoadInfo* info) ;
+	void  ( *setErrorJ9dll)(J9PortLibrary *portLib, struct J9VMDllLoadInfo *info, const char *error, BOOLEAN errorIsAllocated) ;
 	UDATA  ( *runJVMOnLoad)(struct J9JavaVM* vm, struct J9VMDllLoadInfo* loadInfo, char* options) ;
 	struct J9ROMClass*  ( *checkRomClassForError)( struct J9ROMClass *romClass, struct J9VMThread *vmThread ) ;
 	void  ( *setExceptionForErroredRomClass)( struct J9ROMClass *romClass, struct J9VMThread *vmThread ) ;
@@ -5753,7 +5754,7 @@ typedef struct J9JavaVM {
 	UDATA requiredDebugAttributes;
 	UDATA stackSizeIncrement;
 	struct J9JavaLangManagementData *managementData;
-	IDATA  ( *setVerboseState)(struct J9JavaVM *vm, struct J9VerboseSettings *verboseOptions, char **errorString) ;
+	IDATA  ( *setVerboseState)(struct J9JavaVM *vm, struct J9VerboseSettings *verboseOptions, const char **errorString) ;
 	omrthread_monitor_t verboseStateMutex;
 	struct J9SharedClassPreinitConfig* sharedClassPreinitConfig;
 	omrthread_monitor_t runtimeFlagsMutex;

--- a/runtime/oti/verbose_api.h
+++ b/runtime/oti/verbose_api.h
@@ -119,7 +119,7 @@ typedef struct J9VerboseSettings {
 * This may be called multiple times. 
 */
 
-IDATA setVerboseState ( J9JavaVM *vm, J9VerboseSettings *verboseOptions, char **errorString );
+IDATA setVerboseState ( J9JavaVM *vm, J9VerboseSettings *verboseOptions, const char **errorString );
 
 BOOLEAN checkOptsAndInitVerbosegclog(J9JavaVM* vm, J9VMInitArgs* args);
 #ifdef __cplusplus

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -709,6 +709,17 @@ UDATA loadJ9DLL(J9JavaVM * vm, J9VMDllLoadInfo* info);
 */
 IDATA shutdownDLL(J9JavaVM * vm, UDATA descriptor, UDATA shutdownDueToExit);
 
+/**
+ * Update the fatalErrorStr field of the supplied J9VMDllLoadInfo object,
+ * freeing as necessary any allocated string owned by that object.
+ *
+ * @param portLib the port library
+ * @param info the J9VMDllLoadInfo object
+ * @param error the new string (may be NULL)
+ * @param errorIsAllocated indicates whether error (if not NULL) must eventually be freed
+ */
+void setErrorJ9dll(J9PortLibrary *portLib, J9VMDllLoadInfo *info, const char *error, BOOLEAN errorIsAllocated);
+
 
 /* ---------------- exceptiondescribe.c ---------------- */
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -173,6 +173,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	optionValueOperations,
 	dumpStackTrace,
 	loadJ9DLL,
+	setErrorJ9dll,
 	runJVMOnLoad,
 	checkRomClassForError,
 	setExceptionForErroredRomClass,


### PR DESCRIPTION
Continue the effort to fix AIX warnings about converting string literals to mutable char pointers by adding a 'const' qualifier to J9VMDllLoadInfo::fatalErrorStr.

This PR contributes to (but does not close) #14859.