### PR TITLE
Enable write permission before writing into CodeCache segment

### DIFF
--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -409,8 +409,10 @@ static J9MemorySegment * allocateVirtualMemorySegmentInListInternal(J9JavaVM *ja
 				/* For CodeCache segments the JIT will later write a TR::CodeCache structure pointer at the begining of the segment.
 				 * Until then, make sure that a potential reader sees a NULL pointer.
 				 */
+				omrthread_jit_write_protect_disable();
 				*((UDATA**)allocatedBase) = NULL;
 				issueWriteBarrier();
+				omrthread_jit_write_protect_enable();
 			}
 			segment->baseAddress = allocatedBase;
 			segment->heapBase = allocatedBase;


### PR DESCRIPTION
`allocateVirtualMemorySegmentInListInternal` has been changed to write NULL into the code cache segment in #18212. The change does not include `omrthread_jit_write_protect_disable` and `omrthread_jit_write_protect_enable` calls before and after writing to the memory, which results in the crash on Apple Silicon Mac.
This commit inserts `omrthread_jit_write_protect_disable` and `omrthread_jit_write_protect_enable` appropriately.