### PR TITLE
Fix string literal conversion warnings in compile and oti

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -444,7 +444,7 @@ J9::Compilation::isConverterMethod(TR::RecognizedMethod rm)
       case TR::sun_nio_cs_UTF_16_Encoder_encodeUTF16Little:
          return true;
       default:
-      	return false;
+         return false;
       }
 
    return false;
@@ -1526,33 +1526,33 @@ J9::Compilation::notYetRunMeansCold()
                              self()->getOptions()->getInitialBCount() :
                              self()->getOptions()->getInitialCount();
 
-    switch (currentMethod->getRecognizedMethod())
-       {
-       case TR::com_ibm_jit_DecimalFormatHelper_formatAsDouble:
-       case TR::com_ibm_jit_DecimalFormatHelper_formatAsFloat:
-          initialCount = 0;
-          break;
-       default:
-          break;
-       }
+   switch (currentMethod->getRecognizedMethod())
+      {
+      case TR::com_ibm_jit_DecimalFormatHelper_formatAsDouble:
+      case TR::com_ibm_jit_DecimalFormatHelper_formatAsFloat:
+         initialCount = 0;
+         break;
+      default:
+         break;
+      }
 
-    if (currentMethod->containingClass() == self()->getStringClassPointer())
-       {
-       if (currentMethod->isConstructor())
-          {
-          char *sig = currentMethod->signatureChars();
-          if (!strncmp(sig, "([CIIII)", 8) ||
-              !strncmp(sig, "([CIICII)", 9) ||
-              !strncmp(sig, "(II[C)", 6))
-             initialCount = 0;
-          }
-       else
-          {
-          char *sig = "isRepeatedCharCacheHit";
-          if (strncmp(currentMethod->nameChars(), sig, strlen(sig)) == 0)
-             initialCount = 0;
-          }
-       }
+   if (currentMethod->containingClass() == self()->getStringClassPointer())
+      {
+      if (currentMethod->isConstructor())
+         {
+         const char *sig = currentMethod->signatureChars();
+         if (!strncmp(sig, "([CIIII)", 8) ||
+             !strncmp(sig, "([CIICII)", 9) ||
+             !strncmp(sig, "(II[C)", 6))
+            initialCount = 0;
+         }
+      else
+         {
+         const char *sig = "isRepeatedCharCacheHit";
+         if (strncmp(currentMethod->nameChars(), sig, strlen(sig)) == 0)
+            initialCount = 0;
+         }
+      }
 
    if (
       self()->isDLT()

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -719,7 +719,14 @@ J9::SymbolReferenceTable::findOrCreateJavaLangReferenceReferentShadowSymbol(
 // Right now it only works for private fields or fields that are guaranteed to be accessed only from one class
 // because searchRecognizedField only does a name comparison, t does not work if the field is accessed from a subclass of the expected one
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, char* name)
+J9::SymbolReferenceTable::findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol *owningMethodSymbol,
+                                                      TR::Symbol::RecognizedField recognizedField,
+                                                      TR::DataType type,
+                                                      uint32_t offset,
+                                                      bool isVolatile,
+                                                      bool isPrivate,
+                                                      bool isFinal,
+                                                      const char *name)
    {
    TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -175,8 +175,8 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    //
    TR::SymbolReference * findOrCreateDispatchJ9MethodSymbolRef();
 
-   TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);
-   TR::SymbolReference * findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, char* name = NULL);
+   TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol *owningMethodSymbol, int32_t cpIndex, bool isStore);
+   TR::SymbolReference * findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, const char *name = NULL);
 
    /** \brief
     *     Returns a symbol reference for an entity not present in the constant pool.

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -136,7 +136,7 @@ typedef struct TR_JitPrivateConfig
    TR_YesNoMaybe aotValidHeader;
    void          (*j9jitrt_lock_log)(void *voidConfig);
    void          (*j9jitrt_unlock_log)(void *voidConfig);
-   int           (*j9jitrt_printf)(void *voidConfig, char *format, ...) ;
+   int           (*j9jitrt_printf)(void *voidConfig, const char *format, ...) ;
 
    // Runtime phase profiling buffer
    //
@@ -164,31 +164,31 @@ extern "C" {
 
    J9VMThread * getJ9VMThreadFromTR_VM(void * vm);
    J9JITConfig * getJ9JitConfigFromFE(void *vm);
-   TR::FILE *j9jit_fopen(char *fileName, const char *mode, bool useJ9IO);
+   TR::FILE *j9jit_fopen(const char *fileName, const char *mode, bool useJ9IO);
    void j9jit_fclose(TR::FILE *pFile);
    void j9jit_seek(void *voidConfig, TR::FILE *pFile, IDATA offset, I_32 whence);
    IDATA j9jit_read(void *voidConfig, TR::FILE *pFile, void *buf, IDATA nbytes);
    void j9jit_fflush(TR::FILE *pFile);
    void j9jit_lock_vlog(void *voidConfig);
    void j9jit_unlock_vlog(void *voidConfig);
-   void j9jit_printf(void *voidConfig, char *format, ...);
-   I_32 j9jit_vprintf(void *voidConfig, char *format, va_list args);
-   I_32 j9jit_fprintf(TR::FILE *pFile, char *format, ...);
-   I_32 j9jit_vfprintf(TR::FILE *pFile, char *format, va_list args);
+   void j9jit_printf(void *voidConfig, const char *format, ...);
+   I_32 j9jit_vprintf(void *voidConfig, const char *format, va_list args);
+   I_32 j9jit_fprintf(TR::FILE *pFile, const char *format, ...);
+   I_32 j9jit_vfprintf(TR::FILE *pFile, const char *format, va_list args);
 
    void j9jitrt_lock_log(void *voidConfig);
    void j9jitrt_unlock_log(void *voidConfig);
-   I_32 j9jitrt_printf(void *voidConfig, char *format, ...);
+   I_32 j9jitrt_printf(void *voidConfig, const char *format, ...);
 
-   I_32 j9jit_fopenName(char *fileName);
-   I_32 j9jit_fopen_existing(char *fileName);
-   I_32 j9jit_fmove(char * pathExist, char * pathNew);
+   I_32 j9jit_fopenName(const char *fileName);
+   I_32 j9jit_fopen_existing(const char *fileName);
+   I_32 j9jit_fmove(const char * pathExist, const char * pathNew);
    void j9jit_fcloseId(I_32 fileId);
    I_32 j9jit_fread(I_32 fd, void * buf, IDATA nbytes);
    I_32 j9jit_fseek(I_32 fd, I_32 whence);
    I_64 j9jit_time_current_time_millis();
-   I_32 j9jit_vfprintfId(I_32 fileId, char *format, ...);
-   I_32 j9jit_fprintfId(I_32 fileId, char *format, ...);
+   I_32 j9jit_vfprintfId(I_32 fileId, const char *format, ...);
+   I_32 j9jit_fprintfId(I_32 fileId, const char *format, ...);
 
    void jitHookClassLoadHelper(J9VMThread *vmThread,
                                J9JITConfig * jitConfig,

--- a/runtime/compiler/env/jitsupport.cpp
+++ b/runtime/compiler/env/jitsupport.cpp
@@ -79,7 +79,7 @@ I_32 j9jit_fread(I_32 fd, void * buf, IDATA nbytes)
    }
 
 
-I_32 j9jit_fmove(char * pathExist, char * pathNew)
+I_32 j9jit_fmove(const char *pathExist, const char *pathNew)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    I_32 fileId;
@@ -93,7 +93,7 @@ I_32 j9jit_fmove(char * pathExist, char * pathNew)
    }
 
 
-I_32 j9jit_fopen_existing(char *fileName)
+I_32 j9jit_fopen_existing(const char *fileName)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    I_32 fileId;
@@ -113,7 +113,7 @@ void j9jit_fcloseId(I_32 fileId)
    }
 
 
-I_32 j9jit_fopenName(char *fileName)
+I_32 j9jit_fopenName(const char *fileName)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    I_32 fileId;
@@ -127,7 +127,7 @@ I_32 j9jit_fopenName(char *fileName)
 
 
 TR::FILE *
-j9jit_fopen(char *fileName, const char *mode, bool useJ9IO)
+j9jit_fopen(const char *fileName, const char *mode, bool useJ9IO)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    TR::FILE *pFile;
@@ -232,7 +232,7 @@ void j9jitrt_unlock_log(void *voidConfig)
    }
 
 
-I_32 j9jit_vfprintfId(I_32 fileId, char *format, ...)
+I_32 j9jit_vfprintfId(I_32 fileId, const char *format, ...)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    char buf[512];
@@ -264,7 +264,7 @@ I_32 j9jit_vfprintfId(I_32 fileId, char *format, ...)
    }
 
 
-I_32 j9jit_fprintfId(I_32 fileId, char *format, ...)
+I_32 j9jit_fprintfId(I_32 fileId, const char *format, ...)
    {
    va_list args;
    va_start(args, format);
@@ -274,7 +274,7 @@ I_32 j9jit_fprintfId(I_32 fileId, char *format, ...)
    }
 
 
-I_32 j9jit_vfprintf(TR::FILE *pFile, char *format, va_list args)
+I_32 j9jit_vfprintf(TR::FILE *pFile, const char *format, va_list args)
    {
    PORT_ACCESS_FROM_PORT(TR::Compiler->portLib);
    const int32_t BUFSIZE = 640;
@@ -324,7 +324,7 @@ I_32 j9jit_vfprintf(TR::FILE *pFile, char *format, va_list args)
    }
 
 
-I_32 j9jit_fprintf(TR::FILE *pFile, char *format, ...)
+I_32 j9jit_fprintf(TR::FILE *pFile, const char *format, ...)
    {
    va_list args;
    va_start(args, format);
@@ -334,13 +334,13 @@ I_32 j9jit_fprintf(TR::FILE *pFile, char *format, ...)
    }
 
 
-static I_32 vlog_vprintf(J9JITConfig *config, char *format, va_list args)
+static I_32 vlog_vprintf(J9JITConfig *config, const char *format, va_list args)
    {
    return j9jit_vfprintf(((TR_JitPrivateConfig*)config->privateConfig)->vLogFile, format, args);
    }
 
 
-static I_32 vlog_printf(J9JITConfig *config, char *format, ...)
+static I_32 vlog_printf(J9JITConfig *config, const char *format, ...)
    {
    va_list args;
    va_start(args, format);
@@ -350,14 +350,14 @@ static I_32 vlog_printf(J9JITConfig *config, char *format, ...)
    }
 
 
-I_32 j9jit_vprintf(void *voidConfig, char *format, va_list args)
+I_32 j9jit_vprintf(void *voidConfig, const char *format, va_list args)
    {
    J9JITConfig *config = (J9JITConfig *) voidConfig;
    return vlog_vprintf(config, format, args);
    }
 
 
-void j9jit_printf(void *voidConfig, char *format, ...)
+void j9jit_printf(void *voidConfig, const char *format, ...)
    {
    va_list args;
    va_start(args, format);
@@ -366,13 +366,13 @@ void j9jit_printf(void *voidConfig, char *format, ...)
    }
 
 
-static I_32 rtlog_vprintf(J9JITConfig *config, char *format, va_list args)
+static I_32 rtlog_vprintf(J9JITConfig *config, const char *format, va_list args)
    {
    return j9jit_vfprintf(((TR_JitPrivateConfig*)config->privateConfig)->rtLogFile, format, args);
    }
 
 
-I_32 j9jitrt_printf(void *voidConfig, char *format, ...)
+I_32 j9jitrt_printf(void *voidConfig, const char *format, ...)
    {
    va_list args;
    va_start(args, format);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4055,7 +4055,7 @@ typedef struct J9JITConfig {
 	void  ( *jitFlushCompilationQueue)(struct J9VMThread * currentThread, J9JITFlushCompilationQueueReason reason) ;
 	void  ( *jitDecompileMethodForFramePop)(struct J9VMThread * currentThread, UDATA skipCount) ;
 	void  ( *jitExceptionCaught)(struct J9VMThread * currentThread) ;
-	void  ( *j9jit_printf)(void *voidConfig, char *format, ...) ;
+	void  ( *j9jit_printf)(void *voidConfig, const char *format, ...) ;
 	void* tracingHook;
 	void  ( *jitCheckScavengeOnResolve)(struct J9VMThread *currentThread) ;
 	void* jitInstanceOf;


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters in runtime/compiler/compile and `j9jit_printf` related functions.

This PR contributes to (but does not close) #14859