### PR TITLE
Add tests to verify JITServer with SSL

### DIFF
--- a/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
+++ b/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
@@ -26,6 +26,9 @@
 <suite id="jitserverArgumentTesting.xml" timeout="1000">
 	<variable name="ENABLE_JITSERVER" value="-XX:+UseJITServer" />
 	<variable name="DISABLE_JITSERVER" value="-XX:-UseJITServer" />
+	<variable name="JITSERVER_SSL1" value="-XX:JITServerSSLRootCerts=cert.pem" />
+	<variable name="JITSERVER_SSL2" value="-XX:JITServerSSLRootCerts=wrongCert.pem" />
+	<variable name="JITSERVER_SSL3" value="-XX:JITServerSSLRootCerts=nosslserverCert.pem" />
 	<variable name="JITSERVER_VERBOSE" value="-Xjit:verbose={JITServer},verbose={JITServerConns},verbose={compilePerformance}" />
 	<variable name="DEFAULT_JITSERVER_OPTIONS" value="-Xjit" />
 
@@ -89,4 +92,45 @@
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
 	</test>
 
+	<test id="Test SSL success condition">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL1$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="success" caseSensitive="no" regex="no">SSL connection on socket</output>
+		<output type="required" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
+
+	<test id="Test SSL Failure Case with mismatched certificate">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL2$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer::StreamFailure: Failed to SSL_connect</output>
+		<output type="failure" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
+
+	<test id="Test SSL Failure Case with connection to Non-SSL Server">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_VERBOSE$ $JITSERVER_SSL3$" false</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
+		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
+		<output type="required" caseSensitive="no" regex="no">JITServer::StreamFailure: Failed to SSL_connect</output>
+		<output type="failure" caseSensitive="no" regex="no">Connected to a server</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
 </suite>

--- a/test/functional/cmdLineTests/jitserver/jitserverScript.sh
+++ b/test/functional/cmdLineTests/jitserver/jitserverScript.sh
@@ -40,12 +40,22 @@ source $TEST_ROOT/jitserverconfig.sh
 
 JITSERVER_PORT=$(random_port)
 
+JITSERVER_SSL="-XX:JITServerSSLRootCerts"
+
+if grep -q -- "$JITSERVER_SSL" <<< "$JVM_OPTS"; then
+    echo "Generate SSL certificates"
+    source $TEST_ROOT/jitserversslconfig.sh
+    if ! grep -q "nosslserverCert.pem" <<< "$JVM_OPTS"; then
+	SSL_OPTS="-XX:JITServerSSLKey=key.pem -XX:JITServerSSLCert=cert.pem"
+    fi
+fi
+
 if [ "$METRICS" == true ]; then
     METRICS_PORT=$(random_port)
     METRICS_OPTS="-XX:+JITServerMetrics -XX:JITServerMetricsPort=$METRICS_PORT"
 fi
 
-JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT $METRICS_OPTS $JITSERVER_OPTS"
+JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT $METRICS_OPTS $JITSERVER_OPTS $SSL_OPTS"
 
 echo "Starting $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
 $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS &
@@ -77,6 +87,11 @@ if [ "$JITSERVER_EXISTS" == 0 ]; then
     # Running pkill seems to cause a hang...
     #pkill -9 -xf "$TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
     sleep 2
+
+    if grep -q "nosslserverCert.pem" <<< "$JVM_OPTS"; then
+        rm -f *.pem
+    fi
+
 else
     echo "JITSERVER DOES NOT EXIST"
 fi

--- a/test/functional/cmdLineTests/jitserver/jitserversslconfig.sh
+++ b/test/functional/cmdLineTests/jitserver/jitserversslconfig.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+#
+# Copyright IBM Corp. and others 2023
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+#
+
+echo "Creating SSL certificates";
+
+COMMON_NAME="localhost"
+VALID_DAYS=365
+
+# Generate private key
+openssl genrsa -out key.pem 2048
+
+# Generate self-signed certificate
+openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days $VALID_DAYS -subj "/CN=$COMMON_NAME"
+
+# Generate another private key and self-signed certificate
+openssl req -nodes -newkey rsa:2048 -keyout wrongKey.pem -x509 -days 365 -out wrongCert.pem  -subj "/CN=localhost"
+
+# Generate another self-signed certificate
+openssl req -new -x509 -sha256 -key key.pem -out nosslserverCert.pem -days $VALID_DAYS -subj "/CN=$COMMON_NAME"
+
+echo "Certificates generated";


### PR DESCRIPTION
Add tests to the existing `jitserver` tests under `cmdLineTest` for checking/verifying SSL connections with JITServer. This is part 2 for the work done in #17985 .

Closes: ##17967