### PR TITLE
CRIU checkpointRestoreTimeDelta adjustment & add time compensation tests

### DIFF
--- a/runtime/criusupport/j9criu.tdf
+++ b/runtime/criusupport/j9criu.tdf
@@ -52,3 +52,4 @@ TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_load_criu_failure Overhead=1 
 TraceException=Trc_CRIU_setupJNIFieldIDsAndCRIUAPI_not_find_criu_methods Overhead=1 Level=1 Template="setupJNIFieldIDsAndCRIUAPI() The JVM could not find critical criu functions in libcriu.so: %zi"
 
 TraceException=Trc_CRIU_checkpointJVMImpl_triggerOneOffJavaDump Overhead=1 Level=1 Template="checkpointJVMImpl triggerOneOffDump() returns %d"
+TraceEvent=Trc_CRIU_after_criu_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), criuRestoreNanoTimeMonotonic (%lld), criuRestoreNanoUTCTime (%llu), lastRestoreTimeMillis (%lld)"

--- a/test/functional/TestUtilities/src/org/openj9/test/util/TimeUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/TimeUtilities.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.test.util;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Utility class to check time.
+ */
+public class TimeUtilities {
+	public final static long TIME_NANOSECONDS_PER_MILLIS = 1000000;
+
+	public static void showThreadCurrentTime(String msgHeader) {
+		System.out.println(msgHeader + ", current thread name: " + Thread.currentThread().getName() + ", " + new Date()
+				+ ", System.currentTimeMillis() " + System.currentTimeMillis() + ", System.nanoTime() "
+				+ System.nanoTime());
+	}
+
+	public static boolean checkElapseTime(String testName, long startMillisTime, long startNanoTime,
+			long minElapsedMillisTime, long maxElapsedMillisTime, long minElapsedNanoTimeInMillis,
+			long maxElapsedNanoTimeInMillis) {
+		boolean result = true;
+		final long currentMillisTime = System.currentTimeMillis();
+		final long currentNanoTime = System.nanoTime();
+		showThreadCurrentTime(testName + " checkElapseTime starts");
+
+		final long elapsedMillisTime = currentMillisTime - startMillisTime;
+		final long elapsedNanoTime = currentNanoTime - startNanoTime;
+		// Get the smallest value that is greater than or equal to the elapsed nano time
+		// in milliseconds for the case that the elapsed nano
+		// time is slightly less than the elapsedMillisTime, such as the elapsedNanoTime
+		// (1999997603ns) less than elapsedMillisTime * TIME_NANOSECONDS_PER_MILLIS
+		// (2000000000ns)
+		// This behaviour was observed in both RI and OpenJ9.
+		final long elapsedNanoTimeInMillis = elapsedNanoTime / TIME_NANOSECONDS_PER_MILLIS
+				+ ((elapsedNanoTime % TIME_NANOSECONDS_PER_MILLIS == 0) ? 0 : 1);
+
+		System.out.println(testName + ": startMillisTime (" + startMillisTime + "ms) startNanoTime (" + startNanoTime
+				+ "ns)" + " currentMillisTime (" + currentMillisTime + "ms) currentNanoTime (" + currentNanoTime
+				+ "ns) elapsedMillisTime (" + elapsedMillisTime + "ms) elapsedNanoTime (" + elapsedNanoTime + "ns)");
+		if (elapsedMillisTime < minElapsedMillisTime) {
+			result = false;
+			System.out.println("FAILED: " + testName + " elapsedMillisTime (" + elapsedMillisTime
+					+ "ms) should NOT be less than minElapsedMillisTime (" + minElapsedMillisTime + "ms)");
+		} else if (elapsedMillisTime > maxElapsedMillisTime) {
+			result = false;
+			System.out.println("FAILED: " + testName + " elapsedMillisTime (" + elapsedMillisTime
+					+ "ms) should NOT be greater than maxElapsedMillisTime (" + maxElapsedMillisTime + "ms)");
+		}
+		if (elapsedNanoTimeInMillis < minElapsedNanoTimeInMillis) {
+			result = false;
+			System.out.println("FAILED: " + testName + " elapsedNanoTimeInMillis (" + elapsedNanoTimeInMillis
+					+ "ms) should NOT be less than minElapsedNanoTimeInMillis (" + minElapsedNanoTimeInMillis + "ms)");
+		} else if (elapsedNanoTimeInMillis > maxElapsedNanoTimeInMillis) {
+			result = false;
+			System.out.println("FAILED: " + testName + " elapsedNanoTimeInMillis (" + elapsedNanoTimeInMillis
+					+ "ms) should NOT be greater than maxElapsedNanoTimeInMillis (" + maxElapsedNanoTimeInMillis
+					+ "ms)");
+		}
+		showThreadCurrentTime(testName + " checkElapseTime ends");
+
+		return result;
+	}
+
+	private volatile boolean tasksPassed = true;
+	private volatile int taskRunning = 0;
+	private volatile int taskStarted = 0;
+	private volatile int taskExecuted = 0;
+	private final ArrayList<Timer> timers = new ArrayList<Timer>();
+
+	public void timerSchedule(String testName, long startMillisTime, long startNanoTime, long minElapsedMillisTime,
+			long maxElapsedMillisTime, long minElapsedNanoTimeInMillis, long maxElapsedNanoTimeInMillis, long delay) {
+		Timer timer = new Timer(testName);
+		timer.schedule(new TimeTestTask(testName, startMillisTime, startNanoTime, minElapsedMillisTime,
+				maxElapsedMillisTime, minElapsedNanoTimeInMillis, maxElapsedNanoTimeInMillis), delay);
+		timers.add(timer);
+	}
+
+	public boolean getResultAndCancelTimers() {
+		showThreadCurrentTime("getResultAndCancelTimers before Thread.yield() taskRunning = " + taskRunning);
+		while (taskRunning > 0) {
+			Thread.yield();
+		}
+
+		showThreadCurrentTime("getResultAndCancelTimers before timer.cancel()");
+		for (Timer timer : timers) {
+			timer.cancel();
+		}
+
+		showThreadCurrentTime("TimeTestTask tasksPassed: " + tasksPassed + ", taskStarted: " + taskStarted
+				+ ", taskExecuted: " + taskExecuted);
+		return tasksPassed && (taskStarted == taskExecuted);
+	}
+
+	class TimeTestTask extends TimerTask {
+
+		private final String testName;
+		private final long startMillisTime;
+		private final long startNanoTime;
+		private final long minElapsedMillisTime;
+		private final long maxElapsedMillisTime;
+		private final long minElapsedNanoTimeInMillis;
+		private final long maxElapsedNanoTimeInMillis;
+
+		TimeTestTask(String testName, long startMillisTime, long startNanoTime, long minElapsedMillisTime,
+				long maxElapsedMillisTime, long minElapsedNanoTimeInMillis, long maxElapsedNanoTimeInMillis) {
+			this.testName = testName;
+			this.startMillisTime = startMillisTime;
+			this.startNanoTime = startNanoTime;
+			this.minElapsedMillisTime = minElapsedMillisTime;
+			this.maxElapsedMillisTime = maxElapsedMillisTime;
+			this.minElapsedNanoTimeInMillis = minElapsedNanoTimeInMillis;
+			this.maxElapsedNanoTimeInMillis = maxElapsedNanoTimeInMillis;
+
+			taskStarted++;
+			taskRunning++;
+		}
+
+		public void run() {
+			taskExecuted++;
+			if (!checkElapseTime(testName, startMillisTime, startNanoTime, minElapsedMillisTime, maxElapsedMillisTime,
+					minElapsedNanoTimeInMillis, maxElapsedNanoTimeInMillis)) {
+				tasksPassed = false;
+			}
+			taskRunning--;
+		}
+	}
+}

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
@@ -34,6 +34,7 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/cmdLineTest_J9tests" />
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="${PROJECT_ROOT}/src" />
+	<property name="TestUtilities" location="../../TestUtilities/src"/>
 	<property name="build" location="${PROJECT_ROOT}/bin" />
 
 	<target name="init">
@@ -49,6 +50,11 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
 		</javac>
 	</target>
 
@@ -56,6 +62,7 @@
 		<jar jarfile="${DEST}/cmdLineTest_J9tests.jar" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}" />
+			<fileset dir="${TestUtilities}" />
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${PROJECT_ROOT}" includes="*.xml" />

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_elapsedTime.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_elapsedTime.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Copyright IBM Corp. and others 2023
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="Elapsed time measurement" timeout="180">
+	<test id="Verify the elapsed time">
+		<command>$EXE$ -cp $Q$$JARPATH$$Q$ ElapsedTime</command>
+		<output type="success" caseSensitive="yes" regex="no">Thread-0</output>
+		<output type="success" caseSensitive="yes" regex="no">PASSED: testElapsedTime</output>
+		<output type="failure" caseSensitive="yes" regex="no">FAILED: testElapsedTime</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -289,4 +289,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>openj9</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTest_J9test_elapsedTime</testCaseName>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TESTNG)$(P)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_elapsedTime.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
@@ -1,0 +1,67 @@
+
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.openj9.test.util.TimeUtilities;
+import org.testng.AssertJUnit;
+
+public class ElapsedTime {
+	public static void main(String[] args) throws Exception {
+		testElapsedTime();
+	}
+
+	private static void testElapsedTime() throws InterruptedException {
+		TimeUtilities tu = new TimeUtilities();
+		final Object dummy = new Object();
+		long millisTimeStart = System.currentTimeMillis();
+		long nanoTimeStart = System.nanoTime();
+
+		synchronized (dummy) {
+			dummy.wait(100);
+		}
+		AssertJUnit.assertTrue(
+				tu.checkElapseTime("testElapsedTime() wait 100ms", millisTimeStart, nanoTimeStart, 100, 800, 100, 800));
+
+		millisTimeStart = System.currentTimeMillis();
+		nanoTimeStart = System.nanoTime();
+		Thread.currentThread().sleep(100);
+		AssertJUnit.assertTrue(tu.checkElapseTime("testElapsedTime() sleep 100ms", millisTimeStart, nanoTimeStart, 100,
+				800, 100, 800));
+
+		millisTimeStart = System.currentTimeMillis();
+		nanoTimeStart = System.nanoTime();
+		tu.timerSchedule("testElapsedTime() timer delayed 100ms", millisTimeStart, nanoTimeStart, 100, 500, 100, 500,
+				100);
+
+		millisTimeStart = System.currentTimeMillis();
+		nanoTimeStart = System.nanoTime();
+		tu.timerSchedule("testElapsedTime() timer delayed 2s", millisTimeStart, nanoTimeStart, 2000, 3000, 2000, 3000,
+				2000);
+
+		AssertJUnit.assertTrue(tu.getResultAndCancelTimers());
+
+		System.out.println("PASSED: testElapsedTime()");
+	}
+}

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -33,6 +33,7 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/criu" />
 	<property name="src" location="./src"/>
+	<property name="TestUtilities" location="../../TestUtilities/src"/>
 	<property name="build" location="./bin"/>
 
 	<target name="init">
@@ -66,6 +67,11 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<exclude name="${excludeJDK11UpTimeoutAdjustmentTest}" />
 					<exclude name="${excludeTestMachineResourceChange}" />
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar"/>
+					</classpath>
 				</javac>
 			</then>
 			<else>
@@ -76,6 +82,11 @@
 					<compilerarg line="${addExports}" />
 					<compilerarg line="${enablePreview}" />
 					<exclude name="${excludeTestMachineResourceChange}" />
+					<src path="${src}" />
+					<src path="${TestUtilities}" />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar"/>
+					</classpath>
 				</javac>
 			</else>
 		</if>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -1030,4 +1030,20 @@
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
+
+  <test id="Create CRIU checkpoint image and restore once - testTimeCompensation">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print={j9criu,j9jcl.533} --add-exports java.base/openj9.internal.criu=ALL-UNNAMED" $MAINCLASS_TIMECHANGE$ testTimeCompensation 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="success" caseSensitive="yes" regex="no">PASSED: testTimeCompensation</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <output type="failure" caseSensitive="yes" regex="no">FAILED: testTimeCompensation</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
 </suite>


### PR DESCRIPTION
CRIU `checkpointRestoreTimeDelta` adjustment & add time compensation tests

Adjusted `J9JavaVM->checkpointState.checkpointRestoreTimeDelta` and `J9PortLibrary->nanoTimeMonotonicClockDelta` calculation;
Added tests for CRIU and non-CRIU scenarios.

related to https://github.com/eclipse-openj9/openj9/pull/18235

Signed-off-by: Jason Feng <fengj@ca.ibm.com>