### PR TITLE
CRIU adds time compensation for RuntimeMXBean.getUptime()

### DIFF
--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -702,3 +702,5 @@ TraceExit=Trc_JCL_J9SigUsr2Startup_Exit noEnv Overhead=1 Level=1 Template="J9Sig
 
 TraceEntry=Trc_JCL_J9SigUsr2Shutdown_Entry noEnv Overhead=1 Level=1 Template="J9SigUsr2Shutdown"
 TraceExit=Trc_JCL_J9SigUsr2Shutdown_Exit noEnv Overhead=1 Level=1 Template="J9SigUsr2Shutdown"
+
+TraceEvent=Trc_JCL_MXBean_getUptimeImpl Overhead=1 Level=3 Template="RuntimeMXBeanImpl_getUptimeImpl timeNow (%lld) vmStartTime (%lld) criuTimeDeltaMillis (%lld)"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3911,6 +3911,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		}
 	}
 
+	vm->checkpointState.lastRestoreTimeMillis = -1;
 	/* Its unclear if we need an option for this, so we can keep the init here for the time being */
 	vm->checkpointState.maxRetryForNotCheckpointSafe = 100;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -190,12 +190,28 @@
   </test>
 
   <test id="Create CRIU checkpoint image and restore once - testGetLastRestoreTime">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_TIMECHANGE$ testGetLastRestoreTime 1 false false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print=j9criu --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_TIMECHANGE$ testGetLastRestoreTime 1 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
     <output type="success" caseSensitive="yes" regex="no">PASSED: InternalCRIUSupport.getLastRestoreTime()</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: InternalCRIUSupport.getLastRestoreTime()</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
+
+  <test id="Create CRIU checkpoint image and restore once - testMXBeanUpTime">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print={j9criu,j9jcl.533} --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_TIMECHANGE$ testMXBeanUpTime 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="success" caseSensitive="yes" regex="no">PASSED: testMXBeanUpTime()</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: testMXBeanUpTime()</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>


### PR DESCRIPTION
CRIU adds time compensation for `RuntimeMXBean.getUptime()`

Adjusted `RuntimeMXBean.getUptime()` with `checkpointState.checkpointRestoreTimeDelta`;
Added a test.

closes https://github.com/eclipse-openj9/openj9/issues/18106

Signed-off-by: Jason Feng <fengj@ca.ibm.com>