### PR TITLE
Update signature of virtual thread support functions for jdk23+

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -575,7 +575,14 @@ JVM_GetClassFileVersion(JNIEnv *env, jclass cls)
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadHideFrames(JNIEnv *env, jobject vthread, jboolean hide)
+JVM_VirtualThreadHideFrames(
+		JNIEnv *env,
+#if JAVA_SPEC_VERSION >= 23
+		jclass clz,
+#else /* JAVA_SPEC_VERSION >= 23 */
+		jobject vthread,
+#endif /* JAVA_SPEC_VERSION >= 23 */
+		jboolean hide)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
@@ -591,8 +598,11 @@ JVM_VirtualThreadHideFrames(JNIEnv *env, jobject vthread, jboolean hide)
 	 */
 	bool hiddenFrames = J9_ARE_ALL_BITS_SET(currentThread->privateFlags, J9_PRIVATE_FLAGS_VIRTUAL_THREAD_HIDDEN_FRAMES);
 	if (hide) {
-		Assert_SC_true(!hiddenFrames && (vThreadObj == J9_JNI_UNWRAP_REFERENCE(vthread)));
-		enterVThreadTransitionCritical(currentThread, vthread);
+		Assert_SC_true(!hiddenFrames);
+#if JAVA_SPEC_VERSION < 23
+		Assert_SC_true(vThreadObj == J9_JNI_UNWRAP_REFERENCE(vthread));
+#endif /* JAVA_SPEC_VERSION < 23 */
+		enterVThreadTransitionCritical(currentThread, (jobject)&currentThread->threadObject);
 	}
 
 	VM_VMHelpers::virtualThreadHideFrames(currentThread, hide);
@@ -726,7 +736,14 @@ JVM_ExpandStackFrameInfo(JNIEnv *env, jobject object)
 }
 
 JNIEXPORT void JNICALL
-JVM_VirtualThreadDisableSuspend(JNIEnv *env, jobject vthread, jboolean enter)
+JVM_VirtualThreadDisableSuspend(
+		JNIEnv *env,
+#if JAVA_SPEC_VERSION >= 23
+		jclass clz,
+#else /* JAVA_SPEC_VERSION >= 23 */
+		jobject vthread,
+#endif /* JAVA_SPEC_VERSION >= 23 */
+		jboolean enter)
 {
 	/* TODO: Add implementation.
 	 * See https://github.com/eclipse-openj9/openj9/issues/18671 for more details.

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -410,8 +410,10 @@ _IF([(19 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 21)],
 	[_X(JVM_VirtualThreadUnmountEnd, JNICALL, false, void, JNIEnv *env, jobject thread, jboolean lastUnmount)])
 _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])
-_IF([JAVA_SPEC_VERSION >= 20],
+_IF([(20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
+_IF([JAVA_SPEC_VERSION >= 23],
+	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jclass clz, jboolean hide)])
 _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_IsForeignLinkerSupported, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 21],
@@ -428,5 +430,7 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
-_IF([JAVA_SPEC_VERSION >= 22],
+_IF([JAVA_SPEC_VERSION == 22],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])
+_IF([JAVA_SPEC_VERSION >= 23],
+	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jclass clz, jboolean enter)])


### PR DESCRIPTION
In jdk23+ these now implement static methods:
* `JVM_VirtualThreadDisableSuspend()`
* `JVM_VirtualThreadHideFrames()`

See https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/b219248e70dda501605ae717ac12a5b171bddb5b.