### PR TITLE
JDK22+ disable JEP 454 tests

### DIFF
--- a/test/functional/Java22andUp/build.xml
+++ b/test/functional/Java22andUp/build.xml
@@ -76,7 +76,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<target name="build">
 		<if>
 			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-1])$$" />
+				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
 			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />

--- a/test/functional/Java22andUp/playlist.xml
+++ b/test/functional/Java22andUp/playlist.xml
@@ -23,6 +23,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/18349</comment>
+			</disable>
+		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
@@ -49,6 +54,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_UpCall</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/18349</comment>
+			</disable>
+		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \


### PR DESCRIPTION
`JDK22+` disable `JEP 454` tests

`JDK` next extension `openj9` branch and `Valhalla` don't have the latest OpenJDK API updates yet.

Related to https://github.com/eclipse-openj9/openj9/issues/18349

Signed-off-by: Jason Feng fengj@ca.ibm.com