### PR TITLE
Add DDR dummy header size_t strlen(const char *str)

### DIFF
--- a/runtime/ddr/dummy_headers/string.h
+++ b/runtime/ddr/dummy_headers/string.h
@@ -20,6 +20,5 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-
-void * memmove ( void * destination, const void * source, size_t num );
-
+void *memmove(void *destination, const void *source, size_t num);
+size_t strlen(const char *str);


### PR DESCRIPTION
Add DDR dummy header size_t strlen(const char *str)

Fix DDR compilation error:
```
"../oti/VMHelpers.hpp", error: identifier "strlen" is undefined.
```
[Internal J9 Java [Linux Hammer Compressed Pointers] 80 Create source.zip failure](http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=68402960)

related to 
* https://github.com/eclipse-openj9/openj9/pull/17618

FYI @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>