### PR TITLE
Return true from Unsafe.shouldBeInitialized when called from <clinit>

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -810,8 +810,8 @@ Java_sun_misc_Unsafe_shouldBeInitialized(JNIEnv *env, jobject receiver, jclass c
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
 		j9object_t classObject = J9_JNI_UNWRAP_REFERENCE(clazz);
-		J9Class *j9clazz =  J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, classObject);
-		if (VM_VMHelpers::classRequiresInitialization(currentThread, j9clazz)) {
+		J9Class *j9clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, classObject);
+		if (J9ClassInitSucceeded != j9clazz->initializeStatus) {
 			result = JNI_TRUE;
 		}
 	}


### PR DESCRIPTION
When initialization of the class has started but not yet completed, and `shouldBeInitialized` is called from the initializing thread, its result should be true, but it has been returning false instead.

`DirectMethodHandle.checkInitialized` calls `ensureClassInitialized` and then uses this method to determine whether initialization is incomplete because it is still ongoing on the current thread. This fix should allow that usage to work as intended.