### PR TITLE
Revert "Fix implicit conversion causing truncation warnings"

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -10574,7 +10574,7 @@ static TR::Register *inlineStringHashcode(TR::Node *node, TR::CodeGenerator *cg)
 
     // vend = end & (~0xf)
     // if v is 16byte aligned goto VSX_LOOP
-    generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, 0xFFFFFFF0);
+    generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, 0xFFFFFFFFFFFFFFF0);
     generateTrg1Src2Instruction(cg, TR::InstOpCode::AND, node, vendReg, endReg, tempReg);
     loadConstant(cg, node, 0xF, tempReg);
     generateTrg1Src2Instruction(cg, TR::InstOpCode::AND, node, tempReg, valueReg, tempReg);
@@ -10607,7 +10607,7 @@ static TR::Register *inlineStringHashcode(TR::Node *node, TR::CodeGenerator *cg)
     // advance v to next aligned pointer
     // if v >= vend goto POST_VSX
     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, valueReg, valueReg, 0xF);
-    generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, 0xFFFFFFF0);
+    generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, 0xFFFFFFFFFFFFFFF0);
     generateTrg1Src2Instruction(cg, TR::InstOpCode::AND, node, valueReg, valueReg, tempReg);
     generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp8, node, condReg, valueReg, vendReg);
     generateConditionalBranchInstruction(cg, TR::InstOpCode::bge, node, POSTVSXLabel, condReg);

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -62,29 +62,29 @@ void replaceFirstTwoBytesWithData(void *startPC, int32_t startPCToData);
 
 #if defined(TR_HOST_POWER)
 #define  OFFSET_REVERT_INTP_PRESERVED_FSD                (-4)
-#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-(12 + 2 * (int32_t)sizeof(intptr_t)))
+#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-12-2*sizeof(intptr_t))
 
-#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_METHODINFO_FROM_STARTPC         (-(8 + (int32_t)sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16+sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12+sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_METHODINFO_FROM_STARTPC         (-(8+sizeof(intptr_t)))
 #define  OFFSET_SAMPLING_PRESERVED_FROM_STARTPC          (-8)
 #endif
 
 #if defined(TR_HOST_ARM)
-#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-(12 + 2 * (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_METHODINFO_FROM_STARTPC                  (-(8 + (int32_t)sizeof(intptr_t)))
+#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-12-2*sizeof(intptr_t))
+#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16+sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12+sizeof(intptr_t)))
+#define  OFFSET_METHODINFO_FROM_STARTPC                  (-(8+sizeof(intptr_t)))
 #define  OFFSET_SAMPLING_PRESERVED_FROM_STARTPC          (-8)
 #define  START_PC_TO_METHOD_INFO_ADDRESS                  -8 // offset from startpc to jitted body info
 #define  OFFSET_COUNTING_BRANCH_FROM_JITENTRY             36
 #endif
 
 #if defined(TR_HOST_ARM64)
-#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-(12 + 2 * (int32_t)sizeof(intptr_t))) // See generateSwitchToInterpreterPrePrologue()
-#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12 + (int32_t)sizeof(intptr_t)))
-#define  OFFSET_SAMPLING_METHODINFO_FROM_STARTPC         (-(8 + (int32_t)sizeof(intptr_t)))
+#define  OFFSET_REVERT_INTP_FIXED_PORTION                (-12-2*sizeof(intptr_t)) // See generateSwitchToInterpreterPrePrologue()
+#define  OFFSET_SAMPLING_PREPROLOGUE_FROM_STARTPC        (-(16+sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_BRANCH_FROM_STARTPC             (-(12+sizeof(intptr_t)))
+#define  OFFSET_SAMPLING_METHODINFO_FROM_STARTPC         (-(8+sizeof(intptr_t)))
 #define  OFFSET_SAMPLING_PRESERVED_FROM_STARTPC          (-8)
 #define  OFFSET_COUNTING_BRANCH_FROM_JITENTRY            (9*ARM64_INSTRUCTION_LENGTH)
 #endif


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#18269 due to issue #18626