### PR TITLE
Parse softmx on CRIU restore side

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3185,7 +3185,7 @@ gcReinitializeDefaultsForRestore(J9VMThread* vmThread)
 	extensions->gcThreadCountForced = false;
 	extensions->parSweepChunkSize = 0;
 
-	if (!gcParseReconfigurableArguments(vm, vm->checkpointState.restoreArgsList)) {
+	if (!gcParseReconfigurableCommandLine(vm, vm->checkpointState.restoreArgsList)) {
 		result = false;
 	}
 

--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -94,7 +94,8 @@ bool scan_udata_memory_size_helper(J9JavaVM *javaVM, char **cursor, uintptr_t *v
 bool scan_u64_memory_size_helper(J9JavaVM *javaVM, char **cursor, uint64_t *value, const char *argName);
 bool scan_hex_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *argName);
 void gcParseXgcpolicy(MM_GCExtensions *extensions);
-bool gcParseReconfigurableArguments(J9JavaVM *vm, J9VMInitArgs* args);
+bool gcParseReconfigurableSoverignArguments(J9JavaVM *vm, J9VMInitArgs* args);
+bool gcParseReconfigurableCommandLine(J9JavaVM *vm, J9VMInitArgs* args);
 
 #ifdef __cplusplus
 } /* extern "C" { */


### PR DESCRIPTION
Give the user functionality to specify softmx inside an option file for CRIU restore.

Note here we separate gcParseReconfigurableArguments() into gcParseSovereignArguments() and gcParseReconfigurableCommandLine() to distinguish SovereignArguments from general command line options.

Signed-off-by: Frank Kang frank.kang@ibm.com