### PR TITLE
Pass NULL walkState to jvmti callback for JNI local reference on stack

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -646,7 +646,7 @@ MM_ReferenceChainWalker::doStackSlot(J9Object **slotPtr, void *walkState, const 
 	/* Only report heap objects */
 	if (isHeapObject(slotValue) && !_heap->objectIsInGap(slotValue)) {
 		if (J9_STACKWALK_SLOT_TYPE_JNI_LOCAL == ((J9StackWalkState *)walkState)->slotType) {
-			doSlot(slotPtr, J9GC_ROOT_TYPE_JNI_LOCAL, -1, (J9Object *)walkState);
+			doSlot(slotPtr, J9GC_ROOT_TYPE_JNI_LOCAL, -1, NULL);
 		} else {
 			doSlot(slotPtr, J9GC_ROOT_TYPE_STACK_SLOT, -1, (J9Object *)walkState);
 		}


### PR DESCRIPTION
We could not pass walkState parameter to jvmti callback for JNI local reference on stack (except normal Stack slot), it could cause jvmti crash, so pass walkState == NULL for the case.

fix: https://github.com/eclipse-openj9/openj9/issues/18392
Signed-off-by: hulin <linhu@ca.ibm.com>