### PR TITLE
Conform to pre JEP 274 for OpenJ9 MHs

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -688,7 +688,12 @@ public class MethodHandles {
 			 * callerClass is not the same as the lookup class.
 			 */
 			if (isWeakenedLookup() 
+			/*[IF JAVA_SPEC_VERSION >= 9]*/
+			// JEP 274
 			|| ((accessClass != callerClass) && !(declaringClass.isInterface() && declaringClass.isAssignableFrom(callerClass)))
+			/*[ELSE] JAVA_SPEC_VERSION >= 9*/
+			|| (accessClass != callerClass)
+			/*[ENDIF] JAVA_SPEC_VERSION >= 9*/
 			) {
 				/*[MSG "K0585", "{0} could not access {1} - private access required"]*/
 				throw new IllegalAccessException(com.ibm.oti.util.Msg.getString("K0585", accessClass.getName(), callerClass.getName())); //$NON-NLS-1$

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
@@ -2111,6 +2111,9 @@ public class LookupAPITests_Find {
 			Class<?> cls = CrossPackageDefaultMethodInterface.class;
 			MethodType mt = MethodType.methodType(int.class, int.class, int.class);
 			MethodHandles.lookup().findSpecial(cls, "addDefault", mt, cls);
+			if (VersionCheck.major() <= 8) {
+				Assert.fail("[Java 8-] IllegalAccessException not thrown ");
+			}
 		} catch (IllegalAccessException e) {
 			// JEP 274 is implemented from Java 9 onwards; Java 8 with OpenJDK MethodHandles
 			// expects an IllegalAccessException.


### PR DESCRIPTION
This patch closes eclipse-openj9/openj9#14987. OpenJ9 MHs' `checkSpecialAccess` incorrectly supported JEP 274 for all Java versions despite JEP 274 targeting Java 9+.

Closes: eclipse-openj9/openj9#14987
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>