### PR TITLE
Fix string literal conversion warnings in ilgen, runtime, control, ras

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1120,24 +1120,24 @@ public:
    int32_t computeDynamicDumbInlinerBytecodeSizeCutoff(TR::Options *options);
    TR_YesNoMaybe shouldActivateNewCompThread();
 #if DEBUG
-   void debugPrint(char *debugString);
-   void debugPrint(J9VMThread *, char *);
-   void debugPrint(char *, intptr_t);
-   void debugPrint(J9VMThread *, char *, IDATA);
+   void debugPrint(const char *debugString);
+   void debugPrint(J9VMThread *, const char *);
+   void debugPrint(const char *, intptr_t);
+   void debugPrint(J9VMThread *, const char *, IDATA);
    void debugPrint(J9Method*);
-   void debugPrint(char *, J9Method *);
-   void debugPrint(J9VMThread *, char *, TR_MethodToBeCompiled *);
-   void debugPrint(char * debugString, TR::IlGeneratorMethodDetails & details, J9VMThread * vmThread);
+   void debugPrint(const char *, J9Method *);
+   void debugPrint(J9VMThread *, const char *, TR_MethodToBeCompiled *);
+   void debugPrint(const char * debugString, TR::IlGeneratorMethodDetails & details, J9VMThread * vmThread);
    void printQueue();
 #else // !DEBUG
-   void debugPrint(char *debugString) {}
-   void debugPrint(J9VMThread *, char *) {}
-   void debugPrint(char *, intptr_t) {}
-   void debugPrint(J9VMThread *, char *, IDATA) {}
+   void debugPrint(const char *debugString) {}
+   void debugPrint(J9VMThread *, const char *) {}
+   void debugPrint(const char *, intptr_t) {}
+   void debugPrint(J9VMThread *, const char *, IDATA) {}
    void debugPrint(J9Method*) {}
-   void debugPrint(char *, J9Method *) {}
-   void debugPrint(J9VMThread *, char *, TR_MethodToBeCompiled *) {}
-   void debugPrint(char * debugString, TR::IlGeneratorMethodDetails & details, J9VMThread * vmThread) { }
+   void debugPrint(const char *, J9Method *) {}
+   void debugPrint(J9VMThread *, const char *, TR_MethodToBeCompiled *) {}
+   void debugPrint(const char * debugString, TR::IlGeneratorMethodDetails & details, J9VMThread * vmThread) { }
    void printQueue() {}
 #endif // DEBUG
    void debugPrint(TR_OpaqueMethodBlock *omb){ debugPrint((J9Method*)omb); }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -887,7 +887,7 @@ TR::CompilationInfoPerThread::openRTLogFile()
 
       if (!truncated)
          {
-         _rtLogFile = fileOpen(TR::Options::getAOTCmdLineOptions(), jitConfig, fn, "wb", true);
+         _rtLogFile = fileOpen(TR::Options::getAOTCmdLineOptions(), jitConfig, fn, const_cast<char *>("wb"), true);
          }
       else
          {
@@ -986,7 +986,7 @@ TR::CompilationInfoPerThread::waitForGCCycleMonitor(bool threadHasVMAccess)
 #endif
    }
 
-extern char *compilationErrorNames[]; // defined in rossa.cpp
+extern const char *compilationErrorNames[]; // defined in rossa.cpp
 
 void
 TR::CompilationInfoPerThreadBase::setCompilationThreadState(CompilationThreadState v)
@@ -1709,7 +1709,7 @@ TR_Stats statBudgetEpoch("Budget len at begining of epoch");
 TR_Stats statBudgetSmallLag("Budget/comp when smallLag");
 TR_Stats statBudgetMediumLag("Budget/comp when mediumLag");
 TR_Stats statEpochLength("Epoch lengh (ms)");
-char *eventNames[]={"SyncReq", "SmallLag", "LargeLag", "Medium-NoBudget", "Medium-highBudget", "Medium-LowBudget", "Medium-Idle"};
+const char *eventNames[]={"SyncReq", "SmallLag", "LargeLag", "Medium-NoBudget", "Medium-highBudget", "Medium-LowBudget", "Medium-Idle"};
 TR_StatsEvents<7> statEvents("Scenarios", eventNames, 0);
 char *priorityName[]={"High","Normal"};
 TR_StatsEvents<2> statLowPriority("Medium-lowBudget-priority",priorityName,0);
@@ -11690,7 +11690,7 @@ void TR::CompilationInfo::printCompQueue()
 
 #if DEBUG
 void
-TR::CompilationInfo::debugPrint(char * debugString)
+TR::CompilationInfo::debugPrint(const char *debugString)
    {
    if (!_traceCompiling)
       return;
@@ -11698,7 +11698,7 @@ TR::CompilationInfo::debugPrint(char * debugString)
    }
 
 void
-TR::CompilationInfo::debugPrint(J9VMThread * vmThread, char * debugString)
+TR::CompilationInfo::debugPrint(J9VMThread *vmThread, const char *debugString)
    {
    if (!_traceCompiling)
       return;
@@ -11707,7 +11707,7 @@ TR::CompilationInfo::debugPrint(J9VMThread * vmThread, char * debugString)
    }
 
 void
-TR::CompilationInfo::debugPrint(char * debugString, intptr_t val)
+TR::CompilationInfo::debugPrint(const char *debugString, intptr_t val)
    {
    if (!_traceCompiling)
       return;
@@ -11715,7 +11715,7 @@ TR::CompilationInfo::debugPrint(char * debugString, intptr_t val)
    }
 
 void
-TR::CompilationInfo::debugPrint(J9VMThread * vmThread, char * debugString, IDATA val)
+TR::CompilationInfo::debugPrint(J9VMThread *vmThread, const char *debugString, IDATA val)
    {
    if (!_traceCompiling)
       return;
@@ -11724,7 +11724,7 @@ TR::CompilationInfo::debugPrint(J9VMThread * vmThread, char * debugString, IDATA
    }
 
 void
-TR::CompilationInfo::debugPrint(J9Method * method)
+TR::CompilationInfo::debugPrint(J9Method *method)
    {
    if (!_traceCompiling)
       return;
@@ -11743,7 +11743,7 @@ TR::CompilationInfo::debugPrint(J9Method * method)
    }
 
 void
-TR::CompilationInfo::debugPrint(char * debugString, J9Method * method)
+TR::CompilationInfo::debugPrint(const char *debugString, J9Method *method)
    {
    if (!_traceCompiling)
       return;
@@ -11753,7 +11753,7 @@ TR::CompilationInfo::debugPrint(char * debugString, J9Method * method)
    }
 
 void
-TR::CompilationInfo::debugPrint(char * debugString, TR::IlGeneratorMethodDetails & details, J9VMThread * vmThread)
+TR::CompilationInfo::debugPrint(const char *debugString, TR::IlGeneratorMethodDetails & details, J9VMThread *vmThread)
    {
    if (!_traceCompiling)
       return;
@@ -11776,7 +11776,7 @@ TR::CompilationInfo::debugPrint(char * debugString, TR::IlGeneratorMethodDetails
    }
 
 void
-TR::CompilationInfo::debugPrint(J9VMThread * vmThread, char * msg, TR_MethodToBeCompiled *entry)
+TR::CompilationInfo::debugPrint(J9VMThread *vmThread, const char *msg, TR_MethodToBeCompiled *entry)
    {
    if (!_traceCompiling)
       return;

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -67,7 +67,7 @@ static IDATA initializeCompilerArgs(J9JavaVM* vm,
 
    char* xCommandLineOptions = NULL;
 
-   char *VMOPT_WITH_COLON;
+   const char *VMOPT_WITH_COLON;
    const char *fatalErrorStr = NULL;
    if (isXjit)
       {
@@ -221,8 +221,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
    J9JITConfig * jitConfig = 0;
    UDATA initialFlags = 0;
    J9VMDllLoadInfo* loadInfo = FIND_DLL_TABLE_ENTRY( THIS_DLL_NAME );
-   char* xjitCommandLineOptions = "";
-   char* xaotCommandLineOptions = "";
+   char *xjitCommandLineOptions = const_cast<char *>("");
+   char *xaotCommandLineOptions = const_cast<char *>("");
    IDATA fullSpeedDebugSet = FALSE;
    IDATA argIndex = 0;
 

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -208,7 +208,7 @@ TR::OptionSet *findOptionSet(J9Method *method, bool isAOT)
    return optionSet;
    }
 
-static void reportHook(J9VMThread *curThread, char *name, char *format=NULL, ...)
+static void reportHook(J9VMThread *curThread, const char *name, const char *format=NULL, ...)
    {
    J9JITConfig * jitConfig = curThread->javaVM->jitConfig;
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
@@ -228,7 +228,7 @@ static void reportHook(J9VMThread *curThread, char *name, char *format=NULL, ...
       }
    }
 
-static void reportHookFinished(J9VMThread *curThread, char *name, char *format=NULL, ...)
+static void reportHookFinished(J9VMThread *curThread, const char *name, const char *format=NULL, ...)
    {
    J9JITConfig * jitConfig = curThread->javaVM->jitConfig;
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
@@ -246,7 +246,7 @@ static void reportHookFinished(J9VMThread *curThread, char *name, char *format=N
       }
    }
 
-static void reportHookDetail(J9VMThread *curThread, char *name, char *format, ...)
+static void reportHookDetail(J9VMThread *curThread, const char *name, const char *format, ...)
    {
    J9JITConfig * jitConfig = curThread->javaVM->jitConfig;
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
@@ -2513,7 +2513,7 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
 
 void jitFlushCompilationQueue(J9VMThread * currentThread, J9JITFlushCompilationQueueReason reason)
    {
-   char *buffer = "unknown reason";
+   const char *buffer = "unknown reason";
    if (reason == J9FlushCompQueueDataBreakpoint)
       buffer = "DataBreakpoint";
    else
@@ -4458,7 +4458,7 @@ static void samplingObservationsLogic(J9JITConfig * jitConfig, TR::CompilationIn
    compInfo->_stats._methodsSampleWindowReset = 0;
    }
 
-char* jitStateNames[]=
+const char* jitStateNames[]=
    {
    "UNDEFINED",
    "IDLE     ",
@@ -5541,7 +5541,7 @@ static void initJitGCMapCheckAsyncHook(J9JavaVM * vm, IDATA handlerKey, J9JITCon
 
 
 //int32_t samplerThreadStateFrequencies[TR::CompilationInfo::SAMPLER_LAST_STATE+1] = {0, 2, 1000, 100000, INT_MAX, INT_MAX, -1};
-char* samplerThreadStateNames[TR::CompilationInfo::SAMPLER_LAST_STATE+1] =
+const char* samplerThreadStateNames[TR::CompilationInfo::SAMPLER_LAST_STATE+1] =
                                  {
                                    "NOT_INITIALIZED",
                                    "DEFAULT",

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -302,7 +302,7 @@ bool J9::Options::_xrsSync = false;
  * This string array should be kept in sync with the
  * J9::ExternalOptions enum in J9Options.hpp
  */
-char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOptions] =
+const char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExternalOptions] =
    {
    // TR_FirstExternalOption                 = 0
    "-Xnodfpbd",                           // = 0
@@ -400,7 +400,7 @@ enum TR_XlpCodeCacheOptions
    };
 
 // Returns large page flag type string for error handling.
-char *
+const char *
 getLargePageTypeString(UDATA pageFlags)
    {
    if (0 != (J9PORT_VMEM_PAGE_FLAG_PAGEABLE & pageFlags))
@@ -413,7 +413,7 @@ getLargePageTypeString(UDATA pageFlags)
 
 // Formats size to be in terms of X bytes to XX(K/M/G) for printing
 void
-qualifiedSize(UDATA *byteSize, char **qualifier)
+qualifiedSize(UDATA *byteSize, const char **qualifier)
 {
    UDATA size;
 
@@ -448,8 +448,8 @@ J9::Options::useCompressedPointers()
 #define BUILD_TYPE ""
 #endif
 
-char *
-J9::Options::versionOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+J9::Options::versionOption(const char *option, void *base, TR::OptionTable *entry)
    {
    J9JITConfig * jitConfig = (J9JITConfig*)base;
    PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
@@ -460,8 +460,8 @@ J9::Options::versionOption(char * option, void * base, TR::OptionTable *entry)
 #undef BUILD_TYPE
 
 
-char *
-J9::Options::limitOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+J9::Options::limitOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!J9::Options::getDebug() && !J9::Options::createDebug())
       return 0;
@@ -479,8 +479,8 @@ J9::Options::limitOption(char * option, void * base, TR::OptionTable *entry)
    }
 
 
-char *
-J9::Options::limitfileOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+J9::Options::limitfileOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!J9::Options::getDebug() && !J9::Options::createDebug())
       return 0;
@@ -505,8 +505,8 @@ J9::Options::limitfileOption(char * option, void * base, TR::OptionTable *entry)
       }
    }
 
-char *
-J9::Options::inlinefileOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+J9::Options::inlinefileOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!J9::Options::getDebug() && !J9::Options::createDebug())
       return 0;
@@ -575,8 +575,8 @@ static const struct vmX vmStateArray[] =
 namespace J9
 {
 
-char *
-Options::gcOnResolveOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+Options::gcOnResolveOption(const char *option, void *base, TR::OptionTable *entry)
    {
    J9JITConfig * jitConfig = (J9JITConfig*)base;
 
@@ -592,12 +592,12 @@ Options::gcOnResolveOption(char * option, void * base, TR::OptionTable *entry)
    }
 
 
-char *
-Options::vmStateOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+Options::vmStateOption(const char *option, void *base, TR::OptionTable *entry)
    {
-   J9JITConfig * jitConfig = (J9JITConfig*)base;
+   J9JITConfig *jitConfig = (J9JITConfig*)base;
    PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
-   char *p = option;
+   char *p = (char *)option;
    int32_t state = strtol(option, &p, 16);
    if (state > 0)
       {
@@ -687,8 +687,8 @@ Options::vmStateOption(char * option, void * base, TR::OptionTable *entry)
    }
 
 
-char *
-Options::loadLimitOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+Options::loadLimitOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return 0;
@@ -710,8 +710,8 @@ Options::loadLimitOption(char * option, void * base, TR::OptionTable *entry)
    }
 
 
-char *
-Options::loadLimitfileOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+Options::loadLimitfileOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return 0;
@@ -740,8 +740,8 @@ Options::loadLimitfileOption(char * option, void * base, TR::OptionTable *entry)
    }
 
 #if defined(J9VM_OPT_JITSERVER)
-char *
-Options::JITServerAOTCacheLimitOption(char *option, void *base, TR::OptionTable *entry, TR::CompilationFilters *&filters, const char *optName)
+const char *
+Options::JITServerAOTCacheLimitOption(const char *option, void *base, TR::OptionTable *entry, TR::CompilationFilters *&filters, const char *optName)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return NULL;
@@ -760,20 +760,20 @@ Options::JITServerAOTCacheLimitOption(char *option, void *base, TR::OptionTable 
       }
    }
 
-char *
-Options::JITServerAOTCacheStoreLimitOption(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::JITServerAOTCacheStoreLimitOption(const char *option, void *base, TR::OptionTable *entry)
    {
    return JITServerAOTCacheLimitOption(option, base, entry, _JITServerAOTCacheStoreFilters, "jitserverAOTCacheStoreExclude");
    }
 
-char *
-Options::JITServerAOTCacheLoadLimitOption(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::JITServerAOTCacheLoadLimitOption(const char *option, void *base, TR::OptionTable *entry)
    {
    return JITServerAOTCacheLimitOption(option, base, entry, _JITServerAOTCacheLoadFilters, "jitserverAOTCacheLoadExclude");
    }
 
-char *
-Options::JITServerRemoteExclude(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::JITServerRemoteExclude(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return 0;
@@ -793,8 +793,8 @@ Options::JITServerRemoteExclude(char *option, void *base, TR::OptionTable *entry
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-char *
-Options::tprofOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+Options::tprofOption(const char *option, void *base, TR::OptionTable *entry)
    {
    J9JITConfig * jitConfig = (J9JITConfig*)base;
    PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
@@ -802,24 +802,24 @@ Options::tprofOption(char * option, void * base, TR::OptionTable *entry)
    return option;
    }
 
-char *
-Options::setJitConfigRuntimeFlag(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::setJitConfigRuntimeFlag(const char *option, void *base, TR::OptionTable *entry)
    {
    J9JITConfig *jitConfig = (J9JITConfig*)_feBase;
    jitConfig->runtimeFlags |= entry->parm2;
    return option;
    }
 
-char *
-Options::resetJitConfigRuntimeFlag(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::resetJitConfigRuntimeFlag(const char *option, void *base, TR::OptionTable *entry)
    {
    J9JITConfig *jitConfig = (J9JITConfig*)_feBase;
    jitConfig->runtimeFlags &= ~(entry->parm2);
    return option;
    }
 
-char *
-Options::setJitConfigNumericValue(char *option, void *base, TR::OptionTable *entry)
+const char *
+Options::setJitConfigNumericValue(const char *option, void *base, TR::OptionTable *entry)
    {
    char *jitConfig = (char*)_feBase;
    // All numeric fields in jitConfig are declared as UDATA
@@ -1562,7 +1562,7 @@ void J9::Options::preProcessMode(J9JavaVM *vm, J9JITConfig *jitConfig)
          // The aggressivenessLevel can be set directly with -XaggressivenessLevel
          // This option is a second hand citizen option; if other options contradict it, this option is
          // ignored even if it appears later
-         char *aggressiveOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XaggressivenessLevel];
+         const char *aggressiveOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XaggressivenessLevel];
          int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, aggressiveOption, 0);
          if (argIndex >= 0)
             {
@@ -1580,13 +1580,13 @@ void J9::Options::preProcessMode(J9JavaVM *vm, J9JITConfig *jitConfig)
 void J9::Options::preProcessJniAccelerator(J9JavaVM *vm)
    {
    static bool doneWithJniAcc = false;
-   char *jniAccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XjniAcc];
+   const char *jniAccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XjniAcc];
    if (!doneWithJniAcc)
       {
       int32_t argIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, jniAccOption, 0);
       if (argIndex >= 0)
          {
-         char *optValue;
+         const char *optValue;
          doneWithJniAcc = true;
          GET_OPTION_VALUE(argIndex, ':', &optValue);
          if (*optValue == '{')
@@ -1617,7 +1617,7 @@ double getCodeCacheMaxPercentageOfAvailableMemory(J9JavaVM *vm)
    OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
    double codeCacheTotalPercentage = CODECACHE_DEFAULT_MAXRAMPERCENTAGE;
-   char *xxccPercentOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotalMaxRAMPercentage];
+   const char *xxccPercentOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotalMaxRAMPercentage];
    int32_t XXcodeCacheTotalPercentArg = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxccPercentOption, 0);
    if (XXcodeCacheTotalPercentArg >= 0)
       {
@@ -1662,15 +1662,15 @@ void J9::Options::preProcessCodeCacheIncreaseTotalSize(J9JavaVM *vm, J9JITConfig
             }
          }
 #endif
-      char *xccOption  = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecachetotal];
-      char *xxccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotal];
+      const char *xccOption  = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecachetotal];
+      const char *xxccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXcodecachetotal];
       int32_t codeCacheTotalArgIndex   = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, xccOption, 0);
       int32_t XXcodeCacheTotalArgIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, xxccOption, 0);
       int32_t argIndex = 0;
       // Check if option is at all specified
       if (codeCacheTotalArgIndex >= 0 || XXcodeCacheTotalArgIndex >= 0)
          {
-         char *ccTotalOption;
+         const char *ccTotalOption;
          if (XXcodeCacheTotalArgIndex > codeCacheTotalArgIndex)
             {
             argIndex = XXcodeCacheTotalArgIndex;
@@ -1984,7 +1984,7 @@ bool J9::Options::preProcessCodeCacheXlpCodeCache(J9JavaVM *vm, J9JITConfig *jit
       else if (xlpIndex >= 0)
          {
          // GET_MEMORY_VALUE macro casts it's second parameter to (char**)&, so a pointer to the option string is passed rather than the string literal.
-         char *lpOption = "-Xlp";
+         const char *lpOption = "-Xlp";
          GET_MEMORY_VALUE(xlpIndex, lpOption, requestedLargeCodePageSize);
          }
 
@@ -2003,9 +2003,9 @@ bool J9::Options::preProcessCodeCacheXlpCodeCache(J9JavaVM *vm, J9JITConfig *jit
          if (!isRequestedSizeSupported)
             {
             // Generate warning message for user that requested page sizes / type is not supported.
-            char *oldQualifier, *newQualifier;
-            char *oldPageType = NULL;
-            char *newPageType = NULL;
+            const char *oldQualifier, *newQualifier;
+            const char *oldPageType = NULL;
+            const char *newPageType = NULL;
             UDATA oldSize = requestedLargeCodePageSize;
             UDATA newSize = largePageSize;
 
@@ -2086,7 +2086,7 @@ bool J9::Options::preProcessCodeCache(J9JavaVM *vm, J9JITConfig *jitConfig)
    PORT_ACCESS_FROM_JAVAVM(vm);
    OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
-   char *ccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecache];
+   const char *ccOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::Xcodecache];
    int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, ccOption, 0);
    if (argIndex >= 0)
       {
@@ -2110,7 +2110,7 @@ bool J9::Options::preProcessCodeCache(J9JavaVM *vm, J9JITConfig *jitConfig)
 
 void J9::Options::preProcessSamplingExpirationTime(J9JavaVM *vm)
    {
-   char *samplingOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XsamplingExpirationTime];
+   const char *samplingOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XsamplingExpirationTime];
    int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, samplingOption, 0);
    if (argIndex >= 0)
       {
@@ -2128,7 +2128,7 @@ void J9::Options::preProcessCompilationThreads(J9JavaVM *vm, J9JITConfig *jitCon
       {
       notYetParsed = false;
       TR::CompilationInfo *compInfo = getCompilationInfo(jitConfig);
-      char *compThreadsOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XcompilationThreads];
+      const char *compThreadsOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XcompilationThreads];
       int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, compThreadsOption, 0);
       if (argIndex >= 0)
          {
@@ -2224,7 +2224,7 @@ void J9::Options::preProcessDeterministicMode(J9JavaVM *vm)
    // Process the deterministic mode
    if (TR::Options::_deterministicMode == -1) // not yet set
       {
-      char *deterministicOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXdeterministic];
+      const char *deterministicOption = J9::Options::_externalOptionStrings[J9::ExternalOptions::XXdeterministic];
       const UDATA MAX_DETERMINISTIC_MODE = 9; // only levels 0-9 are allowed
       int32_t argIndex = FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, deterministicOption, 0);
       if (argIndex >= 0)
@@ -2687,11 +2687,11 @@ J9::Options::openLogFiles(J9JITConfig *jitConfig)
    {
    char *vLogFileName = ((TR_JitPrivateConfig*)jitConfig->privateConfig)->vLogFileName;
    if (vLogFileName)
-      ((TR_JitPrivateConfig*)jitConfig->privateConfig)->vLogFile = fileOpen(self(), jitConfig, vLogFileName, "wb", true);
+      ((TR_JitPrivateConfig*)jitConfig->privateConfig)->vLogFile = fileOpen(self(), jitConfig, vLogFileName, (char *)"wb", true);
 
    char *rtLogFileName = ((TR_JitPrivateConfig*)jitConfig->privateConfig)->rtLogFileName;
    if (rtLogFileName)
-      ((TR_JitPrivateConfig*)jitConfig->privateConfig)->rtLogFile = fileOpen(self(), jitConfig, rtLogFileName, "wb", true);
+      ((TR_JitPrivateConfig*)jitConfig->privateConfig)->rtLogFile = fileOpen(self(), jitConfig, rtLogFileName, (char *)"wb", true);
    }
 
 #if defined(J9VM_OPT_JITSERVER)
@@ -3295,7 +3295,7 @@ unpackRegex(TR::SimpleRegex *&regexPtr)
    {
    if (!regexPtr)
       return;
-   char *str = (char*)((uintptr_t)&regexPtr + (uintptr_t)regexPtr);
+   const char *str = (const char *)((uintptr_t)&regexPtr + (uintptr_t)regexPtr);
    regexPtr = TR::SimpleRegex::create(str);
    }
 

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -433,7 +433,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _xrsSync;
 
-   static char * _externalOptionStrings[ExternalOptions::TR_NumExternalOptions];
+   static const char * _externalOptionStrings[ExternalOptions::TR_NumExternalOptions];
 
    static void  printPID();
 
@@ -442,35 +442,35 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
 
 
-   static char *kcaOffsets(char *option, void *, TR::OptionTable *entry);
+   static const char *kcaOffsets(const char *option, void *, TR::OptionTable *entry);
 
-   static char *gcOnResolveOption(char *option, void *, TR::OptionTable *entry);
+   static const char *gcOnResolveOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *tprofOption(char *option, void *, TR::OptionTable *entry);
+   static const char *tprofOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *loadLimitOption(char *option, void *, TR::OptionTable *entry);
+   static const char *loadLimitOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *loadLimitfileOption(char *option, void *, TR::OptionTable *entry);
+   static const char *loadLimitfileOption(const char *option, void *, TR::OptionTable *entry);
 
 #if defined(J9VM_OPT_JITSERVER)
-   static char *JITServerAOTCacheStoreLimitOption(char *option, void *, TR::OptionTable *entry);
-   static char *JITServerAOTCacheLoadLimitOption(char *option, void *, TR::OptionTable *entry);
-   static char *JITServerRemoteExclude(char *option, void *base, TR::OptionTable *entry);
+   static const char *JITServerAOTCacheStoreLimitOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *JITServerAOTCacheLoadLimitOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *JITServerRemoteExclude(const char *option, void *base, TR::OptionTable *entry);
    static bool JITServerParseCommonOptions(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo);
    static void JITServerParseLocalSyncCompiles(J9VMInitArgs *vmArgsArray, J9JavaVM *vm, TR::CompilationInfo *compInfo, bool isFSDEnabled);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-   static char *vmStateOption(char *option, void *, TR::OptionTable *entry);
+   static const char *vmStateOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *setJitConfigRuntimeFlag(char *option, void *base, TR::OptionTable *entry);
-   static char *resetJitConfigRuntimeFlag(char *option, void *base, TR::OptionTable *entry);
-   static char *setJitConfigNumericValue(char *option, void *base, TR::OptionTable *entry);
+   static const char *setJitConfigRuntimeFlag(const char *option, void *base, TR::OptionTable *entry);
+   static const char *resetJitConfigRuntimeFlag(const char *option, void *base, TR::OptionTable *entry);
+   static const char *setJitConfigNumericValue(const char *option, void *base, TR::OptionTable *entry);
 
    static bool useCompressedPointers();
-   static char *limitOption(char *option, void *, TR::OptionTable *entry);
-   static char *inlinefileOption(char *option, void *, TR::OptionTable *entry);
-   static char *limitfileOption(char *option, void *, TR::OptionTable *entry);
-   static char *versionOption(char *option, void *, TR::OptionTable *entry);
+   static const char *limitOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *inlinefileOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *limitfileOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *versionOption(const char *option, void *, TR::OptionTable *entry);
 
    /** \brief
     *    Set memory manager functions related configuration.
@@ -626,7 +626,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    private:
 
 #if defined(J9VM_OPT_JITSERVER)
-   static char *JITServerAOTCacheLimitOption(char *option, void *base, TR::OptionTable *entry, TR::CompilationFilters *&filters, const char *optName);
+   static const char *JITServerAOTCacheLimitOption(const char *option, void *base, TR::OptionTable *entry, TR::CompilationFilters *&filters, const char *optName);
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -394,7 +394,7 @@ J9::OptionsPostRestore::processInternalCompilerOptions(bool isAOT)
 
    if (commandLineOptions)
       {
-      char *remainder = TR::Options::processOptionSetPostRestore(_jitConfig, commandLineOptions, options, isAOT);
+      const char *remainder = TR::Options::processOptionSetPostRestore(_jitConfig, commandLineOptions, options, isAOT);
       if (*remainder)
          {
          // TODO: Error condition

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -156,7 +156,7 @@ bool isQuickstart = false;
 TR::Monitor *vpMonitor = 0;
 
 
-char *compilationErrorNames[]={
+const char *compilationErrorNames[]={
    "compilationOK",                                        // 0
    "compilationFailure",                                   // 1
    "compilationRestrictionILNodes",                        // 2
@@ -1317,7 +1317,7 @@ onLoadInternal(
    //
    if (xaotCommandLine)
       {
-      char *endAOTOptions = TR::Options::processOptionsAOT(xaotCommandLine, jitConfig, feWithoutThread);
+      const char *endAOTOptions = TR::Options::processOptionsAOT(xaotCommandLine, jitConfig, feWithoutThread);
       if (*endAOTOptions)
          {
          // Generate AOT error message only if error occurs in -Xaot processing
@@ -1333,7 +1333,7 @@ onLoadInternal(
          }
       }
 
-   char *endJITOptions = TR::Options::processOptionsJIT(xjitCommandLine, jitConfig, feWithoutThread);
+   const char *endJITOptions = TR::Options::processOptionsJIT(xjitCommandLine, jitConfig, feWithoutThread);
 
    if (*endJITOptions)
       {
@@ -1944,7 +1944,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       }
 #endif
 
-   char * endOptionsAOT = TR::Options::latePostProcessAOT(jitConfig);
+   const char *endOptionsAOT = TR::Options::latePostProcessAOT(jitConfig);
    if ((intptr_t)endOptionsAOT == 1)
       return 1;
 
@@ -1958,7 +1958,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       return -1;
       }
 
-   char * endOptions = TR::Options::latePostProcessJIT(jitConfig);
+   const char *endOptions = TR::Options::latePostProcessJIT(jitConfig);
    if ((intptr_t)endOptions == 1)
       return 1;
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2152,14 +2152,14 @@ bool TR_J9ByteCodeIlGenerator::replaceMethods(TR::TreeTop *tt, TR::Node *node)
    return true;
    }
 
-static bool matchFieldOrStaticName(TR::Compilation* comp, TR::Node* node, char* staticOrFieldName) {
+static bool matchFieldOrStaticName(TR::Compilation *comp, TR::Node *node, const char *staticOrFieldName) {
    if ((!node->getOpCode().isLoad() && !node->getOpCode().isStore()) ||
        !node->getOpCode().hasSymbolReference())
       return false;
-   TR::SymbolReference* symRef = node->getSymbolReference();
-   TR::Symbol* sym = symRef->getSymbol();
+   TR::SymbolReference *symRef = node->getSymbolReference();
+   TR::Symbol *sym = symRef->getSymbol();
    if (sym == NULL || symRef->getCPIndex() < 0) return false;
-   TR_ResolvedMethod* method = comp->getOwningMethodSymbol(symRef->getOwningMethodIndex())->getResolvedMethod();
+   TR_ResolvedMethod *method = comp->getOwningMethodSymbol(symRef->getOwningMethodIndex())->getResolvedMethod();
    if (!method) return false;
    switch(sym->getKind()) {
    case TR::Symbol::IsStatic:
@@ -2170,12 +2170,12 @@ static bool matchFieldOrStaticName(TR::Compilation* comp, TR::Node* node, char* 
       int32_t numHelperSymbols = comp->getSymRefTab()->getNumHelperSymbols();
       if ((index < numHelperSymbols) || (index < nonhelperIndex) || !sym->isStaticField()) return false;
 
-      const char * nodeName = method->staticName(symRef->getCPIndex(), comp->trMemory(), stackAlloc);
+      const char *nodeName = method->staticName(symRef->getCPIndex(), comp->trMemory(), stackAlloc);
       return !strcmp(nodeName, staticOrFieldName);
       }
    case TR::Symbol::IsShadow:
       {
-      const char * nodeName = method->fieldName(symRef->getCPIndex(), comp->trMemory(), stackAlloc);
+      const char *nodeName = method->fieldName(symRef->getCPIndex(), comp->trMemory(), stackAlloc);
       return !strcmp(nodeName, staticOrFieldName);
       }
    default:
@@ -2183,8 +2183,8 @@ static bool matchFieldOrStaticName(TR::Compilation* comp, TR::Node* node, char* 
    }
 }
 
-bool TR_J9ByteCodeIlGenerator::replaceField(TR::Node* node, char* destClass,
-                 char* destFieldName, char* destFieldSignature,
+bool TR_J9ByteCodeIlGenerator::replaceField(TR::Node *node, const char *destClass,
+                 const char *destFieldName, const char *destFieldSignature,
                  int parmIndex)
    {
    TR_OpaqueClassBlock *c = fej9()->getClassFromSignature(destClass, strlen(destClass), comp()->getCurrentMethod());
@@ -2242,8 +2242,8 @@ bool TR_J9ByteCodeIlGenerator::replaceField(TR::Node* node, char* destClass,
    return false;
    }
 
-bool TR_J9ByteCodeIlGenerator::replaceStatic(TR::Node* node,
-                                           char* dstClassName, char* staticName, char* type)
+bool TR_J9ByteCodeIlGenerator::replaceStatic(TR::Node *node,
+                                           const char *dstClassName, const char *staticName, const char *type)
    {
    TR_OpaqueClassBlock *c = fej9()->getClassFromSignature(dstClassName, strlen(dstClassName), comp()->getCurrentMethod());
 

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -166,13 +166,13 @@ private:
    TR::SymbolReference *expandPlaceholderSignature(TR::SymbolReference *symRef, int32_t numArgs);
    TR::SymbolReference *expandPlaceholderSignature(TR::SymbolReference *symRef, int32_t numArgs, int32_t firstArgStackDepth);
    TR::SymbolReference *placeholderWithDummySignature();
-   TR::SymbolReference *placeholderWithSignature(char *prefix, int prefixLength, char *middle, int middleLength, char *suffix, int suffixLength);
+   TR::SymbolReference *placeholderWithSignature(const char *prefix, int prefixLength, const char *middle, int middleLength, const char *suffix, int suffixLength);
 
    void chopPlaceholder(TR::Node *placeholder, int32_t firstChild, int32_t numChildren);
 
-   char               *artificialSignature (TR_AllocationKind alloc, char *format, ...);
-   char               *vartificialSignature(TR_AllocationKind alloc, char *format, va_list args);
-   TR::SymbolReference *symRefWithArtificialSignature(TR::SymbolReference *original, char *effectiveSigFormat, ...);
+   char               *artificialSignature (TR_AllocationKind alloc, const char *format, ...);
+   char               *vartificialSignature(TR_AllocationKind alloc, const char *format, va_list args);
+   TR::SymbolReference *symRefWithArtificialSignature(TR::SymbolReference *original, const char *effectiveSigFormat, ...);
 
    // GenLoadStore
    //
@@ -363,8 +363,8 @@ private:
    bool replaceMembersOfFormat();
    bool replaceMethods(TR::TreeTop *tt, TR::Node *node);
    bool replaceFieldsAndStatics(TR::TreeTop *tt, TR::Node *node);
-   bool replaceField(TR::Node* node, char* destClass, char* destFieldName, char* destFieldSignature, int ParmIndex);
-   bool replaceStatic(TR::Node* node, char* dstClassName, char* staticName, char* type);
+   bool replaceField(TR::Node *node, const char* destClass, const char *destFieldName, const char *destFieldSignature, int ParmIndex);
+   bool replaceStatic(TR::Node *node, const char *dstClassName, const char *staticName, const char *type);
 
    uintptr_t walkReferenceChain(TR::Node *node, uintptr_t receiver);
 #if defined(J9VM_OPT_JITSERVER)
@@ -422,8 +422,8 @@ private:
 
    // DecimalFormatPeephole
    struct methodRenamePair{
-      char* srcMethodSignature;
-      char* dstMethodSignature;
+      const char *srcMethodSignature;
+      const char *dstMethodSignature;
    };
 
    static const int32_t              _numDecFormatRenames = 9;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -780,7 +780,7 @@ TR_J9ByteCodeIlGenerator::placeholderWithDummySignature()
    }
 
 TR::SymbolReference *
-TR_J9ByteCodeIlGenerator::placeholderWithSignature(char *prefix, int prefixLength, char *middle, int middleLength, char *suffix, int suffixLength)
+TR_J9ByteCodeIlGenerator::placeholderWithSignature(const char *prefix, int prefixLength, const char *middle, int middleLength, const char *suffix, int suffixLength)
    {
    return symRefWithArtificialSignature(placeholderWithDummySignature(),
       ".#.#.#",
@@ -790,7 +790,7 @@ TR_J9ByteCodeIlGenerator::placeholderWithSignature(char *prefix, int prefixLengt
    }
 
 TR::SymbolReference *
-TR_J9ByteCodeIlGenerator::symRefWithArtificialSignature(TR::SymbolReference *original, char *effectiveSigFormat, ...)
+TR_J9ByteCodeIlGenerator::symRefWithArtificialSignature(TR::SymbolReference *original, const char *effectiveSigFormat, ...)
    {
    TR::StackMemoryRegion stackMemoryRegion(*comp()->trMemory());
 
@@ -804,14 +804,14 @@ TR_J9ByteCodeIlGenerator::symRefWithArtificialSignature(TR::SymbolReference *ori
    return result;
    }
 
-static int32_t processArtificialSignature(char *result, char *format, va_list args)
+static int32_t processArtificialSignature(char *result, const char *format, va_list args)
    {
    int32_t resultLength = 0;
    char *cur = result;
    for (int32_t i = 0; format[i]; i++)
       {
-      int32_t length=-1;
-      char   *startChar=NULL;
+      int32_t length = -1;
+      const char *startChar = NULL;
       if (format[i] == '.') // period is the ONLY character (besides null) that can never appear in a method signature
          {
          // Formatting code
@@ -877,7 +877,7 @@ static int32_t processArtificialSignature(char *result, char *format, va_list ar
                // case, proceed on the assumption that the period was a literal character;
                // if TR has a bug, we will very likely crash soon enough anyway.
                //
-               startChar = format+i-1; // back up to the period
+               startChar = format + i - 1; // back up to the period
                length = 2;
                break;
             }
@@ -885,7 +885,7 @@ static int32_t processArtificialSignature(char *result, char *format, va_list ar
       else
          {
          // Literal character
-         startChar = format+i;
+         startChar = format + i;
          length = 1;
          }
 
@@ -901,7 +901,7 @@ static int32_t processArtificialSignature(char *result, char *format, va_list ar
    return resultLength;
    }
 
-char *TR_J9ByteCodeIlGenerator::artificialSignature(TR_AllocationKind allocKind, char *format, ...)
+char *TR_J9ByteCodeIlGenerator::artificialSignature(TR_AllocationKind allocKind, const char *format, ...)
    {
    va_list args;
    va_start(args, format);
@@ -910,7 +910,7 @@ char *TR_J9ByteCodeIlGenerator::artificialSignature(TR_AllocationKind allocKind,
    return result;
    }
 
-char *TR_J9ByteCodeIlGenerator::vartificialSignature(TR_AllocationKind allocKind, char *format, va_list args)
+char *TR_J9ByteCodeIlGenerator::vartificialSignature(TR_AllocationKind allocKind, const char *format, va_list args)
    {
    // Compute size
    //
@@ -5665,7 +5665,7 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
             // for unresolved primitive the resolve helper only returns an autobox'd object).
             if (isCondyPrimitive)
                {
-               char *autoboxClassSig = NULL;
+               const char *autoboxClassSig = NULL;
                int32_t autoboxClassSigLength = 0;
                switch (returnTypeUtf8Data[0])
                   {
@@ -5777,7 +5777,7 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
             // Condy is primitive type, emit indirect load of the value field from the autobox object.
             if (isCondyPrimitive)
                {
-               char *recogFieldName = NULL;
+               const char *recogFieldName = NULL;
                TR::Symbol::RecognizedField valueRecogField= TR::Symbol::UnknownField;
                TR::DataType dt = TR::NoType;
                switch (returnTypeUtf8Data[0])

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4048,11 +4048,11 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
       return false;
 
    TR_J9InlinerPolicy *j9InlinerPolicy = (TR_J9InlinerPolicy *)getPolicy();
-   static char *polymorphicCalleeSizeThresholdStr = feGetEnv("TR_InlinerPolymorphicConservatismCalleeSize");
+   static const char *polymorphicCalleeSizeThresholdStr = feGetEnv("TR_InlinerPolymorphicConservatismCalleeSize");
    int polymorphicCalleeSizeThreshold = polymorphicCalleeSizeThresholdStr ? atoi(polymorphicCalleeSizeThresholdStr) : 10;
-   static char *polymorphicRootSizeThresholdStr = feGetEnv("TR_InlinerPolymorphicConservatismRootSize");
+   static const char *polymorphicRootSizeThresholdStr = feGetEnv("TR_InlinerPolymorphicConservatismRootSize");
    int polymorphicRootSizeThreshold = polymorphicRootSizeThresholdStr ? atoi(polymorphicRootSizeThresholdStr) : 30;
-   static char *trustedInterfacePattern = feGetEnv("TR_TrustedPolymorphicInterfaces");
+   static const char *trustedInterfacePattern = feGetEnv("TR_TrustedPolymorphicInterfaces");
    static TR::SimpleRegex *trustedInterfaceRegex = trustedInterfacePattern ? TR::SimpleRegex::create(trustedInterfacePattern) : NULL;
    // we need to be conservative about inlining potentially highly polymorphic interface calls for
    // functional frameworks like scala - we limit this to hot and above

--- a/runtime/compiler/ras/kca_offsets_generator.cpp
+++ b/runtime/compiler/ras/kca_offsets_generator.cpp
@@ -47,8 +47,8 @@
 #include <stdio.h>
 
 
-char *
-J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
+const char *
+J9::Options::kcaOffsets(const char *option, void *, TR::OptionTable *entry)
    {
    char szFileName[40];
    char szCMPRSS[8];

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -208,7 +208,7 @@ OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_Runt
    }
 
 void
-OMR::RuntimeAssumption::dumpInfo(char *subclassName)
+OMR::RuntimeAssumption::dumpInfo(const char *subclassName)
    {
    TR_VerboseLog::write("%s@%p: key=%p", subclassName, this, _key);
    }
@@ -1368,9 +1368,9 @@ void TR_AddressSet::setRanges(const std::vector<TR_AddressRange> &ranges)
    }
 #endif
 
-void TR_AddressSet::trace(char *format, ...)
+void TR_AddressSet::trace(const char *format, ...)
    {
-   static char *env = feGetEnv("TR_traceUnloadedClassRanges");
+   static const char *env = feGetEnv("TR_traceUnloadedClassRanges");
    if (env)
       {
       va_list args;

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -134,7 +134,7 @@ void printHashedCallSite ( TR_IPHashedCallSite * hcs, ::FILE* fout = stderr, voi
 
 static bool matchesRegularExpression (TR::Compilation* comp) {
 
-   static char* cRegex = feGetEnv ("TR_printIfRegex");
+   static const char *cRegex = feGetEnv ("TR_printIfRegex");
    if (cRegex && comp->getOptions())
       {
       static TR::SimpleRegex * regex = TR::SimpleRegex::create(cRegex);

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -473,7 +473,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
       mcc_printf("TR::CodeCache::allocated : codeCacheSegment is %p\n",codeCacheSegment);
       if (config.verboseCodeCache())
          {
-         char * verboseLogString = "The code cache repository was allocated between addresses %p and %p";
+         const char *verboseLogString = "The code cache repository was allocated between addresses %p and %p";
          if (preferredStartAddress && self()->isInRange((uintptr_t)(codeCacheSegment->baseAddress), someJitLibraryAddress, MAX_DISTANCE_NEAR_JITLIBRARY_TO_AVOID_TRAMPOLINE))
             {
             verboseLogString = "The code cache repository was allocated between addresses %p and %p to be near the VM/JIT modules to avoid trampolines";

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -729,9 +729,9 @@ TR_ValueProfiler::addListOrArrayProfilingTrees(
          _bdClass = comp()->fe()->getClassFromSignature("Ljava/math/BigDecimal;", 22, owningMethod);
          }
       TR_OpaqueClassBlock * bdClass = _bdClass;
-      char *fieldName = "scale";
+      const char *fieldName = "scale";
       int32_t fieldNameLen = 5;
-      char *fieldSig = "I";
+      const char *fieldSig = "I";
       int32_t fieldSigLen = 1;
 
       scaleOffset = comp()->fej9()->getInstanceFieldOffset(bdClass, fieldName, fieldNameLen, fieldSig, fieldSigLen);
@@ -766,9 +766,9 @@ TR_ValueProfiler::addListOrArrayProfilingTrees(
          }
 
       TR_OpaqueClassBlock * stringClass = _stringClass;
-      char *fieldName = "count";
+      const char *fieldName = "count";
       int32_t fieldNameLen = 5;
-      char *fieldSig = "I";
+      const char *fieldSig = "I";
       int32_t fieldSigLen = 1;
 
       lengthOffset = comp()->fej9()->getInstanceFieldOffset(stringClass, fieldName, fieldNameLen, fieldSig, fieldSigLen);

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1421,7 +1421,7 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
       TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "%p   Nearby stack slots:", vmThread);
       for (i = -9; i <= 9; i++)
          {
-         char *tag = "";
+         const char *tag = "";
          void *slotValue = stack[i];
          if (slotValue == methodHandle)
             tag = " <- target MethodHandle is here";

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1150,7 +1150,7 @@ TR_RelocationRecordWithOffset::applyRelocation(TR_RelocationRuntime *reloRuntime
 
 // TR_BlockFrequency
 //
-char *
+const char *
 TR_RelocationRecordBlockFrequency::name()
    {
    return "TR_BlockFrequency";
@@ -1222,7 +1222,7 @@ TR_RelocationRecordBlockFrequency::applyRelocation(TR_RelocationRuntime *reloRun
 
 // TR_RecompQueuedFlag
 //
-char *
+const char *
 TR_RelocationRecordRecompQueuedFlag::name()
    {
    return "TR_RecompQueuedFlag";
@@ -1273,7 +1273,7 @@ TR_RelocationRecordRecompQueuedFlag::applyRelocation(TR_RelocationRuntime *reloR
 
 // TR_GlobalValue
 //
-char *
+const char *
 TR_RelocationRecordGlobalValue::name()
    {
    return "TR_GlobalValue";
@@ -1288,7 +1288,7 @@ TR_RelocationRecordGlobalValue::preparePrivateData(TR_RelocationRuntime *reloRun
    }
 
 // TR_BodyInfoLoad
-char *
+const char *
 TR_RelocationRecordBodyInfoLoad::name()
    {
    return "TR_BodyInfoLoad";
@@ -1319,7 +1319,7 @@ TR_RelocationRecordBodyInfoLoad::applyRelocation(TR_RelocationRuntime *reloRunti
    }
 
 // TR_ArrayCopyHelper
-char *
+const char *
 TR_RelocationRecordArrayCopyHelper::name()
    {
    return "TR_ArrayCopyHelper";
@@ -1355,7 +1355,7 @@ TR_RelocationRecordArrayCopyHelper::applyRelocation(TR_RelocationRuntime *reloRu
    }
 
 // TR_ArrayCopyToc
-char *
+const char *
 TR_RelocationRecordArrayCopyToc::name()
    {
    return "TR_ArrayCopyToc";
@@ -1374,7 +1374,7 @@ TR_RelocationRecordArrayCopyToc::preparePrivateData(TR_RelocationRuntime *reloRu
    }
 
 // TR_RamMethodSequence
-char *
+const char *
 TR_RelocationRecordRamSequence::name()
    {
    return "TR_RamMethodSequence";
@@ -1471,7 +1471,7 @@ TR_RelocationRecordWithInlinedSiteIndex::action(TR_RelocationRuntime *reloRuntim
 
 
 // Constant Pool relocations
-char *
+const char *
 TR_RelocationRecordConstantPool::name()
    {
    return "TR_ConstantPool";
@@ -1772,7 +1772,7 @@ TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationR
    }
 
 // TR_HelperAddress
-char *
+const char *
 TR_RelocationRecordHelperAddress::name()
    {
    return "TR_HelperAddress";
@@ -1848,7 +1848,7 @@ TR_RelocationRecordHelperAddress::applyRelocation(TR_RelocationRuntime *reloRunt
    return TR_RelocationErrorCode::relocationOK;
    }
 
-char *
+const char *
 TR_RelocationRecordAbsoluteHelperAddress::name()
    {
    return "TR_AbsoluteHelperAddress";
@@ -1877,7 +1877,7 @@ TR_RelocationRecordAbsoluteHelperAddress::applyRelocation(TR_RelocationRuntime *
 
 // Method Address Relocations
 //
-char *
+const char *
 TR_RelocationRecordMethodAddress::name()
    {
    return "TR_MethodAddress";
@@ -1927,7 +1927,7 @@ TR_RelocationRecordMethodAddress::applyRelocation(TR_RelocationRuntime *reloRunt
 
 // Direct JNI Address Relocations
 
-char *
+const char *
 TR_RelocationRecordDirectJNICall::name()
    {
    return "TR_JNITargetAddress";
@@ -2018,7 +2018,7 @@ TR_RelocationRecordRamMethodConst::applyRelocation(TR_RelocationRuntime *reloRun
 
 
 // Data Address Relocations
-char *
+const char *
 TR_RelocationRecordDataAddress::name()
    {
    return "TR_DataAddress";
@@ -2121,7 +2121,7 @@ TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntim
    }
 
 // Class Object Relocations
-char *
+const char *
 TR_RelocationRecordClassAddress::name()
    {
    return "TR_ClassAddress";
@@ -2195,7 +2195,7 @@ TR_RelocationRecordClassAddress::applyRelocation(TR_RelocationRuntime *reloRunti
    }
 
 // MethodObject Relocations
-char *
+const char *
 TR_RelocationRecordMethodObject::name()
    {
    return "TR_MethodObject";
@@ -2220,7 +2220,7 @@ TR_RelocationRecordMethodObject::applyRelocation(TR_RelocationRuntime *reloRunti
    }
 
 // TR_BodyInfoAddress Relocation
-char *
+const char *
 TR_RelocationRecordBodyInfo::name()
    {
    return "TR_BodyInfo";
@@ -2240,7 +2240,7 @@ TR_RelocationRecordBodyInfo::applyRelocation(TR_RelocationRuntime *reloRuntime, 
    }
 
 // TR_Thunks Relocation
-char *
+const char *
 TR_RelocationRecordThunks::name()
    {
    return "TR_Thunks";
@@ -2370,7 +2370,7 @@ TR_RelocationRecordThunks::relocateAndRegisterThunk(
    }
 
 // TR_J2IVirtualThunkPointer Relocation
-char *
+const char *
 TR_RelocationRecordJ2IVirtualThunkPointer::name()
    {
    return "TR_J2IVirtualThunkPointer";
@@ -2413,7 +2413,7 @@ TR_RelocationRecordJ2IVirtualThunkPointer::offsetToJ2IVirtualThunkPointer(
    }
 
 // TR_PicTrampolines Relocation
-char *
+const char *
 TR_RelocationRecordPicTrampolines::name()
    {
    return "TR_PicTrampolines";
@@ -2454,7 +2454,7 @@ TR_RelocationRecordPicTrampolines::applyRelocation(TR_RelocationRuntime *reloRun
 
 // TR_Trampolines Relocation
 
-char *
+const char *
 TR_RelocationRecordTrampolines::name()
    {
    return "TR_Trampolines";
@@ -2575,7 +2575,7 @@ TR_RelocationRecordInlinedAllocation::applyRelocation(TR_RelocationRuntime *relo
    }
 
 // TR_VerifyRefArrayForAlloc Relocation
-char *
+const char *
 TR_RelocationRecordVerifyRefArrayForAlloc::name()
    {
    return "TR_VerifyRefArrayForAlloc";
@@ -2589,7 +2589,7 @@ TR_RelocationRecordVerifyRefArrayForAlloc::verifyClass(TR_RelocationRuntime *rel
 
 
 // TR_VerifyClassObjectForAlloc Relocation
-char *
+const char *
 TR_RelocationRecordVerifyClassObjectForAlloc::name()
    {
    return "TR_VerifyClassObjectForAlloc";
@@ -2949,7 +2949,7 @@ TR_RelocationRecordNopGuard::preparePrivateData(TR_RelocationRuntime *reloRuntim
    }
 
 // TR_InlinedStaticMethodWithNopGuard
-char *
+const char *
 TR_RelocationRecordInlinedStaticMethodWithNopGuard::name()
    {
    return "TR_InlinedStaticMethodWithNopGuard";
@@ -2975,7 +2975,7 @@ TR_RelocationRecordInlinedStaticMethodWithNopGuard::updateSucceededStats(TR_AOTS
 
 
 // TR_RelocationRecordInlinedStaticMethod
-char *
+const char *
 TR_RelocationRecordInlinedStaticMethod::name()
    {
    return "TR_InlinedStaticMethod";
@@ -2988,7 +2988,7 @@ TR_RelocationRecordInlinedStaticMethod::getMethodFromCP(TR_RelocationRuntime *re
    }
 
 // TR_InlinedSpecialMethodWithNopGuard
-char *
+const char *
 TR_RelocationRecordInlinedSpecialMethodWithNopGuard::name()
    {
    return "TR_InlinedSpecialMethodWithNopGuard";
@@ -3013,7 +3013,7 @@ TR_RelocationRecordInlinedSpecialMethodWithNopGuard::updateSucceededStats(TR_AOT
    }
 
 // TR_RelocationRecordInlinedSpecialMethod
-char *
+const char *
 TR_RelocationRecordInlinedSpecialMethod::name()
    {
    return "TR_InlinedSpecialMethod";
@@ -3026,7 +3026,7 @@ TR_RelocationRecordInlinedSpecialMethod::getMethodFromCP(TR_RelocationRuntime *r
    }
 
 // TR_InlinedVirtualMethodWithNopGuard
-char *
+const char *
 TR_RelocationRecordInlinedVirtualMethodWithNopGuard::name()
    {
    return "TR_InlinedVirtualMethodWithNopGuard";
@@ -3060,7 +3060,7 @@ TR_RelocationRecordInlinedVirtualMethodWithNopGuard::updateSucceededStats(TR_AOT
    }
 
 // TR_RelocationRecordInlinedVirtualMethod
-char *
+const char *
 TR_RelocationRecordInlinedVirtualMethod::name()
    {
    return "TR_InlinedVirtualMethod";
@@ -3073,7 +3073,7 @@ TR_RelocationRecordInlinedVirtualMethod::getMethodFromCP(TR_RelocationRuntime *r
    }
 
 // TR_InlinedInterfaceMethodWithNopGuard
-char *
+const char *
 TR_RelocationRecordInlinedInterfaceMethodWithNopGuard::name()
    {
    return "TR_InlinedInterfaceMethodWithNopGuard";
@@ -3113,7 +3113,7 @@ TR_RelocationRecordInlinedInterfaceMethodWithNopGuard::getMethodFromCP(TR_Reloca
    }
 
 // TR_RelocationRecordInlinedInterfaceMethod
-char *
+const char *
 TR_RelocationRecordInlinedInterfaceMethod::name()
    {
    return "TR_InlinedInterfaceMethod";
@@ -3126,7 +3126,7 @@ TR_RelocationRecordInlinedInterfaceMethod::getMethodFromCP(TR_RelocationRuntime 
    }
 
 // TR_InlinedAbstractMethodWithNopGuard
-char *
+const char *
 TR_RelocationRecordInlinedAbstractMethodWithNopGuard::name()
    {
    return "TR_InlinedAbstractMethodWithNopGuard";
@@ -3164,7 +3164,7 @@ TR_RelocationRecordInlinedAbstractMethodWithNopGuard::updateSucceededStats(TR_AO
    }
 
 // TR_RelocationRecordInlinedAbstractMethod
-char *
+const char *
 TR_RelocationRecordInlinedAbstractMethod::name()
    {
    return "TR_InlinedAbstractMethod";
@@ -3177,7 +3177,7 @@ TR_RelocationRecordInlinedAbstractMethod::getMethodFromCP(TR_RelocationRuntime *
    }
 
 // TR_ProfiledInlinedMethod
-char *
+const char *
 TR_RelocationRecordProfiledInlinedMethod::name()
    {
    return "TR_ProfiledInlinedMethod";
@@ -3382,7 +3382,7 @@ TR_RelocationRecordProfiledGuard::invalidateGuard(TR_RelocationRuntime *reloRunt
    }
 
 // TR_ProfileClassGuard
-char *
+const char *
 TR_RelocationRecordProfiledClassGuard::name()
    {
    return "TR_ProfiledClassGuard";
@@ -3416,7 +3416,7 @@ TR_RelocationRecordProfiledClassGuard::updateFailedStats(TR_AOTStats *aotStats)
 
 
 // TR_ProfiledMethodGuard
-char *
+const char *
 TR_RelocationRecordProfiledMethodGuard::name()
    {
    return "TR_ProfiledMethodGuard";
@@ -3451,7 +3451,7 @@ TR_RelocationRecordProfiledMethodGuard::updateFailedStats(TR_AOTStats *aotStats)
 
 
 // TR_RamMethod Relocation
-char *
+const char *
 TR_RelocationRecordRamMethod::name()
    {
    return "TR_RamMethod";
@@ -3515,7 +3515,7 @@ TR_RelocationRecordMethodTracingCheck::applyRelocation(TR_RelocationRuntime *rel
 
 
 // TR_MethodEnterCheck
-char *
+const char *
 TR_RelocationRecordMethodEnterCheck::name()
    {
    return "TR_MethodEnterCheck";
@@ -3531,7 +3531,7 @@ TR_RelocationRecordMethodEnterCheck::action(TR_RelocationRuntime *reloRuntime)
 
 
 // TR_MethodExitCheck
-char *
+const char *
 TR_RelocationRecordMethodExitCheck::name()
    {
    return "TR_MethodExitCheck";
@@ -3547,7 +3547,7 @@ TR_RelocationRecordMethodExitCheck::action(TR_RelocationRuntime *reloRuntime)
 
 
 // TR_RelocationRecordValidateClass
-char *
+const char *
 TR_RelocationRecordValidateClass::name()
    {
    return "TR_ValidateClass";
@@ -3653,7 +3653,7 @@ TR_RelocationRecordValidateClass::failureCode()
 
 
 // TR_VerifyInstanceField
-char *
+const char *
 TR_RelocationRecordValidateInstanceField::name()
    {
    return "TR_ValidateInstanceField";
@@ -3678,7 +3678,7 @@ TR_RelocationRecordValidateInstanceField::failureCode()
    }
 
 // TR_VerifyStaticField
-char *
+const char *
 TR_RelocationRecordValidateStaticField::name()
    {
    return "TR_ValidateStaticField";
@@ -3737,7 +3737,7 @@ TR_RelocationRecordValidateStaticField::validateClass(TR_RelocationRuntime *relo
 
 
 // TR_RelocationRecordValidateArbitraryClass
-char *
+const char *
 TR_RelocationRecordValidateArbitraryClass::name()
    {
    return "TR_ValidateArbitraryClass";
@@ -5537,7 +5537,7 @@ TR_RelocationRecordResolvedTrampolines::applyRelocation(TR_RelocationRuntime *re
 
 
 // TR_HCR
-char *
+const char *
 TR_RelocationRecordHCR::name()
    {
    return "TR_HCR";
@@ -5701,7 +5701,7 @@ TR_RelocationRecordPointer::applyRelocation(TR_RelocationRuntime *reloRuntime, T
    }
 
 // TR_ClassPointer
-char *
+const char *
 TR_RelocationRecordClassPointer::name()
    {
    return "TR_ClassPointer";
@@ -5722,7 +5722,7 @@ TR_RelocationRecordClassPointer::activatePointer(TR_RelocationRuntime *reloRunti
    }
 
 // TR_ArbitraryClassAddress
-char *
+const char *
 TR_RelocationRecordArbitraryClassAddress::name()
    {
    return "TR_ArbitraryClassAddress";
@@ -5778,7 +5778,7 @@ TR_RelocationRecordArbitraryClassAddress::assertBootstrapLoader(TR_RelocationRun
    }
 
 // TR_MethodPointer
-char *
+const char *
 TR_RelocationRecordMethodPointer::name()
    {
    return "TR_MethodPointer";
@@ -5834,7 +5834,7 @@ TR_RelocationRecordMethodPointer::activatePointer(TR_RelocationRuntime *reloRunt
       registerHCRAssumption(reloRuntime, reloLocation);
    }
 
-char *
+const char *
 TR_RelocationRecordInlinedMethodPointer::name()
    {
    return "TR_InlinedMethodPointer";
@@ -5937,7 +5937,7 @@ TR_RelocationRecordEmitClass::bcIndex(TR_RelocationTarget *reloTarget)
    return reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordEmitClassBinaryTemplate *)_record)->_bcIndex);
    }
 
-char *
+const char *
 TR_RelocationRecordDebugCounter::name()
    {
    return "TR_RelocationRecordDebugCounter";
@@ -6130,7 +6130,7 @@ TR_RelocationRecordDebugCounter::findOrCreateCounter(TR_RelocationRuntime *reloR
    }
 
 // ClassUnloadAssumption
-char *
+const char *
 TR_RelocationRecordClassUnloadAssumption::name()
    {
    return "TR_ClassUnloadAssumption";
@@ -6377,7 +6377,7 @@ TR_RelocationRecordValidateIsClassVisible::isVisible(TR_RelocationTarget *reloTa
    }
 
 
-char *
+const char *
 TR_RelocationRecordStaticDefaultValueInstance::name()
    {
    return "TR_StaticDefaultValueInstance";
@@ -6422,7 +6422,7 @@ TR_RelocationRecordStaticDefaultValueInstance::applyRelocation(TR_RelocationRunt
 
 // TR_CatchBlockCounter
 //
-char *
+const char *
 TR_RelocationRecordCatchBlockCounter::name()
    {
    return "TR_CatchBlockCounter";
@@ -6470,7 +6470,7 @@ TR_RelocationRecordCatchBlockCounter::applyRelocation(TR_RelocationRuntime *relo
 
 // TR_StartPC
 //
-char *
+const char *
 TR_RelocationRecordStartPC::name()
    {
    return "TR_StartPC";

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -225,7 +225,7 @@ class TR_RelocationRecord
       void operator delete (void *, TR_RelocationRecord *p) {}
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
-      virtual char *name() { return "TR_RelocationRecord"; }
+      virtual const char *name() { return "TR_RelocationRecord"; }
 
       virtual bool isValidationRecord() { return false; }
 
@@ -306,7 +306,7 @@ class TR_RelocationRecordBodyInfo : public TR_RelocationRecord
    public:
       TR_RelocationRecordBodyInfo() {}
       TR_RelocationRecordBodyInfo(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
@@ -332,7 +332,7 @@ class TR_RelocationRecordBlockFrequency : public TR_RelocationRecord
       TR_RelocationRecordBlockFrequency() {}
       TR_RelocationRecordBlockFrequency(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setFrequencyOffset(TR_RelocationTarget *reloTarget, uintptr_t offset);
@@ -349,7 +349,7 @@ class TR_RelocationRecordRecompQueuedFlag : public TR_RelocationRecord
       TR_RelocationRecordRecompQueuedFlag() {}
       TR_RelocationRecordRecompQueuedFlag(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -361,7 +361,7 @@ class TR_RelocationRecordGlobalValue : public TR_RelocationRecordWithOffset
    public:
       TR_RelocationRecordGlobalValue() {}
       TR_RelocationRecordGlobalValue(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithOffset(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
    };
@@ -371,7 +371,7 @@ class TR_RelocationRecordBodyInfoLoad : public TR_RelocationRecord
    public:
       TR_RelocationRecordBodyInfoLoad() {}
       TR_RelocationRecordBodyInfoLoad(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -383,7 +383,7 @@ class TR_RelocationRecordArrayCopyHelper : public TR_RelocationRecord
    public:
       TR_RelocationRecordArrayCopyHelper() {}
       TR_RelocationRecordArrayCopyHelper(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -395,7 +395,7 @@ class TR_RelocationRecordArrayCopyToc : public TR_RelocationRecordArrayCopyHelpe
    public:
       TR_RelocationRecordArrayCopyToc() {}
       TR_RelocationRecordArrayCopyToc(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordArrayCopyHelper(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
    };
@@ -405,7 +405,7 @@ class TR_RelocationRecordRamSequence : public TR_RelocationRecordWithOffset
    public:
       TR_RelocationRecordRamSequence() {}
       TR_RelocationRecordRamSequence(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithOffset(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
    };
@@ -446,7 +446,7 @@ class TR_RelocationRecordConstantPool : public TR_RelocationRecordWithInlinedSit
    public:
       TR_RelocationRecordConstantPool() {}
       TR_RelocationRecordConstantPool(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setConstantPool(TR_RelocationTarget *reloTarget, uintptr_t constantPool);
@@ -484,7 +484,7 @@ class TR_RelocationRecordHelperAddress : public TR_RelocationRecord
    public:
       TR_RelocationRecordHelperAddress() {}
       TR_RelocationRecordHelperAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setHelperID(TR_RelocationTarget *reloTarget, uint32_t helperID);
@@ -502,7 +502,7 @@ class TR_RelocationRecordAbsoluteHelperAddress : public TR_RelocationRecordHelpe
    public:
       TR_RelocationRecordAbsoluteHelperAddress() {}
       TR_RelocationRecordAbsoluteHelperAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordHelperAddress(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
@@ -512,7 +512,7 @@ class TR_RelocationRecordDataAddress : public TR_RelocationRecordConstantPoolWit
    public:
       TR_RelocationRecordDataAddress() {}
       TR_RelocationRecordDataAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setOffset(TR_RelocationTarget *reloTarget, uintptr_t offset);
@@ -530,7 +530,7 @@ class TR_RelocationRecordMethodAddress : public TR_RelocationRecord
    public:
       TR_RelocationRecordMethodAddress() {}
       TR_RelocationRecordMethodAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       uint8_t *currentMethodAddress(TR_RelocationRuntime *reloRuntime, uint8_t *oldMethodAddress);
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -542,7 +542,7 @@ class TR_RelocationRecordClassAddress : public TR_RelocationRecordConstantPoolWi
    public:
       TR_RelocationRecordClassAddress() {}
       TR_RelocationRecordClassAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       TR_OpaqueClassBlock *computeNewClassAddress(TR_RelocationRuntime *reloRuntime, uintptr_t newConstantPool, uintptr_t inlinedSiteIndex, uintptr_t cpIndex);
 
@@ -555,7 +555,7 @@ class TR_RelocationRecordDirectJNICall : public TR_RelocationRecordConstantPoolW
    public:
    TR_RelocationRecordDirectJNICall() {}
    TR_RelocationRecordDirectJNICall(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
-   virtual char *name();
+   virtual const char *name();
 
    void setOffsetToReloLocation(TR_RelocationTarget *reloTarget, uint8_t offsetToReloLocation);
    uint8_t offsetToReloLocation(TR_RelocationTarget *reloTarget);
@@ -602,7 +602,7 @@ class TR_RelocationRecordRamMethodConst : public TR_RelocationRecordConstantPool
    public:
    TR_RelocationRecordRamMethodConst() {};
    TR_RelocationRecordRamMethodConst(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
-   virtual char *name()=0;
+   virtual const char *name()=0;
    virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    private:
@@ -615,7 +615,7 @@ class TR_RelocationRecordStaticRamMethodConst : public TR_RelocationRecordRamMet
    public:
    TR_RelocationRecordStaticRamMethodConst() {};
    TR_RelocationRecordStaticRamMethodConst(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordRamMethodConst(reloRuntime, record) {}
-   virtual char *name()  { return "TR_RelocationRecordStaticRamMethodConst"; };
+   virtual const char *name()  { return "TR_RelocationRecordStaticRamMethodConst"; };
 
    private:
    virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex)
@@ -629,7 +629,7 @@ class TR_RelocationRecordVirtualRamMethodConst : public TR_RelocationRecordRamMe
    public:
    TR_RelocationRecordVirtualRamMethodConst() {};
    TR_RelocationRecordVirtualRamMethodConst(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordRamMethodConst(reloRuntime, record) {}
-   virtual char *name()  { return "TR_RelocationRecordVirtualRamMethodConst"; };
+   virtual const char *name()  { return "TR_RelocationRecordVirtualRamMethodConst"; };
 
    private:
    virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex)
@@ -643,7 +643,7 @@ class TR_RelocationRecordSpecialRamMethodConst : public TR_RelocationRecordRamMe
    public:
    TR_RelocationRecordSpecialRamMethodConst() {};
    TR_RelocationRecordSpecialRamMethodConst(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordRamMethodConst(reloRuntime, record) {}
-   virtual char *name()  { return "TR_RelocationRecordSpecialRamMethodConst"; };
+   virtual const char *name()  { return "TR_RelocationRecordSpecialRamMethodConst"; };
 
    private:
    virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex)
@@ -657,7 +657,7 @@ class TR_RelocationRecordMethodObject : public TR_RelocationRecordConstantPool
    public:
       TR_RelocationRecordMethodObject() {}
       TR_RelocationRecordMethodObject(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
@@ -668,7 +668,7 @@ class TR_RelocationRecordThunks : public TR_RelocationRecordConstantPool
    public:
       TR_RelocationRecordThunks() {}
       TR_RelocationRecordThunks(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    protected:
@@ -689,7 +689,7 @@ class TR_RelocationRecordJ2IVirtualThunkPointer : public TR_RelocationRecordThun
       TR_RelocationRecordJ2IVirtualThunkPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
          : TR_RelocationRecordThunks(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
 
       void setOffsetToJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget, uintptr_t j2iVirtualThunkPointer);
       uintptr_t getOffsetToJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget);
@@ -704,7 +704,7 @@ class TR_RelocationRecordTrampolines : public TR_RelocationRecordConstantPool
    public:
       TR_RelocationRecordTrampolines() {}
       TR_RelocationRecordTrampolines(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPool(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -713,7 +713,7 @@ class TR_RelocationRecordPicTrampolines : public TR_RelocationRecord
    public:
       TR_RelocationRecordPicTrampolines() {}
       TR_RelocationRecordPicTrampolines(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setNumTrampolines(TR_RelocationTarget *reloTarget, uint32_t numTrampolines);
@@ -744,7 +744,7 @@ class TR_RelocationRecordVerifyRefArrayForAlloc : public TR_RelocationRecordInli
    public:
       TR_RelocationRecordVerifyRefArrayForAlloc() {}
       TR_RelocationRecordVerifyRefArrayForAlloc(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedAllocation(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    protected:
       virtual bool verifyClass(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_OpaqueClassBlock *clazz);
    };
@@ -754,7 +754,7 @@ class TR_RelocationRecordVerifyClassObjectForAlloc : public TR_RelocationRecordI
    public:
       TR_RelocationRecordVerifyClassObjectForAlloc() {}
       TR_RelocationRecordVerifyClassObjectForAlloc(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedAllocation(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setAllocationSize(TR_RelocationTarget *reloTarget, uintptr_t allocationSize);
@@ -828,7 +828,7 @@ class TR_RelocationRecordInlinedStaticMethodWithNopGuard : public TR_RelocationR
    public:
       TR_RelocationRecordInlinedStaticMethodWithNopGuard() {}
       TR_RelocationRecordInlinedStaticMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
@@ -841,7 +841,7 @@ class TR_RelocationRecordInlinedStaticMethod: public TR_RelocationRecordInlinedM
    public:
       TR_RelocationRecordInlinedStaticMethod() {}
       TR_RelocationRecordInlinedStaticMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -852,7 +852,7 @@ class TR_RelocationRecordInlinedSpecialMethodWithNopGuard : public TR_Relocation
    public:
       TR_RelocationRecordInlinedSpecialMethodWithNopGuard() {}
       TR_RelocationRecordInlinedSpecialMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
@@ -865,7 +865,7 @@ class TR_RelocationRecordInlinedSpecialMethod: public TR_RelocationRecordInlined
    public:
       TR_RelocationRecordInlinedSpecialMethod() {}
       TR_RelocationRecordInlinedSpecialMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -875,7 +875,7 @@ class TR_RelocationRecordInlinedVirtualMethodWithNopGuard : public TR_Relocation
    public:
       TR_RelocationRecordInlinedVirtualMethodWithNopGuard() {}
       TR_RelocationRecordInlinedVirtualMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
       virtual void updateFailedStats(TR_AOTStats *aotStats);
@@ -888,7 +888,7 @@ class TR_RelocationRecordInlinedVirtualMethod: public TR_RelocationRecordInlined
    public:
       TR_RelocationRecordInlinedVirtualMethod() {}
       TR_RelocationRecordInlinedVirtualMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -898,7 +898,7 @@ class TR_RelocationRecordInlinedInterfaceMethodWithNopGuard : public TR_Relocati
    public:
       TR_RelocationRecordInlinedInterfaceMethodWithNopGuard() {}
       TR_RelocationRecordInlinedInterfaceMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    protected:
       virtual bool needsReceiverClassFromID() { return true; }
    private:
@@ -913,7 +913,7 @@ class TR_RelocationRecordInlinedInterfaceMethod: public TR_RelocationRecordInlin
    public:
       TR_RelocationRecordInlinedInterfaceMethod() {}
       TR_RelocationRecordInlinedInterfaceMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -923,7 +923,7 @@ class TR_RelocationRecordInlinedAbstractMethodWithNopGuard : public TR_Relocatio
    public:
       TR_RelocationRecordInlinedAbstractMethodWithNopGuard() {}
       TR_RelocationRecordInlinedAbstractMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    protected:
       virtual bool needsReceiverClassFromID() { return true; }
    private:
@@ -938,7 +938,7 @@ class TR_RelocationRecordInlinedAbstractMethod: public TR_RelocationRecordInline
    public:
       TR_RelocationRecordInlinedAbstractMethod() {}
       TR_RelocationRecordInlinedAbstractMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -948,7 +948,7 @@ class TR_RelocationRecordProfiledInlinedMethod : public TR_RelocationRecordInlin
    public:
       TR_RelocationRecordProfiledInlinedMethod() {}
       TR_RelocationRecordProfiledInlinedMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -994,7 +994,7 @@ class TR_RelocationRecordProfiledClassGuard : public TR_RelocationRecordProfiled
    public:
       TR_RelocationRecordProfiledClassGuard() {}
       TR_RelocationRecordProfiledClassGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordProfiledGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    private:
       virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
@@ -1008,7 +1008,7 @@ class TR_RelocationRecordProfiledMethodGuard : public TR_RelocationRecordProfile
    public:
       TR_RelocationRecordProfiledMethodGuard() {}
       TR_RelocationRecordProfiledMethodGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordProfiledGuard(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    private:
       virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
@@ -1038,7 +1038,7 @@ class TR_RelocationRecordMethodEnterCheck : public TR_RelocationRecordMethodTrac
    public:
       TR_RelocationRecordMethodEnterCheck() {}
       TR_RelocationRecordMethodEnterCheck(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordMethodTracingCheck(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationRecordAction action(TR_RelocationRuntime *reloRuntime);
    };
 
@@ -1047,7 +1047,7 @@ class TR_RelocationRecordMethodExitCheck : public TR_RelocationRecordMethodTraci
    public:
       TR_RelocationRecordMethodExitCheck() {}
       TR_RelocationRecordMethodExitCheck(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordMethodTracingCheck(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationRecordAction action(TR_RelocationRuntime *reloRuntime);
    };
 
@@ -1056,7 +1056,7 @@ class TR_RelocationRecordRamMethod : public TR_RelocationRecord
    public:
       TR_RelocationRecordRamMethod() {}
       TR_RelocationRecordRamMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
@@ -1067,7 +1067,7 @@ class TR_RelocationRecordValidateClass : public TR_RelocationRecordConstantPoolW
    public:
       TR_RelocationRecordValidateClass() {}
       TR_RelocationRecordValidateClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordConstantPoolWithIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       virtual bool isStaticFieldValidation() { return false ; }
@@ -1090,7 +1090,7 @@ class TR_RelocationRecordValidateInstanceField : public TR_RelocationRecordValid
    public:
       TR_RelocationRecordValidateInstanceField() {}
       TR_RelocationRecordValidateInstanceField(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClass(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    protected:
       virtual TR_OpaqueClassBlock *getClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, void *void_cp);
@@ -1102,7 +1102,7 @@ class TR_RelocationRecordValidateStaticField : public TR_RelocationRecordValidat
    public:
       TR_RelocationRecordValidateStaticField() {}
       TR_RelocationRecordValidateStaticField(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateInstanceField(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       virtual bool isStaticFieldValidation() { return true; }
@@ -1121,7 +1121,7 @@ class TR_RelocationRecordValidateArbitraryClass : public TR_RelocationRecord
    public:
       TR_RelocationRecordValidateArbitraryClass() {}
       TR_RelocationRecordValidateArbitraryClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setClassChainIdentifyingLoaderOffset(TR_RelocationTarget *reloTarget, uintptr_t classChainOffset,
@@ -1144,7 +1144,7 @@ class TR_RelocationRecordValidateClassByName : public TR_RelocationRecord
       TR_RelocationRecordValidateClassByName() {}
       TR_RelocationRecordValidateClassByName(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassByName"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassByName"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1167,7 +1167,7 @@ class TR_RelocationRecordValidateProfiledClass : public TR_RelocationRecord
       TR_RelocationRecordValidateProfiledClass() {}
       TR_RelocationRecordValidateProfiledClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateProfiledClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateProfiledClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1191,7 +1191,7 @@ class TR_RelocationRecordValidateClassFromCP : public TR_RelocationRecord
       TR_RelocationRecordValidateClassFromCP() {}
       TR_RelocationRecordValidateClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1213,7 +1213,7 @@ class TR_RelocationRecordValidateDefiningClassFromCP : public TR_RelocationRecor
       TR_RelocationRecordValidateDefiningClassFromCP() {}
       TR_RelocationRecordValidateDefiningClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateDefiningClassFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateDefiningClassFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1237,7 +1237,7 @@ class TR_RelocationRecordValidateStaticClassFromCP : public TR_RelocationRecordV
    public:
       TR_RelocationRecordValidateStaticClassFromCP() {}
       TR_RelocationRecordValidateStaticClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateStaticClassFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateStaticClassFromCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1247,7 +1247,7 @@ class TR_RelocationRecordValidateArrayClassFromComponentClass : public TR_Reloca
       TR_RelocationRecordValidateArrayClassFromComponentClass() {}
       TR_RelocationRecordValidateArrayClassFromComponentClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateArrayClassFromComponentClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateArrayClassFromComponentClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1266,7 +1266,7 @@ class TR_RelocationRecordValidateSuperClassFromClass : public TR_RelocationRecor
       TR_RelocationRecordValidateSuperClassFromClass() {}
       TR_RelocationRecordValidateSuperClassFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateSuperClassFromClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateSuperClassFromClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1285,7 +1285,7 @@ class TR_RelocationRecordValidateClassInstanceOfClass : public TR_RelocationReco
       TR_RelocationRecordValidateClassInstanceOfClass() {}
       TR_RelocationRecordValidateClassInstanceOfClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassInstanceOfClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassInstanceOfClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1313,7 +1313,7 @@ class TR_RelocationRecordValidateSystemClassByName : public TR_RelocationRecord
       TR_RelocationRecordValidateSystemClassByName() {}
       TR_RelocationRecordValidateSystemClassByName(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateSystemClassByName"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateSystemClassByName"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1332,7 +1332,7 @@ class TR_RelocationRecordValidateClassFromITableIndexCP : public TR_RelocationRe
    public:
       TR_RelocationRecordValidateClassFromITableIndexCP() {}
       TR_RelocationRecordValidateClassFromITableIndexCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateClassFromITableIndexCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassFromITableIndexCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1341,7 +1341,7 @@ class TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic : public TR_Rel
    public:
       TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic() {}
       TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1351,7 +1351,7 @@ class TR_RelocationRecordValidateConcreteSubClassFromClass : public TR_Relocatio
       TR_RelocationRecordValidateConcreteSubClassFromClass() {}
       TR_RelocationRecordValidateConcreteSubClassFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
          : TR_RelocationRecordValidateSuperClassFromClass(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateConcreteSubClassFromClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateConcreteSubClassFromClass"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1361,7 +1361,7 @@ class TR_RelocationRecordValidateClassChain : public TR_RelocationRecord
       TR_RelocationRecordValidateClassChain() {}
       TR_RelocationRecordValidateClassChain(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassChain"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassChain"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1381,7 +1381,7 @@ class TR_RelocationRecordValidateMethodFromClass : public TR_RelocationRecord
       TR_RelocationRecordValidateMethodFromClass() {}
       TR_RelocationRecordValidateMethodFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateMethodFromClass"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateMethodFromClass"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1425,7 +1425,7 @@ class TR_RelocationRecordValidateStaticMethodFromCP : public TR_RelocationRecord
    public:
       TR_RelocationRecordValidateStaticMethodFromCP() {}
       TR_RelocationRecordValidateStaticMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateStaticMethodFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateStaticMethodFromCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1434,7 +1434,7 @@ class TR_RelocationRecordValidateSpecialMethodFromCP : public TR_RelocationRecor
    public:
       TR_RelocationRecordValidateSpecialMethodFromCP() {}
       TR_RelocationRecordValidateSpecialMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateSpecialMethodFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateSpecialMethodFromCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1443,7 +1443,7 @@ class TR_RelocationRecordValidateVirtualMethodFromCP : public TR_RelocationRecor
    public:
       TR_RelocationRecordValidateVirtualMethodFromCP() {}
       TR_RelocationRecordValidateVirtualMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateVirtualMethodFromCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1453,7 +1453,7 @@ class TR_RelocationRecordValidateVirtualMethodFromOffset : public TR_RelocationR
       TR_RelocationRecordValidateVirtualMethodFromOffset() {}
       TR_RelocationRecordValidateVirtualMethodFromOffset(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromOffset"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateVirtualMethodFromOffset"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1478,7 +1478,7 @@ class TR_RelocationRecordValidateInterfaceMethodFromCP : public TR_RelocationRec
       TR_RelocationRecordValidateInterfaceMethodFromCP() {}
       TR_RelocationRecordValidateInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateInterfaceMethodFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateInterfaceMethodFromCP"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1505,7 +1505,7 @@ class TR_RelocationRecordValidateImproperInterfaceMethodFromCP : public TR_Reloc
    public:
       TR_RelocationRecordValidateImproperInterfaceMethodFromCP() {}
       TR_RelocationRecordValidateImproperInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateMethodFromCP(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordValidateImproperInterfaceMethodFromCP"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateImproperInterfaceMethodFromCP"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1515,7 +1515,7 @@ class TR_RelocationRecordValidateMethodFromClassAndSig : public TR_RelocationRec
       TR_RelocationRecordValidateMethodFromClassAndSig() {}
       TR_RelocationRecordValidateMethodFromClassAndSig(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateMethodFromClassAndSig"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateMethodFromClassAndSig"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1544,7 +1544,7 @@ class TR_RelocationRecordValidateStackWalkerMaySkipFrames : public TR_Relocation
       TR_RelocationRecordValidateStackWalkerMaySkipFrames() {}
       TR_RelocationRecordValidateStackWalkerMaySkipFrames(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateStackWalkerMaySkipFrames"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateStackWalkerMaySkipFrames"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1566,7 +1566,7 @@ class TR_RelocationRecordValidateClassInfoIsInitialized : public TR_RelocationRe
       TR_RelocationRecordValidateClassInfoIsInitialized() {}
       TR_RelocationRecordValidateClassInfoIsInitialized(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassInfoIsInitialized"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateClassInfoIsInitialized"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1585,7 +1585,7 @@ class TR_RelocationRecordValidateMethodFromSingleImpl : public TR_RelocationReco
       TR_RelocationRecordValidateMethodFromSingleImpl() {}
       TR_RelocationRecordValidateMethodFromSingleImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleImpl"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateMethodFromSingleImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1616,7 +1616,7 @@ class TR_RelocationRecordValidateMethodFromSingleInterfaceImpl : public TR_Reloc
       TR_RelocationRecordValidateMethodFromSingleInterfaceImpl() {}
       TR_RelocationRecordValidateMethodFromSingleInterfaceImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleInterfaceImpl"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateMethodFromSingleInterfaceImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1644,7 +1644,7 @@ class TR_RelocationRecordValidateMethodFromSingleAbstractImpl : public TR_Reloca
       TR_RelocationRecordValidateMethodFromSingleAbstractImpl() {}
       TR_RelocationRecordValidateMethodFromSingleAbstractImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleAbstractImpl"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateMethodFromSingleAbstractImpl"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1671,7 +1671,7 @@ class TR_RelocationRecordSymbolFromManager : public TR_RelocationRecord
    public:
       TR_RelocationRecordSymbolFromManager() {}
       TR_RelocationRecordSymbolFromManager(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordSymbolFromManager"; }
+      virtual const char *name() { return "TR_RelocationRecordSymbolFromManager"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual void storePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1693,7 +1693,7 @@ class TR_RelocationRecordDiscontiguousSymbolFromManager : public TR_RelocationRe
    public:
       TR_RelocationRecordDiscontiguousSymbolFromManager() {}
       TR_RelocationRecordDiscontiguousSymbolFromManager(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordSymbolFromManager(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordDiscontiguousSymbolFromManager"; }
+      virtual const char *name() { return "TR_RelocationRecordDiscontiguousSymbolFromManager"; }
       virtual void storePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
@@ -1702,7 +1702,7 @@ class TR_RelocationRecordResolvedTrampolines : public TR_RelocationRecord
    public:
       TR_RelocationRecordResolvedTrampolines() {}
       TR_RelocationRecordResolvedTrampolines(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual char *name() { return "TR_RelocationRecordResolvedTrampolines"; }
+      virtual const char *name() { return "TR_RelocationRecordResolvedTrampolines"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1718,7 +1718,7 @@ class TR_RelocationRecordHCR : public TR_RelocationRecordWithOffset
    public:
       TR_RelocationRecordHCR() {}
       TR_RelocationRecordHCR(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithOffset(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) { }
 
@@ -1761,7 +1761,7 @@ class TR_RelocationRecordClassPointer : public TR_RelocationRecordPointer
    public:
       TR_RelocationRecordClassPointer() {}
       TR_RelocationRecordClassPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordPointer(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
    protected:
       virtual uintptr_t computePointer(TR_RelocationTarget *reloTarget, TR_OpaqueClassBlock *classPointer);
@@ -1775,7 +1775,7 @@ class TR_RelocationRecordArbitraryClassAddress : public TR_RelocationRecordClass
    public:
       TR_RelocationRecordArbitraryClassAddress() {}
       TR_RelocationRecordArbitraryClassAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordClassPointer(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
@@ -1792,7 +1792,7 @@ class TR_RelocationRecordMethodPointer : public TR_RelocationRecordPointer
    public:
       TR_RelocationRecordMethodPointer() {}
       TR_RelocationRecordMethodPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordPointer(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setVTableSlot(TR_RelocationTarget *reloTarget, uintptr_t vTableSlot);
@@ -1808,7 +1808,7 @@ class TR_RelocationRecordInlinedMethodPointer : public TR_RelocationRecordWithIn
    public:
       TR_RelocationRecordInlinedMethodPointer() {}
       TR_RelocationRecordInlinedMethodPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1833,7 +1833,7 @@ class TR_RelocationRecordDebugCounter : public TR_RelocationRecordWithInlinedSit
    public:
       TR_RelocationRecordDebugCounter() {}
       TR_RelocationRecordDebugCounter(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
-      virtual char *name();
+      virtual const char *name();
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
@@ -1867,7 +1867,7 @@ class TR_RelocationRecordClassUnloadAssumption : public TR_RelocationRecord
       TR_RelocationRecordClassUnloadAssumption() {}
       TR_RelocationRecordClassUnloadAssumption(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
 
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
@@ -1878,7 +1878,7 @@ class TR_RelocationRecordMethodCallAddress : public TR_RelocationRecord
       TR_RelocationRecordMethodCallAddress() {}
       TR_RelocationRecordMethodCallAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name() { return "TR_MethodCallAddress"; }
+      virtual const char *name() { return "TR_MethodCallAddress"; }
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
       uint8_t* address(TR_RelocationTarget *reloTarget);
@@ -1895,7 +1895,7 @@ class TR_RelocationRecordBreakpointGuard : public TR_RelocationRecordWithInlined
       TR_RelocationRecordBreakpointGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
          : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
 
-      virtual char *name() { return "TR_Breakpoint"; }
+      virtual const char *name() { return "TR_Breakpoint"; }
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
@@ -1911,7 +1911,7 @@ class TR_RelocationRecordValidateJ2IThunkFromMethod : public TR_RelocationRecord
       TR_RelocationRecordValidateJ2IThunkFromMethod() {}
       TR_RelocationRecordValidateJ2IThunkFromMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateJ2IThunkFromMethod"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateJ2IThunkFromMethod"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1930,7 +1930,7 @@ class TR_RelocationRecordStaticDefaultValueInstance : public TR_RelocationRecord
       TR_RelocationRecordStaticDefaultValueInstance() {}
       TR_RelocationRecordStaticDefaultValueInstance(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordClassAddress(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
    };
@@ -1941,7 +1941,7 @@ class TR_RelocationRecordValidateIsClassVisible : public TR_RelocationRecord
       TR_RelocationRecordValidateIsClassVisible() {}
       TR_RelocationRecordValidateIsClassVisible(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
       virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateIsClassVisible"; }
+      virtual const char *name() { return "TR_RelocationRecordValidateIsClassVisible"; }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
@@ -1963,7 +1963,7 @@ class TR_RelocationRecordCatchBlockCounter : public TR_RelocationRecord
       TR_RelocationRecordCatchBlockCounter() {}
       TR_RelocationRecordCatchBlockCounter(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1976,7 +1976,7 @@ class TR_RelocationRecordStartPC : public TR_RelocationRecord
       TR_RelocationRecordStartPC() {}
       TR_RelocationRecordStartPC(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name();
+      virtual const char *name();
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
@@ -1989,7 +1989,7 @@ class TR_RelocationRecordMethodEnterExitHookAddress : public TR_RelocationRecord
       TR_RelocationRecordMethodEnterExitHookAddress() {}
       TR_RelocationRecordMethodEnterExitHookAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
 
-      virtual char *name() { return "TR_RelocationRecordMethodEnterExitHookAddress"; }
+      virtual const char *name() { return "TR_RelocationRecordMethodEnterExitHookAddress"; }
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       void setIsEnterHookAddr(TR_RelocationTarget *reloTarget, bool isEnterHookAddr);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -81,7 +81,7 @@
 
 #include "exceptions/AOTFailure.hpp"
 
-char *TR_RelocationRuntime::_reloErrorCodeNames[] =
+const char *TR_RelocationRuntime::_reloErrorCodeNames[] =
    {
    "relocationOK",                                     // 0
 
@@ -938,7 +938,7 @@ uintptr_t TR_RelocationRuntime::_globalValueList[TR_NumGlobalValueItems] =
    0          // TR_HeapSizeForBarrierRange0
    };
 
-char *TR_RelocationRuntime::_globalValueNames[TR_NumGlobalValueItems] =
+const char *TR_RelocationRuntime::_globalValueNames[TR_NumGlobalValueItems] =
    {
    "not used (0)",
    "TR_CountForRecompile (1)",
@@ -1036,7 +1036,7 @@ TR_SharedCacheRelocationRuntime::initializeCacheDeltas()
    }
 
 void
-TR_SharedCacheRelocationRuntime::incompatibleCache(U_32 module_name, U_32 reason, char *assumeMessage)
+TR_SharedCacheRelocationRuntime::incompatibleCache(U_32 module_name, U_32 reason, const char *assumeMessage)
    {
    if (TR::Options::isAnyVerboseOptionSet())
       {
@@ -1051,7 +1051,7 @@ TR_SharedCacheRelocationRuntime::incompatibleCache(U_32 module_name, U_32 reason
    }
 
 bool
-TR_SharedCacheRelocationRuntime::generateError(U_32 module_name, U_32 reason, char *assumeMessage)
+TR_SharedCacheRelocationRuntime::generateError(U_32 module_name, U_32 reason, const char *assumeMessage)
    {
    incompatibleCache(module_name, reason, assumeMessage);
    return false;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -311,7 +311,7 @@ class TR_RelocationRuntime {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          _globalValueList[g] = v;
          }
-      static char *       nameOfGlobal(uint32_t g)
+      static const char *       nameOfGlobal(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          return _globalValueNames[g];
@@ -352,7 +352,7 @@ class TR_RelocationRuntime {
       const bool isValidationError(TR_RelocationErrorCode errorCode) { return (errorCode & TR_RelocationErrorCodeType::VALIDATION); }
       const bool isRelocationError(TR_RelocationErrorCode errorCode) { return (errorCode & TR_RelocationErrorCodeType::RELOCATION); }
 
-      static char *getReloErrorCodeName(TR_RelocationErrorCode errorCode) { return _reloErrorCodeNames[TR_RelocationError::decode(errorCode)]; }
+      static const char *getReloErrorCodeName(TR_RelocationErrorCode errorCode) { return _reloErrorCodeNames[TR_RelocationError::decode(errorCode)]; }
 
    private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize)                           { return NULL; }
@@ -388,10 +388,10 @@ class TR_RelocationRuntime {
       static bool       _globalValuesInitialized;
       static uintptr_t  _globalValueList[TR_NumGlobalValueItems];
       static uint8_t    _globalValueSizeList[TR_NumGlobalValueItems];
-      static char      *_globalValueNames[TR_NumGlobalValueItems];
+      static const char      *_globalValueNames[TR_NumGlobalValueItems];
 
       TR_RelocationErrorCode _reloErrorCode;
-      static char *_reloErrorCodeNames[];
+      static const char *_reloErrorCodeNames[];
 
    protected:
 
@@ -476,10 +476,10 @@ private:
       virtual void initializeAotRuntimeInfo();
       virtual void initializeCacheDeltas();
 
-      virtual void incompatibleCache(U_32 module, U_32 reason, char *assumeMessage);
+      virtual void incompatibleCache(U_32 module, U_32 reason, const char *assumeMessage);
 
       void checkAOTHeaderFlags(const TR_AOTHeader *hdrInCache, intptr_t featureFlags);
-      bool generateError(U_32 module_name, U_32 reason, char *assumeMessage);
+      bool generateError(U_32 module_name, U_32 reason, const char *assumeMessage);
 
       bool _sharedCacheIsFull;
 

--- a/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
+++ b/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
@@ -73,7 +73,7 @@ TR_RelocationRuntimeLogger::setupOptions(TR::Options *options)
    }
 
 void
-TR_RelocationRuntimeLogger::debug_printf(char *format, ...)
+TR_RelocationRuntimeLogger::debug_printf(const char *format, ...)
    {
    va_list args;
    char outputBuffer[512];
@@ -88,7 +88,7 @@ TR_RelocationRuntimeLogger::debug_printf(char *format, ...)
    }
 
 void
-TR_RelocationRuntimeLogger::printf(char *format, ...)
+TR_RelocationRuntimeLogger::printf(const char *format, ...)
    {
    va_list args;
    char outputBuffer[512];
@@ -130,7 +130,7 @@ TR_RelocationRuntimeLogger::method(bool newLine)
    if (reloRuntime()->method() == NULL)
       return;
 
-   char * patternString = "%.*s.%.*s%.*s";
+   const char *patternString = "%.*s.%.*s%.*s";
    if (newLine)
       patternString = "%.*s.%.*s%.*s\n";
 
@@ -179,7 +179,7 @@ TR_RelocationRuntimeLogger::metaData()
    if (logEnabled())
       {
       J9JavaVM *javaVM = jitConfig()->javaVM;
-      char *metaDataTag = "relocatableDataMetaDataRT";
+      const char *metaDataTag = "relocatableDataMetaDataRT";
 
       bool wasLocked = lockLog();
       startTag(metaDataTag);
@@ -226,7 +226,7 @@ TR_RelocationRuntimeLogger::relocationTime()
 void
 TR_RelocationRuntimeLogger::versionMismatchWarning()
    {
-   char *warningMessageFormat = "AOT major/minor versions don't match the ones of running JVM: aotMajorVersion %d jvmMajorVersion %d aotMinorVersion %d jvmMinorVersion %d   ";
+   const char *warningMessageFormat = "AOT major/minor versions don't match the ones of running JVM: aotMajorVersion %d jvmMajorVersion %d aotMinorVersion %d jvmMinorVersion %d   ";
    if (verbose())
       {
       bool wasLocked = lockLog();

--- a/runtime/compiler/runtime/RelocationRuntimeLogger.hpp
+++ b/runtime/compiler/runtime/RelocationRuntimeLogger.hpp
@@ -50,8 +50,8 @@ class TR_RelocationRuntimeLogger {
       bool logEnabled()                                    { return _logEnabled; }
       bool logDetailEnabled(int32_t n)                     { return (n <=_logLevel); }
 
-      void debug_printf(char *format, ...);
-      void printf(char *format, ...);
+      void debug_printf(const char *format, ...);
+      void printf(const char *format, ...);
 
       void relocatableDataHeader();
       void method(bool newLine);

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -222,7 +222,7 @@ class TR_AddressSet
    int32_t          _numAddressRanges;
    int32_t          _maxAddressRanges;
 
-   static void trace(char *format, ...);
+   static void trace(const char *format, ...);
    static bool enableTraceDetails();
    static void traceDetails(const char *format, ...);
 


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to (char *)) in compile, runtime, control, and ras.

This PR contributes to (but does not close) #14859

**This PR depends on:**

- **Step 1:**
    - https://github.com/eclipse-openj9/openj9/pull/18083
    - https://github.com/eclipse-openj9/openj9/pull/18455
- **Step 2:**
    - https://github.com/eclipse-openj9/openj9/pull/18467
    - https://github.com/eclipse/omr/pull/7186

**and must be merged in coordination with https://github.com/eclipse/omr/pull/7187**