### PR TITLE
Update Valhalla tests to compile with lw5 head

### DIFF
--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -63,6 +63,8 @@
 			<src path="${transformerListener}" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<compilerarg line='--enable-preview -source 22'/>
+			<!-- uncomment when running with lw5 -->
+			<!--<compilerarg line='-XDenableNullRestrictedTypes' />-->
 			<!-- Also remove this line when running lw5 -->
 			<compilerarg line='-source 22 -XDenablePrimitiveClasses' />
 			<classpath>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -146,13 +146,18 @@ public class ValhallaAttributeTests {
 		c.newInstance();
 	}
 
+	@Test
+	static public void testPutFieldNullToValueTypeField() throws Throwable {
+		Class<?> c = ValhallaAttributeGenerator.generatePutFieldNullToField("TestPutFieldNullToValueTypeField", "TestPutFieldNullToValueTypeFieldField", false);
+		c.newInstance();
+	}
+
 	static public Class<?> testPutFieldNullToNullRestrictedFieldClass = null;
 	static public Class<?> testPutStaticNullToNullRestrictedFieldClass = null;
-	static public Class<?> testWithFieldStoreNullToNullRestrictedFieldClass = null;
 
 	@Test(priority=1)
 	static public void testCreateTestPutFieldNullToNullRestrictedField() throws Throwable {
-		testPutFieldNullToNullRestrictedFieldClass = ValhallaAttributeGenerator.generatePutFieldNullToNullRestrictedField("TestPutFieldNullToNullRestrictedField", "TestPutFieldNullToNullRestrictedFieldField");
+		testPutFieldNullToNullRestrictedFieldClass = ValhallaAttributeGenerator.generatePutFieldNullToField("TestPutFieldNullToNullRestrictedField", "TestPutFieldNullToNullRestrictedFieldField", true);
 	}
 
 	/* Instance field with NullRestricted attribute cannot be set to null. */
@@ -190,15 +195,5 @@ public class ValhallaAttributeTests {
 			throw e;
 		}
 		Assert.fail("Test expected a NullPointerException wrapped in ExceptionInInitializerError.");
-	}
-
-	@Test(priority=1)
-	static public void testCreateTestWithFieldStoreNullToNullRestrictedField() throws Throwable {
-		testWithFieldStoreNullToNullRestrictedFieldClass = ValhallaAttributeGenerator.generateWithFieldStoreNullToNullRestrictedField("TestWithFieldStoreNullToNullRestrictedField", "TestWithFieldStoreNullToNullRestrictedFieldField");
-	}
-
-	@Test(priority=2, invocationCount=2, expectedExceptions = java.lang.NullPointerException.class)
-	static public void testWithFieldStoreNullToNullRestrictedField() throws Throwable {
-		testWithFieldStoreNullToNullRestrictedFieldClass.newInstance();
 	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -32,10 +32,12 @@ public class ValhallaUtils {
 	static final int CLASS_FILE_MAJOR_VERSION = 66;
 
 	/* workaround till the new ASM is released */
-	static final int ACONST_INIT = 203;
-	static final int WITHFIELD = 204;
 	static final int ACC_IDENTITY = 0x20;
 	static final int ACC_VALUE_TYPE = 0x040;
+
+	/* these can be removed with qtypes tests */
+	static final int ACONST_INIT = 203;
+	static final int WITHFIELD = 204;
 	static final int ACC_PRIMITIVE = 0x800;
 
 	/* ImplicitCreation flags */

--- a/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/ValueTypeTests.java
@@ -105,7 +105,6 @@ public class ValueTypeTests {
 
 		void checkFieldAccessWithDefaultValues() throws Throwable {
 			checkEqualPoint2D(defaultPointPositions1);
-			// TODO add putfield tests once withfield is replaced
 		}
 	}
 
@@ -146,7 +145,6 @@ public class ValueTypeTests {
 
 		void checkFieldAccessWithDefaultValues() throws Throwable {
 			checkEqualFlattenedLine2D(defaultLinePositions1);
-			// TODO add putfield tests once withfield is replaced
 		}
 
 		void checkEqualFlattenedLine2D(int[][] positions) throws Throwable {
@@ -180,7 +178,6 @@ public class ValueTypeTests {
 
 		void checkFieldAccessWithDefaultValues() throws Throwable {
 			checkEqualTriangle2D(defaultTrianglePositions);
-			// TODO add putfield tests once withfield is replaced
 		}
 
 		void checkEqualTriangle2D(int[][][] positions) throws Throwable {
@@ -272,7 +269,7 @@ public class ValueTypeTests {
 				new Triangle2D(defaultTrianglePositions));
 		}
 
-		AssortedValueWithLongAlignment checkFieldsWithDefaults() throws Throwable {
+		void checkFieldsWithDefaults() throws Throwable {
 			point.checkEqualPoint2D(defaultPointPositions1);
 			line.checkEqualFlattenedLine2D(defaultLinePositions1);
 			assertEquals(o.val, defaultObject);
@@ -280,8 +277,6 @@ public class ValueTypeTests {
 			assertEquals(d.d, defaultDouble);
 			assertEquals(i.i, defaultInt);
 			tri.checkEqualTriangle2D(defaultTrianglePositions);
-			// TODO add putfield tests once withfield is replaced
-			return this; // should be updated to new defaults once putfield tests are here
 		}
 	}
 
@@ -372,7 +367,7 @@ public class ValueTypeTests {
 				new Triangle2D(defaultTrianglePositions));
 		}
 
-		AssortedValueWithObjectAlignment checkFieldsWithDefaults() throws Throwable {
+		void checkFieldsWithDefaults() throws Throwable {
 			tri.checkEqualTriangle2D(defaultTrianglePositions);
 			point.checkEqualPoint2D(defaultPointPositions1);
 			line.checkEqualFlattenedLine2D( defaultLinePositions1);
@@ -380,8 +375,6 @@ public class ValueTypeTests {
 			assertEquals(i.i, defaultInt);
 			assertEquals(f.f, defaultFloat);
 			tri2.checkEqualTriangle2D(defaultTrianglePositions);
-			// TODO add putfield tests once withfield is replaced
-			return this; // should be updated to new defaults once putfield tests are here
 		}
 	}
 
@@ -476,7 +469,6 @@ public class ValueTypeTests {
 			assertEquals(i.i, defaultInt);
 			assertEquals(f.f, defaultFloat);
 			tri2.checkEqualTriangle2D(defaultTrianglePositions);
-			// TODO add putfield tests once withfield is replaced
 		}
 	}
 
@@ -609,7 +601,6 @@ public class ValueTypeTests {
 			assertEquals(v14.val, defaultObject);
 			assertEquals(v15.val, defaultObject);
 			assertEquals(v16.val, defaultObject);
-			// TODO add putfield tests once withfield is replaced
 		}
 	 }
 
@@ -683,7 +674,6 @@ public class ValueTypeTests {
 				l14.checkFieldsWithDefaults();
 				l15.checkFieldsWithDefaults();
 				l16.checkFieldsWithDefaults();
-				// TODO add putfield tests once withfield is replaced
 			}
 	 }
 
@@ -887,8 +877,6 @@ public class ValueTypeTests {
 
 		assertEquals(point2D.x, x);
 		assertEquals(point2D.y, y);
-
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=1)
@@ -900,8 +888,6 @@ public class ValueTypeTests {
 
 		assertEquals(p.d, d);
 		assertEquals(p.l, l);
-
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=2)
@@ -919,8 +905,6 @@ public class ValueTypeTests {
 		assertEquals(line2D.st.y, y);
 		assertEquals(line2D.en.x, x2);
 		assertEquals(line2D.en.y, y2);
-
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=2)
@@ -938,8 +922,6 @@ public class ValueTypeTests {
 		assertEquals(line2D.st.y, y);
 		assertEquals(line2D.en.x, x2);
 		assertEquals(line2D.en.y, y2);
-
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=3)
@@ -1032,7 +1014,6 @@ public class ValueTypeTests {
 		int i = Integer.MAX_VALUE;
 		ValueInt! valueInt = new ValueInt(i);
 		assertEquals(valueInt.i, i);
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=1)
@@ -1040,7 +1021,6 @@ public class ValueTypeTests {
 		long l = Long.MAX_VALUE;
 		ValueLong! valueLong = new ValueLong(l);
 		assertEquals(valueLong.l, l);
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=1)
@@ -1048,7 +1028,6 @@ public class ValueTypeTests {
 		double d = Double.MAX_VALUE;
 		ValueDouble! valueDouble = new ValueDouble(d);
 		assertEquals(valueDouble.d, d);
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=1)
@@ -1056,7 +1035,6 @@ public class ValueTypeTests {
 		float f = Float.MAX_VALUE;
 		ValueFloat! valueFloat = new ValueFloat(f);
 		assertEquals(valueFloat.f, f);
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=1)
@@ -1064,7 +1042,6 @@ public class ValueTypeTests {
 		Object val = (Object)0xEEFFEEFF;
 		ValueObject! valueObject = new ValueObject(val);
 		assertEquals(valueObject.val, val);
-		// TODO add putfield tests once withfield is replaced
 	}
 
 	@Test(priority=2)
@@ -2403,29 +2380,33 @@ public class ValueTypeTests {
 	static public void testACMPTestOnAssortedValues() throws Throwable {
 		Object assortedValueWithLongAlignment = AssortedValueWithLongAlignment.createObjectWithDefaults();
 		Object assortedValueWithLongAlignment2 = AssortedValueWithLongAlignment.createObjectWithDefaults();
-		Object assortedValueWithLongAlignment3 = AssortedValueWithLongAlignment.createObjectWithDefaults();
-		assortedValueWithLongAlignment3 = ((AssortedValueWithLongAlignment)assortedValueWithLongAlignment3).checkFieldsWithDefaults();
+		Object assortedValueWithLongAlignment3 = new AssortedValueWithLongAlignment(new Point2D(defaultPointPositionsNew),
+				new FlattenedLine2D(defaultLinePositionsNew), new ValueObject(defaultObjectNew),
+				new ValueLong(defaultLongNew), new ValueDouble(defaultDoubleNew), new ValueInt(defaultIntNew),
+				new Triangle2D(defaultTrianglePositionsNew));
 
 		Object assortedValueWithObjectAlignment = AssortedValueWithObjectAlignment.createObjectWithDefaults();
 		Object assortedValueWithObjectAlignment2 = AssortedValueWithObjectAlignment.createObjectWithDefaults();
-		Object assortedValueWithObjectAlignment3 = AssortedValueWithObjectAlignment.createObjectWithDefaults();
-		assortedValueWithObjectAlignment3 = ((AssortedValueWithObjectAlignment)assortedValueWithObjectAlignment3).checkFieldsWithDefaults();
+		Object assortedValueWithObjectAlignment3 = new AssortedValueWithObjectAlignment(
+				new Triangle2D(defaultTrianglePositionsNew), new Point2D(defaultPointPositionsNew),
+				new FlattenedLine2D(defaultLinePositionsNew), new ValueObject(defaultObjectNew),
+				new ValueInt(defaultIntNew), new ValueFloat(defaultFloatNew),
+				new Triangle2D(defaultTrianglePositionsNew));
 
-		// TODO add commented out tests once withfield is replaced
 		assertTrue((assortedValueWithLongAlignment == assortedValueWithLongAlignment), "A substitutability (==) test on the same value should always return true");
 		assertTrue((assortedValueWithObjectAlignment == assortedValueWithObjectAlignment), "A substitutability (==) test on the same value should always return true");
 		assertTrue((assortedValueWithLongAlignment == assortedValueWithLongAlignment2), "A substitutability (==) test on different value the same contents should always return true");
 		assertTrue((assortedValueWithObjectAlignment == assortedValueWithObjectAlignment2), "A substitutability (==) test on different value the same contents should always return true");
-		//assertFalse((assortedValueWithLongAlignment == assortedValueWithLongAlignment3), "A substitutability (==) test on different value should always return false");
+		assertFalse((assortedValueWithLongAlignment == assortedValueWithLongAlignment3), "A substitutability (==) test on different value should always return false");
 		assertFalse((assortedValueWithLongAlignment == assortedValueWithObjectAlignment), "A substitutability (==) test on different value should always return false");
-		//assertFalse((assortedValueWithObjectAlignment == assortedValueWithObjectAlignment3), "A substitutability (==) test on different value should always return false");
+		assertFalse((assortedValueWithObjectAlignment == assortedValueWithObjectAlignment3), "A substitutability (==) test on different value should always return false");
 		assertFalse((assortedValueWithLongAlignment != assortedValueWithLongAlignment), "A substitutability (!=) test on the same value should always return false");
 		assertFalse((assortedValueWithObjectAlignment != assortedValueWithObjectAlignment), "A substitutability (!=) test on the same value should always return false");
 		assertFalse((assortedValueWithLongAlignment != assortedValueWithLongAlignment2), "A substitutability (!=) test on different value the same contents should always return false");
 		assertFalse((assortedValueWithObjectAlignment != assortedValueWithObjectAlignment2), "A substitutability (!=) test on different value the same contents should always return false");
-		//assertTrue((assortedValueWithLongAlignment != assortedValueWithLongAlignment3), "A substitutability (!=) test on different value the same contents should always return false");
+		assertTrue((assortedValueWithLongAlignment != assortedValueWithLongAlignment3), "A substitutability (!=) test on different value the same contents should always return false");
 		assertTrue((assortedValueWithLongAlignment != assortedValueWithObjectAlignment), "A substitutability (!=) test on different value the same contents should always return false");
-		//assertTrue((assortedValueWithObjectAlignment != assortedValueWithObjectAlignment3), "A substitutability (!=) test on different value the same contents should always return false");
+		assertTrue((assortedValueWithObjectAlignment != assortedValueWithObjectAlignment3), "A substitutability (!=) test on different value the same contents should always return false");
 	}
 
 	// *******************************************************************************
@@ -2856,17 +2837,6 @@ public class ValueTypeTests {
 		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastOnInvalidClass", fields);
 		MethodHandle checkCastOnInvalidClass = lookup.findStatic(valueClass, "testCheckCastOnInvalidClass", MethodType.methodType(Object.class));
 		checkCastOnInvalidClass.invoke();
-	}
-
-	/*
-	 * Ensure that casting a non null value type to a valid value type will pass
-	 */
-	@Test(priority=1)
-	static public void testCheckCastValueTypeOnNonNullType() throws Throwable {
-		String fields[] = {"longField:J"};
-		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNonNullType", fields);
-		MethodHandle checkCastValueTypeOnNonNullType = lookup.findStatic(valueClass, "testCheckCastValueTypeOnNonNullType", MethodType.methodType(Object.class));
-		checkCastValueTypeOnNonNullType.invoke();
 	}
 
 	/*


### PR DESCRIPTION
The latest commits in lw5 add a new flag -XDenableNullRestrictedTypes to compile uses of nullrestricted fields. The bytecodes aconst_init and withfield are also removed as is the <vnew> method.

To support these changes this pr:
- remove withfield test ValhallaAttributeTests.testWithFieldStoreNullToNullRestrictedField
- add test ValhallaAttributeTests.testPutFieldNullToValueTypeField to test setting null to a nonrestricted value type field
- remove ValueTypeTests.testCheckCastValueTypeOnNonNullType - this doesn't apply to the new world, nullrestricted behavior can only be set for fields
- replaces all uses of ACONST_INIT and WITHFIELD in ValueTypeTests
- remove TODO comments in ValueTypeTests that were placeholders for withfield tests. In the new version it is not possible to set field values outside of the constructor so these no longer apply