### PR TITLE
Set gcThreadCountSpecified and allow -Xgcmaxthreads for restore VM

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3183,7 +3183,12 @@ gcReinitializeDefaultsForRestore(J9VMThread* vmThread)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
-	extensions->gcThreadCountForced = false;
+	/* If Snapshot VM did not specify -Xgcthreads or -Xgcmaxthreads, the count will be determined from scratch, either as new restore default or through restore specified options.
+	 * If Snapshot VM did specify, we want to continue using the count value unless (only) restore specific options override it */
+	if (!extensions->gcThreadCountSpecified) {
+		extensions->gcThreadCount = 0;
+		extensions->gcThreadCountForced = false;
+	}
 	extensions->parSweepChunkSize = 0;
 
 	if (!gcParseReconfigurableCommandLine(vm, vm->checkpointState.restoreArgsList)) {

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -153,6 +153,7 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 			goto _error;
 		}
 
+		extensions->gcThreadCountSpecified = true;
 		extensions->gcThreadCountForced = true;
 		goto _exit;
 	}		
@@ -233,6 +234,7 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 			goto _error;
 		}
 
+		extensions->gcThreadCountSpecified = true;
 		extensions->gcThreadCountForced = true;
 		goto _exit;
 	}


### PR DESCRIPTION
Set gcThreadCountSpecified if either -Xgcthreads or -Xgcmaxthreads is specified, and use gcThreadCountForced to distinguish between the 2 options. This is a part of the fix that will allow -Xgcmaxthreads to work as expected (another OMR change is needed to make use of now properly set gcThreadCountSpecified flag).

Aslo, allow -Xgcmaxthreads to be specified on restore VM too, and make sure that whichever is the last one wins (in any combination of those 2 options being or not beign specified on snapshot or restore side). Parsing of -Xgcmaxthreads handles it, since it's the latter one that gets processed in the code.

There is also a change in behavior for restore VM. Previosly, if -Xgcthreads was specified on snapshot side, it would be ignored on restore side and the thread count would be recalculated from scratch. Now, if that option (or gcmaxthreads variant) is specified on snapshot side it will obeyed on restore side. Of course if restore side specifies any of the 2 options that will override the snapshot value. That was true before and still true, except that the value will possible to override by either gcthreads or (once fully working) gcmaxthreads variant.