### PR TITLE
Add an additional param to SH_CompositeCacheImpl::reset()

### DIFF
--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -265,7 +265,7 @@ public:
 
 	bool isCacheCorruptReported(void);
 
-	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr);
+	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr, bool canUnlockCache = true);
 
 	void protectPartiallyFilledPages(J9VMThread *currentThread);
 
@@ -364,7 +364,7 @@ private:
 
 	UDATA initializeROMSegmentList(J9VMThread* currentThread);
 
-	IDATA checkForCrash(J9VMThread* currentThread, bool hasClassSegmentMutex);
+	IDATA checkForCrash(J9VMThread* currentThread, bool hasClassSegmentMutex, bool canUnlockCache = true);
 	
 	void reportCorruptCache(J9VMThread* currentThread, SH_CompositeCacheImpl* _ccToUse);
 

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -456,7 +456,7 @@ SH_CompositeCacheImpl::crashDetected(UDATA* localCrashCntr)
  * @param [in] currentThread  Pointer to J9VMThread structure for the current thread
  */
 void
-SH_CompositeCacheImpl::reset(J9VMThread* currentThread)
+SH_CompositeCacheImpl::reset(J9VMThread* currentThread, bool canUnlockCache)
 {
 	if (!_started) {
 		Trc_SHR_Assert_ShouldNeverHappen();
@@ -475,8 +475,10 @@ SH_CompositeCacheImpl::reset(J9VMThread* currentThread)
 	_maxAOTUnstoredBytes = 0;
 	_maxJITUnstoredBytes = 0;
 
-	/* If cache is locked, unlock it */
-	doUnlockCache(currentThread);
+	if (canUnlockCache) {
+		/* If cache is locked, unlock it */
+		doUnlockCache(currentThread);
+	}
 
 	Trc_SHR_CC_reset_Exit(currentThread);
 }

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -140,7 +140,7 @@ public:
 
 	bool crashDetected(UDATA* localCrashCntr);
 
-	void reset(J9VMThread* currentThread);
+	void reset(J9VMThread* currentThread, bool canUnlockCache = true);
 
 	BlockPtr nextEntry(J9VMThread* currentThread, UDATA* staleItems);
 	


### PR DESCRIPTION
Add an parameter to SH_CompositeCacheImpl::reset() to indicate whether the SCC can be unlocked by it or not. When updating romClass resources or doing stale marking, the SCC should always be locked. Do not unlock the SCC in these 2 cases.

Fixes #18526