### PR TITLE
Virtual Thread Support

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -40,12 +40,6 @@ extern "C" {
 
 #if JAVA_SPEC_VERSION >= 19
 extern J9JavaVM *BFUjavaVM;
-
-/* These come from jvm.c */
-extern IDATA (*f_monitorEnter)(omrthread_monitor_t monitor);
-extern IDATA (*f_monitorExit)(omrthread_monitor_t monitor);
-extern IDATA (*f_monitorWait)(omrthread_monitor_t monitor);
-extern IDATA (*f_monitorNotifyAll)(omrthread_monitor_t monitor);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 /* Define for debug

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -274,10 +274,10 @@ enterVThreadTransitionCritical(J9VMThread *currentThread, jobject thread)
 
 	while(!objectAccessBarrier.inlineMixedObjectCompareAndSwapU64(currentThread, threadObj, vm->virtualThreadInspectorCountOffset, 0, (U_64)-1)) {
 		/* Thread is being inspected or unmounted, wait. */
-		vmFuncs->internalExitVMToJNI(currentThread);
+		vmFuncs->internalReleaseVMAccess(currentThread);
 		VM_AtomicSupport::yieldCPU();
 		/* After wait, the thread may suspend here. */
-		vmFuncs->internalEnterVMFromJNI(currentThread);
+		vmFuncs->internalAcquireVMAccess(currentThread);
 		threadObj = J9_JNI_UNWRAP_REFERENCE(thread);
 	}
 }

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -209,11 +209,7 @@ typedef IDATA (*MonitorEnter)(omrthread_monitor_t monitor);
 typedef IDATA (*MonitorExit)(omrthread_monitor_t monitor);
 typedef IDATA (*MonitorInit)(omrthread_monitor_t* handle, UDATA flags, char* name);
 typedef IDATA (*MonitorDestroy)(omrthread_monitor_t monitor);
-typedef IDATA (*MonitorWait)(omrthread_monitor_t monitor);
-typedef IDATA (*MonitorWaitTimed)(omrthread_monitor_t monitor, I_64 millis, IDATA nanos);
-typedef IDATA (*MonitorNotify)(omrthread_monitor_t monitor);
-typedef IDATA (*MonitorNotifyAll)(omrthread_monitor_t monitor) ;
-typedef IDATA (* ThreadLibControl)(const char * key, UDATA value) ;
+typedef IDATA (* ThreadLibControl)(const char * key, UDATA value);
 typedef IDATA (*SetCategory)(omrthread_t thread, UDATA category, UDATA type);
 typedef IDATA (*LibEnableCPUMonitor)(omrthread_t thread);
 
@@ -270,12 +266,8 @@ static ThreadDetach f_threadDetach;
 /* Share these with the other *.c in the DLL */
 MonitorEnter f_monitorEnter;
 MonitorExit f_monitorExit;
-MonitorWait f_monitorWait;
-MonitorNotifyAll f_monitorNotifyAll;
 static MonitorInit f_monitorInit;
 static MonitorDestroy f_monitorDestroy;
-static MonitorWaitTimed f_monitorWaitTimed;
-static MonitorNotify f_monitorNotify;
 static PortInitLibrary portInitLibrary;
 static PortGetSize portGetSizeFn;
 static PortGetVersion portGetVersionFn;
@@ -1020,15 +1012,11 @@ preloadLibraries(void)
 	f_monitorExit = (MonitorExit) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_exit");
 	f_monitorInit = (MonitorInit) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_init_with_name");
 	f_monitorDestroy = (MonitorDestroy) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_destroy");
-	f_monitorWait = (MonitorWait) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_wait");
-	f_monitorWaitTimed = (MonitorWaitTimed) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_wait_timed");
-	f_monitorNotify = (MonitorNotify) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_notify");
-	f_monitorNotifyAll = (MonitorNotifyAll) GetProcAddress (threadDLL, (LPCSTR) "omrthread_monitor_notify_all");
 	f_threadLibControl = (ThreadLibControl) GetProcAddress (threadDLL, (LPCSTR) "omrthread_lib_control");
 	f_setCategory = (SetCategory) GetProcAddress (threadDLL, (LPCSTR) "omrthread_set_category");
 	f_libEnableCPUMonitor = (LibEnableCPUMonitor) GetProcAddress (threadDLL, (LPCSTR) "omrthread_lib_enable_cpu_monitor");
-	if (!f_threadGlobal || !f_threadAttachEx || !f_threadDetach || !f_monitorEnter || !f_monitorExit || !f_monitorInit || !f_monitorDestroy || !f_monitorWaitTimed
-		|| !f_monitorNotify || !f_monitorNotifyAll || !f_threadLibControl || !f_setCategory || !f_libEnableCPUMonitor || !f_monitorWait
+	if (!f_threadGlobal || !f_threadAttachEx || !f_threadDetach || !f_monitorEnter || !f_monitorExit || !f_monitorInit
+		|| !f_monitorDestroy || !f_threadLibControl || !f_setCategory || !f_libEnableCPUMonitor
 	) {
 		FreeLibrary(vmDLL);
 		FreeLibrary(threadDLL);
@@ -1451,15 +1439,11 @@ preloadLibraries(void)
 	f_monitorExit = (MonitorExit) dlsym (threadDLL, "omrthread_monitor_exit");
 	f_monitorInit = (MonitorInit) dlsym (threadDLL, "omrthread_monitor_init_with_name");
 	f_monitorDestroy = (MonitorDestroy) dlsym (threadDLL, "omrthread_monitor_destroy");
-	f_monitorWait = (MonitorWait) dlsym (threadDLL, "omrthread_monitor_wait");
-	f_monitorWaitTimed = (MonitorWaitTimed) dlsym (threadDLL, "omrthread_monitor_wait_timed");
-	f_monitorNotify = (MonitorNotify) dlsym (threadDLL, "omrthread_monitor_notify");
-	f_monitorNotifyAll = (MonitorNotifyAll) dlsym (threadDLL, "omrthread_monitor_notify_all");
 	f_threadLibControl = (ThreadLibControl) dlsym (threadDLL, "omrthread_lib_control");
 	f_setCategory = (SetCategory) dlsym (threadDLL, "omrthread_set_category");
 	f_libEnableCPUMonitor = (LibEnableCPUMonitor) dlsym (threadDLL, "omrthread_lib_enable_cpu_monitor");
-	if (!f_threadGlobal || !f_threadAttachEx || !f_threadDetach || !f_monitorEnter || !f_monitorExit || !f_monitorInit || !f_monitorDestroy || !f_monitorWaitTimed
-		|| !f_monitorNotify || !f_monitorNotifyAll || !f_threadLibControl || !f_setCategory || !f_libEnableCPUMonitor || !f_monitorWait
+	if (!f_threadGlobal || !f_threadAttachEx || !f_threadDetach || !f_monitorEnter || !f_monitorExit || !f_monitorInit
+		|| !f_monitorDestroy || !f_threadLibControl || !f_setCategory || !f_libEnableCPUMonitor
 	) {
 		dlclose(vmDLL);
 #ifdef J9ZOS390

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -539,10 +539,10 @@ retry:
 	vthreadInspectorCount = J9OBJECT_I64_LOAD(currentThread, threadObj, vm->virtualThreadInspectorCountOffset);
 	if (vthreadInspectorCount < 0) {
 		/* Thread is in transition, wait. */
-		vmFuncs->internalExitVMToJNI(currentThread);
+		vmFuncs->internalReleaseVMAccess(currentThread);
 		VM_AtomicSupport::yieldCPU();
 		/* After wait, the thread may suspend here. */
-		vmFuncs->internalEnterVMFromJNI(currentThread);
+		vmFuncs->internalAcquireVMAccess(currentThread);
 		if (spin) {
 			goto retry;
 		} else {


### PR DESCRIPTION
**1. Update acquireVThreadInspector and enterVThreadTransitionCritical**

VM is entered by the invocation of `internalEnterVMFromJNI`.
VM is exited by the invocation of `internalExitVMToJNI`.

VM is always entered before `acquireVThreadInspector` and
`enterVThreadTransitionCritical` are invoked.

In these functions, the goal can be achieved by just releasing
and re-acquiring VM access. The new changes just release and
re-acquire VM access instead of exiting and entering the VM.
This has less overhead.

Addresses: https://github.com/eclipse-openj9/openj9/pull/18420#issuecomment-1802476741

**2. Update error handling in JVMTI NotifyFramePop**

Return `JVMTI_ERROR_THREAD_NOT_SUSPENDED` if the thread was not
suspended and was not the current thread.

For virtual threads, `VirtualThread.state` is read and it is checked
if `JVMTI_VTHREAD_STATE_SUSPENDED` is set in `VirtualThread.state`.

This check is incorrect because `JVMTI_VTHREAD_STATE_SUSPENDED`
represents an internal state at the Java level. It does not
imply if the virtual thread is suspended through JVMTI.

JVMTI NotifyFramePop is updated to check if the virtual thread
is suspended through JVMTI.

**3. Remove unused variables in jvm.c**

This improves perf by saving the resources used to store and
initialize these variable.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>