### PR TITLE
In CriticalRegionTest System.gc once, testAcquireAndGC timeout 10sec

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/jni/CriticalRegionTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/jni/CriticalRegionTest.java
@@ -138,9 +138,7 @@ public class CriticalRegionTest
 	
 	private static void discardAndGC()
 	{
-		// Double-GC to try for an aggressive collect
 		garbage = null;
-		System.gc();
 		System.gc();
 	}
 	
@@ -868,8 +866,8 @@ public class CriticalRegionTest
 		try {
 			//lock.wait(sleepTime * 2);
 			for(int i = 0; i < threadCount; i++) {
-				/* CMVC 195423 : Increase timeout to 5 seconds to allow all child threads to complete */
-				threads[i].join(sleepTime * 5);
+				/* Increase timeout to 10 seconds to allow all child threads to complete */
+				threads[i].join(sleepTime * 10);
 			}
 		} catch (InterruptedException e) {}
 			


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/18077

5 x 6x grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/2873/ - passed