### PR TITLE
Fix Tree Simplifier convertCurrentTimeMillis()

### DIFF
--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -362,9 +362,11 @@ J9::Simplifier::simplifylCallMethods(TR::Node * node, TR::Block * block)
 //
 //   to:
 //
+// <new tree>
+//    lcall currentTimeMaxPrecision
 // <tree>
 //    ldiv
-//      lcall currentTimeMaxPrecision
+//      ==>lcall currentTimeMaxPrecision
 //      lconst <divisor value>
 TR::Node *J9::Simplifier::convertCurrentTimeMillis(TR::Node * node, TR::Block * block)
    {
@@ -386,6 +388,7 @@ TR::Node *J9::Simplifier::convertCurrentTimeMillis(TR::Node * node, TR::Block * 
       divConstNode->setLongInt(OMRPORT_TIME_HIRES_MILLITIME_DIVISOR);
 
       TR::Node::recreate(node, TR::ldiv);
+      callTreeTop->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, lcallNode)));
       node->setNumChildren(2);
       node->setAndIncChild(0, lcallNode);
 


### PR DESCRIPTION
The convertCurrentTimeMillis() function was recreating a currentTimeMillis() call into a new call target which would be replaced in codegen with a Z specific instruction. To convert the results into milliseconds the value has to be divided by a constant and the tree was incorrectly converted into an ldiv with a call child that is not anchored which allowed dead trees elimination to remove the treetop resulting in the the ldiv to be moved in a way that would change the semantic of the java method.