### PR TITLE
Add error check for checkpointGCThreads

### DIFF
--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1439,6 +1439,10 @@ gcParseXXArguments(J9JavaVM *vm)
 				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_MUST_BE_ABOVE, "-XX:CheckpointGCThreads=", (UDATA)0);
 				goto _error;
 			}
+			if (extensions->checkpointGCthreadCount > extensions->gcThreadCount) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NO_GREATER_THAN, "-XX:CheckpointGCThreads=", VMOPT_XGCTHREADS);
+				goto _error;
+			}
 		}
 	}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
Add error check in gcParseXXArguments() for -XX:CheckpointGCThread=
to make sure it cannot be larger than the existing gcthreads value.

Signed off by: Frank.Kang@ibm.com