### PR TITLE
Do not skip InjectedInvoker class in getCallerClass and getStackClass

### DIFF
--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -358,15 +358,10 @@ public:
 			U_16 originalNameLength = anonNameLength - ROM_ADDRESS_LENGTH - 1;
 			U_8 *anonClassNameData = J9UTF8_DATA(_anonClassName);
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-			/* ROM class format: <HOST_NAME>/InjectedInvoker/<ROM_ADDRESS_LENGTH>.
-			 * Search for InjectedInvoker in _anonClassName using the above format.
-			 * If found, reset the class name to "InjectedInvoker" in the class file.
+			/* If the class is an InjectedInvoker, reset the class name to
+			 * "InjectedInvoker" in the class file.
 			 */
-			IDATA startIndex = anonNameLength - J9UTF8_LENGTH(&injectedInvokerClassname) - ROM_ADDRESS_LENGTH - 1;
-			U_8 *start = anonClassNameData + startIndex;
-			if ((startIndex >= 0)
-			&& (0 == memcmp(start, J9UTF8_DATA(&injectedInvokerClassname), J9UTF8_LENGTH(&injectedInvokerClassname)))
-			) {
+			if (J9_ARE_ALL_BITS_SET(_romClass->extraModifiers, J9AccClassIsInjectedInvoker)) {
 				_isInjectedInvoker = TRUE;
 				originalNameLength = J9UTF8_LENGTH(&injectedInvokerClassname);
 				anonClassNameData = J9UTF8_DATA(&injectedInvokerClassname);

--- a/runtime/bcutil/ROMClassBuilder.hpp
+++ b/runtime/bcutil/ROMClassBuilder.hpp
@@ -164,6 +164,9 @@ private:
 			U_32 modifiers, U_32 extraModifiers, U_32 optionalFlags, ROMClassCreationContext * context, U_32 sizeToCompareForLambda, bool isLambda);
 	SharedCacheRangeInfo getSharedCacheSRPRangeInfo(void *address);
 	void getSizeInfo(ROMClassCreationContext *context, ROMClassWriter *romClassWriter, SRPOffsetTable *srpOffsetTable, bool *countDebugDataOutOfLine, SizeInformation *sizeInformation);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	bool isInjectedInvoker(void) const;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 };
 
 #endif /* ROMCLASSBUILDER_HPP_ */

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -107,6 +107,7 @@
 #define J9AccSealed 0x200
 #define J9AccRecord 0x400
 #define J9AccClassAnonClass 0x800
+#define J9AccClassIsInjectedInvoker 0x1000
 #define J9AccClassUseBisectionSearch 0x2000
 #define J9AccClassInnerClass 0x4000
 #define J9AccClassHidden 0x8000

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -209,15 +209,23 @@ getCallerClassIterator(J9VMThread * currentThread, J9StackWalkState * walkState)
 
 
 static UDATA
-getCallerClassJEP176Iterator(J9VMThread * currentThread, J9StackWalkState * walkState)
+getCallerClassJEP176Iterator(J9VMThread *currentThread, J9StackWalkState *walkState)
 {
-	J9JavaVM * vm = currentThread->javaVM;
+	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
+	J9Class *currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 
 	Assert_SunVMI_mustHaveVMAccess(currentThread);
 
-	if (J9_ARE_ALL_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method)->modifiers, J9AccMethodFrameIteratorSkip)) {
+	if (J9_ARE_ALL_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method)->modifiers, J9AccMethodFrameIteratorSkip)
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE) && (JAVA_SPEC_VERSION <= 11)
+			/* Do not skip InjectedInvoker classes despite them having the J9AccMethodFrameIteratorSkip
+			 * modifier set via the @Hidden attribute. Skipping them causes incorrect, unexpected
+			 * behaviour when using OpenJDK method handles pre-hidden-class support.
+			 */
+			&& J9_ARE_NO_BITS_SET(currentClass->romClass->extraModifiers, J9AccClassIsInjectedInvoker)
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) && (JAVA_SPEC_VERSION <= 11) */
+	) {
 		/* Skip methods with java.lang.invoke.FrameIteratorSkip / jdk.internal.vm.annotation.Hidden / java.lang.invoke.LambdaForm$Hidden annotation */
 		return J9_STACKWALK_KEEP_ITERATING;
 	}
@@ -239,8 +247,8 @@ getCallerClassJEP176Iterator(J9VMThread * currentThread, J9StackWalkState * walk
 #if JAVA_SPEC_VERSION >= 18
 				|| (walkState->method == vm->jlrMethodInvokeMH)
 #endif /* JAVA_SPEC_VERSION >= 18 */
-				|| (vm->srMethodAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srMethodAccessor))))
-				|| (vm->srConstructorAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t*) vm->srConstructorAccessor))))
+				|| (vm->srMethodAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t *)vm->srMethodAccessor))))
+				|| (vm->srConstructorAccessor && vmFuncs->instanceOfOrCheckCast(currentClass, J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, *((j9object_t *)vm->srConstructorAccessor))))
 		) {
 			/* skip reflection classes and MethodHandle.invokeWithArguments() when reaching depth 0 */
 			return J9_STACKWALK_KEEP_ITERATING;
@@ -253,7 +261,6 @@ getCallerClassJEP176Iterator(J9VMThread * currentThread, J9StackWalkState * walk
 	walkState->userData1 = (void *) (((UDATA) walkState->userData1) - 1);
 	return J9_STACKWALK_KEEP_ITERATING;
 }
-
 
 /**
  * JVM_GetCallerClass


### PR DESCRIPTION
This patch fixes both eclipse-openj9/openj9#14553 and eclipse-openj9/openj9#18245. When OJDK MHs are enabled for JDK11, the Hidden attribute for InjectedInvoker classes caused getStackClass and getCallerClass to return the incorrect class. The solution is to not iterate over InjectedInvoker classes despite them having the J9AccMethodFrameIteratorSkip modifier set due to the Hidden attribute.

Closes: eclipse-openj9/openj9#14553 eclipse-openj9/openj9#18245
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>