### PR TITLE
Ensure thread GC environment exists during restore

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -819,6 +819,7 @@ public final class CRIUSupport {
 				SecurityProviders.registerRestoreSecurityProviders();
 
 				J9InternalCheckpointHookAPI.runPreCheckpointHooksConcurrentThread();
+				System.gc();
 				try {
 					checkpointJVMImpl(imageDir, leaveRunning, shellJob, extUnixSupport, logLevel, logFile, fileLocks,
 							workDir, tcpEstablished, autoDedup, trackMemory, unprivileged, optionsFile, envFilePath);


### PR DESCRIPTION
Add System.gc() before checkpointJVMImpl to ensure that 
the thread GC environment exists during restore.

Issue: https://github.com/eclipse-openj9/openj9/issues/17731
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>