### PR TITLE
(0.43) Use the new centos6 image to build xlinux with gcc 11.2

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -167,11 +167,17 @@ boot_jdk_default:
 cuda:
   extra_configure_options: '--enable-cuda'
 #========================================#
-# Cuda with version
+# CUDA version 9
 #========================================#
-cuda_version:
+cuda_9:
   extends: ['cuda']
   extra_configure_options: '--with-cuda=/usr/local/cuda-9.0'
+#========================================#
+# CUDA default version
+#========================================#
+cuda_default:
+  extends: ['cuda']
+  extra_configure_options: '--with-cuda=/usr/local/cuda'
 #========================================#
 # Valhalla
 #========================================#
@@ -192,7 +198,7 @@ ojdk292:
 # Linux PPCLE 64bits
 #========================================#
 ppc64le_linux:
-  extends: ['boot_jdk_default', 'cuda_version', 'debuginfo', 'openjdk_reference_repo', 'openssl']
+  extends: ['boot_jdk_default', 'cuda_9', 'debuginfo', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     arch: 'ppc64le'
     os: 'linux'
@@ -265,7 +271,7 @@ ppc64_aix:
 # Linux x86 64bits
 #========================================#
 x86-64_linux:
-  extends: ['boot_jdk_default', 'cuda_version', 'debuginfo', 'openjdk_reference_repo', 'openssl']
+  extends: ['boot_jdk_default', 'cuda_default', 'debuginfo', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     arch: 'x64'
     os: 'linux'
@@ -279,15 +285,18 @@ x86-64_linux:
       8: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
       11: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
     docker_image:
-      8: 'eclipseopenj9/jenkins-agent-x86-centos6:28'
-      11: 'eclipseopenj9/jenkins-agent-x86-centos6:28'
+      8: 'eclipseopenj9/jenkins-agent-x86-centos6:29'
+      11: 'eclipseopenj9/jenkins-agent-x86-centos6:29'
   build_env:
     cmd:
       all: 'source /home/jenkins/set_gcc_11.2.0_env'
-      # use default gcc for 8, 11 (v7.5)
+      # use env vars to configure gcc for 8, 11 (v11.2)
       8: ''
       11: ''
-    vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
+    vars:
+      all: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
+      8: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
+      11: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
   extra_test_labels:
     11: '!sw.os.cent.6'
     17: '!sw.os.cent.6'


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/18477

Cherry pick https://github.com/eclipse-openj9/openj9/pull/18498 for 0.43