### PR TITLE
Fix interpreter transition in getThreadAllocBytes

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -465,7 +465,6 @@ Java_com_ibm_lang_management_internal_ExtendedThreadMXBeanImpl_getThreadAllocate
 
 	/* Shortcut for the current thread. */
 	if (getThreadID(currentThread, (j9object_t)currentThread->threadObject) == threadID) {
-		vmfns->internalExitVMToJNI(currentThread);
 		if (mmfns->j9gc_get_cumulative_bytes_allocated_by_thread(currentThread, &allocatedBytes)) {
 			result = (jlong) allocatedBytes;
 		}

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
@@ -1068,8 +1068,9 @@ public class TestThreadMXBean {
 		com.sun.management.ThreadMXBean sunTB = (com.sun.management.ThreadMXBean)tb;
 		AssertJUnit.assertTrue(sunTB.isThreadAllocatedMemoryEnabled());
 		AssertJUnit.assertTrue(sunTB.isThreadAllocatedMemorySupported());
+		long tid = Thread.currentThread().getId();
 
-		long bytes1 = sunTB.getCurrentThreadAllocatedBytes();
+		long bytes1 = sunTB.getThreadAllocatedBytes(tid);
 		AssertJUnit.assertTrue(bytes1 > 0);
 		ArrayList list = new ArrayList<>();
 
@@ -1077,22 +1078,22 @@ public class TestThreadMXBean {
 			list.add(new Object[100]);
 		}
 
-		long bytes2 = sunTB.getCurrentThreadAllocatedBytes();
+		long bytes2 = sunTB.getThreadAllocatedBytes(tid);
 		AssertJUnit.assertTrue(bytes2 > bytes1);
 
 		sunTB.setThreadAllocatedMemoryEnabled(false);
-		long bytes3 = sunTB.getCurrentThreadAllocatedBytes();
+		long bytes3 = sunTB.getThreadAllocatedBytes(tid);
 		AssertJUnit.assertTrue(bytes3 == -1);
 
 		sunTB.setThreadAllocatedMemoryEnabled(false);
-		long bytes4 = sunTB.getCurrentThreadAllocatedBytes();
+		long bytes4 = sunTB.getThreadAllocatedBytes(tid);
 		AssertJUnit.assertTrue(bytes4 >= bytes3);
 
 		for (int i = 0; i < 1000; i++) {
 			list.add(new Object[100]);
 		}
 
-		long bytes5 = sunTB.getCurrentThreadAllocatedBytes();
+		long bytes5 = sunTB.getThreadAllocatedBytes(tid);
 		AssertJUnit.assertTrue(bytes5 >= bytes4);
 	}
 


### PR DESCRIPTION
Fix interpreter transition in getThreadAllocatedBytes. Also use parameterized variant of the API to support JDK8.