### PR TITLE
CRIU adds jdk.crac APIs

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/crac/CheckpointException.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/CheckpointException.java
@@ -1,0 +1,36 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package jdk.crac;
+
+/**
+ * An exception representing a failure in the JVM before checkpoint.
+ */
+public class CheckpointException extends Exception {
+	public CheckpointException() {
+		super("Default CheckpointException"); //$NON-NLS-1$
+	}
+
+	public CheckpointException(Throwable cause) {
+		super("Default CheckpointException", cause); //$NON-NLS-1$
+	}
+}

--- a/jcl/src/java.base/share/classes/jdk/crac/Context.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Context.java
@@ -1,0 +1,50 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package jdk.crac;
+
+/**
+ * A Resource that allows other Resources to be registered with it.
+ */
+public abstract class Context<R extends Resource> {
+	final static boolean debug = System.getProperty("enable.jdk.crac.api.debug") != null; //$NON-NLS-1$
+
+	protected Context() {
+	}
+
+	/**
+	 * @param resource a Context
+	 * @throws CheckpointException if this failed with an exception
+	 */
+	public abstract void beforeCheckpoint(Context<? extends Resource> resource) throws CheckpointException;
+
+	/**
+	 * @param resource a Context
+	 * @throws RestoreException if this failed with an exception
+	 */
+	public abstract void afterRestore(Context<? extends Resource> resource) throws RestoreException;
+
+	/**
+	 * @param resource a Resource to be registered
+	 */
+	public abstract void register(R resource) throws Exception;
+}

--- a/jcl/src/java.base/share/classes/jdk/crac/Core.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Core.java
@@ -1,0 +1,111 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package jdk.crac;
+
+import java.nio.file.Paths;
+
+import openj9.internal.criu.InternalCRIUSupport;
+import openj9.internal.criu.JVMCheckpointException;
+import openj9.internal.criu.JVMRestoreException;
+
+/**
+ * The CRIU Support API.
+ */
+public class Core {
+	private static CRIUSupportContext<?> globalContext = new CRIUSupportContext<>();
+
+	/**
+	 * Get a global context.
+	 *
+	 * @return a Context
+	 */
+	public static Context<Resource> getGlobalContext() {
+		return (Context<Resource>)globalContext;
+	}
+
+	/**
+	 * Invoke InternalCRIUSupport with default settings.
+	 *
+	 * @throws CheckpointException if this failed with a CheckpointException
+	 * @throws RestoreException    if this failed with a RestoreException
+	 */
+	public static void checkpointRestore() throws CheckpointException, RestoreException {
+		if (InternalCRIUSupport.isCRaCSupportEnabled()) {
+			try {
+				globalContext.checkpointJVM();
+			} catch (Throwable t) {
+				throw new CheckpointException(t);
+			}
+		} else {
+			throw new UnsupportedOperationException("CRaC support is not enabled"); //$NON-NLS-1$
+		}
+	}
+}
+
+class CRIUSupportContext<R extends Resource> extends Context<R> {
+	private InternalCRIUSupport internalCRIUSupport = new InternalCRIUSupport(
+			Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir())).setLeaveRunning(false).setShellJob(true)
+			.setFileLocks(true);
+
+	@Override
+	public void register(R resource) throws Exception {
+		if (Context.debug) {
+			System.out.print("Register: " + resource); //$NON-NLS-1$
+		}
+
+		try {
+			internalCRIUSupport.registerPreCheckpointHook(() -> {
+				try {
+					resource.beforeCheckpoint(this);
+				} catch (Throwable t) {
+					throw new JVMCheckpointException(t.getMessage(), 0, t.getCause());
+				}
+			}, InternalCRIUSupport.HookMode.CONCURRENT_MODE, InternalCRIUSupport.LOWEST_USER_HOOK_PRIORITY);
+			internalCRIUSupport.registerPostRestoreHook(() -> {
+				try {
+					resource.afterRestore(this);
+				} catch (Throwable t) {
+					throw new JVMRestoreException(t.getMessage(), 0, t.getCause());
+				}
+			}, InternalCRIUSupport.HookMode.CONCURRENT_MODE, InternalCRIUSupport.LOWEST_USER_HOOK_PRIORITY);
+		} catch (JVMCheckpointException jce) {
+			throw new CheckpointException(jce);
+		} catch (JVMRestoreException jre) {
+			throw new RestoreException(jre);
+		}
+	}
+
+	@Override
+	public void beforeCheckpoint(Context<? extends Resource> resource) throws CheckpointException {
+		throw new UnsupportedOperationException("CRaC CRIUSupportContext.beforeCheckpoint() is not supported"); //$NON-NLS-1$
+	}
+
+	@Override
+	public void afterRestore(Context<? extends Resource> resource) throws RestoreException {
+		throw new UnsupportedOperationException("CRaC CRIUSupportContext.afterRestore() is not supported"); //$NON-NLS-1$
+	}
+
+	public void checkpointJVM() {
+		internalCRIUSupport.checkpointJVM();
+	}
+}

--- a/jcl/src/java.base/share/classes/jdk/crac/Resource.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Resource.java
@@ -1,0 +1,44 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package jdk.crac;
+
+/**
+ * An interface representing checkpoint and restore notifications.
+ */
+public interface Resource {
+	/**
+	 * A notification method to be invoked before the checkpoint.
+	 *
+	 * @param resource a Context
+	 * @throws Exception if this failed with an exception
+	 */
+	public abstract void beforeCheckpoint(Context<? extends Resource> resource) throws Exception;
+
+	/**
+	 * A notification method to be invoked after the restore.
+	 *
+	 * @param resource a Context
+	 * @throws Exception if this failed with an exception
+	 */
+	public abstract void afterRestore(Context<? extends Resource> resource) throws Exception;
+}

--- a/jcl/src/java.base/share/classes/jdk/crac/RestoreException.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/RestoreException.java
@@ -1,0 +1,36 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package jdk.crac;
+
+/**
+ * An exception representing a JVM failure after restore.
+ */
+public class RestoreException extends Exception {
+	public RestoreException() {
+		super("Default RestoreException"); //$NON-NLS-1$
+	}
+
+	public RestoreException(Throwable cause) {
+		super("Default RestoreException", cause); //$NON-NLS-1$
+	}
+}

--- a/jcl/src/java.base/share/classes/jdk/crac/package-info.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/package-info.java
@@ -1,0 +1,28 @@
+/*[INCLUDE-IF CRAC_SUPPORT]*/
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+/**
+ * This package enables access to openj9.internal.criu.J9InternalCheckpointHookAPI.
+ *
+ * The jdk.crac API doc is https://crac.github.io/openjdk-builds/javadoc/api/java.base/jdk/crac/package-summary.html.
+ */
+package jdk.crac;

--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -67,6 +67,9 @@ exports jdk.internal.access to
 opens jdk.internal.access to
     openj9.criu;
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+/*[IF CRAC_SUPPORT]*/
+exports jdk.crac;
+/*[ENDIF] CRAC_SUPPORT*/
 exports jdk.internal.misc to
     openj9.criu;
 exports openj9.internal.criu to

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -95,7 +95,7 @@ public final class CRIUSupport {
 	/**
 	 * Queries if CRIU support is enabled and criu library has been loaded.
 	 *
-	 * @return TRUE if support is enabled and the library is loaded, FALSE otherwise
+	 * @return TRUE if CRIU support is enabled and the library is loaded, FALSE otherwise
 	 */
 	public static boolean isCRIUSupportEnabled() {
 		return InternalCRIUSupport.isCRIUSupportEnabledAndNativeLoaded();
@@ -511,16 +511,20 @@ public final class CRIUSupport {
 	 * @throws JVMRestoreException           if an error occurred during or after restore
 	 */
 	public synchronized void checkpointJVM() {
-		try {
-			internalCRIUSupport.checkpointJVM();
-		} catch (openj9.internal.criu.JVMCheckpointException jce) {
-			throw new JVMCheckpointException(jce.getMessage(), 0, jce);
-		} catch (openj9.internal.criu.JVMRestoreException jre) {
-			throw new JVMRestoreException(jre.getMessage(), 0, jre);
-		} catch (openj9.internal.criu.SystemCheckpointException sce) {
-			throw new JVMCheckpointException(sce.getMessage(), 0, sce);
-		} catch (openj9.internal.criu.SystemRestoreException sre) {
-			throw new JVMRestoreException(sre.getMessage(), 0, sre);
+		if (isCRIUSupportEnabled()) {
+			try {
+				internalCRIUSupport.checkpointJVM();
+			} catch (openj9.internal.criu.JVMCheckpointException jce) {
+				throw new JVMCheckpointException(jce.getMessage(), 0, jce);
+			} catch (openj9.internal.criu.JVMRestoreException jre) {
+				throw new JVMRestoreException(jre.getMessage(), 0, jre);
+			} catch (openj9.internal.criu.SystemCheckpointException sce) {
+				throw new JVMCheckpointException(sce.getMessage(), 0, sce);
+			} catch (openj9.internal.criu.SystemRestoreException sre) {
+				throw new JVMRestoreException(sre.getMessage(), 0, sre);
+			}
+		} else {
+			throw new UnsupportedOperationException("CRIU support is not enabled"); //$NON-NLS-1$
 		}
 	}
 }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2364,7 +2364,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          // Enable JITServer client mode if
          // 1) CRIU support is enabled
          // 2) client mode is not explicitly disabled
-         bool implicitClientMode = ifuncs->isCRIUSupportEnabled(currentThread) && !useJitServerExplicitlyDisabled;
+         bool implicitClientMode = ifuncs->isCRaCorCRIUSupportEnabled(currentThread) && !useJitServerExplicitlyDisabled;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
          if (useJitServerExplicitlySpecified

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9414,7 +9414,7 @@ bool
 TR_J9VMBase::isSnapshotModeEnabled()
    {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   return getJ9JITConfig()->javaVM->internalVMFunctions->isCRIUSupportEnabled(vmThread());
+   return getJ9JITConfig()->javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(vmThread());
 #else /* defined(J9VM_OPT_CRIU_SUPPORT) */
    return false;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3038,7 +3038,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 				extensions->concurrentScavengerHWSupport = hwSupported
 					&& !extensions->softwareRangeCheckReadBarrierForced
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-					&& !vm->internalVMFunctions->isCRIUSupportEnabled_VM(vm)
+					&& !vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 					&& !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
 			}

--- a/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
+++ b/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
@@ -85,7 +85,7 @@ isMetronomeGCPolicySupported(MM_GCExtensions *extensions)
 {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	J9JavaVM *vm = extensions->getJavaVM();
-	if (vm->internalVMFunctions->isCRIUSupportEnabled_VM(vm)) {
+	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "metronome");
 		return false;
@@ -107,7 +107,7 @@ isBalancedGCPolicySupported(MM_GCExtensions *extensions)
 {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	J9JavaVM *vm = extensions->getJavaVM();
-	if (vm->internalVMFunctions->isCRIUSupportEnabled_VM(vm)) {
+	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "balanced");
 		return false;

--- a/runtime/jcl/common/criu.cpp
+++ b/runtime/jcl/common/criu.cpp
@@ -129,5 +129,26 @@ Java_openj9_internal_criu_InternalCRIUSupport_getRestoreSystemProperites(JNIEnv 
 
 	return systemProperties;
 }
+
+#if defined(J9VM_OPT_CRAC_SUPPORT)
+jstring JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getCRaCCheckpointToDirImpl(JNIEnv *env, jclass unused)
+{
+	jstring result = NULL;
+	char *cracCheckpointToDir = ((J9VMThread*)env)->javaVM->checkpointState.cracCheckpointToDir;
+
+	if (NULL != cracCheckpointToDir) {
+		result = env->NewStringUTF(cracCheckpointToDir);
+	}
+
+	return result;
+}
+
+jboolean JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_isCRaCSupportEnabledImpl(JNIEnv *env, jclass unused)
+{
+	return J9_ARE_ANY_BITS_SET(((J9VMThread*)env)->javaVM->checkpointState.flags, J9VM_CRAC_IS_CHECKPOINT_ENABLED);
+}
+#endif /* defined(J9VM_OPT_CRAC_SUPPORT) */
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -675,11 +675,17 @@ if(J9VM_OPT_CRIU_SUPPORT)
 		Java_openj9_internal_criu_InternalCRIUSupport_enableCRIUSecProviderImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_getCheckpointRestoreNanoTimeDeltaImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_getLastRestoreTimeImpl
-		Java_openj9_internal_criu_InternalCRIUSupport_getRestoreSystemProperites;
+		Java_openj9_internal_criu_InternalCRIUSupport_getRestoreSystemProperites
 		Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl
 		Java_openj9_internal_criu_InternalCRIUSupport_isCRIUSupportEnabledImpl
-		Java_openj9_internal_criu_InternalCRIUSupport_setupJNIFieldIDsAndCRIUAPI;
+		Java_openj9_internal_criu_InternalCRIUSupport_setupJNIFieldIDsAndCRIUAPI
 	)
+	if(J9VM_OPT_CRAC_SUPPORT)
+		omr_add_exports(jclse
+			Java_openj9_internal_criu_InternalCRIUSupport_getCRaCCheckpointToDirImpl
+			Java_openj9_internal_criu_InternalCRIUSupport_isCRaCSupportEnabledImpl
+		)
+	endif()
 endif()
 
 # Java 19 only

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -28,6 +28,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<xi:include href="uma/se6_vm-side_natives_exports.xml"></xi:include>
 	<xi:include href="uma/se6_vm-side_lifecycle_exports.xml"></xi:include>
 	<xi:include href="uma/attach_exports.xml"></xi:include>
+	<xi:include href="uma/crac_exports.xml"></xi:include>
 	<xi:include href="uma/criu_exports.xml"></xi:include>
 	<xi:include href="uma/se7_exports.xml"></xi:include>
 	<xi:include href="uma/se626_orb_ludcl_exports.xml"></xi:include>
@@ -100,6 +101,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="sun_misc_Unsafe_inl"/>
 			<group name="attach">
 				<include-if condition="spec.flags.opt_sidecar"/>
+			</group>
+			<group name="crac">
+				<include-if condition="spec.flags.opt_cracSupport"/>
 			</group>
 			<group name="criu">
 				<include-if condition="spec.flags.opt_criuSupport"/>

--- a/runtime/jcl/uma/crac_exports.xml
+++ b/runtime/jcl/uma/crac_exports.xml
@@ -1,0 +1,25 @@
+<!--
+Copyright IBM Corp. and others 2024
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<exports group="crac">
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_getCRaCCheckpointToDirImpl" />
+	<export name="Java_openj9_internal_criu_InternalCRIUSupport_isCRaCSupportEnabledImpl" />
+</exports>

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2306,3 +2306,10 @@ J9NLS_VM_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA.explanation=checkpointResto
 J9NLS_VM_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_NEGATIVE_CHECKPOINT_RESTORE_TIME_DELTA.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_CRAC_INCOMPATIBLE_SETTING=The command line options -XX:+EnableCRIUSupport and -XX:CRaCCheckpointTo=[DIR] are not compatible.
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_CRAC_INCOMPATIBLE_SETTING.explanation=-XX:+EnableCRIUSupport and -XX:CRaCCheckpointTo=[DIR] are specified at the same time.
+J9NLS_VM_CRIU_CRAC_INCOMPATIBLE_SETTING.system_action=The JVM will fail to start.
+J9NLS_VM_CRIU_CRAC_INCOMPATIBLE_SETTING.user_response=Remove one of the options from the command line.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -366,6 +366,7 @@ static const struct { \
 #define J9_IS_STRING_DESCRIPTOR(str, strLen) (((strLen) > 2) && (IS_REF_OR_VAL_SIGNATURE(*(str))) && (';' == *((str) + (strLen) - 1)))
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+#define J9_IS_CRIU_OR_CRAC_CHECKPOINT_ENABLED(vm) (J9_ARE_ANY_BITS_SET(vm->checkpointState.flags, J9VM_CRAC_IS_CHECKPOINT_ENABLED | J9VM_CRIU_IS_CHECKPOINT_ENABLED))
 #define J9_IS_SINGLE_THREAD_MODE(vm) (J9_ARE_ALL_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_CRIU_SINGLE_THREAD_MODE))
 #define J9_THROW_BLOCKING_EXCEPTION_IN_SINGLE_THREAD_MODE(vm) (J9_ARE_ALL_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_CRIU_SINGLE_THROW_BLOCKING_EXCEPTIONS))
 #define J9_IS_CRIU_RESTORED(vm) (0 != vm->checkpointState.checkpointRestoreTimeDelta)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4211,6 +4211,7 @@ typedef struct J9DelayedLockingOpertionsRecord {
 #define J9VM_CRIU_IS_THROW_ON_DELAYED_CHECKPOINT_ENABLED 0x10
 #define J9VM_CRIU_IS_PORTABLE_JVM_RESTORE_MODE 0x20
 #define J9VM_CRIU_ENABLE_CRIU_SEC_PROVIDER 0x40
+#define J9VM_CRAC_IS_CHECKPOINT_ENABLED 0x80
 
 typedef struct J9CRIUCheckpointState {
 	U_32 flags;
@@ -4256,6 +4257,9 @@ typedef struct J9CRIUCheckpointState {
 	struct J9VMInitArgs *restoreArgsList;
 	char *restoreArgsChars;
 	IDATA jucForkJoinPoolParallelismOffset;
+#if defined(J9VM_OPT_CRAC_SUPPORT)
+	char *cracCheckpointToDir;
+#endif /* defined(J9VM_OPT_CRAC_SUPPORT) */
 } J9CRIUCheckpointState;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
@@ -5030,8 +5034,9 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	BOOLEAN (*jvmCheckpointHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*jvmRestoreHooks)(struct J9VMThread *currentThread);
+	BOOLEAN (*isCRaCorCRIUSupportEnabled)(struct J9VMThread *currentThread);
+	BOOLEAN (*isCRaCorCRIUSupportEnabled_VM)(struct J9JavaVM *vm);
 	BOOLEAN (*isCRIUSupportEnabled)(struct J9VMThread *currentThread);
-	BOOLEAN (*isCRIUSupportEnabled_VM)(struct J9JavaVM *vm);
 	BOOLEAN (*enableCRIUSecProvider)(struct J9VMThread *currentThread);
 	BOOLEAN (*isCheckpointAllowed)(struct J9VMThread *currentThread);
 	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1320,6 +1320,13 @@ Java_openj9_internal_criu_InternalCRIUSupport_setupJNIFieldIDsAndCRIUAPI(JNIEnv 
 
 void JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_checkpointJVMImpl(JNIEnv *env, jclass unused, jstring imagesDir, jboolean leaveRunning, jboolean shellJob, jboolean extUnixSupport, jint logLevel, jstring logFile, jboolean fileLocks, jstring workDir, jboolean tcpEstablished, jboolean autoDedup, jboolean trackMemory, jboolean unprivileged, jstring optionsFile, jstring environmentFile);
+
+#if defined(J9VM_OPT_CRAC_SUPPORT)
+jstring JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_getCRaCCheckpointToDirImpl(JNIEnv *env, jclass unused);
+jboolean JNICALL
+Java_openj9_internal_criu_InternalCRIUSupport_isCRaCSupportEnabledImpl(JNIEnv *env, jclass unused);
+#endif /* defined(J9VM_OPT_CRAC_SUPPORT) */
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if JAVA_SPEC_VERSION >= 19

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -441,6 +441,10 @@ enum INIT_STAGE {
 #define VMOPT_XXSLEEPMILLISECONDSFORNOTCHECKPOINTSAFE_EQUALS "-XX:sleepMillisecondsForNotCheckpointSafe="
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+#if defined(J9VM_OPT_CRAC_SUPPORT)
+#define VMOPT_XXCRACCHECKPOINTTO "-XX:CRaCCheckpointTo="
+#endif /* defined(J9VM_OPT_CRAC_SUPPORT) */
+
 /* Compatibility options. */
 #define VMOPT_XXCOMPATIBILITY_EQUALS "-XX:Compatibility="
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -498,24 +498,34 @@ internalCreateRAMClassFromROMClass(J9VMThread *vmThread, J9ClassLoader *classLoa
 
 /* ---------------- CRIUHelpers.cpp ---------------- */
 /**
+ * @brief Queries if CRaC or CRIU support is enabled. By default support
+ * is not enabled, it can be enabled with -XX:CRaCCheckpointTo or -XX:+EnableCRIUSupport.
+ *
+ * @param currentThread vmthread token
+ * @return TRUE if enabled, FALSE otherwise
+ */
+BOOLEAN
+isCRaCorCRIUSupportEnabled(J9VMThread *currentThread);
+
+/**
+ * @brief Queries if CRaC or CRIU support is enabled. By default support
+ * is not enabled, it can be enabled with -XX:CRaCCheckpointTo or -XX:+EnableCRIUSupport.
+ *
+ * @param vm javaVM token
+ * @return TRUE if enabled, FALSE otherwise
+ */
+BOOLEAN
+isCRaCorCRIUSupportEnabled_VM(J9JavaVM *vm);
+
+/**
  * @brief Queries if CRIU support is enabled. By default support
- * is not enabled, it can be enabled with `-XX:+EnableCRIUSupport`
+ * is not enabled, it can be enabled with -XX:+EnableCRIUSupport.
  *
  * @param currentThread vmthread token
  * @return TRUE if enabled, FALSE otherwise
  */
 BOOLEAN
 isCRIUSupportEnabled(J9VMThread *currentThread);
-
-/**
- * @brief Queries if CRIU support is enabled. By default support
- * is not enabled, it can be enabled with `-XX:+EnableCRIUSupport`
- *
- * @param vm javaVM token
- * @return TRUE if enabled, FALSE otherwise
- */
-BOOLEAN
-isCRIUSupportEnabled_VM(J9JavaVM *vm);
 
 /**
  * @brief Checks if the CRIU security provider is enabled when CRIU

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -103,7 +103,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 	nas.name = (J9UTF8 *)&runPostRestoreHooks_name;
 	nas.signature = (J9UTF8 *)&runPostRestoreHooks_sig;
 
-	Assert_VM_true(isCRIUSupportEnabled_VM(vm));
+	Assert_VM_true(isCRaCorCRIUSupportEnabled_VM(vm));
 
 	if (J9_ARE_ALL_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_IS_NON_PORTABLE_RESTORE_MODE)) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
@@ -125,15 +125,21 @@ jvmRestoreHooks(J9VMThread *currentThread)
 }
 
 BOOLEAN
-isCRIUSupportEnabled(J9VMThread *currentThread)
+isCRaCorCRIUSupportEnabled(J9VMThread *currentThread)
 {
-	return isCRIUSupportEnabled_VM(currentThread->javaVM);
+	return isCRaCorCRIUSupportEnabled_VM(currentThread->javaVM);
 }
 
 BOOLEAN
-isCRIUSupportEnabled_VM(J9JavaVM *vm)
+isCRaCorCRIUSupportEnabled_VM(J9JavaVM *vm)
 {
-	return J9_ARE_ALL_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_IS_CHECKPOINT_ENABLED);
+	return J9_IS_CRIU_OR_CRAC_CHECKPOINT_ENABLED(vm);
+}
+
+BOOLEAN
+isCRIUSupportEnabled(J9VMThread *currentThread)
+{
+	return J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_CHECKPOINT_ENABLED);
 }
 
 BOOLEAN
@@ -141,7 +147,7 @@ isCheckpointAllowed(J9VMThread *currentThread)
 {
 	BOOLEAN result = FALSE;
 
-	if (isCRIUSupportEnabled(currentThread)) {
+	if (isCRaCorCRIUSupportEnabled(currentThread)) {
 		result = J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_CHECKPOINT_ALLOWED);
 	}
 
@@ -153,7 +159,7 @@ enableCRIUSecProvider(J9VMThread *currentThread)
 {
 	BOOLEAN result = FALSE;
 
-	if (isCRIUSupportEnabled(currentThread)) {
+	if (isCRaCorCRIUSupportEnabled(currentThread)) {
 		result = J9_ARE_ANY_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_ENABLE_CRIU_SEC_PROVIDER);
 	}
 
@@ -169,7 +175,7 @@ isNonPortableRestoreMode(J9VMThread *currentThread)
 BOOLEAN
 isJVMInPortableRestoreMode(J9VMThread *currentThread)
 {
-	return (!isNonPortableRestoreMode(currentThread) || J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_PORTABLE_JVM_RESTORE_MODE)) && isCRIUSupportEnabled(currentThread);
+	return (!isNonPortableRestoreMode(currentThread) || J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_PORTABLE_JVM_RESTORE_MODE)) && isCRaCorCRIUSupportEnabled(currentThread);
 }
 
 /**

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -407,8 +407,9 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	jvmCheckpointHooks,
 	jvmRestoreHooks,
+	isCRaCorCRIUSupportEnabled,
+	isCRaCorCRIUSupportEnabled_VM,
 	isCRIUSupportEnabled,
-	isCRIUSupportEnabled_VM,
 	enableCRIUSecProvider,
 	isCheckpointAllowed,
 	isNonPortableRestoreMode,

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -961,3 +961,4 @@ TraceException=Trc_VM_criu_setupJNIFieldIDsAndCRIUAPI_null_init Overhead=1 Level
 
 TraceExit=Trc_VM_criu_checkpointJVMImpl_Exit Overhead=1 Level=2 Template="Java_openj9_internal_criu_CRIUSupport_checkpointJVMImpl"
 TraceEvent=Trc_VM_criu_after_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), criuRestoreNanoTimeMonotonic (%lld), criuRestoreNanoUTCTime (%llu), lastRestoreTimeMillis (%lld)"
+TraceEvent=Trc_VM_crac_checkpointTo NoEnv Overhead=1 Level=3 Template="-XX:CRaCCheckpointTo=%s"

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -61,6 +61,14 @@
 			</else>
 		</if>
 		<if>
+			<not>
+				<contains string="${TEST_FLAG}" substring="CRAC" />
+			</not>
+			<then>
+				<property name="excludeTestJDKCRAC" value="org/openj9/criu/TestJDKCRAC.java" />
+			</then>
+		</if>
+		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8" />
 			<then>
 				<property name="excludeJDK11UpTimeoutAdjustmentTest" value="org/openj9/criu/JDK11UpTimeoutAdjustmentTest.java" />
@@ -81,6 +89,7 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<compilerarg line="${addExports}" />
 					<compilerarg line="${enablePreview}" />
+					<exclude name="${excludeTestJDKCRAC}" />
 					<exclude name="${excludeTestMachineResourceChange}" />
 					<src path="${src}" />
 					<src path="${TestUtilities}" />
@@ -112,7 +121,10 @@
 
 	<target name="build" depends="buildCmdLineTestTools">
 		<if>
-			<contains string="${TEST_FLAG}" substring="CRIU" />
+			<or>
+				<contains string="${TEST_FLAG}" substring="CRAC" />
+				<contains string="${TEST_FLAG}" substring="CRIU" />
+			</or>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/functional/cmdLineTests/criu/cracScript.sh
+++ b/test/functional/cmdLineTests/criu/cracScript.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+#
+# Copyright IBM Corp. and others 2024
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+#
+
+echo "start running script";
+# the expected arguments are:
+# $1 is the TEST_ROOT
+# $2 is the JAVA_COMMAND
+# $3 is the JVM_OPTIONS
+# $4 is the MAINCLASS
+# $5 is the APP ARGS
+# $6 is the NUM_CHECKPOINT
+# $7 is the KEEP_CHECKPOINT
+# $8 is the KEEP_TEST_OUTPUT
+
+echo "export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.pthread.rseq=0:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+echo "$2 $3 -cp "$1/criu.jar" $4 $5 $6"
+$2 $3 -cp "$1/criu.jar" $4 $5 $6 >testOutput 2>&1;
+
+if [ "$7" != true ]; then
+    NUM_CHECKPOINT=$6
+    for ((i=0; i<$NUM_CHECKPOINT; i++)); do
+        sleep 2;
+        criu restore -D ./cpData --shell-job >criuOutput 2>&1;
+    done
+fi
+
+cat testOutput criuOutput;
+
+if  [ "$7" != true ]; then
+    if [ "$8" != true ]; then
+        rm -rf testOutput criuOutput
+        echo "Removed test output files"
+    fi
+fi
+echo "finished script";

--- a/test/functional/cmdLineTests/criu/criu_nonPortable_jdk_crac.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable_jdk_crac.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2024
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Criu Command-Line Option Tests - jdk.crac" timeout="300">
+  <variable name="MAINCLASS_TESTJDKCRAC" value="org.openj9.criu.TestJDKCRAC" />
+  <variable name="EXPORTS" value="--add-exports=java.base/openj9.internal.criu=ALL-UNNAMED"/>
+  <variable name="CRACCHECKPOINTTO" value="-XX:CRaCCheckpointTo=./cpData"/>
+
+  <test id="jdk.crac - create and restore once">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $EXPORTS$ $CRACCHECKPOINTTO$" $MAINCLASS_TESTJDKCRAC$ unusedArgument 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
+</suite>

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -134,6 +134,41 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>cmdLineTester_criu_nonPortableRestore_jdk_crac</testCaseName>
+		<variations>
+			<variation>-Xgcpolicy:optthruput</variation>
+			<variation>-Xgcpolicy:optavgpause</variation>
+			<variation>-Xgcpolicy:gencon -Xgcthreads64 -XX:CheckpointGCThreads=1</variation>
+			<variation>-Xgcpolicy:gencon -Xgcthreads1</variation>
+		</variations>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
+				<platform>ppc64le.*</platform>
+			</disable>
+		</disables>
+		<command>
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+			-DSCRIPPATH=$(TEST_RESROOT)$(D)cracScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
+			-DJAVA_COMMAND=$(JAVA_COMMAND) -DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)criu_nonPortable_jdk_crac.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+			$(TEST_STATUS)
+		</command>
+		<features>
+			<feature>CRAC:required</feature>
+		</features>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>cmdLineTester_criu_jitPostRestore</testCaseName>
 		<variations>
 			<variation>-Xjit</variation>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestJDKCRAC.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestJDKCRAC.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+package org.openj9.criu;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import openj9.internal.criu.InternalCRIUSupport;
+
+public class TestJDKCRAC {
+
+	public static void main(String args[]) throws Exception {
+		Path imagePath = Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir());
+		CRIUTestUtils.deleteCheckpointDirectory(imagePath);
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+
+		CRIUTestUtils.showThreadCurrentTime("Pre-checkpoint - jdk.crac.Core.checkpointRestore()");
+		jdk.crac.Core.checkpointRestore();
+		CRIUTestUtils.showThreadCurrentTime("Post-checkpoint - jdk.crac.Core.checkpointRestore()");
+	}
+}


### PR DESCRIPTION
CRIU adds `jdk.crac` APIs

Added `jdk.crac.CheckpointException/RestoreException`;
Added `jdk.crac.Context/Resource`;
Added `jdk.crac.Core`;
Added a new flag `J9VM_CRAC_IS_CHECKPOINT_ENABLED`;
Added a test with a new feature `CRAC`.

Co-authored with Tobi Ajila <atobia@ca.ibm.com>
Signed-off-by: Jason Feng <fengj@ca.ibm.com>