### PR TITLE
Check null value and null object ref in zero flattened field count

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -301,10 +301,9 @@
 			<variation>-Xint -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
 			<variation>-Xint -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-Xjit:count=0</variation>
-			<!-- https://github.com/eclipse-openj9/openj9/issues/18742 -->
-			<!--<variation>-Xjit:count=1,disableAsyncCompilation</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
 			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
-			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation> -->
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \


### PR DESCRIPTION
There is a corner case where the flattened field count can be 0. For example,
```
class B {}

class A {
  B field;
}
```
If `field` is flattened in class A, the flattened field count in `TR::TypeLayout` for A is 0 in this case.

The spec on `putfield` requires
- NPE is thrown if object ref is null
- NPE is thrown if the field is null restricted field and the value being stored is null

Fixes: #18742