### PR TITLE
Reduce counts only for implict SCC

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -575,12 +575,12 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
             }
          else // ROM class not in shared class cache (no space or ineligible - maybe because of implicit SCC)
             {
-            // SCC is used, either explicit or implicit; this is a sign that start-up may be important
-            // If there is enough CPU power to compile sooner, do so by using lower counts
-            // but only for the classes loaded during startup
+            // For an implicit SCC, if there is enough CPU power to compile sooner,
+            // do so by using lower counts, but only for the classes loaded during startup
             if (!TR::Options::getCountsAreProvidedByUser() && !countInOptionSet)
                {
                if (TR::Options::getCmdLineOptions()->getOption(TR_UseLowerCountsForNonSCCMethodsDuringStartup) &&
+                   J9_ARE_NO_BITS_SET(jitConfig->javaVM->sharedClassConfig->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHE_NON_BOOT_CLASSES) &&
                    (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP) &&
                    TR::Compiler->target.numberOfProcessors() >= TR_NUMPROC_FOR_LARGE_SMP)
                   {


### PR DESCRIPTION
PR #18356 introduced a change to reduce the counts of a method whose class is not in the shared class cache (SCC), if SCC is enabled and the load of that class happens during start-up. This change improves performance of some short running benchmarks from the DaCapo suite (when run with default options), but was discovered to also cause a small (2-3%) throughput regression when running the Daytrader benchmark on top of tWAS.
This commit restricts the change from PR #18356 to just environments that use an implicit SCC (by default, OpenJ9 creates an implict SCC that is only allowed to to store bootstrap classes).