### PR TITLE
valuetypeddrtests with Valhalla lw5

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -221,7 +221,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE)) {
 					if (modifiers.anyBitsIn(J9FieldFlagObject)) {
 						if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(localField))
-							|| ((modifiers.intValue() & J9FieldFlagIsNullRestricted) != 0)
+							|| modifiers.anyBitsIn(J9FieldFlagIsNullRestricted)
 						) {
 							J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(instanceClass, J9ROMFieldShapeHelper.getName(localField));
 							if (valueTypeHelper.isJ9FieldIsFlattened(fieldClass, localField)) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -26,6 +26,7 @@ import static com.ibm.j9ddr.vm29.j9.ObjectFieldInfo.BACKFILL_SIZE;
 import static com.ibm.j9ddr.vm29.j9.ObjectFieldInfo.LOCKWORD_SIZE;
 import static com.ibm.j9ddr.vm29.j9.ObjectFieldInfo.NO_BACKFILL_AVAILABLE;
 import static com.ibm.j9ddr.vm29.j9.ObjectFieldInfo.fj9object_t_SizeOf;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagIsNullRestricted;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
 import static com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags.J9AccStatic;
@@ -219,7 +220,9 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			} else {
 				if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE)) {
 					if (modifiers.anyBitsIn(J9FieldFlagObject)) {
-						if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(localField))) {
+						if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(localField))
+							|| ((modifiers.intValue() & J9FieldFlagIsNullRestricted) != 0)
+						) {
 							J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(instanceClass, J9ROMFieldShapeHelper.getName(localField));
 							if (valueTypeHelper.isJ9FieldIsFlattened(fieldClass, localField)) {
 								UDATA size = null;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -395,7 +395,7 @@ public class ObjectFieldInfo {
 			if (!modifiers.anyBitsIn(J9AccStatic) ) {
 				if (modifiers.anyBitsIn(J9FieldFlagObject)) {
 					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))
-						|| ((modifiers.intValue() & J9FieldFlagIsNullRestricted) != 0)
+						|| modifiers.anyBitsIn(J9FieldFlagIsNullRestricted)
 					) {
 						int size = 0;
 						J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(containerClazz, J9ROMFieldShapeHelper.getName(f));

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -21,6 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.j9;
 
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagIsNullRestricted;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
 import static com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags.J9AccStatic;
@@ -393,7 +394,9 @@ public class ObjectFieldInfo {
 			UDATA modifiers = f.modifiers();
 			if (!modifiers.anyBitsIn(J9AccStatic) ) {
 				if (modifiers.anyBitsIn(J9FieldFlagObject)) {
-					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))) {
+					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))
+						|| ((modifiers.intValue() & J9FieldFlagIsNullRestricted) != 0)
+					) {
 						int size = 0;
 						J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(containerClazz, J9ROMFieldShapeHelper.getName(f));
 						if (!valueTypeHelper.isJ9FieldIsFlattened(fieldClass, f)) {

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -301,9 +301,10 @@
 			<variation>-Xint -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
 			<variation>-Xint -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-Xjit:count=0</variation>
-			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
+			<!-- https://github.com/eclipse-openj9/openj9/issues/18742 -->
+			<!--<variation>-Xjit:count=1,disableAsyncCompilation</variation>
 			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
-			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation> -->
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -90,9 +90,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $flatSingleBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">o (offset = 12) (ValueObject)</output>
-		<output regex="no" type="success" showMatch="yes">i (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 4\) \(.*ValueLong\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">o \(offset = 12\) \(.*ValueObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">i \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="success" showMatch="yes">// FlatSingleBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
@@ -103,6 +103,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!flatobject $flatSingleBackfillInstance$</input>
 			<input>quit</input>
 		</command>
+		<!-- TODO change to J l = 0xFAFBFCFD11223344 for lw5-->
 		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344</output>
 		<output regex="no" type="success" showMatch="yes">I i = 0x12123434</output>
 		<output regex="no" type="success" showMatch="yes">i (offset = 0) (ValueInt)</output>
@@ -127,9 +128,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $objectBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">o (offset = 0) (ValueObject)</output>
-		<output regex="no" type="success" showMatch="yes">// FlatObjectBackfill</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 4\) \(.*ValueLong\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">o \(offset = 0\) \(.*ValueObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*FlatObjectBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -140,7 +141,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">J j = 0xFAFBFCFD11223344</output>
-		<output regex="no" type="success" showMatch="yes">// ValueLong</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*ValueLong</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -171,10 +172,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $flatUnAlignedSingleBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">singles (offset = 12) (FlatUnAlignedSingle)</output>
-		<output regex="no" type="success" showMatch="yes">o (offset = 0) (ValueObject)</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 4\) \(.*ValueLong\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">singles \(offset = 12\) \(.*FlatUnAlignedSingle\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">o \(offset = 0\) \(.*ValueObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*FlatUnAlignedSingleBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -245,10 +246,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $flatUnAlignedSingleBackfill2Instance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">l (offset = 12) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">singles (offset = 0) (FlatUnAlignedSingle)</output>
-		<output regex="no" type="success" showMatch="yes">singles2 (offset = 20) (FlatUnAlignedSingle)</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedSingleBackfill2</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 12\) /(.*ValueLong/)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">singles /(offset = 0/) /(.*FlatUnAlignedSingle/)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">singles2 /(offset = 20/) /(.*FlatUnAlignedSingle/)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*FlatUnAlignedSingleBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -274,10 +275,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $flatUnAlignedObjectBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">objects (offset = 0) (FlatUnAlignedObject)</output>
-		<output regex="no" type="success" showMatch="yes">objects2 (offset = 20) (FlatUnAlignedObject)</output>
-		<output regex="no" type="success" showMatch="yes">l (offset = 12) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedObjectBackfill</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">objects \(offset = 0\) \(.*FlatUnAlignedObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">objects2 \(offset = 20\) \(.*FlatUnAlignedObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 12\) \(.*ValueLong\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*FlatUnAlignedObjectBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -301,10 +302,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $flatUnAlignedObjectBackfill2Instance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">o (offset = 0) (ValueObject)</output>
-		<output regex="no" type="success" showMatch="yes">objects (offset = 12) (FlatUnAlignedObject)</output>
-		<output regex="no" type="success" showMatch="yes">l (offset = 4) (ValueLong)</output>
-		<output regex="no" type="success" showMatch="yes">// FlatUnAlignedObjectBackfill2</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">o \(offset = 0\) \(.*ValueObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">objects \(offset = 12\) \(.*FlatUnAlignedObject\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">l \(offset = 4\) \(.*ValueLong\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*FlatUnAlignedObjectBackfill2</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -328,10 +329,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $singleBackfillInstance$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J l = 0xFAFBFCFD11223344 (offset = 4) (SingleBackfill)</output>
-		<output regex="no" type="success" showMatch="yes">(offset = 12) (SingleBackfill)</output>
-		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (SingleBackfill)</output>
-		<output regex="no" type="success" showMatch="yes">// SingleBackfill</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">J l = 0xFAFBFCFD11223344 \(offset = 4\) \(.*SingleBackfill\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">\(offset = 12\) \(.*SingleBackfill\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x12123434 \(offset = 0\) \(.*SingleBackfill\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*SingleBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -364,8 +365,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<input>!j9object $objectBackfillInstance2$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">J l = 0xFAFBFCFD11223344 (offset = 4) (ObjectBackfill)</output>
-		<output regex="no" type="success" showMatch="yes">// ObjectBackfill</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">J l = 0xFAFBFCFD11223344 \(offset = 4\) \(.*ObjectBackfill\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">// .*ObjectBackfill</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2019
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
+	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
+	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
+	<variable name="DUMPFILE" value="j9core.dmp" />
+
+	<test id="Create core file">
+		<exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+		<exec command="rm -f $DUMPFILE$" />
+		<exec command="rm -f core*" />
+		<command showMatch="yes">$EXE$ -Xmx24m $ARGS$ $JARS$ $PROGRAM$</command>
+		<output regex="no" type="success" showMatch="yes">System dump written</output>
+		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
+		<output regex="no" type="failure">Exception caught!</output>
+	</test>
+
+	<test id="Run !threads">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!threads</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!stack 0x</output>
+		<saveoutput regex="no" type="required" saveName="mainThreadId" splitIndex="1" splitBy="!stack ">!stack 0x</saveoutput>
+		<output regex="no" type="failure">DDR is not enabled for this core file</output>
+	</test>
+
+	<test id="Run !stackslots $mainThreadId$">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!stackslots $mainThreadId$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $objectAddr$ to display container array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $objectAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr$ to show the fields of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">tri (offset = 0) (Triangle2D)</output>
+		<output regex="no" type="success" showMatch="yes">line (offset = 56) (FlattenedLine2D)</output>
+		<output regex="no" type="success" showMatch="yes">i (offset = 72) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr$ i to show the int contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr$ i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayAddr$ to display flattened array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="arrayIndex1Addr" splitIndex="1" splitBy="!j9object " showMatch="yes">[0] = !j9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayIndex2Addr" splitIndex="1" splitBy="!j9object " showMatch="yes">[1] = !j9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayIndex1Addr$.i to show value of the variable i">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayIndex1Addr$.i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayIndex2Addr$.i to show the value of the variable i">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayIndex2Addr$.i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x45456767 (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $arrayIndex1Addr$ to recursively show the contents of the object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $arrayIndex1Addr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x12123434</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $arrayIndex2Addr$ to recursively show the contents of the object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $arrayIndex2Addr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x45456767</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr1$ to show the fields of the reference object. Make sure field vline is not flattened">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="no" type="required" showMatch="yes"> i (offset = 12) (ValueInt)</output>
+		<output regex="no" type="required" showMatch="yes"> i2 (offset = 16) (ValueInt)</output>
+		<output regex="no" type="required" showMatch="yes"> point (offset = 20) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 4) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> line (offset = 28) (FlattenedLine2D)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 0\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $valueAddr1$ to show the all fields of ValueTypeWithVolatileFields. Make sure all the flattened fields have the correct values">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i (.)* \(offset = 12\)[\n\r](.)*I i = 0x12123434</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i2 (.)* \(offset = 16\)[\n\r](.)*I i = 0x12123434</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 20\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
+		<saveoutput regex="no" type="required" saveName="vlineAddr" splitIndex="1" splitBy="vline = !fj9object " showMatch="yes">vline = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $vlineAddr$ to show the field vline of ValueTypeWithVolatileFields. Make sure it has the correct values">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $vlineAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> FlattenedLine2D</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Create nocompressedrefs core file">
+		<command showMatch="yes">$EXE$ -Xmx24m $ARGS_NOCR$ $JARS$ $PROGRAM$</command>
+		<output regex="no" type="success" showMatch="yes">System dump written</output>
+		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
+		<output regex="no" type="failure">Exception caught!</output>
+	</test>
+
+	<test id="Run !threads on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!threads</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!stack 0x</output>
+		<saveoutput regex="no" type="required" saveName="mainThreadId" splitIndex="1" splitBy="!stack ">!stack 0x</saveoutput>
+		<output regex="no" type="failure">DDR is not enabled for this core file</output>
+	</test>
+
+	<test id="Run !stackslots $mainThreadId$ on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!stackslots $mainThreadId$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $objectAddr$ to display container array contents on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $objectAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr1$ to show the fields are all at 8 bytes aligned offsets on nocompressedrefs core">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 0)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 8)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 16)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 24)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 32)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 48)</output>
+
+		<output regex="no" type="failure">(offset = 4)</output>
+		<output regex="no" type="failure">(offset = 12)</output>
+		<output regex="no" type="failure">(offset = 20)</output>
+		<output regex="no" type="failure">(offset = 28)</output>
+		<output regex="no" type="failure">(offset = 36)</output>
+		<output regex="no" type="failure">(offset = 44)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+</suite>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
@@ -73,7 +73,6 @@
 		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
 		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
-		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -83,9 +82,9 @@
 			<input>!j9object $valueAddr$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">tri (offset = 0) (Triangle2D)</output>
-		<output regex="no" type="success" showMatch="yes">line (offset = 56) (FlattenedLine2D)</output>
-		<output regex="no" type="success" showMatch="yes">i (offset = 72) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">Triangle2D; tri = !j9object 0x.* tri \(offset = 0\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">FlattenedLine2D; line = !j9object 0x.* line \(offset = 56\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">ValueInt; i = !j9object 0x.* i \(offset = 72\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -95,7 +94,7 @@
 			<input>!j9object $valueAddr$ i</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x12123434 \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -117,7 +116,7 @@
 			<input>!j9object $arrayIndex1Addr$.i</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x12123434 \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -127,7 +126,7 @@
 			<input>!j9object $arrayIndex2Addr$.i</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I i = 0x45456767 (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x45456767 \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -151,48 +150,19 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $valueAddr1$ to show the fields of the reference object. Make sure field vline is not flattened">
+	<test id="Run !flatobject $valueAddr$ to show the all fields of AssortedValueWithSingleAlignment. Make sure all the flattened fields have the correct values">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
-			<input>!j9object $valueAddr1$</input>
+			<input>!flatobject $valueAddr$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="no" type="required" showMatch="yes"> i (offset = 12) (ValueInt)</output>
-		<output regex="no" type="required" showMatch="yes"> i2 (offset = 16) (ValueInt)</output>
-		<output regex="no" type="required" showMatch="yes"> point (offset = 20) (Point2D)</output>
-		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 4) (Point2D)</output>
-		<output regex="no" type="required" showMatch="yes"> line (offset = 28) (FlattenedLine2D)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 0\)</output>
-		<output regex="no" type="failure">Problem running command</output>
-	</test>
-
-	<test id="Run !flatobject $valueAddr1$ to show the all fields of ValueTypeWithVolatileFields. Make sure all the flattened fields have the correct values">
-		<command command="$JDMPVIEW_EXE$">
-			<arg>-core $DUMPFILE$</arg>
-			<input>!flatobject $valueAddr1$</input>
-			<input>quit</input>
-		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i (.)* \(offset = 12\)[\n\r](.)*I i = 0x12123434</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i2 (.)* \(offset = 16\)[\n\r](.)*I i = 0x12123434</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 20\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="no" type="success" showMatch="yes">AssortedValueWithSingleAlignment</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 48\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="no" type="success" showMatch="yes">FlattenedLine2D</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
-		<saveoutput regex="no" type="required" saveName="vlineAddr" splitIndex="1" splitBy="vline = !fj9object " showMatch="yes">vline = !fj9object 0x</saveoutput>
-		<output regex="no" type="failure">Problem running command</output>
-	</test>
-
-	<test id="Run !flatobject $vlineAddr$ to show the field vline of ValueTypeWithVolatileFields. Make sure it has the correct values">
-		<command command="$JDMPVIEW_EXE$">
-			<arg>-core $DUMPFILE$</arg>
-			<input>!flatobject $vlineAddr$</input>
-			<input>quit</input>
-		</command>
-		<output regex="no" type="success" showMatch="yes"> FlattenedLine2D</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i (.)* \(offset = 72\)[\n\r](.)*I i = 0x12123434</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueFloat f (.)* \(offset = 76\)[\n\r](.)*F f = 0x7F7FFFFF</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -234,23 +204,22 @@
 		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
 		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
-		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $valueAddr1$ to show the fields are all at 8 bytes aligned offsets on nocompressedrefs core">
+	<test id="Run !j9object $valueAddr$ to show the fields are all at 8 bytes aligned offsets on nocompressedrefs core">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
-			<input>!j9object $valueAddr1$</input>
+			<input>!j9object $valueAddr$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="no" type="success" showMatch="yes">AssortedValueWithSingleAlignment</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 0)</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 8)</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 16)</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 24)</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 32)</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 48)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 56)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 72)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 80)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 88)</output>
 
 		<output regex="no" type="failure">(offset = 4)</output>
 		<output regex="no" type="failure">(offset = 12)</output>
@@ -258,6 +227,11 @@
 		<output regex="no" type="failure">(offset = 28)</output>
 		<output regex="no" type="failure">(offset = 36)</output>
 		<output regex="no" type="failure">(offset = 44)</output>
+		<output regex="no" type="failure">(offset = 52)</output>
+		<output regex="no" type="failure">(offset = 60)</output>
+		<output regex="no" type="failure">(offset = 68)</output>
+		<output regex="no" type="failure">(offset = 76)</output>
+		<output regex="no" type="failure">(offset = 84)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -93,7 +93,7 @@
 			<input>!fj9object $intAddr1$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I i = 0x12123434 (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x12123434 \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -114,7 +114,7 @@
 			<input>!fj9object $intAddr2$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes">I i = 0x45456767 (offset = 0) (ValueInt)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i = 0x45456767 \(offset = 0\) \(.*ValueInt\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 


### PR DESCRIPTION
- Create copy flattenedvaluetypeddrtests
- Modify valuetypeddrtests to work with lw5
- Add checks for lw5 attributes to ddr and vm

The lw5 tests can be run manually by including changes from https://github.com/eclipse-openj9/openj9/pull/18558 and using a build of https://github.com/openjdk/valhalla/tree/lw5 as `TEST_JDK_HOME` while running `make compile`