### PR TITLE
Enable disabled tests

### DIFF
--- a/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
@@ -24,12 +24,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<include>../variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_forceLazySymbolResolution</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/11076</comment>
-				<version>15+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -583,12 +583,6 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_jvmtitests_hcr_OSRG_nongold</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14014</comment>
-				<version>17+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode107-OSRG</variation>
 			<variation>Mode110-OSRG</variation>


### PR DESCRIPTION

https://github.com/eclipse-openj9/openj9/issues/10917
Enabling below test cases 

- cmdLineTester_forceLazySymbolResolution
     [Grinder JDK17 x86-64_linux](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35100/console)
- cmdLineTester_jvmtitests_hcr_OSRG_nongold
[Grinder JDK17 x86-64_linux](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35098/console)
[Grinder JDK17 x86-64_mac](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35099/console)
[Grinder JDK17 x86-64_windows](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35097/console)

@llxia 
Signed-off-by: Kapil Powar [kapil.powar@in.ibm.com](mailto:kapil.powar@in.ibm.com)
