### PR TITLE
Add intermediate casts so values are large enough for pointer cast

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -528,7 +528,7 @@ uint8_t *TR::PPCUnresolvedCallSnippet::emitSnippetBody()
       TR::ExternalRelocation::create(
          cursor,
          *(uint8_t **)cursor,
-         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
          TR_Trampolines,
          cg()),
       __FILE__,

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -182,7 +182,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
       TR::ExternalRelocation::create(
          cursor,
          *(uint8_t **)cursor,
-         getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+         getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
          TR_ConstantPool,
          cg()),
       __FILE__,
@@ -200,7 +200,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
       if (getDataSymbol()->isConstObjectRef() || getDataSymbol()->isConstantDynamic())
          {
          cg()->addProjectSpecializedRelocation(cursor, *(uint8_t **)(cursor-4),
-               getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
+               getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
                                 __FILE__,
                                 __LINE__,
                                 getNode());


### PR DESCRIPTION
Fix AIX warnings concerning values with type `int16_t` that are too small to be pointers being cast into pointers of type `(uint8_t *)` by adding an intermediate cast to `uintptr_t`.

This PR contributes to (but does not close) #14859