### PR TITLE
(0.41) Update OpenSSL with the fix for CVE-2023-5678

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -134,7 +134,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=3.0.12'
+  extra_getsource_options: '--openssl-version=openssl-3.0.12+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Cherry pick https://github.com/eclipse-openj9/openj9/pull/18423 for 0.41