### PR TITLE
Fix continuation stacks when breakpointing

### DIFF
--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1244,7 +1244,7 @@ ROMClassWriter::writeMethods(Cursor *cursor, Cursor *lineNumberCursor, Cursor *v
 	 *  - nextROMMethod() in util/mthutil.c
 	 *  - allSlotsInROMMethodsSectionDo() in util/romclasswalk.c
 	 *  - dbgNextROMMethod() in dbgext/j9dbgext.c
-	 *  - createBreakpointedMethod() in jvmti/jvmtiHelpers.c
+	 *  - createBreakpointedMethod() in jvmti/jvmtiHelpers.cpp
 	 * All the above are involved in walking or walking over ROMMethods.
 	 *
 	 */

--- a/runtime/jvmti/CMakeLists.txt
+++ b/runtime/jvmti/CMakeLists.txt
@@ -37,7 +37,7 @@ j9vm_add_library(j9jvmti SHARED
 	jvmtiGeneral.c
 	jvmtiHeap.c
 	jvmtiHeap10.c
-	jvmtiHelpers.c
+	jvmtiHelpers.cpp
 	jvmtiHook.c
 	jvmtiJNIFunctionInterception.c
 	jvmtiLocalVariable.c

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -898,7 +898,7 @@ jvmtiIterateOverReachableObjects(jvmtiEnv* env,
 	const void * user_data);
 
 
-/* ---------------- jvmtiHelpers.c ---------------- */
+/* ---------------- jvmtiHelpers.cpp ---------------- */
 
 /**
  * @brief Allocate a thread local storage key (which represents a jvmtiEnv) to index into a thread


### PR DESCRIPTION
The breakpoint handling code was only fixing stacks actively running on
a thread. The stacks for continuations also need to be fixed.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18088

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>