### PR TITLE
Fix asm.jar path mismatch in valuetype tests

### DIFF
--- a/test/functional/cmdLineTests/valuetypeddrtests/build.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/build.xml
@@ -27,7 +27,8 @@
 	<description>
 		Build valuetype ddr tests
 	</description>
-
+	<property name="LIB" value="asm_all,testng,jcommander" />
+	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
 
 	<!-- set properties for this build -->
@@ -40,7 +41,7 @@
 		</copy>
 	</target>
 
-	<target name="build" depends="buildCmdLineTestTools">
+	<target name="build" depends="buildCmdLineTestTools,getDependentLibs">
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
 			<then>

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -35,9 +35,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
-			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
-			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DASMJAR=$(Q)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
@@ -74,9 +74,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
-			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
-			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DASMJAR=$(Q)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
@@ -114,9 +114,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DOPT=-Xint \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
-			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
-			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DASMJAR=$(Q)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
@@ -154,9 +154,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 			-DOPT=-Xjit \
 			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
-			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
-			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DASMJAR=$(Q)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \


### PR DESCRIPTION
related: https://github.com/eclipse-openj9/openj9/pull/18597#issuecomment-1885142840