### PR TITLE
Change In Config Due To Moving Forced Flags to Extbase

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -37,7 +37,6 @@
 
 #include "mmparse.h"
 
-#include "Configuration.hpp"
 #include "GCExtensions.hpp"
 #if defined(J9VM_GC_REALTIME)
 #include "Scheduler.hpp"
@@ -642,7 +641,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
-			extensions->configuration->_packetListSplitForced = true;
+			extensions->packetListSplitForced = true;
 			continue;
 		}
 		
@@ -657,7 +656,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
-			extensions->configuration->_cacheListSplitForced = true;
+			extensions->cacheListSplitForced = true;
 			continue;
 		}
 #endif /* J9VM_GC_MODRON_SCAVENGER */
@@ -701,7 +700,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				break;
 			}
 			extensions->enableHybridMemoryPool = true;
-			extensions->configuration->_splitFreeListAmountForced = true;
+			extensions->splitFreeListAmountForced = true;
 			continue;
 		}
 
@@ -716,7 +715,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
-			extensions->configuration->_splitFreeListAmountForced = true;
+			extensions->splitFreeListAmountForced = true;
 			continue;
 		}
 


### PR DESCRIPTION
Because packetListSplitForced, cachelistsplit, and splitfreelistamount are moved from config to extbase, we need to change the usage here.

Signed off by: Frank.Kang@ibm.com