### PR TITLE
Perform lastLoopVersioner only if we can afford the extra CPU consump…

### DIFF
--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -332,7 +332,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
 #ifdef TR_HOST_S390
    { OMR::globalCopyPropagation,                     OMR::IfVoluntaryOSR        },
 #endif
-   { OMR::lastLoopVersionerGroup,                    OMR::IfLoops               },
+   { OMR::lastLoopVersionerGroup,                    OMR::IfLoopsAndNotCompileTimeSensitive},
 #ifdef TR_HOST_S390
    { OMR::globalDeadStoreElimination,                OMR::IfEnabledAndLoops          },
    { OMR::deadTreesElimination                                                       },


### PR DESCRIPTION
…tion

Experiments have shown that eliminating the lastLoopVersioner pass from the warm optimization strategy can reduce compilation overhead by 5-6%. This commit avoids the lastLoopVersioner pass in all cases except (1) AOT compilations. Rationale: It is expected that most runs will be "warm" runs (with a populated SCC) rather than "cold".
(2) Pre-checkpoint in a CRIU enabled run. Rationale: The pre-checkpoint phase happens during container image creation and we can afford a little more extra time. (3) Under -Xtune:throughput. Rationale: This option is a signal that the user is willing to spend more CPU compiling to achieve peak throughput.

The changes implemented by this commit can be overridden by defining the following environment variable:
TR_EnableExpensiveOptsAtWarm=1

Depends on: https://github.com/eclipse/omr/pull/7215