### PR TITLE
Updated recognized methods for newer JDKs

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -317,6 +317,7 @@
    java_util_HashMap_findNullKeyEntry,
    java_util_HashMap_get,
    java_util_HashMap_getNode,
+   java_util_HashMap_getNode_Object,
    java_util_HashMap_findNonNullKeyEntry,
    java_util_HashMap_putImpl,
    java_util_HashMap_resize,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2141,6 +2141,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_util_HashMap_findNullKeyEntry,      "findNullKeyEntry",           "()Ljava/util/HashMap$Entry;")},
       {x(TR::java_util_HashMap_get,                   "get",           "(Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_util_HashMap_getNode,               "getNode",       "(ILjava/lang/Object;)Ljava/util/HashMap$Node;")},
+      {x(TR::java_util_HashMap_getNode_Object,        "getNode",       "(Ljava/lang/Object;)Ljava/util/HashMap$Node;")},
       {x(TR::java_util_HashMap_putImpl,               "putImpl",       "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_util_HashMap_findNonNullKeyEntry,   "findNonNullKeyEntry",         "(Ljava/lang/Object;II)Ljava/util/HashMap$Entry;")},
       {x(TR::java_util_HashMap_resize,                "resize",         "()[Ljava/util/HashMap$Node;")},
@@ -2887,6 +2888,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::sun_misc_Unsafe_putFloatVolatile_jlObjectJF_V,         "putFloatRelease",   "(Ljava/lang/Object;JF)V")},
       {x(TR::sun_misc_Unsafe_putDoubleVolatile_jlObjectJD_V,        "putDoubleRelease",  "(Ljava/lang/Object;JD)V")},
       {x(TR::sun_misc_Unsafe_putObjectVolatile_jlObjectJjlObject_V, "putObjectRelease",  "(Ljava/lang/Object;JLjava/lang/Object;)V")},
+      {x(TR::sun_misc_Unsafe_putObjectVolatile_jlObjectJjlObject_V, "putReferenceRelease",  "(Ljava/lang/Object;JLjava/lang/Object;)V")},
 
       {x(TR::sun_misc_Unsafe_putInt_jlObjectII_V,           "putInt",     "(Ljava/lang/Object;II)V")},
 
@@ -2921,6 +2923,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::sun_misc_Unsafe_getFloatVolatile_jlObjectJ_F,          "getFloatAcquire",   "(Ljava/lang/Object;J)F")},
       {x(TR::sun_misc_Unsafe_getDoubleVolatile_jlObjectJ_D,         "getDoubleAcquire",  "(Ljava/lang/Object;J)D")},
       {x(TR::sun_misc_Unsafe_getObjectVolatile_jlObjectJ_jlObject,  "getObjectAcquire",  "(Ljava/lang/Object;J)Ljava/lang/Object;")},
+      {x(TR::sun_misc_Unsafe_getObjectVolatile_jlObjectJ_jlObject,  "getReferenceAcquire",  "(Ljava/lang/Object;J)Ljava/lang/Object;")},
 
       {x(TR::sun_misc_Unsafe_putByte_JB_V,                  "putByte",    "(JB)V")},
       {x(TR::sun_misc_Unsafe_putShort_JS_V,                 "putShort",   "(JS)V")},

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -280,6 +280,7 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_util_HashtableHashEnumerator_hasMoreElements,
    TR::java_util_HashtableHashEnumerator_nextElement,
    TR::java_util_HashMap_getNode,
+   TR::java_util_HashMap_getNode_Object,
    TR::java_util_HashMap_resize,
    //TR::java_util_HashMapHashIterator_nextNode,  /* Unsafe if the Iterator is being incorrectly used (concurrent execution) */
    TR::java_util_HashMapHashIterator_init,        /* Safe because the object is only visible by one thread when init() is executing */

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -387,6 +387,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_StringUTF16_newBytesFor:
       case TR::java_util_HashMap_get:
       case TR::java_util_HashMap_getNode:
+      case TR::java_util_HashMap_getNode_Object:
       case TR::java_lang_String_getChars_charArray:
       case TR::java_lang_String_getChars_byteArray:
       case TR::java_lang_Integer_toUnsignedLong:

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -507,11 +507,12 @@ int32_t TR_UnsafeFastPath::perform()
             case TR::sun_misc_Unsafe_getObject_jlObjectJ_jlObject:
                switch (methodSymbol->getRecognizedMethod())
                   {
-               case TR::java_util_concurrent_ConcurrentHashMap_tabAt:
-               case TR::java_util_concurrent_ConcurrentHashMap_setTabAt:
-                  isArrayOperation = true;
-               default:
-                  break;
+                  case TR::java_util_concurrent_ConcurrentHashMap_tabAt:
+                  case TR::java_util_concurrent_ConcurrentHashMap_setTabAt:
+                     isArrayOperation = true;
+                     break;
+                  default:
+                     break;
                   }
                break;
             case TR::com_ibm_jit_JITHelpers_getByteFromArrayVolatile:
@@ -554,14 +555,14 @@ int32_t TR_UnsafeFastPath::perform()
             case TR::sun_misc_Unsafe_putObject_jlObjectJjlObject_V:
                switch (comp()->getMethodSymbol()->getRecognizedMethod())
                   {
-               case TR::java_util_concurrent_ConcurrentHashMap_setTabAt:
-                  type = TR::Address;
-                  value = node->getChild(3);
-                  break;
-               default:
-                  break;
-                  // by not setting type the call will not be recognized here and will
-                  // be left to the inliner since we need to generate control flow
+                  case TR::java_util_concurrent_ConcurrentHashMap_setTabAt:
+                     type = TR::Address;
+                     value = node->getChild(3);
+                     break;
+                  default:
+                     break;
+                     // by not setting type the call will not be recognized here and will
+                     // be left to the inliner since we need to generate control flow
                   }
                break;
             case TR::com_ibm_jit_JITHelpers_getByteFromArrayByIndex:
@@ -588,13 +589,13 @@ int32_t TR_UnsafeFastPath::perform()
             case TR::sun_misc_Unsafe_getObject_jlObjectJ_jlObject:
                switch (methodSymbol->getRecognizedMethod())
                   {
-               case TR::java_util_concurrent_ConcurrentHashMap_tabAt:
-                  type = TR::Address;
-                  break;
-               default:
-                  break;
-                  // by not setting type the call will not be recognized here and will
-                  // be left to the inliner since we need to generate control flow
+                  case TR::java_util_concurrent_ConcurrentHashMap_tabAt:
+                     type = TR::Address;
+                     break;
+                  default:
+                     break;
+                     // by not setting type the call will not be recognized here and will
+                     // be left to the inliner since we need to generate control flow
                   }
                break;
             case TR::sun_misc_Unsafe_putInt_jlObjectJI_V:


### PR DESCRIPTION
Method recognition has been updated for the following three cases:

As of JDK12, `ConcurrentHashMap.tabAt` now calls `Unsafe.getReferenceAcquire` instead of `Unsafe.getObjectVolatile`. `Unsafe.getReferenceAcquire` is now recognized so it triggers the Unsafe Fast Path opt.

As of JDK12, `ConcurrentHashMap.setTabAt` now calls `Unsafe.putReferenceRelease` instead of `Unsafe.putObjectVolatile`. `Unsafe.putReferenceRelease` is also now recognized for Unsafe Fast Path.

As of JDK15, the signature for `HashMap.getNode` no longer has an int parameter. An entry for this case has been added so the method is forced to be inlined like it was before.