### PR TITLE
WIP: Clean up the calls to memcpy

### DIFF
--- a/runtime/bcutil/ClassFileParser.cpp
+++ b/runtime/bcutil/ClassFileParser.cpp
@@ -110,8 +110,8 @@ ClassFileParser::restoreOriginalMethodBytecodes()
 
 	for (J9CfrMethod *method = _j9CfrClassFile->methods; method != end; method++) {
 		J9CfrAttributeCode *codeAttribute = method->codeAttribute;
-		if (NULL != codeAttribute) {			
-			codeAttribute->code = reinterpret_cast<U_8 *>(codeAttribute->originalCode); 
+		if (NULL != codeAttribute) {
+            codeAttribute->code = codeAttribute->originalCode;
 		}
 	}
 }

--- a/runtime/bcutil/ClassFileParser.cpp
+++ b/runtime/bcutil/ClassFileParser.cpp
@@ -110,8 +110,8 @@ ClassFileParser::restoreOriginalMethodBytecodes()
 
 	for (J9CfrMethod *method = _j9CfrClassFile->methods; method != end; method++) {
 		J9CfrAttributeCode *codeAttribute = method->codeAttribute;
-		if (NULL != codeAttribute) {
-			memcpy(codeAttribute->code, codeAttribute->originalCode, codeAttribute->codeLength);
+		if (NULL != codeAttribute) {			
+			codeAttribute->code = reinterpret_cast<U_8 *>(codeAttribute->originalCode); 
 		}
 	}
 }

--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -282,9 +282,8 @@ private:
 #endif /* J9VM_ENV_LITTLE_ENDIAN */
 	}
 
-	void writeData(U_32 length, void * bytes)
-	{
-		memcpy(_classFileCursor, bytes, length);
+	void writeData(U_32 length, void * bytes){		
+		_classFileCursor = reinterpret_cast<U_8*>(bytes)
 		_classFileCursor += length;
 	}
 

--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -282,8 +282,8 @@ private:
 #endif /* J9VM_ENV_LITTLE_ENDIAN */
 	}
 
-	void writeData(U_32 length, void * bytes){		
-		_classFileCursor = reinterpret_cast<U_8*>(bytes)
+	void writeData(U_32 length, void * bytes){
+        memcpy(_classFileCursor, bytes, length);
 		_classFileCursor += length;
 	}
 
@@ -377,7 +377,7 @@ public:
 				_buildResult = OutOfMemory;
 			} else {
 				J9UTF8_SET_LENGTH(_originalClassName, originalNameLength);
-				memcpy(((U_8 *)J9UTF8_DATA(_originalClassName)), anonClassNameData, originalNameLength);
+                memcpy(((U_8 *)J9UTF8_DATA(_originalClassName)), anonClassNameData, originalNameLength);
 				*(((U_8 *)J9UTF8_DATA(_originalClassName)) + originalNameLength) = '\0';
 			}
 		}

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -257,7 +257,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 				return -2;
 			}
 			code->originalCode = index;
-			memcpy (code->code, index, code->codeLength);
+            code->code = index;
 			index += code->codeLength;
 
 			CHECK_EOF(2);
@@ -862,7 +862,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 			}
 
 			CHECK_EOF(stackMap->mapLength);
-			memcpy (stackMap->entries, index, stackMap->mapLength);
+            stackMap->entries = index;
 			index += stackMap->mapLength;
 			
 			break;
@@ -1080,7 +1080,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 				return -2;
 			}
 			CHECK_EOF(length);
-			memcpy (((J9CfrAttributeUnknown *) attrib)->value, index, length);
+            ((J9CfrAttributeUnknown *)attrib)->value = index;
 			index += length;
 			break;
 		}
@@ -3413,8 +3413,8 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 				if (!ALLOC_ARRAY(method->codeAttribute->code, method->codeAttribute->codeLength, U_8)) {
 					Trc_BCU_inlineJsrs_Exit();
 					return -2;
-				}				
-				method->codeAttribute->code = reinterpret_cast<U_8*>(method->codeAttribute->originalCode);
+				}
+                method->codeAttribute->code = method->codeAttribute->originalCode;
 			}
 		}
 

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include <stdlib.h>
 #include "cfreader.h"
 #include "j9protos.h"
 #include "j9user.h"
@@ -3412,8 +3413,8 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 				if (!ALLOC_ARRAY(method->codeAttribute->code, method->codeAttribute->codeLength, U_8)) {
 					Trc_BCU_inlineJsrs_Exit();
 					return -2;
-				}
-				memcpy(method->codeAttribute->code, method->codeAttribute->originalCode, method->codeAttribute->codeLength);
+				}				
+				method->codeAttribute->code = reinterpret_cast<U_8*>(method->codeAttribute->originalCode);
 			}
 		}
 

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -95,11 +95,11 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module * j9module, U_8 * classN
 		}
 	}
 	mbString[mbLength] = 0;		/* ensure null terminated */
-	memcpy(mbString, className, classNameLength);
+    mbString = className;
 	
 	CHECK_BUFFER(dynamicLoadStats->name, dynamicLoadStats->nameBufferLength, (mbLength + 1));
 	dynamicLoadStats->nameLength = mbLength;
-	memcpy(dynamicLoadStats->name, mbString, mbLength + 1);
+    dynamicLoadStats->name = mbString;
 	
 	Trc_BCU_findLocallyDefinedClass_Entry(mbString, classPathEntryCount);
 	
@@ -452,7 +452,7 @@ convertToOSFilename (J9JavaVM * javaVM, U_8 * dir, UDATA dirLength, U_8 * module
 	pathSeparator = (U_8) javaVM->pathSeparator;
 
 	/* copy the possible directory name into the search buffer */
-	memcpy(filename, dir, dirLength);
+    filename = dir;
 	writePos = &filename[dirLength];
 	if (filename[dirLength - 1] != pathSeparator
 #if defined(WIN32) || defined(OS2)
@@ -463,7 +463,7 @@ convertToOSFilename (J9JavaVM * javaVM, U_8 * dir, UDATA dirLength, U_8 * module
 	}
 
 	if (NULL != moduleDir) {
-		memcpy(writePos, moduleDir, moduleDirLength);
+        writePos = moduleDir;
 		writePos += moduleDirLength;
 		*writePos++ = pathSeparator;
 	}
@@ -478,7 +478,7 @@ convertToOSFilename (J9JavaVM * javaVM, U_8 * dir, UDATA dirLength, U_8 * module
 	}
 
 	/* tack on the final .class */
-	memcpy(writePos, classSuffix, SUFFIX_LENGTH);
+    writePos = classSuffix;
 	writePos[SUFFIX_LENGTH] = 0;
 	return 0;
 }
@@ -522,7 +522,7 @@ convertToClassFilename (J9JavaVM * javaVM, U_8 * className, UDATA classNameLengt
 	filename = javaVM->dynamicLoadBuffers->searchFilenameBuffer;
 
 	/* copy the class name into the search buffer */
-	memcpy(filename, className, classNameLength);
+    filename = className;
 
 	/* tack on the final .class */
 	memcpy(&filename[classNameLength], classSuffix, SUFFIX_LENGTH);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10147,12 +10147,13 @@ TR::CompilationInfoPerThreadBase::compile(
          omrthread_jit_write_protect_disable();
          // Put a metaData pointer into the Code Cache Header(s).
          //
-         uint8_t *warmMethodHeader = compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader);         
-         reinterpret_cast<OMR::CodeCacheMethodHeader *>(warmMethodHeader)->_metaData = metaData;
-         if ( metaData->startColdPC ){
-            uint8_t *coldMethodHeader = reinterpret_cast<uint8_t *>(metaData->startColdPC) - sizeof(OMR::CodeCacheMethodHeader);            
-            reinterpret_cast<OMR::CodeCacheMethodHeader *>(coldMethodHeader)->_metaData = metaData;
-         }
+         OMR::CodeCacheMethodHeader *warmMethodHeader = reinterpret_cast<OMR::CodeCacheMethodHeader*>(compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader));         
+         warmMethodHeader->_metaData = metaData;
+         if ( metaData->startColdPC )
+            {
+            OMR::CodeCacheMethodHeader* coldMethodHeader = reinterpret_cast<OMR::CodeCacheMethodHeader*>(<uint8_t *>(metaData->startColdPC) - sizeof(OMR::CodeCacheMethodHeader));
+            coldMethodHeader->_metaData = metaData;
+            }
          // FAR: should we do postpone this copying until after CHTable commit?
          metaData->runtimeAssumptionList = *(compiler->getMetadataAssumptionList());
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10147,14 +10147,12 @@ TR::CompilationInfoPerThreadBase::compile(
          omrthread_jit_write_protect_disable();
          // Put a metaData pointer into the Code Cache Header(s).
          //
-         uint8_t *warmMethodHeader = compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader);
-         memcpy( warmMethodHeader + offsetof(OMR::CodeCacheMethodHeader, _metaData), &metaData, sizeof(metaData) );
-         if ( metaData->startColdPC )
-            {
-            uint8_t *coldMethodHeader = reinterpret_cast<uint8_t *>(metaData->startColdPC) - sizeof(OMR::CodeCacheMethodHeader);
-            memcpy( coldMethodHeader + offsetof(OMR::CodeCacheMethodHeader, _metaData), &metaData, sizeof(metaData) );
-            }
-
+         uint8_t *warmMethodHeader = compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader);         
+         reinterpret_cast<OMR::CodeCacheMethodHeader *>(warmMethodHeader)->_metaData = metaData;
+         if ( metaData->startColdPC ){
+            uint8_t *coldMethodHeader = reinterpret_cast<uint8_t *>(metaData->startColdPC) - sizeof(OMR::CodeCacheMethodHeader);            
+            reinterpret_cast<OMR::CodeCacheMethodHeader *>(coldMethodHeader)->_metaData = metaData;
+         }
          // FAR: should we do postpone this copying until after CHTable commit?
          metaData->runtimeAssumptionList = *(compiler->getMetadataAssumptionList());
 

--- a/runtime/compiler/runtime/GPUHelpers.cpp
+++ b/runtime/compiler/runtime/GPUHelpers.cpp
@@ -842,8 +842,8 @@ cudaInfoHashPut(CudaInfo *cudaInfo, void **hostref, int32_t elementSize, CUdevic
 
       cudaInfo->hashSize = hashSize;
       cudaInfo->hashTable = hashTable;
-
-      memcpy(cudaInfo->hashTable, oldHashTable, oldHashSize * sizeof(HashEntry));
+      // Makes no sense hashTable to oldHashTable in 2 lines???
+      cudaInfo->hashTable = oldHashTable
 
       TR_Memory::jitPersistentFree(oldHashTable);
 
@@ -1504,12 +1504,11 @@ launchKernel(int tracing, CudaInfo *cudaInfo, int gridDimX, int gridDimY, int gr
       TR_VerboseLog::writeLine(TR_Vlog_GPU, "\tgrid: Dim(%d %d %d), Block(%d %d %d)", gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ);
       }
 
-   if (needExtraArg)
-      {
+   if (needExtraArg){
       _args = (void **)malloc((argCount + 1) * sizeof(void**));
-      memcpy(_args, args, argCount * sizeof(void**));
+      _args = args;
       argCount++;
-      }
+  }
    _args[argCount-1] = &(cudaInfo->exceptionPointer);
 
    if (tracing > 1)

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -195,21 +195,19 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
          // here because compilation object hasn't been initialized yet
 
          std::string sigStr(sigLen, 0);
-         if (className[0] == '[')
-            {
-            memcpy(&sigStr[0], className, sigLen);
-            }
-         else
-            {
+         if (className[0] == '['){
+            sigStr = className;
+        }
+         else{
             if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
                 TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
                 TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
                sigStr[0] = 'Q';
             else
                sigStr[0] = 'L';
-            memcpy(&sigStr[1], className, sigLen - 2);
+            sigStr.replace(1,sigLen-2,std::string(className).substr(0,sigLen-2));
             sigStr[sigLen-1]=';';
-            }
+         }
 
          J9ClassLoader * cl = (J9ClassLoader *)(it->second._classLoader);
          ClassLoaderStringPair key = { cl, sigStr };
@@ -756,16 +754,13 @@ ClientSessionData::cacheWellKnownClassChainOffsets(unsigned int includedClasses,
    OMR::CriticalSection wellKnownClasses(_wellKnownClassesMonitor);
 
    _wellKnownClasses._includedClasses = includedClasses;
-   memcpy(_wellKnownClasses._classChainOffsets, classChainOffsets,
-          numClasses * sizeof(classChainOffsets[0]));
+   _wellKnownClasses._classChainOffsets = classChainOffsets;
    // Zero out the tail of the array
-   memset(_wellKnownClasses._classChainOffsets + numClasses, 0,
-          (WELL_KNOWN_CLASS_COUNT - numClasses) * sizeof(classChainOffsets[0]));
+   memset(_wellKnownClasses._classChainOffsets + numClasses, 0, (WELL_KNOWN_CLASS_COUNT - numClasses) * sizeof(classChainOffsets[0]));
    _wellKnownClasses._wellKnownClassChainOffsets = wellKnownClassChainOffsets;
 
    // Create and save AOT cache well-known classes record if requested
-   wellKnownClassesRecord = classChainRecords ?
-      _aotCache->getWellKnownClassesRecord(classChainRecords, numClasses, includedClasses) : NULL;
+   wellKnownClassesRecord = classChainRecords ? _aotCache->getWellKnownClassesRecord(classChainRecords, numClasses, includedClasses) : NULL;
    _wellKnownClasses._aotCacheWellKnownClassesRecord = wellKnownClassesRecord;
    }
 

--- a/runtime/ddr/j9ddr.c
+++ b/runtime/ddr/j9ddr.c
@@ -255,7 +255,7 @@ copyStringTable(J9DDRTranslationData * data)
 		size_t len = strlen(cString);
 
 		J9UTF8_SET_LENGTH(utf, (U_16)len);
-		cString = reinterpret_cast<char *>(J9UTF8_DATA(utf))
+        memcpy(J9UTF8_DATA(utf), cString, len);
 
 		entry = hashTableNextDo(&state);
 	}

--- a/runtime/ddr/j9ddr.c
+++ b/runtime/ddr/j9ddr.c
@@ -255,7 +255,7 @@ copyStringTable(J9DDRTranslationData * data)
 		size_t len = strlen(cString);
 
 		J9UTF8_SET_LENGTH(utf, (U_16)len);
-		memcpy(J9UTF8_DATA(utf), cString, len);
+		cString = reinterpret_cast<char *>(J9UTF8_DATA(utf))
 
 		entry = hashTableNextDo(&state);
 	}

--- a/runtime/jcl/common/mgmtinit.c
+++ b/runtime/jcl/common/mgmtinit.c
@@ -801,7 +801,7 @@ gcEndEvent(J9JavaVM *vm, UDATA heapSize, UDATA heapUsed, UDATA *totals, UDATA *f
 			}
 		}
 		if (NULL != notification) {
-			memcpy(notification->gcInfo, gcInfo, sizeof(*notification->gcInfo));
+            notification->gcInfo = gcInfo;
 
 			notification->type = END_OF_GARBAGE_COLLECTION;
 			notification->next = NULL;

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -5195,7 +5195,7 @@ fetchStartupHintsFromSharedCache(J9VMThread* currentThread)
 			if (0 < j9shr_findSharedData(currentThread, key, strlen(key), J9SHR_DATA_TYPE_STARTUP_HINTS, 0, &dataDescriptor, NULL)) {
 				Trc_SHR_Assert_True(J9SHR_DATA_TYPE_STARTUP_HINTS == dataDescriptor.type);
 				Trc_SHR_Assert_True(sizeof(J9SharedStartupHintsDataDescriptor) == dataDescriptor.length);
-				memcpy(&vm->sharedClassConfig->localStartupHints.hintsData, dataDescriptor.address, sizeof(J9SharedStartupHintsDataDescriptor));
+                vm->sharedClassConfig->localStartupHints.hintsData = dataDescriptor;
 				vm->sharedClassConfig->localStartupHints.localStartupHintFlags |= J9SHR_LOCAL_STARTUPHINTS_FLAG_FETCHED;
 				Trc_SHR_INIT_fetchStartupHintsFromSharedCache_Hints_Found(currentThread, vm->sharedClassConfig->localStartupHints.hintsData.flags,
 						vm->sharedClassConfig->localStartupHints.hintsData.heapSize1, vm->sharedClassConfig->localStartupHints.hintsData.heapSize2);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3279,7 +3279,7 @@ fail:
 
 				/* fill in superclass array */
 				if (superclassCount != 0) {
-					memcpy(ramClass->superclasses, superclass->superclasses, superclassCount * sizeof(UDATA));
+                    ramClass->superclasses = superclass->superclasses;
 				}
 				ramClass->superclasses[superclassCount] = superclass;
 

--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -139,7 +139,7 @@ convertToJavaFullyQualifiedName(J9VMThread *vmThread, J9UTF8 *fullyQualifiedName
 		char *cursor = result;
 		char *end = result + length;
 
-		memcpy(result, J9UTF8_DATA(fullyQualifiedNameUTF), length);
+        result = reinterpret_cast<char *>(J9UTF8_DATA(fullyQualifiedNameUTF));
 		while (cursor < end) {
 			if ('/' == *cursor) {
 				*cursor = '.';


### PR DESCRIPTION
Replace string based memcpy with reinterpret_cast across /runtime folder
- cfreader.c
- ClassFileParser.cpp
- ClassFileWriter.hpp
- CompilationThread.cpp
- j9addr.c

Closes: #14981