### PR TITLE
Fix JITServer bug related to ChangesCurrentThread annotation

### DIFF
--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1512,6 +1512,7 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    _isForceInline = methodInfoStruct.isForceInline;
    _isDontInline = methodInfoStruct.isDontInline;
    _isIntrinsicCandidate = methodInfoStruct.isIntrinsicCandidate;
+   _isChangesCurrentThread = methodInfoStruct.isChangesCurrentThread;
 
    auto &bodyInfoStr = std::get<1>(methodInfo);
    auto &methodInfoStr = std::get<2>(methodInfo);


### PR DESCRIPTION
Methods that are annotated with @ChangesCurrentThread may receive special treatment from the inliner. This is a feature present only in Java21 and up. When creating a resolvedMethod mirror, the client retrieves the information related to @ChangesCurrentThread annotation and packs it into the message sent back to the server. Current code contained a bug where the information related to this annotation is not unpacked at the server. The net effect was that the inliner refused to inline some methods, reducing throughput. This commit rectifies the problem, by correctly unpacking the information related to the ChangesCurrentThread annotation.