### PR TITLE
Need to pass _trackVisibleStackFrameDepth for scanContinuationSlots()

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -401,7 +401,7 @@ MM_ReferenceChainWalker::scanContinuationNativeSlots(J9Object *objectPtr)
 		StackIteratorData localData;
 		localData.rootScanner = this;
 
-		GC_VMThreadStackSlotIterator::scanContinuationSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForReferenceChainWalker, false, false);
+		GC_VMThreadStackSlotIterator::scanContinuationSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForReferenceChainWalker, false, _trackVisibleStackFrameDepth);
 	}
 }
 


### PR DESCRIPTION
Base on comment for _trackVisibleStackFrameDepth "Should the stack walker be told to track the visible frame depth. Default false, should set to true when doing JVMTI walks that report stack slots", need to pass _trackVisibleStackFrameDepth for scanContinuationSlots().

Signed-off-by: hulin <linhu@ca.ibm.com>