### PR TITLE
Fix erroneously large section size in ROM walk

### DIFF
--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -210,8 +210,12 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
 	/* add CP NAS section */
-	firstMethod = J9ROMCLASS_ROMMETHODS(romClass);
-	count = (U_32)(((UDATA)firstMethod - (UDATA)srpCursor) / (sizeof(J9SRP) * 2));
+	if (0 != romClass->romMethodCount) {
+		firstMethod = J9ROMCLASS_ROMMETHODS(romClass);
+		count = (U_32)(((UDATA)firstMethod - (UDATA)srpCursor) / (sizeof(J9SRP) * 2));
+	} else {
+		count = 0;
+	}
 	rangeValid = callbacks->validateRangeCallback(romClass, srpCursor, count * sizeof(J9SRP) * 2, userData);
 	if (rangeValid) {
 		callbacks->sectionCallback(romClass, srpCursor, count * sizeof(J9SRP) * 2, "cpNamesAndSignaturesSRPs", userData);


### PR DESCRIPTION
If a ROM class has no methods, the CP NAS section should have size zero. Before, the section size would be calculated unconditionally based on the location of the `J9ROMCLASS_ROMMETHODS` of the ROM class. When the `romMethods` field is a null SRP, that would result in a negative pointer difference that would then wrap to a very large `U_32` value.

Signed-off-by: Christian Despres