### PR TITLE
[FFI/Jreg_JDK21] Fix the issue with the nested struct in libffi

### DIFF
--- a/longabout.html
+++ b/longabout.html
@@ -167,7 +167,7 @@ MurmurHash3 was written by Austin Appleby, and is placed in the public domain. T
 Note - The x86 and x64 versions do _not_ produce the same results, as the algorithms are optimized for their respective platforms. You can still compile and run any of them on any platform, but your performance with the non-native version will be less than optimal
 <p>
 <h4>libFFI pre 3.5</h4>
-libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2023  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 <p>
 Permission is hereby granted, free of charge, to any person obtaining

--- a/runtime/include/about.html
+++ b/runtime/include/about.html
@@ -85,7 +85,7 @@ jloup@gzip.org&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;madler
 
 <p>The software is modified from the original version.</p>
 
-<p>libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.</p>
+<p>libffi - Copyright (c) 1996-2023  Anthony Green, Red Hat, Inc and others.</p>
 
 <p>
 Permission is hereby granted, free of charge, to any person obtaining

--- a/runtime/libffi/about.html
+++ b/runtime/libffi/about.html
@@ -6,7 +6,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
  
-<p><em>Mar 14, 2022</em></p>
+<p><em>Nov 13, 2023</em></p>
 <h3>License</h3>
 
 <p>This program and the accompanying materials are made available under the terms of the
@@ -46,7 +46,7 @@ should look to the Redistributor's license for terms and conditions of use.</p>
 
 <p>The software is modified from the original version.</p>
 
-<p>libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.</p>
+<p>libffi - Copyright (c) 1996-2023  Anthony Green, Red Hat, Inc and others.</p>
 
 <p>
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
The change simply adopts the fix at libffi/libffi#805
to resolve the the issue with the nested struct in libffi on AIX.

Related: #18287

Note:
The changes should be kept in sync with the code at libffi/libffi#805
if any update.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>