### PR TITLE
Add 'const' qualifier to some string parameters

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -766,8 +766,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto &field = std::get<1>(recv);
          auto &sig = std::get<2>(recv);
          uintptr_t options = std::get<3>(recv);
-         client->write(response, fe->getInstanceFieldOffset(clazz, const_cast<char *>(field.data()), field.length(),
-                                                            const_cast<char *>(sig.data()), sig.length(), options));
+         client->write(response, fe->getInstanceFieldOffset(clazz, field.data(), field.length(),
+                                                            sig.data(), sig.length(), options));
          }
          break;
       case MessageType::VM_getJavaLangClassHashCode:

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6564,7 +6564,7 @@ TR_J9VMBase::getNumInnerClasses(TR_OpaqueClassBlock * classPointer)
 
 
 uint32_t
-TR_J9VMBase::getInstanceFieldOffsetIncludingHeader(char* classSignature, char * fieldName, char * fieldSig,
+TR_J9VMBase::getInstanceFieldOffsetIncludingHeader(const char* classSignature, const char * fieldName, const char * fieldSig,
    TR_ResolvedMethod* method)
    {
    TR_OpaqueClassBlock *classBlock=getClassFromSignature(classSignature, strlen(classSignature), method, true);
@@ -6579,8 +6579,8 @@ TR_J9VMBase::getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *profiledInfo)
    }
 
 uint32_t
-TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, char * fieldName, uint32_t fieldLen,
-                               char * sig, uint32_t sigLen, UDATA options)
+TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, const char * fieldName, uint32_t fieldLen,
+                               const char * sig, uint32_t sigLen, UDATA options)
    {
    TR::VMAccessCriticalSection getInstanceFieldOffset(this);
    TR_ASSERT(clazz, "clazz should be set!");
@@ -6593,8 +6593,8 @@ TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, char * fieldNam
    }
 
 uint32_t
-TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, char * fieldName, uint32_t fieldLen,
-                                    char * sig, uint32_t sigLen)
+TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, const char * fieldName, uint32_t fieldLen,
+                                    const char * sig, uint32_t sigLen)
    {
    return getInstanceFieldOffset(clazz, fieldName, fieldLen, sig, sigLen, J9_LOOK_NO_JAVA);
    }
@@ -8535,8 +8535,8 @@ TR_J9SharedCacheVM::javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPoi
    }
 
 uint32_t
-TR_J9SharedCacheVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, uint32_t fieldLen,
-                                    char * sig, uint32_t sigLen, UDATA options)
+TR_J9SharedCacheVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, uint32_t fieldLen,
+                                    const char * sig, uint32_t sigLen, UDATA options)
    {
 
    TR::Compilation* comp = _compInfoPT->getCompilation();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -315,19 +315,19 @@ public:
    bool fsdIsEnabled() { return _flags.testAny(FSDIsEnabled); }
    void setFSDIsEnabled(bool b) { _flags.set(FSDIsEnabled, b); }
 
-   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, char * sig)
+   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, const char * sig)
       {
       return getInstanceFieldOffset(classPointer, fieldName, (uint32_t)strlen(fieldName), sig, (uint32_t)strlen(sig));
       }
-   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, char * sig, uintptr_t options)
+   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, const char * sig, uintptr_t options)
       {
       return getInstanceFieldOffset(classPointer, fieldName, (uint32_t)strlen(fieldName), sig, (uint32_t)strlen(sig), options);
       }
 
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName,
-                                                     uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options);
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName,
-                                                     uint32_t fieldLen, char * sig, uint32_t sigLen);
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName,
+                                                     uint32_t fieldLen, const char * sig, uint32_t sigLen, UDATA options);
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName,
+                                                     uint32_t fieldLen, const char * sig, uint32_t sigLen);
 
    // Not implemented
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *) { return 0; }
@@ -610,24 +610,24 @@ public:
    virtual uintptr_t           getStaticReferenceFieldAtAddress(uintptr_t fieldAddress);
    virtual int32_t              getInt32FieldAt(uintptr_t objectPointer, uintptr_t fieldOffset);
 
-   int32_t getInt32Field(uintptr_t objectPointer, char *fieldName)
+   int32_t getInt32Field(uintptr_t objectPointer, const char *fieldName)
       {
       return getInt32FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "I"));
       }
 
-   int64_t getInt64Field(uintptr_t objectPointer, char *fieldName)
+   int64_t getInt64Field(uintptr_t objectPointer, const char *fieldName)
       {
       return getInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"));
       }
    virtual int64_t              getInt64FieldAt(uintptr_t objectPointer, uintptr_t fieldOffset);
    virtual void                 setInt64FieldAt(uintptr_t objectPointer, uintptr_t fieldOffset, int64_t newValue);
-   void setInt64Field(uintptr_t objectPointer, char *fieldName, int64_t newValue)
+   void setInt64Field(uintptr_t objectPointer, const char *fieldName, int64_t newValue)
       {
       setInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"), newValue);
       }
 
    virtual bool                 compareAndSwapInt64FieldAt(uintptr_t objectPointer, uintptr_t fieldOffset, int64_t oldValue, int64_t newValue);
-   bool compareAndSwapInt64Field(uintptr_t objectPointer, char *fieldName, int64_t oldValue, int64_t newValue)
+   bool compareAndSwapInt64Field(uintptr_t objectPointer, const char *fieldName, int64_t oldValue, int64_t newValue)
       {
       return compareAndSwapInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"), oldValue, newValue);
       }
@@ -1390,7 +1390,7 @@ public:
    virtual uintptr_t getLocalFragmentOffset();
    virtual int32_t getLocalObjectAlignmentInBytes();
 
-   uint32_t getInstanceFieldOffsetIncludingHeader(char* classSignature, char * fieldName, char * fieldSig, TR_ResolvedMethod* method);
+   uint32_t getInstanceFieldOffsetIncludingHeader(const char* classSignature, const char * fieldName, const char * fieldSig, TR_ResolvedMethod* method);
 
    virtual void markHotField( TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool);
    virtual void reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency);
@@ -1583,8 +1583,8 @@ public:
    virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
    virtual void               getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
    virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);
-   virtual uint32_t           getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName,
-                                                     uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options);
+   virtual uint32_t           getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName,
+                                                     uint32_t fieldLen, const char * sig, uint32_t sigLen, UDATA options);
 
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true);
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1385,7 +1385,7 @@ TR_J9ServerVM::isUnloadAssumptionRequired(TR_OpaqueClassBlock *clazz, TR_Resolve
    }
 
 uint32_t
-TR_J9ServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldName, uint32_t fieldLen, char *sig, uint32_t sigLen, UDATA options)
+TR_J9ServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, const char *fieldName, uint32_t fieldLen, const char *sig, uint32_t sigLen, UDATA options)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getInstanceFieldOffset, clazz, std::string(fieldName, fieldLen), std::string(sig, sigLen), options);
@@ -2865,8 +2865,8 @@ TR_J9SharedCacheServerVM::javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * cl
    }
 
 uint32_t
-TR_J9SharedCacheServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, uint32_t fieldLen,
-                                    char * sig, uint32_t sigLen, UDATA options)
+TR_J9SharedCacheServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, uint32_t fieldLen,
+                                    const char * sig, uint32_t sigLen, UDATA options)
    {
    TR::Compilation* comp = _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -152,7 +152,7 @@ public:
    virtual bool isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *) override;
    virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp) override;
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp) override;
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldName, uint32_t fieldLen, char *sig, uint32_t sigLen, UDATA options) override;
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, const char *fieldName, uint32_t fieldLen, const char *sig, uint32_t sigLen, UDATA options) override;
    virtual int32_t getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, bool &hashCodeComputed) override;
    virtual bool hasFinalizer(TR_OpaqueClassBlock *clazz) override;
    virtual uintptr_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz) override;
@@ -321,7 +321,7 @@ public:
    virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp) override;
    virtual int32_t getJavaLangClassHashCode(TR::Compilation * comp, TR_OpaqueClassBlock * clazzPointer, bool &hashCodeComputed) override;
    virtual bool javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result) override;
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options) override;
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, uint32_t fieldLen, const char * sig, uint32_t sigLen, UDATA options) override;
    virtual TR_OpaqueClassBlock * getClassOfMethod(TR_OpaqueMethodBlock *method) override;
    virtual TR_OpaqueClassBlock * getSuperClass(TR_OpaqueClassBlock *classPointer) override;
    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *) override;

--- a/runtime/compiler/infra/J9Monitor.cpp
+++ b/runtime/compiler/infra/J9Monitor.cpp
@@ -32,7 +32,7 @@
 TR::MonitorTable *OMR::MonitorTable::_instance = 0;
 
 TR::Monitor *
-J9::Monitor::create(char *name)
+J9::Monitor::create(const char *name)
    {
    return TR::MonitorTable::get()->create(name);
    }
@@ -44,7 +44,7 @@ J9::Monitor::destroy(TR::Monitor *monitor)
    }
 
 bool
-J9::Monitor::init(char *name)
+J9::Monitor::init(const char *name)
    {
    setNext(0);
    if (j9thread_monitor_init_with_name((J9ThreadMonitor**)&_monitor, 0, name))

--- a/runtime/compiler/infra/J9Monitor.hpp
+++ b/runtime/compiler/infra/J9Monitor.hpp
@@ -47,7 +47,7 @@ class Monitor : public TR_Link0<TR::Monitor>
    {
    public:
 
-   static TR::Monitor *create(char *name);
+   static TR::Monitor *create(const char *name);
    static void destroy(TR::Monitor *monitor);
 
    void enter();
@@ -81,7 +81,7 @@ class Monitor : public TR_Link0<TR::Monitor>
    void operator delete(void *p);
    void operator delete(void *p, void *) {}
 
-   bool init(char *name);
+   bool init(const char *name);
 
    bool initFromVMMutex(void *mutex);
 

--- a/runtime/compiler/infra/J9MonitorTable.cpp
+++ b/runtime/compiler/infra/J9MonitorTable.cpp
@@ -91,7 +91,7 @@ J9::MonitorTable::allocInitClassUnloadMonitorHolders(uint32_t allowedTotalCompTh
    }
 
 TR::Monitor *
-J9::MonitorTable::create(char *name)
+J9::MonitorTable::create(const char *name)
    {
    PORT_ACCESS_FROM_PORT(_portLib);
 

--- a/runtime/compiler/infra/J9MonitorTable.hpp
+++ b/runtime/compiler/infra/J9MonitorTable.hpp
@@ -73,7 +73,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    friend class J9::RWMonitor;
    friend class TR::MonitorTable;
 
-   TR::Monitor *create(char *name);
+   TR::Monitor *create(const char *name);
    void insert(TR::Monitor *monitor);
 
    J9PortLibrary *_portLib;

--- a/runtime/compiler/infra/RWMonitor.cpp
+++ b/runtime/compiler/infra/RWMonitor.cpp
@@ -62,7 +62,7 @@ J9::RWMonitor::destroy()
 
 
 bool
-J9::RWMonitor::init(char *name)
+J9::RWMonitor::init(const char *name)
    {
    return j9thread_rwmutex_init(&_monitor, 0, name) == 0 ? true : false;
    }
@@ -113,7 +113,7 @@ J9::RWMonitor::destroy()
 
 
 bool
-J9::RWMonitor::init(char *name)
+J9::RWMonitor::init(const char *name)
    {
    return j9thread_monitor_init_with_name((J9ThreadMonitor**)&_monitor, 0, name) == 0 ? true : false;
    }

--- a/runtime/compiler/infra/RWMonitor.hpp
+++ b/runtime/compiler/infra/RWMonitor.hpp
@@ -49,7 +49,7 @@ class RWMonitor
    private:
 
    friend class J9::MonitorTable;
-   bool init(char *name);
+   bool init(const char *name);
    bool initFromVMMutex(void *mutex);
 
 #ifdef J9VM_JIT_CLASS_UNLOAD_RWMONITOR

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1381,7 +1381,7 @@ void TR_AddressSet::trace(char *format, ...)
       }
    }
 
-void TR_AddressSet::traceDetails(char *format, ...)
+void TR_AddressSet::traceDetails(const char *format, ...)
    {
    if (enableTraceDetails())
       {

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -224,7 +224,7 @@ class TR_AddressSet
 
    static void trace(char *format, ...);
    static bool enableTraceDetails();
-   static void traceDetails(char *format, ...);
+   static void traceDetails(const char *format, ...);
 
    void moveAddressRanges(int32_t desiredHole, int32_t currentHole);
    void moveAddressRangesBy(int32_t low, int32_t high, int32_t distance);


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding a 'const' qualifier to string parameters in getInstanceFieldOffset related functions, TR_AddressSet::traceDetails, and J9::Monitor::create.

Contributes to (but does not close) #14859