### PR TITLE
Support reimplemented MethodHandleProxies.asInterfaceInstance

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -325,7 +325,12 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda, 
 
 	/* check if adding host package name to anonymous class is needed */
 	UDATA newHostPackageLength = 0;
-	if (memcmp(originalStringBytes, hostPackageName, hostPackageLength) != 0) {
+	if ((0 != memcmp(originalStringBytes, hostPackageName, hostPackageLength))
+#if JAVA_SPEC_VERSION >= 22
+	/* Don't add the host package name if a package name already exists in the class name. */
+	&& (NULL == strchr(originalStringBytes, '/'))
+#endif /* JAVA_SPEC_VERSION >= 22 */
+	) {
 		newHostPackageLength = hostPackageLength + 1;
 	}
 	UDATA newAnonClassNameLength = originalStringLength + 1 + ROM_ADDRESS_LENGTH + 1 + newHostPackageLength;

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -156,7 +156,12 @@ internalDefineClass(
 		if ((NULL != hostClass) && (J2SE_VERSION(vm) >= J2SE_V11)) {
 			J9ROMClass *hostROMClass = hostClass->romClass;
 			/* From Java 9 and onwards, set IllegalArgumentException when host class and anonymous class have different packages. */
-			if (!hasSamePackageName(romClass, hostROMClass)) {
+			if (!hasSamePackageName(romClass, hostROMClass)
+#if JAVA_SPEC_VERSION >= 22
+			/* The below error only applies if the host class is not an interface. */
+			&& !J9ROMCLASS_IS_INTERFACE(hostROMClass)
+#endif /* JAVA_SPEC_VERSION >= 22 */
+			) {
 				omrthread_monitor_exit(vm->classTableMutex);
 				setIllegalArgumentExceptionHostClassAnonClassHaveDifferentPackages(vmThread, romClass, hostROMClass);
 				freeAnonROMClass(vm, romClass);


### PR DESCRIPTION
In JDK22, `MethodHandleProxies.asInterfaceInstance` was reimplemented
using a more direct `MethodHandle` approach to improve performance.

This approach introduces hidden classes which have an interface for
its host class.

In this case, the hidden and host class don't need to exist in the
same package, and they can have different packages.

Two operations have been updated to accommodate the above changes:
**[1]** In `ROMClassBuilder::handleAnonClassName`, the host class's package
is not appended to the hidden class if the class name already has a
package.
**[2]** In `internalDefineClass`, hidden and host class are allowed to have
different package names if the host class is an interface.

**[1]** solves the `NoClassDefFoundError` seen in the below issues:
- #18694
- #18698
- #18699
- #18700
- #18701
- #18702

**[2]** solves the `IllegalArgumentException`, which is seen after the
`NoClassDefFoundError` is fixed.