### PR TITLE
Adjust signature of JVM_MoreStackWalk() for jdk22

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1334,7 +1334,7 @@ JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject arg1, jobject arg2
 
 jint JNICALL
 #if JAVA_SPEC_VERSION >= 22
-JVM_MoreStackWalk(JNIEnv *env, jobject arg1, jint arg2, jlong arg3, jint arg4, jint arg5, jobjectArray arg6, jobjectArray arg7)
+JVM_MoreStackWalk(JNIEnv *env, jobject arg1, jint arg2, jlong arg3, jint arg4, jint arg5, jint arg6, jobjectArray arg7, jobjectArray arg8)
 #else /* JAVA_SPEC_VERSION >= 22 */
 JVM_MoreStackWalk(JNIEnv *env, jobject arg1, jlong arg2, jlong arg3, jint arg4, jint arg5, jobjectArray arg6, jobjectArray arg7)
 #endif /* JAVA_SPEC_VERSION >= 22 */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -319,7 +319,7 @@ _IF([JAVA_SPEC_VERSION >= 11],
 _IF([(11 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 22)],
 	[_X(JVM_MoreStackWalk,JNICALL,false,jint,JNIEnv *env, jobject arg1, jlong arg2, jlong arg3, jint arg4, jint arg5, jobjectArray arg6, jobjectArray arg7)])
 _IF([JAVA_SPEC_VERSION >= 22],
-	[_X(JVM_MoreStackWalk,JNICALL,false,jint,JNIEnv *env, jobject arg1, jint arg2, jlong arg3, jint arg4, jint arg5, jobjectArray arg6, jobjectArray arg7)])
+	[_X(JVM_MoreStackWalk,JNICALL,false,jint,JNIEnv *env, jobject arg1, jint arg2, jlong arg3, jint arg4, jint arg5, jint arg6, jobjectArray arg7, jobjectArray arg8)])
 _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_ConstantPoolGetClassRefIndexAt,JNICALL,false,jint,JNIEnv *env, jobject arg1, jlong arg2, jint arg3)])
 _IF([JAVA_SPEC_VERSION >= 11],


### PR DESCRIPTION
See
* [8316456: StackWalker may skip Continuation::yield0 frame mistakenly](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/8b4c6af1080ba01c4e35ed0ebc1e6d74bfd47056)