### PR TITLE
0.42.0 Release note updated -XX:[+|-]CRIUSecProvider option

### DIFF
--- a/doc/release-notes/0.42/0.42.md
+++ b/doc/release-notes/0.42/0.42.md
@@ -67,6 +67,13 @@ The following table covers notable changes in v0.42.0. Further information about
 <td valign="top">All versions</td>
 <td valign="top">The VM uses heuristics to decide whether to collect interpreter profiling information during the VM startup. You can now overrule the heuristics and control the collection of the profiling information during the startup phase by using the <tt>-XX:[+|-]IProfileDuringStartupPhase</tt> option.</td>
 </tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/18354">#18354</a></td>
+<td valign="top">The <tt>-XX:[+|-]CRIUSecProvider</tt> option is added to control the use of <tt>CRIUSECProvider</tt> during the checkpoint phase.</td>
+<td valign="top">OpenJDK 21 (Linux&reg;)</td>
+<td valign="top">When you enable CRIU support, all the existing security providers are removed from the security provider list during the checkpoint phase and <tt>CRIUSECProvider</tt> is added by default. Therefore, you can use only those security algorithms that are available in <tt>CRIUSECProvider</tt>. You can now choose to disable the use of <tt>CRIUSECProvider</tt> with the <tt>-XX:-CRIUSecProvider</tt> option and continue to use all the existing security providers during the checkpoint and restore phase.</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1244

0.42.0 release note updated with the new option -XX:[+|-]CRIUSecProvider

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com