### PR TITLE
Add CT helper to check for ChangesCurrentThread annotation

### DIFF
--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -29,9 +29,9 @@
 
 extern "C" {
 
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
 J9_DECLARE_CONSTANT_UTF8(ojdk_changesCurrentThread, "Ljdk/internal/vm/annotation/ChangesCurrentThread");
-#endif /* JAVA_SPEC_VERSION >= 20 */
+#endif /* JAVA_SPEC_VERSION >= 21 */
 
 #if JAVA_SPEC_VERSION >= 16
 J9_DECLARE_CONSTANT_UTF8(ojdk_intrinsicCandidate, "Ljdk/internal/vm/annotation/IntrinsicCandidate;");
@@ -266,11 +266,11 @@ jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *met
 BOOLEAN
 jitIsMethodTaggedWithChangesCurrentThread(J9VMThread *currentThread, J9Method *method)
 {
-#if JAVA_SPEC_VERSION >= 20
+#if JAVA_SPEC_VERSION >= 21
 	return FALSE != methodContainsRuntimeAnnotation(currentThread, method, (J9UTF8 *)&ojdk_changesCurrentThread);
-#else /* JAVA_SPEC_VERSION >= 20 */
+#else /* JAVA_SPEC_VERSION >= 21 */
 	return FALSE;
-#endif /* JAVA_SPEC_VERSION >= 20 */
+#endif /* JAVA_SPEC_VERSION >= 21 */
 }
 
 }

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -29,6 +29,10 @@
 
 extern "C" {
 
+#if JAVA_SPEC_VERSION >= 20
+J9_DECLARE_CONSTANT_UTF8(ojdk_changesCurrentThread, "Ljdk/internal/vm/annotation/ChangesCurrentThread");
+#endif /* JAVA_SPEC_VERSION >= 20 */
+
 #if JAVA_SPEC_VERSION >= 16
 J9_DECLARE_CONSTANT_UTF8(ojdk_intrinsicCandidate, "Ljdk/internal/vm/annotation/IntrinsicCandidate;");
 #endif /* JAVA_SPEC_VERSION >= 16 */
@@ -250,6 +254,23 @@ jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *met
 #else /* JAVA_SPEC_VERSION >= 16 */
 	return FALSE;
 #endif /* JAVA_SPEC_VERSION >= 16 */
+}
+
+/**
+ * Queries if the method is annotated with @ChangesCurrentThread
+ *
+ * @param currentThread the currentThread
+ * @param method the method to check for the annotation
+ * @return true if method is annotated with @ChangesCurrentThread, false otherwise
+ */
+BOOLEAN
+jitIsMethodTaggedWithChangesCurrentThread(J9VMThread *currentThread, J9Method *method)
+{
+#if JAVA_SPEC_VERSION >= 20
+	return FALSE != methodContainsRuntimeAnnotation(currentThread, method, (J9UTF8 *)&ojdk_changesCurrentThread);
+#else /* JAVA_SPEC_VERSION >= 20 */
+	return FALSE;
+#endif /* JAVA_SPEC_VERSION >= 20 */
 }
 
 }

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1136,6 +1136,7 @@ extern J9_CFUNC BOOLEAN jitIsFieldStable(J9VMThread *currentThread, J9Class *cla
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithForceInline(J9VMThread *currentThread, J9Method *method);
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithDontInline(J9VMThread *currentThread, J9Method *method);
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *method);
+extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithChangesCurrentThread(J9VMThread *currentThread, J9Method *method);
 
 typedef struct J9MethodFromSignatureWalkState {
 	const char *className;
@@ -1399,4 +1400,3 @@ extern J9_CFUNC void  jitAddPicToPatchOnClassUnload (void *classPointer, void *a
 #endif
 
 #endif /* J9PROTOS_H */
-


### PR DESCRIPTION
This is required for implementing the JIT inlining behaviour expected for the methods annotated by `@ChangesCurrentThread`.

Issue: #17519