### PR TITLE
(0.43) Use correct GC flag in HCR dark matter cleanup

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1233,7 +1233,10 @@ redefineClassesCommon(jvmtiEnv* env,
 		/* Eliminate dark matter so that none will be encountered in prepareToFixMemberNames(). */
 		UDATA savedAllowUserHeapWalkFlag = vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
 		vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
-		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_EXCLUSIVE_VMACCESS_ALREADY_ACQUIRED);
+		/* J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT allows the GC to run while the current thread is holding
+		 * exclusive VM access.
+		 */
+		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT);
 		if (0 == savedAllowUserHeapWalkFlag) {
 			/* Clear the flag to restore its original value. */
 			vm->requiredDebugAttributes &= ~J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;


### PR DESCRIPTION
The current flag does nothing - use the flag that's used in other similar callers throughout the VM.

Fixes: #18482


Cherry pick https://github.com/eclipse-openj9/openj9/pull/18540 for 0.43