### PR TITLE
Add missing default cases to switch statements

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1075,6 +1075,8 @@ int32_t J9::ARM64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
       case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
          specialArgReg = getProperties().getVTableIndexArgumentRegister();
          break;
+      default:
+         break;
       }
    if (specialArgReg != TR::RealRegister::NoReg)
       {

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -2226,6 +2226,8 @@ J9::ARM64::TreeEvaluator::VMinstanceofEvaluator(TR::Node *node, TR::CodeGenerato
                }
             }
             break;
+         default:
+            break;
          }
 
       switch (current)
@@ -2533,6 +2535,8 @@ J9::ARM64::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR::CodeGenerator
                generateLabelInstruction(cg, TR::InstOpCode::b, node, callHelperLabel);
                }
             }
+            break;
+         default:
             break;
          }
 


### PR DESCRIPTION
Add missing default cases to switch statements which were causing "enumeration values not handled in switch" warnings on [`aarch64_mac` OpenJ9 builds](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/18194/). These additions (along with a few corresponding additions in [OMR](https://github.com/eclipse/omr/pull/7123)) fix the warnings without changing the behaviour of the code. This, of course, assumes that there are no switch cases that should be handled but aren't.

This PR contributes to (but does not close) #14859.