### PR TITLE
Need to define OMRZTPF guard macro to openJ9 UMA build for z/TPF

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -172,7 +172,7 @@ TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-isystem $d/opensource/include)
 TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-isystem $d/noship/include)
 TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-isystem $d)
 
-TPF_FLAGS := -D_GNU_SOURCE -DIBM_ATOE -D_TPF_SOURCE -DZTPF_POSIX_SOCKET -DJ9ZTPF
+TPF_FLAGS := -D_GNU_SOURCE -DIBM_ATOE -D_TPF_SOURCE -DZTPF_POSIX_SOCKET -DJ9ZTPF -DOMRZTPF
 TPF_FLAGS += -fexec-charset=ISO-8859-1 -fmessage-length=0 -funsigned-char -fverbose-asm -fno-builtin-abort -fno-builtin-exit -fno-builtin-sprintf -ffloat-store -gdwarf-2 -Wno-format-extra-args -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-write-strings
 TPF_FLAGS += -Wno-unused
 TPF_FLAGS += -fno-delete-null-pointer-checks -fno-tree-dse -fno-lifetime-dse -fno-optimize-strlen


### PR DESCRIPTION
As part of a Pull Request in the OMR Repository it was realized that J9ZTPF guard macros should not be used in the OMR Repository.   Instead, as part of building OMR with OpenJ9 for z/TPF that the OMRZTPF guard macro should be turned on in the OpenJ9 build for z/TPF.

This pull request is simply proposing we define OMRZTPF in the runtime/makelib/targets.mk.ftl for the z/TPF spec only.