### PR TITLE
Remove Object.wait(timeout) tests

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
@@ -34,15 +34,8 @@ public class ElapsedTime {
 
 	private static void testElapsedTime() throws InterruptedException {
 		TimeUtilities tu = new TimeUtilities();
-		final Object dummy = new Object();
 		long millisTimeStart = System.currentTimeMillis();
 		long nanoTimeStart = System.nanoTime();
-
-		synchronized (dummy) {
-			dummy.wait(100);
-		}
-		AssertJUnit.assertTrue(
-				tu.checkElapseTime("testElapsedTime() wait 100ms", millisTimeStart, nanoTimeStart, 100, 800, 100, 800));
 
 		millisTimeStart = System.currentTimeMillis();
 		nanoTimeStart = System.nanoTime();

--- a/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortableJDK11Up.xml
@@ -82,7 +82,7 @@
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
 
-  <test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedNoNanoSecond">
+  <!-- test id="Create CRIU checkpoint image and restore once - testObjectWaitTimedNoNanoSecond">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $TRACECRIU$ $EXPORTS$" "$MAINCLASS_TIMEOUTADJUSTMENT$ testObjectWaitTimedNoNanoSecond" 1 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">PASSED: expected wait time</output>
     <output type="required" caseSensitive="no" regex="no">Killed</output>
@@ -91,11 +91,9 @@
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: expected wait time</output>
     <output type="failure" caseSensitive="yes" regex="no">InterruptedException</output>
-    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
-    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
@@ -109,12 +107,10 @@
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <output type="failure" caseSensitive="yes" regex="no">FAILED: expected wait time</output>
     <output type="failure" caseSensitive="yes" regex="no">InterruptedException</output>
-    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
     <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
     <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
     <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
-    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
     <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
-  </test>
+  </test -->
 </suite>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -116,15 +116,8 @@ public class TimeChangeTest {
 		}
 		CRIUTestUtils.showThreadCurrentTime("testTimeCompensation() starts");
 		final TimeUtilities tu = new TimeUtilities();
-		final Object dummy = new Object();
 		long millisTimeStart = System.currentTimeMillis();
 		long nanoTimeStart = System.nanoTime();
-
-		synchronized (dummy) {
-			dummy.wait(100);
-		}
-		TimeUtilities.checkElapseTime("testTimeCompensation() wait 100ms", millisTimeStart, nanoTimeStart, 100, 800,
-				100, 800);
 
 		millisTimeStart = System.currentTimeMillis();
 		nanoTimeStart = System.nanoTime();


### PR DESCRIPTION
Remove `Object.wait(timeout)` tests

The spurious wakeup breaks the time measurement.

close https://github.com/eclipse-openj9/openj9/issues/18456

Signed-off-by: Jason Feng <fengj@ca.ibm.com>