### PR TITLE
Add NullCHK when storing value into NullRestricted field

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -255,12 +255,14 @@
 			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
 			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-XX:+EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput</variation>
 			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
 			<variation>-XX:+EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput</variation>
 			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
 			<variation>-XX:+EnableHCR -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-XX:-EnableHCR -Xjit:count=0</variation>
+			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput</variation>
 			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>
 			<variation>-XX:-EnableHCR -Xjit:count=1,disableAsyncCompilation,initialOptLevel=warm -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-XX:-EnableHCR -Xgcpolicy:optthruput</variation>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
@@ -343,4 +343,65 @@ public class NullRestrictedTypeOptTests {
 			escape8 = p;
 		}
 	}
+
+	public static class TestStoreToNullRestrictedField {
+		public PrimPair nullRestrictedInstanceField;
+		public static PrimPair nullRestrictedStaticField;
+
+		public void replaceInstanceField(Object val) {
+			nullRestrictedInstanceField = (PrimPair) val;
+		}
+
+		public static void replaceStaticField(Object val) {
+			nullRestrictedStaticField = (PrimPair) val;
+		}
+	}
+
+	public static primitive class TestWithFieldStoreToNullRestrictedField {
+		public PrimPair nullRestrictedInstanceField;
+
+		public TestWithFieldStoreToNullRestrictedField(Object val) {
+			this.nullRestrictedInstanceField = (PrimPair) val;
+		}
+	}
+
+	@Test
+	static public void testStoreNullValueToNullRestrictedInstanceField() throws Throwable {
+		TestStoreToNullRestrictedField storeFieldObj = new TestStoreToNullRestrictedField();
+		storeFieldObj.replaceInstanceField(new PrimPair(1, 2));
+
+		try {
+			storeFieldObj.replaceInstanceField(null);
+		} catch (NullPointerException npe) {
+			return; /* pass */
+		}
+
+		Assert.fail("Expect a NullPointerException. No exception or wrong kind of exception thrown");
+	}
+
+	@Test
+	static public void testStoreNullValueToNullRestrictedStaticField() throws Throwable {
+		TestStoreToNullRestrictedField.replaceStaticField(new PrimPair(1, 2));
+
+		try {
+			TestStoreToNullRestrictedField.replaceStaticField(null);
+		} catch (NullPointerException npe) {
+			return; /* pass */
+		}
+
+		Assert.fail("Expect a NullPointerException. No exception or wrong kind of exception thrown");
+	}
+
+	@Test
+	static public void testWithFieldStoreToNullRestrictedField() throws Throwable {
+		TestWithFieldStoreToNullRestrictedField withFieldObj = new TestWithFieldStoreToNullRestrictedField(new PrimPair(1, 2));
+
+		try {
+			withFieldObj = new TestWithFieldStoreToNullRestrictedField(null);
+		} catch (NullPointerException npe) {
+			return; /* pass */
+		}
+
+		Assert.fail("Expect a NullPointerException. No exception or wrong kind of exception thrown");
+	}
 }


### PR DESCRIPTION
Add NullCHK when storing value into NullRestricted field.

This applies to `putfield`, `putstatic`, and `withfield`.

Related: #17340