### PR TITLE
Disable maximum elapsed time tests

### DIFF
--- a/test/functional/TestUtilities/src/org/openj9/test/util/TimeUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/TimeUtilities.java
@@ -64,7 +64,7 @@ public class TimeUtilities {
 			result = false;
 			System.out.println("FAILED: " + testName + " elapsedMillisTime (" + elapsedMillisTime
 					+ "ms) should NOT be less than minElapsedMillisTime (" + minElapsedMillisTime + "ms)");
-		} else if (elapsedMillisTime > maxElapsedMillisTime) {
+		} else if ((maxElapsedMillisTime > 0) && (elapsedMillisTime > maxElapsedMillisTime)) {
 			result = false;
 			System.out.println("FAILED: " + testName + " elapsedMillisTime (" + elapsedMillisTime
 					+ "ms) should NOT be greater than maxElapsedMillisTime (" + maxElapsedMillisTime + "ms)");
@@ -73,7 +73,7 @@ public class TimeUtilities {
 			result = false;
 			System.out.println("FAILED: " + testName + " elapsedNanoTimeInMillis (" + elapsedNanoTimeInMillis
 					+ "ms) should NOT be less than minElapsedNanoTimeInMillis (" + minElapsedNanoTimeInMillis + "ms)");
-		} else if (elapsedNanoTimeInMillis > maxElapsedNanoTimeInMillis) {
+		} else if ((maxElapsedNanoTimeInMillis > 0) && (elapsedNanoTimeInMillis > maxElapsedNanoTimeInMillis)) {
 			result = false;
 			System.out.println("FAILED: " + testName + " elapsedNanoTimeInMillis (" + elapsedNanoTimeInMillis
 					+ "ms) should NOT be greater than maxElapsedNanoTimeInMillis (" + maxElapsedNanoTimeInMillis
@@ -82,6 +82,13 @@ public class TimeUtilities {
 		showThreadCurrentTime(testName + " checkElapseTime ends");
 
 		return result;
+	}
+
+	// The maximum elapsed time is not always guaranteed on some platforms.
+	// https://github.com/eclipse-openj9/openj9/issues/18487#issuecomment-1829111868
+	public static boolean checkElapseTime(String testName, long startMillisTime, long startNanoTime,
+			long minElapsedMillisTime, long minElapsedNanoTimeInMillis) {
+		return checkElapseTime(testName, startMillisTime, startNanoTime, minElapsedMillisTime, 0, minElapsedNanoTimeInMillis, 0);
 	}
 
 	private volatile boolean tasksPassed = true;
@@ -140,8 +147,7 @@ public class TimeUtilities {
 
 		public void run() {
 			taskExecuted++;
-			if (!checkElapseTime(testName, startMillisTime, startNanoTime, minElapsedMillisTime, maxElapsedMillisTime,
-					minElapsedNanoTimeInMillis, maxElapsedNanoTimeInMillis)) {
+			if (!checkElapseTime(testName, startMillisTime, startNanoTime, minElapsedMillisTime, minElapsedNanoTimeInMillis)) {
 				tasksPassed = false;
 			}
 			taskRunning--;

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/ElapsedTime.java
@@ -40,8 +40,7 @@ public class ElapsedTime {
 		millisTimeStart = System.currentTimeMillis();
 		nanoTimeStart = System.nanoTime();
 		Thread.currentThread().sleep(100);
-		AssertJUnit.assertTrue(tu.checkElapseTime("testElapsedTime() sleep 100ms", millisTimeStart, nanoTimeStart, 100,
-				800, 100, 800));
+		AssertJUnit.assertTrue(tu.checkElapseTime("testElapsedTime() sleep 100ms", millisTimeStart, nanoTimeStart, 100, 100));
 
 		millisTimeStart = System.currentTimeMillis();
 		nanoTimeStart = System.nanoTime();

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TimeChangeTest.java
@@ -127,8 +127,7 @@ public class TimeChangeTest {
 		millisTimeStart = System.currentTimeMillis();
 		nanoTimeStart = System.nanoTime();
 		Thread.currentThread().sleep(100);
-		TimeUtilities.checkElapseTime("testTimeCompensation() sleep 100ms", millisTimeStart, nanoTimeStart, 100, 800,
-				100, 800);
+		TimeUtilities.checkElapseTime("testTimeCompensation() sleep 100ms", millisTimeStart, nanoTimeStart, 100, 100);
 
 		// this TimerTask is to run before CRIUR checkpoint
 		tu.timerSchedule("testTimeCompensation() preCheckpoint timer delayed 100ms", System.currentTimeMillis(),
@@ -151,7 +150,7 @@ public class TimeChangeTest {
 			public void run() {
 				// check time elapsed within preCheckpoint hook
 				TimeUtilities.checkElapseTime("testTimeCompensation() preCheckpointHook", preCheckpointMillisTime,
-						preCheckpointNanoTime, 2000, 4000, 2000, 4000);
+						preCheckpointNanoTime, 2000, 2000);
 
 				// scheduled task can't run before the checkpoint because all threads are halted
 				// in single threaded mode except the current thread performing CRIU checkpoit
@@ -166,7 +165,7 @@ public class TimeChangeTest {
 			public void run() {
 				// check time elapsed within postRestore hook
 				TimeUtilities.checkElapseTime("testTimeCompensation() postRestoreHook", preCheckpointMillisTime,
-						preCheckpointNanoTime, 4000, 8000, 2000, 4000);
+						preCheckpointNanoTime, 4000, 2000);
 
 				tu.timerSchedule("testTimeCompensation() postRestoreHook timer delayed 10ms",
 						System.currentTimeMillis(), System.nanoTime(), 10, 800, 9, 800, 10);
@@ -176,12 +175,12 @@ public class TimeChangeTest {
 		});
 
 		TimeUtilities.checkElapseTime("testTimeCompensation() preCheckpoint", preCheckpointMillisTime,
-				preCheckpointNanoTime, 2000, 3000, 2000, 3000);
+				preCheckpointNanoTime, 2000, 2000);
 
 		CRIUTestUtils.checkPointJVMNoSetup(criu, CRIUTestUtils.imagePath, false);
 
 		TimeUtilities.checkElapseTime("testTimeCompensation() after CRIU restore", preCheckpointMillisTime,
-				preCheckpointNanoTime, 2000, 6000, 2000, 6000);
+				preCheckpointNanoTime, 2000, 2000);
 
 		CRIUTestUtils.showThreadCurrentTime("testTimeCompensation() postRestore");
 		final long postRestoreMillisTime = System.currentTimeMillis();
@@ -197,7 +196,7 @@ public class TimeChangeTest {
 		Thread.currentThread().sleep(2000);
 
 		TimeUtilities.checkElapseTime("testTimeCompensation() postRestore", postRestoreMillisTime, postRestoreNanoTime,
-				2000, 3000, 2000, 3000);
+				2000, 2000);
 
 		if (tu.getResultAndCancelTimers()) {
 			System.out.println("PASSED: " + "testTimeCompensation");


### PR DESCRIPTION
Disable maximum elapsed time tests

The maximum elapsed time is not always guaranteed on some platforms.

Related
* https://github.com/eclipse-openj9/openj9/issues/18487
* https://github.com/eclipse-openj9/openj9/issues/18513

FYI @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>