### PR TITLE
Warning when checkpointGCthreadCount conflicts with gcThread

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -172,7 +172,9 @@ public:
 		MM_UserSpecifiedParameterUDATA _Xmns; /**< Initial value of -Xmns specified by the user */
 		MM_UserSpecifiedParameterUDATA _Xmnx; /**< Initial value of -Xmnx specified by the user */
 		MM_UserSpecifiedParameterUDATA _Xmx; /**< Initial value of -Xmx specified by the user */
-
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		MM_UserSpecifiedParameterUDATA _checkpointGCThreads; /**< Initial value of -XX:CheckpointGCThreads specified by the user */
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	private:
 	protected:
 	public:
@@ -181,6 +183,9 @@ public:
 			, _Xmns()
 			, _Xmnx()
 			, _Xmx()
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+			, _checkpointGCThreads()
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 		{
 		}
 	};

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3200,9 +3200,8 @@ gcReinitializeDefaultsForRestore(J9VMThread* vmThread)
 	 */
 	extensions->usablePhysicalMemory = omrsysinfo_get_addressable_physical_memory();
 	/* If the thread count is being forced, check its validity and display a warning message if it is invalid, then mark it as invalid. */
-	if (extensions->gcThreadCountForced && (extensions->gcThreadCount < extensions->dispatcher->threadCountMaximum())) {
+	if (extensions->gcThreadCountSpecified && (extensions->gcThreadCount < extensions->dispatcher->threadCountMaximum())) {
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_GC_THREAD_VALUE_MUST_BE_ABOVE_WARN, (UDATA)extensions->dispatcher->threadCountMaximum());
-		extensions->gcThreadCountForced = false;
 	}
 
 	/**

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1435,7 +1435,7 @@ gcParseXXArguments(J9JavaVM *vm)
 		PORT_ACCESS_FROM_JAVAVM(vm);
 
 		if (-1 != FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, "-XX:CheckpointGCThreads=", NULL)) {
-			result = option_set_to_opt_integer(vm, "-XX:CheckpointGCThreads=", &index, EXACT_MEMORY_MATCH, &extensions->checkpointGCthreadCount);
+			result = option_set_to_opt_integer(vm, "-XX:CheckpointGCThreads=", &index, EXACT_MEMORY_MATCH, &extensions->userSpecifiedParameters._checkpointGCThreads._valueSpecified);
 			if (OPTION_OK != result) {
 				if (OPTION_MALFORMED == result) {
 					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_MUST_BE_NUMBER, "-XX:CheckpointGCThreads=");
@@ -1445,10 +1445,12 @@ gcParseXXArguments(J9JavaVM *vm)
 				goto _error;
 			}
 
-			if (0 == extensions->checkpointGCthreadCount) {
+			if (0 == extensions->userSpecifiedParameters._checkpointGCThreads._valueSpecified) {
 				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_MUST_BE_ABOVE, "-XX:CheckpointGCThreads=", (UDATA)0);
 				goto _error;
 			}
+			extensions->userSpecifiedParameters._checkpointGCThreads._wasSpecified = true;
+			extensions->checkpointGCthreadCount = extensions->userSpecifiedParameters._checkpointGCThreads._valueSpecified;
 		}
 	}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/nls/j9gc/j9modron.nls
+++ b/runtime/nls/j9gc/j9modron.nls
@@ -989,3 +989,22 @@ J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN.system_action=The
 J9NLS_GC_OPTIONS_HIERARCHICAL_SCAN_ORDERING_NOT_SUPPORTED_WARN.user_response=Refer to the OpenJ9 documentation for -Xgc:hierarchicalScanOrdering.
 
 # END NON-TRANSLATABLE
+
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN=-XX:CheckpointGCThreads will be ignored. The specified value %zu must not be larger than user specified value of the total GC threads %zu using -Xgcthreads, -Xgcmaxthreads or -Xgc:threads
+# START NON-TRANSLATABLE
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN.explanation=-XX:CheckpointGCThreads must be smaller than or equal to the number of gc threads
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN.system_action=The JVM ignores the -XX:CheckpointGCThreads option.
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN.user_response=Refer to the OpenJ9 documentation and adjust -Xgcthreads/-XX:CheckpointGCThreads to make sure number of gc threads is larger than or equal to the number of checkpointgcthreads
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN.sample_input_1=6
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_SPECIFIED_GCTHREAD_VALUE_WARN.sample_input_2=4
+
+# END NON-TRANSLATABLE
+
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN=-XX:CheckpointGCThreads will be ignored. The specified value %zu must not be larger than calculated value of the total GC threads %zu
+# START NON-TRANSLATABLE
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN.explanation=-XX:CheckpointGCThreads must be smaller than or equal to the number of gc threads
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN.system_action=The JVM ignores the -XX:CheckpointGCThreads option.
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN.user_response=Refer to the OpenJ9 documentation and adjust -XX:CheckpointGCThreads to make sure number of gc threads is larger than or equal to the number of checkpointgcthreads
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN.sample_input_1=6
+J9NLS_CHECKPOINTGCTHREAD_VALUE_MUST_BE_AT_MOST_HEURISTIC_GCTHREAD_VALUE_WARN.sample_input_2=4
+# END NON-TRANSLATABLE


### PR DESCRIPTION
CheckpointGCthreadCount conflicts with gcThread Warning
CheckpointGCthreadCount is expected to be no larger than
the number of gc threads.

We have two cases here:
1. If the user doesn't set the checkpointGCthreadCount,
the amount is adjusted to match the number of gc threads

2. If the user sets the checkpointGCthreadCount, a warning
is generated and the checkpointGCthreadCount is ignored

Signed off by: Frank.Kang@ibm.com