### PR TITLE
Valhalla: test updates for lw5

### DIFF
--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -57,16 +57,16 @@
 		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
 			<src path="${src}"/>
-			<!-- uncomment when running with the latest Valhalla compiler (currently in lw5 branch but will eventually be merged) -->
-			<src path="${src_qtypes}"/>
-			<!-- <src path="${src_lw5}"/> -->
+			<!-- uncomment when running with the latest Valhalla compiler (currently in lw5 branch but will eventually be merged)-->
+			<!-- <src path="${src_qtypes}"/> -->
+			<src path="${src_lw5}"/>
 			<src path="${transformerListener}" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<compilerarg line='--enable-preview -source 22'/>
 			<!-- uncomment when running with lw5 -->
-			<!--<compilerarg line='-XDenableNullRestrictedTypes' />-->
+			<compilerarg line='-XDenableNullRestrictedTypes' />
 			<!-- Also remove this line when running lw5 -->
-			<compilerarg line='-source 22 -XDenablePrimitiveClasses' />
+			<!--<compilerarg line='-source 22 -XDenablePrimitiveClasses' />-->
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -53,10 +53,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeTestsJIT</testCaseName>
@@ -90,10 +86,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeArrayTests</testCaseName>
@@ -127,10 +119,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeArrayTestsJIT</testCaseName>
@@ -174,10 +162,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeUnsafeTests</testCaseName>
@@ -205,10 +189,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeOptTests</testCaseName>
@@ -246,10 +226,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>NullRestrictedTypeOptTests</testCaseName>
@@ -289,10 +265,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValhallaAttributeTests</testCaseName>
@@ -321,10 +293,6 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>ValueTypeSystemArraycopyTests</testCaseName>
@@ -371,9 +339,5 @@
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 </playlist>

--- a/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/ValueTypeTests.java
@@ -1653,6 +1653,10 @@ public class ValueTypeTests {
 	}
 
 	static void checkObject(Object ...objects) throws Throwable {
-		com.ibm.jvm.Dump.SystemDump();
+		// Access this method reflectively because I'm using OpenJDK to compile with thw lw5 javac
+		//com.ibm.jvm.Dump.SystemDump();
+		Class<?> c = Class.forName("com.ibm.jvm.Dump");
+		java.lang.reflect.Method m = c.getMethod("SystemDump");
+		m.invoke(null);
 	}
 }

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -56,8 +56,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!stackslots $mainThreadId$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
-		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<!-- this regex is a hack until reflection for ValueTypeTests.checkObject is no longer needed -->
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</output>
+		<!-- navigate to I-Slot: a0[0x] = <address> after call to ValueTypeTests.checkObject -->
+		<saveoutput regex="yes" javaUtilPattern="yes" type="required" saveName="objectAddr" splitIndex="93" splitBy="= " showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</saveoutput>
+		<!--<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>-->
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -103,8 +107,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!flatobject $flatSingleBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<!-- TODO change to J l = 0xFAFBFCFD11223344 for lw5-->
-		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344</output>
+		<output regex="no" type="success" showMatch="yes">J l = 0xFAFBFCFD11223344</output>
 		<output regex="no" type="success" showMatch="yes">I i = 0x12123434</output>
 		<output regex="no" type="success" showMatch="yes">i (offset = 0) (ValueInt)</output>
 		<output regex="no" type="success" showMatch="yes">// FlatSingleBackfill</output>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
@@ -59,8 +59,12 @@
 			<input>!stackslots $mainThreadId$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
-		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<!-- this regex is a hack until reflection for ValueTypeTests.checkObject is no longer needed -->
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</output>
+		<!-- navigate to I-Slot: a0[0x] = <address> after call to ValueTypeTests.checkObject -->
+		<saveoutput regex="yes" javaUtilPattern="yes" type="required" saveName="objectAddr" splitIndex="93" splitBy="= " showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</saveoutput>
+		<!--<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>-->
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -190,8 +194,13 @@
 			<input>!stackslots $mainThreadId$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
-		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+
+		<!-- this regex is a hack until reflection for ValueTypeTests.checkObject is no longer needed -->
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</output>
+		<!-- navigate to I-Slot: a0[0x] = <address> after call to ValueTypeTests.checkObject -->
+		<saveoutput regex="yes" javaUtilPattern="yes" type="required" saveName="objectAddr" splitIndex="93" splitBy="= " showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</saveoutput>
+		<!--<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>-->
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -41,7 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
-			-config $(Q)$(TEST_RESROOT)$(D)flattenedvaluetypeddrtests.xml$(Q) \
+			-config $(Q)$(TEST_RESROOT)$(D)flattenedvaluetypeddrtests_lw5.xml$(Q) \
 			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 			${TEST_STATUS}
 		</command>
@@ -56,10 +56,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_unflattenedvaluetypeddrtests</testCaseName>
@@ -95,10 +91,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_flattened32bitRefBackfillTest</testCaseName>
@@ -135,10 +127,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_flattened32bitRefBackfillTestJIT</testCaseName>
@@ -175,9 +163,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>Valhalla</version>
 		</versions>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -58,8 +58,12 @@
 			<input>!stackslots $mainThreadId$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
-		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<!-- this regex is a hack until reflection for ValueTypeTests.checkObject is no longer needed -->
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</output>
+		<!-- navigate to I-Slot: a0[0x] = <address> after call to ValueTypeTests.checkObject -->
+		<saveoutput regex="yes" javaUtilPattern="yes" type="required" saveName="objectAddr" splitIndex="93" splitBy="= " showMatch="yes">checkObject.*\n.*\n.*\n.*\n.*</saveoutput>
+		<!--<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>-->
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdline_options_tester/src/TestConfigParser.java
+++ b/test/functional/cmdline_options_tester/src/TestConfigParser.java
@@ -202,6 +202,9 @@ class TestConfigParser {
 				if (hasAllowedPlatform((String)attributes.get("platforms"))) {
 					String regex = (String)attributes.get("regex");
 					String javaUtilPattern = "no";
+					if (null != attributes.get("javaUtilPattern")) {
+						javaUtilPattern = (String)attributes.get("javaUtilPattern");
+					}
 					String showRegexMatch = "no";
 					if (null != attributes.get("showMatch")) {
 						showRegexMatch = (String)attributes.get("showMatch");


### PR DESCRIPTION
This draft is to track vm changes that are needed for OpenJ9 vm to support ValueTypes in the OpenJDK lw5 branch and will be needed once those changes have been merged to the main branch.
- Enable lw5 tests and disable qtype tests. Some of these changes won't be needed such as using reflection to call com.ibm.jvm.Dump.SystemDump in ValueTypeTests.checkObject and !stackslots hack in ddr tests.
- Allow ValueType creation with new/<init>/putfield

This is related to https://github.com/eclipse-openj9/openj9/issues/18157