### PR TITLE
re-enable cmdLineTester_dumpromclasstests

### DIFF
--- a/test/functional/cmdLineTests/dumpromtests/playlist.xml
+++ b/test/functional/cmdLineTests/dumpromtests/playlist.xml
@@ -24,12 +24,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<include>../variables.mk</include>
 	<test>
 		<testCaseName>cmdLineTester_dumpromclasstests</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/3562</comment>
-				<platform>.*aix.*</platform>
-			</disable>
-		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 	-DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/10917
Enabling below test case `cmdLineTester_dumpromclasstests`


Grinder test links
[aix_ppc-64 JDK8](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35217/)
[aix_ppc-64 JDK11](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35211/)
[aix_ppc-64 JDK17](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/35215/)

@llxia
Signed-off-by: Kapil Powar [kapil.powar@in.ibm.com](mailto:kapil.powar@in.ibm.com)