### PR TITLE
Re-enable criu_nonPortableRestore tests on s390x

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -110,10 +110,6 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
 				<platform>ppc64le.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18570</comment>
-				<platform>s390x.*</platform>
-			</disable>
 		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \


### PR DESCRIPTION
Re-enable criu_nonPortableRestore tests on s390x as the 
test labels were removed from the internal IBM s390x 
machines that seem to have CRIU setup incorrectly.

Issue: https://github.com/eclipse-openj9/openj9/issues/18570
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>