### PR TITLE
Eliminate tautological comparisons

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1566,7 +1566,7 @@ void J9::Options::preProcessMode(J9JavaVM *vm, J9JITConfig *jitConfig)
             {
             UDATA aggressivenessValue = 0;
             IDATA ret = GET_INTEGER_VALUE(argIndex, aggressiveOption, aggressivenessValue);
-            if (ret == OPTION_OK && aggressivenessValue >= 0)
+            if (ret == OPTION_OK && aggressivenessValue < LAST_AGGRESSIVENESS_LEVEL)
                {
                _aggressivenessLevel = aggressivenessValue;
                }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6589,9 +6589,9 @@ TR_J9VMBase::getInstanceFieldOffset(TR_OpaqueClassBlock * clazz, char * fieldNam
 TR_OpaqueClassBlock *
 TR_J9VM::getSuperClass(TR_OpaqueClassBlock * classPointer)
    {
-   J9Class * clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer);
-   UDATA classDepth = J9CLASS_DEPTH(clazz) - 1;
-   return convertClassPtrToClassOffset(classDepth >= 0 ? clazz->superclasses[classDepth]: 0);
+   J9Class *clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer);
+   UDATA classDepth = J9CLASS_DEPTH(clazz);
+   return convertClassPtrToClassOffset(classDepth >= 1 ? clazz->superclasses[classDepth - 1] : 0);
    }
 
 bool


### PR DESCRIPTION
Fix an AIX warning concerning tautological comparisons (i.e. boolean comparisons which will always evaluate to the same value) by eliminating them. In both situations, variables with type `UDATA` (which is an unsigned data type and would therefore never be negative) were compared with zero.

This PR contributes to (but does not close) #14859