### PR TITLE
Replace NULL with 0 in call to generateSrc1Instruction

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -8035,7 +8035,7 @@ void J9::Power::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node* node, TR:
       iCursor = loadAddressConstant(cg, doRelocation, node, (intptr_t) funcdescrptr, temp1Reg, NULL, false, TR_ArrayCopyHelper);
       }
 
-   iCursor = generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, temp1Reg, NULL, iCursor);
+   iCursor = generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, temp1Reg, 0, iCursor);
    // the C routine expects length measured by slots
    lengthReg = conditions->searchPreConditionRegister(TR::RealRegister::gr8);
    int32_t elementSize;


### PR DESCRIPTION
Fix AIX warning concerning an implicit conversion of NULL to int32_t. The null was being passed into generateSrc1Instruction, which was expecting an immediate of type int32_t. Other calls to this function in this same file pass a 0 to this parameter, so it seems sensible to do the same here for consistency.

This PR contributes to (but does not close) #14859