### PR TITLE
(0.43) jdk11 - Don't cache instances of TemporaryLoggerFinder

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1802,13 +1802,13 @@ public abstract static class LoggerFinder {
 								(PrivilegedAction<LoggerFinder>) () -> jdk.internal.logger.LoggerFinderLoader.getLoggerFinder(),
 								AccessController.getContext(),
 								com.ibm.oti.util.RuntimePermissions.permissionLoggerFinder);
-			/*[IF JAVA_SPEC_VERSION >= 17]*/
+			/*[IF JAVA_SPEC_VERSION >= 11]*/
 			/*[IF JAVA_SPEC_VERSION != 21] Temporary until jdk21 picks up the OpenJDK change */
 			if (localFinder instanceof jdk.internal.logger.LoggerFinderLoader.TemporaryLoggerFinder) {
 				return localFinder;
 			}
 			/*[ENDIF] JAVA_SPEC_VERSION != 21 */
-			/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+			/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			loggerFinder = localFinder;
 		}
 		return localFinder;


### PR DESCRIPTION
The OpenJDK change has been backported to jdk11.
See https://github.com/eclipse-openj9/openj9/pull/18406

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/18462 for 0.43