### PR TITLE
JDK22+ adds JavaLangAccess.findMethod(isPublic, methodName, parameters)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -750,6 +750,12 @@ final class Access implements JavaLangAccess {
 	public void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
 		string.copyToSegmentRaw(segment, offset);
 	}
+
+	// No @Override to avoid breaking valhalla builds which is behind latest OpenJDK head stream update.
+	public Method findMethod(Class<?> clazz, boolean isPublic, String methodName, Class<?>... parameterTypes) {
+		return clazz.findMethod(isPublic, methodName, parameterTypes);
+	}
+
 /*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 /*[IF INLINE-TYPES]*/


### PR DESCRIPTION
`JDK22+` adds `JavaLangAccess.findMethod(isPublic, methodName, parameters)`

`getMethodHelper()` is updated to take the method type to be searched.

Required by latest OpenJDK updated
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/706
[JEP 463: Implicitly Declared Classes and Instance Main Methods (Second Preview)](https://openjdk.org/jeps/463)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>