### PR TITLE
Allow zlinux testing to run on rhel8

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -223,11 +223,6 @@ s390x_linux:
     11: 'linux-s390x-normal-server-release'
   node_labels:
     build: 'ci.role.build && hw.arch.s390x && sw.os.rhel.7'
-  extra_test_labels:
-    11: '!sw.os.rhel.8'
-    17: '!sw.os.rhel.8'
-    21: '!sw.os.rhel.8'
-    next: '!sw.os.rhel.8'
   build_env:
     cmd:
       all: 'source /home/jenkins/set_gcc_11.2.0_env'


### PR DESCRIPTION
Excluded the problematic test
https://github.com/adoptium/aqa-tests/pull/4780