### PR TITLE
Eliminate dark matter before determining classes to recreate

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1131,6 +1131,7 @@ redefineClassesCommon(jvmtiEnv* env,
 	J9HashTable * methodEquivalences = NULL;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	j9object_t memberNamesToFix = NULL;
+	UDATA savedAllowUserHeapWalkFlag = 0;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9JVMTIHCRJitEventData jitEventData;
@@ -1224,28 +1225,29 @@ redefineClassesCommon(jvmtiEnv* env,
 		}
 	}
 
-	/* Determine all ROM classes which need a new RAM class, and pair them with their current RAM class */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	/* Eliminate dark matter so that none will be encountered in prepareToFixMemberNames(). */
+	savedAllowUserHeapWalkFlag = vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
+	vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
 
+	/* This is to help with Metronome to avoid requesting Exclusive if we already have SafePoint, which may not look as Exclusive to the requester thread */
+	vm->alreadyHaveExclusive = TRUE;
+
+	vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_EXCLUSIVE_VMACCESS_ALREADY_ACQUIRED);
+
+	vm->alreadyHaveExclusive = FALSE;
+
+	if (0 == savedAllowUserHeapWalkFlag) {
+		/* Clear the flag to restore its original value. */
+		vm->requiredDebugAttributes &= ~J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
+	/* Determine all ROM classes which need a new RAM class, and pair them with their current RAM class. */
 	rc = determineClassesToRecreate(currentThread, class_count, specifiedClasses, &classPairs,
 			&methodPairs, jitEventDataPtr, !extensionsEnabled);
 	if (rc == JVMTI_ERROR_NONE) {
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-		/* Eliminate dark matter so that none will be encountered in prepareToFixMemberNames(). */
-		UDATA savedAllowUserHeapWalkFlag = vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
-		vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
-
-		/* This is to help with Metronome to avoid requesting Exclusive if we already have SafePoint, which may not look as Exclusive to the requester thread */
-		vm->alreadyHaveExclusive = TRUE;
-
-		vm->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_EXCLUSIVE_VMACCESS_ALREADY_ACQUIRED);
-
-		vm->alreadyHaveExclusive = FALSE;
-
-		if (0 == savedAllowUserHeapWalkFlag) {
-			/* Clear the flag to restore its original value. */
-			vm->requiredDebugAttributes &= ~J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
-		}
-
 		/* Identify the MemberNames needing fix-up based on classPairs. */
 		memberNamesToFix = prepareToFixMemberNames(currentThread, classPairs);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */


### PR DESCRIPTION
Eliminating dark matter before determining classes to recreate prevents
dying and unloaded classes to be encountered while recreating RAM
classes.

Related: #18750