### PR TITLE
JDK 8/11 OPENJDK_METHODHANDLES require AccessController.doPrivileged()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1239,7 +1239,22 @@ public Class<?> loadClass(String className) throws ClassNotFoundException {
 		throw new ClassNotFoundException(className);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION > 8 */
+
+/*[IF OPENJDK_METHODHANDLES & (JAVA_SPEC_VERSION <= 11)]*/
+	try {
+		return java.security.AccessController.doPrivileged((java.security.PrivilegedExceptionAction<Class<?>>) () -> {
+			return loadClass(className, false);
+		});
+	} catch (java.security.PrivilegedActionException e) {
+		Throwable t = e.getCause();
+		if (t instanceof ClassNotFoundException) {
+			throw (ClassNotFoundException)t;
+		}
+		throw new InternalError(t);
+	}
+/*[ELSE] OPENJDK_METHODHANDLES & (JAVA_SPEC_VERSION <= 11)*/
 	return loadClass(className, false);
+/*[ENDIF] OPENJDK_METHODHANDLES & (JAVA_SPEC_VERSION <= 11)*/
 }
 
 /**


### PR DESCRIPTION
JDK 8/11 OPENJDK_METHODHANDLES requires AccessController.doPrivileged()

Wrapped `ClassLoader.loadClass(className, false)` call with `AccessController.doPrivileged()`.

Related 
* https://github.com/eclipse-openj9/openj9/issues/14555

[Personal build 1](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/18487/)
[Personal build 2](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline-Build-Test-Personal/18506/)

FYI @babsingh 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>