### PR TITLE
Ensure ROM class cache shutdown is necessary

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1226,6 +1226,8 @@ ClientSessionHT::purgeOldDataIfNeeded()
             oldAge = OLD_AGE_UNDER_LOW_MEMORY; //memory is low
             }
          }
+
+      bool hadExistingClients = !_clientSessionMap.empty();
       // Time for a purge operation.
       // Scan the entire table and delete old elements that are not in use
       for (auto iter = _clientSessionMap.begin(); iter != _clientSessionMap.end(); ++iter)
@@ -1241,8 +1243,8 @@ ClientSessionHT::purgeOldDataIfNeeded()
             _clientSessionMap.erase(iter); // delete the mapping from the hashtable
             }
          }
-      // If all the clients were deleted, shut down the shared ROMClass cache
-      if (_clientSessionMap.empty())
+      // If the purge operation was responsible for deleting the last client sessions, shut down the shared ROM class cache as well
+      if (hadExistingClients && _clientSessionMap.empty())
          {
          if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
             cache->shutdown();


### PR DESCRIPTION
In #18656, I did not check to see if any clients were actually deleted in the purge operation. If none were, then the shared ROM class cache would necessarily have been shut down already. Attempting to shut it down again would lead to a segfault. Checking if the purge operation was responsible for deleting the last clients before shutting down the shared ROM class cache avoids this issue.

Attn @mpirvu.