### PR TITLE
Tolerate null in getLoaderNameID()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -720,6 +720,9 @@ final class Access implements JavaLangAccess {
 /*[IF JAVA_SPEC_VERSION >= 11]*/
 	@Override
 	public String getLoaderNameID(ClassLoader loader) {
+		if (loader == null) {
+			return "null";
+		}
 		StringBuilder buffer = new StringBuilder();
 		String name = loader.getName();
 


### PR DESCRIPTION
New tests were added in
* [8319436: Proxy.newProxyInstance throws NPE if loader is null and interface not visible from class loader](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/632f56c297a11578b8638460f63ba71a1928933a)

that will pass `null` to `getLoaderNameID()`; see [test/jdk/java/lang/reflect/Proxy/ClassRestrictions.java](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/632f56c297a11578b8638460f63ba71a1928933a/test/jdk/java/lang/reflect/Proxy/ClassRestrictions.java#L100).