### PR TITLE
(0.43) Don't cache instances of TemporaryLoggerFinder for jdk21

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1803,11 +1803,9 @@ public abstract static class LoggerFinder {
 								AccessController.getContext(),
 								com.ibm.oti.util.RuntimePermissions.permissionLoggerFinder);
 			/*[IF JAVA_SPEC_VERSION >= 11]*/
-			/*[IF JAVA_SPEC_VERSION != 21] Temporary until jdk21 picks up the OpenJDK change */
 			if (localFinder instanceof jdk.internal.logger.LoggerFinderLoader.TemporaryLoggerFinder) {
 				return localFinder;
 			}
-			/*[ENDIF] JAVA_SPEC_VERSION != 21 */
 			/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			loggerFinder = localFinder;
 		}


### PR DESCRIPTION
The OpenJDK change was added in 21.0.2

Related to
https://github.com/eclipse-openj9/openj9/pull/18406
https://github.com/ibmruntimes/openj9-openjdk-jdk21/commit/dd964e7a71b

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/18768 for 0.43