### PR TITLE
JDK22+ add latest APIs for Valhalla & enable JEP 454 tests

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -501,15 +501,15 @@ final class Access implements JavaLangAccess {
 
 /*[IF JAVA_SPEC_VERSION >= 20]*/
 	@Override
-/*[IF (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 22]*/
 	public void ensureNativeAccess(Module mod, Class<?> clsOwner, String methodName, Class<?> clsCaller) {
 		mod.ensureNativeAccess(clsOwner, methodName, clsCaller);
 	}
-/*[ELSE] (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES */
+/*[ELSE] JAVA_SPEC_VERSION >= 22 */
 	public void ensureNativeAccess(Module mod, Class<?> clsOwner, String methodName) {
 		mod.ensureNativeAccess(clsOwner, methodName);
 	}
-/*[ENDIF] (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 	public void addEnableNativeAccessToAllUnnamed() {
 		Module.implAddEnableNativeAccessToAllUnnamed();
@@ -737,7 +737,7 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
-/*[IF (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 22]*/
 	@Override
 	public boolean bytesCompatible(String string, Charset charset) {
 		return string.bytesCompatible(charset);
@@ -747,7 +747,7 @@ final class Access implements JavaLangAccess {
 	public void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
 		string.copyToSegmentRaw(segment, offset);
 	}
-/*[ENDIF] (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 /*[IF INLINE-TYPES]*/
 	@Override

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -765,11 +765,11 @@ public class InternalDowncallHandler {
 		try (Arena arena = Arena.ofConfined()) {
 			SetDependency(arena.scope());
 			returnVal = invokeNative(
-					/*[IF (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES]*/
+					/*[IF JAVA_SPEC_VERSION >= 22]*/
 					linkerOpts.isCritical(),
-					/*[ELSE] (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES */
+					/*[ELSE] JAVA_SPEC_VERSION >= 22 */
 					linkerOpts.isTrivial(),
-					/*[ENDIF] (JAVA_SPEC_VERSION >= 22) & !INLINE-TYPES */
+					/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 					getValidDowncallMemAddr(stateSegmt),
 					retMemAddr,
 					getValidDowncallMemAddr(downcallAddr),

--- a/test/functional/Java22andUp/build.xml
+++ b/test/functional/Java22andUp/build.xml
@@ -76,7 +76,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<target name="build">
 		<if>
 			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
+				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-1])$$" />
 			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />

--- a/test/functional/Java22andUp/playlist.xml
+++ b/test/functional/Java22andUp/playlist.xml
@@ -23,11 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18349</comment>
-			</disable>
-		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
@@ -54,11 +49,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_UpCall</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18349</comment>
-			</disable>
-		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \


### PR DESCRIPTION
`JDK22+` add latest APIs for `Valhalla` & enable `JEP` `454` tests

`Valhalla` extension repo now has the latest `openjdk` updates.

closes https://github.com/eclipse-openj9/openj9/issues/18349

Signed-off-by: Jason Feng <fengj@ca.ibm.com>