### PR TITLE
Add option to enforce/disable IProfiler during startup phase

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -123,7 +123,9 @@ enum ExternalOptions
    XXcodecachetotalMaxRAMPercentage            = 67,
    XXplusJITServerAOTCacheDelayMethodRelocation  = 68,
    XXminusJITServerAOTCacheDelayMethodRelocation = 69,
-   TR_NumExternalOptions                         = 70
+   XXplusIProfileDuringStartupPhase            = 70,
+   XXminusIProfileDuringStartupPhase           = 71,
+   TR_NumExternalOptions                       = 72
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -183,6 +183,8 @@ class OptionsPostRestore
    int32_t _argIndexDisableUseJITServer;
    int32_t _argIndexJITServerAddress;
    int32_t _argIndexJITServerAOTCacheName;
+   int32_t _argIndexIProfileDuringStartupPhase;
+   int32_t _argIndexDisableIProfileDuringStartupPhase;
    };
 
 }


### PR DESCRIPTION
Making a new option, `-XX:[+/-]IProfileDuringStartupPhase`, that enforce/disable IProfiler during the startup phase. 

If the option is not used the default existing algorithm will determine the behaviour.
This option will replaces the `TR_DisableNoIProfilerDuringStartupPhase` environment variable and overrides `-Xjit:noIProfilerDuringStartupPhase`.


This option will be used in cold-runs/`populate_scc` scripts to ensure more IProfiler information are being collected and stored in the SCC.

Docs: https://github.com/eclipse-openj9/openj9-docs/issues/1204