### PR TITLE
Exclude jvmtitests_hcr rc021

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
@@ -138,10 +138,10 @@
 		<return type="success" value="0"/>
 	</test>
 
-	<test id="rc021">
+	<!-- <test id="rc021">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rc021 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
-	</test>
+	</test> -->
 
  	<test id="rtc001">
 		<command>$EXE$ $JVM_OPTS$ $EXTRA_Add_OPEN_OPTION$ $AGENTLIB$=test:rtc001 -Dsun.reflect.noInflation=true  -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>


### PR DESCRIPTION
The test fails regularly and fixing it is in the backlog.

Issue https://github.com/eclipse-openj9/openj9/issues/14115

Tested via https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3159 the test runs but rc021 does not.