### PR TITLE
Consume -XX:[+/-]UseZlibNX options in OpenJ9 builds

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -483,6 +483,9 @@ enum INIT_STAGE {
 #define VMOPT_XXSETHWPREFETCH_OS_DEFAULT "-XXsetHWPrefetch:os-default"
 #define VMOPT_XXSETHWPREFETCH_EQUALS "-XXsetHWPrefetch="
 
+#define VMOPT_XXUSEZLIBNX "-XX:+UseZlibNX"
+#define VMOPT_XXNOUSEZLIBNX "-XX:-UseZlibNX"
+
 #define VMOPT_XXLAZYSYMBOLRESOLUTION "-XX:+LazySymbolResolution"
 #define VMOPT_XXNOLAZYSYMBOLRESOLUTION "-XX:-LazySymbolResolution"
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2658,7 +2658,11 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			if (FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XXSETHWPREFETCH_EQUALS, NULL) >= 0) {
 				vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_SET_HW_PREFETCH;
 			}
-#endif
+#if defined(OPENJ9_BUILD)
+			FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXUSEZLIBNX, NULL);
+			FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXNOUSEZLIBNX, NULL);
+#endif /* defined(OPENJ9_BUILD) */
+#endif /* defined(AIXPPC) */
 
 			/* set the default mode */
 			vm->lockwordMode =LOCKNURSERY_ALGORITHM_ALL_BUT_ARRAY;


### PR DESCRIPTION
Related to https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/664