### PR TITLE
Fix interpretation of compressed strings

### DIFF
--- a/runtime/jcl/common/jclreflect.c
+++ b/runtime/jcl/common/jclreflect.c
@@ -28,12 +28,12 @@ compareJavaStringToPartialUTF8(J9VMThread * vmThread, j9object_t string, U_8 * u
 {
 	UDATA unicodeLength = J9VMJAVALANGSTRING_LENGTH(vmThread, string);
 	j9object_t unicodeBytes = J9VMJAVALANGSTRING_VALUE(vmThread, string);
-	UDATA i;
+	UDATA i = 0;
 
 	if (IS_STRING_COMPRESSED(vmThread, string)) {
 		for (i = 0; i < unicodeLength; i++) {
-			U_16 utfChar;
-			U_32 count;
+			U_16 utfChar = 0;
+			U_32 count = 0;
 
 			/* If the String is longer than the UTF, then they don't match */
 
@@ -51,14 +51,14 @@ compareJavaStringToPartialUTF8(J9VMThread * vmThread, j9object_t string, U_8 * u
 			if (utfChar == '/') {
 				utfChar = '.';
 			}
-			if (utfChar != J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i)) {
+			if (utfChar != (U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i)) {
 				return FALSE;
 			}
 		}
 	} else {
 		for (i = 0; i < unicodeLength; i++) {
-			U_16 utfChar;
-			U_32 count;
+			U_16 utfChar = 0;
+			U_32 count = 0;
 
 			/* If the String is longer than the UTF, then they don't match */
 
@@ -84,5 +84,3 @@ compareJavaStringToPartialUTF8(J9VMThread * vmThread, j9object_t string, U_8 * u
 
 	return TRUE;
 }
-
-

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -1750,9 +1750,10 @@ static jvmtiIterationControl
 wrap_stringPrimitiveCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData)
 {
 	jvmtiIterationControl rc = JVMTI_ITERATION_ABORT;
-	jlong tag;
-	jint stringLength, i;
-	jchar * stringValue;
+	jlong tag = 0;
+	jint stringLength = 0;
+	jint i = 0;
+	jchar * stringValue = NULL;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	j9object_t bytes = J9VMJAVALANGSTRING_VALUE(iteratorData->currentThread, iteratorData->object);
 	UDATA offset = 0;
@@ -1774,7 +1775,7 @@ wrap_stringPrimitiveCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData)
 		/* Decompress the string byte at a time, this probably can't be
 		 */
 		for (i = 0; i < stringLength; i++) {
-			stringValue[i] = J9JAVAARRAYOFBYTE_LOAD(iteratorData->currentThread, bytes, offset);
+			stringValue[i] = (U_8)J9JAVAARRAYOFBYTE_LOAD(iteratorData->currentThread, bytes, offset);
 			offset++;
 		}
 	} else {

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -125,7 +125,7 @@ classHashEqualFn(void *tableNode, void *queryNode, void *userData)
 	BOOLEAN isTableNodeHiddenClass = (TYPE_CLASS == tableNodeType)
 									&& (TAG_RAM_CLASS == (tableNodeTag & MASK_RAM_CLASS))
 									&& J9ROMCLASS_IS_HIDDEN(((KeyHashTableClassEntry*)tableNode)->ramClass->romClass);
-	
+
 	if (isTableNodeHiddenClass) {
 		/* Hidden class is keyed on its rom address, not on its name. */
 		PORT_ACCESS_FROM_JAVAVM(javaVM);
@@ -149,7 +149,7 @@ classHashEqualFn(void *tableNode, void *queryNode, void *userData)
 				U_8 c = 0;
 
 				if (isCompressed) {
-					unicode = J9JAVAARRAYOFBYTE_LOAD_VM(javaVM, charArray, i);
+					unicode = (U_8)J9JAVAARRAYOFBYTE_LOAD_VM(javaVM, charArray, i);
 				} else {
 					unicode = J9JAVAARRAYOFCHAR_LOAD_VM(javaVM, charArray, i);
 				}
@@ -246,7 +246,7 @@ classHashFn(void *key, void *userData)
 
 			if (IS_STRING_COMPRESSED_VM(javaVM, stringObject)) {
 				while (i < end) {
-					hash = (hash << 5) - hash + J9JAVAARRAYOFBYTE_LOAD_VM(javaVM, charArray, i);
+					hash = (hash << 5) - hash + (U_8)J9JAVAARRAYOFBYTE_LOAD_VM(javaVM, charArray, i);
 					++i;
 				}
 			} else {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -75,8 +75,8 @@ compareCompressedUnicode(J9VMThread *vmThread, j9object_t unicodeBytes1, j9objec
 	if (unicodeBytes1 != unicodeBytes2) {
 		UDATA i = 0;
 		while (0 != length) {
-			U_16 unicodeChar1 = (U_16)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes1, i);
-			U_16 unicodeChar2 = (U_16)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes2, i);
+			U_16 unicodeChar1 = (U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes1, i);
+			U_16 unicodeChar2 = (U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes2, i);
 			if (unicodeChar1 != unicodeChar2) {
 				result = 0;
 				break;
@@ -103,7 +103,7 @@ compareCompressedUnicodeToUncompressedUnicode(J9VMThread *vmThread, j9object_t u
 	UDATA i = 0;
 	while (0 != length) {
 		U_16 unicodeChar1 = J9JAVAARRAYOFCHAR_LOAD(vmThread, unicodeBytes1, i);
-		U_16 unicodeChar2 = (U_16)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes2, i);
+		U_16 unicodeChar2 = (U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes2, i);
 		if (unicodeChar1 != unicodeChar2) {
 			result = 0;
 			break;
@@ -129,7 +129,7 @@ compareStrings(J9VMThread *vmThread, j9object_t string1, j9object_t string2)
 		UDATA stringLength1 = J9VMJAVALANGSTRING_LENGTH(vmThread, string1);
 		UDATA stringLength2 = J9VMJAVALANGSTRING_LENGTH(vmThread, string2);
 
-	        if (stringLength1 != stringLength2) {
+		if (stringLength1 != stringLength2) {
 			result = 0;
 		} else {
 			j9object_t unicodeBytes1 = J9VMJAVALANGSTRING_VALUE(vmThread, string1);
@@ -177,8 +177,8 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 
 	if (IS_STRING_COMPRESSED(vmThread, string)) {
 		while ((tmpUtfLength != 0) && (tmpStringLength != 0)) {
-			U_16 unicodeChar = (U_16)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i);
-			U_16 utfChar;
+			U_16 unicodeChar = (U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i);
+			U_16 utfChar = 0;
 			UDATA consumed = decodeUTF8Char(tmpUtfData, &utfChar);
 
 			if (translateDots) {


### PR DESCRIPTION
Cast `J9JAVAARRAYOFBYTE_LOAD()` to `U_8` where appropriate.

Fixes: #18791.