### PR TITLE
Update 0.41.0 release note

### DIFF
--- a/doc/release-notes/0.41/0.41.md
+++ b/doc/release-notes/0.41/0.41.md
@@ -49,14 +49,14 @@ The following table covers notable changes in v0.41.0. Further information about
 
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16724">#16724</a></td>
-<td valign="top">A new <tt>-XX:[+|-]ShowCarrierFrames</tt> option is available to add the stack trace of the carrier thread in addition to the virtual thread stack trace to the <tt>Throwable.getStackTrace()</tt> method, if an exception occurs.</td>
+<td valign="top">The <tt>-XX:[+|-]ShowCarrierFrames</tt> option is available to add the stack trace of the carrier thread in addition to the virtual thread stack trace to the <tt>Throwable.getStackTrace()</tt> method, if an exception occurs.</td>
 <td valign="top">OpenJDK 21 and later</td>
 <td valign="top">A VM maintains multiple platform threads that are used as carrier threads to run the virtual threads. Earlier, if an exception occurred on running the virtual threads, the thread dumps did not include stack frames from the carrier thread's stack. You can use the <tt>-XX:+ShowCarrierFrames</tt> option to add the stack trace of the carrier thread in addition to the virtual thread stack trace to the <tt>Throwable.getStackTrace()</tt> method, if an exception occurs. </td>
 </tr>
 
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/16452">#16452</a></td>
-<td valign="top"><tt>-XX:+CompactStrings</tt> option is now enabled by default</td>
+<td valign="top">The <tt>-XX:+CompactStrings</tt> option is now enabled by default</td>
 <td valign="top">OpenJDK 11 and later</td>
 <td valign="top">Like HotSpot, the <tt>-XX:+CompactStrings</tt> option is now enabled by default on Java&trade; 11 and later. In the earlier versions, this option is disabled by default.</td>
 </tr>
@@ -70,19 +70,19 @@ Now, with the change in behavior of the <tt>-Xshareclasses:readonly</tt> option,
 </tr>
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/17215">#17215</a></td>
-<td valign="top">New <tt>-XX:[+|-]EnableDynamicAgentLoading</tt> option is added to enable or disable the dynamic loading of agents into a running VM.</tt></td>
+<td valign="top">The <tt>-XX:[+|-]EnableDynamicAgentLoading</tt> option is added to enable or disable the dynamic loading of agents into a running VM.</tt></td>
 <td valign="top">All versions</td>
 <td valign="top">With the Attach API, your application can load an agent dynamically into a running VM to run tasks. You can disable the dynamic loading of the agents into a VM after startup with the <tt>-XX:-EnableDynamicAgentLoading</tt> option to prevent the misuse of the Attach API to dynamically load an agent without the approval of the application owner.<br>For Java 21 and later, warnings are issued when the agents are loaded dynamically without specifying the <tt>-XX:+EnableDynamicAgentLoading</tt> option and the same agents were not loaded before.</td>
 </tr>
 <tr>
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/17643">#17643</a></td>
-<td valign="top">New <tt>-XX:ContinuationCache</tt> option is added to tune the continuation tier 1 and 2 cache size.</tt></td>
+<td valign="top">The <tt>-XX:ContinuationCache</tt> option is added to tune the continuation tier 1 and 2 cache size.</tt></td>
 <td valign="top">OpenJDK 21 and later</td>
 <td valign="top">New continuations can reuse the cached structure instead of allocating new memory for it. The continuation cache is implemented in two tiers, tier 1 and tier 2. You can set the maximum size for the two tiers with the <tt>-XX:ContinuationCache</tt> option. If an application uses more than 10000 virtual threads, setting a larger cache size might improve performance.</td>
 </tr>
 <tr>
 <td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/265">#265</a></td>
-<td valign="top">New <tt>-XX:[+|-]UseZlibNX</tt> option is added to control the loading of the <tt>zlibnx</tt> library in the <tt>LIBPATH</tt> environment variable.</td>
+<td valign="top">The <tt>-XX:[+|-]UseZlibNX</tt> is added to control the loading of the <tt>zlibnx</tt> library in the <tt>LIBPATH</tt> environment variable.</td>
 <td valign="top">All versions (AIX&reg;)</td>
 <td valign="top">The AIX system adds the <tt>zlibNX</tt> library location, if available, to the <tt>LIBPATH</tt> variable by default. But, having the <tt>zlibNX</tt> library directory location in the <tt>LIBPATH</tt> variable might cause some issues. You can disable adding of the <tt>zlibNX</tt> library location to that variable with the <tt>-XX:-UseZlibNX</tt> option.</td>
 </tr>
@@ -91,6 +91,12 @@ Now, with the change in behavior of the <tt>-Xshareclasses:readonly</tt> option,
 <td valign="top">OpenSSL 3.x is now supported on all operating systems.</td>
 <td valign="top">All versions</td>
 <td valign="top">In the earlier releases, OpenSSL 3.x was supported only on Linux. Now, OpenSSL 3.x is supported on all operating systems.</td>
+</tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/18202">#18202</a></td>
+<td valign="top">Support is added for the <tt>com.sun.management.ThreadMXBean.getThreadAllocatedBytes()</tt> API.</td>
+<td valign="top">All versions (All operating systems except z/OS&reg;)</td>
+<td valign="top">In the earlier releases, thread memory allocation measurement was not supported. With this release, the OpenJ9 VM implementation supports thread memory allocation measurement (<tt>com.sun.management.ThreadMXBean.getThreadAllocatedBytes()</tt> API). The <tt>isThreadAllocatedMemorySupported()</tt> method now returns true instead of false. The <tt>setThreadAllocatedMemoryEnabled()</tt> and <tt>isThreadAllocatedMemoryEnabled()</tt> methods do not throw the "UnsupportedOperationException" error now and are enabled by default.</td>
 </tr>
 
 </tbody>
@@ -116,7 +122,7 @@ The v0.41.0 release contains the following known issues and limitations:
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/15011">#15011</a></td>
 <td valign="top">The default stack size for the main thread is a smaller platform-dependent value.</td>
 <td valign="top">All</td>
-<td valign="top">The main thread stack size was 1 MB in releases prior to 0.32. In the 0.32 release and later it was modified to a smaller
+<td valign="top">The main thread stack size was 1 MB in releases before 0.32. In the 0.32 release and later it was modified to a smaller
 platform-dependent value, the same value as the <tt>-Xmso</tt> setting. The 0.33 release increased the default <tt>-Xmso</tt> stack size
 on x64 platforms, but builds with OpenJDK 17 and later also require more stack space to run. These changes might result in a
 <tt>java.lang.StackOverflowError: operating system stack overflow</tt>.</td>


### PR DESCRIPTION
Updated the release note for 0.41.0 release. New change related to getThreadAllocatedBytes MXBean API support backported from 0.42.0 release.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com