### PR TITLE
Fix string literal conversion warnings in optimizer, p

### DIFF
--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -743,15 +743,15 @@ TR::Node* TR_DataAccessAccelerator::insertDecimalSetIntrinsic(TR::TreeTop* callT
    return NULL;
    }
 
-bool TR_DataAccessAccelerator::inlineCheckPackedDecimal(TR::TreeTop* callTreeTop, TR::Node* callNode)
+bool TR_DataAccessAccelerator::inlineCheckPackedDecimal(TR::TreeTop *callTreeTop, TR::Node *callNode)
    {
-   TR::Node* byteArrayNode = callNode->getChild(0);
-   TR::Node* offsetNode = callNode->getChild(1);
-   TR::Node* precisionNode = callNode->getChild(2);
-   TR::Node* ignoreHighNibbleForEvenPrecisionNode = callNode->getChild(3);
-   TR::Node* canOverwriteHighNibbleForEvenPrecisionNode = callNode->getChild(4);
+   TR::Node *byteArrayNode = callNode->getChild(0);
+   TR::Node *offsetNode = callNode->getChild(1);
+   TR::Node *precisionNode = callNode->getChild(2);
+   TR::Node *ignoreHighNibbleForEvenPrecisionNode = callNode->getChild(3);
+   TR::Node *canOverwriteHighNibbleForEvenPrecisionNode = callNode->getChild(4);
    int32_t precision = precisionNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (!precisionNode->getOpCode().isLoadConst())
       failMsg = "precisionNode is not constant.";
@@ -784,9 +784,9 @@ bool TR_DataAccessAccelerator::inlineCheckPackedDecimal(TR::TreeTop* callTreeTop
       insertByteArrayBNDCHK(callTreeTop, callNode, byteArrayNode, offsetNode, 0);
       insertByteArrayBNDCHK(callTreeTop, callNode, byteArrayNode, offsetNode, precisionSizeInNumberOfBytes - 1);
 
-      TR::SymbolReference* packedDecimalSymbolReference = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, NULL, precisionSizeInNumberOfBytes, fe());
+      TR::SymbolReference *packedDecimalSymbolReference = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, NULL, precisionSizeInNumberOfBytes, fe());
 
-      TR::Node* pdchkChild0Node = TR::Node::createWithSymRef(TR::pdloadi, 1, 1, constructAddressNode(callNode, byteArrayNode, offsetNode), packedDecimalSymbolReference);
+      TR::Node *pdchkChild0Node = TR::Node::createWithSymRef(TR::pdloadi, 1, 1, constructAddressNode(callNode, byteArrayNode, offsetNode), packedDecimalSymbolReference);
 
       // The size argument passed to create an array shadow symbol reference is the size in number of bytes that this PackedDecimal represents.
       // Unfortunately when a Node is constructed with this symbol reference we extract the size from the symbol reference and convert it to a
@@ -1233,10 +1233,10 @@ bool TR_DataAccessAccelerator::genComparisionIntrinsic(TR::TreeTop* treeTop, TR:
    return printInliningStatus(true, callNode);
    }
 
-bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* callNode, bool isI2PD, bool isByteBuffer)
+bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop *treeTop, TR::Node *callNode, bool isI2PD, bool isByteBuffer)
    {
    int precision = callNode->getChild(3)->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (!isChildConst(callNode, 3) || !isChildConst(callNode, 4))
       failMsg = "Child (3|4) is not constant";
@@ -1252,16 +1252,16 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
       return printInliningStatus(false, callNode, failMsg);
       }
 
-   TR::Node* intNode = NULL;
-   TR::Node* pdNode = NULL;
-   TR::Node* offsetNode = NULL;
-   TR::Node* precNode = NULL;
-   TR::Node* errorCheckingNode = NULL;
+   TR::Node *intNode = NULL;
+   TR::Node *pdNode = NULL;
+   TR::Node *offsetNode = NULL;
+   TR::Node *precNode = NULL;
+   TR::Node *errorCheckingNode = NULL;
 
    // Backing storage info for ByteBuffer
-   TR::Node * pdBufAddressNodeCopy = NULL;
-   TR::Node * pdBufCapacityNode = NULL;
-   TR::Node * pdBufPositionNode = NULL;
+   TR::Node *pdBufAddressNodeCopy = NULL;
+   TR::Node *pdBufCapacityNode = NULL;
+   TR::Node *pdBufPositionNode = NULL;
 
    TR::TreeTop *slowPathTreeTop = NULL;
    TR::TreeTop *fastPathTreeTop = NULL;
@@ -1300,7 +1300,7 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
 
       //create a TR::i2pd node and an pdstore.
       //this will not cause an exception, so it is safe to remove BCDCHK
-      TR::Node * i2pdNode = TR::Node::create((isI2PD)?TR::i2pd:TR::l2pd, 1, intNode);
+      TR::Node *i2pdNode = TR::Node::create((isI2PD)?TR::i2pd:TR::l2pd, 1, intNode);
       i2pdNode->setDecimalPrecision(precision);
 
       /**
@@ -1349,20 +1349,20 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
        * With AddrNode2 and AddrNode3 commoned up, the LocalCSE is able to copy propagate pdshlOverflow to the pd2zd
        * tree and replace its pdloadi.
        */
-      TR::Node * outOfLineCopyBackAddr = constructAddressNode(callNode, pdNode, offsetNode);
-      TR::Node * storeAddressNode      = constructAddressNode(callNode, pdNode, offsetNode);
+      TR::Node *outOfLineCopyBackAddr = constructAddressNode(callNode, pdNode, offsetNode);
+      TR::Node *storeAddressNode      = constructAddressNode(callNode, pdNode, offsetNode);
 
-      TR::TreeTop * nextTT = treeTop->getNextTreeTop();
-      TR::TreeTop * prevTT = treeTop->getPrevTreeTop();
+      TR::TreeTop *nextTT = treeTop->getNextTreeTop();
+      TR::TreeTop *prevTT = treeTop->getPrevTreeTop();
 
       TR::ILOpCodes op = comp()->il.opCodeForIndirectStore(TR::PackedDecimal);
 
-      TR::Node * pdstore = NULL;
-      TR::Node * bcdchkNode = NULL;
+      TR::Node *pdstore = NULL;
+      TR::Node *bcdchkNode = NULL;
       if (needsBCDCHK)
          {
          i2pdNode->setDecimalPrecision((isI2PD)? 10:19);
-         TR::Node * pdshlNode = TR::Node::create(TR::pdshlOverflow, 2, i2pdNode, TR::Node::create(callNode, TR::iconst, 0));
+         TR::Node *pdshlNode = TR::Node::create(TR::pdshlOverflow, 2, i2pdNode, TR::Node::create(callNode, TR::iconst, 0));
          pdshlNode->setDecimalPrecision(precision);
 
          /* Attaching all the original callNode's children as the children to BCDCHK.
@@ -1406,7 +1406,7 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
          pdstore = TR::Node::create(op, 2, storeAddressNode, i2pdNode);
          }
 
-      TR::TreeTop* pdstoreTT = TR::TreeTop::create(comp(), pdstore);
+      TR::TreeTop *pdstoreTT = TR::TreeTop::create(comp(), pdstore);
 
       if (isByteBuffer)
          {
@@ -1433,7 +1433,7 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
          callBlock->createConditionalBlocksBeforeTree(treeTop, isValidAddrTreeTop, slowPathTreeTop, fastPathTreeTop, cfg, false, true);
          }
 
-      TR::SymbolReference * symRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, outOfLineCopyBackAddr, 8, fe());
+      TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, outOfLineCopyBackAddr, 8, fe());
       pdstore->setSymbolReference(symRef);
       pdstore->setDecimalPrecision(precision);
 
@@ -1606,17 +1606,17 @@ void TR_DataAccessAccelerator::createPrecisionDiamond(TR::Compilation* comp,
    }
 
 bool
-TR_DataAccessAccelerator::generatePD2IConstantParameter(TR::TreeTop* treeTop, TR::Node* callNode, bool isPD2i, bool isByteBuffer)
+TR_DataAccessAccelerator::generatePD2IConstantParameter(TR::TreeTop *treeTop, TR::Node *callNode, bool isPD2i, bool isByteBuffer)
    {
-   TR::Node* pdInputNode    = callNode->getChild(0);
-   TR::Node* offsetNode     = callNode->getChild(1);
-   TR::Node* precisionNode  = callNode->getChild(2);
-   TR::Node* overflowNode   = callNode->getChild(3);
+   TR::Node *pdInputNode    = callNode->getChild(0);
+   TR::Node *offsetNode     = callNode->getChild(1);
+   TR::Node *precisionNode  = callNode->getChild(2);
+   TR::Node *overflowNode   = callNode->getChild(3);
 
    // Backing storage info for ByteBuffer
-   TR::Node * pdBufAddressNodeCopy = NULL;
-   TR::Node * pdBufCapacityNode = NULL;
-   TR::Node * pdBufPositionNode = NULL;
+   TR::Node *pdBufAddressNodeCopy = NULL;
+   TR::Node *pdBufCapacityNode = NULL;
+   TR::Node *pdBufPositionNode = NULL;
 
    TR::TreeTop *slowPathTreeTop = NULL;
    TR::TreeTop *fastPathTreeTop = NULL;
@@ -1628,7 +1628,7 @@ TR_DataAccessAccelerator::generatePD2IConstantParameter(TR::TreeTop* treeTop, TR
    TR::TreeTop *bcdchkTreeTop = NULL;
    int precision = precisionNode->getInt();
    int overflow = overflowNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (precision < 1)
       failMsg = "Invalid precision. Precision can not be less than 1";
@@ -2119,19 +2119,19 @@ bool TR_DataAccessAccelerator::genArithmeticIntrinsic(TR::TreeTop* treeTop, TR::
    return false;
    }
 
-bool TR_DataAccessAccelerator::genShiftRightIntrinsic(TR::TreeTop* treeTop, TR::Node* callNode)
+bool TR_DataAccessAccelerator::genShiftRightIntrinsic(TR::TreeTop *treeTop, TR::Node *callNode)
    {
-   TR::Node * dstNode = callNode->getChild(0);
-   TR::Node * dstOffsetNode = callNode->getChild(1);
-   TR::Node * dstPrecNode = callNode->getChild(2);
+   TR::Node *dstNode = callNode->getChild(0);
+   TR::Node *dstOffsetNode = callNode->getChild(1);
+   TR::Node *dstPrecNode = callNode->getChild(2);
 
-   TR::Node * srcNode = callNode->getChild(3);
-   TR::Node * srcOffsetNode = callNode->getChild(4);
-   TR::Node * srcPrecNode = callNode->getChild(5);
+   TR::Node *srcNode = callNode->getChild(3);
+   TR::Node *srcOffsetNode = callNode->getChild(4);
+   TR::Node *srcPrecNode = callNode->getChild(5);
 
-   TR::Node * shiftNode = callNode->getChild(6);
-   TR::Node * roundNode = callNode->getChild(7);
-   TR::Node * overflowNode = callNode->getChild(8);
+   TR::Node *shiftNode = callNode->getChild(6);
+   TR::Node *roundNode = callNode->getChild(7);
+   TR::Node *overflowNode = callNode->getChild(8);
 
    int srcPrec = srcPrecNode->getInt();
    int dstPrec = dstPrecNode->getInt();
@@ -2139,7 +2139,7 @@ bool TR_DataAccessAccelerator::genShiftRightIntrinsic(TR::TreeTop* treeTop, TR::
    int shiftAmount = shiftNode->getInt();
    int isRound   = roundNode->getInt();
    int isCheckOverflow = overflowNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (!isChildConst(callNode, 2) || !isChildConst(callNode, 5) ||
            !isChildConst(callNode, 7) || !isChildConst(callNode, 8))
@@ -2228,24 +2228,24 @@ bool TR_DataAccessAccelerator::genShiftRightIntrinsic(TR::TreeTop* treeTop, TR::
    return printInliningStatus(true, callNode);
    }
 
-bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop* treeTop, TR::Node* callNode)
+bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop *treeTop, TR::Node *callNode)
    {
 
 
-   TR::Node * dstNode = callNode->getChild(0);
-   TR::Node * dstOffsetNode = callNode->getChild(1);
-   TR::Node * dstPrecNode = callNode->getChild(2);
+   TR::Node *dstNode = callNode->getChild(0);
+   TR::Node *dstOffsetNode = callNode->getChild(1);
+   TR::Node *dstPrecNode = callNode->getChild(2);
 
-   TR::Node * srcNode = callNode->getChild(3);
-   TR::Node * srcOffsetNode = callNode->getChild(4);
-   TR::Node * srcPrecNode = callNode->getChild(5);
+   TR::Node *srcNode = callNode->getChild(3);
+   TR::Node *srcOffsetNode = callNode->getChild(4);
+   TR::Node *srcPrecNode = callNode->getChild(5);
 
-   TR::Node * shiftNode = callNode->getChild(6);
+   TR::Node *shiftNode = callNode->getChild(6);
 
    int srcPrec = srcPrecNode->getInt();
    int dstPrec = dstPrecNode->getInt();
    int shiftAmount = shiftNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (!isChildConst(callNode, 2) || !isChildConst(callNode, 5) ||
            !isChildConst(callNode, 6) || !isChildConst(callNode, 7))
@@ -2281,18 +2281,18 @@ bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop* treeTop, TR::N
    TR::Node* pdStoreAddrNode       = constructAddressNode(callNode, dstNode, dstOffsetNode);
 
    //pdload:
-   TR::Node * pdload = TR::Node::create(TR::pdloadi, 1, srcAddrNode);
-   TR::SymbolReference * symRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, srcAddrNode, 8, fe());
+   TR::Node *pdload = TR::Node::create(TR::pdloadi, 1, srcAddrNode);
+   TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, srcAddrNode, 8, fe());
    symRef->setOffset(0);
    pdload->setSymbolReference(symRef);
    pdload->setDecimalPrecision(srcPrec);
 
    // Always use BCDCHK node for exception handling (invalid digits/sign).
-   TR::Node * pdshlNode = TR::Node::create(TR::pdshlOverflow, 2, pdload, shiftNode);
+   TR::Node *pdshlNode = TR::Node::create(TR::pdshlOverflow, 2, pdload, shiftNode);
    pdshlNode->setDecimalPrecision(dstPrec);
 
    TR::SymbolReference* bcdChkSymRef = callNode->getSymbolReference();
-   TR::Node* bcdchkNode = TR::Node::createWithSymRef(TR::BCDCHK, 10, 10,
+   TR::Node *bcdchkNode = TR::Node::createWithSymRef(TR::BCDCHK, 10, 10,
                                        pdshlNode, outOfLineCopyBackAddr,
                                        callNode->getChild(0), callNode->getChild(1),
                                        callNode->getChild(2), callNode->getChild(3),
@@ -2306,19 +2306,19 @@ bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop* treeTop, TR::N
 
    //following pdstore
    TR::ILOpCodes op = comp()->il.opCodeForIndirectStore(TR::PackedDecimal);
-   TR::SymbolReference * symRefPdstore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, outOfLineCopyBackAddr, 8, fe());
-   TR::Symbol * symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), TR::PackedDecimal, TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, dstPrec));
+   TR::SymbolReference *symRefPdstore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, outOfLineCopyBackAddr, 8, fe());
+   TR::Symbol *symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), TR::PackedDecimal, TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, dstPrec));
    symStore->setArrayShadowSymbol();
    symRefPdstore->setSymbol(symStore);
 
-   TR::Node * pdstore = TR::Node::create(op, 2, pdStoreAddrNode, pdshlNode);
+   TR::Node *pdstore = TR::Node::create(op, 2, pdStoreAddrNode, pdshlNode);
    pdstore->setSymbolReference(symRefPdstore);
    pdstore->setDecimalPrecision(dstPrec);
 
    //gen treeTop tops
-   TR::TreeTop * nextTT      = treeTop->getNextTreeTop();
-   TR::TreeTop * prevTT      = treeTop->getPrevTreeTop();
-   TR::TreeTop * pdstoreTT   = TR::TreeTop::create(comp(), pdstore);
+   TR::TreeTop *nextTT      = treeTop->getNextTreeTop();
+   TR::TreeTop *prevTT      = treeTop->getPrevTreeTop();
+   TR::TreeTop *pdstoreTT   = TR::TreeTop::create(comp(), pdstore);
 
    prevTT->join(treeTop);
    treeTop->setNode(bcdchkNode);
@@ -2329,19 +2329,19 @@ bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop* treeTop, TR::N
    return printInliningStatus(true, callNode);
    }
 
-bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* callNode, bool isUD2PD)
+bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop *treeTop, TR::Node *callNode, bool isUD2PD)
    {
-   TR::Node * decimalNode = callNode->getChild(0);
-   TR::Node * decimalOffsetNode = callNode->getChild(1);
-   TR::Node * pdNode = callNode->getChild(2);
-   TR::Node * pdOffsetNode = callNode->getChild(3);
-   TR::Node * precNode = callNode->getChild(4);
-   TR::Node * typeNode = callNode->getChild(5);
+   TR::Node *decimalNode = callNode->getChild(0);
+   TR::Node *decimalOffsetNode = callNode->getChild(1);
+   TR::Node *pdNode = callNode->getChild(2);
+   TR::Node *pdOffsetNode = callNode->getChild(3);
+   TR::Node *precNode = callNode->getChild(4);
+   TR::Node *typeNode = callNode->getChild(5);
 
    //first, check decimalType
    int type = typeNode->getInt();
    int prec = precNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
 
    if (!isChildConst(callNode, 4) || !isChildConst(callNode, 5))
       failMsg = "Child (4|5) is not constant";
@@ -2405,12 +2405,12 @@ bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* cal
          }
 
       //create decimalload
-      TR::Node * decimalAddressNode;
+      TR::Node *decimalAddressNode;
       int offset = decimalOffsetNode->getInt();
-      TR::Node * twoConstNode;
-      TR::Node * multipliedOffsetNode;
-      TR::Node * totalOffsetNode;
-      TR::Node * headerConstNode;
+      TR::Node *twoConstNode;
+      TR::Node *multipliedOffsetNode;
+      TR::Node *totalOffsetNode;
+      TR::Node *headerConstNode;
       if (comp()->target().is64Bit())
          {
          headerConstNode = TR::Node::create(callNode, TR::lconst, 0, 0);
@@ -2441,17 +2441,17 @@ bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* cal
       decimalload->setDecimalPrecision(prec);
 
       //create PDaddress
-      TR::Node * pdAddressNode = constructAddressNode(callNode, pdNode, pdOffsetNode);
+      TR::Node *pdAddressNode = constructAddressNode(callNode, pdNode, pdOffsetNode);
 
       int elementSize = isUD2PD ? TR::DataType::getUnicodeElementSize() : TR::DataType::getZonedElementSize();
 
       //bound values
       int pdPrecSize = TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, prec) - 1;
       int decimalPrecSize = (TR::DataType::getSizeFromBCDPrecision(dt, prec) / elementSize) - 1;
-      TR::Node * pdBndvalue = TR::Node::create(TR::iadd, 2,
+      TR::Node *pdBndvalue = TR::Node::create(TR::iadd, 2,
                                               pdOffsetNode,
                                               TR::Node::create(callNode, TR::iconst, 0, pdPrecSize));
-      TR::Node * decimalBndvalue = TR::Node::create(TR::iadd, 2,
+      TR::Node *decimalBndvalue = TR::Node::create(TR::iadd, 2,
                                               decimalOffsetNode,
                                               TR::Node::create(callNode, TR::iconst, 0, decimalPrecSize)); //size of unicode is 2 bytes
 
@@ -2488,7 +2488,7 @@ bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* cal
             TR_ASSERT(false, "illegal decimalType.\n");
          }
 
-      TR::Node * decimal2pdNode = NULL;
+      TR::Node *decimal2pdNode = NULL;
       if (isUD2PD || type == 1)
          {
          //for converting zd to pd (here type == 1), dont need the additional intermediate conversion
@@ -2503,46 +2503,46 @@ bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* cal
          decimal2pdNode->setDecimalPrecision(prec);
 
       //create pdstore
-      TR::Node * pdstoreNode = TR::Node::create(TR::pdstorei, 2, pdAddressNode, decimal2pdNode);
-      TR::SymbolReference * symRefStore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, pdAddressNode, 8, fe());
-      TR::Symbol * symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), TR::PackedDecimal, TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, prec));
+      TR::Node *pdstoreNode = TR::Node::create(TR::pdstorei, 2, pdAddressNode, decimal2pdNode);
+      TR::SymbolReference *symRefStore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, pdAddressNode, 8, fe());
+      TR::Symbol *symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), TR::PackedDecimal, TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, prec));
       symRefStore->setSymbol(symStore);
 
       pdstoreNode->setSymbolReference(symRefStore);
       pdstoreNode->setDecimalPrecision(prec);
 
       //set up bndchks, and null chks
-      TR::Node * pdPassThroughNode = TR::Node::create(TR::PassThrough, 1, pdNode);
-      TR::Node * decimalPassThroughNode = TR::Node::create(TR::PassThrough, 1, decimalNode);
+      TR::Node *pdPassThroughNode = TR::Node::create(TR::PassThrough, 1, pdNode);
+      TR::Node *decimalPassThroughNode = TR::Node::create(TR::PassThrough, 1, decimalNode);
 
-      TR::Node * pdArrayLengthNode = TR::Node::create(TR::arraylength, 1, pdNode);
-      TR::Node * decimalArrayLengthNode = TR::Node::create(TR::arraylength, 1, decimalNode);
+      TR::Node *pdArrayLengthNode = TR::Node::create(TR::arraylength, 1, pdNode);
+      TR::Node *decimalArrayLengthNode = TR::Node::create(TR::arraylength, 1, decimalNode);
 
-      TR::Node * pdNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, pdPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
-      TR::Node * decimalNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, decimalPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
+      TR::Node *pdNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, pdPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
+      TR::Node *decimalNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, decimalPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
 
-      TR::Node * pdBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * pdBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdBndvalue,   getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * decimalBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalOffsetNode,
+      TR::Node *pdBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *pdBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdBndvalue,   getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *decimalBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalOffsetNode,
                                                 getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * decimalBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalBndvalue,
+      TR::Node *decimalBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalBndvalue,
                                                 getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
 
       //gen tree tops
-      TR::TreeTop * pdNullChktt = TR::TreeTop::create(comp(), pdNullChkNode);
-      TR::TreeTop * decimalNullChktt = TR::TreeTop::create(comp(), decimalNullChkNode);
+      TR::TreeTop *pdNullChktt = TR::TreeTop::create(comp(), pdNullChkNode);
+      TR::TreeTop *decimalNullChktt = TR::TreeTop::create(comp(), decimalNullChkNode);
 
-      TR::TreeTop * pdBndChktt1 = TR::TreeTop::create(comp(), pdBndChk);
-      TR::TreeTop * pdBndChktt2 = TR::TreeTop::create(comp(), pdBndChk2);
-      TR::TreeTop * decimalBndChktt1 = TR::TreeTop::create(comp(), decimalBndChk );
-      TR::TreeTop * decimalBndChktt2 = TR::TreeTop::create(comp(), decimalBndChk2);
+      TR::TreeTop *pdBndChktt1 = TR::TreeTop::create(comp(), pdBndChk);
+      TR::TreeTop *pdBndChktt2 = TR::TreeTop::create(comp(), pdBndChk2);
+      TR::TreeTop *decimalBndChktt1 = TR::TreeTop::create(comp(), decimalBndChk );
+      TR::TreeTop *decimalBndChktt2 = TR::TreeTop::create(comp(), decimalBndChk2);
 
-      TR::TreeTop * ttPdstore = TR::TreeTop::create(comp(), pdstoreNode);
+      TR::TreeTop *ttPdstore = TR::TreeTop::create(comp(), pdstoreNode);
 
 
       //link together
-      TR::TreeTop * nextTT = treeTop->getNextTreeTop();
-      TR::TreeTop * prevTT = treeTop->getPrevTreeTop();
+      TR::TreeTop *nextTT = treeTop->getNextTreeTop();
+      TR::TreeTop *prevTT = treeTop->getPrevTreeTop();
 
       prevTT->join(decimalNullChktt);
       decimalNullChktt->join(pdNullChktt);
@@ -2560,18 +2560,18 @@ bool TR_DataAccessAccelerator::generateUD2PD(TR::TreeTop* treeTop, TR::Node* cal
    return false;
    }
 
-bool TR_DataAccessAccelerator::generatePD2UD(TR::TreeTop* treeTop, TR::Node* callNode, bool isPD2UD)
+bool TR_DataAccessAccelerator::generatePD2UD(TR::TreeTop *treeTop, TR::Node *callNode, bool isPD2UD)
    {
-   TR::Node * pdNode = callNode->getChild(0);
-   TR::Node * pdOffsetNode = callNode->getChild(1);
-   TR::Node * decimalNode = callNode->getChild(2);
-   TR::Node * decimalOffsetNode = callNode->getChild(3);
-   TR::Node * precNode = callNode->getChild(4);
-   TR::Node * typeNode = callNode->getChild(5);
+   TR::Node *pdNode = callNode->getChild(0);
+   TR::Node *pdOffsetNode = callNode->getChild(1);
+   TR::Node *decimalNode = callNode->getChild(2);
+   TR::Node *decimalOffsetNode = callNode->getChild(3);
+   TR::Node *precNode = callNode->getChild(4);
+   TR::Node *typeNode = callNode->getChild(5);
 
    //first, check decimalType
    int type = typeNode->getInt();
-   char* failMsg = NULL;
+   const char *failMsg = NULL;
    int prec = precNode->getInt();
 
    if (!isChildConst(callNode, 4) || !isChildConst(callNode, 5))
@@ -2601,23 +2601,23 @@ bool TR_DataAccessAccelerator::generatePD2UD(TR::TreeTop* treeTop, TR::Node* cal
                                                                                  isPD2UD ? "pd2ud" : "pd2ed"));
 
       //set up pdload:
-      TR::Node * arrayAddressNode = constructAddressNode(callNode, pdNode, pdOffsetNode);
+      TR::Node *arrayAddressNode = constructAddressNode(callNode, pdNode, pdOffsetNode);
 
       int size = TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, prec) - 1;
       TR::SymbolReference * symRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, arrayAddressNode, 8, fe());
       symRef->setOffset(0);
 
-      TR::Node * pdload = TR::Node::create(TR::pdloadi, 1, arrayAddressNode);
+      TR::Node *pdload = TR::Node::create(TR::pdloadi, 1, arrayAddressNode);
       pdload->setSymbolReference(symRef);
       pdload->setDecimalPrecision(prec);
 
       //set up decimal arrayAddressNode
-      TR::Node * decimalAddressNode;
+      TR::Node *decimalAddressNode;
          {
-         TR::Node * twoConstNode;
-         TR::Node * multipliedOffsetNode;
-         TR::Node * totalOffsetNode;
-         TR::Node * headerConstNode;
+         TR::Node *twoConstNode;
+         TR::Node *multipliedOffsetNode;
+         TR::Node *totalOffsetNode;
+         TR::Node *headerConstNode;
          if (comp()->target().is64Bit())
             {
             headerConstNode = TR::Node::create(callNode, TR::lconst, 0, 0);
@@ -2693,62 +2693,62 @@ bool TR_DataAccessAccelerator::generatePD2UD(TR::TreeTop* treeTop, TR::Node* cal
          TR_ASSERT(false, "unsupported decimalType.\n");
          }
 
-      TR::Node * pd2decimalNode = NULL;
+      TR::Node *pd2decimalNode = NULL;
       if (isPD2UD || type == 1)
          {
          pd2decimalNode = TR::Node::create(op, 1, pdload);
          }
       else //ED2PD
          {
-         TR::Node * toZDNode = TR::Node::create(interOp, 1, pdload);
+         TR::Node *toZDNode = TR::Node::create(interOp, 1, pdload);
          toZDNode->setDecimalPrecision(precNode->getInt());
          pd2decimalNode = TR::Node::create(op, 1, toZDNode);
          }
       pd2decimalNode->setDecimalPrecision(precNode->getInt());
 
       //set up decimalStore node
-      TR::SymbolReference * symRefDecimalStore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(dt, decimalAddressNode, 8, fe());
-      TR::Symbol * symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), dt, TR::DataType::getSizeFromBCDPrecision(dt, prec));
+      TR::SymbolReference *symRefDecimalStore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(dt, decimalAddressNode, 8, fe());
+      TR::Symbol *symStore =  TR::Symbol::createShadow(comp()->trHeapMemory(), dt, TR::DataType::getSizeFromBCDPrecision(dt, prec));
       symStore->setArrayShadowSymbol();
       symRefDecimalStore->setSymbol(symStore);
 
-      TR::Node * decimalStore = TR::Node::create(storeOp, 2, decimalAddressNode, pd2decimalNode);
+      TR::Node *decimalStore = TR::Node::create(storeOp, 2, decimalAddressNode, pd2decimalNode);
       decimalStore->setSymbolReference(symRefDecimalStore);
       decimalStore->setDecimalPrecision(precNode->getInt());
 
       //set up bndchks, and null chks
-      TR::Node * pdPassThroughNode = TR::Node::create(TR::PassThrough, 1, pdNode);
-      TR::Node * decimalPassThroughNode = TR::Node::create(TR::PassThrough, 1, decimalNode);
+      TR::Node *pdPassThroughNode = TR::Node::create(TR::PassThrough, 1, pdNode);
+      TR::Node *decimalPassThroughNode = TR::Node::create(TR::PassThrough, 1, decimalNode);
       int elementSize = isPD2UD ? TR::DataType::getUnicodeElementSize() : TR::DataType::getZonedElementSize();
       int pdPrecSize = TR::DataType::getSizeFromBCDPrecision(TR::PackedDecimal, prec) - 1;
       int decimalPrecSize = (TR::DataType::getSizeFromBCDPrecision(dt, prec) / elementSize) - 1;
-      TR::Node * pdBndvalue = TR::Node::create(TR::iadd, 2, pdOffsetNode, TR::Node::create(callNode, TR::iconst, 0, pdPrecSize));
-      TR::Node * decimalBndvalue = TR::Node::create(TR::iadd, 2, decimalOffsetNode, TR::Node::create(callNode, TR::iconst, 0, decimalPrecSize)); //size of unicode is 2 bytes
+      TR::Node *pdBndvalue = TR::Node::create(TR::iadd, 2, pdOffsetNode, TR::Node::create(callNode, TR::iconst, 0, pdPrecSize));
+      TR::Node *decimalBndvalue = TR::Node::create(TR::iadd, 2, decimalOffsetNode, TR::Node::create(callNode, TR::iconst, 0, decimalPrecSize)); //size of unicode is 2 bytes
 
-      TR::Node * pdArrayLengthNode = TR::Node::create(TR::arraylength, 1, pdNode);
-      TR::Node * decimalArrayLengthNode = TR::Node::create(TR::arraylength, 1, decimalNode);
+      TR::Node *pdArrayLengthNode = TR::Node::create(TR::arraylength, 1, pdNode);
+      TR::Node *decimalArrayLengthNode = TR::Node::create(TR::arraylength, 1, decimalNode);
 
-      TR::Node * pdNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, pdPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
-      TR::Node * decimalNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, decimalPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
+      TR::Node *pdNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, pdPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
+      TR::Node *decimalNullChkNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, decimalPassThroughNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_nullCheck, false, true, true));
 
-      TR::Node * pdBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * pdBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdBndvalue, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * decimalBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
-      TR::Node * decimalBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalBndvalue, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *pdBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *pdBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, pdArrayLengthNode, pdBndvalue, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *decimalBndChk = TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalOffsetNode, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
+      TR::Node *decimalBndChk2 =TR::Node::createWithSymRef(TR::BNDCHK, 2, 2, decimalArrayLengthNode, decimalBndvalue, getSymRefTab()->findOrCreateRuntimeHelper(TR_arrayBoundsCheck, false, true, true));
 
       //gen tree tops
-      TR::TreeTop * nextTT = treeTop->getNextTreeTop();
-      TR::TreeTop * prevTT = treeTop->getPrevTreeTop();
+      TR::TreeTop *nextTT = treeTop->getNextTreeTop();
+      TR::TreeTop *prevTT = treeTop->getPrevTreeTop();
 
-      TR::TreeTop * pdNullChktt = TR::TreeTop::create(comp(), pdNullChkNode);
-      TR::TreeTop * decimalNullChktt = TR::TreeTop::create(comp(), decimalNullChkNode);
+      TR::TreeTop *pdNullChktt = TR::TreeTop::create(comp(), pdNullChkNode);
+      TR::TreeTop *decimalNullChktt = TR::TreeTop::create(comp(), decimalNullChkNode);
 
-      TR::TreeTop * pdBndChktt1 = TR::TreeTop::create(comp(), pdBndChk);
-      TR::TreeTop * pdBndChktt2 = TR::TreeTop::create(comp(), pdBndChk2);
-      TR::TreeTop * decimalBndChktt1 = TR::TreeTop::create(comp(), decimalBndChk);
-      TR::TreeTop * decimalBndChktt2 = TR::TreeTop::create(comp(), decimalBndChk2);
+      TR::TreeTop *pdBndChktt1 = TR::TreeTop::create(comp(), pdBndChk);
+      TR::TreeTop *pdBndChktt2 = TR::TreeTop::create(comp(), pdBndChk2);
+      TR::TreeTop *decimalBndChktt1 = TR::TreeTop::create(comp(), decimalBndChk);
+      TR::TreeTop *decimalBndChktt2 = TR::TreeTop::create(comp(), decimalBndChk2);
 
-      TR::TreeTop * decimalStoreTT    = TR::TreeTop::create(comp(), decimalStore);
+      TR::TreeTop *decimalStoreTT    = TR::TreeTop::create(comp(), decimalStore);
 
       prevTT->join(pdNullChktt);
       pdNullChktt->join(decimalNullChktt);

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -8226,7 +8226,7 @@ void TR_EscapeAnalysis::scanForExtraCallsToInline()
 
          TR::TreeTop *callTreeToInline = NULL;
          TR::Node    *callNode = NULL;
-         char *reason = "??";
+         const char *reason = "??";
          if (  tt->getNode()->getNumChildren() >= 1
             && tt->getNode()->getFirstChild()->getOpCode().isCall()
             && tt->getNode()->getFirstChild()->getSymbol()->isResolvedMethod())
@@ -8360,7 +8360,7 @@ FieldInfo& Candidate::findOrSetFieldInfo(TR::Node *fieldRefNode, TR::SymbolRefer
    }
 
 
-void TR_EscapeAnalysis::printCandidates(char *title)
+void TR_EscapeAnalysis::printCandidates(const char *title)
    {
    if (title)
       traceMsg(comp(), "\n%s\n", title);
@@ -8376,7 +8376,7 @@ void TR_EscapeAnalysis::printCandidates(char *title)
 static void printSymRefList(TR_ScratchList<TR::SymbolReference> *list, TR::Compilation *comp)
    {
    ListIterator<TR::SymbolReference> iter(list);
-   char *sep = "";
+   const char *sep = "";
    for (TR::SymbolReference *symRef = iter.getFirst(); symRef; symRef = iter.getNext())
       {
       traceMsg(comp, "%s#%d", sep, symRef->getReferenceNumber());

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -673,7 +673,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    void     setHasFlushOnEntry(int32_t blockNum) {_blocksWithFlushOnEntry->set(blockNum);}
    void     rememoize(Candidate *c, bool mayDememoizeNextTime=false);
 
-   void     printCandidates(char *);
+   void     printCandidates(const char *);
 
    char *getClassName(TR::Node *classNode);
 

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -3363,13 +3363,13 @@ TR_CISCTransformer::isBlockInLoopBody(TR::Block *block)
 
 
 void
-TR_CISCTransformer::showEmbeddedData(char *title, uint8_t *data)
+TR_CISCTransformer::showEmbeddedData(const char *title, uint8_t *data)
    {
    int32_t i, j;
-   traceMsg(comp(), "%s\n    ",title);
+   traceMsg(comp(), "%s\n    ", title);
    for (j = 0; j < _numPNodes; j++)
       {
-      traceMsg(comp(), "%3d",j);
+      traceMsg(comp(), "%3d", j);
       }
    traceMsg(comp(), "\n  --");
    for (j = 0; j < _numPNodes; j++)
@@ -3386,7 +3386,7 @@ TR_CISCTransformer::showEmbeddedData(char *title, uint8_t *data)
          if (this_result == _Unknown || this_result == _NotEmbed)
             traceMsg(comp(), "|  ");
          else
-            traceMsg(comp(), "| %X",data[idx(j, i)]);
+            traceMsg(comp(), "| %X", data[idx(j, i)]);
          }
       traceMsg(comp(), "\n");
       }
@@ -5144,7 +5144,7 @@ TR_CISCTransformer::moveCISCNodesInList(List<TR_CISCNode> *l, TR_CISCNode *from,
 // * _T->_orderByData
 //*****************************************************************************
 void
-TR_CISCTransformer::moveCISCNodes(TR_CISCNode *from, TR_CISCNode *to, TR_CISCNode *moveTo, char *debugStr)
+TR_CISCTransformer::moveCISCNodes(TR_CISCNode *from, TR_CISCNode *to, TR_CISCNode *moveTo, const char *debugStr)
    {
    if (showMesssagesStdout())
       {
@@ -7665,7 +7665,7 @@ TR_CISCTransformer::computeTopologicalEmbedding(TR_CISCGraph *P, TR_CISCGraph *T
 
    if (trace() || showMesssagesStdout())
       {
-      char *bcinfo = "";
+      char *bcinfo = (char *)"";
 #if SHOW_BCINDICES
       char tmpbuf[256];
       int32_t minIndex, maxIndex;

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -1304,7 +1304,7 @@ class TR_CISCTransformer : public TR_LoopTransformer
 
    bool computeTopologicalEmbedding(TR_CISCGraph *P, TR_CISCGraph *T);
    bool embeddingHasConflictingBranches();
-   void showEmbeddedData(char *title, uint8_t *data);
+   void showEmbeddedData(const char *title, uint8_t *data);
    bool computeEmbeddedForData();
    bool computeEmbeddedForCFG();
    bool dagEmbed(TR_CISCNode *, TR_CISCNode*);
@@ -1452,7 +1452,7 @@ class TR_CISCTransformer : public TR_LoopTransformer
    void showCandidates();
    void registerCandidates();
    void moveCISCNodesInList(List<TR_CISCNode> *l, TR_CISCNode *from, TR_CISCNode *to, TR_CISCNode *moveTo);
-   void moveCISCNodes(TR_CISCNode *from, TR_CISCNode *to, TR_CISCNode *moveTo, char *debugStr = NULL);
+   void moveCISCNodes(TR_CISCNode *from, TR_CISCNode *to, TR_CISCNode *moveTo, const char *debugStr = NULL);
    TR::Block *searchPredecessorOfBlock(TR::Block *block);
    TR::Block *modifyBlockByVersioningCheck(TR::Block *block, TR::TreeTop *startTop, TR::Node *lengthNode, List<TR::Node> *guardList = NULL);
    TR::Block *modifyBlockByVersioningCheck(TR::Block *block, TR::TreeTop *startTop, List<TR::Node> *guardList);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -173,7 +173,7 @@ static int32_t getJ9InitialBytecodeSize(TR_ResolvedMethod * feMethod, TR::Resolv
 
 static bool insideIntPipelineForEach(TR_ResolvedMethod *method, TR::Compilation *comp)
    {
-   char *sig = "accept";
+   const char *sig = "accept";
    bool returnValue = true; //default is true since if first method is IntPipeline.forEach true is returned
 
    //Searches up the owning method chain until IntPipeline.forEach is found
@@ -3490,7 +3490,7 @@ void TR_MultipleCallTargetInliner::weighCallSite( TR_CallStack * callStack , TR_
          if (isHot(comp()))
             {
             TR_ResolvedMethod *m = calltarget->_calleeSymbol->getResolvedMethod();
-            char *sig = "toString";
+            const char *sig = "toString";
             if (strncmp(m->nameChars(), sig, strlen(sig)) == 0)
                {
                size >>= 1;

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -60,7 +60,7 @@ extern int32_t          *InlinedSizes;       // Defined in Inliner.cpp
 
 
 //duplicated as long as there are two versions of findInlineTargets
-static uintptr_t *failMCS(char *reason, TR_CallSite *callSite, TR_InlinerBase* inliner)
+static uintptr_t *failMCS(const char *reason, TR_CallSite *callSite, TR_InlinerBase* inliner)
    {
    debugTrace(inliner->tracer(),"  Fail isMutableCallSiteTargetInvokeExact(%p): %s", callSite, reason);
    return NULL;
@@ -440,7 +440,7 @@ bool TR_InlinerBase::inlineCallTarget(TR_CallStack *callStack, TR_CallTarget *ca
 
    TR_InlinerDelimiter delimiter(tracer(),"TR_InlinerBase::inlineCallTarget");
 
-   char *sig = "multiLeafArrayCopy";
+   const char *sig = "multiLeafArrayCopy";
    if (strncmp(calltarget->_calleeMethod->nameChars(), sig, strlen(sig)) == 0)
       {
       _nodeCountThreshold = 8192;

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -3542,7 +3542,7 @@ bool J9::ValuePropagation::isUnreliableSignatureType(
    return true;
    }
 
-static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, TR::SymbolReference *&getHelpersSymRef, TR::SymbolReference *&helperSymRef, char *helperSig, int32_t helperSigLen, TR::MethodSymbol::Kinds helperCallKind)
+static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, TR::SymbolReference *&getHelpersSymRef, TR::SymbolReference *&helperSymRef, const char *helperSig, int32_t helperSigLen, TR::MethodSymbol::Kinds helperCallKind)
    {
    //Function to retrieve the JITHelpers.getHelpers and JITHelpers.<helperSig> method symbol references.
    //

--- a/runtime/compiler/optimizer/SignExtendLoads.cpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.cpp
@@ -49,12 +49,12 @@
 // -------------------------------------------------------------------------------------------
 bool shouldEnableSEL(TR::Compilation *comp)
    {
-   static char * enableSEL = feGetEnv("TR_SIGNEXTENDLOADS");
+   static const char *enableSEL = feGetEnv("TR_SIGNEXTENDLOADS");
    if (comp->target().cpu.isZ())
       {
       // enable only for 390
-      static char * nenableSEL = feGetEnv("TR_NSIGNEXTENDLOADS");
-      if(nenableSEL ==NULL) enableSEL = "enable";
+      static const char *nenableSEL = feGetEnv("TR_NSIGNEXTENDLOADS");
+      if (nenableSEL == NULL) enableSEL = "enable";
       }
    return ((enableSEL != NULL) &&
            comp->target().is64Bit());

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -161,41 +161,41 @@ TR::SymbolReference* TR_StringPeepholes::MethodEnumToArgsForMethodSymRefFromName
           m !=  END_STRINGPEEPHOLES_METHODS , "wrong constant!!");
 
 
-   static char* classNames [] = {"java/math/BigDecimal",
-                                 "java/math/BigDecimal",
-                         "java/math/BigDecimal",
-                         "java/math/BigDecimal",
-                          NULL,
-                         "java/lang/String",
-                         "java/lang/String",
-                         "java/lang/String",
-                                 "java/lang/String",
-                         "java/lang/String",
-                         "java/lang/String"};
+   static const char* classNames [] =  {"java/math/BigDecimal",
+                                        "java/math/BigDecimal",
+                                        "java/math/BigDecimal",
+                                        "java/math/BigDecimal",
+                                        NULL,
+                                        "java/lang/String",
+                                        "java/lang/String",
+                                        "java/lang/String",
+                                        "java/lang/String",
+                                        "java/lang/String",
+                                        "java/lang/String"};
 
-   static char* methodNames [] = {"SMAAMSS",
-                                  "SMSS",
-                          "AAMSS",
-                          "MSS",
-                                  NULL,
-                                  "<init>",
-                          "<init>",
-                          "<init>",
-                          "<init>",
-                                  "<init>",
-                          "<init>"};
+   static const char* methodNames [] = {"SMAAMSS",
+                                        "SMSS",
+                                        "AAMSS",
+                                        "MSS",
+                                        NULL,
+                                        "<init>",
+                                        "<init>",
+                                        "<init>",
+                                        "<init>",
+                                        "<init>",
+                                        "<init>"};
 
-   static char* signatures [] =  {        "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;IIII)Ljava/math/BigDecimal;",
-                                  "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;II)Ljava/math/BigDecimal;",
-                          "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;III)Ljava/math/BigDecimal;",
-                          "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;I)Ljava/math/BigDecimal;",
-                                  NULL,
-                                  "(Ljava/lang/String;C)V",
-                                  "(Ljava/lang/String;Ljava/lang/String;)V",
-                                  "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
-                                  "(Ljava/lang/String;I)V",
-                                  "([BIIZ)V",
-                                  "(ILjava/lang/String;ILjava/lang/String;Ljava/lang/String;)V"};
+   static const char* signatures [] =  {"(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;IIII)Ljava/math/BigDecimal;",
+                                        "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;II)Ljava/math/BigDecimal;",
+                                        "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;III)Ljava/math/BigDecimal;",
+                                        "(Ljava/math/BigDecimal;Ljava/math/BigDecimal;I)Ljava/math/BigDecimal;",
+                                        NULL,
+                                        "(Ljava/lang/String;C)V",
+                                        "(Ljava/lang/String;Ljava/lang/String;)V",
+                                        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                                        "(Ljava/lang/String;I)V",
+                                        "([BIIZ)V",
+                                        "(ILjava/lang/String;ILjava/lang/String;Ljava/lang/String;)V"};
 
    // TODO: This is a workaround as we switched to using a byte[] backing array in String*. Remove this workaround once obsolete.
    if (m == SPH_String_init_AIIZ)
@@ -2088,7 +2088,7 @@ TR::TreeTop *TR_StringPeepholes::searchForStringAppend(const char *sig, TR::Tree
             }
          else
             {
-            char *sig2 = "java/lang/Integer.toString(I)";
+            const char *sig2 = "java/lang/Integer.toString(I)";
 
             // Expected reference count for the Integer.toString may change if pending pushes are being
             // generated

--- a/runtime/compiler/optimizer/VPBCDConstraint.cpp
+++ b/runtime/compiler/optimizer/VPBCDConstraint.cpp
@@ -58,7 +58,7 @@ TR::VP_BCDValue         *TR::VP_BCDValue::asBCDValue()                  { return
 TR::VP_BCDSign          *TR::VP_BCDSign::asBCDSign()                    { return this; }
 
 
-char *TR::VP_BCDSign::TR_BCDSignConstraintNames[TR_Sign_Num_Types] =
+const char *TR::VP_BCDSign::TR_BCDSignConstraintNames[TR_Sign_Num_Types] =
    {
    "<unknown_sign_state>",
    "<clean>",

--- a/runtime/compiler/optimizer/VPBCDConstraint.hpp
+++ b/runtime/compiler/optimizer/VPBCDConstraint.hpp
@@ -89,10 +89,10 @@ class VP_BCDSign : public TR::VPConstraint
 
    static bool signsAreConsistent(TR_BCDSignConstraint signOne, TR_BCDSignConstraint signTwo);
 
-   char *getName()
+   const char *getName()
       { return getName(_sign); }
 
-   static char *getName(TR_BCDSignConstraint sign)
+   static const char *getName(TR_BCDSignConstraint sign)
       { return ((sign < TR_Sign_Num_Types) ? TR_BCDSignConstraintNames[sign] : (char*)"invalid_sign_constraint"); }
 
    static TR_BCDSignConstraint getSignConstraintFromBCDSign(TR_BCDSignCode bcdSign)
@@ -147,7 +147,7 @@ class VP_BCDSign : public TR::VPConstraint
    TR::DataType _dataType;
 
    private:
-   static char  *TR_BCDSignConstraintNames[TR_Sign_Num_Types];
+   static const char *TR_BCDSignConstraintNames[TR_Sign_Num_Types];
    };
 
 class VP_BCDValue : public TR::VP_BCDSign

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -1181,7 +1181,7 @@ TR_MHJ2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNod
 uint8_t *
 TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cursor, int32_t argSize)
    {
-   char *storeGPROpName;
+   const char *storeGPROpName;
    int32_t offset = 0,
            intArgNum = 0,
            floatArgNum = 0;
@@ -1427,8 +1427,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCCallSnippet * snippet)
 
    cursor = printPPCArgumentsFlush(pOutFile, callNode, cursor, snippet->getSizeOfArguments());
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(glueRef, cursor, distance))
       info = " Through trampoline";
 
@@ -1526,8 +1526,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualUnresolvedSnippet * snippet)
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Virtual Unresolved Call Snippet");
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(_cg->getSymRef(TR_PPCvirtualUnresolvedHelper), cursor, distance))
       info = " Through trampoline";
 
@@ -1575,8 +1575,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCInterfaceCallSnippet * snippet)
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Interface Call Snippet");
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(_cg->getSymRef(TR_PPCinterfaceCallHelper), cursor, distance))
       info = " Through trampoline";
 

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -236,7 +236,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCForceRecompilationSnippet * snippet)
       cursor += 4;
       }
 
-   char    *info = "";
+   const char *info = "";
    if (isBranchToTrampoline(_cg->getSymRef(TR_PPCinduceRecompilation), cursor, value))
       info = " Through trampoline";
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -8816,7 +8816,7 @@ static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8
    if (!isArray)
       {
       TR_OpaqueClassBlock * bdClass;
-      char *className, *fieldSig;
+      const char *className, *fieldSig;
       int32_t classNameLen, fieldSigLen;
 
       fieldSigLen = 1;
@@ -8878,7 +8878,7 @@ static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8
             shiftAmount = 3;
 
          TR_OpaqueClassBlock * bdClass;
-         char *className, *fieldSig;
+         const char *className, *fieldSig;
          int32_t classNameLen, fieldSigLen;
 
          fieldSigLen = 1;
@@ -9379,7 +9379,7 @@ static TR::Register *inlineAtomicOperation(TR::Node *node, TR::CodeGenerator *cg
    else if (!isArray)
       {
       TR_OpaqueClassBlock *classBlock;
-      char *className, *fieldSig;
+      const char *className, *fieldSig;
       int32_t classNameLen, fieldSigLen;
       fieldSigLen = 1;
 
@@ -9432,7 +9432,7 @@ static TR::Register *inlineAtomicOperation(TR::Node *node, TR::CodeGenerator *cg
       fieldOffset = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 
       TR_OpaqueClassBlock *classBlock;
-      char *className, *fieldSig;
+      const char *className, *fieldSig;
       int32_t classNameLen, fieldSigLen;
       fieldSigLen = 1;
 

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -316,8 +316,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
          glueRef = _cg->getSymRef(TR_PPCinterpreterUnresolvedStaticDataGlue);
       }
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(glueRef, cursor, distance))
       info = " Through Trampoline";
 

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -93,8 +93,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCRecompilationSnippet * snippet)
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Counting Recompilation Snippet");
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t    distance;
    if (isBranchToTrampoline(_cg->getSymRef(TR_PPCcountingRecompileMethod), cursor, distance))
       info = " Through trampoline";
 

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
@@ -353,8 +353,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCStackCheckFailureSnippet * snippet)
       cursor += 4;
       }
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(_comp->getSymRefTab()->element(TR_stackOverflow), cursor, distance))
       info = " Through trampoline";
 

--- a/runtime/compiler/p/runtime/PPCHWProfilerAIX.cpp
+++ b/runtime/compiler/p/runtime/PPCHWProfilerAIX.cpp
@@ -67,7 +67,7 @@ struct pmapiInterface
    int (*pm_delete_program_mythread)();
    int (*pm_start_mythread)();
    int (*pm_stop_mythread)();
-   char* (*pm_strerror)(char *where, int error);
+   char* (*pm_strerror)(const char *where, int error);
    int (*pm_get_data_mythread)(pm_data_t *data);
    // Private, not declared in pmapi.h
    int (*pm_set_ebb_handler)(void *handler_address, void *data_area);
@@ -107,7 +107,7 @@ static bool pmapiInit()
       goto fail;
       }
 
-   char *curSym;
+   const char *curSym;
    curSym = "pm_initialize";
    pmapi.pm_initialize = (int (*)(int, pm_info2_t *, pm_groups_info_t *, int))dlsym(pmapi.dlHandle, curSym);
    if (!pmapi.pm_initialize)
@@ -149,7 +149,7 @@ static bool pmapiInit()
    if (!pmapi.pm_disable_bhrb)
       goto pmapiClose;
    curSym = "pm_strerror";
-   pmapi.pm_strerror = (char* (*)(char *, int))dlsym(pmapi.dlHandle, curSym);
+   pmapi.pm_strerror = (char* (*)(const char *, int))dlsym(pmapi.dlHandle, curSym);
    if (!pmapi.pm_strerror)
       goto pmapiClose;
    curSym = "pm_get_data_mythread";


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to (char *)) in optimizer and p.

This PR contributes to (but does not close) https://github.com/eclipse-openj9/openj9/issues/14859

**This PR depends on:**

- **Step 1:**
    - https://github.com/eclipse-openj9/openj9/pull/18083
    - https://github.com/eclipse-openj9/openj9/pull/18455
- **Step 2:**
    - https://github.com/eclipse-openj9/openj9/pull/18467
    - https://github.com/eclipse/omr/pull/7186
- **Step 3:**
    - https://github.com/eclipse-openj9/openj9/pull/18470
    - https://github.com/eclipse/omr/pull/7187