### PR TITLE
Valhalla disables JDK22+ Jep454Tests temporarily

### DIFF
--- a/test/functional/Java22andUp/playlist.xml
+++ b/test/functional/Java22andUp/playlist.xml
@@ -23,6 +23,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/18583</comment>
+				<testflag>VTSTANDARD</testflag>
+			</disable>
+		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
@@ -49,6 +55,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_UpCall</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/18583</comment>
+				<testflag>VTSTANDARD</testflag>
+			</disable>
+		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \


### PR DESCRIPTION
Valhalla disables JDK22+ Jep454Tests temporarily

`Valhalla` extension repo is well behind OpenJDK head, and doesn't support some latest APIs. Disabled Jep454Tests temporarily until the valhalla project is updated w/ a recent OpenJDK tag.

related
* https://github.com/eclipse-openj9/openj9/issues/18583

FYI @hangshao0 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>