### PR TITLE
Need writeBarrier between resetting the state and freeContinuation

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -306,6 +306,7 @@ yieldContinuation(J9VMThread *currentThread, BOOLEAN isFinished)
 	 */
 	Assert_VM_true(VM_ContinuationHelpers::isMountedWithCarrierThread(*continuationStatePtr, currentThread));
 	VM_ContinuationHelpers::resetCarrierID(continuationStatePtr);
+	VM_AtomicSupport::writeBarrier();
 	/* Logically postUnmountContinuation(), which add the related continuation Object to the rememberedSet or dirty the Card for concurrent marking for future scanning, should be called
 	 * before resetCarrierID(), but the scan might happened before resetCarrierID() if concurrent card clean happens, then the related compensating scan might be
 	 * missed due to the continuation still is stated as mounted(we don't scan any mounted continuation, it should be scanned during root scanning via J9VMThread->currentContinuation).


### PR DESCRIPTION
For weak memory ordering system such as PowerPC, we need to writeBarrier between resetting the state of continuation(set the state to unmounted) and freeing continuation/postUnmountContinuation during continuation unmounting to avoid potential assert/issue caused by inconsist state (in case the instructions are reordered).

related: https://github.com/eclipse-openj9/openj9/issues/16728

Signed-off-by: hulin <linhu@ca.ibm.com>