### PR TITLE
Don't check JNI absolute paths on z/OS, for loading datasets

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2021,6 +2021,17 @@ static void loadLibrary(Class<?> caller, String name, boolean fullPath) {
 }
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
+/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
+static void loadZOSLibrary(Class<?> caller, String name) {
+	ClassLoader loader = (caller == null) ? null : caller.getClassLoader();
+	NativeLibraries nls = (loader == null) ? BootLoader.getNativeLibraries() : loader.nativelibs;
+	NativeLibrary nl = nls.loadZOSLibrary(caller, name);
+	if (nl == null) {
+		/*[MSG "K0647", "Can't load {0}"]*/
+		throw new UnsatisfiedLinkError(com.ibm.oti.util.Msg.getString("K0647", name));//$NON-NLS-1$
+	}
+}
+/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 */
 static void loadLibrary(Class<?> caller, File file) {
 	ClassLoader loader = (caller == null) ? null : caller.getClassLoader();
 	NativeLibraries nls = (loader == null) ? BootLoader.getNativeLibraries() : loader.nativelibs;
@@ -2030,6 +2041,8 @@ static void loadLibrary(Class<?> caller, File file) {
 		throw new UnsatisfiedLinkError(com.ibm.oti.util.Msg.getString("K0647", file));//$NON-NLS-1$
 	}
 }
+/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
+
 static void loadLibrary(Class<?> caller, String libName) {
 	ClassLoader loader = (caller == null) ? null : caller.getClassLoader();
 	if (loader == null) {
@@ -2042,12 +2055,16 @@ static void loadLibrary(Class<?> caller, String libName) {
 		NativeLibraries nls = loader.nativelibs;
 		String libfilename = loader.findLibrary(libName);
 		if (libfilename != null) {
+			/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
+			NativeLibrary nl = nls.loadZOSLibrary(caller, libfilename);
+			/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 */
 			File libfile = new File(libfilename);
 			if (!libfile.isAbsolute()) {
 				/*[MSG "K0648", "Not an absolute path: {0}"]*/
 				throw new UnsatisfiedLinkError(com.ibm.oti.util.Msg.getString("K0648", libfilename));//$NON-NLS-1$
 			}
 			NativeLibrary nl = nls.loadLibrary(caller, libfile);
+			/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
 			if (nl == null) {
 				/*[MSG "K0647", "Can't load {0}"]*/
 				throw new UnsatisfiedLinkError(com.ibm.oti.util.Msg.getString("K0647", libfilename));//$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1074,14 +1074,17 @@ public static void load(String pathName) {
 		smngr.checkLink(pathName);
 	}
 /*[IF JAVA_SPEC_VERSION >= 15]*/
+	/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
+	ClassLoader.loadZOSLibrary(getCallerClass(), pathName);
+	/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 */
 	File fileName = new File(pathName);
-	if (fileName.isAbsolute()) {
-		ClassLoader.loadLibrary(getCallerClass(), fileName);
-	} else {
+	if (!fileName.isAbsolute()) {
 		/*[MSG "K0648", "Not an absolute path: {0}"]*/
 		throw new UnsatisfiedLinkError(Msg.getString("K0648", pathName));//$NON-NLS-1$
 	}
-/*[ELSE]
+	ClassLoader.loadLibrary(getCallerClass(), fileName);
+	/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
+/*[ELSE] JAVA_SPEC_VERSION >= 15 */
 	ClassLoader.loadLibraryWithPath(pathName, ClassLoader.callerClassLoader(), null);
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }


### PR DESCRIPTION
Checks can be done on the JCL side. Adds ClassLoader.loadZOSLibray().

Issue https://github.ibm.com/runtimes/openj9-openjdk-jdk17-zos/issues/843/