### PR TITLE
Update uses of Linker.Option.critical() in tests

### DIFF
--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
@@ -306,7 +306,7 @@ public class PrimitiveTypeTests1 {
 	public void test_validateTrivialOption_1() throws Throwable {
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT);
 		MemorySegment functionSymbol = nativeLibLookup.find("validateTrivialOption").get();
-		MethodHandle mh = linker.downcallHandle(functionSymbol, fd, Linker.Option.critical());
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd, Linker.Option.critical(false));
 		int result = (int)mh.invokeExact(111);
 		Assert.assertEquals(result, 111);
 	}

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests2.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests2.java
@@ -306,7 +306,7 @@ public class PrimitiveTypeTests2 {
 	public void test_validateTrivialOption_2() throws Throwable {
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT);
 		MemorySegment functionSymbol = nativeLibLookup.find("validateTrivialOption").get();
-		MethodHandle mh = linker.downcallHandle(fd, Linker.Option.critical());
+		MethodHandle mh = linker.downcallHandle(fd, Linker.Option.critical(false));
 		int result = (int)mh.invokeExact(functionSymbol, 111);
 		Assert.assertEquals(result, 111);
 	}

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/InvalidUpCallTests.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/InvalidUpCallTests.java
@@ -296,7 +296,7 @@ public class InvalidUpCallTests {
 
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_add2IntStructs_returnStruct,
-					FunctionDescriptor.of(structLayout, structLayout, structLayout), arena, Linker.Option.critical());
+					FunctionDescriptor.of(structLayout, structLayout, structLayout), arena, Linker.Option.critical(false));
 			fail("Failed to throw out IllegalArgumentException in the case of the invalid linker option for upcall.");
 		}
 	}
@@ -305,7 +305,7 @@ public class InvalidUpCallTests {
 	public void test_InvalidLinkerOptions_isTrivial_2() throws Throwable {
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
 		MemorySegment functionSymbol = nativeLibLookup.find("captureTrivialOptionByUpcallMH").get();
-		MethodHandle mh = linker.downcallHandle(functionSymbol, fd, Linker.Option.critical());
+		MethodHandle mh = linker.downcallHandle(functionSymbol, fd, Linker.Option.critical(false));
 
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment upcallFuncAddr = linker.upcallStub(UpcallMethodHandles.MH_captureTrivialOption,


### PR DESCRIPTION
A parameter was added in
* [8254693: Add Panama feature to pass heap segments to native code](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/3c1c081e4410d872bea0caabf5556eba111befcd)