### PR TITLE
Update baseOS from osx to mac

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -923,7 +923,7 @@ def get_node_platform(nodeLabels) {
         return ''
     }
     switch (baseOS) {
-        case ['aix', 'windows', 'osx', 'zos']:
+        case ['aix', 'windows', 'mac', 'zos']:
             return baseOS
             break
         case ['linux', 'ubuntu', 'rhel', 'cent', 'sles'] :


### PR DESCRIPTION
When determining the OS, we look to the labels.
A while back we switched from sw.os.osx labels to
sw.os.mac. This was missed.

Related #13937 and infra 7907