### PR TITLE
CHTable Opts Policy

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -562,16 +562,24 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
             if (isAOT && !isJIT && TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))
                  TR::Options::getCmdLineOptions()->setOption(TR_DisableInterpreterProfiling, true);
 
+            // If -Xnojit, then recompilation is not supported
+            if (!TR::Options::canJITCompile())
+               {
+               TR::Options::getJITCmdLineOptions()->setAllowRecompilation(false);
+               TR::Options::getAOTCmdLineOptions()->setAllowRecompilation(false);
+               }
 
-            if (!TR::Options::canJITCompile()) // -Xnojit, then recompilation is not supported
-                                              // Ensure JIT and AOT flags are set appropriately
-              {
-              TR::Options::getAOTCmdLineOptions()->setAllowRecompilation(false);
-              TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
-
-              TR::Options::getJITCmdLineOptions()->setAllowRecompilation(false);
-              TR::Options::getJITCmdLineOptions()->setOption(TR_DisableCHOpts);
-              }
+            // if AOT is not possible and recompilation is disabled,
+            // disable CH Table opts
+            if (!TR::Options::sharedClassCache())
+               {
+               if (!TR::Options::getJITCmdLineOptions()->allowRecompilation()
+                   || !TR::Options::getAOTCmdLineOptions()->allowRecompilation())
+                  {
+                  TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
+                  TR::Options::getJITCmdLineOptions()->setOption(TR_DisableCHOpts);
+                  }
+               }
 
             if (!isJIT)
                {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1972,12 +1972,6 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       return -1;
       }
 
-   if (!TR::Options::getCmdLineOptions()->allowRecompilation() || !TR::Options::getAOTCmdLineOptions()->allowRecompilation())
-      {
-      TR::Options::getCmdLineOptions()->setOption(TR_DisableCHOpts);
-      TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
-      }
-
    // Get local var names if available (ie. classfile was compiled with -g).
    // We just check getDebug() for lack of a reliable way to check whether there are any methods being logged.
    //


### PR DESCRIPTION
Only disable CHTable Opts under -Xnojit if AOT compilation is not possible; otherwise, SCC validation will fail. Furthermore, if recompilation is not allowed, only disable the CHTable Opts if AOT compilation is also not possible.

CHTable opts and Recompilation have been coupled together for a long time, and in https://github.com/eclipse-openj9/openj9/pull/11247 the coupling was made further implicit. This PR decouples it under AOT.

Closes https://github.com/eclipse-openj9/openj9/issues/17918