### PR TITLE
Update JVM_VirtualThreadDisableSuspend

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -441,11 +441,6 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 22)
 	jvm_add_exports(jvm
 		JVM_ExpandStackFrameInfo
-	)
-endif()
-
-if(NOT JAVA_SPEC_VERSION LESS 23)
-	jvm_add_exports(jvm
 		JVM_VirtualThreadDisableSuspend
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -450,10 +450,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk22">
 		<!-- Additions for Java 22 (General) -->
 		<export name="JVM_ExpandStackFrameInfo"/>
-	</exports>
-
-	<exports group="jdk23">
-		<!-- Additions for Java 23 (General) -->
 		<export name="JVM_VirtualThreadDisableSuspend"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -724,14 +724,14 @@ JVM_ExpandStackFrameInfo(JNIEnv *env, jobject object)
 {
 	assert(!"JVM_ExpandStackFrameInfo unimplemented");
 }
-#endif /* JAVA_SPEC_VERSION >= 22 */
 
-#if JAVA_SPEC_VERSION >= 23
 JNIEXPORT void JNICALL
 JVM_VirtualThreadDisableSuspend(JNIEnv *env, jobject vthread, jboolean enter)
 {
-	assert(!"JVM_VirtualThreadDisableSuspend unimplemented");
+	/* TODO: Add implementation.
+	 * See https://github.com/eclipse-openj9/openj9/issues/18671 for more details.
+	 */
 }
-#endif /* JAVA_SPEC_VERSION >= 23 */
+#endif /* JAVA_SPEC_VERSION >= 22 */
 
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -429,5 +429,5 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
-_IF([JAVA_SPEC_VERSION >= 23],
+_IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])


### PR DESCRIPTION
Enable `JVM_VirtualThreadDisableSuspend` in JDK22. A PR has been
opened to move it to JDK22 in the RI. Eventually, we will see this
method in JDK22.

The above method is invoked in the `VirtualThread` class. So, the
assertion in the stub will trigger and cause failures in the builds.

Leaving the stub empty should be fine. See #18671 for more details.

Related:
- #18671
- #18667
- #18663