### PR TITLE
Support ChangesCurrentThread annotation in the JIT

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3872,6 +3872,19 @@ TR_J9VMBase::isDontInline(TR_ResolvedMethod *method)
    }
 
 bool
+TR_J9VMBase::isChangesCurrentThread(TR_ResolvedMethod *method)
+   {
+#if JAVA_SPEC_VERSION >= 21
+   TR_OpaqueMethodBlock* m = method->getPersistentIdentifier();
+   // @ChangesCurrentThread should be ignored if used outside the class library
+   if (isClassLibraryMethod(m))
+      return jitIsMethodTaggedWithChangesCurrentThread(vmThread(), (J9Method*)m);
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
+   return false;
+   }
+
+bool
 TR_J9VMBase::isIntrinsicCandidate(TR_ResolvedMethod *method)
    {
    return jitIsMethodTaggedWithIntrinsicCandidate(vmThread(),

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1060,6 +1060,16 @@ public:
     */
    virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method);
 
+   /**
+    * \brief Determine whether a method is annotated with @ChangesCurrentThread.
+    * This annotation is only intended for use within JCL code, and will be ignored
+    * if the method is not part of JCL.
+    *
+    * \param method the method
+    * \return true if method is part of JCL AND annotated with @ChangesCurrentThread, false otherwise.
+    */
+   virtual bool isChangesCurrentThread(TR_ResolvedMethod *method);
+
    /*
     * \brief
     *    tell whether it's possible to dereference a field given the field symbol at compile time

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2433,6 +2433,12 @@ TR_J9ServerVM::isDontInline(TR_ResolvedMethod *method)
    }
 
 bool
+TR_J9ServerVM::isChangesCurrentThread(TR_ResolvedMethod *method)
+   {
+   return static_cast<TR_ResolvedJ9JITServerMethod *>(method)->isChangesCurrentThread();
+   }
+
+bool
 TR_J9ServerVM::isPortableSCCEnabled()
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -163,6 +163,7 @@ public:
    virtual bool isForceInline(TR_ResolvedMethod *method) override;
    virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method) override;
    virtual bool isDontInline(TR_ResolvedMethod *method) override;
+   virtual bool isChangesCurrentThread(TR_ResolvedMethod *method) override;
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual void markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart) override;
    virtual void reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency) override;

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1452,6 +1452,7 @@ TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &m
    methodInfoStruct.isForceInline = static_cast<TR_J9VMBase *>(fe)->isForceInline(resolvedMethod);
    methodInfoStruct.isDontInline = static_cast<TR_J9VMBase *>(fe)->isDontInline(resolvedMethod);
    methodInfoStruct.isIntrinsicCandidate = static_cast<TR_J9VMBase *>(fe)->isIntrinsicCandidate(resolvedMethod);
+   methodInfoStruct.isChangesCurrentThread = static_cast<TR_J9VMBase *>(fe)->isChangesCurrentThread(resolvedMethod);
 
    TR_PersistentJittedBodyInfo *bodyInfo = NULL;
    // Method may not have been compiled

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -55,6 +55,7 @@ TR_ResolvedJ9JITServerMethodInfoStruct
    bool isForceInline;
    bool isDontInline;
    bool isIntrinsicCandidate;
+   bool isChangesCurrentThread;
    };
 
 
@@ -221,6 +222,7 @@ public:
    bool isForceInline() const { return _isForceInline; }
    bool isDontInline() const { return _isDontInline; }
    bool isIntrinsicCandidate() const { return _isIntrinsicCandidate; }
+   bool isChangesCurrentThread() const { return _isChangesCurrentThread; }
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
@@ -263,6 +265,7 @@ private:
    bool _isForceInline;
    bool _isDontInline;
    bool _isIntrinsicCandidate;
+   bool _isChangesCurrentThread;
 
    void unpackMethodInfo(TR_OpaqueMethodBlock *aMethod, TR_FrontEnd *fe, TR_Memory *trMemory, uint32_t vTableSlot,
                          TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5050,6 +5050,21 @@ TR_InlinerFailureReason
          }
       }
 
+#if JAVA_SPEC_VERSION >= 21
+   // A method that is annotated with @ChangesCurrentThread is not inlinable
+   // unless the caller is also annotated with @ChangesCurrentThread
+   if (comp->fej9()->isChangesCurrentThread(resolvedMethod)
+    && !comp->fej9()->isChangesCurrentThread(callsite->_callerResolvedMethod))
+      {
+      if (comp->trace(OMR::inlining))
+         traceMsg(
+            comp,
+            "Preventing inlining of %s as it is a JCL method annotated with @ChangesCurrentThread without its caller sharing the same annotation.\n",
+            resolvedMethod->signature(comp->trMemory()));
+      return DontInline_Callee;
+      }
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
    TR::RecognizedMethod rm = resolvedMethod->getRecognizedMethod();
 
    // Don't inline methods that are going to be reduced in ilgen or UnsafeFastPath


### PR DESCRIPTION
A method annotated with `@ChangesCurrentThread` must not be inlined unless its caller is also annotated with `@ChangesCurrentThread`. This annotation is only to be obeyed for JCL methods.

Issue: #17519