### PR TITLE
Fix comparison of non-pointer to NULL

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -570,7 +570,7 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
                      generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, temp3Reg, TR::MemoryReference::createWithDisplacement(self(), pointerReg, (int32_t)(TR::Compiler->om.sizeofReferenceField()*2), 4));
                   }
 
-               if (comp->getOptions()->getHeapBase() != NULL)
+               if (comp->getOptions()->getHeapBase() != 0)
                   {
                   loadAddressConstant(self(), comp->compileRelocatableCode(), node, (intptr_t)(comp->getOptions()->getHeapBase()), tempReg);
                   generateTrg1Src2Instruction(self(), TR::InstOpCode::cmpl4, node, condReg, temp3Reg, tempReg);


### PR DESCRIPTION
Fix plinux warning concerning a comparison of a non-pointer to NULL by replacing the NULL with 0. `getHeapBase()` returns a value of type `intptr_t`, which is an integer value and therefore can not be NULL. Since the variable being returned, `_heapBase`, it is initialized to 0 in [omr/compiler/control/OMROptions.hpp](https://github.com/eclipse/omr/blob/4aa604baf16d8ef55fb13c3b5243984e8edf00a1/compiler/control/OMROptions.hpp#L1407), it seems sensible to compare its value to 0 instead of NULL.

This PR contributes to (but does not close) #14859