### PR TITLE
UMA: Use DWARF version 4 on Linux

### DIFF
--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -254,6 +254,12 @@ ifdef j9vm_uma_gnuDebugSymbols
   <#if uma.spec.processor.x86 || uma.spec.processor.amd64>
     ASFLAGS += --gdwarf2
   </#if>
+
+  # Tell gcc to use DWARF version 4, not 5 (which is the default for compiler
+  # versions 11+). All GNU compiler versions, that might reasonably be used,
+  # understand these options, so this doesn't need to check the compiler version.
+  CFLAGS   += -gdwarf-4
+  CXXFLAGS += -gdwarf-4
 endif
 
 <#if uma.spec.processor.x86 || uma.spec.processor.amd64 || uma.spec.processor.riscv64>


### PR DESCRIPTION
This makes UMA builds consistent with cmake builds.