### PR TITLE
Accelerate String.indexOf(char) in JDK17+

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -222,6 +222,7 @@
    java_lang_String_startsWith,
 
    java_lang_StringLatin1_indexOf,
+   java_lang_StringLatin1_indexOfChar,
 
    java_lang_StringUTF16_charAt,
    java_lang_StringUTF16_checkIndex,
@@ -230,6 +231,7 @@
    java_lang_StringUTF16_compareValues,
    java_lang_StringUTF16_getChar,
    java_lang_StringUTF16_indexOf,
+   java_lang_StringUTF16_indexOfCharUnsafe,
    java_lang_StringUTF16_length,
    java_lang_StringUTF16_newBytesFor,
    java_lang_StringUTF16_putChar,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3195,6 +3195,7 @@ void TR_ResolvedJ9Method::construct()
    static X StringLatin1Methods[] =
       {
       { x(TR::java_lang_StringLatin1_indexOf,                                 "indexOf",       "([BI[BII)I")},
+      { x(TR::java_lang_StringLatin1_indexOfChar,                             "indexOfChar",   "([BIII)I")},
       { x(TR::java_lang_StringLatin1_inflate,                                 "inflate",       "([BI[CII)V")},
       { TR::unknownMethod }
       };
@@ -3208,6 +3209,7 @@ void TR_ResolvedJ9Method::construct()
       { x(TR::java_lang_StringUTF16_compareValues,                            "compareValues",      "([B[BII)I")},
       { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",            "([BI)C")},
       { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",            "([BI[BII)I")},
+      { x(TR::java_lang_StringUTF16_indexOfCharUnsafe,                        "indexOfCharUnsafe",  "([BIII)I")},
       { x(TR::java_lang_StringUTF16_length,                                   "length",             "([B)I")},
       { x(TR::java_lang_StringUTF16_newBytesFor,                              "newBytesFor",        "(I)[B")},
       { x(TR::java_lang_StringUTF16_putChar,                                  "putChar",            "([BII)V")},

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4805,7 +4805,9 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             }
          break;
       case TR::java_lang_StringLatin1_indexOf:
+      case TR::java_lang_StringLatin1_indexOfChar:
       case TR::java_lang_StringUTF16_indexOf:
+      case TR::java_lang_StringUTF16_indexOfCharUnsafe:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1854,7 +1854,24 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             return;
          break;
          }
-
+      case TR::java_lang_StringLatin1_indexOfChar:
+      case TR::java_lang_StringUTF16_indexOfCharUnsafe:
+         {
+         TR::Node *sourceStringNode = node->getFirstChild();
+         TR::Node *targetCharNode = node->getSecondChild();
+         TR::Node *startNode = node->getChild(2);
+         TR::Node *lengthNode = node->getChild(3);
+         bool is16Bit = rm == TR::java_lang_StringUTF16_indexOfCharUnsafe;
+         if (transformIndexOfKnownString(
+               node,
+               sourceStringNode,
+               targetCharNode,
+               startNode,
+               lengthNode,
+               is16Bit))
+            return;
+         break;
+         }
       default:
          break;
       }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4029,9 +4029,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
       {
       switch (methodSymbol->getRecognizedMethod())
          {
+         case TR::java_lang_StringLatin1_indexOfChar:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
             resultReg = TR::TreeEvaluator::inlineIntrinsicIndexOf(node, cg, true);
             return true;
+         case TR::java_lang_StringUTF16_indexOfCharUnsafe:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
             resultReg = TR::TreeEvaluator::inlineIntrinsicIndexOf(node, cg, false);
             return true;


### PR DESCRIPTION
[Intrinsic methods for indexOf(char) in JITHelpers class](https://github.com/eclipse-openj9/openj9/blob/7bbeb0f43dcf2ac8677928512e1c134b14ae4f46/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java#L679-L712) is not used in JDK17+ because OpenJDK's `java/lang/String` class is used.
OpenJDK class library has intrinsic methods in `java/lang/StringLatin1` and `java/lang/StringUTF16` classes. The logic of those intrinsic methods are identical to those of JITHelpers class except that they are defined as static methods. This commit adds intrinsic methods of StringLatin1 and StringUTF16 to the recognized method table and update x/p/z/aarch64 codegen to generate the specialized instruction sequence which already exists for JITHelpers methods.

Related issue: https://github.com/eclipse-openj9/openj9/issues/6404

--- 

## Callgraph of String.indexOf(char) in JDK8 and JDK11
<img width="775" alt="String indexOf_char_JDK8_11_callgraph" src="https://github.com/eclipse-openj9/openj9/assets/35320034/1bd922be-313f-495c-b47f-4befd85276f9">

All intrinsic methods exist in JITHelpers class. All platforms offer specialized implementation for `JITHelpers.intrinsicIndexOfLatin1(Object array, byte ch, int offset, int length)` and `JITHelpers.intrinsicIndexOfUTF16(Object array, char ch, int offset, int length)`.

--- 

## Callgraph of String.indexOf(char) in JDK17

<img width="1129" alt="String indexOf_char_JDK17_callgraph" src="https://github.com/eclipse-openj9/openj9/assets/35320034/31775f1f-22b8-495a-8b64-68d9d8c952fe">

Note that red nodes are methods with `@IntrinsicCandidate` annotation.

Intrinsic methods of `StringLatin1` and `StringUTF16` classes are used in this version. We do not recognize intrinsic methods of these classes on any platform.
There are 2 methods that are annotated as `@IntrinsicCandidate`

- `StringLatin1.indexOfChar(byte[] value, int ch, int fromIndex, int max)`
- `StringUTF16.indexOfChar(byte[] value, int ch, int fromIndex, int max)`

`StringUTF16.indexOfChar(byte[] value, int ch, int fromIndex, int max)` calls `checkBoundsBeginEnd` and the actual search logic resides in `StringUTF16.indexOfCharUnsafe(byte[] value, int ch, int fromIndex, int max)`. Thus, **this change recognizes `StringUTF16.indexOfCharUnsafe` method rather than `StringUTF16.indexOfChar`**.

The logic of `StringLatin1.indexOfChar(byte[] value, int ch, int fromIndex, int max)` and `StringUTF16.indexOfCharUnsafe(byte[] value, int ch, int fromIndex, int max)` are same as those of JITHelper intrinsic methods. This PR simply maps JITHelper intrinsics to those StringLatin1 and StringUTF16 methods.

--- 

## Callgraph of String.indexOf(char) in JDK21

<img width="1319" alt="String indexOf_char_JDK21_callgraph" src="https://github.com/eclipse-openj9/openj9/assets/35320034/c453647d-0a2e-49c8-9190-81c2c58de736">

Almost same as Java17 except for the newly added API `String.indexOf(int ch, int beginIndex, int endIndex)`. No changes for intrinsic methods.