### PR TITLE
Adapt getCallerClass MH tests for ojdk11 MHs

### DIFF
--- a/test/functional/cmdline_options_testresources/src/com/ibm/j9/getcallerclass/TestGroup.java
+++ b/test/functional/cmdline_options_testresources/src/com/ibm/j9/getcallerclass/TestGroup.java
@@ -74,11 +74,11 @@ public class TestGroup {
 
 		subTestResult &= GetCallerClassTests.test_getCallerClass_fromBootExtWithAnnotation();
 		subTestResult &= GetCallerClassTests.test_ensureCalledFromBootstrapClass_fromBootWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Helper_Reflection_fromBootExtWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Direct_Reflection_fromBootExtClassLoader();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Helper_MethodHandle_fromBootExtWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Direct_MethodHandle_fromBootExtClassLoader();
-		subTestResult &= RefectionMHTests.test_getCallerClass_MethodHandle_ArgumentHelper();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Helper_Reflection_fromBootExtWithAnnotation();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Direct_Reflection_fromBootExtClassLoader();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Helper_MethodHandle_fromBootExtWithAnnotation();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Direct_MethodHandle_fromBootExtClassLoader();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_MethodHandle_ArgumentHelper();
 
 		subTestResult &= GetCallerClassTests.test_getCallerClass_fromBootExtWithoutAnnotation();
 		subTestResult &= GetCallerClassTests.test_ensureCalledFromBootstrapClass_fromBootExtWithoutAnnotation();
@@ -91,11 +91,11 @@ public class TestGroup {
 
 		subTestResult &= GetCallerClassTests.test_getCallerClass_fromBootExtWithAnnotation();
 		subTestResult &= GetCallerClassTests.test_ensureCalledFromBootstrapClass_fromExtWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Helper_Reflection_fromBootExtWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Direct_Reflection_fromBootExtClassLoader();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Helper_MethodHandle_fromBootExtWithAnnotation();
-		subTestResult &= RefectionMHTests.test_getCallerClass_Direct_MethodHandle_fromBootExtClassLoader();
-		subTestResult &= RefectionMHTests.test_getCallerClass_MethodHandle_ArgumentHelper();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Helper_Reflection_fromBootExtWithAnnotation();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Direct_Reflection_fromBootExtClassLoader();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Helper_MethodHandle_fromBootExtWithAnnotation();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_Direct_MethodHandle_fromBootExtClassLoader();
+		subTestResult &= ReflectionMHTests.test_getCallerClass_MethodHandle_ArgumentHelper();
 
 		subTestResult &= GetCallerClassTests.test_getCallerClass_fromBootExtWithoutAnnotation();
 		subTestResult &= GetCallerClassTests.test_ensureCalledFromBootstrapClass_fromBootExtWithoutAnnotation();

--- a/test/functional/cmdline_options_testresources/src_80/com/ibm/j9/getcallerclass/ReflectionMHTests.java
+++ b/test/functional/cmdline_options_testresources/src_80/com/ibm/j9/getcallerclass/ReflectionMHTests.java
@@ -31,7 +31,7 @@ import java.lang.reflect.Method;
 /**
  * Test cases intended for reflection and MethodHandle
  */
-public class RefectionMHTests {
+public class ReflectionMHTests {
 
 	/**
 	 * Call getCallerClass() with a helper method via reflection from the bootstrap/extension
@@ -46,7 +46,7 @@ public class RefectionMHTests {
 			method = GetCallerClassTests.class.getDeclaredMethod("test_getCallerClass_MethodHandle");
 			cls = (Class<?>) method.invoke(null, new Object[0]);
 
-			if (cls == RefectionMHTests.class) {
+			if (cls == ReflectionMHTests.class) {
 				System.out.println(TESTCASE_NAME + ": PASSED: return " + cls.getName());
 				return true;
 			} else {

--- a/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
+++ b/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
@@ -32,11 +32,20 @@ import org.openj9.test.util.VersionCheck;
 /**
  * Test cases intended for reflection and MethodHandle
  */
-public class RefectionMHTests {
+public class ReflectionMHTests {
 
 	private static boolean isSecurityFrameOrInjectedInvoker(Class<?> cls) {
-		return ("java.lang.invoke.SecurityFrame" == cls.getName()
-			|| cls.getName().startsWith(RefectionMHTests.class.getName() + "$$InjectedInvoker/"));
+		boolean rc = "java.lang.invoke.SecurityFrame" == cls.getName();
+		if (!rc) {
+			String injectedInvoker;
+			if (VersionCheck.major() < 15) {
+				injectedInvoker = ReflectionMHTests.class.getPackageName() + ".InjectedInvoker/";
+			} else {
+				injectedInvoker = ReflectionMHTests.class.getName() + "$$InjectedInvoker/";
+			}
+			rc = cls.getName().startsWith(injectedInvoker);
+		}
+		return rc;
 	}
 
 	/**
@@ -56,7 +65,7 @@ public class RefectionMHTests {
 			if (VersionCheck.major() >= 18) {
 				isClassNameExpected = isSecurityFrameOrInjectedInvoker(cls);
 			} else {
-				isClassNameExpected = (cls == RefectionMHTests.class);
+				isClassNameExpected = (cls == ReflectionMHTests.class);
 			}
 
 			if (isClassNameExpected) {


### PR DESCRIPTION
This patch addresses eclipse-openj9/openj9#14989 for ojdk11 MHs. Hidden Classes changed InjectedInvoker class signatures. This patch updates the test case to support pre-hidden-class signatures.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>