### PR TITLE
AArch64: Add vectorized implementation of intrinsicIndexOf helper functions

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -86,6 +86,10 @@ J9::ARM64::CodeGenerator::initialize()
       {
       cg->setSupportsInlineStringHashCode();
       }
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf)))
+      {
+      cg->setSupportsInlineStringIndexOf();
+      }
    if (comp->fej9()->hasFixedFrameC_CallingConvention())
       cg->setHasFixedFrameC_CallingConvention();
    }


### PR DESCRIPTION
This commit implements a vectorized version of JITHelpers.intrinsicIndexOfLatin1 and intrinsicIndexOfUTF16 on AArch64 codegen.

Depends on https://github.com/eclipse/omr/pull/7203.