### PR TITLE
Fix Criu test failures for JITServer SSL Tests

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
+++ b/test/functional/cmdLineTests/criu/criu_jitserverPostRestore.xml
@@ -144,7 +144,8 @@
 		<command>bash $CATSCRIPPATH$ sslVlog1 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">SSL connection on socket</output>
-		<output regex="no" type="required">Connected to a server</output>
+		<output regex="no" type="success">Connected to a server</output>
+		<output regex="no" type="failure">Could not connect to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
@@ -156,7 +157,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
 		<output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
 		<output type="required" caseSensitive="yes" regex="no">Successfully initialized SSL context</output>
-		<output type="required" caseSensitive="yes" regex="no">certificate verify failed</output>
+		<output type="success" caseSensitive="yes" regex="no">certificate verify failed</output>
 		<!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
 		<output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
 		<output type="success" caseSensitive="yes" regex="no">do not match expected</output>
@@ -171,7 +172,8 @@
 		<command>bash $CATSCRIPPATH$ sslVlog2 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">JITServer::StreamFailure: Failed to SSL_connect</output>
-		<output regex="no" type="required">Could not connect to a server</output>
+		<output regex="no" type="success">Could not connect to a server</output>
+		<output regex="no" type="failure">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 
@@ -197,7 +199,8 @@
 		<command>bash $CATSCRIPPATH$ sslVlog3 true true</command>
 		<output regex="no" type="success">CHECKPOINT RESTORE: Ready for restore</output>
 		<output regex="no" type="success">JITServer::StreamFailure: Failed to SSL_connect</output>
-		<output regex="no" type="required">Could not connect to a server</output>
+		<output regex="no" type="success">Could not connect to a server</output>
+		<output regex="no" type="failure">Connected to a server</output>
 		<output regex="no" type="success">CAT VLOG FORCE PASS</output>
 	</test>
 </suite>


### PR DESCRIPTION
Recently added CRIU tests are failing in some cases because of the `required` condition, which will never succeed if we don't have a vlog because of cases like when CRIU can't acquire the original thread IDs. In such cases the output with have something similar to:

```
 [OUT] pie: 3450382: Error (criu/pie/restorer.c:1833): Unable to create a thread: 3450384
 [OUT] pie: 3450384: Error (criu/pie/restorer.c:598): Thread pid mismatch 3450384/3450383
 [OUT] pie: 3450384: Error (criu/pie/restorer.c:651): Restorer abnormal termination for 3450382
 [OUT] Error (criu/cr-restore.c:2536): Restoring FAILED.
 [OUT] Error (criu/cr-restore.c:1494): 3450382 exited, status=1
```

The tests conditions needs to be altered to adapt to this expected scenario and silently succeed in such cases.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18148
Fixes: https://github.com/eclipse-openj9/openj9/issues/18140