### PR TITLE
Remove java.lang.Compiler for Java 21+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Compiler.java
+++ b/jcl/src/java.base/share/classes/java/lang/Compiler.java
@@ -1,6 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
-package java.lang;
-
+/*[INCLUDE-IF JAVA_SPEC_VERSION < 21]*/
 /*******************************************************************************
  * Copyright IBM Corp. and others 1998
  *
@@ -22,7 +20,8 @@ package java.lang;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
- 
+package java.lang;
+
 /**
  * This class is a placeholder for environments which
  * explicitly manage the action of a "Just In Time"
@@ -82,8 +81,8 @@ private static native boolean compileClassImpl(Class classToCompile);
 
 /**
  * Compiles all classes whose name matches the argument
- * using the JIT compiler. Answers true if the compilation 
- * was successful, or false if it failed or there was no 
+ * using the JIT compiler. Answers true if the compilation
+ * was successful, or false if it failed or there was no
  * JIT compiler available.
  *
  * @return		boolean

--- a/runtime/tests/access/CMakeLists.txt
+++ b/runtime/tests/access/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright IBM Corp. and others 2017
+# Copyright IBM Corp. and others 2023
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,41 +20,15 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ################################################################################
 
-add_subdirectory(access)
-if(OMR_OS_AIX)
-	add_subdirectory(aixerrmsg)
-endif()
-add_subdirectory(algorithm)
-add_subdirectory(annotationtests)
-if(OMR_OS_WINDOWS AND NOT OMR_ENV_DATA64)
-	add_subdirectory(bcprof)
-endif()
-add_subdirectory(bcverify)
-add_subdirectory(clinkerffi)
-add_subdirectory(cutest)
-add_subdirectory(gp)
-add_subdirectory(j9vm)
-add_subdirectory(jni)
-add_subdirectory(jniarg)
-add_subdirectory(jsig)
-add_subdirectory(jvmtitests)
-add_subdirectory(lazyclassload)
-if(OMR_OS_OSX)
-	add_subdirectory(loadLibraryTest)
-endif()
-add_subdirectory(port)
-add_subdirectory(props)
-add_subdirectory(redirector)
-add_subdirectory(shared)
-if(OMR_OS_WINDOWS AND NOT OMR_ENV_DATA64)
-	add_subdirectory(shared_service)
-endif()
-add_subdirectory(thread)
-if(OMR_OS_LINUX)
-	add_subdirectory(unresolved)
-endif()
-add_subdirectory(vm)
-add_subdirectory(vm_lifecycle)
-if(OMR_OS_ZOS)
-	add_subdirectory(zos)
-endif()
+j9vm_add_library(access SHARED
+	compiler.cpp
+)
+
+target_link_libraries(access
+	PRIVATE
+		j9vm_interface
+)
+
+omr_add_exports(access
+	Java_org_openj9_test_util_CompilerAccess_registerNatives
+)

--- a/runtime/tests/access/compiler.cpp
+++ b/runtime/tests/access/compiler.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+/**
+ * @file compiler.cpp
+ * @brief File is compiled into shared library (access)
+ * in support of org.openj9.test.util.CompilerAccess.
+ */
+
+#include "j9.h"
+#include "j9lib.h"
+#include "jni.h"
+
+struct NativeMapping
+{
+	const char *methodName;
+	const char *methodSignature;
+	const char *implementationName;
+	const char *implementationSignature;
+};
+
+static const NativeMapping mappings[] =
+{
+	{
+		"commandImpl",
+		"(Ljava/lang/Object;)Ljava/lang/Object;",
+		"Java_java_lang_Compiler_commandImpl",
+		"LLLL"
+	},
+	{
+		"compileClassImpl",
+		"(Ljava/lang/Class;)Z",
+		"Java_java_lang_Compiler_compileClassImpl",
+		"ZLLL"
+	},
+	{
+		"compileClassesImpl",
+		"(Ljava/lang/String;)Z",
+		"Java_java_lang_Compiler_compileClassesImpl",
+		"ZLLL"
+	},
+	{
+		"disable",
+		"()V",
+		"Java_java_lang_Compiler_disable",
+		"VLL"
+	},
+	{
+		"enable",
+		"()V",
+		"Java_java_lang_Compiler_enable",
+		"VLL"
+	},
+};
+
+#define METHOD_COUNT (sizeof(mappings) / sizeof(mappings[0]))
+
+extern "C" jboolean
+Java_org_openj9_test_util_CompilerAccess_registerNatives(JNIEnv *env, jclass clazz)
+{
+	jboolean result = JNI_FALSE;
+	PORT_ACCESS_FROM_ENV(env);
+	uintptr_t j9jcl = 0;
+	JNINativeMethod methods[METHOD_COUNT];
+
+	if ((0 != j9sl_open_shared_library((char *)J9_JAVA_SE_DLL_NAME, &j9jcl, OMRPORT_SLOPEN_DECORATE))
+		|| (0 == j9jcl)
+	) {
+		j9tty_printf(PORTLIB,"CompilerAccess: could not open %s.\n", J9_JAVA_SE_DLL_NAME);
+		goto done;
+	}
+
+	for (uintptr_t i = 0; i < METHOD_COUNT; ++i) {
+		const NativeMapping *mapping = &mappings[i];
+		JNINativeMethod *method = &methods[i];
+		uintptr_t function = 0;
+
+		if ((0 != j9sl_lookup_name(
+				j9jcl,
+				(char *)mapping->implementationName,
+				&function,
+				(char *)mapping->implementationSignature))
+			|| (0 == function)
+		) {
+			j9tty_printf(PORTLIB,"CompilerAccess: '%s' not found.\n", mapping->implementationName);
+			goto done;
+		}
+
+		method->name      = (char *)mapping->methodName;
+		method->signature = (char *)mapping->methodSignature;
+		method->fnPtr     = (void *)function;
+	}
+
+	if (JNI_OK != env->RegisterNatives(clazz, methods, METHOD_COUNT)) {
+		j9tty_printf(PORTLIB,"CompilerAccess: RegisterNatives failed.\n");
+		goto done;
+	}
+
+	result = JNI_TRUE;
+
+done:
+	if (0 != j9jcl) {
+		j9sl_close_shared_library(j9jcl);
+	}
+
+	return result;
+}

--- a/runtime/tests/access/module.xml
+++ b/runtime/tests/access/module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright IBM Corp. and others 2023
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+	<exports group="all">
+		<export name="Java_org_openj9_test_util_CompilerAccess_registerNatives"/>
+	</exports>
+	<artifact type="shared" name="access" appendrelease="false">
+		<phase>core quick j2se</phase>
+		<exports>
+			<group name="all"/>
+		</exports>
+		<includes>
+			<include path="j9include"/>
+			<include path="j9oti"/>
+		</includes>
+	</artifact>
+</module>

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -24,7 +24,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<include>ddrSettings.mk</include>
 	<test>
 		<testCaseName>testDDRExt_General</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .;  ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -41,7 +43,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExt_Class</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestClassExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -58,7 +62,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExt_Callsites</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -75,7 +81,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExt_JITExt</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -92,7 +100,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExt_SharedClasses</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestSharedClassesExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -109,7 +119,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExtJunit_CollisionResilientHashtable</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestCollisionResilientHashtable$(Q) -DEXTRADUMPOPT=$(Q)-XX:stringTableListToTreeThreshold=64$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -126,7 +138,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExtJunit_StackMap</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DCOREGEN=$(Q)j9vm.test.corehelper.StackMapCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DCOREGEN=$(Q)j9vm.test.corehelper.StackMapCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestStackMap$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
@@ -147,7 +161,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=1 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase1$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -172,7 +188,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=2 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase2$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -197,7 +215,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=3 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase3$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -222,7 +242,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=4 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase4$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -247,7 +269,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=5 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase5$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -272,7 +296,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; $(ADD_JVM_LIB_DIR_TO_LIBPATH) ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DTESTNUM=6 -DCOREGEN=$(Q)j9vm.test.corehelper.DeadlockCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestDeadlockCase6$(Q) -DEXTRADUMPOPT=$(Q)-Xdump:system:events=throw,filter=*HelperExceptionForCoreGeneration*,request=exclusive$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
@@ -293,7 +319,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testDDRExtJunit_FindExtThread</testCaseName>
-		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DCOREGEN=$(Q)j9vm.test.corehelper.FindExtCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
+	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) -DCOREGEN=$(Q)j9vm.test.corehelper.FindExtCoreGenerator$(Q) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
 	-Dtest.list=$(Q)TestFindExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(REPORTDIR)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/CoreGen.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/CoreGen.java
@@ -21,17 +21,18 @@
  *******************************************************************************/
 package j9vm.test.corehelper;
 
+import org.openj9.test.util.CompilerAccess;
 
- public class CoreGen {
+public class CoreGen {
 
- 	public static void main(String[] args) {
+	public static void main(String[] args) {
 		SimpleThread st = new SimpleThread();
 
 		/* Fork a thread for TestJITExt that is guaranteed to have a JIT frame
-		 * at the top of the stack. Fix until  https://github.com/eclipse-openj9/openj9/issues/5966 
+		 * at the top of the stack. Fix until https://github.com/eclipse-openj9/openj9/issues/5966
 		 * is resolved.
 		 */
-		Compiler.compileClass(j9vm.test.corehelper.TestJITExtHelperThread.class);
+		CompilerAccess.compileClass(TestJITExtHelperThread.class);
 		TestJITExtHelperThread tjet = new TestJITExtHelperThread();
 
 		tjet.configureJittedHelperThread();

--- a/test/functional/JIT_Test/build.xml
+++ b/test/functional/JIT_Test/build.xml
@@ -1,38 +1,37 @@
 <?xml version="1.0"?>
-
 <!--
-  Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2016
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-
 <project name="JIT_Test" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
-    	JIT_Test
-    </description>
+		JIT_Test
+	</description>
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/JIT_Test" />
 
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 	<property name="build" location="./bin" />
 	<property name="jarfile" value="${DEST}/jitt.jar" />
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
@@ -54,6 +53,7 @@
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${transformerListener}" />
+			<src path="${TestUtilities}" />
 			<exclude name="jit/test/jitt/codecache/**" />
 			<exclude name="jit/test/tr/MonitorElimination/**" />
 			<exclude name="jit/test/tr/loopReplicator/**" />

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -755,6 +755,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			 If the launcher doesn't exist we assume that the build doesn't support JITServer and trivially pass the test. -->
 		<command>if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
 	then \
+		$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 		$(JAVA_COMMAND) \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 		-DSERVER_EXE=$(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) \

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-	Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2016
 
-	This program and the accompanying materials are made available under
-	the terms of the Eclipse Public License 2.0 which accompanies this
-	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-	or the Apache License, Version 2.0 which accompanies this distribution and
-	is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-	This Source Code may also be made available under the following
-	Secondary Licenses when the conditions for such availability set
-	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-	General Public License, version 2 with the GNU Classpath
-	Exception [1] and GNU General Public License, version 2 with the
-	OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-	[1] https://www.gnu.org/software/classpath/license.html
-	[2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<!-- jit.test.jitt tests start here -->
@@ -125,7 +125,7 @@
 			<variation>-Xjit:count=0,disableZ14</variation>
 			<variation>-Xjit:count=0,disableZ15</variation>
 		</variations>
-		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \
@@ -152,7 +152,7 @@
 			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=3 -Xmx512m</variation>
 			<variation>-Xjit:disableAsyncCompilation,count=1 -XXgc:forcedShiftingCompressionAmount=4 -Xmx512m</variation>
 		</variations>
-		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \
@@ -351,7 +351,8 @@
 		<variations>
 			<variation>-Xjit:optlevel=warm,count=0 -DjarTesterArgs=$(Q)$(TEST_RESROOT)$(D)jitt.jar$(Q)</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \
@@ -445,13 +446,13 @@
 			<variation>-Xjit:count=50,limit={*testSIMDCommonedAddress*},optLevel=scorching,disableAsyncCompilation</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-        -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
-        org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-        -testnames \
-        SIMDCommonedAddressTest \
-        -groups $(TEST_GROUP) \
-        -excludegroups $(DEFAULT_EXCLUDE); \
-        $(TEST_STATUS)</command>
+		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+		-testnames \
+		SIMDCommonedAddressTest \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -667,7 +668,8 @@
 		<variations>
 			<variation>-Xdump</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \

--- a/test/functional/JIT_Test/src/jit/test/jar/JarTestClassLoader.java
+++ b/test/functional/JIT_Test/src/jit/test/jar/JarTestClassLoader.java
@@ -21,22 +21,22 @@
  *******************************************************************************/
 package jit.test.jar;
 
-import java.util.zip.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.openj9.test.util.CompilerAccess;
 import org.testng.Assert;
 
 class JarTestClassLoader extends ZipTestClassLoader {
 
-	protected Class defineClass(
-		ZipFile file,
-		ZipEntry entry,
-		String className) {
-		Class clazz = super.defineClass(file, entry, className);
-		if (clazz != null){
-			if (Compiler.compileClass(clazz) == false){
+	protected Class<?> defineClass(ZipFile file, ZipEntry entry, String className) {
+		Class<?> clazz = super.defineClass(file, entry, className);
+		if (clazz != null) {
+			if (CompilerAccess.compileClass(clazz) == false) {
 				Assert.fail("Compilation of " + className + " failed -- aborting");
-                System.exit(1);
-            }
-        }
+				System.exit(1);
+			}
+		}
 		return clazz;
 	}
+
 }

--- a/test/functional/JIT_Test/src/jit/test/jar/ZipTestClassLoaderMT.java
+++ b/test/functional/JIT_Test/src/jit/test/jar/ZipTestClassLoaderMT.java
@@ -28,247 +28,246 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import org.openj9.test.util.CompilerAccess;
 import org.testng.log4testng.Logger;
 
 /**
  * @author mesbaha
- * ZipTestClassLoaderMT extends {@link jit.test.jar.ZipTestClassLoader} and overrides the processZipFiles(java.lang.String) method 
+ * ZipTestClassLoaderMT extends {@link jit.test.jar.ZipTestClassLoader} and overrides the processZipFiles(java.lang.String) method
  * in order to accommodate multi-threaded class loading.
  */
 public class ZipTestClassLoaderMT extends ZipTestClassLoader {
+
 	private static Logger logger = Logger.getLogger(ZipTestClassLoaderMT.class);
 
-	/*By default, we use 5 threads to load classes*/
+	/* By default, we use 5 threads to load classes. */
 	private static final int JARS_PER_THREAD = 5;
-	
+
 	private boolean pauseRequested = false;
-	
+
 	private boolean stopCompilation = false;
-	
-	private boolean parallelLoad = false; 
-	
+
+	private boolean parallelLoad = false;
+
 	private ArrayList<CompilationThread> compilationThreadList = null;
 
-	
 	/**
 	 * Default Constructor for ZipTestClassLoaderMT
 	 * @param lifespan life space of a surrogate class loader, a smaller value means more class loaders used
 	 * @param forceGC flag to indicate whether GC should be forced
 	 * @param parallelLoad flag to indicate whether multiple threads should be used for class loading
 	 */
-	public ZipTestClassLoaderMT ( int lifespan, boolean forceGC , boolean parallelLoad ) {
-		super( lifespan, forceGC);
+	public ZipTestClassLoaderMT(int lifespan, boolean forceGC, boolean parallelLoad) {
+		super(lifespan, forceGC);
 		this.parallelLoad = parallelLoad;
-		this.compilationThreadList = new ArrayList<CompilationThread> () ;
+		this.compilationThreadList = new ArrayList<CompilationThread>();
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see jit.test.jar.ZipTestClassLoader#processZipFiles(java.lang.String)
-	 * This method is used for loading classes in a multi-threaded manner instead of sequential loading which is what 
-	 * the super class version of processZipFiles() does. This method uses one dedicated class loader thread for each 
+	 * This method is used for loading classes in a multi-threaded manner instead of sequential loading which is what
+	 * the super class version of processZipFiles() does. This method uses one dedicated class loader thread for each
 	 * subset of JARS_PER_THREAD number of jars to be loaded*/
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void processZipFiles( String classFilter ) {
+	public void processZipFiles(String classFilter) {
 		/*Iterate zip files in order*/
-		Iterator classIter = orderedZipRecords.iterator();
-		
-		errMsgs = new HashMap();
-		
-		int jarCounter = 0 ; 
-		CompilationThread clThread = null ; 
-		ArrayList<ZipRecord> jarList = new ArrayList<ZipRecord>();
-		
+		Iterator<?> classIter = orderedZipRecords.iterator();
+
+		errMsgs = new HashMap<>();
+
+		int jarCounter = 0;
+		CompilationThread clThread = null;
+		ArrayList<ZipRecord> jarList = new ArrayList<>();
+
 		/*If parallel load is chosen, we dedicate one class loader thread per JARS_PER_THREAD number of jars*/
-		if ( parallelLoad ) {
+		if (parallelLoad) {
 			/*Iterate through the given jar files*/
-			while( classIter.hasNext() ) {
-				jarCounter ++ ; 
-				
+			while (classIter.hasNext()) {
+				jarCounter++;
+
 				/*Once we have counted 'n' number of jars, we want to dedicate the loading task of this subset to a new thread*/
-				if ( jarCounter % JARS_PER_THREAD == 0 ) {
-					clThread = new CompilationThread( this, jarList, classFilter );
+				if (jarCounter % JARS_PER_THREAD == 0) {
+					clThread = new CompilationThread(this, jarList, classFilter);
 					compilationThreadList.add(clThread);
-					if ( jarCounter < orderedZipRecords.size() ) {
-						jarList = new ArrayList<ZipRecord>();
+					if (jarCounter < orderedZipRecords.size()) {
+						jarList = new ArrayList<>();
 					}
 				}
-				
-				ZipRecord record =  (ZipRecord) classIter.next(); // a jar file 
-				jarList.add(record); // construct a list of jars 
+
+				ZipRecord record = (ZipRecord) classIter.next(); // a jar file
+				jarList.add(record); // construct a list of jars
 			}
-		
+
 			/*Create a new class loader thread if we have left-over jars*/
-			if ( jarList.size() != 0 ) {
-				clThread = new CompilationThread ( this, jarList, classFilter );
-				compilationThreadList.add( clThread );
+			if (jarList.size() != 0) {
+				clThread = new CompilationThread(this, jarList, classFilter);
+				compilationThreadList.add(clThread);
 			}
 		}
-		
-		/*If parallel load is NOT requested, we only use one class loader thread*/
+
+		/* If parallel load is NOT requested, we only use one class loader thread. */
 		else {
-			while( classIter.hasNext() ) {
-				ZipRecord record =  (ZipRecord) classIter.next(); // a jar file 
-				jarList.add(record); // construct a list of jars 
+			while (classIter.hasNext()) {
+				ZipRecord record = (ZipRecord) classIter.next(); // a jar file
+				jarList.add(record); // construct a list of jars
 			}
-			clThread = new CompilationThread( this, jarList, classFilter);
+			clThread = new CompilationThread(this, jarList, classFilter);
 			compilationThreadList.add(clThread);
 		}
-		
-		logger.debug("Total JarTesterMT compilation thread to be used = " + compilationThreadList.size() );
-		
-		/*Once we have divided up the class loading work to threads, start them off*/
-		for ( int i = 0 ; i < compilationThreadList.size() ; i ++ ) {
+
+		logger.debug("Total JarTesterMT compilation thread to be used = " + compilationThreadList.size());
+
+		/* Once we have divided up the class loading work to threads, start them off. */
+		for (int i = 0; i < compilationThreadList.size(); i++) {
 			compilationThreadList.get(i).start();
 		}
-	
-		/*Wait for all threads to finish, process pause, resume and stop requests if they are issued*/
-		
+
+		/* Wait for all threads to finish, process pause, resume and stop requests if they are issued. */
+
 		boolean stillLoading = true;
-		
-		while ( stillLoading ) {
-			
-			/*If class loading pause has been requested, pause all running class loader thread and sleep*/
-			if ( pauseRequested ) {
+
+		while (stillLoading) {
+
+			/* If class loading pause has been requested, pause all running class loader thread and sleep. */
+			if (pauseRequested) {
 				logger.debug("INFO: ZipTestClassLoaderMT: Compilation PAUSE request received, suspending compilation...");
-				for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
+				for (int i = 0; i < compilationThreadList.size(); i++) {
 					compilationThreadList.get(i).requestPause();
 				}
-				
-				while( pauseRequested ) {
+
+				while (pauseRequested) {
 					try {
-						Thread.sleep( 1000 );
+						Thread.sleep(1000);
 					} catch (InterruptedException e) {
 						e.printStackTrace();
 					}
 				}
-				
-				/*When resumption is requested after pause, wake up the class loader threads and resume business*/
+
+				/* When resumption is requested after pause, wake up the class loader threads and resume business. */
 				logger.debug("INFO: ZipTestClassLoaderMT: Compilation RESUMPTION request received, starting compilation...");
-				
-				for (int i = 0 ; i < compilationThreadList.size() ; i++) {
+
+				for (int i = 0; i < compilationThreadList.size(); i++) {
 					compilationThreadList.get(i).requestResumption();
 					compilationThreadList.get(i).interrupt();
 				}
 			}
-			
-			/*If user requested to abort class loading, issue stop request to each class loader thread, make sure 
-			 * each class loader thread exited and quit*/
-			if ( stopCompilation ) {
-				
+
+			/* If user requested to abort class loading, issue stop request to
+			 * each class loader thread, make sure each class loader thread
+			 * exited and quit.
+			 */
+			if (stopCompilation) {
+
 				logger.debug("INFO: ZipTestClassLoaderMT: Compilation STOP request received, attempting to stop compilation threads...");
-				
-				for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
+
+				for (int i = 0; i < compilationThreadList.size(); i++) {
 					compilationThreadList.get(i).requestStop();
 				}
-				
-				while ( isStillCompiling() ) {
+
+				while (isStillCompiling()) {
 					try {
 						Thread.sleep(200);
-					}
-					catch(InterruptedException e){
+					} catch (InterruptedException e) {
 						e.printStackTrace();
 					}
 				}
-				
+
 				logger.debug("INFO: ZipTestClassLoaderMT: Compilation threads have all exited");
 			}
-			
-			/*During regular operation of class loading, the 'main' ZipTestClassLoaderMT thread should mostly sleep*/
-			/*Check if there is at least one class loader thread alive, if yes, we are still not done*/
+
+			/* During regular operation of class loading, the 'main' ZipTestClassLoaderMT thread should mostly sleep. */
+			/* Check if there is at least one class loader thread alive, if yes, we are still not done. */
 			stillLoading = isStillCompiling();
-			
-			if( stillLoading ) {
+
+			if (stillLoading) {
 				try {
-					Thread.sleep( 3000 );
-				} catch ( InterruptedException e ) {
+					Thread.sleep(3000);
+				} catch (InterruptedException e) {
 					e.printStackTrace();
 				}
 			}
 		}
-			
+
 		/*Accumulate the results*/
-		int error = 0 ; 
-		int classCount = 0 ; 
-		
-		for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
+		int error = 0;
+		int classCount = 0;
+
+		for (int i = 0; i < compilationThreadList.size(); i++) {
 			error += compilationThreadList.get(i).getTotalErrorCount();
 			classCount += compilationThreadList.get(i).getTotalClassCount();
 		}
 
-		logger.debug( "Total class compiled = " + classCount );
-		logger.debug( "Total error = " + error );
+		logger.debug("Total class compiled = " + classCount);
+		logger.debug("Total error = " + error);
 	}
-	
-	/*The thread class to be used for compilation*/
+
+	/* The thread class to be used for compilation. */
 	private static class CompilationThread extends Thread {
-		private ZipTestClassLoaderMT loader ; 
+		private ZipTestClassLoaderMT loader ;
 		private boolean wait;
 		private boolean stopCompilation;
 		private ArrayList<ZipRecord> jarsToLoad;
 		private int cCount;
 		private int eCount;
 		private String classFilter;
-		
-		public CompilationThread ( ZipTestClassLoaderMT loader, ArrayList<ZipRecord> jarsToLoad, String f ) {
+
+		public CompilationThread(ZipTestClassLoaderMT loader, ArrayList<ZipRecord> jarsToLoad, String f) {
 			this.loader = loader;
 			this.jarsToLoad = jarsToLoad;
 			this.classFilter = f;
-			cCount = 0; 
+			cCount = 0;
 			eCount = 0;
 		}
-		
-		@SuppressWarnings("rawtypes")
-		public void run () {
+
+		public void run() {
 			boolean stopped = false;
 			this.setName("JarTesterMT compilation " + this.getName());
-			for ( int m = 0 ; m < jarsToLoad.size() ; m ++ ) {
-				
-				if ( stopped ) {
+			for (int m = 0; m < jarsToLoad.size(); m++) {
+
+				if (stopped) {
 					break;
 				}
-				
-				int jarLevelClassCount = 0 ; 
-				int jarLevelErrorCount = 0 ; 
-			    ZipRecord aJar = jarsToLoad.get(m);
-				Iterator entryIter = aJar.entries.entrySet().iterator(); 
-			    
-			    while( entryIter.hasNext() ) {
-			    	String className = null;
-					ZipEntry zipEntry = null;
-					Map.Entry classPair = null;
-					
-			    	classPair = (Map.Entry)entryIter.next();
-			   
-			    	/*Check if compilation should be paused*/
-		            if ( wait ) {
-	                   synchronized(this) {
-	                	   try {
-								wait();
-							} catch (InterruptedException e) {}
-	                   	}
-	                }
-		            
-		            /*Check if compilation should be stopped*/
-		            if ( stopCompilation ) {
-                    	stopped = true;
-                    	break;
-	                }
 
-		            zipEntry = (ZipEntry) classPair.getValue();
+				int jarLevelClassCount = 0;
+				int jarLevelErrorCount = 0;
+				ZipRecord aJar = jarsToLoad.get(m);
+				Iterator<Map.Entry<?, ?>> entryIter = aJar.entries.entrySet().iterator();
+
+				while (entryIter.hasNext()) {
+					String className = null;
+					ZipEntry zipEntry = null;
+					Map.Entry<?, ?> classPair = entryIter.next();
+
+					/* Check if compilation should be paused. */
+					if (wait) {
+						synchronized (this) {
+							try {
+								wait();
+							} catch (InterruptedException e) {
+							}
+						}
+					}
+
+					/* Check if compilation should be stopped. */
+					if (stopCompilation) {
+						stopped = true;
+						break;
+					}
+
+					zipEntry = (ZipEntry) classPair.getValue();
 					className = (String) classPair.getKey();
-					
-					/*Compile the class only if it's name contains classFilter*/ 
-					if ( className.indexOf(classFilter) < 0 ) {
+
+					/*Compile the class only if it's name contains classFilter*/
+					if (className.indexOf(classFilter) < 0) {
 						continue;
 					}
-					
-					Class clazz = loader.defineClass( aJar.file, zipEntry, className );
-		
-					if ( clazz != null ) {
+
+					Class<?> clazz = loader.defineClass(aJar.file, zipEntry, className);
+
+					if (clazz != null) {
 						jarLevelClassCount++;
 						cCount++;
-						synchronized ( this ) {
+						synchronized (this) {
 							loader.surrogate.age++;
 						}
 					} else {
@@ -276,8 +275,8 @@ public class ZipTestClassLoaderMT extends ZipTestClassLoader {
 						eCount++;
 					}
 				}
-			    
-			    StringBuffer buff = new StringBuffer();
+
+				StringBuffer buff = new StringBuffer();
 				buff.append(jarLevelClassCount);
 				buff.append("/");
 				buff.append(aJar.classCount);
@@ -293,19 +292,23 @@ public class ZipTestClassLoaderMT extends ZipTestClassLoader {
 				eCount += jarLevelErrorCount;
 			}
 		}
-		
-		public int getTotalErrorCount () {
+
+		public int getTotalErrorCount() {
 			return eCount;
 		}
-		public int getTotalClassCount () {
+
+		public int getTotalClassCount() {
 			return cCount;
 		}
+
 		public void requestPause() {
 			wait = true;
 		}
+
 		public void requestResumption() {
 			wait = false;
 		}
+
 		public void requestStop() {
 			stopCompilation = true;
 		}
@@ -314,40 +317,38 @@ public class ZipTestClassLoaderMT extends ZipTestClassLoader {
 	/* (non-Javadoc)
 	 * @see jit.test.jar.ZipTestClassLoader#defineClass(java.util.zip.ZipFile, java.util.zip.ZipEntry, java.lang.String)
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	protected Class defineClass( ZipFile file, ZipEntry entry, String className ) {
-		Class clazz = super.defineClass( file, entry, className );
-		if ( clazz != null ) {
-			if ( Compiler.compileClass( clazz ) == false ) {
-				logger.error( "Compilation of " + className + " failed" );
+	protected Class<?> defineClass(ZipFile file, ZipEntry entry, String className) {
+		Class<?> clazz = super.defineClass(file, entry, className);
+		if (clazz != null) {
+			if (CompilerAccess.compileClass(clazz) == false) {
+				logger.error("Compilation of " + className + " failed");
 				return null;
 			}
 		}
 		return clazz;
 	}
-	
+
 	/**
 	 * @return true if any class loader thread is still alive
 	 */
 	public boolean isStillCompiling() {
-		for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
-			if ( compilationThreadList.get(i).isAlive()) {
+		for (int i = 0; i < compilationThreadList.size(); i++) {
+			if (compilationThreadList.get(i).isAlive()) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	/**
-	 * This method is used externally to issue a request to pause all the class loader threads 
-	 * The method returns only when all compilation child threads have been suspended
+	 * This method is used externally to issue a request to pause all the class loader threads.
+	 * The method returns only when all compilation child threads have been suspended.
 	 */
 	public void pauseCompilation() {
-		
-		//first make sure the threads are running
-		for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
-			while( compilationThreadList.get(i).getState().compareTo(State.WAITING) == 0 ) {
+		// first make sure the threads are running
+		for (int i = 0; i < compilationThreadList.size(); i++) {
+			while (compilationThreadList.get(i).getState().compareTo(State.WAITING) == 0) {
 				try {
 					Thread.sleep(50);
 				} catch (InterruptedException e) {
@@ -355,34 +356,32 @@ public class ZipTestClassLoaderMT extends ZipTestClassLoader {
 				}
 			}
 		}
-		
-		//request pause
+
+		// request pause
 		pauseRequested = true;
-		
-		//make sure the threads have been paused
-		for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
-			while( compilationThreadList.get(i).getState().compareTo(State.RUNNABLE) == 0) {
+
+		// make sure the threads have been paused
+		for (int i = 0; i < compilationThreadList.size(); i++) {
+			while (compilationThreadList.get(i).getState().compareTo(State.RUNNABLE) == 0) {
 				try {
 					Thread.sleep(50);
-					//logger.debug("Waiting for thread to pause : " + compilationThreadList.get(i).getName() );
+					// logger.debug("Waiting for thread to pause : " + compilationThreadList.get(i).getName());
 				} catch (InterruptedException e) {
 					e.printStackTrace();
 				}
 			}
 		}
-		
 	}
-	
+
 	/**
-	 * This method is used externally to issue a request to resume all paused class loader threads 
-	 * The method returns only when all compilation child threads have been woken up
+	 * This method is used externally to issue a request to resume all paused class loader threads.
+	 * The method returns only when all compilation child threads have been woken up.
 	 */
 	public void resumeCompilation() {
-		
 		pauseRequested = false;
-		
-		for ( int i = 0 ; i < compilationThreadList.size() ; i++ ) {
-			while( compilationThreadList.get(i).getState().compareTo(State.WAITING) == 0 ) {
+
+		for (int i = 0; i < compilationThreadList.size(); i++) {
+			while (compilationThreadList.get(i).getState().compareTo(State.WAITING) == 0) {
 				try {
 					Thread.sleep(50);
 				} catch (InterruptedException e) {
@@ -391,20 +390,18 @@ public class ZipTestClassLoaderMT extends ZipTestClassLoader {
 			}
 		}
 	}
-	
+
 	/**
 	 * This method is used externally to issue a request to stop all class loader threads
-	 * The method returns 
+	 * The method returns
 	 */
 	public void stopCompilation() {
-		
 		stopCompilation = true;
-		
-		while ( isStillCompiling() ) {
+
+		while (isStillCompiling()) {
 			try {
 				Thread.sleep(200);
-			}
-			catch(InterruptedException e){
+			} catch (InterruptedException e) {
 				e.printStackTrace();
 			}
 		}

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -926,7 +926,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-XX:+RestrictContended</variation>
 			<variation>-XX:-EnableContended</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(JVM_TEST_ROOT)$(D)InstrumentationAgent$(D)instrumentation.jar$(Q) \
 		-javaagent:$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)InstrumentationAgent$(D)instrumentation.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
@@ -959,7 +960,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-XX:+RestrictContended</variation>
 			<variation>-XX:-EnableContended</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(JVM_TEST_ROOT)$(D)InstrumentationAgent$(D)instrumentation.jar$(Q) \
 		-javaagent:$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)InstrumentationAgent$(D)instrumentation.jar$(Q) \
@@ -1011,7 +1013,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-XX:RecreateClassfileOnload</variation>
 			<variation>-XX:+CompactStrings</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1115,7 +1118,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1161,7 +1165,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-Xshareclasses:none</variation>
 			<variation>-Xshareclasses:none -XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1264,7 +1269,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-Xshareclasses:none</variation>
 			<variation>-XX:RecreateClassfileOnload -Xshareclasses:none</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1400,7 +1406,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
@@ -1782,7 +1789,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode351 -Xjit:noJitUntilMain,count=0,optlevel=warm</variation>
 			<variation>Mode610 -Xjit:noJitUntilMain,count=0,optlevel=warm</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \
@@ -1897,7 +1905,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode600</variation>
 			<variation>Mode619</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames TestArrayCopy \
@@ -1924,7 +1933,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode600</variation>
 			<variation>Mode619</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames TestArrayCopy \
@@ -1950,7 +1960,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode600</variation>
 			<variation>Mode619</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames TestArrayCopy \
@@ -2070,7 +2081,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode351</variation>
 			<variation>Mode551</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames jniOnLoadExceptions \
@@ -2099,7 +2111,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode610</variation>
 			<variation>Mode551</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames badUTF8inJNI \
@@ -2123,7 +2136,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>pthreadDestructor</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames pthreadDestructor \
@@ -2365,7 +2379,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>reattachAfterExit</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames reattachAfterExit \
@@ -2569,7 +2584,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames testStringInterning \
@@ -2704,7 +2720,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>loadLegacyLibrary</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 			-testnames loadLegacyLibrary \
@@ -2729,7 +2746,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>classRelationshipVerifierTests</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-XX:+ClassRelationshipVerifier \
 			-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
@@ -2754,7 +2772,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>LoadClassWithUTF8PkgNameTest</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 			-testnames LoadClassWithUTF8PkgNameTest \
@@ -2796,7 +2815,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>RuntimeAnnotationTests</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			$(ADD_EXPORTS_JDK_INTERNAL_REFLECT) $(ADD_EXPORTS_JDK_INTERNAL_MISC) $(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
@@ -2821,7 +2841,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>ConstantPoolTests</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			$(ADD_EXPORTS_JDK_INTERNAL_REFLECT) $(ADD_EXPORTS_JDK_INTERNAL_MISC) $(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1356,7 +1356,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>-XX:RecreateClassfileOnload</variation>
 			<variation>-XX:+CompactStrings</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_sm.xml$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Compiler.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Compiler.java
@@ -21,22 +21,35 @@
  *******************************************************************************/
 package org.openj9.test.java.lang;
 
+import org.openj9.test.util.CompilerAccess;
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.Test;
 import org.testng.Assert;
-import org.testng.AssertJUnit;
 
 @Test(groups = { "level.sanity" })
 public class Test_Compiler {
 
 	/**
-	* @tests java.lang.Compiler#Compiler()
-	*/
+	 * @tests java.lang.Compiler#Compiler()
+	 */
 	@Test
 	public void test_Constructor() {
+		if (VersionCheck.major() >= 21) {
+			// java.lang.Compiler is not available
+			return;
+		}
+		Class<?> compilerClass;
 		try {
-			Compiler c = (Compiler)Compiler.class.newInstance();
-			AssertJUnit.assertTrue("Constructor should have failed.", false);
-		} catch (Exception e) {//Correct.
+			compilerClass = Class.forName("java.lang.Compiler");
+		} catch (ClassNotFoundException e) {
+			Assert.fail("Cannot find class java.lang.Compiler", e);
+			return;
+		}
+		try {
+			compilerClass.newInstance();
+			Assert.fail("Constructor should have failed.");
+		} catch (Exception e) {
+			// correct
 		}
 	}
 
@@ -46,9 +59,9 @@ public class Test_Compiler {
 	@Test
 	public void test_command() {
 		try {
-			AssertJUnit.assertTrue("Incorrect behavior.", Compiler.command(new Object()) == null);
+			Assert.assertNull(CompilerAccess.command(new Object()), "Incorrect behavior.");
 		} catch (Exception e) {
-			AssertJUnit.assertTrue("Exception during test.", false);
+			Assert.fail("Exception during test.", e);
 		}
 	}
 
@@ -60,9 +73,9 @@ public class Test_Compiler {
 		try {
 			// Do not test return value, may return true or false depending on
 			// if the jit is enabled. Make the call to ensure it doesn't crash.
-			Compiler.compileClass(Compiler.class);
+			CompilerAccess.compileClass(CompilerAccess.class);
 		} catch (Exception e) {
-			Assert.fail("Exception during test.");
+			Assert.fail("Exception during test.", e);
 		}
 	}
 
@@ -74,9 +87,9 @@ public class Test_Compiler {
 		try {
 			// Do not test return value, may return true or false depending on
 			// if the jit is enabled. Make the call to ensure it doesn't crash.
-			Compiler.compileClasses("Compiler");
+			CompilerAccess.compileClasses("Integer");
 		} catch (Exception e) {
-			Assert.fail("Exception during test.");
+			Assert.fail("Exception during test.", e);
 		}
 	}
 
@@ -86,11 +99,11 @@ public class Test_Compiler {
 	@Test
 	public void test_disable() {
 		try {
-			Compiler.disable();
-			Compiler.compileClass(Compiler.class);
-			AssertJUnit.assertTrue("Correct behavior.", true);
+			CompilerAccess.disable();
+			CompilerAccess.compileClass(CompilerAccess.class);
+			// correct behavior
 		} catch (Exception e) {
-			AssertJUnit.assertTrue("Exception during test.", false);
+			Assert.fail("Exception during test.", e);
 		}
 	}
 
@@ -100,12 +113,12 @@ public class Test_Compiler {
 	@Test
 	public void test_enable() {
 		try {
-			Compiler.disable();
-			Compiler.enable();
-			Compiler.compileClass(Compiler.class);
-			AssertJUnit.assertTrue("Correct behavior.", true);
+			CompilerAccess.disable();
+			CompilerAccess.enable();
+			CompilerAccess.compileClass(CompilerAccess.class);
+			// correct behavior
 		} catch (Exception e) {
-			AssertJUnit.assertTrue("Exception during test.", false);
+			Assert.fail("Exception during test.", e);
 		}
 	}
 }

--- a/test/functional/TestUtilities/src/org/openj9/test/util/CompilerAccess.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/CompilerAccess.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.test.util;
+
+import org.testng.Assert;
+
+/**
+ * This provides test access to the API of java.lang.Compiler, which was
+ * removed in Java 21. This class simply reuses the native implementations
+ * from java.lang.Compiler.
+ */
+public final class CompilerAccess {
+
+	static {
+		System.loadLibrary("access");
+		if (!registerNatives()) {
+			Assert.fail("failed to register natives");
+		}
+	}
+
+	public static Object command(Object cmd) {
+		if (cmd == null) {
+			throw new NullPointerException();
+		}
+		return commandImpl(cmd);
+	}
+
+	private static native Object commandImpl(Object cmd);
+
+	public static boolean compileClass(Class<?> classToCompile) {
+		if (classToCompile == null) {
+			throw new NullPointerException();
+		}
+		return compileClassImpl(classToCompile);
+	}
+
+	private static native boolean compileClassImpl(Class classToCompile);
+
+	public static boolean compileClasses(String nameRoot) {
+		if (nameRoot == null) {
+			throw new NullPointerException();
+		}
+		return compileClassesImpl(nameRoot);
+	}
+
+	private static native boolean compileClassesImpl(String nameRoot);
+
+	public static native void disable();
+
+	public static native void enable();
+
+	private static native boolean registerNatives();
+
+}

--- a/test/functional/UnsafeTest/playlist.xml
+++ b/test/functional/UnsafeTest/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2016
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
@@ -28,8 +28,9 @@
 			<variation>-DScenario=Compiled</variation>
 			<variation>-DScenario=Compiled -Xjit:optLevel=noOpt</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
- 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames UnsafeTests \
 	-groups $(TEST_GROUP) \
@@ -56,7 +57,8 @@
 			<variation>-DScenario=Compiled</variation>
 			<variation>-DScenario=Compiled -Xjit:optLevel=noOpt</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-opens java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \

--- a/test/functional/UnsafeTest/src_90/org/openj9/test/unsafe/MainTester.java
+++ b/test/functional/UnsafeTest/src_90/org/openj9/test/unsafe/MainTester.java
@@ -22,22 +22,19 @@
 package org.openj9.test.unsafe;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Vector;
 
+import org.openj9.test.util.CompilerAccess;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Factory;
 import org.testng.log4testng.Logger;
 
 public class MainTester {
 
-	private static Logger logger = Logger.getLogger(MainTester.class);
-	public final static String REGULAR_RUN = "Regular";
-	public final static String COMPILED = "Compiled";
-	
+	private static final Logger logger = Logger.getLogger(MainTester.class);
+	public static final String REGULAR_RUN = "Regular";
+	public static final String COMPILED = "Compiled";
+
 	@Factory
 	public Object[] createInstances() {
 		String scenario = System.getProperty("Scenario");
@@ -61,7 +58,7 @@ public class MainTester {
 		result.add(new TestUnsafeGetAndOp(scenario));
 		return result.toArray();
 	}
-	
+
 	private static void compileClass() {
 		Class<?>[] classes = {MainTester.class, TestUnsafeAccess.class, TestUnsafeAccessOpaque.class,
 				TestUnsafeAccessOrdered.class, TestUnsafeAccessVolatile.class, TestUnsafeAllocateDirectByteBuffer.class,
@@ -69,14 +66,12 @@ public class MainTester {
 				TestUnsafeCompareAndExchange.class, TestUnsafeCompareAndSet.class, TestUnsafeSetMemory.class, UnsafeTestBase.class,
 				TestUnsafeAccessUnaligned.class };
 
-		for (int i = 0; i < classes.length; i++) {
-			Class clazz = classes[i];
-			if (Compiler.compileClass(clazz) == false) {
-				logger.error("Compilation of " + clazz.getName()
-						+ " failed or compiler is not available -- aborting");
+		for (Class<?> clazz : classes) {
+			if (CompilerAccess.compileClass(clazz)) {
+				logger.debug("Compiler.compileClass( " + clazz.getName() + " )");
+			} else {
+				logger.error("Compilation of " + clazz.getName() + " failed or compiler is not available -- aborting");
 				AssertJUnit.fail();
-			}else{
-				logger.debug("Compiler.compileClass( "+  clazz.getName() + " )");
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick #18571 and #18578 for the 0.43.0 release branch.