### PR TITLE
JDK22+ add Throwable.jfrTracing

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright IBM Corp. and others 1998
  *
@@ -54,6 +54,11 @@ import static com.ibm.oti.util.Util.appendLnTo;
  */
 public class Throwable implements java.io.Serializable {
 	private static final long serialVersionUID = -3042686055658047285L;
+
+	/*[IF JAVA_SPEC_VERSION >= 22]*/
+	// The default value is false, JFR is not supported.
+	static final boolean jfrTracing = false;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 	/**
 	 * The message provided when the exception was created.


### PR DESCRIPTION
`JDK22+` add `Throwable.jfrTracing`

close https://github.com/eclipse-openj9/openj9/issues/18427

Signed-off-by: Jason Feng <fengj@ca.ibm.com>