### PR TITLE
Fix TestOperatingSystemMXBean HardwareModel test

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
@@ -461,7 +461,7 @@ public class TestOperatingSystemMXBean {
 				} else if (name.equals("ProcessCpuLoad")) {
 					AssertJUnit.assertTrue(value instanceof Double);
 				} else if (name.equals("HardwareModel")) {
-					AssertJUnit.assertTrue(value instanceof String);
+					AssertJUnit.assertTrue((value == null) || (value instanceof String));
 				} else if (name.equals("HardwareEmulated")) {
 					AssertJUnit.assertTrue(value instanceof Boolean);
 				} else if (name.equals("OpenFileDescriptorCount")) {


### PR DESCRIPTION
null is a valid value when the hardware model can't be retrieved.