### PR TITLE
Support for java.lang.Class.asNullRestrictedType

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2636,6 +2636,15 @@ public native boolean isValue();
 public native boolean isIdentity();
 
 /**
+ * Returns the Null-Restricted type of this class.
+ *
+ * @return Null-Restricted class
+ */
+public Class<?> asNullRestrictedType() {
+	return this;
+}
+
+/**
  * Return class file version (minorVersion << 16 + majorVersion) in an int.
  *
  * @return	the class file version


### PR DESCRIPTION
This method is used during initialization of a Null-Restricted array. This addition makes NullRestrictedTypeOptTests in the src_lw5 folder pass.

Related https://github.com/eclipse-openj9/openj9/issues/17340 and https://github.com/eclipse-openj9/openj9/pull/18275