### PR TITLE
Delete now-unnecessary TR_Removed*Guard guard kinds

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2666,16 +2666,9 @@ static TR_ExternalRelocationTargetKind getReloKindFromGuardSite(TR::CodeGenerato
       case TR_NonoverriddenGuard:
          type = TR_InlinedVirtualMethodWithNopGuard;
          break;
-      case TR_RemovedNonoverriddenGuard:
-         type = TR_InlinedVirtualMethod;
-         break;
 
       case TR_InterfaceGuard:
          type = TR_InlinedInterfaceMethodWithNopGuard;
-         break;
-      case TR_RemovedInterfaceGuard:
-         traceMsg(cg->comp(), "TR_RemovedInterfaceMethod\n");
-         type = TR_InlinedInterfaceMethod;
          break;
 
       case TR_AbstractGuard:
@@ -2706,11 +2699,6 @@ static TR_ExternalRelocationTargetKind getReloKindFromGuardSite(TR::CodeGenerato
          else
             TR_ASSERT(0,"Unexpected TR_MethodEnterExitGuard at site %p guard %p node %p\n",
                               site, site->getGuard(), site->getGuard()->getCallNode());
-         break;
-
-      case TR_RemovedProfiledGuard:
-         traceMsg(cg->comp(), "TR_ProfiledInlinedMethodRelocation\n");
-         type = TR_ProfiledInlinedMethodRelocation;
          break;
 
       case TR_ProfiledGuard:

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 53; // ID: 7dZlozupV5RwUvR62RqE
+   static const uint16_t MINOR_NUMBER = 54; // ID: s1vXKnpdqqsBmQnhpK+e
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -103,8 +103,6 @@
 
 #define LOCAL_OBJECTS_COLLECTABLE 1
 
-extern void createGuardSiteForRemovedGuard(TR::Compilation *comp, TR::Node* ifNode);
-
 static bool blockIsInLoop(TR::Block *block)
    {
    for (TR_Structure *s = block->getStructureOf()->getParent(); s; s = s->getParent())
@@ -5901,8 +5899,6 @@ bool TR_EscapeAnalysis::fixupNode(TR::Node *node, TR::Node *parent, TR::NodeChec
       if (firstValue == secondValue)
          {
          compareValue = 0;
-
-         createGuardSiteForRemovedGuard(comp(), node);
          }
       else
          {


### PR DESCRIPTION
AOT now takes care of generating the `TR_Inlined*Method` relocations for inlined methods without corresponding guards, so we can remove guards without creating stand-ins.