### PR TITLE
Make JVM_VirtualThreadDisableSuspend() available for jdk22

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -442,11 +442,6 @@ if(JAVA_SPEC_VERSION LESS 22)
 else()
 	jvm_add_exports(jvm
 		JVM_ExpandStackFrameInfo
-	)
-endif()
-
-if(NOT JAVA_SPEC_VERSION LESS 23)
-	jvm_add_exports(jvm
 		JVM_VirtualThreadDisableSuspend
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -450,10 +450,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk22">
 		<!-- Additions for Java 22 (General) -->
 		<export name="JVM_ExpandStackFrameInfo"/>
-	</exports>
-
-	<exports group="jdk23">
-		<!-- Additions for Java 23 (General) -->
 		<export name="JVM_VirtualThreadDisableSuspend"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -724,14 +724,14 @@ JVM_ExpandStackFrameInfo(JNIEnv *env, jobject object)
 {
 	assert(!"JVM_ExpandStackFrameInfo unimplemented");
 }
-#endif /* JAVA_SPEC_VERSION >= 22 */
 
-#if JAVA_SPEC_VERSION >= 23
 JNIEXPORT void JNICALL
 JVM_VirtualThreadDisableSuspend(JNIEnv *env, jobject vthread, jboolean enter)
 {
-	assert(!"JVM_VirtualThreadDisableSuspend unimplemented");
+	/* TODO: Add implementation.
+	 * See https://github.com/eclipse-openj9/openj9/issues/18671 for more details.
+	 */
 }
-#endif /* JAVA_SPEC_VERSION >= 23 */
+#endif /* JAVA_SPEC_VERSION >= 22 */
 
 } /* extern "C" */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -85,9 +85,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk22">
 				<include-if condition="spec.java22"/>
 			</group>
-			<group name="jdk23">
-				<include-if condition="spec.java23"/>
-			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -428,5 +428,5 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
-_IF([JAVA_SPEC_VERSION >= 23],
+_IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])


### PR DESCRIPTION
The function will be needed in the next jdk22 build; see
* [8311218: fatal error: stuck in JvmtiVTMSTransitionDisabler::VTMS_transition_disable](https://github.com/ibmruntimes/openj9-openjdk-jdk22/commit/a5df744ebd27e3798a2026cc6fda50edb09e16f9)

The back-port to jdk22 was anticipated in https://github.com/eclipse-openj9/openj9/issues/18671.