### PR TITLE
JDK next adds JVM_VirtualThreadDisableSuspend

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -441,6 +441,7 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 22)
 	jvm_add_exports(jvm
 		JVM_ExpandStackFrameInfo
+		JVM_VirtualThreadDisableSuspend
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -450,5 +450,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk22">
 		<!-- Additions for Java 22 (General) -->
 		<export name="JVM_ExpandStackFrameInfo"/>
+		<export name="JVM_VirtualThreadDisableSuspend"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -724,6 +724,12 @@ JVM_ExpandStackFrameInfo(JNIEnv *env, jobject object)
 {
 	assert(!"JVM_ExpandStackFrameInfo unimplemented");
 }
+
+JNIEXPORT void JNICALL
+JVM_VirtualThreadDisableSuspend(JNIEnv *env, jobject vthread, jboolean enter)
+{
+	assert(!"JVM_VirtualThreadDisableSuspend unimplemented");
+}
 #endif /* JAVA_SPEC_VERSION >= 22 */
 
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -429,3 +429,5 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
+_IF([JAVA_SPEC_VERSION >= 22],
+	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])


### PR DESCRIPTION
JDK next adds `JVM_VirtualThreadDisableSuspend`

This fixes JDK next abuild failure https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/446/consoleFull
```
23:44:10  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/native/java.base/libjava/VirtualThread.o:(.data.rel+0x88): undefined reference to `JVM_VirtualThreadDisableSuspend'
23:44:10  collect2: error: ld returned 1 exit status
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>