### PR TITLE
Modify SCC queries to take non-persistent parameters

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -152,13 +152,13 @@ J9::AheadOfTimeCompile::offsetInSharedCacheFromPointer(TR_SharedCache *sharedCac
    }
 
 uintptr_t
-J9::AheadOfTimeCompile::offsetInSharedCacheFromROMClass(TR_SharedCache *sharedCache, J9ROMClass *romClass)
+J9::AheadOfTimeCompile::offsetInSharedCacheFromClass(TR_SharedCache *sharedCache, TR_OpaqueClassBlock *clazz)
    {
    uintptr_t offset = 0;
-   if (sharedCache->isROMClassInSharedCache(romClass, &offset))
+   if (sharedCache->isClassInSharedCache(clazz, &offset))
       return offset;
    else
-      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find romClass %p in SCC", romClass);
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find clazz %p in SCC", clazz);
 
    return offset;
    }
@@ -550,8 +550,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
             flags |= methodTracingEnabled;
 
          TR_OpaqueClassBlock *inlinedMethodClass = resolvedMethod->containingClass();
-         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedMethodClass));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromClass(sharedCache, inlinedMethodClass);
 
          imRecord->setReloFlags(reloTarget, flags);
          imRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
@@ -577,8 +576,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t inlinedSiteIndex = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          TR::AOTClassInfo *aotCI = reinterpret_cast<TR::AOTClassInfo *>(relocation->getTargetAddress2());
 
-         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(aotCI->_clazz));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromClass(sharedCache, aotCI->_clazz);
 
          vsfRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          vsfRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(aotCI->_constantPool));
@@ -621,9 +619,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_ResolvedMethod *inlinedMethod = comp->getInlinedResolvedMethod(inlinedSiteIndex);
          TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
 
-         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
-         traceMsg(comp, "class is %p, romclass is %p, offset is %llu\n", inlinedCodeClass, romClass, romClassOffsetInSharedCache);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromClass(sharedCache, inlinedCodeClass);
+         traceMsg(comp, "class is %p, romclass is %p, offset is %llu\n",
+                  inlinedCodeClass,
+                  reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass)),
+                  romClassOffsetInSharedCache);
 
          uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoader(inlinedCodeClass);
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -194,10 +194,10 @@ protected:
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    /**
-    * @brief TR_J9SharedCache::offsetInSharedCacheFrom* asserts if the pointer
-    * passed in does not exist in the SCC. Under HCR, when an agent redefines
-    * a class, it causes the J9Class pointer to stay the same, but the
-    * J9ROMClass pointer changes. This means that if the compiler has a
+    * @brief TR_J9SharedCache::offsetInSharedCacheFrom* asserts if the persistent pointer
+    * (J9ROMClass, J9ROMMethod) underlying the value passed in does not exist in the SCC.
+    * Under HCR, when an agent redefines a class, it causes the J9Class pointer to stay the
+    * same, but the J9ROMClass pointer changes. This means that if the compiler has a
     * reference to a J9Class who J9ROMClass was in the SCC at one point in the
     * compilation, it may no longer be so at another point in the compilation.
     *
@@ -206,9 +206,9 @@ protected:
     * compilation, the compiler will fail the compile if such a redefinition
     * occurred.
     *
-    * Calling TR_J9SharedCache::offsetInSharedCacheFromPointer after such a
+    * Calling TR_J9SharedCache::offsetInSharedCacheFromClass after such a
     * redefinition could result in an assert. Therefore, this method exists as
-    * a wrapper around TR_J9SharedCache::isROMClassInSharedCache which doesn't
+    * a wrapper around TR_J9SharedCache::isClassInSharedCache which doesn't
     * assert and conveniently, updates the location referred to by the cacheOffset
     * pointer passed in as a parameter.
     *
@@ -216,10 +216,10 @@ protected:
     * compilation. If the ptr is in the SCC, then the cacheOffset will be updated.
     *
     * @param sharedCache pointer to the TR_SharedCache object
-    * @param romClass J9ROMClass * whose offset in the SCC is required
+    * @param clazz J9Class * whose J9ROMClass offset in the SCC is required
     * @return The offset into the SCC of romClass
     */
-   uintptr_t offsetInSharedCacheFromROMClass(TR_SharedCache *sharedCache, J9ROMClass *romClass);
+   uintptr_t offsetInSharedCacheFromClass(TR_SharedCache *sharedCache, TR_OpaqueClassBlock *clazz);
 
    /**
     * @brief Same circumstance as offsetInSharedCacheFromROMClass above

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7902,7 +7902,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
 
             // Eligibility checks
             && !entry->_doNotUseAotCodeFromSharedCache
-            && fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass)
+            && fe->sharedCache()->isClassInSharedCache(J9_CLASS_FROM_METHOD(method))
             && !_compInfo.isMethodIneligibleForAot(method)
             && (!TR::Options::getAOTCmdLineOptions()->getOption(TR_AOTCompileOnlyFromBootstrap)
                 || fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)method), true)

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -464,7 +464,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
          TR_J9VMBase *fej9 = TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM);
          TR_J9SharedCache *sc = fej9 ? fej9->sharedCache() : NULL;
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-         if (sc && sc->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass))
+         if (sc && sc->isClassInSharedCache(J9_CLASS_FROM_METHOD(method)))
             {
             PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
             I_64 sharedQueryTime = 0;
@@ -642,7 +642,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       int32_t sigLen = sprintf(buf, "%.*s.%.*s%.*s", J9UTF8_LENGTH(className), utf8Data(className), J9UTF8_LENGTH(name), utf8Data(name), J9UTF8_LENGTH(signature), utf8Data(signature));
       printf("Initial: Signature %s Count %d isLoopy %d isAOT %" OMR_PRIuPTR " is in SCC %d SCCContainsProfilingInfo %d \n",buf,TR::CompilationInfo::getInvocationCount(method),J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod),
             TR::Options::sharedClassCache() ? jitConfig->javaVM->sharedClassConfig->existsCachedCodeForROMMethod(vmThread, romMethod) : 0,
-            TR::Options::sharedClassCache() ? TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) : 0,containsInfo) ; fflush(stdout);
+            TR::Options::sharedClassCache() ? TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isClassInSharedCache(J9_CLASS_FROM_METHOD(method)) : 0,containsInfo) ; fflush(stdout);
       }
    }
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1885,7 +1885,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          // Collect AOT stats
          TR_ResolvedJ9Method *resolvedMethod = std::get<0>(methodInfo).remoteMirror;
 
-         isRomClassForMethodInSC = fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
+         isRomClassForMethodInSC = fe->sharedCache()->isClassInSharedCache(J9_CLASS_FROM_METHOD(j9method));
 
          J9Class *j9clazz = (J9Class *) J9_CLASS_FROM_CP(((J9RAMConstantPoolItem *) J9_CP_FROM_METHOD(((J9Method *)j9method))));
          TR_OpaqueClassBlock *clazzOfInlinedMethod = fe->convertClassPtrToClassOffset(j9clazz);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -811,6 +811,13 @@ TR_J9SharedCache::isROMStructureInSharedCache(void *romStructure, uintptr_t *cac
    }
 
 bool
+TR_J9SharedCache::isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset)
+   {
+   J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fe()->getPersistentClassPointerFromClassPointer(clazz));
+   return isROMClassInSharedCache(romClass, cacheOffset);
+   }
+
+bool
 TR_J9SharedCache::isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset)
    {
    return isROMStructureInSharedCache(romClass, cacheOffset);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -225,16 +225,18 @@ public:
    virtual bool isOffsetInSharedCache(uintptr_t encoded_offset, void *ptr = NULL);
 
    /**
-    * \brief Checks whether the specified J9ROMClass exists in the SCC
+    * \brief Checks whether the J9ROMClass underlying the given class exists in the SCC
     *
-    * \param[in] romClass The J9ROMClass * to check
-    * \param[out] cacheOffset If the J9ROMClass is in the SCC and this parameter
+    * \param[in] clazz The J9Class * to check
+    * \param[out] cacheOffset If the J9ROMClass associated to the J9Class is in the SCC and this parameter
     *             is not NULL the result of converting romClass into an offset will
-    *             be returned here. If romClass does not point into the SCC, this
+    *             be returned here. If it does not point into the SCC, this
     *             parameter is ignored.
     * \return True if romClass points into the SCC, false otherwise.
     */
-   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL);
+   virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL);
+   virtual bool isClassInSharedCache(J9Class *clazz, uintptr_t *cacheOffset = NULL)
+      { return isClassInSharedCache(reinterpret_cast<TR_OpaqueClassBlock *>(clazz)); }
 
    /**
     * \brief Checks whether the specified offset is within the ROMClass section
@@ -504,6 +506,18 @@ private:
     * \return True if offset is within the ROMClass section of the SCC, false otherwise
     */
    virtual bool isOffsetinROMClassesSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, uintptr_t offset);
+
+   /**
+    * \brief Checks whether the specified J9ROMClass exists in the SCC
+    *
+    * \param[in] romClass The J9ROMClass * to check
+    * \param[out] cacheOffset If the J9ROMClass is in the SCC and this parameter
+    *             is not NULL the result of converting romClass into an offset will
+    *             be returned here. If romClass does not point into the SCC, this
+    *             parameter is ignored.
+    * \return True if romClass points into the SCC, false otherwise.
+    */
+   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL);
 
    /**
     * \brief Gets the cached result of a prior class chain validation

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -51,7 +51,8 @@ public:
 
    virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
    virtual uintptr_t offsetInSharedCacheFromROMClass(J9ROMClass *romClass) { return 0; }
-   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL) { return false; }
+   virtual uintptr_t offsetInSharedCacheFromClass(TR_OpaqueClassBlock *clazz) { return 0; }
+   virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL) { return false; }
    virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL) { return false; }
 
    virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset) { return NULL; }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -794,10 +794,11 @@ static intptr_t getInitialCountForMethod(TR_ResolvedMethod *rm, TR::Compilation 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    if (TR::Options::sharedClassCache())
       {
+      J9Class *ramClass = m->constantPoolHdr();
       J9ROMClass *romClass = m->romClassPtr();
       J9ROMMethod *romMethod = m->romMethod();
 
-      if (!comp->fej9()->sharedCache()->isROMClassInSharedCache(romClass))
+      if (!comp->fej9()->sharedCache()->isClassInSharedCache(ramClass))
          {
 #if defined(J9ZOS390)
           // Do not change the counts on zos at the moment since the shared cache capacity is higher on this platform
@@ -1847,7 +1848,7 @@ TR_ResolvedRelocatableJ9Method::createResolvedMethodFromJ9Method(TR::Compilation
          isSystemClassLoader = ((void*)_fe->vmThread()->javaVM->systemClassLoader->classLoaderObject ==  (void*)_fe->getClassLoader(clazzOfInlinedMethod));
          }
 
-      bool methodInSCC = _fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
+      bool methodInSCC = _fe->sharedCache()->isClassInSharedCache(J9_CLASS_FROM_METHOD(j9method));
       if (methodInSCC)
          {
          bool sameLoaders = false;

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1390,7 +1390,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(TR_Resolved
             isSystemClassLoader = ((void*)fej9->vmThread()->javaVM->systemClassLoader->classLoaderObject ==  (void*)fej9->getClassLoader(clazzOfInlinedMethod));
             }
 
-         if (fej9->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass))
+         if (fej9->sharedCache()->isClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)))
             {
             bool sameLoaders = false;
             TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3055,7 +3055,7 @@ TR_IPBCDataCallGraph::canBePersisted(TR_J9SharedCache *sharedCache, TR::Persiste
             return IPBC_ENTRY_PERSIST_UNLOADED;
             }
 
-         if (!sharedCache->isROMClassInSharedCache(clazz->romClass))
+         if (!sharedCache->isClassInSharedCache(clazz))
             {
             releaseEntry(); // release the lock on the entry
             return IPBC_ENTRY_PERSIST_NOTINSCC;
@@ -3114,8 +3114,7 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
       TR_OpaqueClassBlock *clazz =  (TR_OpaqueClassBlock*)_csInfo.getClazz(indexMaxWeight);
       if (!info->isUnloadedClass(clazz, true))
          {
-         J9ROMClass *romClass = ((J9Class*)clazz)->romClass;
-         if (sharedCache->isROMClassInSharedCache(romClass))
+         if (sharedCache->isClassInSharedCache(clazz))
             {
             uintptr_t *classChain = sharedCache->rememberClass(clazz);
             if (classChain)

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -440,7 +440,7 @@ JITServerAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR
 
    // Check that the ROMClass is in the SCC and get its SCC offset
    uintptr_t offset = (uintptr_t)-1;
-   if (!_sharedCache->isROMClassInSharedCache(ramClass->romClass, &offset))
+   if (!_sharedCache->isClassInSharedCache(ramClass, &offset))
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: ROMClass %p %.*s ID %zu is not in SCC",


### PR DESCRIPTION
The high-level shared class cache interface currently supports a number of queries like

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/env/J9SharedCache.cpp#L716

These queries (`offsetInSharedCacheFromROMMethod` is another) are sometimes used directly, and sometimes form the basis of other queries like

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp#L155

A typical use of these methods is this:

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp#L552-L554

Whenever we use these methods we always have something like a `TR_OpaqueClassBlock *` (ultimately a `J9Class *` - that `getPersistentClassPointerFromClassPointer` immediately converts the opaque class block to a `J9Class`) or `J9Method *` on hand, that we then convert to persistent form (`J9ROMClass` or `J9ROMMethod`) to pass to the existing queries. Currently this is fine, but in https://github.com/eclipse-openj9/openj9/pull/18301 I will not be able to rely on a local SCC being present. Instead, when compiling at the server I will have to look up "offsets" (JITServer AOT cache record IDs) using only cached client data and the JITServer AOT cache. The queries supported by these caches all require more information than something like a `J9ROMClass` - they effectively need a full `J9Class *` (or `J9Method *`).

To support https://github.com/eclipse-openj9/openj9/pull/18301, this PR changes these query functions to take non-persistent JVM entities (`TR_OpaqueClassBlock *` coming from a `J9Class *`, for instance, rather than `J9ROMClass`). All we do now is convert them immediately to persistent form and look them up in the SCC, but in https://github.com/eclipse-openj9/openj9/pull/18301 I will override this behaviour when we are compiling a method intended for the JITServer AOT cache, instead looking up the relevant information in the client session data or JITServer AOT cache using the extra information that these queries will now receive.

I'd argue that these new functions have a certain symmetry with the existing `rememberClass(J9Class *clazz)`. That function takes a class and returns an offset to its persistent representation (`J9ROMClass`) inside the local SCC. The new functions will ask the matching question, "What is the offset of the persistent representation of the given class?", instead of current "What is the offset of this `J9ROMClass *`?".

------

An example of the kind of lookup that's available at the server is:

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/runtime/JITClientSession.hpp#L475

That lookup involves the data stored in the maps

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/runtime/JITClientSession.hpp#L504

and

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/runtime/JITServerAOTCache.hpp#L600

That `ClassKey` needs more than just a `J9ROMClass` as well:

https://github.com/eclipse-openj9/openj9/blob/d15ef63fcb72fc518415b4e4ee96c479002b2695/runtime/compiler/runtime/JITServerAOTCache.hpp#L517

Technically speaking, I could add a new cache that lets me look up the relevant data using only, say, a `J9ROMClass *`, but that seems less desirable, for reasons I mentioned in https://github.com/eclipse-openj9/openj9/pull/18301#issuecomment-1908451582.

------

Since this PR is motivated by https://github.com/eclipse-openj9/openj9/pull/18301, it may change based on the ultimate requirements of that PR as I finish it. I will also need to modify https://github.com/eclipse-openj9/openj9/pull/18301 to base it on this one, so this will need to be merged before https://github.com/eclipse-openj9/openj9/pull/18301.
