### PR TITLE
Prevent requesting exclusive, if already acquired

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1233,10 +1233,14 @@ redefineClassesCommon(jvmtiEnv* env,
 		/* Eliminate dark matter so that none will be encountered in prepareToFixMemberNames(). */
 		UDATA savedAllowUserHeapWalkFlag = vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
 		vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
-		/* J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT allows the GC to run while the current thread is holding
-		 * exclusive VM access.
-		 */
-		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT);
+
+		/* This is to help with Metronome to avoid requesting Exclusive if we already have SafePoint, which may not look as Exclusive to the requester thread */
+		vm->alreadyHaveExclusive = TRUE;
+
+		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_EXCLUSIVE_VMACCESS_ALREADY_ACQUIRED);
+
+		vm->alreadyHaveExclusive = FALSE;
+
 		if (0 == savedAllowUserHeapWalkFlag) {
 			/* Clear the flag to restore its original value. */
 			vm->requiredDebugAttributes &= ~J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5920,6 +5920,7 @@ typedef struct J9JavaVM {
 	UDATA addModulesCount;
 	UDATA safePointState;
 	UDATA safePointResponseCount;
+	BOOLEAN alreadyHaveExclusive;
 	struct J9VMRuntimeStateListener vmRuntimeStateListener;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
 #if defined(J9UNIX) || defined(AIXPPC)


### PR DESCRIPTION
This is to prevent requestExclusiveVMAccessMetronomeTemp (used from alarm thread) from blocking if exclusive VM access is already requested prior to calling a system GC. This prevention
(synchronizeRequestsFromExternalThread) already works for plain exclusive, but not if safePoint is acquired (since it does not set exclusiveAccessState to J9_XACCESS_EXCLUSIVE).

While proper solution might be around fixing
synchronizeRequestsFromExternalThread to account for safePointState and how exclusiveAccessState is changed during safePoint acquire, it would require more time to get it right.

This solution is a workaround where there is an additional flag that is to be set by after safePoint is acquired and before GC is invoked. That flag will be checked by requestExclusiveVMAccessMetronomeTemp before actually proceeding with the request.

There should be no timing hole where
requestExclusiveVMAccessMetronomeTemp is called after safe point is acquired and the flag is set, since
requestExclusiveVMAccessMetronomeTemp itself cannot be invoked if GC is not in progress (and indeed system GC has not been triggered yet).

Fixes: https://github.com/eclipse-openj9/openj9/issues/18482