### PR TITLE
Add AIX sun.font.FontManagerNativeLibrary.load() test

### DIFF
--- a/test/functional/cmdLineTests/loadLibraryTest/build.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/build.xml
@@ -47,7 +47,19 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
+			<then>
+				<property name="addExports" value="" />
+			</then>
+			<else>
+				<property name="addExports" value='--add-exports java.desktop/sun.font=ALL-UNNAMED' />
+			</else>
+		</if>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
+			<compilerarg line='${addExports}' />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/cmdLineTests/loadLibraryTest/loadLibraryTestAIX.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/loadLibraryTestAIX.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2023
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="LoadLibrary test intended for AIX" timeout="6000">
+	<test id="LoadLibrary testcase with libfontmanager.so">
+		<command>$JAVA_COMMAND$ $ADDEXPORTS$ -cp $TESTSJARPATH$ org.openj9.test.loadLibrary.TestLoadLibraryAIX</command>
+		<output type="success" regex="no" showMatch="yes">TestLoadLibraryAIX passed</output>
+		<output type="failure" regex="no" showMatch="yes">java.lang.UnsatisfiedLinkError</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Java dump</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/loadLibraryTest/playlist.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/playlist.xml
@@ -43,4 +43,52 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTester_loadLibraryTestsAIX_JDK8</testCaseName>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJAVA_COMMAND=$(JAVA_COMMAND) \
+	-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)loadLibraryTest.jar$(Q) \
+	-DADDEXPORTS= \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)loadLibraryTestAIX.xml$(Q) \
+	-nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>8</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_loadLibraryTestsAIX</testCaseName>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJAVA_COMMAND=$(JAVA_COMMAND) \
+	-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)loadLibraryTest.jar$(Q) \
+	-DADDEXPORTS=$(Q)--add-exports java.desktop/sun.font=ALL-UNNAMED$(Q) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)loadLibraryTestAIX.xml$(Q) \
+	-nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/loadLibraryTest/src/org/openj9/test/loadLibrary/TestLoadLibraryAIX.java
+++ b/test/functional/cmdLineTests/loadLibraryTest/src/org/openj9/test/loadLibrary/TestLoadLibraryAIX.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.test.loadLibrary;
+
+public class TestLoadLibraryAIX
+{
+	static {
+		// AIX UnsatisfiedLinkError: Failed to load library libfontmanager.so
+		// https://github.com/eclipse-openj9/openj9/issues/17759
+		sun.font.FontManagerNativeLibrary.load();
+	}
+
+	public static void main(String[] args) {
+		System.out.println("TestLoadLibraryAIX passed");
+	}
+}


### PR DESCRIPTION
Add `AIX` `sun.font.FontManagerNativeLibrary.load()` test

related 
* https://github.com/eclipse-openj9/openj9/issues/17759

The `UnsatisfiedLinkError` was fixed initially (via an extension repo JCL patch), however the change was overridden by OpenJDK updates, and the error in `extended.openjdk` was marked as infra issues.
This `sanity.functional` test can detect such regression earlier and is easier for triaging. 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>