### PR TITLE
Recognize AArch64 and RISC-V in DDR TraceFileHeaderWriter

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/TraceFileHeaderWriter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/TraceFileHeaderWriter.java
@@ -47,8 +47,9 @@ public class TraceFileHeaderWriter {
 	private int type = 0;
 	private int generations = 0;
 	
-	private final static String[] Archs = { "Unknown", "x86", "S390", "Power", "IA64", "S390X", "AMD64" };
-	private final static String[] SubTypes = { "i486", "i586", "Pentium II", "Pentium III", "Merced", "McKinley", "PowerRS", "PowerPC", "GigaProcessor", "ESA", "Pentium IV", "T-Rex", "Opteron" };
+	private final static String[] Archs = { "Unknown", "x86", "S390", "Power", "IA64", "S390X", "AMD64", "RISCV", "AArch64" };
+	private final static String[] SubTypes = { "i486", "i586", "Pentium II", "Pentium III", "Merced", "McKinley",
+		"PowerRS", "PowerPC", "GigaProcessor", "ESA", "Pentium IV", "T-Rex", "Opteron", "RV64G", "Armv8-A" };
 	private final static String[] trCounter = { "Sequence Counter", "Special", "RDTSC Timer", "AIX Timer", "MFSPR Timer", "MFTB Timer", "STCK Timer", "J9 timer" };
 	
 	/**


### PR DESCRIPTION
Fixes: #18647