### PR TITLE
CRIU adds InternalCRIUSupport.getLastRestoreTime()

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -35,6 +35,7 @@ public final class InternalCRIUSupport {
 	private static native boolean isCRIUSupportEnabledImpl();
 	private static native boolean isCheckpointAllowedImpl();
 	private static native long getCheckpointRestoreNanoTimeDeltaImpl();
+	private static native long getLastRestoreTimeImpl();
 
 	/**
 	 * Retrieve the elapsed time between Checkpoint and Restore.
@@ -47,6 +48,17 @@ public final class InternalCRIUSupport {
 			checkpointRestoreNanoTimeDelta = getCheckpointRestoreNanoTimeDeltaImpl();
 		}
 		return checkpointRestoreNanoTimeDelta;
+	}
+
+	/**
+	 * Retrieve the time when the last restore occurred. In the case of multiple
+	 * restores the previous times are overwritten.
+	 *
+	 * @return the time in milliseconds since the start of the epoch, -1 if restore
+	 *         has not occurred.
+	 */
+	public static long getLastRestoreTime() {
+		return getLastRestoreTimeImpl();
 	}
 
 	/**

--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #include "util_api.h"
 #include "vmargs_api.h"
 
+#define J9TIME_NANOSECONDS_PER_MILLIS 1000000
 #define STRING_BUFFER_SIZE 256
 #define ENV_FILE_BUFFER 1024
 
@@ -940,6 +941,7 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 		VM_VMHelpers::setVMState(currentThread, J9VMSTATE_CRIU_SUPPORT_RESTORE_PHASE_START);
 		restoreNanoTimeMonotonic = j9time_nano_time();
 		restoreNanoUTCTime = j9time_current_time_nanos(&success);
+		vm->checkpointState.lastRestoreTimeMillis = (I_64)(restoreNanoUTCTime/J9TIME_NANOSECONDS_PER_MILLIS);
 		Trc_CRIU_after_checkpoint(currentThread, restoreNanoTimeMonotonic, restoreNanoUTCTime);
 		if (!syslogFlagNone) {
 			/* Re-open the system logger, and set options with saved string value. */

--- a/runtime/jcl/common/criu.cpp
+++ b/runtime/jcl/common/criu.cpp
@@ -38,6 +38,14 @@ Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaI
 	return currentThread->javaVM->checkpointState.checkpointRestoreTimeDelta;
 }
 
+jlong JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getLastRestoreTimeImpl(JNIEnv *env, jclass unused)
+{
+	J9VMThread *currentThread = (J9VMThread *)env;
+
+	return currentThread->javaVM->checkpointState.lastRestoreTimeMillis;
+}
+
 jboolean JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused)
 {
@@ -63,7 +71,5 @@ Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl(JNIEnv *e
 
 	return res;
 }
-
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -670,6 +670,7 @@ endif()
 if(J9VM_OPT_CRIU_SUPPORT)
 	omr_add_exports(jclse
 		Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl
+		Java_openj9_internal_criu_InternalCRIUSupport_getLastRestoreTimeImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl
 	)

--- a/runtime/jcl/uma/criu_exports.xml
+++ b/runtime/jcl/uma/criu_exports.xml
@@ -21,6 +21,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 -->
 <exports group="criu">
 	<export name="Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl" />
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_getLastRestoreTimeImpl" />
 	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl" />
 	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl" />
 </exports>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4215,6 +4215,7 @@ typedef struct J9CRIUCheckpointState {
 	 * Only supports one Checkpoint, could be restored multiple times.
 	 */
 	I_64 checkpointRestoreTimeDelta;
+	I_64 lastRestoreTimeMillis;
 	UDATA maxRetryForNotCheckpointSafe;
 	jclass criuJVMCheckpointExceptionClass;
 	jclass criuSystemCheckpointExceptionClass;

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1293,6 +1293,9 @@ Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject insta
 jlong JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl(JNIEnv *env, jclass unused);
 
+jlong JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getLastRestoreTimeImpl(JNIEnv *env, jclass unused);
+
 jboolean JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused);
 

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -189,6 +189,22 @@
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
+  <test id="Create CRIU checkpoint image and restore once - testGetLastRestoreTime">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_TIMECHANGE$ testGetLastRestoreTime 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="success" caseSensitive="yes" regex="no">PASSED: InternalCRIUSupport.getLastRestoreTime()</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: InternalCRIUSupport.getLastRestoreTime()</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
+
   <test id="Create Criu Checkpoint Image once and no restore - TestSingleThreadModeCheckpointException">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_SINGLETHREADMODE_CHECKPOINT$ 1 1 true true</command>
     <output type="success" caseSensitive="yes" regex="no">testSingleThreadModeCheckpointExceptionJUCLock: PASSED</output>


### PR DESCRIPTION
CRIU adds `InternalCRIUSupport.getLastRestoreTime()`

Retrieve the time when the last restore occurred. In the case of multiple restores the previous times are overwritten.
The times returned are in milliseconds since the start of the epoch, `-1` if restore has not occurred;
Added a test `testGetLastRestoreTime()`.

closes https://github.com/eclipse-openj9/openj9/issues/18105

Signed-off-by: Jason Feng <fengj@ca.ibm.com>