### PR TITLE
(0.43) Add -XX:[+|-]ShowUnmountedThreadStacks option

### DIFF
--- a/runtime/oti/j9dump.h
+++ b/runtime/oti/j9dump.h
@@ -34,16 +34,17 @@ typedef struct RasDumpGlobalStorage {
 	UDATA allocationRangeMin;
 	UDATA allocationRangeMax;
 
-	U_32 noProtect; /* If set, do not take dumps under their own signal handler */
-	U_32 noFailover; /* If set, do not failover to /tmp etc if unable to write dump */
+	U_32 noProtect; /* If set, do not take dumps under their own signal handler. */
+	U_32 noFailover; /* If set, do not failover to /tmp etc if unable to write dump. */
 
-	U_32 showNativeSymbols; /* How to handle resolving native stack symbols. */
+	U_32 dumpFlags; /* Flags to control java dump behaviour. */
 } RasDumpGlobalStorage;
 
-/* Values for RasDumpGlobalStorage.showNativeSymbols. */
-#define J9RAS_JAVADUMP_SHOW_NATIVE_STACK_SYMBOLS_NONE  0
-#define J9RAS_JAVADUMP_SHOW_NATIVE_STACK_SYMBOLS_BASIC 1
-#define J9RAS_JAVADUMP_SHOW_NATIVE_STACK_SYMBOLS_ALL   2
+/* Flags on how to handle resolving native stack symbols. */
+#define J9RAS_JAVADUMP_SHOW_NATIVE_STACK_SYMBOLS_BASIC 0x1
+#define J9RAS_JAVADUMP_SHOW_NATIVE_STACK_SYMBOLS_ALL   0x2
+/* Flag to show unmounted Thread stacktrace in java dump. */
+#define J9RAS_JAVADUMP_SHOW_UNMOUNTED_THREAD_STACKS    0x4
 
 struct J9RASdumpAgent; /* Forward struct declaration */
 struct J9RASdumpContext; /* Forward struct declaration */

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -454,6 +454,12 @@ enum INIT_STAGE {
 #define VMOPT_XXSHOWNATIVESTACKSYMBOLS_BASIC "-XX:+ShowNativeStackSymbols=basic" /* show only easily acquired native stack symbols */
 #define VMOPT_XXSHOWNATIVESTACKSYMBOLS_ALL "-XX:+ShowNativeStackSymbols=all" /* show all available native stack symbols */
 
+#if JAVA_SPEC_VERSION >= 21
+/* Option to control if unmounted thread stacktraces are shown in java core dumps. */
+#define VMOPT_XXSHOWUNMOUNTEDTHREADSTACKS "-XX:+ShowUnmountedThreadStacks"
+#define VMOPT_XXNOSHOWUNMOUNTEDTHREADSTACKS "-XX:-ShowUnmountedThreadStacks"
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
 /* Option to turn on exception on synchronization on instances of value-based classes */
 #define VMOPT_XXDIAGNOSE_SYNC_ON_VALUEBASED_CLASSES_EQUALS1 "-XX:DiagnoseSyncOnValueBasedClasses=1"
 /* Option to turn on warning on synchronization on instances of value-based classes */


### PR DESCRIPTION
Refactor RasDumpGlobalStorage.showNativeSymbols field into a bit flag dumpFlags Add new J9RAS_JAVADUMP_SHOW_UNMOUNTED_THREAD_STACKS bit flag

Add VThread info to javacore
- Fix writeThreadName API to correctly reflect mounted virtual thread name
- Add new tag for virtual thread related info
- Move get VThread name code inside j9sig_protect call

Port of https://github.com/eclipse-openj9/openj9/pull/18218