### PR TITLE
JDK23 Thread.blockedOn(Interruptible) changed to static

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -90,14 +90,12 @@ import sun.reflect.annotation.AnnotationType;
  */
 final class Access implements JavaLangAccess {
 
+	/*[IF JAVA_SPEC_VERSION == 8]*/
 	/** Set thread's blocker field. */
 	public void blockedOn(java.lang.Thread thread, Interruptible interruptable) {
-		/*[IF JAVA_SPEC_VERSION >= 11]*/
-		Thread.blockedOn(interruptable);
-		/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 		thread.blockedOn(interruptable);
-		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION == 8 */
 
 	/**
 	 * Get the AnnotationType instance corresponding to this class.
@@ -398,7 +396,11 @@ final class Access implements JavaLangAccess {
 
 /*[IF JAVA_SPEC_VERSION >= 11]*/
 	public void blockedOn(Interruptible interruptible) {
+		/*[IF JAVA_SPEC_VERSION >= 23]*/
+		Thread.currentThread().blockedOn(interruptible);
+		/*[ELSE] JAVA_SPEC_VERSION >= 23 */
 		Thread.blockedOn(interruptible);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 	}
 	public byte[] getBytesNoRepl(String str, Charset charset) throws CharacterCodingException {
 		/*[IF JAVA_SPEC_VERSION < 17]*/


### PR DESCRIPTION
`JDK23` `Thread.blockedOn(Interruptible)` changed to `static`

required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/723

Signed-off-by: Jason Feng <fengj@ca.ibm.com>