### PR TITLE
Collect debuginfo files to help diagnose omr_ddrgen failures with gcc11

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -528,7 +528,10 @@ def archive_diagnostics(javaVersionJdkImageDir = null) {
     findCrashDataCmd += " -o -name 'jitdump.*.dmp'"
     findCrashDataCmd += " -o -name 'Snap.*.trc'"
 
-    if (SPEC.contains('win')) {
+    if (SPEC.contains('linux')) {
+        // collect *.debuginfo files to help diagnose omr_ddrgen failures
+        findCrashDataCmd += " -o -name '*.debuginfo'"
+    } else if (SPEC.contains('win')) {
         // collect *.pdb files to help diagnose omr_ddrgen failures
         findCrashDataCmd += " -o -name '*.pdb'"
     } else if (SPEC.contains('zos')) {


### PR DESCRIPTION
None were collected in https://openj9-jenkins.osuosl.org/job/Build_JDK21_aarch64_linux_gcc11_Personal/1; this should fix that.