### PR TITLE
Fix casts to ensure variables are wide enough to accommodate shifts

### DIFF
--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -135,9 +135,9 @@ TR::Instruction *TR_PPCRecompilation::generatePrologue(TR::Instruction *cursor)
          {
          intptr_t adjustedAddr = HI_VALUE(addr);
          // lis gr11, upper 16-bits
-         cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::lis, firstNode, gr11, (int16_t)adjustedAddr>>32, cursor );
+         cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::lis, firstNode, gr11, (int16_t)(adjustedAddr >> 32), cursor );
          // ori gr11, gr11, next 16-bit
-         cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::ori, firstNode, gr11, gr11, ((adjustedAddr>>16) & 0x0000FFFF), cursor);
+         cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::ori, firstNode, gr11, gr11, ((adjustedAddr >> 16) & 0x0000FFFF), cursor);
          // rldicr gr11, gr11, 32, 31
          cursor = generateTrg1Src1Imm2Instruction(cg(), TR::InstOpCode::rldicr, firstNode, gr11, gr11, 32, CONSTANT64(0xFFFFFFFF00000000), cursor);
          // oris  gr11, gr11, next 16-bits

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -786,7 +786,7 @@ static uint64_t QueryCounter()
    {
    timebasestruct_t tb;
    read_real_time(&tb, sizeof(tb));
-   uint64_t result = tb.tb_high << 32 | tb.tb_low;
+   uint64_t result = (((uint64_t)tb.tb_high) << 32) | tb.tb_low;
    return result;
    }
 #else


### PR DESCRIPTION
Fix AIX warnings concerning integers being shifted beyond the width of their type by casting them (or removing casts) so that they can accommodate the shifts. Additional fixes in [omr #7134](https://github.com/eclipse/omr/pull/7134).

This PR contributes to (but does not close) #14859