### PR TITLE
Implement Thread.findScopedValueBindings()

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -165,6 +165,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<classref name="jdk/internal/foreign/AbstractMemorySegmentImpl" flags="opt_openjdkFfi" versions="17-"/>
 	<classref name="jdk/internal/foreign/NativeMemorySegmentImpl" flags="opt_openjdkFfi" versions="17-"/>
 
+	<!-- Class references used in Thread.findScopedValueBindings(). -->
+	<classref name="java/lang/ScopedValue$Carrier" versions="20-"/>
+	<classref name="java/lang/ScopedValue$Snapshot" versions="20-"/>
+
 <!--
 	NOTE: the resolution code in jclcinit.c only looks at the J9ROMClassRef->runtimeFlags to determine
 	whether or not to attempt the class load.  The flags sepcified on the fields are ignored.


### PR DESCRIPTION
Walk the stack frames to look for the `runWith()` method and get
its first argument, which should be an instance of
`java.lang.ScopedValue$Snapshot`.

Closes: #16677

Closes: #17402

Co-authored-by: Gengchen Tuo <gengchen.tuo@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>