### PR TITLE
Add debug option to force GPF on heap initialization error

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -425,3 +425,25 @@ MM_GCExtensions::exitContinuationConcurrentGCScan(J9VMThread *vmThread, j9object
 	MM_GCExtensions::exitConcurrentGCScan(continuationStatePtr, isGlobalGC);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 }
+
+void
+MM_GCExtensions::handleInitializeHeapError(J9JavaVM *vm, const char *errorMessage)
+{
+	if (forceGPFOnHeapInitializationError) {
+		/* Print error message if it is available */
+		if (NULL != errorMessage) {
+			PORT_ACCESS_FROM_JAVAVM(vm);
+			j9tty_printf(PORTLIB, "\n--- %s\n\n", errorMessage);
+		}
+
+		/*
+		 * This function is called very early in JVM Startup.
+		 * Trace Engine might be not initialized fully yet.
+		 * So, instead of using Assert_MM_unreachable() just force GPF
+		 */
+
+		/* force GPF */
+		uintptr_t *p = NULL;
+		*p = 0x12345678;
+	}
+}

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -197,6 +197,8 @@ public:
 	UDATA freeSizeThresholdForSurvivor; /**< if average freeSize(freeSize/freeCount) of the region is smaller than the Threshold, the region would not be reused by collector as survivor, for balanced GC only */
 	bool recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
 
+	bool forceGPFOnHeapInitializationError; /**< if set causes GPF generation on heap initialization error */
+
 	enum ContinuationListOption {
 		disable_continuation_list = 0,
 		enable_continuation_list = 1,
@@ -303,6 +305,13 @@ public:
 	void releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9object_t objectPtr);
 
 	/**
+	 * Prints error message and forces GPF if -XXgc:forceGPFOnHeapInitializationError is provided
+	 * @param[in] vm the current J9JavaVM
+	 * @param[in] errorMessage error message set by GC heap initialization if available
+	 */
+	void handleInitializeHeapError(J9JavaVM *vm, const char *errorMessage);
+
+	/**
 	 * Check if we need to scan the java stack for the Continuation Object
 	 * Used during main scan phase of GC (object graph traversal) or heap object iteration (in sliding compact).
 	 * Not meant to be used during root scanning (neither strong roots nor weak roots)!
@@ -385,6 +394,7 @@ public:
 		, minimumFreeSizeForSurvivor(DEFAULT_SURVIVOR_MINIMUM_FREESIZE)
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
+		, forceGPFOnHeapInitializationError(false)
 		, continuationListOption(enable_continuation_list)
 		, timingAddContinuationInList(onCreated)
 	{

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -536,6 +536,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 	return JNI_OK;
 
 error_no_memory:
+	extensions->handleInitializeHeapError(vm, loadInfo->fatalErrorStr);
 	return JNI_ENOMEM;
 }
 

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1555,6 +1555,12 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->timingAddContinuationInList = MM_GCExtensions::onCreated;
 			continue;
 		}
+
+		if (try_scan(&scan_start, "forceGPFOnHeapInitializationError")) {
+			extensions->forceGPFOnHeapInitializationError = true;
+			continue;
+		}
+
 		/* Couldn't find a match for arguments */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_UNKNOWN, error_scan);
 		returnValue = JNI_EINVAL;


### PR DESCRIPTION
There is kind of the problem Service observes often - an attempt to launch JVM is failed due Object Heap initialization error. For example there are multiple cases for Windows users trying to use harge heaps with Compressed Refs JVM. Generation of system core for investigation is problematic because this failure occurs very early in JVM startup. Adding debug non-published option
-XXgc:forceGPFOnHeapInitializationError to help Service investigate this kind of the problem.