### PR TITLE
Use defining symrefs from defining map for <eaEscapeHelper> call

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
@@ -202,7 +202,7 @@ void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolRef
                   if ((definingSym->isAuto() || definingSym->isParm())
                       && (deadSymRefs == NULL || !deadSymRefs->isSet(definingSymRefNum)))
                      {
-                     symRefsToLoad.set(symRefNum);
+                     symRefsToLoad.set(definingSymRefNum);
 
                      if (_comp->trace(OMR::escapeAnalysis) || _comp->getOption(TR_TraceOSR))
                         {


### PR DESCRIPTION
`TR_EscapeAnalysisTools::processSymbolReferences` uses a `BitVector` to accumulate the symbol reference numbers for symbols that are to be loaded on an `<eaEscapeHelper>` call.  In walking through the set of defining symbols associated with a particular local symbol, the code was adding the reference number for the original symbol to the `BitVector` of symbols to be loaded for the `<eaEscapeHelper>` call rather than the reference numbers for the associated defining symbols.  That can lead Escape Analysis to miss potential escapes of references through induce OSR blocks or peeked calls.

This fixes a problem that was introduced in commit eddbd1b, at [line 156 of EscapeAnalysisTools.cpp](https://github.com/eclipse-openj9/openj9/commit/eddbd1b7abb9ced535e009e124d20b3aceafbef0#diff-0858e6725bceb8897e3c4ab5302400c3ecb973800d8c0cc67b360afcdf5f234aL152-R157).

Fixes #18246