### PR TITLE
Add support for -XX:Compatibility=elasticsearch

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2108,7 +2108,6 @@ J9NLS_VM_CRIU_SINGLETHREADMODE_JVMCRIUEXCEPTION.user_response=View CRIU document
 
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED=The JVM could not initialize Xtrace upon restoring the JVM
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.user_response=Check documentation for CRIUSupport restore options.
@@ -2116,7 +2115,6 @@ J9NLS_VM_CRIU_RESTORE_INITIALIZE_TRACE_FAILED.user_response=Check documentation 
 
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET=The JVM could not re-seed j.u.Random.seed.value due to invalid seed offset
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2124,7 +2122,6 @@ J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_SEEDOFFSET.user_response=View CRIU document
 
 J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF=The JVM could not re-seed j.u.Random.seed.value due to j.u.c.a.AtomicLong not found
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2132,7 +2129,6 @@ J9NLS_VM_CRIU_RESTORE_RESEED_ATOMICLONG_CNF.user_response=View CRIU documentatio
 
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET=The JVM could not re-seed j.u.Random.seed.value due to invalid value offset
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2140,7 +2136,6 @@ J9NLS_VM_CRIU_RESTORE_RESEED_INVALID_VALUEOFFSET.user_response=View CRIU documen
 
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_DUMP_FAILED=The JVM could not initialize Xdump upon restoring the JVM
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_INITIALIZE_DUMP_FAILED.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_DUMP_FAILED.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_DUMP_FAILED.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_INITIALIZE_DUMP_FAILED.user_response=Check documentation for CRIUSupport restore options.
@@ -2154,7 +2149,6 @@ J9NLS_VM_ILLEGAL_THREAD_STATE_UPCALL.user_response=Ensure the specified linker o
 
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_CNF=The JVM could not reset java.lang.VirtualThread.ForkJoinPool.parallelism due to java.util.concurrent.ForkJoinPool class not found
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_CNF.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_CNF.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_CNF.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_CNF.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2162,7 +2156,6 @@ J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_FORKJOINPOOL_
 
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAULT_SCHEDULER_ADDRESS=The JVM could not reset java.lang.VirtualThread.ForkJoinPool.parallelism due to invalid DEFAULT_SCHEDULER address
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAULT_SCHEDULER_ADDRESS.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAULT_SCHEDULER_ADDRESS.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAULT_SCHEDULER_ADDRESS.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAULT_SCHEDULER_ADDRESS.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2170,7 +2163,6 @@ J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_DEFAU
 
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET=The JVM could not reset java.lang.VirtualThread.ForkJoinPool.parallelism due to invalid parallelism offset
 # START NON-TRANSLATABLE
-J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.sample_input_1=1
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.explanation=CRIUSupport::checkpointJVM failed.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_RESTORE_RESET_VIRTUALTHREAD_FORKJOINPOOL_PARALLELISM_INVALID_PARALLELISM_OFFSET.user_response=View CRIU documentation to determine how to resolve the exception.
@@ -2190,4 +2182,21 @@ J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS=A
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Note: -XX:Compatibility= is a command-line option and should not be translated.
+J9NLS_VM_COMPATIBILITY_REPEATED=The command-line option -XX:Compatibility=[mode] is allowed at most once.
+# START NON-TRANSLATABLE
+J9NLS_VM_COMPATIBILITY_REPEATED.explanation=The specified command-line option may not be repeated.
+J9NLS_VM_COMPATIBILITY_REPEATED.system_action=The JVM will fail to start.
+J9NLS_VM_COMPATIBILITY_REPEATED.user_response=Remove the repetition of the option from the command line.
+# END NON-TRANSLATABLE
+
+# Note: -XX:Compatibility= is a command-line option and should not be translated.
+J9NLS_VM_COMPATIBILITY_UNSUPPORTED=The compatibility mode specified in \"-XX:Compatibility=%s\" is not supported.
+# START NON-TRANSLATABLE
+J9NLS_VM_COMPATIBILITY_UNSUPPORTED.sample_input_1=unsupported
+J9NLS_VM_COMPATIBILITY_UNSUPPORTED.explanation=The specified compatibility mode is not supported.
+J9NLS_VM_COMPATIBILITY_UNSUPPORTED.system_action=The JVM will fail to start.
+J9NLS_VM_COMPATIBILITY_UNSUPPORTED.user_response=Remove the option from the command line.
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -392,6 +392,10 @@ typedef struct J9ROMClassCfrMember {
 	U_16 attributesCount;
 } J9ROMClassCfrMember;
 
+/* @ddr_namespace: map_to_type=J9Compatibility */
+
+#define J9COMPATIBILITY_ELASTICSEARCH 0x1 /* -XX:Compatibility=elasticsearch */
+
 /* @ddr_namespace: map_to_type=J9ContendedLoadTableEntry */
 
 typedef struct J9ContendedLoadTableEntry {
@@ -5981,6 +5985,7 @@ typedef struct J9JavaVM {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	omrthread_monitor_t delayedLockingOperationsMutex;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+	U_32 compatibilityFlags;
 } J9JavaVM;
 
 #define J9VM_PHASE_STARTUP  1

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -433,6 +433,13 @@ enum INIT_STAGE {
 #define VMOPT_XXDISABLETHROWONDELAYECHECKPOINTOPERATION "-XX:-ThrowOnDelayedCheckpointOperation"
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+/* Compatibility options. */
+#define VMOPT_XXCOMPATIBILITY_EQUALS "-XX:Compatibility="
+
+/* Options recognized only in combination with -XX:Compatibility=elasticsearch. */
+#define VMOPT_XXCOMPATIBILITY_ENABLEG1GC "-XX:+UseG1GC"
+#define VMOPT_XXCOMPATIBILITY_DISABLEG1GC "-XX:-UseG1GC"
+
 /*
  * Options to control how much effort is expended
  * resolving native symbols in java dumps.

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2996,7 +2996,9 @@ checkArgsConsumed(J9JavaVM * vm, J9PortLibrary* portLibrary, J9VMInitArgs* j9vm_
 	IDATA xxIgnoreUnrecognizedXXColonOptionsEnableIndex = -1;
 	IDATA xxIgnoreUnrecognizedXXColonOptionsDisableIndex = -1;
 
-	if (findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXVM_IGNOREUNRECOGNIZED, NULL, TRUE) >= 0) {
+	if (J9_ARE_ANY_BITS_SET(vm->compatibilityFlags, J9COMPATIBILITY_ELASTICSEARCH)
+		|| (findArgInVMArgs(PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXVM_IGNOREUNRECOGNIZED, NULL, TRUE) >= 0)
+	) {
 		ignoreUnrecognized = JNI_TRUE;
 	}
 
@@ -6885,6 +6887,30 @@ xlogret:
 	return rc;
 }
 
+/*
+ * Compute the heap region size that G1GC would use for the specified maximum
+ * heap size. G1GC aims for 2048 regions with the size of each region being a
+ * power of 2, no less than 1MB and no more than 32MB.
+ */
+static size_t
+computeG1HeapRegionSize(size_t maxHeapSize)
+{
+	size_t minSize = 1024 * 1024;
+	size_t maxSize = 32 * minSize;
+	size_t regionSize = (maxHeapSize + 2047) / 2048;
+	size_t result = minSize;
+
+	/* A simple loop is sufficient here. It clearly achieves our goal, and
+	 * the cost is low (we iterate at most 5 times and this function is used
+	 * at most once).
+	 */
+	while ((result < regionSize) && (result < maxSize)) {
+		result <<= 1;
+	}
+
+	return result;
+}
+
 static UDATA
 protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 {
@@ -6903,6 +6929,7 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	int filter = -1;
 #endif
 	J9JavaVM** BFUjavaVM;
+	IDATA xxUseG1GC = 0; /* +1 if -XX:+UseG1GC used; -1 if -XX:-UseG1GC used */
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	J9HookInterface** vmHooks;
@@ -7101,6 +7128,39 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 			}
 		} else {
 			doParseXlogForCompatibility = TRUE;
+		}
+	}
+
+	{
+		IDATA argIndex = FIND_AND_CONSUME_ARG_FORWARD(vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XXCOMPATIBILITY_EQUALS, NULL);
+		const char *mode = NULL;
+
+		if (argIndex >= 0) {
+			GET_OPTION_VALUE(argIndex, '=', &mode);
+
+			if (0 == j9_cmdla_stricmp(mode, "elasticsearch")) {
+				vm->compatibilityFlags |= J9COMPATIBILITY_ELASTICSEARCH;
+				doParseXlogForCompatibility = FALSE;
+			} else {
+				j9nls_printf(portLibrary, J9NLS_ERROR, J9NLS_VM_COMPATIBILITY_UNSUPPORTED, mode);
+				goto error;
+			}
+
+			if (FIND_AND_CONSUME_NEXT_ARG_FORWARD(vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XXCOMPATIBILITY_EQUALS, NULL, argIndex) >= 0) {
+				j9nls_printf(portLibrary, J9NLS_ERROR, J9NLS_VM_COMPATIBILITY_REPEATED);
+				goto error;
+			}
+		}
+	}
+
+	if (J9_ARE_ANY_BITS_SET(vm->compatibilityFlags, J9COMPATIBILITY_ELASTICSEARCH)) {
+		IDATA enabled = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXCOMPATIBILITY_ENABLEG1GC, NULL);
+		IDATA disabled = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXCOMPATIBILITY_DISABLEG1GC, NULL);
+
+		if (enabled > disabled) {
+			xxUseG1GC = 1;
+		} else if (disabled >= 0) {
+			xxUseG1GC = -1;
 		}
 	}
 
@@ -7436,7 +7496,6 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		if (enabled > disabled) {
 			size_t maxHeapSize = (size_t) (vm->memoryManagerFunctions->j9gc_get_maximum_heap_size(vm));
 			uint64_t maxDirectMemorySize = (uint64_t) (((~(UDATA)0) == vm->directByteBufferMemoryMax) ? 0 : vm->directByteBufferMemoryMax);
-			const char *howset = NULL;
 
 			/*
 			 * Emulate Hotspot -XX:+PrintFlagsFinal output for two specific flags:
@@ -7445,29 +7504,50 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 			 *    size_t MaxHeapSize                              = 4294967296                                {product} {ergonomic}
 			 *  uint64_t MaxDirectMemorySize                      = 3758096384                                {product} {default}
 			 *
-			 * OpenJ9 stores both of these values as UDATA, so they will both be printed
-			 * as "size_t" type.
+			 * When -XX:Compatibility=elasticsearch is specified, four more flags are included:
+			 *
+			 *    size_t G1HeapRegionSize                         = 2097152                                   {product} {ergonomic}
+			 *     uintx G1ReservePercent                         = 10                                        {product} {default}
+			 *     uintx InitiatingHeapOccupancyPercent           = 45                                        {product} {default}
+			 *      bool UseG1GC                                  = true                                      {product} {ergonomic}
 			 *
 			 * NOTE that Hotspot produces this output on STDOUT, and applications
-			 * expect to parse it there, which means this code does not use j9tty_printf
-			 * like most of the VM (which prints to STDERR). Instead,
-			 * j9file_printf(PORTLIB, J9PORT_TTY_OUT, ...) is used.
+			 * expect to parse it there, which means this code does not use
+			 * j9tty_printf() like most of the VM (which prints to STDERR).
+			 * Instead, j9file_printf(PORTLIB, J9PORT_TTY_OUT, ...) is used.
 			 */
+
+#define PRINT_FLAG(fmt, type, name, value, howset) \
+	j9file_printf(PORTLIB, J9PORT_TTY_OUT, \
+			"%9s %-40s = %-41" fmt " {product} {%s}\n", \
+			(type), (name), (value), (howset))
 
 			j9file_printf(PORTLIB, J9PORT_TTY_OUT, "[Global flags]\n");
 
-			howset = "ergonomic";
-			if ((findArgInVMArgs( PORTLIB, vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XMX, NULL, 0) >= 0)) {
-				howset = "command line";
-			}
-			j9file_printf(PORTLIB, J9PORT_TTY_OUT, "   size_t MaxHeapSize                              = %-41zu {product} {%s}\n", maxHeapSize, howset);
+			PRINT_FLAG("zu", "size_t", "MaxHeapSize",
+					maxHeapSize,
+					(findArgInVMArgs(PORTLIB, vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XMX, NULL, 0) >= 0)
+							? "command line" : "ergonomic");
 
-			howset = "ergonomic";
-			if ((findArgInVMArgs( PORTLIB, vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS, NULL, 0) >= 0)) {
-				howset = "command line";
+			PRINT_FLAG("llu", "uint64_t", "MaxDirectMemorySize",
+					maxDirectMemorySize,
+					(findArgInVMArgs(PORTLIB, vm->vmArgsArray, STARTSWITH_MATCH, VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS, NULL, 0) >= 0)
+							?  "command line" : "ergonomic");
+
+			if (J9_ARE_ANY_BITS_SET(vm->compatibilityFlags, J9COMPATIBILITY_ELASTICSEARCH)) {
+				PRINT_FLAG("zu", "size_t", "G1HeapRegionSize",
+						computeG1HeapRegionSize(maxHeapSize), "ergonomic");
+				PRINT_FLAG("u", "uintx", "G1ReservePercent",
+						10, "default");
+				PRINT_FLAG("u", "uintx", "InitiatingHeapOccupancyPercent",
+						45, "default");
+				PRINT_FLAG("s", "bool", "UseG1GC",
+						(0 <= xxUseG1GC) ? "true" : "false",
+						(0 != xxUseG1GC) ? "command line" : "ergonomic");
 			}
-			j9file_printf(PORTLIB, J9PORT_TTY_OUT, " uint64_t MaxDirectMemorySize                      = %-41llu {product} {%s}\n", maxDirectMemorySize, howset);
 		}
+
+#undef PRINT_FLAG
 	}
 
 	return JNI_OK;


### PR DESCRIPTION
If `-XX:Compatibility=elasticsearch` is specified:
  * recognize `-XX:+UseG1GC` and `-XX:-UseG1GC`
  * include flags `G1HeapRegionSize`, `G1ReservePercent`, `InitiatingHeapOccupancyPercent` and `UseG1GC` in `-XX:+PrintFlagsFinal` output (`G1HeapRegionSize` is derived from `MaxHeapSize`)

If `-XX:Compatibility=` is specified more than once, or with a mode other than `"elasticsearch"` (not case-sensitive), the JVM will refuse to start.

Issue: #18265.