### PR TITLE
Fix string literal conversion warnings in codegen and il

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -490,7 +490,7 @@ static const char* getOpCodeName(TR::ILOpCodes opcode) {
 }
 
 
-char *nvvmTypeNames[TR::NumOMRTypes] =
+const char *nvvmTypeNames[TR::NumOMRTypes] =
    {
    "void",    // TR::NoType
    "i8",      // TR::Int8
@@ -515,7 +515,7 @@ static const char* getTypeName(TR::DataType type) {
        }
 }
 
-char *nvvmVarTypeNames[TR::NumOMRTypes] =
+const char *nvvmVarTypeNames[TR::NumOMRTypes] =
    {
    "void",    // TR::NoType
    "i8",      // TR::Int8
@@ -572,7 +572,7 @@ class NVVMIRBuffer
       buffer = (char*)m->allocateHeapMemory(size);
       s = buffer;
       }
-   void print(char *format, ...)
+   void print(const char *format, ...)
       {
       va_list args;
       va_start (args, format);
@@ -671,7 +671,7 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
       }
    }
 
-char* getNVVMMathFunctionName(TR::Node *node)
+const char* getNVVMMathFunctionName(TR::Node *node)
    {
    switch (((TR::MethodSymbol*)node->getSymbolReference()->getSymbol())->getRecognizedMethod())
       {
@@ -1121,7 +1121,7 @@ bool isThisPointer(TR::SymbolReference * symRef)
           ((TR::ParameterSymbol *)symRef->getSymbol())->getSlot() == 0;
    }
 
-char * getTypeNameFromSignature(char* sig, int32_t sigLength)
+const char *getTypeNameFromSignature(char* sig, int32_t sigLength)
    {
    TR_ASSERT(sigLength == 2 && sig[0] == '[', "only handling static shared arrays");
    switch (sig[1])

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1350,7 +1350,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
    //Anchoring node to either extract register pressure(performance)
    //or ensure instanceof doesn't have a parent node of CALL (correctness)
    //
-   char *anchoringReason = "register hog";
+   const char *anchoringReason = "register hog";
    switch (node->getOpCodeValue())
       {
       // Extract heavy register pressure trees when dictated at the start of the walk
@@ -2977,7 +2977,7 @@ void J9::CodeGenerator::addExternalRelocation(TR::Relocation *r, TR::RelocationD
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 void J9::CodeGenerator::addProjectSpecializedRelocation(uint8_t *location, uint8_t *target, uint8_t *target2,
-      TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
+      TR_ExternalRelocationTargetKind kind, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    (target2 == NULL) ?
          self()->addExternalRelocation(
@@ -3002,7 +3002,7 @@ void J9::CodeGenerator::addProjectSpecializedRelocation(uint8_t *location, uint8
    }
 
 void J9::CodeGenerator::addProjectSpecializedRelocation(TR::Instruction *instr, uint8_t *target, uint8_t *target2,
-      TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
+      TR_ExternalRelocationTargetKind kind, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    (target2 == NULL) ?
          self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(instr, target, kind, self()),
@@ -3012,7 +3012,7 @@ void J9::CodeGenerator::addProjectSpecializedRelocation(TR::Instruction *instr, 
    }
 
 void J9::CodeGenerator::addProjectSpecializedPairRelocation(uint8_t *location, uint8_t *location2, uint8_t *target,
-      TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
+      TR_ExternalRelocationTargetKind kind, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(location, location2, target, kind, self()),
          generatingFileName, generatingLineNumber, node);

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -158,7 +158,7 @@ public:
                                           uint8_t *target,
                                           uint8_t *target2,  //pass in NULL when no target2
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node);
    //TR::ExternalOrderedPair32BitRelocation
@@ -166,7 +166,7 @@ public:
                                           uint8_t *location2,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node);
    //TR::BeforeBinaryEncodingExternalRelocation
@@ -174,7 +174,7 @@ public:
                                           uint8_t *target,
                                           uint8_t *target2,   //pass in NULL when no target2
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node);
 

--- a/runtime/compiler/il/J9DataTypes.cpp
+++ b/runtime/compiler/il/J9DataTypes.cpp
@@ -147,7 +147,7 @@ const int32_t packedDecimalPrecisionToByteLengthMap[TR_MAX_DECIMAL_PRECISION+1]
 
 
 
-char *J9::DataType::_TR_RawBCDSignCodeNames[num_raw_bcd_sign_codes] =
+const char *J9::DataType::_TR_RawBCDSignCodeNames[num_raw_bcd_sign_codes] =
    {
    "raw_bcd_sign_unknown",
    "0xc",
@@ -163,7 +163,7 @@ int32_t J9::DataType::_TR_RawBCDSignCodeValues[num_raw_bcd_sign_codes] =
    0xf,                                  // raw_bcd_sign_0xf
    };
 
-char *J9::DataType::_TR_BCDSignCodeNames[num_bcd_sign_codes] =
+const char *J9::DataType::_TR_BCDSignCodeNames[num_bcd_sign_codes] =
    {
    "bcd_sign_unknown",
    "plus",

--- a/runtime/compiler/il/J9DataTypes.hpp
+++ b/runtime/compiler/il/J9DataTypes.hpp
@@ -248,20 +248,20 @@ public:
       return bcd_invalid_sign;
       }
 
-   static char *getName(TR_RawBCDSignCode s)
+   static const char *getName(TR_RawBCDSignCode s)
       {
       if (s < num_raw_bcd_sign_codes)
          return _TR_RawBCDSignCodeNames[s];
       else
-         return (char*)"unknown raw sign";
+         return "unknown raw sign";
       }
 
-   static char *getName(TR_BCDSignCode s)
+   static const char *getName(TR_BCDSignCode s)
       {
       if (s < num_bcd_sign_codes)
          return _TR_BCDSignCodeNames[s];
       else
-         return (char*)"unknown bcd sign";
+         return "unknown bcd sign";
       }
 
    static int32_t getValue(TR_RawBCDSignCode s)
@@ -345,9 +345,9 @@ public:
    static bool normalizedSignIsNegative(TR::DataType dt, TR_BCDSignCode normalizedSign);
 
 private:
-   static char*         _TR_RawBCDSignCodeNames[num_raw_bcd_sign_codes];
-   static int32_t       _TR_RawBCDSignCodeValues[num_raw_bcd_sign_codes];
-   static char*         _TR_BCDSignCodeNames[num_bcd_sign_codes];
+   static const char* _TR_RawBCDSignCodeNames[num_raw_bcd_sign_codes];
+   static int32_t     _TR_RawBCDSignCodeValues[num_raw_bcd_sign_codes];
+   static const char* _TR_BCDSignCodeNames[num_bcd_sign_codes];
    };
 
 }

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -202,7 +202,7 @@ J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * ow
       int32_t  totalLen;
       char    *fieldName;
       fieldName = owningMethod->staticName(cpIndex, totalLen, comp->trMemory());  // totalLen = strlen("<class>" + "<field>" + "<sig>") + 3
-      static char *assertionsDisabledStr = "$assertionsDisabled Z";
+      static const char *assertionsDisabledStr = "$assertionsDisabled Z";
       //string will be of the form "<class>.$assertionsDisabled Z"
       if (declaringClass
           && totalLen >= 22

--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -72,7 +72,7 @@ SymbolReference::SymbolReference(
    }
 
 
-static char * dataTypeToSig[] = {0,"B","Z","C","S","I","J","F","D",0,0,0};
+static const char *dataTypeToSig[] = {0, "B", "Z", "C", "S", "I", "J", "F", "D", 0, 0, 0};
 
 /**
  * This method is used when _cpIndex is to be used for resolution.

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -301,17 +301,17 @@ class TR_RelocationRuntime {
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual OMRProcessorDesc getProcessorDescriptionFromSCC(J9VMThread *curThread);
 
-      static uintptr_t    getGlobalValue(uint32_t g)
+      static uintptr_t   getGlobalValue(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          return _globalValueList[g];
          }
-      static void         setGlobalValue(uint32_t g, uintptr_t v)
+      static void        setGlobalValue(uint32_t g, uintptr_t v)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          _globalValueList[g] = v;
          }
-      static const char *       nameOfGlobal(uint32_t g)
+      static const char *nameOfGlobal(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          return _globalValueNames[g];
@@ -385,10 +385,10 @@ class TR_RelocationRuntime {
       TR_AotRelocationCleanUp _relocationStatus;
       void relocationFailureCleanup();
 
-      static bool       _globalValuesInitialized;
-      static uintptr_t  _globalValueList[TR_NumGlobalValueItems];
-      static uint8_t    _globalValueSizeList[TR_NumGlobalValueItems];
-      static const char      *_globalValueNames[TR_NumGlobalValueItems];
+      static bool        _globalValuesInitialized;
+      static uintptr_t   _globalValueList[TR_NumGlobalValueItems];
+      static uint8_t     _globalValueSizeList[TR_NumGlobalValueItems];
+      static const char *_globalValueNames[TR_NumGlobalValueItems];
 
       TR_RelocationErrorCode _reloErrorCode;
       static const char *_reloErrorCodeNames[];


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to `(char *)`) in runtime/compiler/codegen and runtime/compiler/il.

This PR contributes to (but does not close) #14859

**This PR must be merged in coordination with https://github.com/eclipse/omr/pull/7185**