### PR TITLE
Disable idiomRecognition on x86 for warm opt levels

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9149,6 +9149,21 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   {
                   options->setOption(TR_DisableStoreSinking);
                   }
+               // On x86, disable idiomRecognition for compilation at warm or below to save compilation time
+               // However, don't disable it for AOT compilations or precheckpoint or under -Xtune:throughput
+               if (TR::Compiler->target.cpu.isX86() &&
+                   options->getOptLevel() <= warm &&
+                   !vm->isAOT_DEPRECATED_DO_NOT_USE() &&
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+                  !(jitConfig->javaVM->internalVMFunctions->isNonPortableRestoreMode(vmThread) &&
+                    jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)) &&
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+                   TR::Options::getAggressivityLevel() != TR::Options::TR_AggresivenessLevel::AGGRESSIVE_THROUGHPUT)
+                  {
+                  static char *enableIdiomRecognitionAtWarm = feGetEnv("TR_EnableIdiomRecognitionAtWarm");
+                  if (!enableIdiomRecognitionAtWarm)
+                     options->setDisabled(OMR::idiomRecognition, true);
+                  }
                } // end of compilation strategy tweaks for Java
 
 


### PR DESCRIPTION
To save compilation time, this commit disables the idiomRecognition optimization on x86 for optimization levels "warm" and below. Performance experiments have shown that CPU consumed by compilation threads reduces by about 4% while there is no effect on throughput. This change can be disabled at runtime by defining the following environment variable: TR_EnableIdiomRecognitionAtWarm=1 The chage will not apply for AOT compilations, for compilations before CRIU checkpoint or under -Xtune:throughput mode.