### PR TITLE
The java.compiler system property is obsolete in jdk21+

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
@@ -72,7 +72,12 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 	 */
 	@Override
 	public String getName() {
-		return com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("java.compiler"); //$NON-NLS-1$
+		return com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().
+/*[IF JAVA_SPEC_VERSION < 21]*/
+				getProperty("java.compiler"); //$NON-NLS-1$
+/*[ELSE] JAVA_SPEC_VERSION < 21 */
+				getProperty("openj9.compiler"); //$NON-NLS-1$
+/*[ENDIF] JAVA_SPEC_VERSION < 21*/
 	}
 
 	/**

--- a/runtime/include/vmi.h
+++ b/runtime/include/vmi.h
@@ -276,7 +276,7 @@ GetInitArgs(VMInterface* vmi);
 <BR>OpenJ9   - 1ca0ab98
 <BR>OMR      - 05d2b8a2
 <BR>JCL      - c2aa0348 based on jdk8u172-b11"</TD></TR>
- * <TR><TD>java.compiler</TD>			<TD>"j9jit29"</TD></TR>
+ * <TR><TD>java.compiler</TD>			<TD>"j9jit29" - not supported from jdk21</TD></TR>
  * <TR><TD>java.class.version</TD>		<TD>"52.0"</TD></TR>
  * <TR><TD>java.home</TD>			<TD>the absolute path of the parent directory of the directory containing the vm
 <BR>i.e. for a vm /clear/bin/vm.exe, java.home is /clear</TD></TR>

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -36,6 +36,7 @@
 #include "jclprots.h"
 
 #include "ut_j9jcl.h"
+#include "j9jclnls.h"
 
 #if defined(J9ZOS390)
 #include "atoe.h"
@@ -551,6 +552,17 @@ systemPropertyIterator(char* key, char* value, void* userData)
 		return;
 	}
 
+#if JAVA_SPEC_VERSION >= 21
+	if (0 == strcmp("java.compiler", key)) {
+		PORT_ACCESS_FROM_ENV(env);
+		if ((0 == strcmp("jitc", value)) || (0 == strcmp(J9_JIT_DLL_NAME, value))) {
+			j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JCL_JAVA_COMPILER_WARNING_XJIT);
+		} else {
+			j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JCL_JAVA_COMPILER_WARNING_XINT);
+		}
+		return;
+	}
+#endif /* JAVA_SPEC_VERSION >= 21 */
 
 	/* check for overridden system properties, use linear scan for now */
 	for (i=0; i < defaultCount; i+=2) {

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -588,3 +588,21 @@ J9NLS_JCL_CRIU_FAILED_TO_ENABLE_ALL_RESTORE_OPTIONS.explanation=NOTAG
 J9NLS_JCL_CRIU_FAILED_TO_ENABLE_ALL_RESTORE_OPTIONS.system_action=
 J9NLS_JCL_CRIU_FAILED_TO_ENABLE_ALL_RESTORE_OPTIONS.user_response=
 # END NON-TRANSLATABLE
+
+# Note: "java.compiler" is a system property name and should not be translated.
+# Note: "-Xjit" is a command line parameter and should not be translated.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XJIT=Setting the java.compiler system property is obsolete in version 21 and later, use -Xjit instead.
+# START NON-TRANSLATABLE
+J9NLS_JCL_JAVA_COMPILER_WARNING_XJIT.explanation=The java.compiler system property can no longer be used to enable or disable the JIT.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XJIT.system_action=Setting the java.compiler system property is ignored.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XJIT.user_response=Use the -Xjit option to enable the JIT.
+# END NON-TRANSLATABLE
+
+# Note: "java.compiler" is a system property name and should not be translated.
+# Note: "-Xint" is a command line parameter and should not be translated.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XINT=Setting the java.compiler system property is obsolete in version 21 and later, use -Xint instead.
+# START NON-TRANSLATABLE
+J9NLS_JCL_JAVA_COMPILER_WARNING_XINT.explanation=The java.compiler system property can no longer be used to enable or disable the JIT.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XINT.system_action=Setting the java.compiler system property is ignored.
+J9NLS_JCL_JAVA_COMPILER_WARNING_XINT.user_response=Use the -Xint option to disable the JIT.
+# END NON-TRANSLATABLE

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1388,7 +1388,9 @@ addEnvironmentVariables(J9PortLibrary *portLib, JavaVMInitArgs *launcherArgs, J9
 	IDATA status = 0;
 	if (
 			(0 != mapEnvVarToArgument(portLib, ENVVAR_IBM_MIXED_MODE_THRESHOLD, MAPOPT_XJIT_COUNT_EQUALS, vmArgumentsList, EXACT_MAP_WITH_OPTIONS, verboseFlags))
+#if JAVA_SPEC_VERSION < 21
 			|| (0 != mapEnvVarToArgument(portLib, ENVVAR_JAVA_COMPILER, SYSPROP_DJAVA_COMPILER_EQUALS, vmArgumentsList, EXACT_MAP_WITH_OPTIONS, verboseFlags))
+#endif /* JAVA_SPEC_VERSION < 21 */
 			|| (0 != mapEnvVarToArgument(portLib, ENVVAR_IBM_NOSIGHANDLER, VMOPT_XRS, vmArgumentsList, EXACT_MAP_NO_OPTIONS, verboseFlags))
 #if defined(J9ZOS390)
 			|| (0 != mapEnvVarToArgument(portLib, ENVVAR_JAVA_THREAD_MODEL, MAPOPT_XTHR_TW_EQUALS, vmArgumentsList, EXACT_MAP_WITH_OPTIONS, verboseFlags))

--- a/runtime/vm/vmifunc.c
+++ b/runtime/vm/vmifunc.c
@@ -204,7 +204,7 @@ vmi_getPortLibrary(VMInterface* vmi)
 <BR>OpenJ9   - 1ca0ab98
 <BR>OMR      - 05d2b8a2
 <BR>JCL      - c2aa0348 based on jdk8u172-b11"</TD></TR>
- * <TR><TD>java.compiler</TD>			<TD>"j9jit29"</TD></TR>
+ * <TR><TD>java.compiler</TD>			<TD>"j9jit29" - not supported from jdk21</TD></TR>
  * <TR><TD>java.class.version</TD>		<TD>"52.0"</TD></TR>
  * <TR><TD>java.home</TD>			<TD>the absolute path of the parent directory of the directory containing the vm
 <BR>i.e. for a vm /clear/bin/vm.exe, java.home is /clear</TD></TR>

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -744,11 +744,13 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 #endif
 
+#if JAVA_SPEC_VERSION < 21
 	/* Don't know the JIT yet, put in a placeholder and make it writeable for now */
 	rc = addSystemProperty(vm, "java.compiler", "", J9SYSPROP_FLAG_WRITEABLE);
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto fail;
 	}
+#endif /* JAVA_SPEC_VERSION < 21 */
 
 	/* We don't have enough information yet. Put in placeholders. */
 #if defined(J9VM_OPT_SIDECAR) && !defined(WIN32)

--- a/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -115,7 +115,7 @@ public class VmArgumentTests {
 	private static final String  MAPOPT_XJIT_COUNT_EQUALS = "-Xjit:count="+MIXED_MODE_THRESHOLD_VALUE;
 
 	private static final String JAVA_COMPILER = "JAVA_COMPILER";
-	private static final String JAVA_COMPILER_VALUE=System.getProperty("java.compiler");
+	private static final String JAVA_COMPILER_VALUE = System.getProperty(VersionCheck.major() < 21 ? "java.compiler" : "openj9.compiler");
 	private static final String SYSPROP_DJAVA_COMPILER_EQUALS = "-Djava.compiler="+JAVA_COMPILER_VALUE;
 
 	private static final boolean isIBM;
@@ -499,7 +499,12 @@ public class VmArgumentTests {
 			env.put(IBM_JAVA_OPTIONS, ibmJavaOptionsArg);
 
 			actualArguments = runAndGetArgumentList(pb);
-			final String[] expectedArguments = new String[] {MAPOPT_XJIT_COUNT_EQUALS, SYSPROP_DJAVA_COMPILER_EQUALS, VMOPT_XRS, ibmJavaOptionsArg};
+			final String[] expectedArguments;
+			if (VersionCheck.major() < 21) {
+				expectedArguments = new String[] {MAPOPT_XJIT_COUNT_EQUALS, SYSPROP_DJAVA_COMPILER_EQUALS, VMOPT_XRS, ibmJavaOptionsArg};
+			} else {
+				expectedArguments = new String[] {MAPOPT_XJIT_COUNT_EQUALS, VMOPT_XRS, ibmJavaOptionsArg};
+			}
 			HashMap<String, Integer> argumentPositions = checkArguments(actualArguments, expectedArguments);
 			checkArgumentSequence(expectedArguments, argumentPositions, true);
 			/* mapped options in environment variables should come before other non-implicit arguments */


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9/issues/18430

Test build and VmArgumentTests passing results for jdk11, 21
https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/459/
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3118
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3119/