### PR TITLE
JDK23 adds JVM_VirtualThreadDisableSuspend

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -441,6 +441,11 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 22)
 	jvm_add_exports(jvm
 		JVM_ExpandStackFrameInfo
+	)
+endif()
+
+if(NOT JAVA_SPEC_VERSION LESS 23)
+	jvm_add_exports(jvm
 		JVM_VirtualThreadDisableSuspend
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -450,6 +450,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk22">
 		<!-- Additions for Java 22 (General) -->
 		<export name="JVM_ExpandStackFrameInfo"/>
+	</exports>
+
+	<exports group="jdk23">
+		<!-- Additions for Java 23 (General) -->
 		<export name="JVM_VirtualThreadDisableSuspend"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -724,12 +724,14 @@ JVM_ExpandStackFrameInfo(JNIEnv *env, jobject object)
 {
 	assert(!"JVM_ExpandStackFrameInfo unimplemented");
 }
+#endif /* JAVA_SPEC_VERSION >= 22 */
 
+#if JAVA_SPEC_VERSION >= 23
 JNIEXPORT void JNICALL
 JVM_VirtualThreadDisableSuspend(JNIEnv *env, jobject vthread, jboolean enter)
 {
 	assert(!"JVM_VirtualThreadDisableSuspend unimplemented");
 }
-#endif /* JAVA_SPEC_VERSION >= 22 */
+#endif /* JAVA_SPEC_VERSION >= 23 */
 
 } /* extern "C" */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -85,6 +85,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk22">
 				<include-if condition="spec.java22"/>
 			</group>
+			<group name="jdk23">
+				<include-if condition="spec.java23"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -429,5 +429,5 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
-_IF([JAVA_SPEC_VERSION >= 22],
+_IF([JAVA_SPEC_VERSION >= 23],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -86,6 +86,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk22">
 				<include-if condition="spec.java22"/>
 			</group>
+			<group name="jdk23">
+				<include-if condition="spec.java23"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
`JDK23` adds `JVM_VirtualThreadDisableSuspend`

`JVM_VirtualThreadDisableSuspend` was added for `JDK23` instead.

Related to 
* https://github.com/eclipse-openj9/openj9/pull/18663#issuecomment-1865175406

Signed-off-by: Jason Feng <fengj@ca.ibm.com>