### PR TITLE
Do not add LambdaForm classes to SCC with OJDK MHs

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -182,6 +182,7 @@ public:
 	U_8 *classFileBytes() const { return _classFileBytes; }
 	UDATA classFileSize() const { return _classFileSize; }
 	UDATA findClassFlags() const {return _findClassFlags; }
+	void addFindClassFlags(UDATA flag) { _findClassFlags |= flag; }
 	U_8* className() const {return _className; }
 	UDATA classNameLength() const {return _classNameLength; }
 	U_8* hostPackageName() const {return _hostPackageName; }

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -114,21 +114,6 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 			 */
 			*options |= J9_FINDCLASS_FLAG_NAME_IS_INVALID;
 		}
-
-		if (J9_ARE_ANY_BITS_SET(*options, J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE)) {
-			/*
-			 * Prevent generated LambdaForm classes from MethodHandles to be stored to the shared cache.
-			 * When there are a large number of such classes in the shared cache, they trigger a lot of class comparisons.
-			 * Performance can be much worse (compared to shared cache turned off).
-			 */
-#define J9NON_SHARING_CLASS_NAME "java/lang/invoke/LambdaForm$"
-			if ((utf8Length > LITERAL_STRLEN(J9NON_SHARING_CLASS_NAME))
-				&& J9UTF8_LITERAL_EQUALS(utf8Name, LITERAL_STRLEN(J9NON_SHARING_CLASS_NAME), J9NON_SHARING_CLASS_NAME)
-			) {
-				*options |= J9_FINDCLASS_FLAG_DO_NOT_SHARE;
-			}
-#undef J9NON_SHARING_CLASS_NAME
-		}
 	}
 
 	if (isContiguousClassBytes) {


### PR DESCRIPTION
This patch fixes eclipse-openj9/openj9#18757.
In JDK8 and JDK11 with OpenJDK MethodHandles, MH creation uses defineAnonymousClass which passes a null class name downstream for ROM class creation. The previous check and flag-setting indicating that LambdaForms should not be held in the SCC relies on a class name being non-null. This patch pushes further downstream the flag-setting for omitting LambdaForms from the SCC to ensure that the class name is known (non-null) and available for comparison.

Issues: eclipse-openj9/openj9#18757
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>