### PR TITLE
Update graph_tool_script.build in Windows specs to msvc2022

### DIFF
--- a/buildspecs/win_x86-64.spec
+++ b/buildspecs/win_x86-64.spec
@@ -70,7 +70,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
 		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
 		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
-		<property name="graph_tool_script.build" value="msvc140_amd64"/>
+		<property name="graph_tool_script.build" value="msvc2022_amd64"/>
 		<property name="graph_tool_script.test" value="msvc100_amd64"/>
 		<property name="graph_variant.testing_suffix" value=""/>
 		<property name="graph_variant.trailingID" value=""/>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -69,7 +69,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
 		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
 		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
-		<property name="graph_tool_script.build" value="msvc140_amd64"/>
+		<property name="graph_tool_script.build" value="msvc2022_amd64"/>
 		<property name="graph_tool_script.test" value="msvc100_amd64"/>
 		<property name="graph_variant.testing_suffix" value=""/>
 		<property name="graph_variant.trailingID" value=""/>

--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -70,7 +70,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
 		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
 		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
-		<property name="graph_tool_script.build" value="msvc140"/>
+		<property name="graph_tool_script.build" value="msvc2022"/>
 		<property name="graph_tool_script.test" value="msvc100"/>
 		<property name="graph_variant.testing_suffix" value=""/>
 		<property name="graph_variant.trailingID" value=""/>


### PR DESCRIPTION
Compile Windows with VS2022.

Tested via [internal build](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=60371)