### PR TITLE
Fix string literal conversion warnings in env

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -790,8 +790,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto &className = std::get<0>(recv);
          auto &methodName = std::get<1>(recv);
          auto &signature = std::get<2>(recv);
-         client->write(response, fe->getMethodFromName(const_cast<char *>(className.data()), const_cast<char *>(methodName.data()),
-                                                       const_cast<char *>(signature.data())));
+         client->write(response, fe->getMethodFromName(className.data(), methodName.data(),
+                                                       signature.data()));
          }
          break;
       case MessageType::VM_getMethodFromClass:
@@ -801,8 +801,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto &methodName = std::get<1>(recv);
          auto &signature = std::get<2>(recv);
          TR_OpaqueClassBlock *callingClass = std::get<3>(recv);
-         client->write(response, fe->getMethodFromClass(methodClass, const_cast<char *>(methodName.data()),
-                                                        const_cast<char *>(signature.data()), callingClass));
+         client->write(response, fe->getMethodFromClass(methodClass, methodName.data(),
+                                                        signature.data(), callingClass));
          }
          break;
       case MessageType::VM_createMethodHandleArchetypeSpecimen:

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -516,7 +516,7 @@ class TR_PersistentFieldInfo : public TR_Link<TR_PersistentFieldInfo>
                           int32_t sigLength = -1,
                           TR_PersistentFieldInfo *next = NULL,
                           uint8_t b = VALID_BUT_NOT_ALWAYS_INITIALIZED,
-                          char *c = 0,
+                          const char *c = 0,
                           int32_t numChars = -1)
 
       : TR_Link<TR_PersistentFieldInfo>(next),
@@ -705,7 +705,7 @@ class TR_PersistentArrayFieldInfo : public TR_PersistentFieldInfo
                                int32_t *dimensionInfo = NULL,
                                uint8_t b1 = VALID_BUT_NOT_ALWAYS_INITIALIZED,
                                uint8_t b2 = VALID_BUT_NOT_ALWAYS_INITIALIZED,
-                               char *c = "",
+                               const char *c = "",
                                int32_t numChars = -1)
       : TR_PersistentFieldInfo(sig, sigLength, next, b2, c, numChars),
         _numDimensions(numDimensions),

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -73,7 +73,7 @@ TR_MHJ2IThunk::allocate(
    }
 
 
-TR_MHJ2IThunkTable::TR_MHJ2IThunkTable(TR_PersistentMemory *m, char *name):
+TR_MHJ2IThunkTable::TR_MHJ2IThunkTable(TR_PersistentMemory *m, const char *name):
    _name(name),
    _monitor(TR::Monitor::create(name)),
    _nodes(m)

--- a/runtime/compiler/env/J2IThunk.hpp
+++ b/runtime/compiler/env/J2IThunk.hpp
@@ -94,7 +94,7 @@ class TR_MHJ2IThunkTable
 
    private: // Fields
 
-   char *_name;
+   const char *_name;
    TR::Monitor *_monitor;
    TR_PersistentArray<Node> _nodes;
 
@@ -116,7 +116,7 @@ class TR_MHJ2IThunkTable
    int16_t terseSignatureLength(char *signature);
    void getTerseSignature(char *buf, int16_t bufLength, char *signature);
 
-   TR_MHJ2IThunkTable(TR_PersistentMemory *m, char *name);
+   TR_MHJ2IThunkTable(TR_PersistentMemory *m, const char *name);
    TR_PERSISTENT_ALLOC(TR_Memory::JSR292)
 
    void dumpTo(TR_FrontEnd *fe, TR::FILE *file);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -194,7 +194,7 @@ TR_J9SharedCache::getCacheDescriptorList()
    }
 
 void
-TR_J9SharedCache::log(char *format, ...)
+TR_J9SharedCache::log(const char *format, ...)
    {
    PORT_ACCESS_FROM_PORT(_javaVM->portLibrary);
    char outputBuffer[512] = "TR_J9SC:";

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -381,7 +381,7 @@ private:
 
    TR_AOTStats *aotStats() { return _aotStats; }
 
-   void log(char *format, ...);
+   void log(const char *format, ...);
 
    SCCHint getHint(J9VMThread * vmThread, J9Method *method);
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4247,10 +4247,10 @@ TR_J9VMBase::persistMHJ2IThunk(void *thunk)
    }
 
 static char *
-getJ2IThunkSignature(char *invokeHandleSignature, uint32_t signatureLength, int argsToSkip, char *description, TR::Compilation *comp)
+getJ2IThunkSignature(char *invokeHandleSignature, uint32_t signatureLength, int argsToSkip, const char *description, TR::Compilation *comp)
    {
    char *argsToCopy;
-   for (argsToCopy = invokeHandleSignature+1; argsToSkip > 0; argsToSkip--)
+   for (argsToCopy = invokeHandleSignature + 1; argsToSkip > 0; argsToSkip--)
       argsToCopy = nextSignatureArgument(argsToCopy);
    uint32_t lengthToCopy = signatureLength - (argsToCopy - invokeHandleSignature);
 
@@ -4263,7 +4263,7 @@ getJ2IThunkSignature(char *invokeHandleSignature, uint32_t signatureLength, int 
    }
 
 static TR::Node *
-getEquivalentVirtualCallNode(TR::Node *callNode, int argsToSkip, char *description, TR::Compilation *comp)
+getEquivalentVirtualCallNode(TR::Node *callNode, int argsToSkip, const char *description, TR::Compilation *comp)
    {
    TR::Node *j2iThunkCall = TR::Node::createWithSymRef(callNode, callNode->getOpCodeValue(), callNode->getNumChildren() - argsToSkip + 1, callNode->getSymbolReference());
    j2iThunkCall->setChild(0, callNode->getFirstChild()); // first child should be vft pointer but we don't have one
@@ -4400,7 +4400,7 @@ TR_J9VMBase::mutableCallSite_findOrCreateBypassLocation(uintptr_t mutableCallSit
    return mutableCallSite_bypassLocation(mutableCallSite);
    }
 
-static TR_OpaqueMethodBlock *findClosestArchetype(TR_OpaqueClassBlock *clazz, char *name, char *signature, char *currentArgument, TR_FrontEnd *fe, J9VMThread *vmThread)
+static TR_OpaqueMethodBlock *findClosestArchetype(TR_OpaqueClassBlock *clazz, const char *name, const char *signature, char *currentArgument, TR_FrontEnd *fe, J9VMThread *vmThread)
    {
    // NOTE: signature will be edited in-place
 
@@ -4457,7 +4457,7 @@ static TR_OpaqueMethodBlock *findClosestArchetype(TR_OpaqueClassBlock *clazz, ch
    }
 
 TR_OpaqueMethodBlock *
-TR_J9VMBase::lookupArchetype(TR_OpaqueClassBlock *clazz, char *name, char *signature)
+TR_J9VMBase::lookupArchetype(TR_OpaqueClassBlock *clazz, const char *name, const char *signature)
    {
    // Find the best match for the signature.  Start by appending an "I"
    // placeholder argument.  findClosestArchetype will progressively truncate
@@ -4583,15 +4583,14 @@ TR::KnownObjectTable::Index TR_J9VMBase::mutableCallSiteEpoch(TR::Compilation *c
    if (knot == NULL)
       return TR::KnownObjectTable::UNKNOWN;
 
-   // getVolatileReferenceField() doesn't accept const char*
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-   char *fieldName = "target"; // There is no separate epoch field.
-#else
-   char *fieldName = "epoch";
-#endif
-
+   // There is no separate epoch field
    uintptr_t mh = getVolatileReferenceField(
-      mutableCallSite, fieldName, "Ljava/lang/invoke/MethodHandle;");
+      mutableCallSite, "target", "Ljava/lang/invoke/MethodHandle;");
+#else
+   uintptr_t mh = getVolatileReferenceField(
+      mutableCallSite, "epoch", "Ljava/lang/invoke/MethodHandle;");
+#endif
 
    return mh == 0 ? TR::KnownObjectTable::UNKNOWN : knot->getOrCreateIndex(mh);
    }
@@ -5035,7 +5034,7 @@ TR_J9VMBase::getVMIndexOffset()
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 TR::KnownObjectTable::Index
-TR_J9VMBase::getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName)
+TR_J9VMBase::getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, const char *fieldName)
    {
    TR::VMAccessCriticalSection dereferenceKnownObjectField(this);
    TR::KnownObjectTable *knot = comp->getKnownObjectTable();
@@ -5974,7 +5973,7 @@ void revertMethodToInterpreted(J9Method * method)
 
 struct TrustedClass
    {
-   char   * name;
+   const char   * name;
    int32_t length;
    int32_t argNum;
    };
@@ -6324,7 +6323,7 @@ TR_J9VMBase::getBytecodePC(TR_OpaqueMethodBlock *method, TR_ByteCodeInfo &bcInfo
 //whose signatures are given in methodSig. methodCount is the number of methods.
 //Returns the number of methods found in the class
 //This function handles static and virtual functions only.
-int TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* classSig, char** methodSig, TR::SymbolReference** symRefs, int methodCount)
+int TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *classSig, const char **methodSig, TR::SymbolReference **symRefs, int methodCount)
    {
    TR_OpaqueClassBlock *c = getClassFromSignature(classSig,
                                                   strlen(classSig),
@@ -6389,7 +6388,7 @@ int TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMet
 //Given a class signature and a method signature returns a symref for that method.
 //If the method is not resolved or doesn't exist in that class, it returns NULL
 //This function handles static and virtual functions only.
-TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* classSig, char* methodSig)
+TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *classSig, const char *methodSig)
    {
    TR::SymbolReference* symRef = NULL;
    int numMethodsFound = findOrCreateMethodSymRef(comp, owningMethodSym, classSig, &methodSig, &symRef, 1);
@@ -6400,15 +6399,15 @@ TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp
 //returns a symref for that method. If the method is not resolved or doesn't exist
 //in that class, it returns NULL
 //This function handles static and virtual functions only.
-TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* methodSig) {
+TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *methodSig) {
    int methodSigLen = strlen(methodSig);
-   char* classSig = (char*)comp->trMemory()->allocateStackMemory(sizeof(char)*methodSigLen);
-   char* separator = strchr(methodSig, '.');
+   char *classSig = (char *)comp->trMemory()->allocateStackMemory(sizeof(char) * methodSigLen);
+   const char *separator = strchr(methodSig, '.');
    TR_ASSERT(separator, ". not found in method name");
    int classSigLen = separator - methodSig;
    strncpy(classSig, methodSig, classSigLen);
    classSig[classSigLen] = 0;
-   TR::SymbolReference* result = findOrCreateMethodSymRef(comp, owningMethodSym, classSig, methodSig);
+   TR::SymbolReference *result = findOrCreateMethodSymRef(comp, owningMethodSym, classSig, methodSig);
    return result;
 }
 
@@ -6416,7 +6415,7 @@ TR::SymbolReference* TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp
 //gives symrefs for those methods. The number of input methods are given in methodCount.
 //The function returns the number of methods found
 //this function handles static and virtual functions only
-int TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char** methodSig, TR::SymbolReference** symRefs, int methodCount) {
+int TR_J9VMBase::findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char **methodSig, TR::SymbolReference **symRefs, int methodCount) {
    int numMethodsFound = 0;
    for (int i = 0; i < methodCount; i++) {
       if (!methodSig[i]) continue;
@@ -6786,7 +6785,7 @@ TR_J9VMBase::getClassFlagsValue(TR_OpaqueClassBlock * classPointer)
 #define LOOKUP_OPTION_NO_THROW 8192
 
 TR_OpaqueMethodBlock *
-TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature)
+TR_J9VM::getMethodFromName(const char *className, const char *methodName, const char *signature)
    {
    TR::VMAccessCriticalSection getMethodFromName(this);
    TR_OpaqueClassBlock *methodClass = getSystemClassFromClassName(className, strlen(className), true);
@@ -6820,7 +6819,7 @@ TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature)
  *     Only methods visible to the callingClass will be returned.
  */
 TR_OpaqueMethodBlock *
-TR_J9VMBase::getMethodFromClass(TR_OpaqueClassBlock * methodClass, char * methodName, char * signature, TR_OpaqueClassBlock * callingClass)
+TR_J9VMBase::getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass)
    {
    J9JNINameAndSignature nameAndSig;
    nameAndSig.name = methodName;

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -162,7 +162,7 @@ TR_StaticFinalData
 extern "C" {
 #endif
 
-   J9VMThread * getJ9VMThreadFromTR_VM(void * vm);
+   J9VMThread * getJ9VMThreadFromTR_VM(void *vm);
    J9JITConfig * getJ9JitConfigFromFE(void *vm);
    TR::FILE *j9jit_fopen(const char *fileName, const char *mode, bool useJ9IO);
    void j9jit_fclose(TR::FILE *pFile);
@@ -184,15 +184,15 @@ extern "C" {
    I_32 j9jit_fopen_existing(const char *fileName);
    I_32 j9jit_fmove(const char * pathExist, const char * pathNew);
    void j9jit_fcloseId(I_32 fileId);
-   I_32 j9jit_fread(I_32 fd, void * buf, IDATA nbytes);
+   I_32 j9jit_fread(I_32 fd, void *buf, IDATA nbytes);
    I_32 j9jit_fseek(I_32 fd, I_32 whence);
    I_64 j9jit_time_current_time_millis();
    I_32 j9jit_vfprintfId(I_32 fileId, const char *format, ...);
    I_32 j9jit_fprintfId(I_32 fileId, const char *format, ...);
 
    void jitHookClassLoadHelper(J9VMThread *vmThread,
-                               J9JITConfig * jitConfig,
-                               J9Class * cl,
+                               J9JITConfig *jitConfig,
+                               J9Class *cl,
                                TR::CompilationInfo *compInfo,
                                UDATA *classLoadEventFailed);
 
@@ -297,15 +297,15 @@ public:
 
    virtual TR::DataType dataTypeForLoadOrStore(TR::DataType dt) { return (dt == TR::Int8 || dt == TR::Int16) ? TR::Int32 : dt; }
 
-   static bool createGlobalFrontEnd(J9JITConfig * jitConfig, TR::CompilationInfo * compInfo);
+   static bool createGlobalFrontEnd(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
    static TR_J9VMBase * get(J9JITConfig *, J9VMThread *, VM_TYPE vmType=DEFAULT_VM);
    static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, size_t, char *, char *, bool suffix=false);
 
    int32_t *getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, bool isVettedForAOT);
-   virtual bool stringEquals(TR::Compilation * comp, uintptr_t* stringLocation1, uintptr_t* stringLocation2, int32_t& result);
-   virtual bool getStringHashCode(TR::Compilation * comp, uintptr_t* stringLocation, int32_t& result);
+   virtual bool stringEquals(TR::Compilation *comp, uintptr_t *stringLocation1, uintptr_t *stringLocation2, int32_t &result);
+   virtual bool getStringHashCode(TR::Compilation *comp, uintptr_t *stringLocation, int32_t &result);
 
-   virtual bool isThunkArchetype(J9Method * method);
+   virtual bool isThunkArchetype(J9Method *method);
 
    J9VMThread * vmThread();
 
@@ -315,22 +315,22 @@ public:
    bool fsdIsEnabled() { return _flags.testAny(FSDIsEnabled); }
    void setFSDIsEnabled(bool b) { _flags.set(FSDIsEnabled, b); }
 
-   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, const char * sig)
+   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName, const char *sig)
       {
       return getInstanceFieldOffset(classPointer, fieldName, (uint32_t)strlen(fieldName), sig, (uint32_t)strlen(sig));
       }
-   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, const char * sig, uintptr_t options)
+   uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName, const char *sig, uintptr_t options)
       {
       return getInstanceFieldOffset(classPointer, fieldName, (uint32_t)strlen(fieldName), sig, (uint32_t)strlen(sig), options);
       }
 
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName,
-                                                     uint32_t fieldLen, const char * sig, uint32_t sigLen, UDATA options);
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName,
-                                                     uint32_t fieldLen, const char * sig, uint32_t sigLen);
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName,
+                                                     uint32_t fieldLen, const char *sig, uint32_t sigLen, UDATA options);
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName,
+                                                     uint32_t fieldLen, const char *sig, uint32_t sigLen);
 
    // Not implemented
-   virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *) { return 0; }
+   virtual TR_ResolvedMethod *getObjectNewInstanceImplMethod(TR_Memory *) { return 0; }
 
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) = 0;
 
@@ -405,9 +405,9 @@ protected:
    bool isAotResolvedVirtualDispatchGuaranteed(TR::Compilation *comp);
 
 public:
-   virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL);
+   virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *, const char *, const char *, TR_OpaqueClassBlock * = NULL);
 
-   TR_OpaqueMethodBlock * getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature, bool validate = true);
+   TR_OpaqueMethodBlock *getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock *classPointer, const char* methodName, const char *signature, bool validate = true);
 
    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
    /**
@@ -428,11 +428,11 @@ public:
 
    TR_OpaqueMethodBlock *getResolvedInterfaceMethod(J9ConstantPool *ownerCP, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
 
-   uintptr_t getReferenceField(uintptr_t objectPointer, char *fieldName, char *fieldSignature)
+   uintptr_t getReferenceField(uintptr_t objectPointer, const char *fieldName, const char *fieldSignature)
       {
       return getReferenceFieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, fieldSignature));
       }
-   uintptr_t getVolatileReferenceField(uintptr_t objectPointer, char *fieldName, char *fieldSignature)
+   uintptr_t getVolatileReferenceField(uintptr_t objectPointer, const char *fieldName, const char *fieldSignature)
       {
       return getVolatileReferenceFieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, fieldSignature));
       }
@@ -835,7 +835,7 @@ public:
    virtual uintptr_t *mutableCallSite_bypassLocation(uintptr_t mutableCallSite);
    virtual uintptr_t *mutableCallSite_findOrCreateBypassLocation(uintptr_t mutableCallSite);
 
-   virtual TR_OpaqueMethodBlock *lookupArchetype(TR_OpaqueClassBlock *clazz, char *name, char *signature);
+   virtual TR_OpaqueMethodBlock *lookupArchetype(TR_OpaqueClassBlock *clazz, const char *name, const char *signature);
    virtual TR_OpaqueMethodBlock *lookupMethodHandleThunkArchetype(uintptr_t methodHandle);
    virtual TR_ResolvedMethod    *createMethodHandleArchetypeSpecimen(TR_Memory *, uintptr_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0);
    virtual TR_ResolvedMethod    *createMethodHandleArchetypeSpecimen(TR_Memory *, TR_OpaqueMethodBlock *archetype, uintptr_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0); // more efficient if you already know the archetype
@@ -1000,7 +1000,7 @@ public:
     * \param mhIndex known object index of the java/lang/invoke/MemberName object
     * \param fieldName the name of the field for which we return the known object index
     */
-   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName);
+   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, const char *fieldName);
 
    /**
     * \brief
@@ -1342,10 +1342,10 @@ public:
    uint8_t *allocateDataCacheRecord(uint32_t numBytes,  TR::Compilation *comp, bool contiguous,
                                 bool *shouldRetryAllocation, uint32_t allocationType, uint32_t *size);
 
-   virtual int findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* classSig, char** methodSig, TR::SymbolReference** symRefs, int methodCount);
-   virtual int findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char** methodSig, TR::SymbolReference** symRefs, int methodCount);
-   virtual TR::SymbolReference* findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* classSig, char* methodSig);
-   virtual TR::SymbolReference* findOrCreateMethodSymRef(TR::Compilation* comp, TR::ResolvedMethodSymbol* owningMethodSym, char* methodSig);
+   virtual int findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *classSig, const char **methodSig, TR::SymbolReference **symRefs, int methodCount);
+   virtual int findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char **methodSig, TR::SymbolReference **symRefs, int methodCount);
+   virtual TR::SymbolReference* findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *classSig, const char *methodSig);
+   virtual TR::SymbolReference* findOrCreateMethodSymRef(TR::Compilation *comp, TR::ResolvedMethodSymbol *owningMethodSym, const char *methodSig);
 
    virtual bool isOwnableSyncClass(TR_OpaqueClassBlock *clazz);
    const char *getJ9MonitorName(J9ThreadMonitor* monitor);
@@ -1479,7 +1479,7 @@ public:
    virtual void               initializeHasFixedFrameC_CallingConvention();
 
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
-   virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature);
+   virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature);
 
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1429,7 +1429,7 @@ TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
    }
 
 TR_OpaqueMethodBlock *
-TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signature)
+TR_J9ServerVM::getMethodFromName(const char *className, const char *methodName, const char *signature)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getMethodFromName, std::string(className, strlen(className)),
@@ -1438,7 +1438,7 @@ TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signat
    }
 
 TR_OpaqueMethodBlock *
-TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass)
+TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getMethodFromClass, methodClass, std::string(methodName, strlen(methodName)),
@@ -2387,7 +2387,7 @@ TR_J9ServerVM::getVMIndexOffset()
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 TR::KnownObjectTable::Index
-TR_J9ServerVM::getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName)
+TR_J9ServerVM::getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, const char *fieldName)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex, mhIndex, std::string(fieldName));
@@ -2532,7 +2532,7 @@ TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, boo
    }
 
 TR_OpaqueMethodBlock *
-TR_J9SharedCacheServerVM::getMethodFromClass(TR_OpaqueClassBlock * methodClass, char * methodName, char * signature, TR_OpaqueClassBlock *callingClass)
+TR_J9SharedCacheServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass)
    {
    TR_OpaqueMethodBlock* omb = TR_J9ServerVM::getMethodFromClass(methodClass, methodName, signature, callingClass);
    if (omb)
@@ -3269,7 +3269,7 @@ TR_J9SharedCacheServerVM::getClassFromNewArrayType(int32_t arrayType)
    }
 
 TR_OpaqueMethodBlock *
-TR_J9SharedCacheServerVM::getMethodFromName(char *className, char *methodName, char *signature)
+TR_J9SharedCacheServerVM::getMethodFromName(const char *className, const char *methodName, const char *signature)
    {
    // The TR_J9VM version of this method implicitly creates SVM record during AOT compilation.
    // The TR_J9ServerVM version doesn't account for that, so need to override it

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -157,8 +157,8 @@ public:
    virtual bool hasFinalizer(TR_OpaqueClassBlock *clazz) override;
    virtual uintptr_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz) override;
    virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock * clazz) override;
-   virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
-   virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass) override;
+   virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature) override;
+   virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass) override;
    virtual bool isStable(J9Class *fieldClass, int cpIndex) override;
    virtual bool isForceInline(TR_ResolvedMethod *method) override;
    virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method) override;
@@ -245,7 +245,7 @@ public:
    virtual UDATA getVMTargetOffset() override;
    virtual UDATA getVMIndexOffset() override;
 #endif
-   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName) override;
+   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, const char *fieldName) override;
    virtual bool isMethodHandleExpectedType(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, TR::KnownObjectTable::Index expectedTypeIndex) override;
    virtual bool inSnapshotMode() override;
    virtual bool isSnapshotModeEnabled() override;
@@ -312,55 +312,55 @@ public:
 
    virtual bool shouldDelayAotLoad() override                                  { return true; }
    virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) override { return false; }
-   virtual bool isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueClassBlock * destClass) override;
+   virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool traceableMethodsCanBeInlined() override;
    virtual bool canMethodEnterEventBeHooked() override;
    virtual bool canMethodExitEventBeHooked() override;
    virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp) override;
-   virtual int32_t getJavaLangClassHashCode(TR::Compilation * comp, TR_OpaqueClassBlock * clazzPointer, bool &hashCodeComputed) override;
-   virtual bool javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result) override;
-   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, const char * fieldName, uint32_t fieldLen, const char * sig, uint32_t sigLen, UDATA options) override;
-   virtual TR_OpaqueClassBlock * getClassOfMethod(TR_OpaqueMethodBlock *method) override;
-   virtual TR_OpaqueClassBlock * getSuperClass(TR_OpaqueClassBlock *classPointer) override;
+   virtual int32_t getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer, bool &hashCodeComputed) override;
+   virtual bool javaLangClassGetModifiersImpl(TR_OpaqueClassBlock *clazzPointer, int32_t &result) override;
+   virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName, uint32_t fieldLen, const char *sig, uint32_t sigLen, UDATA options) override;
+   virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method) override;
+   virtual TR_OpaqueClassBlock *getSuperClass(TR_OpaqueClassBlock *classPointer) override;
    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *) override;
-   virtual TR_ResolvedMethod * getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature) override;
+   virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock *classPointer, const char *methodName, const char *signature) override;
    virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false) override;
-   virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL) override;
+   virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *, const char *, const char *, TR_OpaqueClassBlock * = NULL) override;
    virtual bool supportAllocationInlining(TR::Compilation *comp, TR::Node *node) override;
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock *castClass, bool instanceIsFixed, bool castIsFixed = true, bool optimizeForAOT = false) override;
-   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT = false) override;
-   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT = false) override;
-   virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;
-   virtual TR_OpaqueClassBlock * getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *profiledInfo) override;
+   virtual TR_OpaqueClassBlock *getClassFromSignature(const char *sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT = false) override;
+   virtual TR_OpaqueClassBlock *getClassFromSignature(const char *sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT = false) override;
+   virtual TR_OpaqueClassBlock *getSystemClassFromClassName(const char *name, int32_t length, bool isVettedForAOT = false) override;
+   virtual TR_OpaqueClassBlock *getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *profiledInfo) override;
    virtual bool isPublicClass(TR_OpaqueClassBlock *clazz) override;
-   virtual bool hasFinalizer(TR_OpaqueClassBlock * classPointer) override;
-   virtual uintptr_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer) override;
-   virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock * classPointer) override;
+   virtual bool hasFinalizer(TR_OpaqueClassBlock *classPointer) override;
+   virtual uintptr_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock *classPointer) override;
+   virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock *classPointer) override;
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazzPointer) override;
-   virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass) override;
-   virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
-   virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass) override;
-   virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims) override;
-   virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType) override;
+   virtual TR_OpaqueClassBlock *getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass) override;
+   virtual TR_OpaqueClassBlock *getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
+   virtual TR_OpaqueClassBlock *getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass) override;
+   virtual TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t & numDims) override;
+   virtual TR_OpaqueClassBlock *getClassFromNewArrayType(int32_t arrayType) override;
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *) override;
    virtual bool isReferenceArray(TR_OpaqueClassBlock *) override;
-   virtual TR_OpaqueMethodBlock * getInlinedCallSiteMethod(TR_InlinedCallSite *ics) override;
+   virtual TR_OpaqueMethodBlock *getInlinedCallSiteMethod(TR_InlinedCallSite *ics) override;
    virtual bool sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *) override { return false; }
    virtual bool isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *) override { return true; }
    virtual bool classHasBeenExtended(TR_OpaqueClassBlock *) override { return true; }
-   virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *) override { return NULL; }
-   virtual TR::CodeCache * getResolvedTrampoline(TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) override { return 0; }
+   virtual TR_ResolvedMethod *getObjectNewInstanceImplMethod(TR_Memory *) override { return NULL; }
+   virtual TR::CodeCache *getResolvedTrampoline(TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) override { return 0; }
    virtual intptr_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override { TR_ASSERT_FATAL(0, "methodTrampolineLookup not implemented for AOT");  return 0; }
-   virtual TR::CodeCache * getDesignatedCodeCache(TR::Compilation *comp) override;
-   virtual void * persistMHJ2IThunk(void *thunk) override { TR_ASSERT_FATAL(0, "persistMHJ2IThunk should not be called on the server"); return NULL; }
-   virtual void * findPersistentMHJ2IThunk(char *signatureChars) override { TR_ASSERT_FATAL(0, "findPersistentMHJ2IThunk should not be called on the server"); return NULL; }
-   virtual J9Class * getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
+   virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation *comp) override;
+   virtual void *persistMHJ2IThunk(void *thunk) override { TR_ASSERT_FATAL(0, "persistMHJ2IThunk should not be called on the server"); return NULL; }
+   virtual void *findPersistentMHJ2IThunk(char *signatureChars) override { TR_ASSERT_FATAL(0, "findPersistentMHJ2IThunk should not be called on the server"); return NULL; }
+   virtual J9Class *getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
    virtual bool ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes) override;
-   virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
-   virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
-   virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex) override;
+   virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature) override;
+   virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock *classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
+   virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock *classObject, int32_t cpIndex) override;
 
 protected :
    bool validateClass(TR_OpaqueMethodBlock * method, TR_OpaqueClassBlock* j9class, bool isVettedForAOT);

--- a/runtime/compiler/env/annotations/AnnotationBase.hpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.hpp
@@ -55,11 +55,6 @@ typedef enum {
 } AnnotationType;
 
 
-  typedef struct{
-    char           * name;
-    AnnotationType   type;
-  } AnnotationEntry;
-
 typedef enum {
 #undef ANNOT_ENTRY
 #define ANNOT_ENTRY(A,B) A,
@@ -70,7 +65,7 @@ typedef enum {
 
 
 typedef struct {
-   char        * name;
+   const char  * name;
    int32_t       nameLen;
    J9Class     * clazz; // annotation class
    } AnnotationTable;

--- a/runtime/compiler/env/annotations/Annotations.cpp
+++ b/runtime/compiler/env/annotations/Annotations.cpp
@@ -51,64 +51,76 @@ TR_Debug::printAnnotationInfoEntry(J9AnnotationInfo * annotationInfo,
    int32_t flag = annotationInfoEntryPtr->flags;
    #define ANNO_NAMEBUF_LEN 30
    char annNameBuffer[ANNO_NAMEBUF_LEN];
-   char * signatureName="";
+   const char *signatureName = "";
    switch(flag)
       {
       case ANNOTATION_TYPE_CLASS:
-	 annotationTypeName="class";
-	 break;
+         {
+         annotationTypeName = "class";
+         break;
+         }
 
-      case ANNOTATION_TYPE_FIELD:{
+      case ANNOTATION_TYPE_FIELD:
+         {
          int32_t len;
-         J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->memberName,J9UTF8*);
-	 annotationTypeName="field:";
-	 signatureName=utf8Data(name,len);
-         strncpy(stringBufferA,signatureName,len);
+         J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->memberName, J9UTF8*);
+         annotationTypeName = "field:";
+         signatureName = utf8Data(name,len);
+         strncpy(stringBufferA, signatureName, len);
          stringBufferA[len] = ' ';
          stringBufferA[len+1] = '\0';
          // append the type signature
          int32_t len2;
-         char * typeName = utf8Data(SRP_GET(annotationInfoEntryPtr->memberSignature,J9UTF8*),len2);
-         strncat(stringBufferA,typeName,len2);
-         stringBufferA[len+len2+1] = '\0';
-         TR_ASSERT(len+len2+1 < bufLen, "Buffer length of %d exceeded",bufLen);
+         char * typeName = utf8Data(SRP_GET(annotationInfoEntryPtr->memberSignature, J9UTF8*), len2);
+         strncat(stringBufferA, typeName, len2);
+         stringBufferA[len + len2 + 1] = '\0';
+         TR_ASSERT(len + len2 + 1 < bufLen, "Buffer length of %d exceeded", bufLen);
 
          signatureName = stringBufferA;
 
-	 //filterOnName=true;
-	 break;
-      }
-      case ANNOTATION_TYPE_METHOD:
-	 annotationTypeName="method";
-	 filterOnName=true;
-	 break;
+         //filterOnName=true;
+         break;
+         }
 
-      case ANNOTATION_TYPE_ANNOTATION:{
+      case ANNOTATION_TYPE_METHOD:
+         {
+         signatureName = "";
+         annotationTypeName = "method";
+         filterOnName=true;
+         break;
+         }
+
+      case ANNOTATION_TYPE_ANNOTATION:
+         {
          int32_t len;
-         J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->annotationType,J9UTF8*);
-	 annotationTypeName="annotation:";
-	 signatureName=utf8Data(name,len);
-         strncpy(stringBufferA,signatureName,len);
+         J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->annotationType, J9UTF8*);
+         annotationTypeName = "annotation:";
+         signatureName = utf8Data(name, len);
+         strncpy(stringBufferA, signatureName, len);
          stringBufferA[len] = '\0';
          signatureName = stringBufferA;
-	 break;
-	 }
+         break;
+         }
+
       default:
-	 if ((flag & ~ANNOTATION_PARM_MASK) == ANNOTATION_TYPE_PARAMETER)
-	    {
-	    sprintf(annNameBuffer,"parm(%d)",(flag & ANNOTATION_PARM_MASK)>> ANNOTATION_PARM_SHIFT);
-	    TR_ASSERT( strlen(annNameBuffer) < ANNO_NAMEBUF_LEN, "buffer length somehow exceeded\n");
-	    annotationTypeName=annNameBuffer;
-	    filterOnName=true;
-	    break;
-	    }
+         {
+         signatureName = "";
+         if ((flag & ~ANNOTATION_PARM_MASK) == ANNOTATION_TYPE_PARAMETER)
+            {
+            sprintf(annNameBuffer,"parm(%d)",(flag & ANNOTATION_PARM_MASK) >> ANNOTATION_PARM_SHIFT);
+            TR_ASSERT( strlen(annNameBuffer) < ANNO_NAMEBUF_LEN, "buffer length somehow exceeded\n");
+            annotationTypeName = annNameBuffer;
+            filterOnName = true;
+            break;
+            }
          else
-	    annotationTypeName = "unknown";
+            annotationTypeName = "unknown";
+         }
       }
 
    if (filterOnName){
-      J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->memberName,J9UTF8*);
-      J9UTF8 *signature = SRP_GET(annotationInfoEntryPtr->memberSignature,J9UTF8*);
+      J9UTF8 *name      = SRP_GET(annotationInfoEntryPtr->memberName, J9UTF8*);
+      J9UTF8 *signature = SRP_GET(annotationInfoEntryPtr->memberSignature, J9UTF8*);
 
      //trfprintf(_file,"name=%s sig=%s\n",utf8Data(name),utf8Data(signature));
 
@@ -125,41 +137,41 @@ TR_Debug::printAnnotationInfoEntry(J9AnnotationInfo * annotationInfo,
 
    J9AnnotationState state;
    void *data;
-   J9UTF8 * namePtr = intFunc->annotationElementIteratorStart(&state,annotationInfoEntryPtr,&data);
+   J9UTF8 *namePtr = intFunc->annotationElementIteratorStart(&state, annotationInfoEntryPtr, &data);
    while (namePtr)
       {
-      int32_t * ptr = (int32_t *)data;
+      int32_t *ptr = (int32_t *)data;
       int32_t tag = *ptr & ANNOTATION_TAG_MASK;
 
 
-      for (int32_t j=0;j< indentationLevel;++j) trfprintf(_file,"\t");
+      for (int32_t j=0; j< indentationLevel; ++j) trfprintf(_file, "\t");
       int32_t len;
-      char *dataName = utf8Data(namePtr,len);
+      char *dataName = utf8Data(namePtr, len);
 
-      trfprintf(_file,"\ttype=%s%s %.*s=",annotationTypeName,signatureName,len,dataName);
+      trfprintf(_file, "\ttype=%s%s %.*s=", annotationTypeName, signatureName, len, dataName);
 
       ++ptr;// point at data
 
       switch(tag)
          {
-         case 'B': trfprintf(_file,"%d\n",*(int32_t *)ptr);break;
-         case 'C': trfprintf(_file,"%d\n",*(int32_t*)ptr);break;
-         case 'D': trfprintf(_file,"%e\n",*(double*)ptr);break;
-         case 'F': trfprintf(_file,"%f\n",*(float*)ptr);break;
-         case 'I':trfprintf(_file,"%d\n",*(int32_t*)ptr);break;
-         case 'J':trfprintf(_file,"%lld\n",*(int64_t*)ptr);break;
-         case 'S':trfprintf(_file,"%d\n",*(int32_t*)ptr);break;
-         case 'Z':trfprintf(_file,"%d\n",*(int32_t*)ptr);break;
+         case 'B': trfprintf(_file, "%d\n", *(int32_t *)ptr); break;
+         case 'C': trfprintf(_file, "%d\n", *(int32_t*)ptr); break;
+         case 'D': trfprintf(_file, "%e\n", *(double*)ptr); break;
+         case 'F': trfprintf(_file, "%f\n", *(float*)ptr); break;
+         case 'I': trfprintf(_file, "%d\n", *(int32_t*)ptr); break;
+         case 'J': trfprintf(_file, "%lld\n", *(int64_t*)ptr); break;
+         case 'S': trfprintf(_file, "%d\n", *(int32_t*)ptr); break;
+         case 'Z': trfprintf(_file, "%d\n", *(int32_t*)ptr); break;
          case 'e':
             {
             J9SRP *typeNamePtr = (J9SRP* )ptr++;
             J9SRP *valueNamePtr = (J9SRP* )ptr;
-            J9UTF8 *typeName =  (J9UTF8 *)SRP_PTR_GET(typeNamePtr,J9UTF8*);
-            J9UTF8 *valueName = (J9UTF8 *)SRP_PTR_GET(valueNamePtr,J9UTF8*);
-            int32_t dataLen,typeLen;
-            char *vName = utf8Data(valueName,dataLen);
-            char * tName = utf8Data(typeName,typeLen);
-            trfprintf(_file,"%.*s enum_type=\"%.*s\"\n",dataLen,vName,typeLen,tName);
+            J9UTF8 *typeName =  (J9UTF8 *)SRP_PTR_GET(typeNamePtr, J9UTF8*);
+            J9UTF8 *valueName = (J9UTF8 *)SRP_PTR_GET(valueNamePtr, J9UTF8*);
+            int32_t dataLen, typeLen;
+            char *vName = utf8Data(valueName, dataLen);
+            char *tName = utf8Data(typeName, typeLen);
+            trfprintf(_file, "%.*s enum_type=\"%.*s\"\n", dataLen, vName, typeLen, tName);
 
             break;
             }
@@ -168,25 +180,25 @@ TR_Debug::printAnnotationInfoEntry(J9AnnotationInfo * annotationInfo,
             {
             J9SRP *stringNamePtr = (J9SRP* )ptr;
             int32_t len;
-            char *dataName = utf8Data(SRP_PTR_GET(stringNamePtr,J9UTF8*),len);
-            trfprintf(_file,"\"%.*s\"\n",len,dataName);
+            char *dataName = utf8Data(SRP_PTR_GET(stringNamePtr, J9UTF8*), len);
+            trfprintf(_file, "\"%.*s\"\n", len, dataName);
             break;
             }
 
          case '@':
             {
-            J9AnnotationInfoEntry *infoPtr = SRP_PTR_GET(ptr,J9AnnotationInfoEntry *);
-            int32_t j,mLen,sLen;
-            for (j=0;j< indentationLevel;++j) trfprintf(_file,"\t");
-            trfprintf(_file,"(nested annotation)\n\n");
-            char * mName=  utf8Data(SRP_GET(annotationInfoEntryPtr->memberName,J9UTF8*),mLen);
+            J9AnnotationInfoEntry *infoPtr = SRP_PTR_GET(ptr, J9AnnotationInfoEntry *);
+            int32_t j, mLen, sLen;
+            for (j=0; j< indentationLevel; ++j) trfprintf(_file, "\t");
+            trfprintf(_file, "(nested annotation)\n\n");
+            char *mName = utf8Data(SRP_GET(annotationInfoEntryPtr->memberName, J9UTF8*), mLen);
 
-            char *sName = utf8Data(SRP_GET(annotationInfoEntryPtr->memberSignature,J9UTF8*),sLen);
-            trfprintf(_file, "\t<annotations name=\"%.*s %.*s\">\n",mLen,mName,sLen,sName);
+            char *sName = utf8Data(SRP_GET(annotationInfoEntryPtr->memberSignature,J9UTF8*), sLen);
+            trfprintf(_file, "\t<annotations name=\"%.*s %.*s\">\n", mLen, mName, sLen, sName);
 
-            printAnnotationInfoEntry( annotationInfo,infoPtr,++indentationLevel);
+            printAnnotationInfoEntry(annotationInfo, infoPtr, ++indentationLevel);
 
-            for (j=0;j< indentationLevel;++j) trfprintf(_file,"\t");
+            for (j=0; j < indentationLevel; ++j) trfprintf(_file,"\t");
                trfprintf(_file, "</annotations>\n\n");
             break;
             }
@@ -196,44 +208,44 @@ TR_Debug::printAnnotationInfoEntry(J9AnnotationInfo * annotationInfo,
             uint32_t arraySize = *ptr++;
             uint32_t numElements = *ptr++;
             char *charPtr = (char *)ptr;
-            bool truncateOutput = 40< arraySize/sizeof(uint32_t);
-            int32_t upperLimit =  arraySize/sizeof(uint32_t);
+            bool truncateOutput = 40 < arraySize / sizeof(uint32_t);
+            int32_t upperLimit =  arraySize / sizeof(uint32_t);
             if (truncateOutput) upperLimit = 40;
 
-            for (int32_t i =0; i < upperLimit;++i)
+            for (int32_t i = 0; i < upperLimit; ++i)
                {
-               if (((i+1) % 12) == 0) trfprintf(_file,"\n\t\t");
+               if (((i + 1) % 12) == 0) trfprintf(_file, "\n\t\t");
 
-               trfprintf(_file,"%x ",*ptr++);
+               trfprintf(_file, "%x ", *ptr++);
                }
-            if (truncateOutput) trfprintf(_file," (truncated)...");
-            trfprintf(_file,"\n");
+            if (truncateOutput) trfprintf(_file, " (truncated)...");
+            trfprintf(_file, "\n");
             break;
             }
 
          default:
-            trfprintf(_file,"Unknown tag:%x %c\n",tag,tag);
+            trfprintf(_file, "Unknown tag:%x %c\n", tag, tag);
          }
 
 
-      namePtr = intFunc->annotationElementIteratorNext(&state,&data);
+      namePtr = intFunc->annotationElementIteratorNext(&state, &data);
       }
 
-   J9VMThread* vmContext = intFunc->currentVMThread(javaVM);
-   J9Class * clazz = (J9Class *)_comp->getCurrentMethod()->containingClass();
+   J9VMThread *vmContext = intFunc->currentVMThread(javaVM);
+   J9Class *clazz = (J9Class *)_comp->getCurrentMethod()->containingClass();
                                                  //NOTE: acquireVMAccess() has already been called
    // default query is broken right now
    J9AnnotationInfoEntry *defaultEntry;
-   defaultEntry =  intFunc->getAnnotationDefaultsForAnnotation(vmContext,clazz,annotationInfoEntryPtr,
+   defaultEntry =  intFunc->getAnnotationDefaultsForAnnotation(vmContext, clazz, annotationInfoEntryPtr,
                                                                J9_FINDCLASS_FLAG_EXISTING_ONLY);
    if (defaultEntry)
       {
-      trfprintf(_file,"\n");
+      trfprintf(_file, "\n");
       int32_t j;
-      for (j=0;j< indentationLevel;++j) trfprintf(_file,"\t");
-      trfprintf(_file,"Default values:\n");
+      for (j=0; j < indentationLevel; ++j) trfprintf(_file, "\t");
+      trfprintf(_file, "Default values:\n");
 
-      printAnnotationInfoEntry(annotationInfo,defaultEntry,indentationLevel);
+      printAnnotationInfoEntry(annotationInfo, defaultEntry, indentationLevel);
       }
    }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -677,7 +677,7 @@ char *
 TR_ResolvedJ9MethodBase::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind)
    {
    if (cpIndex == -1)
-      return "<internal name>";
+      return (char *)"<internal name>";
 
    J9ROMFieldRef * ref = (J9ROMFieldRef *) (&romCPBase()[cpIndex]);
    J9ROMNameAndSignature * nameAndSignature = J9ROMFIELDREF_NAMEANDSIGNATURE(ref);
@@ -709,7 +709,7 @@ TR_ResolvedJ9MethodBase::staticName(I_32 cpIndex, TR_Memory * m, TR_AllocationKi
 char *
 TR_ResolvedJ9MethodBase::fieldName(I_32 cpIndex, int32_t & len, TR_Memory * m, TR_AllocationKind kind)
    {
-   if (cpIndex < 0) return "<internal field>";
+   if (cpIndex < 0) return (char *)"<internal field>";
    return fieldOrStaticName(cpIndex, len, m, kind);
    }
 
@@ -7697,8 +7697,8 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             // Inspect source and target types and decide what to do
             //
             char sourceBuf[2], targetBuf[2];
-            char *sourceName = sourceBuf; char *sourceType = sourceBuf;
-            char *targetName = targetBuf; char *targetType = targetBuf;
+            const char *sourceName = sourceBuf; const char *sourceType = sourceBuf;
+            const char *targetName = targetBuf; const char *targetType = targetBuf;
             switch (sourceSig[0])
                {
                case 'Q':
@@ -8004,8 +8004,8 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          int32_t i;
          int32_t permuteLength;
          TR::Node *originalArgs;
-         char * oldSignature;
-         char * newSignature;
+         char *oldSignature;
+         char *newSignature;
          TR::Node* extraArrayNode = NULL;
          TR::Node* extraL[5];
          if (rm == TR::java_lang_invoke_BruteArgumentMoverHandle_permuteArgs)
@@ -8028,7 +8028,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             // Do the server-side operations
             originalArgs = genNodeAndPopChildren(TR::icall, 1, placeholderWithDummySignature());
             oldSignature = originalArgs->getSymbolReference()->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->signatureChars();
-            newSignature = "()I";
+            newSignature = (char *)"()I";
             if (comp()->getOption(TR_TraceILGen))
                traceMsg(comp(), "  permuteArgs: oldSignature is %s\n", oldSignature);
             for (i=0; i < permuteLength; i++)
@@ -8110,7 +8110,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             // Push args while computing the result placeholder's signature
             //
             oldSignature = originalArgs->getSymbolReference()->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->signatureChars();
-            newSignature = "()I";
+            newSignature = (char *)"()I";
             permuteLength = fej9->getArrayLengthInElements(permuteArray);
             if (comp()->getOption(TR_TraceILGen))
                traceMsg(comp(), "  permuteArgs: oldSignature is %s\n", oldSignature);
@@ -8758,7 +8758,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
              placeholder->getAndDecChild(i);
              }
 
-         char * newSignature = "()I";
+         char *newSignature = (char *)"()I";
          // The rest of the stack should be the arg positions if there are any
          for (int i=0; i<numCombinerArgs; i++)
              {
@@ -8924,7 +8924,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          // This is required beyond the scope of the stack memory region
          TR::Node *placeholder = NULL;
-         char * newSignature = "()I";
+         char *newSignature = (char *)"()I";
 
          {
          TR::StackMemoryRegion stackMemoryRegion(*comp()->trMemory());

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -108,20 +108,20 @@ J9::Recompilation::isAlreadyBeingCompiled(
    return TR::Recompilation::isAlreadyPreparedForRecompile(startPC);
    }
 
-void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName, TR::Compilation * comp)
+void setDllSlip(const char *CodeStart, const char *CodeEnd, const char *dllName, TR::Compilation *comp)
 {
 #if defined(J9ZOS390)
-   char  errBuf[512];
-   UDATA rc=0;
+   char errBuf[512];
+   UDATA rc = 0;
    J9PortLibrary *portLib = jitConfig->javaVM->portLibrary;
    PORT_ACCESS_FROM_PORT(portLib);
 
    TR_ASSERT(comp, "Logging requires a compilation object");
-   traceMsg(comp, "code start 0x%016p , code end 0x%016p ,size = %d\n",CodeStart,CodeEnd,CodeStart-CodeEnd);
+   traceMsg(comp, "code start 0x%016p , code end 0x%016p ,size = %d\n", CodeStart, CodeEnd, CodeStart - CodeEnd);
 
-   if (sliphandle==0)
+   if (sliphandle == 0)
       {
-      rc = j9sl_open_shared_library(dllName, &sliphandle, FALSE);
+      rc = j9sl_open_shared_library(const_cast<char *>(dllName), &sliphandle, FALSE);
       if (rc)
          {
          traceMsg(comp, "Failed to open SLIP DLL: %s (%s) %016p\n", dllName, j9error_last_error_message(), sliphandle);
@@ -131,17 +131,17 @@ void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName, TR::Compilation * comp
    if (sliphandle != 0)
       {
       if (do_slip_func == 0)
-         j9sl_lookup_name(sliphandle, "do_slip", &do_slip_func, (char*)NULL);
+         j9sl_lookup_name(sliphandle, "do_slip", &do_slip_func, (char *)NULL);
       if (do_slip_func != 0)
          {
          fptrl=(void (*)(char *, char *, void *, void *, char *, char *, char *))do_slip_func;
-         (*fptrl)(CodeStart,
-                  CodeEnd,
-                  (void*)NULL,
-                  (void*)NULL,
-                  (char*)NULL,
-                  (char*)NULL,
-                  (char*)NULL
+         (*fptrl)(const_cast<char *>(CodeStart),
+                  const_cast<char *>(CodeEnd),
+                  (void *)NULL,
+                  (void *)NULL,
+                  (char *)NULL,
+                  (char *)NULL,
+                  (char *)NULL
                  );
          }
       else if (comp)


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to (char *)) in runtime/compiler/env.

This PR contributes to (but does not close) #14859

**This PR depends on:**

- **Step 1:**
    - #18083
    - #18455

**and must be merged in coordination with https://github.com/eclipse/omr/pull/7186**