### PR TITLE
Adapt tests for removal of java.lang.Compiler

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -755,6 +755,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			 If the launcher doesn't exist we assume that the build doesn't support JITServer and trivially pass the test. -->
 		<command>if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
 	then \
+		$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 		$(JAVA_COMMAND) \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 		-DSERVER_EXE=$(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) \

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1356,7 +1356,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-XX:RecreateClassfileOnload</variation>
 			<variation>-XX:+CompactStrings</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_sm.xml$(Q) \


### PR DESCRIPTION
Update tests to use `$(ADD_JVM_LIB_DIR_TO_LIBPATH)` as appropriate.

All failures noted in https://github.com/eclipse-openj9/openj9/pull/18571#issuecomment-1844203234 and https://github.com/eclipse-openj9/openj9/pull/18571#issuecomment-1845415859 are for `JCL_Test_SE80` or `testJITServer` which are corrected by this and now pass; see grinders:
* https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3103
* https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3110