### PR TITLE
Remove Class.isUnnamedClass() from Java 22+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4100,11 +4100,11 @@ private native String getSimpleNameImpl();
  * @see #isAnonymousClass()
  */
 public String getSimpleName() {
-/*[IF JAVA_SPEC_VERSION >= 21]*/
+/*[IF JAVA_SPEC_VERSION == 21]*/
 	if (isUnnamedClass()) {
 		return "";
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+/*[ENDIF] JAVA_SPEC_VERSION == 21 */
 	MetadataCache cache = getMetadataCache();
 	if (cache.cachedSimpleName != null) {
 		String cachedSimpleName = cache.cachedSimpleName.get();
@@ -4193,11 +4193,11 @@ public String getSimpleName() {
  * @see #isLocalClass()
  */
 public String getCanonicalName() {
-/*[IF JAVA_SPEC_VERSION >= 21]*/
+/*[IF JAVA_SPEC_VERSION == 21]*/
 	if (isUnnamedClass()) {
 		return null;
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+/*[ENDIF] JAVA_SPEC_VERSION == 21 */
 	MetadataCache cache = getMetadataCache();
 	if (cache.cachedCanonicalName != null) {
 		String cachedCanonicalName = cache.cachedCanonicalName.get();
@@ -5795,10 +5795,10 @@ SecurityException {
 		return AccessFlag.maskToAccessFlags(rawModifiers, location);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 20 */
-/*[IF JAVA_SPEC_VERSION >= 21]*/
+/*[IF JAVA_SPEC_VERSION == 21]*/
 	/**
 	 * Answers true if the class is an unnamed class.
-	 * @return	true if the class is an unnamed class, and false otherwise.
+	 * @return true if the class is an unnamed class, and false otherwise
 	 *
 	 * @since 21
 	 */
@@ -5814,7 +5814,7 @@ SecurityException {
 		}
 		return rc;
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+/*[ENDIF] JAVA_SPEC_VERSION == 21 */
 /*[IF JAVA_SPEC_VERSION >= 22]*/
 	/**
 	 * Returns the Class object with the given primitive type name.


### PR DESCRIPTION
It was part of a preview feature that is not present in Java 22+.
See:
* https://bugs.openjdk.org/browse/JDK-8319044
* https://github.com/ibmruntimes/openj9-openjdk-jdk22/commit/fbb1f0a307c9ef2e3def4f689a4792d9ccf581ad