### PR TITLE
(0.41) AArch64 macOS: Stop assigning x18

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -4638,7 +4638,9 @@ J9::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *
       TR::addDependency(deps, NULL, (TR::RealRegister::RegNum)i, TR_GPR, cg);
       }
    // x16 and x17 are reserved registers
+#if !defined(OSX)
    TR::addDependency(deps, NULL, TR::RealRegister::x18, TR_GPR, cg);
+#endif // !defined(OSX)
 
    generateMovInstruction(cg, node, x0Reg, metaReg);
    generateMovInstruction(cg, node, tmp1Reg, srcObjReg);
@@ -4753,7 +4755,9 @@ J9::ARM64::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node *node, TR::Code
       TR::addDependency(deps, NULL, (TR::RealRegister::RegNum)i, TR_GPR, cg);
       }
    // x16 and x17 are reserved registers
+#if !defined(OSX)
    TR::addDependency(deps, NULL, TR::RealRegister::x18, TR_GPR, cg);
+#endif // !defined(OSX)
 
    intptr_t *funcdescrptr = (intptr_t *)fej9->getReferenceArrayCopyHelperAddress();
    loadAddressConstant(cg, cg->needRelocationsForHelpers(), node, (intptr_t)funcdescrptr, tmpReg, NULL, TR_ArrayCopyHelper);


### PR DESCRIPTION
This commit stops the JIT assigning the x18 register on AArch64 macOS.

Original PR in master: #18351