### PR TITLE
JDK22 adds PinnedThreadPrinter.printStackTrace(out, reason, printAll)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
+++ b/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
@@ -27,9 +27,9 @@ import java.lang.StackWalker.StackFrame;
 import java.lang.StackWalker.StackFrameImpl;
 import java.util.List;
 import java.util.stream.Collectors;
-/*[IF JAVA_SPEC_VERSION >= 23]*/
+/*[IF JAVA_SPEC_VERSION >= 22]*/
 import jdk.internal.vm.Continuation;
-/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 /**
  * Prints the stack trace of a pinned thread that is attempting to yield.
@@ -57,10 +57,10 @@ final class PinnedThreadPrinter {
 		}
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 23]*/
+/*[IF JAVA_SPEC_VERSION >= 22]*/
 	static void printStackTrace(PrintStream out, Continuation.Pinned reason, boolean printAll) {
 		out.println(Thread.currentThread() + " reason:" + reason); //$NON-NLS-1$
 		printStackTraceHelper(out, printAll);
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 }


### PR DESCRIPTION
Extend #18716 to Java 22.

Acceptance build is failing (e.g. https://openj9-jenkins.osuosl.org/job/Build_JDK22_x86-64_linux_OpenJDK22/27):
```
[2024-01-19T04:30:05.994Z] /home/jenkins/workspace/Build_JDK22_x86-64_linux_OpenJDK22/src/java.base/share/classes/java/lang/VirtualThread.java:205: error: method printStackTrace in class PinnedThreadPrinter cannot be applied to given types;
[2024-01-19T04:30:05.994Z]                     PinnedThreadPrinter.printStackTrace(System.out, reason, printAll);
[2024-01-19T04:30:05.994Z]                                        ^
[2024-01-19T04:30:05.994Z]   required: PrintStream,boolean
[2024-01-19T04:30:05.994Z]   found:    PrintStream,Pinned,boolean
[2024-01-19T04:30:05.994Z]   reason: actual and formal argument lists differ in length
```