### PR TITLE
Fix JNI Local Reference reporting issue

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -644,9 +644,12 @@ MM_ReferenceChainWalker::doStackSlot(J9Object **slotPtr, void *walkState, const 
 	J9Object *slotValue = *slotPtr;
 
 	/* Only report heap objects */
-
 	if (isHeapObject(slotValue) && !_heap->objectIsInGap(slotValue)) {
-		doSlot(slotPtr, J9GC_ROOT_TYPE_STACK_SLOT, -1, (J9Object *)walkState);
+		if (J9_STACKWALK_SLOT_TYPE_JNI_LOCAL == ((J9StackWalkState *)walkState)->slotType) {
+			doSlot(slotPtr, J9GC_ROOT_TYPE_JNI_LOCAL, -1, (J9Object *)walkState);
+		} else {
+			doSlot(slotPtr, J9GC_ROOT_TYPE_STACK_SLOT, -1, (J9Object *)walkState);
+		}
 	}
 }
 


### PR DESCRIPTION
JNI Local References could be found on the stack(first 8 of them) or from GC_VMThreadJNISlotIterator (vmThread->jniLocalReferences). need to update MM_ReferenceChainWalker::doVMThreadSlot() to report J9GC_ROOT_TYPE_JNI_LOCAL type for the case  walkState->slotType = J9_STACKWALK_SLOT_TYPE_JNI_LOCAL.

relate: https://github.com/eclipse-openj9/openj9/pull/18378 and https://github.com/eclipse-openj9/openj9/issues/17712
Signed-off-by: hulin <linhu@ca.ibm.com>