### PR TITLE
Add explicit enum casts to prevent warnings

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -341,12 +341,12 @@ J9::Compilation::printCompYieldStats()
 const char *
 J9::Compilation::getContextName(TR_CallingContext context)
    {
-   if (context == OMR::endOpts || context == TR_CallingContext::NO_CONTEXT)
+   if (context == (TR_CallingContext)OMR::endOpts || context == TR_CallingContext::NO_CONTEXT)
       return "NO CONTEXT";
-   else if (context < OMR::numOpts)
+   else if (context < (TR_CallingContext)OMR::numOpts)
       return TR::Optimizer::getOptimizationName((OMR::Optimizations)context);
    else
-      return callingContextNames[context-OMR::numOpts];
+      return callingContextNames[context - (TR_CallingContext)OMR::numOpts];
    }
 
 void


### PR DESCRIPTION
Fix AIX warnings concerning comparisons between two enum values of different types by explicitly casting one value into the type of the other.

This PR contributes to (but does not close) #14859