### PR TITLE
[0.43.0] Disable simplifying j9Class to j.l.Class to j9Class

### DIFF
--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -1203,8 +1203,13 @@ J9::Simplifier::simplifyIndirectLoadPatterns(TR::Node *node)
 
          TR::SymbolReference *childSymref = firstChild->getSymbolReference();
 
+         // Temporarily disable simplification of j9class->java/lang/Class->j9class to j9class
+         // The potential introduction of an l2a is causing problems for l2aEvaluator,
+         // which makes the assumption that l2a is only used for compressed references
+#if 0
          if (symRefPairMatches(nodeSymref, childSymref, getSymRefTab()->findClassFromJavaLangClassSymbolRef(), getSymRefTab()->findJavaLangClassFromClassSymbolRef()))
             fieldsAreComplementary = true;
+#endif
 
          if (symRefPairMatches(nodeSymref, childSymref, getSymRefTab()->findClassFromJavaLangClassAsPrimitiveSymbolRef(), getSymRefTab()->findJavaLangClassFromClassSymbolRef()))
             fieldsAreComplementary = true;


### PR DESCRIPTION
Tree Simplification recognizes an indirect load that gets a `java/lang/Class` from a `j9Class` pointer, and then gets the `j9Class` pointer from that `java/lang/Class`, can be simplified to refer to the original `j9Class` pointer itself.  However, that introduces an `l2a` operation which causes problems for Code Generation's `l2aEvaluators`, as they assume that `l2a` operations are only used for compressed references.  Until the two different kinds of conversions of integers to addresses can be distinguished from one another &mdash; as described in eclipse/omr#6508 &mdash; this transformation in Tree Simplification will be disabled.

This delivers the contents of pull request #18743 to the 0.43.0-release branch.