### PR TITLE
Update genAconst_init to check NullRestricted attribute

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -597,9 +597,10 @@ static void addEntryForFieldImpl(TR_VMField *field, TR::TypeLayoutBuilder &tlb, 
 
       char *fieldName = mergeFieldNames(prefix, prefixLength, field->shape, region, mergedLength);
       int32_t offset = offsetBase + field->offset + TR::Compiler->om.objectHeaderSizeInBytes();
-      bool isVolatile = (field->modifiers & J9AccVolatile) ? true : false;
-      bool isPrivate = (field->modifiers & J9AccPrivate) ? true : false;
-      bool isFinal = (field->modifiers & J9AccFinal) ? true : false;
+      bool isVolatile = J9_ARE_ALL_BITS_SET(field->modifiers, J9AccVolatile);
+      bool isPrivate = J9_ARE_ALL_BITS_SET(field->modifiers, J9AccPrivate);
+      bool isFinal = J9_ARE_ALL_BITS_SET(field->modifiers, J9AccFinal);
+      bool isFieldNullRestricted = J9_ARE_ALL_BITS_SET(field->modifiers, J9FieldFlagIsNullRestricted);
 
       int sigLen = strlen(signature);
       char *fieldSignature = new (region) char[sigLen+1];
@@ -608,7 +609,7 @@ static void addEntryForFieldImpl(TR_VMField *field, TR::TypeLayoutBuilder &tlb, 
 
       if (trace)
          traceMsg(comp, "type layout definingClass %p field: %s signature: %s field offset: %d offsetBase %d\n", definingClass, fieldName, fieldSignature, field->offset, offsetBase);
-      tlb.add(TR::TypeLayoutEntry(dataType, offset, fieldName, isVolatile, isPrivate, isFinal, fieldSignature));
+      tlb.add(TR::TypeLayoutEntry(dataType, offset, fieldName, isVolatile, isPrivate, isFinal, isFieldNullRestricted, fieldSignature));
       }
    }
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6589,12 +6589,15 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
                   {
                   if (!TR::Compiler->om.isQDescriptorForValueTypesSupported())
                      {
-                     TR_ASSERT_FATAL(false, "Support for null-restricted types without Q descriptor is to be implemented!!!");
+                     isNullRestricted = entry._isNullRestricted;
                      }
                   else if (fieldSignature[0] == 'Q')
                      {
                      isNullRestricted = true;
+                     }
 
+                  if (isNullRestricted)
+                     {
                      // In non-SVM AOT compilation, cpIndex is required for AOT relocation.
                      // In this case, cpindex is unknown for the field.
                      if (comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager))
@@ -6606,7 +6609,7 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
                                                                                      comp()->getCurrentMethod());
                      if (comp()->getOption(TR_TraceILGen))
                         {
-                        traceMsg(comp(), "fieldSignature %s fieldClass %p\n", fieldSignature, fieldClass);
+                        traceMsg(comp(), "isNullRestricted 1 fieldSignature %s fieldClass %p\n", fieldSignature, fieldClass);
                         }
 
                      // Set cpIndex as -1 since it's unknown for the field class


### PR DESCRIPTION
Update `genAconst_init` to check `NullRestricted` attribute

- [ ] Depends on https://github.com/eclipse/omr/pull/7125

Related: #18170