### PR TITLE
Fix Criu test failures for JITServer SSL Tests

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
@@ -144,7 +144,7 @@
 		<command>bash $CATSCRIPPATH$ sslVlog1 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">SSL connection on socket</output>
-		<output regex="no" type="required">Connected to a server</output>
+		<output regex="no" type="failure">Could not connect to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
@@ -156,7 +156,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
 		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
 		<output type="required" caseSensitive="yes" regex="no">Successfully initialized SSL context</output>
-		<output type="required" caseSensitive="yes" regex="no">certificate verify failed</output>
+		<output type="success" caseSensitive="yes" regex="no">certificate verify failed</output>
 		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
@@ -171,7 +171,7 @@
 		<command>bash $CATSCRIPPATH$ sslVlog2 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">JITServer::StreamFailure: Failed to SSL_connect</output>
-		<output regex="no" type="required">Could not connect to a server</output>
+		<output regex="no" type="failure">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
@@ -197,7 +197,7 @@
 		<command>bash $CATSCRIPPATH$ sslVlog3 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">JITServer::StreamFailure: Failed to SSL_connect</output>
-		<output regex="no" type="required">Could not connect to a server</output>
+		<output regex="no" type="failure">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
+++ b/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
@@ -26,6 +26,9 @@
 <suite id="jitserverArgumentTesting.xml" timeout="1000">
 	<variable name="ENABLE_JITSERVER" value="-XX:+UseJITServer" />
 	<variable name="DISABLE_JITSERVER" value="-XX:-UseJITServer" />
+	<variable name="JITSERVER_SSL1" value="-XX:JITServerSSLRootCerts=cert.pem" />
+	<variable name="JITSERVER_SSL2" value="-XX:JITServerSSLRootCerts=wrongCert.pem" />
+	<variable name="JITSERVER_SSL3" value="-XX:JITServerSSLRootCerts=nosslserverCert.pem" />
 	<variable name="JITSERVER_VERBOSE" value="-Xjit:verbose={JITServer},verbose={JITServerConns},verbose={compilePerformance}" />
 	<variable name="DEFAULT_JITSERVER_OPTIONS" value="-Xjit" />
 
@@ -89,4 +92,46 @@
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
 	</test>
 
+	<test id="Test SSL success condition">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL1$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="success" caseSensitive="no" regex="no">SSL connection on socket</output>
+		<output type="success" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
+
+	<test id="Test SSL Failure Case with mismatched certificate">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL2$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="success" caseSensitive="no" regex="no">JITServer: Error accepting SSL connection</output>
+		<output type="success" caseSensitive="no" regex="no">JITServer::StreamFailure: Failed to SSL_connect</output>
+		<output type="failure" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
+
+	<test id="Test SSL Failure Case with connection to Non-SSL Server">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL3$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="success" caseSensitive="no" regex="no">JITServer::StreamFailure: Failed to SSL_connect</output>
+		<output type="failure" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
 </suite>

--- a/test/functional/cmdLineTests/jitserver/jitserversslconfig.sh
+++ b/test/functional/cmdLineTests/jitserver/jitserversslconfig.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Set certificate details
+COMMON_NAME="localhost"
+VALID_DAYS=365
+
+# Generate private key
+openssl genrsa -out key.pem 2048
+
+# Generate self-signed certificate
+openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days $VALID_DAYS -subj "/CN=$COMMON_NAME"
+
+# Generate another private key and self-signed certificate
+openssl req -nodes -newkey rsa:2048 -keyout wrongKey.pem -x509 -days 365 -out wrongCert.pem  -subj "/CN=localhost"
+
+# Generate another self-signed certificate
+openssl req -new -x509 -sha256 -key key.pem -out nosslserverCert.pem -days $VALID_DAYS -subj "/CN=$COMMON_NAME"
+echo "Certificates generated"


### PR DESCRIPTION
 Recently added CRIU tests are failing in some cases because of the `required` condition, which will never succeed if we don't have a vlog because of cases like when CRIU can't acquire the original thread IDs. In such cases the output with have something similar to:

```
 [OUT] pie: 3450382: Error (criu/pie/restorer.c:1833): Unable to create a thread: 3450384
 [OUT] pie: 3450384: Error (criu/pie/restorer.c:598): Thread pid mismatch 3450384/3450383
 [OUT] pie: 3450384: Error (criu/pie/restorer.c:651): Restorer abnormal termination for 3450382
 [OUT] Error (criu/cr-restore.c:2536): Restoring FAILED.
 [OUT] Error (criu/cr-restore.c:1494): 3450382 exited, status=1
```

The tests conditions needs to be altered to adapt to this expected scenario and silently succeed in such cases.
