### PR TITLE
Clear vmthread from thread object at shutdown

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -455,6 +455,10 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 	/* Do the java dance to indicate thread death */
 	acquireVMAccess(vmThread);
 	cleanUpAttachedThread(vmThread);
+	/* Cleanup code is not guaranteed to run succesfully. Remove any connection
+	 * to the thread object before deallocating the j9vmthread.
+	 */
+	J9VMJAVALANGTHREAD_SET_THREADREF(vmThread, vmThread->threadObject, NULL);
 	releaseVMAccess(vmThread);
 
 


### PR DESCRIPTION
Related to: https://github.com/eclipse-openj9/openj9/issues/16659