### PR TITLE
Fix mismatched JITServer message type

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1141,7 +1141,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
          TR_J9VMBase::MemberNameMethodInfo info = {};
-         uintptr_t ok = fe->getMemberNameMethodInfo(comp, std::get<0>(recv), &info);
+         bool ok = fe->getMemberNameMethodInfo(comp, std::get<0>(recv), &info);
          client->write(response, ok, info.vmtarget, info.vmindex, info.clazz, info.refKind);
          }
          break;


### PR DESCRIPTION
The client's response to the `VM_getMemberNameMethodInfo` message from the server is expected to include a `bool ok` value when received by the server. The client now conforms to this expectation.

Formerly, the client would send a `uintptr_t` value (unnecessarily converting the `bool` return value of `getMemberNameMethodInfo`) and this would trigger an assert here:

https://github.com/eclipse-openj9/openj9/blob/06c3abcca73751a569836b2df970873366b50312/runtime/compiler/env/VMJ9Server.cpp#L2310

at the server when using a debug build.