### PR TITLE
Make java.lang.Thread.container a known field

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -846,25 +846,12 @@ getVirtualThreadState(J9VMThread *currentThread, jthread thread)
 				break;
 			case JVMTI_VTHREAD_STATE_STARTED:
 			{
-				JNIEnv *env = (JNIEnv *)currentThread;
-				jfieldID fid = NULL;
-				jclass jlThread = NULL;
-
-				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
-				jlThread = env->FindClass("java/lang/Thread");
-				if (NULL != jlThread) {
-					fid = env->GetFieldID(jlThread, "container", "Ljdk/internal/vm/ThreadContainer;");
-				}
-				if ((NULL != fid)
-					&& (NULL == env->GetObjectField(thread, fid))
-				) {
+				j9object_t threadContainer = J9VMJAVALANGTHREAD_CONTAINER(currentThread, vThreadObject);
+				if (NULL == threadContainer) {
 					rc = JVMTI_JAVA_LANG_THREAD_STATE_NEW;
 				} else {
 					rc = JVMTI_JAVA_LANG_THREAD_STATE_RUNNABLE;
 				}
-				vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-				/* Re-fetch object to correctly set the isSuspendedInternal field. */
-				vThreadObject = J9_JNI_UNWRAP_REFERENCE(thread);
 				break;
 			}
 			case JVMTI_VTHREAD_STATE_RUNNABLE:

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -247,6 +247,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<!-- Field references for Java 19 Virtual Thread. -->
 	<fieldref class="java/lang/Thread" name="cont" signature="Ljdk/internal/vm/Continuation;" versions="19-"/>
 	<fieldref class="java/lang/Thread" name="holder" signature="Ljava/lang/Thread$FieldHolder;" versions="19-"/>
+	<fieldref class="java/lang/Thread" name="container" signature="Ljdk/internal/vm/ThreadContainer;" versions="19-"/>
 	<fieldref class="java/lang/Thread$FieldHolder" name="daemon" signature="Z" versions="19-"/>
 	<fieldref class="java/lang/Thread$FieldHolder" name="group" signature="Ljava/lang/ThreadGroup;" versions="19-"/>
 	<fieldref class="java/lang/Thread$FieldHolder" name="priority" signature="I" versions="19-"/>


### PR DESCRIPTION
`java.lang.Thread.container` is added in `vmconstantpool.xml`.

Accessing `java.lang.Thread.container` as a known field simplifies
and fixes the incorrect error handling in `getVirtualThreadState`.
