### PR TITLE
Use -fno-omit-frame-pointer on x86_64-mac JIT builds

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -237,11 +237,20 @@ if(OMR_OS_LINUX OR OMR_OS_OSX)
 		-Wno-deprecated
 		-Wno-enum-compare
 		-Wno-write-strings
-		-fomit-frame-pointer
 		-fasynchronous-unwind-tables
 		-Wreturn-type
 		-pthread
 	)
+	# Workaround for problem seen in x86_64-macOS builds for JDK 22.
+	if((NOT JAVA_SPEC_VERSION LESS 22) AND OMR_OS_OSX AND OMR_ARCH_X86)
+		list(APPEND J9_SHAREDFLAGS
+			-fno-omit-frame-pointer
+		)
+	else()
+		list(APPEND J9_SHAREDFLAGS
+			-fomit-frame-pointer
+		)
+	endif()
 
 	# Platform-specific CXX flags, also derived from the makefiles.
 	list(APPEND J9_CXXFLAGS


### PR DESCRIPTION
A bug in libunwind on x86_64-macOS results in intermittent crashes from libunwind if a C++ exception is thrown from
`OMR::Compilation::failCompilation`.  In order to work around the problem, the JIT compiler needs to be compiled with `-fno-omit-frame-pointer` on that combination of CPU and operating system.

That option will be used only on JDK 22 or later builds for now, while the impact on compile-time and start-up performance is evaluated.

Fixes #18321