### PR TITLE
Update Artifactory doc with new OSU Art URL

### DIFF
--- a/buildenv/jenkins/ARTIFACTORY.md
+++ b/buildenv/jenkins/ARTIFACTORY.md
@@ -266,10 +266,10 @@ do
   if [[ $var = https* ]]
   then
     echo "Original parameter: $var"
-    echo "Modified to UNB mirror: `echo $var | sed 's#140-211-168-230-openstack.osuosl.org#192.168.10.216#'`"
+    echo "Modified to UNB mirror: `echo $var | sed 's#openj9-artifactory.osuosl.org#192.168.10.216#'`"
   fi
 done
-echo $@ | sed 's#--user .*:.* ##' | xargs /usr/bin/curl --resolve 140-211-168-230-openstack.osuosl.org:443:192.168.10.216
+echo $@ | sed 's#--user .*:.* ##' | xargs /usr/bin/curl --resolve openj9-artifactory.osuosl.org:443:192.168.10.216
 ```
 
 # Configure UNB nodes to accept self-signed certificate (upload only)


### PR DESCRIPTION
Curl wrapper needs to use the 'new' OSU Artifactory url or else it will not redirect to the UNB mirror site