### PR TITLE
Apply idiomRecognition only to high frequency blocks

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -3097,6 +3097,10 @@ int32_t TR_CISCTransformer::perform()
 
       for (nextLoop = loopIt.getFirst(); nextLoop != 0; nextLoop = loopIt.getNext())
          {
+         if (comp()->getMethodHotness() <= warm &&
+             nextLoop->getEntryBlock()->getFrequency() < comp()->getOptions()->getIdiomRecognitionFrequencyThresholdAtWarm())
+            continue;
+
          // make bb list for each loop
          TR::Block *block;
          bblistPred.init();


### PR DESCRIPTION
This commit attempts to reduce compilation overhead of warm opt levels by not performing idiomRecognition on blocks with a frequency lower than a specified threshold. The threshold can be modified with
`-Xjit:idiomRecognitionFrequencyThresholdAtWarm=NNN` A value of 0 means that idiomRecognition will be applied to all blocks. A value of 10001 means the idiomRecognition will not be applied at all, since 10000 is the largest possible block frequency. Compilations at hot and above optimization levels are not affected by this change.

Depends on eclipse/omr/#7162