### PR TITLE
Fix metronome GC to work within safepoint VM access

### DIFF
--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1126,12 +1126,7 @@ MM_MetronomeDelegate::postRequestExclusiveVMAccess(OMR_VMThread *threadRequestin
 uintptr_t
 MM_MetronomeDelegate::requestExclusiveVMAccess(MM_EnvironmentBase *env, uintptr_t block, uintptr_t *gcPriority)
 {
-	BOOLEAN rc = TRUE;
-
-	if (J9_XACCESS_EXCLUSIVE != _javaVM->safePointState) {
-		rc = _javaVM->internalVMFunctions->requestExclusiveVMAccessMetronomeTemp(_javaVM, block, &_vmResponsesRequiredForExclusiveVMAccess, &_jniResponsesRequiredForExclusiveVMAccess, gcPriority);
-	}
-	return rc;
+	return _javaVM->internalVMFunctions->requestExclusiveVMAccessMetronomeTemp(_javaVM, block, &_vmResponsesRequiredForExclusiveVMAccess, &_jniResponsesRequiredForExclusiveVMAccess, gcPriority);
 }
 
 /**
@@ -1144,10 +1139,8 @@ MM_MetronomeDelegate::waitForExclusiveVMAccess(MM_EnvironmentBase *env, bool wai
 {
 	J9VMThread *mainGCThread = (J9VMThread *)env->getLanguageVMThread();
 	
-	if (J9_XACCESS_EXCLUSIVE != _javaVM->safePointState) {
-		if (waitRequired) {
-			_javaVM->internalVMFunctions->waitForExclusiveVMAccessMetronomeTemp((J9VMThread *)env->getLanguageVMThread(), _vmResponsesRequiredForExclusiveVMAccess, _jniResponsesRequiredForExclusiveVMAccess);
-		}
+	if (waitRequired) {
+		_javaVM->internalVMFunctions->waitForExclusiveVMAccessMetronomeTemp((J9VMThread *)env->getLanguageVMThread(), _vmResponsesRequiredForExclusiveVMAccess, _jniResponsesRequiredForExclusiveVMAccess);
 	}
 	++(mainGCThread->omrVMThread->exclusiveCount);
 }
@@ -1162,12 +1155,11 @@ MM_MetronomeDelegate::acquireExclusiveVMAccess(MM_EnvironmentBase *env, bool wai
 {
 	J9VMThread *mainGCThread = (J9VMThread *)env->getLanguageVMThread();
 
-	if (J9_XACCESS_EXCLUSIVE != _javaVM->safePointState) {
-		if (waitRequired) {
-			_javaVM->internalVMFunctions->acquireExclusiveVMAccessFromExternalThread(_javaVM);
-		}
+	if (waitRequired) {
+		_javaVM->internalVMFunctions->acquireExclusiveVMAccessFromExternalThread(_javaVM);
 	}
 	++(mainGCThread->omrVMThread->exclusiveCount);
+
 }
 
 /**
@@ -1182,22 +1174,14 @@ MM_MetronomeDelegate::releaseExclusiveVMAccess(MM_EnvironmentBase *env, bool rel
 
 	--(mainGCThread->omrVMThread->exclusiveCount);
 	if (releaseRequired) {
-		--(mainGCThread->omrVMThread->exclusiveCount);
-
-		Assert_MM_true(mainGCThread->omrVMThread->exclusiveCount==0);
-
-		_javaVM->internalVMFunctions->internalReleaseVMAccessNoMutex(mainGCThread);
-
-		if (J9_XACCESS_EXCLUSIVE != _javaVM->safePointState) {
-			_javaVM->internalVMFunctions->releaseExclusiveVMAccessFromExternalThread(_javaVM);
-		}
+		_javaVM->internalVMFunctions->releaseExclusiveVMAccessMetronome(mainGCThread);
+		/* Set the exclusive access response counts to an unusual value,
+		 * just for debug purposes, so we can detect scenarios, when main
+		 * thread is waiting for Xaccess with noone requesting it before.
+		 */
+		_vmResponsesRequiredForExclusiveVMAccess = 0x7fffffff;
+		_jniResponsesRequiredForExclusiveVMAccess = 0x7fffffff;
 	}
-	/* Set the exclusive access response counts to an unusual value,
-	 * just for debug purposes, so we can detect scenarios, when main
-	 * thread is waiting for Xaccess with noone requesting it before.
-	 */
-	_vmResponsesRequiredForExclusiveVMAccess = 0x7fffffff;
-	_jniResponsesRequiredForExclusiveVMAccess = 0x7fffffff;
 }
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1233,7 +1233,9 @@ redefineClassesCommon(jvmtiEnv* env,
 		/* Eliminate dark matter so that none will be encountered in prepareToFixMemberNames(). */
 		UDATA savedAllowUserHeapWalkFlag = vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
 		vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
+		vm->alreadyHaveExclusive = TRUE;
 		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_EXCLUSIVE_VMACCESS_ALREADY_ACQUIRED);
+		vm->alreadyHaveExclusive = FALSE;
 		if (0 == savedAllowUserHeapWalkFlag) {
 			/* Clear the flag to restore its original value. */
 			vm->requiredDebugAttributes &= ~J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5916,6 +5916,7 @@ typedef struct J9JavaVM {
 	UDATA addModulesCount;
 	UDATA safePointState;
 	UDATA safePointResponseCount;
+	UDATA alreadyHaveExclusive;
 	struct J9VMRuntimeStateListener vmRuntimeStateListener;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
 #if defined(J9UNIX) || defined(AIXPPC)

--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -755,8 +755,8 @@ acquireExclusiveVMAccessFromExternalThread(J9JavaVM * vm)
 	UDATA vmResponsesExpected = 0;
 	UDATA jniResponsesExpected = 0;
 
-	/* If safepoiont exclusive has already been acquired, nothing need be done here */
-	if (J9_XACCESS_EXCLUSIVE == vm->safePointState) {
+	/* If exclusive has already been acquired, nothing need be done here */
+	if (vm->alreadyHaveExclusive) {
 		return;
 	}
 
@@ -842,8 +842,8 @@ releaseExclusiveVMAccessFromExternalThread(J9JavaVM * vm)
 {
 	J9VMThread * currentThread;
 
-	/* If safepoiont exclusive has already been acquired, nothing need be done here */
-	if (J9_XACCESS_EXCLUSIVE == vm->safePointState) {
+	/* If exclusive has already been acquired, nothing need be done here */
+	if (vm->alreadyHaveExclusive) {
 		return;
 	}
 
@@ -924,8 +924,8 @@ requestExclusiveVMAccessMetronomeTemp(J9JavaVM *vm, UDATA block, UDATA *vmRespon
 	UDATA jniResponsesExpected = 0;
 	*gcPriority = J9THREAD_PRIORITY_MAX;
 
-	/* If safepoiont exclusive has already been acquired, nothing need be done here */
-	if (J9_XACCESS_EXCLUSIVE == vm->safePointState) {
+	/* If exclusive has already been acquired, nothing need be done here */
+	if (vm->alreadyHaveExclusive) {
 		return TRUE;
 	}
 
@@ -1028,22 +1028,24 @@ waitForExclusiveVMAccessMetronomeTemp(J9VMThread * vmThread, UDATA vmResponsesRe
 {
 	J9JavaVM *vm = vmThread->javaVM;
 
-	/* No need to wait if we already have safepoint exclusive */
-	if (J9_XACCESS_EXCLUSIVE != vm->safePointState) {
-		waitForResponseFromExternalThread(vmThread->javaVM, vmResponsesRequired, jniResponsesRequired);
-
-		VM_VMAccess::backOffFromSafePoint(vmThread);
-	
-		/* Do not wait on JAVA_SUSPEND, since we are not real JAVA thread.
-		 * This patch was needed for some debug scenarios with JVMTI, that would result in a deadlock otherwise.
-		 * TODO: re-examine with latest JDWP
-		 */
-		internalAcquireVMAccessNoMutexWithMask(vmThread, J9_PUBLIC_FLAGS_HALT_THREAD_ANY_NO_JAVA_SUSPEND);
-
-		Assert_VM_true(vmThread->omrVMThread->exclusiveCount==0);
-
-		++(vmThread->omrVMThread->exclusiveCount);
+	/* If exclusive has already been acquired, nothing need be done here */
+	if (vm->alreadyHaveExclusive) {
+		return;
 	}
+
+	waitForResponseFromExternalThread(vmThread->javaVM, vmResponsesRequired, jniResponsesRequired);
+
+	VM_VMAccess::backOffFromSafePoint(vmThread);
+
+	/* Do not wait on JAVA_SUSPEND, since we are not real JAVA thread.
+	 * This patch was needed for some debug scenarios with JVMTI, that would result in a deadlock otherwise.
+	 * TODO: re-examine with latest JDWP
+	 */
+	internalAcquireVMAccessNoMutexWithMask(vmThread, J9_PUBLIC_FLAGS_HALT_THREAD_ANY_NO_JAVA_SUSPEND);
+
+	Assert_VM_true(vmThread->omrVMThread->exclusiveCount==0);
+
+	++(vmThread->omrVMThread->exclusiveCount);
 }
 
 void


### PR DESCRIPTION
Allow the metronome GC to function correctly when the calling thread already has safepoint exclusive VM access.

Fixes: #18482