### PR TITLE
Update jdkcompliance for JAVA21 and JAVA22

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -161,7 +161,7 @@
 		  label="JAVA21"
 		  outputpath="JAVA21/src"
 		  dependencies="JAVA17"
-		  jdkcompliance="19">
+		  jdkcompliance="21">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
@@ -189,7 +189,7 @@
 		  label="JAVA22"
 		  outputpath="JAVA22/src"
 		  dependencies="JAVA21"
-		  jdkcompliance="19">
+		  jdkcompliance="21">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>


### PR DESCRIPTION
Eclipse 2023-09 supports the Java 21 execution environment with a [patch available in the marketplace](https://marketplace.eclipse.org/content/java-21-support-eclipse-2023-09-429).