### PR TITLE
Shut down ROM class cache if purging all clients

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1241,6 +1241,13 @@ ClientSessionHT::purgeOldDataIfNeeded()
             _clientSessionMap.erase(iter); // delete the mapping from the hashtable
             }
          }
+      // If all the clients were deleted, shut down the shared ROMClass cache
+      if (_clientSessionMap.empty())
+         {
+         if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
+            cache->shutdown();
+         }
+
       _timeOfLastPurge = crtTime;
 
       // JITServer TODO: keep stats on how many elements were purged


### PR DESCRIPTION
The JITServer expects that the shared ROM class cache will have been initialized only if the `_clientSessionMap` is empty.

Fixes #18631.