### PR TITLE
Enable disabled tests

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -204,12 +204,6 @@
 	</test>
 	<test>
 		<testCaseName>jit_jitt_openj9_none_SCC</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15152</comment>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit:noJitUntilMain,count=0,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>
 			<variation>-Xrs -Xjit:noJitUntilMain,count=0,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>

--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -23,13 +23,6 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
 		<testCaseName>TestFlushReflectionCache</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15152</comment>
-				<version>19+</version>
-				<variation>Mode107</variation>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode100</variation>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/10917
Enabling test cases `TestFlushReflectionCache` & `jit_jitt_openj9_none_SCC`
[Grinder JDK21 x86-64_linux](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35188) 
[Grinder JDK21 x86-64_mac](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35189)
[Grinder JDK21 x86-64_windows](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35190)

@llxia 

Signed-off-by: Kapil Powar [kapil.powar@in.ibm.com](mailto:kapil.powar@in.ibm.com)
