### PR TITLE
Coordinate IProfiler Thread across a Checkpoint/Restore

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2927,12 +2927,55 @@ TR::CompilationInfo::suspendJITThreadsForCheckpoint(J9VMThread *vmThread)
       j9thread_monitor_exit(_jitConfig->samplerMonitor);
       }
 
+   // Suspend IProfiler Thread
+   TR_IProfiler *iProfiler = TR_J9VMBase::get(_jitConfig, NULL)->getIProfiler();
+   if (iProfiler && iProfiler->getIProfilerMonitor())
+      {
+      iProfiler->getIProfilerMonitor()->enter();
+
+      TR_ASSERT_FATAL(iProfiler->getIProfilerThreadLifetimeState() != TR_IProfiler::IPROF_THR_SUSPENDED,
+                      "IProfiler Thread should not already be in state IPROF_THR_SUSPENDED.\n");
+
+      // Don't change the state if the JVM is currently shutting down.
+      if (iProfiler->getIProfilerThreadLifetimeState() != TR_IProfiler::IPROF_THR_STOPPING)
+         iProfiler->setIProfilerThreadLifetimeState(TR_IProfiler::IPROF_THR_SUSPENDING);
+
+      // During shutdown, both the IProfiler Thread and the Shutdown Thread could be
+      // waiting on the IProfiler Monitor, so notifyAll so that the IProfiler Thread
+      // wakes up.
+      iProfiler->getIProfilerMonitor()->notifyAll();
+
+      // Determine whether to wait on the CR Monitor.
+      //
+      // Note, this thread releases the iprofiler monitor and then
+      // acquires the CR monitor inside releaseCompMonitorUntilNotifiedOnCRMonitor.
+      while (!shouldCheckpointBeInterrupted()
+             && iProfiler->getIProfilerThreadLifetimeState() != TR_IProfiler::IPROF_THR_SUSPENDED)
+         {
+         iProfiler->getIProfilerMonitor()->exit();
+         releaseCompMonitorUntilNotifiedOnCRMonitor(vmThread);
+         iProfiler->getIProfilerMonitor()->enter();
+         }
+
+      iProfiler->getIProfilerMonitor()->exit();
+      }
+
    return !shouldCheckpointBeInterrupted();
    }
 
 void
 TR::CompilationInfo::resumeJITThreadsForRestore(J9VMThread *vmThread)
    {
+   // Resume suspended IProfiler Thread
+   TR_IProfiler *iProfiler = TR_J9VMBase::get(_jitConfig, NULL)->getIProfiler();
+   if (iProfiler && iProfiler->getIProfilerMonitor())
+      {
+      iProfiler->getIProfilerMonitor()->enter();
+      iProfiler->setIProfilerThreadLifetimeState(TR_IProfiler::IPROF_THR_RESUMING);
+      iProfiler->getIProfilerMonitor()->notifyAll();
+      iProfiler->getIProfilerMonitor()->exit();
+      }
+
    // Resume suspended Sampler Thread
    if (_jitConfig->samplerMonitor)
       {

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -508,7 +508,10 @@ public:
       IPROF_THR_NOT_CREATED = 0,
       IPROF_THR_FAILED_TO_ATTACH,
       IPROF_THR_INITIALIZED,
+      IPROF_THR_WAITING_FOR_WORK,
+      IPROF_THR_SUSPENDING,
       IPROF_THR_SUSPENDED,
+      IPROF_THR_RESUMING,
       IPROF_THR_STOPPING,
       IPROF_THR_DESTROYED,
       IPROF_THR_LAST_STATE // must be the last one
@@ -695,6 +698,15 @@ private:
     * @note This method must be called with IProfiler Monitor in hand
     */
    void discardFilledIProfilerBuffers();
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   /**
+    * @brief Suspend the IProfiler Thread
+    *
+    * @note This method is called by the IProfiler Thread to suspend itself.
+    */
+   void suspendIProfilerThreadForCheckpoint();
+#endif
 
    // data members
    J9PortLibrary                  *_portLib;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -502,6 +502,18 @@ class TR_IProfiler : public TR_ExternalProfiler
 public:
 
    TR_PERSISTENT_ALLOC(TR_Memory::IProfiler);
+
+   enum TR_IprofilerThreadLifetimeStates
+      {
+      IPROF_THR_NOT_CREATED = 0,
+      IPROF_THR_FAILED_TO_ATTACH,
+      IPROF_THR_INITIALIZED,
+      IPROF_THR_SUSPENDED,
+      IPROF_THR_STOPPING,
+      IPROF_THR_DESTROYED,
+      IPROF_THR_LAST_STATE // must be the last one
+      };
+
    static TR_IProfiler *allocate (J9JITConfig *);
    static uint32_t getProfilerMemoryFootprint();
 
@@ -577,14 +589,10 @@ public:
    j9thread_t getIProfilerOSThread() { return _iprofilerOSThread; }
    TR::Monitor* getIProfilerMonitor() { return _iprofilerMonitor; }
    bool processProfilingBuffer(J9VMThread *vmThread, const U_8* dataStart, UDATA size);
-   void setAttachAttempted(bool b) { _iprofilerThreadAttachAttempted = b; }
    void processWorkingQueue();
-   bool getAttachAttempted() const { return _iprofilerThreadAttachAttempted; }
    IProfilerBuffer *getCrtProfilingBuffer() const { return _crtProfilingBuffer; }
    void setCrtProfilingBuffer(IProfilerBuffer *b) { _crtProfilingBuffer = b; }
-   void setIProfilerThreadExitFlag() { _iprofilerThreadExitFlag = 1; }
    void jitProfileParseBuffer(J9VMThread *vmThread);
-   uint32_t getIProfilerThreadExitFlag() { return _iprofilerThreadExitFlag; }
    bool postIprofilingBufferToWorkingQueue(J9VMThread * vmThread, const U_8* dataStart, UDATA size);
    // this is wrapper of registered version, for the helper function, from JitRunTime
 
@@ -603,6 +611,10 @@ public:
    static uintptr_t getSearchPCFromMethodAndBCIndex(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR::Compilation * comp);
    virtual TR_IPBytecodeHashTableEntry *searchForSample(uintptr_t pc, int32_t bucket);
    virtual TR_IPMethodHashTableEntry *searchForMethodSample(TR_OpaqueMethodBlock *omb, int32_t bucket);
+
+   // Use _iprofilerMonitor for these two routines
+   TR_IprofilerThreadLifetimeStates getIProfilerThreadLifetimeState() const { return _iprofilerThreadLifetimeState; }
+   void setIProfilerThreadLifetimeState(TR_IprofilerThreadLifetimeStates s) { _iprofilerThreadLifetimeState = s; }
 
 protected:
    bool isCompact(U_8 byteCode);
@@ -677,6 +689,12 @@ private:
    uint32_t walkILTreeForEntries(uintptr_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator, TR_OpaqueMethodBlock *method, TR::Compilation *comp,
                                  vcount_t visitCount, int32_t callerIndex, TR_BitVector *BCvisit, bool &abort);
 
+   /**
+    * @brief Moves buffers in the working queue to the free list.
+    *
+    * @note This method must be called with IProfiler Monitor in hand
+    */
+   void discardFilledIProfilerBuffers();
 
    // data members
    J9PortLibrary                  *_portLib;
@@ -716,8 +734,6 @@ private:
    uint64_t                        _numRequests;
    uint64_t                        _numRequestsSkipped;
    uint64_t                        _numRequestsHandedToIProfilerThread;
-   volatile uint32_t               _iprofilerThreadExitFlag;
-   volatile bool                   _iprofilerThreadAttachAttempted;
    uint64_t                        _iprofilerNumRecords; // info stats only
 
    TR_IPMethodHashTableEntry       **_methodHashTable;
@@ -725,6 +741,7 @@ private:
    uint32_t                        _iprofilerBufferSize;
    TR_ReadSampleRequestsHistory   *_readSampleRequestsHistory;
 
+   volatile TR_IprofilerThreadLifetimeStates _iprofilerThreadLifetimeState;
 
    public:
    static int32_t                  _STATS_noProfilingInfo;


### PR DESCRIPTION
* Update the IProfiler to use a Lifetime State rather than a special buffer to indicate shutdown
* Coordinate the IProfiler Thread across a Checkpoint/Restore
* Allow the IProfiler thread to finish processing all outstanding buffers prior to suspending itself

Part of https://github.com/eclipse-openj9/openj9/issues/16853