### PR TITLE
Set the ITERATE_FRAMES flag to invoke the frameWalkFunction

### DIFF
--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -386,6 +386,7 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 			/* The number of frames skipped is stored in userData1. */
 			walkState.userData1 = (void *)0;
 #if JAVA_SPEC_VERSION >= 20
+			walkState.flags |= J9_STACKWALK_ITERATE_FRAMES;
 			walkState.frameWalkFunction = genericFrameIterator;
 #endif /* JAVA_SPEC_VERSION >= 20 */
 
@@ -815,6 +816,7 @@ jvmtiInternalGetStackTrace(
 	/* The number of frames skipped is stored in userData1. */
 	walkState.userData1 = (void *)0;
 #if JAVA_SPEC_VERSION >= 20
+	walkState.flags |= J9_STACKWALK_ITERATE_FRAMES;
 	walkState.frameWalkFunction = genericFrameIterator;
 #endif /* JAVA_SPEC_VERSION >= 20 */
 	genericWalkStackFramesHelper(currentThread, targetThread, threadObject, &walkState);


### PR DESCRIPTION
Without the `J9_STACKWALK_ITERATE_FRAMES` flag, the `genericFrameIterator`
is not invoked. If there are methods with the `JvmtiMountTransition`
annotation on the stack, they won't be ignored because the
`genericFrameIterator` (`frameWalkFunction`) does not get invoked.

Related: #17871