### PR TITLE
Implement StackWalker.Option.DROP_METHOD_INFO

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -429,11 +429,11 @@ K0688=Lookup does not have the ORIGINAL access bit
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"
+K0639D="Stack walker configured with DROP_METHOD_INFO"
 K0640="getCallerClass called from method with no caller"
 K0641="estimatedDepth must be greater than 0"
 K0642="This classloader has more than one helper"
 K0643="Error obtaining JDK boostrap loader: {0}"
-
 K0644="Caller-sensitive method called StackWalker.getCallerClass()"
 
 #java.lang.ClassLoader

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -220,6 +220,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodSignature" signature="Ljava/lang/String;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="frameModule" signature="Ljava/lang/Module;" versions="9-"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="monitors" signature="[Ljava/lang/Object;" versions="21-"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="flags" signature="I" versions="22-"/>
 
 	<!-- Common field references shared between OpenJ9 and OpenJDK Thread. -->
 	<fieldref class="java/lang/Thread" name="contextClassLoader" signature="Ljava/lang/ClassLoader;"/>


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/18146.

* copy flags from StackWalker to StackFrameImpl objects
* thrown UnsupportedOperationException as appropriate
* skip collecting method details if DROP_METHOD_INFO was specified

Tidy up:
* use parentheses consistently
* use J9_ARE_ANY_BITS_SET for testing a single bit
* cast carefully