### PR TITLE
(0.41) Update JVM_IsUseContainerSupport

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1689,13 +1689,12 @@ JVM_IsUseContainerSupport(JNIEnv *env)
 {
 	J9VMThread *const currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
-	BOOLEAN inContainer = FALSE;
+	jboolean result = JNI_FALSE;
 
 	if (J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_USE_CONTAINER_SUPPORT)) {
-		PORT_ACCESS_FROM_ENV(env);
-		OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
-		inContainer = omrsysinfo_is_running_in_container();
+		/* Return true if -XX:+UseContainerSupport is specified. This option is enabled by default. */
+		result = JNI_TRUE;
 	}
 
-	return inContainer ? JNI_TRUE : JNI_FALSE;
+	return result;
 }


### PR DESCRIPTION
Backport of #18185.

Currently, in comparison to the RI, OpenJ9 shows a different output for
-XshowSettings:system outside a container because our
JVM_IsUseContainerSupport implementation differs from the RI.

This PR matches the latest RI behaviour for JVM_IsUseContainerSupport.

The RI returns TRUE from JVM_IsUseContainerSupport IFF
-XX:+UseContainerSupport is specified. This option is enabled by
default.

Currently, we return TRUE from JVM_IsUseContainerSupport if
-XX:+UseContainerSupport is specified && we are inside a container.

The return value of JVM_IsUseContainerSupport determines the output
of -XshowSettings:system.

If JVM_IsUseContainerSupport returns FALSE, -XshowSettings:system has
the below output:

    Operating System Metrics:
        No metrics available for this platform

If JVM_IsUseContainerSupport returns TRUE, -XshowSettings:system has
the below output:

    Operating System Metrics:
        Provider: cgroupv2
        Effective CPU Count: 8
        CPU Period: -1
        CPU Quota: -1
        CPU Shares: -1
        List of Processors: N/A
        List of Effective Processors: N/A
        List of Memory Nodes: N/A
        List of Available Memory Nodes: N/A
        Memory Limit: Unlimited
        Memory Soft Limit: 0.00K
        Memory & Swap Limit: Unlimited
        Maximum Processes Limit: Unlimited

Port of https://github.com/eclipse-openj9/openj9/pull/18185 for 0.41

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>