### PR TITLE
Remove redundant assertion to avoid acquiring VMAccess

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -557,7 +557,6 @@ JVM_VirtualThreadHideFrames(JNIEnv *env, jobject vthread, jboolean hide)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 
-	Assert_SC_true(IS_JAVA_LANG_VIRTUALTHREAD(currentThread, currentThread->threadObject));
 	if (hide) {
 		Assert_SC_true(J9_ARE_NO_BITS_SET(currentThread->privateFlags, J9_PRIVATE_FLAGS_VIRTUAL_THREAD_HIDDEN_FRAMES));
 	} else {


### PR DESCRIPTION
Removing the check prevents any incorrect referencing without VMAccess while GC is modifying the threadObject reference.

Fixes: #18353 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>