### PR TITLE
Update 0.41.0 release note - JITServer supported for Linux on AArch64

### DIFF
--- a/doc/release-notes/0.41/0.41.md
+++ b/doc/release-notes/0.41/0.41.md
@@ -98,6 +98,13 @@ Now, with the change in behavior of the <tt>-Xshareclasses:readonly</tt> option,
 <td valign="top">All versions (All operating systems except z/OS&reg;)</td>
 <td valign="top">In the earlier releases, thread memory allocation measurement was not supported. With this release, the OpenJ9 VM implementation supports thread memory allocation measurement (<tt>com.sun.management.ThreadMXBean.getThreadAllocatedBytes()</tt> API). The <tt>isThreadAllocatedMemorySupported()</tt> method now returns true instead of false. The <tt>setThreadAllocatedMemoryEnabled()</tt> and <tt>isThreadAllocatedMemoryEnabled()</tt> methods do not throw the "UnsupportedOperationException" error now and are enabled by default.</td>
 </tr>
+<tr><td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/18717">#18717</td>
+<td valign="top">JITServer technology is now a supported feature for Linux on AArch64.
+
+ Linux on IBM Z&reg; systems are supported since version 0.32.0 and Linux on x86-64 and Linux on Power&reg; (Little Endian) are supported since version 0.29.0.</td>
+<td valign="top">All versions (Linux on AArch64)</td>
+<td valign="top">JITServer decouples the JIT compiler from the OpenJ9 VM, freeing up CPU and memory for an application. JITServer then runs in its own process, either locally or on a remote machine, where resources can be separately managed.</td>
+</tr>
 
 </tbody>
 </table>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1243

Updated the release note. JITServer technology is now a supported feature for Linux on AArch64

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com