### PR TITLE
Recognize JNI local refs in JNINativeMethodFrames

### DIFF
--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -701,6 +701,7 @@ static void
 walkMethodFrame(J9StackWalkState * walkState)
 {
 	J9SFMethodFrame * methodFrame = (J9SFMethodFrame *) ((U_8*) walkState->walkSP + (UDATA) walkState->literals);
+	BOOLEAN isJNINative = (J9SF_FRAME_TYPE_JNI_NATIVE_METHOD == (UDATA)walkState->pc);
 
 	walkState->bp = (UDATA *) &(methodFrame->savedA0);
 	walkState->frameFlags = methodFrame->specialFrameFlags;
@@ -734,7 +735,7 @@ walkMethodFrame(J9StackWalkState * walkState)
 #endif
 
 	if ((walkState->flags & J9_STACKWALK_ITERATE_O_SLOTS) && walkState->literals) {
-		if (walkState->frameFlags & J9_SSF_JNI_REFS_REDIRECTED) {
+		if ((walkState->frameFlags & J9_SSF_JNI_REFS_REDIRECTED) || isJNINative) {
 			walkPushedJNIRefs(walkState);
 		} else {
 			walkObjectPushes(walkState);


### PR DESCRIPTION
First 8 JNI local refs are directly stored inside the `J9SFJNINativeMethodFrame` before allocating `J9JNIReferenceFrame` to store additional references. StackWalker should check if the object pushes from method frame is JNI local when walking O-Slots.

Related: #17712 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>