### PR TITLE
Log task start time to verify delays and modify the loop to skip intermediate state

### DIFF
--- a/test/functional/JIT_Test/src/jit/test/tr/chtable/VirtualGuardTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/chtable/VirtualGuardTest.java
@@ -70,8 +70,11 @@ public class VirtualGuardTest implements Notifiable {
 	}
 	
 	private char bar() {
+		System.out.println("TASK A loaded at:"+java.lang.System.currentTimeMillis());
 		char state = 'A';
-		while (keepOnGoing) {								
+		int  count = 0;
+		while (keepOnGoing ||
+			(state == '?' && count <= 1)) {
 			int result = goo();
 			switch (result) {
 				case 4*'A':
@@ -83,6 +86,7 @@ public class VirtualGuardTest implements Notifiable {
 				default:
 					AssertJUnit.assertTrue("switching to ?", state == 'A' && result > 4*'A' && result < 4*'B');
 					state = '?';
+					++count;
 					break;
 			}			
 		}
@@ -114,9 +118,13 @@ public class VirtualGuardTest implements Notifiable {
 	public void wakeUp(int event) {
 		switch (event) {
 			case TASK_LOAD_B:
-				f = new B(); break;
+				f = new B();
+				System.out.println("TASK B loaded at:"+java.lang.System.currentTimeMillis());
+				break;
 			case TASK_FIN:
-				keepOnGoing = false; break;			
+				keepOnGoing = false;
+				System.out.println("TASK FIN loaded at:"+java.lang.System.currentTimeMillis());
+				break;
 		}
 		
 	}


### PR DESCRIPTION
This add few debug information to collect in order to debug further the issue https://github.com/eclipse-openj9/openj9/issues/14469 which is not reproducible locally. The issue happens due to the intermediate state set in between the testcase from Task A to Task B and exits. This commit will also let the testcase run one another time so it will skip the intermediate state.

Signed-off-by: Bhavani SN (bhavani.sn@ibm.com)