### PR TITLE
Cumulative thread allocaton stats

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -249,6 +249,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 #endif /* !J9VM_ENV_DATA64 */
 #endif /* J9VM_GC_OBJECT_ACCESS_BARRIER */
 	j9gc_get_bytes_allocated_by_thread,
+	j9gc_get_cumulative_bytes_allocated_by_thread,
 	j9mm_iterate_all_ownable_synchronizer_objects,
 	j9mm_iterate_all_continuation_objects,
 	ownableSynchronizerObjectCreated,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -291,6 +291,7 @@ extern BOOLEAN j9gc_stringHashEqualFn (void *leftKey, void *rightKey, void *user
 
 /* modronapi.cpp */
 extern J9_CFUNC UDATA j9gc_get_bytes_allocated_by_thread(J9VMThread* vmThread);
+extern J9_CFUNC BOOLEAN j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread *vmThread, UDATA *cumulativeValue);
 
 #ifdef __cplusplus
 }

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -968,6 +968,17 @@ j9gc_get_bytes_allocated_by_thread(J9VMThread *vmThread)
 }
 
 /**
+ * @param[in] vmThread the vmThread we are querying about
+ * @param[out] cumulativeValue pointer to a variable where to store cumulative number of bytes allocated by a thread since the start of VM
+ * @return false if the value just rolled over or if cumulativeValue pointer is null, otherwise true
+ */
+BOOLEAN
+j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread *vmThread, UDATA *cumulativeValue)
+{
+	return MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread)->_objectAllocationInterface->getAllocationStats()->bytesAllocatedCumulative(cumulativeValue);
+}
+
+/**
  * Return information about the total CPU time consumed by GC threads, as well
  * as the number of GC threads. The time for the main and worker threads is
  * reported separately, with the worker threads returned as a total.

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -93,6 +93,7 @@ void j9gc_set_memoryController(J9VMThread *vmThread, j9object_t objectPtr, j9obj
 void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);
 void j9gc_set_allocation_threshold(J9VMThread *vmThread, UDATA low, UDATA high);
 UDATA j9gc_get_bytes_allocated_by_thread(J9VMThread *vmThread);
+BOOLEAN j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread *vmThread, UDATA *cumulativeValue);
 void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64 *mainCpuMillis, U_64 *workerCpuMillis, U_32 *maxThreads, U_32 *currentThreads);
 J9HookInterface** j9gc_get_private_hook_interface(J9JavaVM *javaVM);
 /**

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4619,7 +4619,9 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *j9gc_objaccess_staticCompareAndSwapLongSplit)(struct J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1) ;
 #endif /* !J9VM_ENV_DATA64 */
 #endif /* J9VM_GC_OBJECT_ACCESS_BARRIER */
-	UDATA  ( *j9gc_get_bytes_allocated_by_thread)(struct J9VMThread* vmThread) ;
+	UDATA  ( *j9gc_get_bytes_allocated_by_thread)(struct J9VMThread *vmThread) ;
+	BOOLEAN ( *j9gc_get_cumulative_bytes_allocated_by_thread)(struct J9VMThread *vmThread, UDATA *cumulativeValue) ;
+
 	jvmtiIterationControl  ( *j9mm_iterate_all_ownable_synchronizer_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;
 	jvmtiIterationControl  ( *j9mm_iterate_all_continuation_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;
 	UDATA ( *ownableSynchronizerObjectCreated)(struct J9VMThread *vmThread, j9object_t object) ;


### PR DESCRIPTION
Inter-module GC API for cumulative thread allocation stats. Just a wrapper for an existing API in OMR GC.