### PR TITLE
Enable OJDK MHs in JDK8+

### DIFF
--- a/buildspecs/core.feature
+++ b/buildspecs/core.feature
@@ -112,12 +112,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="opt_inlineJsrs" value="true"/>
 		<flag id="opt_jfr" value="false"/>
 		<flag id="opt_jitserver" value="false"/>
-		<flag id="opt_methodHandle" value="true"/>
+		<flag id="opt_methodHandle" value="false"/>
 		<flag id="opt_methodHandleCommon" value="true"/>
 		<flag id="opt_newObjectHash" value="true"/>
 		<flag id="opt_newRomClassBuilder" value="true"/>
 		<flag id="opt_openjdkFfi" value="true"/>
-		<flag id="opt_openjdkMethodhandle" value="false"/>
+		<flag id="opt_openjdkMethodhandle" value="true"/>
 		<flag id="opt_phpSupport" value="false"/>
 		<flag id="opt_romImageSupport" value="true"/>
 		<flag id="opt_useOmrDdr" value="false"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -51,7 +51,7 @@
 	<configuration
 		  label="SIDECAR18-SE"
 		  outputpath="SIDECAR18-SE/src"
-		  flags="Sidecar18-SE,Sidecar70_27,Sidecar17,Sidecar16,SharedClasses"
+		  flags="Sidecar18-SE,Sidecar70_27,Sidecar17,Sidecar16,SharedClasses,OPENJDK_METHODHANDLES"
 		  jdkcompliance="1.8">
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun180.jar"/>
 		<source path="src/java.base/share/classes"/>
@@ -131,7 +131,6 @@
 	<configuration
 		  label="JAVA17"
 		  outputpath="JAVA17/src"
-		  flags="OPENJDK_METHODHANDLES"
 		  dependencies="JAVA11"
 		  jdkcompliance="17">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>


### PR DESCRIPTION
OJDK MHs are already enabled in JDK17+.

This PR enables OJDK MHs in JDK8 and JDK11.