### PR TITLE
Invalidate JNI IDs for unloaded classes

### DIFF
--- a/runtime/jvmti/jvmtiBreakpoint.c
+++ b/runtime/jvmti/jvmtiBreakpoint.c
@@ -47,7 +47,7 @@ jvmtiSetBreakpoint(jvmtiEnv* env,
 		ENSURE_PHASE_LIVE(env);
 		ENSURE_CAPABILITY(env, can_generate_breakpoint_events);
 
-		ENSURE_JMETHODID_NON_NULL(method);
+		ENSURE_JMETHODID_VALID(method);
 
 		/* Ensure the location is valid for the method */
 
@@ -119,7 +119,7 @@ jvmtiClearBreakpoint(jvmtiEnv* env,
 		ENSURE_PHASE_LIVE(env);
 		ENSURE_CAPABILITY(env, can_generate_breakpoint_events);
 
-		ENSURE_JMETHODID_NON_NULL(method);
+		ENSURE_JMETHODID_VALID(method);
 
 		/* Ensure the location is valid for the method */
 

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -3586,7 +3586,7 @@ jvmtiGetJ9method(jvmtiEnv *env, ...)
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(mid);
+	ENSURE_JMETHODID_VALID(mid);
 	ENSURE_NON_NULL(j9MethodPtr);
 
 	rv_j9Method = ((J9JNIMethodID *) mid)->method;

--- a/runtime/jvmti/jvmtiField.c
+++ b/runtime/jvmti/jvmtiField.c
@@ -53,7 +53,7 @@ jvmtiGetFieldName(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 
 		romFieldShape = ((J9JNIFieldID *) field)->field;
 
@@ -149,7 +149,7 @@ jvmtiGetFieldDeclaringClass(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(declaring_class_ptr);
 
 		fieldClass = getCurrentClass(((J9JNIFieldID *) field)->declaringClass);
@@ -188,7 +188,7 @@ jvmtiGetFieldModifiers(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(modifiers_ptr);
 
 		romField = ((J9JNIFieldID *) field)->field;
@@ -230,7 +230,7 @@ jvmtiIsFieldSynthetic(jvmtiEnv* env,
 		ENSURE_CAPABILITY(env, can_get_synthetic_attribute);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(is_synthetic_ptr);
 
 		romFieldShape = ((J9JNIFieldID *) field)->field;

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -52,7 +52,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
 
@@ -141,7 +141,7 @@ jvmtiGetMethodDeclaringClass(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JMETHODID_NON_NULL(method);
+		ENSURE_JMETHODID_VALID(method);
 		ENSURE_NON_NULL(declaring_class_ptr);
 
 		methodClass = getCurrentClass(J9_CLASS_FROM_METHOD(((J9JNIMethodID *) method)->method));
@@ -171,7 +171,7 @@ jvmtiGetMethodModifiers(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(modifiers_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
@@ -200,7 +200,7 @@ jvmtiGetMaxLocals(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(max_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
@@ -238,7 +238,7 @@ jvmtiGetArgumentsSize(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(size_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
@@ -277,7 +277,7 @@ jvmtiGetLineNumberTable(jvmtiEnv* env,
 	ENSURE_PHASE_START_OR_LIVE(env);
 	ENSURE_CAPABILITY(env, can_get_line_numbers);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(entry_count_ptr);
 	ENSURE_NON_NULL(table_ptr);
 
@@ -356,7 +356,7 @@ jvmtiGetMethodLocation(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(start_location_ptr);
 	ENSURE_NON_NULL(end_location_ptr);
 
@@ -404,7 +404,7 @@ jvmtiGetLocalVariableTable(jvmtiEnv* env,
 	ENSURE_PHASE_LIVE(env);
 	ENSURE_CAPABILITY(env, can_access_local_variables);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(entry_count_ptr);
 	ENSURE_NON_NULL(table_ptr);
 
@@ -520,7 +520,7 @@ jvmtiGetBytecodes(jvmtiEnv* env,
 	ENSURE_PHASE_START_OR_LIVE(env);
 	ENSURE_CAPABILITY(env, can_get_bytecodes);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(bytecode_count_ptr);
 	ENSURE_NON_NULL(bytecodes_ptr);
 
@@ -843,7 +843,7 @@ jvmtiIsMethodNative(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(is_native_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
@@ -872,7 +872,7 @@ jvmtiIsMethodSynthetic(jvmtiEnv* env,
 	ENSURE_PHASE_START_OR_LIVE(env);
 	ENSURE_CAPABILITY(env, can_get_synthetic_attribute);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(is_synthetic_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
@@ -899,7 +899,7 @@ jvmtiIsMethodObsolete(jvmtiEnv* env,
 
 	ENSURE_PHASE_START_OR_LIVE(env);
 
-	ENSURE_JMETHODID_NON_NULL(method);
+	ENSURE_JMETHODID_VALID(method);
 	ENSURE_NON_NULL(is_obsolete_ptr);
 
 	rv_is_obsolete = (J9CLASS_FLAGS(J9_CLASS_FROM_METHOD(((J9JNIMethodID *) method)->method)) & J9AccClassHotSwappedOut) ? JNI_TRUE : JNI_FALSE;

--- a/runtime/jvmti/jvmtiWatchedField.c
+++ b/runtime/jvmti/jvmtiWatchedField.c
@@ -127,7 +127,7 @@ setFieldWatch(jvmtiEnv* env,
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 
@@ -231,7 +231,7 @@ clearFieldWatch(jvmtiEnv* env,
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 		ENSURE_JCLASS_NON_NULL(klass);
-		ENSURE_JFIELDID_NON_NULL(field);
+		ENSURE_JFIELDID_VALID(field);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3812,6 +3812,11 @@ typedef struct J9JNIFieldID {
 	struct J9Class* declaringClass;
 } J9JNIFieldID;
 
+typedef union J9GenericJNIID {
+	J9JNIFieldID fieldID;
+	J9JNIMethodID methodID;
+} J9GenericJNIID;
+
 typedef struct J9ITable {
 	struct J9Class* interfaceClass;
 	UDATA depth;

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -436,16 +436,16 @@ typedef struct jvmtiGcp_translation {
 		} \
 	} while(0) 
 
-#define ENSURE_JMETHODID_NON_NULL(var) \
+#define ENSURE_JMETHODID_VALID(var) \
 	do { \
-		if ((var) == NULL) { \
+		if ((NULL == (var)) || (UDATA_MAX == (UDATA)((J9JNIMethodID*)(var))->method)) { \
 			JVMTI_ERROR(JVMTI_ERROR_INVALID_METHODID); \
 		} \
 	} while(0)
 
-#define ENSURE_JFIELDID_NON_NULL(var) \
+#define ENSURE_JFIELDID_VALID(var) \
 	do { \
-		if ((var) == NULL) { \
+		if ((NULL == (var)) || (UDATA_MAX == (UDATA)((J9JNIFieldID*)(var))->declaringClass)) { \
 			JVMTI_ERROR(JVMTI_ERROR_INVALID_FIELDID); \
 		} \
 	} while(0)
@@ -515,8 +515,8 @@ typedef struct jvmtiGcp_translation {
 #define ENSURE_CAPABILITY(env, capability)
 #define ENSURE_NON_NULL(var)
 #define ENSURE_NON_NEGATIVE(var)
-#define ENSURE_JMETHODID_NON_NULL(var)
-#define ENSURE_JFIELDID_NON_NULL(var)
+#define ENSURE_JMETHODID_VALID(var)
+#define ENSURE_JFIELDID_VALID(var)
 #define ENSURE_JOBJECT_NON_NULL(var)
 #define ENSURE_JCLASS_NON_NULL(var)
 #define ENSURE_JTHREADGROUP_NON_NULL(var)

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -377,7 +377,15 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 	}
 
 	if (NULL != classLoader->jniIDs) {
-		if (J9_ARE_NO_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_KEEP_JNI_IDS)) {
+		if (J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_KEEP_JNI_IDS)) {
+			pool_state idWalkState;
+			J9GenericJNIID *jniID = pool_startDo(classLoader->jniIDs, &idWalkState);
+
+			while (NULL != jniID) {
+				memset(jniID, -1, sizeof(J9GenericJNIID));
+				jniID = pool_nextDo(&idWalkState);
+			}
+		} else {
 			pool_kill(classLoader->jniIDs);
 		}
 		classLoader->jniIDs = NULL;

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -52,11 +52,6 @@
 
 extern "C" {
 
-typedef union J9GenericJNIID {
-	J9JNIFieldID fieldID;
-	J9JNIMethodID methodID;
-} J9GenericJNIID;
-
 #define METHODID_CLASS_REF(methodID) ((jclass) &(J9_CP_FROM_METHOD(((J9JNIMethodID *) (methodID))->method)->ramClass->classObject))
 
 #define MAX_LOCAL_CAPACITY (64 * 1024)


### PR DESCRIPTION
If the -XX:+KeepJNIIDs option is specified, invalidate IDs for unloaded classes rather than freeing them.

Detect invalidated IDs in JVMTI calls and return the appropriate error.

JNI calls may be updated in a future PR (we will need to decide how to handle invalid IDs in those cases as there is no standard error handling mechanism in JNI).

Related: #17466