### PR TITLE
(0.43) Use jdk21 to build jdk21 and later versions

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -155,8 +155,8 @@ boot_jdk_default:
       8: '8'
       11: '11'
       17: '17'
-      21: '20'
-      next: '20'
+      21: '21'
+      next: '21'
     dir_strip:
       all: '1'
     url:


### PR DESCRIPTION
See also https://github.com/eclipse-openj9/openj9/pull/18766