### PR TITLE
CRIU tests get accurate pre-checkpoint time

### DIFF
--- a/runtime/criusupport/criusupport.cpp
+++ b/runtime/criusupport/criusupport.cpp
@@ -656,13 +656,13 @@ Java_org_eclipse_openj9_criu_CRIUSupport_checkpointJVMImpl(JNIEnv *env,
 	bool setupCRIU = true;
 	PORT_ACCESS_FROM_VMC(currentThread);
 
+	Trc_CRIU_checkpointJVMImpl_Entry(currentThread);
 	if (NULL == vm->checkpointState.criuJVMCheckpointExceptionClass) {
 		setupCRIU = setupJNIFieldIDsAndCRIUAPI(env, &currentExceptionClass, &systemReturnCode, &nlsMsgFormat);
 	}
 
 	vm->checkpointState.checkpointThread = currentThread;
 
-	Trc_CRIU_checkpointJVMImpl_Entry(currentThread);
 	if (vmFuncs->isCheckpointAllowed(currentThread) && setupCRIU) {
 #if defined(LINUX)
 		j9object_t cpDir = NULL;

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -82,27 +82,25 @@ public class CRIUTestUtils {
 				deleteCheckpointDirectory(path);
 			}
 		} else {
-			System.err.println("CRIU is not enabled");
+			throw new RuntimeException("CRIU is not enabled");
 		}
 	}
 
 	public static CRIUSupport prepareCheckPointJVM(Path path) {
-		CRIUSupport criu = null;
 		if (CRIUSupport.isCRIUSupportEnabled()) {
 			deleteCheckpointDirectory(path);
 			createCheckpointDirectory(path);
-			criu = new CRIUSupport(path);
+			return (new CRIUSupport(path)).setLeaveRunning(false).setShellJob(true).setFileLocks(true);
 		} else {
-			System.err.println("CRIU is not enabled");
+			throw new RuntimeException("CRIU is not enabled");
 		}
-		return criu;
 	}
 
 	public static void checkPointJVMNoSetup(CRIUSupport criu, Path path, boolean deleteDir) {
 		if (criu != null) {
 			try {
 				showThreadCurrentTime("Performing CRIUSupport.checkpointJVM()");
-				criu.setLeaveRunning(false).setShellJob(true).setFileLocks(true).checkpointJVM();
+				criu.checkpointJVM();
 			} catch (SystemRestoreException e) {
 				e.printStackTrace();
 			}
@@ -110,7 +108,7 @@ public class CRIUTestUtils {
 				deleteCheckpointDirectory(path);
 			}
 		} else {
-			System.err.println("CRIU is not enabled");
+			throw new RuntimeException("CRIU is not enabled");
 		}
 	}
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/JDK11UpTimeoutAdjustmentTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/JDK11UpTimeoutAdjustmentTest.java
@@ -48,9 +48,6 @@ public class JDK11UpTimeoutAdjustmentTest {
 
 	private void test(String testName) throws InterruptedException {
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			return;
-		}
 		System.out.println("Start test name: " + testName);
 		CRIUTestUtils.showThreadCurrentTime("Before starting " + testName);
 		switch (testName) {

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestConcurrentMode.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestConcurrentMode.java
@@ -75,10 +75,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePreCheckpointHookThrowException() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookThrowException() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPreCheckpointHook(() -> {
 			throw new RuntimeException("TestConcurrentModePreCheckpointHookThrowException() within preCheckpointHook");
 		}, CRIUSupport.HookMode.CONCURRENT_MODE, USER_HOOK_MODE_PRIORITY_LOW);
@@ -92,10 +88,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePreCheckpointHookThrowExceptionPriority() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookThrowExceptionPriority() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPreCheckpointHook(
 				() -> CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookThrowExceptionPriority() within preCheckpointHook"),
 				CRIUSupport.HookMode.CONCURRENT_MODE, 100);
@@ -109,10 +101,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePreCheckpointHookRunOnce() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookRunOnce() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPreCheckpointHook(
 				() -> CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookRunOnce() within preCheckpointHook"),
 				CRIUSupport.HookMode.CONCURRENT_MODE, USER_HOOK_MODE_PRIORITY_LOW);
@@ -126,10 +114,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePreCheckpointHookPriorities() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePreCheckpointHookPriorities() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		final TestResult testResult = new TestResult(true, 0);
 		criu.registerPreCheckpointHook(() -> {
 			CRIUTestUtils.showThreadCurrentTime("The preCheckpointHook with lower priority in CONCURRENT_MODE");
@@ -190,10 +174,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePostRestoreHookThrowException() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookThrowException() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPostRestoreHook(() -> {
 			throw new RuntimeException("TestConcurrentModePostRestoreHookThrowException() within postRestoreHook");
 		}, CRIUSupport.HookMode.CONCURRENT_MODE, 1);
@@ -207,10 +187,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePostRestoreHookThrowExceptionPriority() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookThrowExceptionPriority() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPostRestoreHook(
 				() -> CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookRunOnce() within postRestoreHook"),
 				CRIUSupport.HookMode.CONCURRENT_MODE, -1);
@@ -224,10 +200,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePostRestoreHookRunOnce() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookRunOnce() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		criu.registerPostRestoreHook(
 				() -> CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookRunOnce() within postRestoreHook"),
 				CRIUSupport.HookMode.CONCURRENT_MODE, 1);
@@ -241,10 +213,6 @@ public class TestConcurrentMode {
 	static void TestConcurrentModePostRestoreHookPriorities() {
 		CRIUTestUtils.showThreadCurrentTime("TestConcurrentModePostRestoreHookPriorities() starts ..");
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 		final TestResult testResult = new TestResult(true, 0);
 		criu.registerPostRestoreHook(() -> {
 			CRIUTestUtils.showThreadCurrentTime("The postRestoreHook with lower priority in CONCURRENT_MODE");

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestMachineResourceChange.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestMachineResourceChange.java
@@ -97,10 +97,6 @@ public class TestMachineResourceChange {
 
 	private void test(String testName) throws InterruptedException {
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// prepareCheckPointJVM() has an error message "CRIU is not enabled".
-			return;
-		}
 		CRIUTestUtils.showThreadCurrentTime("Before starting " + testName);
 		switch (testName) {
 		case "testVirtualThreadForkJoinPoolParallelism":

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeCheckpointException.java
@@ -77,10 +77,6 @@ public class TestSingleThreadModeCheckpointException {
 		CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeCheckpointExceptionJUCLock() before ReentrantLock.lock()");
 		jucLock.lock();
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 
 		try {
 			// ensure the lock already taken before performing a checkpoint
@@ -131,10 +127,6 @@ public class TestSingleThreadModeCheckpointException {
 				"testSingleThreadModeCheckpointExceptionSynLock() before synchronized on " + synLock);
 		synchronized (synLock) {
 			CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-			if (criu == null) {
-				// "CRIU is not enabled" is to appear and cause the test failure.
-				return;
-			}
 
 			try {
 				// ensure the lock already taken before performing a checkpoint

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestSingleThreadModeRestoreException.java
@@ -82,10 +82,6 @@ public class TestSingleThreadModeRestoreException {
 		CRIUTestUtils.showThreadCurrentTime("testSingleThreadModeRestoreExceptionJUCLock() before ReentrantLock.lock()");
 		jucLock.lock();
 		CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-		if (criu == null) {
-			// "CRIU is not enabled" is to appear and cause the test failure.
-			return;
-		}
 
 		try {
 			// ensure the lock already taken before performing a checkpoint
@@ -139,10 +135,6 @@ public class TestSingleThreadModeRestoreException {
 				"testSingleThreadModeRestoreExceptionSynLock() before synchronized on " + synLock);
 		synchronized (synLock) {
 			CRIUSupport criu = CRIUTestUtils.prepareCheckPointJVM(CRIUTestUtils.imagePath);
-			if (criu == null) {
-				// "CRIU is not enabled" is to appear and cause the test failure.
-				return;
-			}
 
 			try {
 				// ensure the lock already taken before performing a checkpoint


### PR DESCRIPTION
CRIU tests get accurate pre-checkpoint time

Use `CRIUTestUtils.prepareCheckPointJVM()` to avoid potential long disk file-related API calls before taking the pre-checkpoint time.

[100x grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/35917/console) - no failure reproduced, a few infra errors.

closes https://github.com/eclipse-openj9/openj9/issues/18384

Signed-off-by: Jason Feng <fengj@ca.ibm.com>