### PR TITLE
Optimize primitive unboxing method calls

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -155,10 +155,19 @@
    java_lang_Float_init,
    java_lang_Double_init,
    java_lang_String_init,
-
    // When adding a new recognized constructor for one of the immutable classes listed above you must also
    // properly alias the recognized constructor in TR::SymbolReferenceTable::immutableConstructorId. Otherwise
    // the JIT may consider the new constructor as side-effect free which will result in invalid transformations.
+
+   // Unboxing methods
+   java_lang_Boolean_booleanValue,
+   java_lang_Byte_byteValue,
+   java_lang_Character_charValue,
+   java_lang_Short_shortValue,
+   java_lang_Integer_intValue,
+   java_lang_Long_longValue,
+   java_lang_Float_floatValue,
+   java_lang_Double_doubleValue,
 
    java_lang_String_init_String_char,
    java_lang_String_init_String,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2122,6 +2122,7 @@ void TR_ResolvedJ9Method::construct()
 
    static X DoubleMethods[] =
       {
+      {x(TR::java_lang_Double_doubleValue, "doubleValue", "()D")},
       {x(TR::java_lang_Double_longBitsToDouble, "longBitsToDouble", "(J)D")},
       {x(TR::java_lang_Double_doubleToLongBits, "doubleToLongBits", "(D)J")},
       {x(TR::java_lang_Double_doubleToRawLongBits, "doubleToRawLongBits", "(D)J")},
@@ -2131,6 +2132,7 @@ void TR_ResolvedJ9Method::construct()
 
    static X FloatMethods[] =
       {
+      {x(TR::java_lang_Float_floatValue, "floatValue", "()F")},
       {x(TR::java_lang_Float_intBitsToFloat, "intBitsToFloat", "(I)F")},
       {x(TR::java_lang_Float_floatToIntBits, "floatToIntBits", "(F)I")},
       {x(TR::java_lang_Float_floatToRawIntBits, "floatToRawIntBits", "(F)I")},
@@ -3265,6 +3267,7 @@ void TR_ResolvedJ9Method::construct()
 
    static X IntegerMethods[] =
       {
+      {x(TR::java_lang_Integer_intValue,                "intValue",              "()I")},
       {x(TR::java_lang_Integer_bitCount,                "bitCount",              "(I)I")},
       {x(TR::java_lang_Integer_highestOneBit,           "highestOneBit",         "(I)I")},
       {x(TR::java_lang_Integer_lowestOneBit,            "lowestOneBit",          "(I)I")},
@@ -3285,6 +3288,7 @@ void TR_ResolvedJ9Method::construct()
 
    static X LongMethods[] =
       {
+      {x(TR::java_lang_Long_longValue,                  "longValue",             "()J")},
       {x(TR::java_lang_Long_bitCount,                   "bitCount",              "(J)I")},
       {x(TR::java_lang_Long_highestOneBit,              "highestOneBit",         "(J)J")},
       {x(TR::java_lang_Long_lowestOneBit,               "lowestOneBit",          "(J)J")},
@@ -3304,6 +3308,7 @@ void TR_ResolvedJ9Method::construct()
    static X BooleanMethods[] =
       {
       {  TR::java_lang_Boolean_init,          6,    "<init>", (int16_t)-1,    "*"},
+      {x(TR::java_lang_Boolean_booleanValue,            "booleanValue",          "()Z")},
       {  TR::unknownMethod}
       };
 
@@ -3316,6 +3321,7 @@ void TR_ResolvedJ9Method::construct()
    static X CharacterMethods[] =
       {
       {  TR::java_lang_Character_init,          6,    "<init>", (int16_t)-1,    "*"},
+      {x(TR::java_lang_Character_charValue,           "charValue",            "()C")},
       {x(TR::java_lang_Character_isDigit,             "isDigit",              "(I)Z")},
       {x(TR::java_lang_Character_isLetter,            "isLetter",             "(I)Z")},
       {x(TR::java_lang_Character_isUpperCase,         "isUpperCase",          "(I)Z")},
@@ -3345,12 +3351,14 @@ void TR_ResolvedJ9Method::construct()
 
    static X ByteMethods[] =
       {
+      {x(TR::java_lang_Byte_byteValue, "byteValue", "()B")},
       {  TR::java_lang_Byte_init,          6,    "<init>", (int16_t)-1,    "*"},
       {  TR::unknownMethod}
       };
 
    static X ShortMethods[] =
       {
+      {x(TR::java_lang_Short_shortValue, "shortValue", "()S")},
       {x(TR::java_lang_Short_reverseBytes,             "reverseBytes",         "(S)S")},
       {  TR::java_lang_Short_init,          6,    "<init>", (int16_t)-1,    "*"},
       {  TR::unknownMethod}


### PR DESCRIPTION
Boxed primitive classes have a method that unboxes their value, which are implemented as simple getter methods. These methods are marked as @IntrinsicCandidates, intended for simplification by the compiler.

This commit recognizes the primitive unboxing methods and generates simplified IL during IL generation instead of emitting the call where possible.