### PR TITLE
Prepare for value objects to be created with new bytecode

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -728,8 +728,8 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       if (clazz == NULL)
          return -1;
 
-      // Arrays of primitive value type classes must have all their elements initialized with the
-      // default value of the component type.  For now, prevent inline allocation of them.
+      // Arrays of null-restricted (a.k.a, primitive value type) classes must have all their elements initialized
+      // with the default value of the component type.  For now, prevent inline allocation of them.
       //
       if (areValueTypesEnabled && TR::Compiler->cls.isPrimitiveValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
          {

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -123,6 +123,12 @@ J9::ObjectModel::areValueTypesEnabled()
    }
 
 bool
+J9::ObjectModel::areValueTypeInstancesCreatedWithBCNew()
+   {
+   return false;
+   }
+
+bool
 J9::ObjectModel::areFlattenableValueTypesEnabled()
    {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -63,25 +63,36 @@ public:
    bool mayRequireSpineChecks();
 
    /**
-   * @brief Whether or not value object is enabled
-   */
+    * @brief Whether or not value object is enabled
+    */
    bool areValueTypesEnabled();
+
    /**
-   * @brief Whether or not flattenable value object (aka null restricted) type is enabled
-   */
+    * \brief Indicates whether \c new bytecode can create value type instances
+    *
+    * \returns \c true if \c new creates value type instances; or
+    *          \c false if \c aconst_init and \c withfield create value type instances.
+    */
+   bool areValueTypeInstancesCreatedWithBCNew();
+
+   /**
+    * @brief Whether or not flattenable value object (aka null restricted) type is enabled
+    */
    bool areFlattenableValueTypesEnabled();
+
    /**
-   * @brief Whether or not `Q` signature is supported
-   */
+    * @brief Whether or not `Q` signature is supported
+    */
    bool isQDescriptorForValueTypesSupported();
 
    /**
-   * @brief Whether the check is enabled on monitor object being value based class type
-   */
+    * @brief Whether the check is enabled on monitor object being value based class type
+    */
    bool areValueBasedMonitorChecksEnabled();
+
    /**
-   * @brief Whether the array flattening is enabled for value types
-   */
+    * @brief Whether the array flattening is enabled for value types
+    */
    bool isValueTypeArrayFlatteningEnabled();
 
    int32_t sizeofReferenceField();

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -552,7 +552,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
 
          case J9BCaconst_init:
             {
-            if (TR::Compiler->om.areValueTypesEnabled())
+            if (TR::Compiler->om.areValueTypesEnabled() && !TR::Compiler->om.areValueTypeInstancesCreatedWithBCNew())
                {
                genAconst_init(next2Bytes());
                _bcIndex += 3;
@@ -564,7 +564,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
             break;
             }
          case J9BCwithfield:
-            if (TR::Compiler->om.areValueTypesEnabled())
+            if (TR::Compiler->om.areValueTypesEnabled() && !TR::Compiler->om.areValueTypeInstancesCreatedWithBCNew())
                {
                genWithField(next2Bytes());
                _bcIndex += 3;
@@ -6129,6 +6129,12 @@ TR_J9ByteCodeIlGenerator::genNew(TR::ILOpCodes opCode)
    if (!node->getFirstChild()->getSymbolReference()->isUnresolved() && node->getFirstChild()->getSymbol()->isStatic())
       {
       TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock*)node->getFirstChild()->getSymbol()->castToStaticSymbol()->getStaticAddress();
+
+      if (TR::Compiler->cls.isValueTypeClass(clazz) && TR::Compiler->om.areValueTypeInstancesCreatedWithBCNew())
+         {
+         node->setIdentityless(true);
+         }
+
       int32_t len;
       char *sig;
       sig = TR::Compiler->cls.classSignature_DEPRECATED(comp(), clazz, len, comp()->trMemory());

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -191,7 +191,15 @@ bool TR_EscapeAnalysis::isImmutableObject(TR::Node *node)
       return false;
       }
 
-   char *className = getClassName(node->getFirstChild());
+   TR::Node *classNode = node->getFirstChild();
+
+   TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *)classNode->getSymbol()->getStaticSymbol()->getStaticAddress();
+   if (TR::Compiler->cls.isValueTypeClass(clazz))
+      {
+      return true;
+      }
+
+   char *className = getClassName(classNode);
 
    if (NULL != className &&
           !strncmp("java/lang/", className, 10) &&


### PR DESCRIPTION
This change sets up changes to the JIT compiler that will be needed to permit value objects to be created with the `new` bytecode.  Previously they could only be created with the `aconst_init` and `withfield` bytecode instructions.  The `new` bytecode will be translated to the `TR::New` opcode in IL, but existing optimizations that create value type instances will continue to use the `TR::newvalue` opcode, so optimizations need to be prepared for both possibilities for now.

A new `J9::ObjectModel::areValueTypeInstancesCreatedWithBCNew` method is used to enable creation of value type instances with the new bytecode.

This change will require a co-ordinated merge with OMR pull request eclipse/omr#7239