### PR TITLE
Make use of the new `alwaysIProfileDuringStartupPhase` option

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3150,8 +3150,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
             if (J9_ARE_ALL_BITS_SET(javaVM->sharedClassConfig->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHE_NON_BOOT_CLASSES))
                {
                TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
-               static char * dnipdsp = feGetEnv("TR_DisableNoIProfilerDuringStartupPhase");
-               if (compInfo->isWarmSCC() == TR_yes && !dnipdsp)
+               if (compInfo->isWarmSCC() == TR_yes && !self()->getOption(TR_AlwaysIProfileDuringStartupPhase))
                   {
                   self()->setOption(TR_NoIProfilerDuringStartupPhase);
                   }


### PR DESCRIPTION
Make use of the new `alwaysIProfileDuringStartupPhase` option instead of the `TR_DisableNoIProfilerDuringStartupPhase` environment variable in deciding whether we kick-in the IProfiler during the startup phase or not.

Depends on https://github.com/eclipse/omr/pull/7157