### PR TITLE
Modify rememberClass to return the offset to the class chain identifying the class

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -49,10 +49,10 @@ J9::AheadOfTimeCompile::getClassChainOffset(TR_OpaqueClassBlock *classToRemember
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)self()->comp()->fe();
    TR_SharedCache *sharedCache = fej9->sharedCache();
-   void *classChain = sharedCache->rememberClass(classToRemember, &classChainRecord);
-   if (!classChain)
-      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("classChain == NULL");
-   return self()->offsetInSharedCacheFromPointer(sharedCache, classChain);
+   uintptr_t classChainOffset = sharedCache->rememberClass(classToRemember, &classChainRecord);
+   if (classChainOffset == 0)
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("classChainOffset == 0");
+   return classChainOffset;
    }
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -766,11 +766,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::ClassByNameRecord *svmRecord = reinterpret_cast<TR::ClassByNameRecord *>(relocation->getTargetAddress());
 
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, svmRecord->_classChain);
-
          cbnRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_class));
          cbnRecord->setBeholderID(reloTarget, symValManager->getSymbolIDFromValue(svmRecord->_beholder));
-         cbnRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
+         cbnRecord->setClassChainOffset(reloTarget, svmRecord->_classChainOffset,
                                         self(), svmRecord->getAOTCacheClassChainRecord());
          }
          break;
@@ -875,14 +873,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::SystemClassByNameRecord *svmRecord = reinterpret_cast<TR::SystemClassByNameRecord *>(relocation->getTargetAddress());
 
          TR_OpaqueClassBlock *classToValidate = svmRecord->_class;
-         void *classChainForClassToValidate = svmRecord->_classChain;
-
-         // Store class chain to get name of class. Checking the class chain for
-         // this record eliminates the need for a separate class chain validation.
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
 
          scmRecord->setSystemClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
-         scmRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         scmRecord->setClassChainOffset(reloTarget, svmRecord->_classChainOffset,
                                         self(), svmRecord->getAOTCacheClassChainRecord());
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -477,12 +477,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_RelocationRecordValidateInstanceField *fieldRecord = reinterpret_cast<TR_RelocationRecordValidateInstanceField *>(reloRecord);
          uintptr_t inlinedSiteIndex = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          TR::AOTClassInfo *aotCI = reinterpret_cast<TR::AOTClassInfo *>(relocation->getTargetAddress2());
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, aotCI->_classChain);
 
          fieldRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          fieldRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(aotCI->_constantPool));
          fieldRecord->setCpIndex(reloTarget, static_cast<uintptr_t>(aotCI->_cpIndex));
-         fieldRecord->setClassChainOffsetInSharedCache(reloTarget, classChainOffsetInSharedCache,
+         fieldRecord->setClassChainOffsetInSharedCache(reloTarget, aotCI->_classChainOffset,
                                                        self(), aotCI->getAOTCacheClassChainRecord());
          }
          break;
@@ -595,12 +594,10 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t inlinedSiteIndex = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          TR::AOTClassInfo *aotCI = reinterpret_cast<TR::AOTClassInfo *>(relocation->getTargetAddress2());
 
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, aotCI->_classChain);
-
          vcRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          vcRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(aotCI->_constantPool));
          vcRecord->setCpIndex(reloTarget, aotCI->_cpIndex);
-         vcRecord->setClassChainOffsetInSharedCache(reloTarget, classChainOffsetInSharedCache,
+         vcRecord->setClassChainOffsetInSharedCache(reloTarget, aotCI->_classChainOffset,
                                                     self(), aotCI->getAOTCacheClassChainRecord());
          }
          break;
@@ -738,12 +735,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetIdentifyingLoader(classToValidate);
 
-         void *classChainForClassToValidate = aotCI->_classChain;
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
-
          vacRecord->setClassChainIdentifyingLoaderOffset(reloTarget, classChainOffsetInSharedCacheForCL,
                                                          self(), aotCI->getAOTCacheClassChainRecord());
-         vacRecord->setClassChainOffsetForClassBeingValidated(reloTarget, classChainOffsetInSharedCache,
+         vacRecord->setClassChainOffsetForClassBeingValidated(reloTarget, aotCI->_classChainOffset,
                                                               self(), aotCI->getAOTCacheClassChainRecord());
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -50,8 +50,8 @@ J9::AheadOfTimeCompile::getClassChainOffset(TR_OpaqueClassBlock *classToRemember
    TR_J9VMBase *fej9 = (TR_J9VMBase *)self()->comp()->fe();
    TR_SharedCache *sharedCache = fej9->sharedCache();
    uintptr_t classChainOffset = sharedCache->rememberClass(classToRemember, &classChainRecord);
-   if (classChainOffset == 0)
-      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("classChainOffset == 0");
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("classChainOffset == INVALID_CLASS_CHAIN_OFFSET");
    return classChainOffset;
    }
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -924,14 +924,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::ClassChainRecord *svmRecord = reinterpret_cast<TR::ClassChainRecord *>(relocation->getTargetAddress());
 
          TR_OpaqueClassBlock *classToValidate = svmRecord->_class;
-         void *classChainForClassToValidate = svmRecord->_classChain;
-
-         // Store class chain to get name of class. Checking the class chain for
-         // this record eliminates the need for a separate class chain validation.
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
 
          ccRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
-         ccRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         ccRecord->setClassChainOffset(reloTarget, svmRecord->_classChainOffset,
                                        self(), svmRecord->getAOTCacheClassChainRecord());
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -782,16 +782,13 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR::ProfiledClassRecord *svmRecord = reinterpret_cast<TR::ProfiledClassRecord *>(relocation->getTargetAddress());
 
          TR_OpaqueClassBlock *classToValidate = svmRecord->_class;
-         void *classChainForClassToValidate = svmRecord->_classChain;
 
          //store the classchain's offset for the classloader for the class
          uintptr_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetIdentifyingLoader(classToValidate);
 
-         //store the classchain's offset for the class that needs to be validated in the second run
-         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
-
          pcRecord->setClassID(reloTarget, symValManager->getSymbolIDFromValue(classToValidate));
-         pcRecord->setClassChainOffset(reloTarget, classChainOffsetInSharedCache,
+         //store the classchain's offset for the class that needs to be validated in the second run
+         pcRecord->setClassChainOffset(reloTarget, svmRecord->_classChainOffset,
                                        self(), svmRecord->getAOTCacheClassChainRecord());
          pcRecord->setClassChainOffsetForClassLoader(reloTarget, classChainOffsetInSharedCacheForCL,
                                                      self(), svmRecord->getAOTCacheClassChainRecord());

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2570,7 +2570,7 @@ static void addValidationRecords(TR::CodeGenerator *cg)
          {
          traceMsg(cg->comp(), "processing AOT class info: %p in %s\n", *info, cg->comp()->signature());
          traceMsg(cg->comp(), "ramMethod: %p cp: %p cpIndex: %x relo %d\n", (*info)->_method, (*info)->_constantPool, (*info)->_cpIndex, (*info)->_reloKind);
-         traceMsg(cg->comp(), "clazz: %p classChain: %p\n", (*info)->_clazz, (*info)->_classChain);
+         traceMsg(cg->comp(), "clazz: %p classChainOffset: %" OMR_PRIuPTR "\n", (*info)->_clazz, (*info)->_classChainOffset);
 
          TR_OpaqueMethodBlock *ramMethod = (*info)->_method;
 

--- a/runtime/compiler/compile/AOTClassInfo.hpp
+++ b/runtime/compiler/compile/AOTClassInfo.hpp
@@ -89,7 +89,7 @@ public:
    void *_constantPool;                         // constant pool owning the cp entry, initialized based on _method
    TR_OpaqueClassBlock *_clazz;                 // class on which assumption is formed
    uintptr_t _classChainOffset;                 // class chain offset for clazz: captures the assumption
-                                                // == NULL for TR_ValidateStaticField validations
+                                                // == TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET for TR_ValidateStaticField validations
 #if defined(J9VM_OPT_JITSERVER)
    const AOTCacheClassChainRecord *_aotCacheClassChainRecord; // NULL at JITServer if compiled method won't be cached
                                                               // Always NULL at JIT client

--- a/runtime/compiler/compile/AOTClassInfo.hpp
+++ b/runtime/compiler/compile/AOTClassInfo.hpp
@@ -56,14 +56,14 @@ public:
    AOTClassInfo(
          TR_FrontEnd *fe,
          TR_OpaqueClassBlock *clazz,
-         void *classChain,
+         uintptr_t classChainOffset,
          TR_OpaqueMethodBlock *method,
          uint32_t cpIndex,
          TR_ExternalRelocationTargetKind reloKind,
          const AOTCacheClassChainRecord *aotCacheClassChainRecord = NULL
    ) :
       _clazz(clazz),
-      _classChain(classChain),
+      _classChainOffset(classChainOffset),
       _method(method),
       _constantPool((void *) ((TR_J9VMBase *)fe)->getConstantPoolFromMethod(method)),
       _cpIndex(cpIndex),
@@ -88,7 +88,7 @@ public:
                                                 // _method must be compiled method or some method in the inlined site table
    void *_constantPool;                         // constant pool owning the cp entry, initialized based on _method
    TR_OpaqueClassBlock *_clazz;                 // class on which assumption is formed
-   void *_classChain;                           // class chain for clazz: captures the assumption
+   uintptr_t _classChainOffset;                 // class chain offset for clazz: captures the assumption
                                                 // == NULL for TR_ValidateStaticField validations
 #if defined(J9VM_OPT_JITSERVER)
    const AOTCacheClassChainRecord *_aotCacheClassChainRecord; // NULL at JITServer if compiled method won't be cached

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7909,7 +7909,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
 
             // Ensure we can generate a class chain for the class of the
             // method to be compiled
-            && (NULL != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)))
+            && (0 != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)))
 
             // Do not perform AOT compilation if field watch is enabled; there
             // is no benefit to having an AOT body with field watch as it increases

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7909,7 +7909,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
 
             // Ensure we can generate a class chain for the class of the
             // method to be compiled
-            && (0 != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)))
+            && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)))
 
             // Do not perform AOT compilation if field watch is enabled; there
             // is no benefit to having an AOT body with field watch as it increases

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2147,8 +2147,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          std::vector<JITServerHelpers::ClassInfoTuple> uncachedClassInfos;
          if (create && getClasses && classChain)
             {
-            // The first word of the class chain data stores the size of the whole record in bytes
-            uintptr_t numClasses = classChain[0] / sizeof(classChain[0]) - 1;
+            // The first word of the class chain data stores the size of the whole record in bytes, so the number of classes
+            // is 1 less than the necessary class chain length.
+            uintptr_t numClasses = fe->necessaryClassChainLength(clazz) - 1;
             ramClassChain = JITServerHelpers::getRAMClassChain(clazz, numClasses, vmThread, trMemory, compInfo,
                                                                uncachedRAMClasses, uncachedClassInfos);
             }
@@ -3167,8 +3168,9 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
       classChain = compiler->fej9vm()->sharedCache()->rememberClass(clazz);
       if (classChain)
          {
-         // The first word of the class chain data stores the size of the whole record in bytes
-         uintptr_t numClasses = classChain[0] / sizeof(classChain[0]) - 1;
+         // The first word of the class chain data stores the size of the whole record in bytes, so the number of classes
+         // is 1 less than the necessary class chain length.
+         uintptr_t numClasses = compiler->fej9vm()->necessaryClassChainLength(clazz) - 1;
          ramClassChain = JITServerHelpers::getRAMClassChain(clazz, numClasses, vmThread, compiler->trMemory(),
                                                             compInfo, uncachedRAMClasses, uncachedClassInfos);
          }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2145,7 +2145,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          std::vector<J9Class *> ramClassChain;
          std::vector<J9Class *> uncachedRAMClasses;
          std::vector<JITServerHelpers::ClassInfoTuple> uncachedClassInfos;
-         if (create && getClasses && classChainOffset)
+         if (create && getClasses && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset))
             {
             // The first word of the class chain data stores the size of the whole record in bytes, so the number of classes
             // is 1 less than the necessary class chain length.
@@ -3159,14 +3159,14 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
       ? std::string((const char *)compiler->getRecompilationInfo()->getMethodInfo(), sizeof(TR_PersistentMethodInfo))
       : std::string();
 
-   uintptr_t classChainOffset = 0;
+   uintptr_t classChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
    std::vector<J9Class *> ramClassChain;
    std::vector<J9Class *> uncachedRAMClasses;
    std::vector<JITServerHelpers::ClassInfoTuple> uncachedClassInfos;
    if (aotCacheStore || aotCacheLoad)
       {
       classChainOffset = compiler->fej9vm()->sharedCache()->rememberClass(clazz);
-      if (classChainOffset)
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset)
          {
          // The first word of the class chain data stores the size of the whole record in bytes, so the number of classes
          // is 1 less than the necessary class chain length.

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -894,8 +894,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       entry._stream = stream; // Add the stream to the entry
 
       auto aotCache = clientSession->getOrCreateAOTCache(stream);
-      _aotCacheStore = classChainOffset && aotCache && JITServerAOTCacheMap::cacheHasSpace();
-      aotCacheLoad = aotCacheLoad && classChainOffset && aotCache;
+      _aotCacheStore = (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && aotCache && JITServerAOTCacheMap::cacheHasSpace();
+      aotCacheLoad = aotCacheLoad && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && aotCache;
       if (aotCache && !aotCacheLoad)
          aotCache->incNumCacheBypasses();
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -568,7 +568,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          uint64_t, uint32_t, uint32_t, J9Method *, J9Class *, TR_OptimizationPlan, std::string,
          J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock *>, std::vector<TR_OpaqueClassBlock *>,
          JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string,
-         bool, bool, bool, uint32_t, uintptr_t *, std::vector<J9Class *>, std::vector<J9Class *>,
+         bool, bool, bool, uint32_t, uintptr_t, std::vector<J9Class *>, std::vector<J9Class *>,
          std::vector<JITServerHelpers::ClassInfoTuple>, std::vector<uintptr_t>
       >();
 
@@ -591,7 +591,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       bool isInStartupPhase         = std::get<16>(req);
       bool aotCacheLoad             = std::get<17>(req);
       _methodIndex                  = std::get<18>(req);
-      uintptr_t *classChain         = std::get<19>(req);
+      uintptr_t classChainOffset    = std::get<19>(req);
       auto &ramClassChain           = std::get<20>(req);
       auto &uncachedRAMClasses      = std::get<21>(req);
       auto &uncachedClassInfos      = std::get<22>(req);
@@ -894,8 +894,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       entry._stream = stream; // Add the stream to the entry
 
       auto aotCache = clientSession->getOrCreateAOTCache(stream);
-      _aotCacheStore = classChain && aotCache && JITServerAOTCacheMap::cacheHasSpace();
-      aotCacheLoad = aotCacheLoad && classChain && aotCache;
+      _aotCacheStore = classChainOffset && aotCache && JITServerAOTCacheMap::cacheHasSpace();
+      aotCacheLoad = aotCacheLoad && classChainOffset && aotCache;
       if (aotCache && !aotCacheLoad)
          aotCache->incNumCacheBypasses();
 
@@ -904,7 +904,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // Get defining class chain record to use as a part of the key to lookup or store the method in AOT cache
          JITServerHelpers::cacheRemoteROMClassBatch(clientSession, uncachedRAMClasses, uncachedClassInfos);
          bool missingLoaderInfo = false;
-         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChain, ramClassChain, stream, missingLoaderInfo);
+         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChainOffset, ramClassChain, stream, missingLoaderInfo);
          if (!_definingClassChainRecord)
             {
             if (TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -189,8 +189,8 @@ TR_PersistentClassLoaderTable::associateClassLoaderWithClass(J9VMThread *vmThrea
    uint16_t nameLength = J9UTF8_LENGTH(nameStr);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-   void *chain = _sharedCache->rememberClass(clazz);
-   if (!chain)
+   uintptr_t classChainOffset = _sharedCache->rememberClass(clazz);
+   if (classChainOffset == 0)
       {
 #if defined(J9VM_OPT_JITSERVER)
       if (useAOTCache && TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -201,6 +201,7 @@ TR_PersistentClassLoaderTable::associateClassLoaderWithClass(J9VMThread *vmThrea
 #endif /* defined(J9VM_OPT_JITSERVER) */
       return;
       }
+   void *chain = _sharedCache->pointerFromOffsetInSharedCache(classChainOffset);
    TR_ASSERT(_sharedCache->isPointerInSharedCache(chain), "Class chain must be in SCC");
 
    info = new (_persistentMemory) TR_ClassLoaderInfo(loader, chain);

--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -190,7 +190,7 @@ TR_PersistentClassLoaderTable::associateClassLoaderWithClass(J9VMThread *vmThrea
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    uintptr_t classChainOffset = _sharedCache->rememberClass(clazz);
-   if (classChainOffset == 0)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
       {
 #if defined(J9VM_OPT_JITSERVER)
       if (useAOTCache && TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -57,6 +57,10 @@
 #define UPDATEPTR(ca) (((uint8_t *)(ca)) + (ca)->updateSRP)
 #define SEGUPDATEPTR(ca) (((uint8_t *)(ca)) + (ca)->segmentSRP)
 
+// Used by TR_J9SharedCache::rememberClass() to communicate that a class has not been recorded in the SCC but could have been recorded.
+#define COULD_CREATE_CLASS_CHAIN 1
+static_assert(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != COULD_CREATE_CLASS_CHAIN, "These values must be distinct");
+
 TR_J9SharedCache::TR_J9SharedCacheDisabledReason TR_J9SharedCache::_sharedCacheState = TR_J9SharedCache::UNINITIALIZED;
 TR_YesNoMaybe TR_J9SharedCache::_sharedCacheDisabledBecauseFull = TR_maybe;
 UDATA TR_J9SharedCache::_storeSharedDataFailedLength = 0;
@@ -873,7 +877,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
    if (!isROMClassInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(1,"\trom class not in shared cache, returning\n");
-      return 0;
+      return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       }
 
    char key[17]; // longest possible key length is way less than 16 digits
@@ -885,7 +889,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
    chainData = findChainForClass(clazz, key, keyLength);
    if (chainData != NULL)
       {
-      uintptr_t chainOffset = 0;
+      uintptr_t chainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       if (classMatchesCachedVersion(clazz, chainData))
          {
          LOG(1, "\tcurrent class and class chain found (%p) are identical; returning the class chain\n", chainData);
@@ -893,8 +897,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
          }
       else
          {
-         LOG(1, "\tcurrent class and class chain found (%p) do not match, so cannot use class chain; returning 0\n", chainData);
-         chainOffset = 0;
+         LOG(1, "\tcurrent class and class chain found (%p) do not match, so cannot use class chain; returning INVALID_CLASS_CHAIN_OFFSET\n", chainData);
          }
       return chainOffset;
       }
@@ -909,19 +912,19 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
    if (chainLength > maxClassChainLength * sizeof(uintptr_t))
       {
       LOG(1, "\t\t > %u so bailing\n", maxClassChainLength);
-      return 0;
+      return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       }
 
    if (!fillInClassChain(clazz, chainData, chainLength, numSuperclasses, numInterfaces))
       {
       LOG(1, "\tfillInClassChain failed, bailing\n");
-      return 0;
+      return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       }
 
    if (!create)
       {
-      LOG(1, "\tnot asked to create but could create, returning non-null\n");
-      return 1;
+      LOG(1, "\tnot asked to create but could create, returning COULD_CREATE_CLASS_CHAIN\n");
+      return COULD_CREATE_CLASS_CHAIN;
       }
 
    uintptr_t chainDataLength = chainData[0];
@@ -950,7 +953,11 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
       setStoreSharedDataFailedLength(chainDataLength);
       }
 #endif
-   return offsetInSharedCacheFromPointer(chainData);
+   uintptr_t chainOffset = 0;
+   if (isPointerInSharedCache(chainData, &chainOffset))
+      return chainOffset;
+   else
+      return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
    }
 
 UDATA
@@ -1369,7 +1376,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    TR_ASSERT_FATAL(classChainRecord || !create, "Must pass classChainRecord if creating class chain at JITServer");
    TR_ASSERT(_stream, "stream must be initialized by now");
 
-   uintptr_t classChainOffset = 0;
+   uintptr_t classChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
    TR::Compilation *comp = TR::compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool needClassChainRecord = create && comp->isAOTCacheStore();
@@ -1388,7 +1395,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
       }
 
    // If the class chain is cached and the AOT cache record is either cached or not needed, return the cached values
-   if (classChainOffset && (record || !needClassChainRecord))
+   if ((TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && (record || !needClassChainRecord))
       {
       if (classChainRecord)
          *classChainRecord = record;
@@ -1399,7 +1406,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create, needClassChainRecord);
    auto recv = _stream->read<uintptr_t, std::vector<J9Class *>, std::vector<J9Class *>,
                              std::vector<JITServerHelpers::ClassInfoTuple>>();
-   if (classChainOffset)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset)
       TR_ASSERT_FATAL(std::get<0>(recv) == classChainOffset, "Received mismatching class chain offset: %" OMR_PRIuPTR " != %" OMR_PRIuPTR,
                       std::get<0>(recv), classChainOffset);
    classChainOffset = std::get<0>(recv);
@@ -1408,7 +1415,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    auto &uncachedClassInfos = std::get<3>(recv);
 
    // Cache the result if the class chain was succesfully created at the client
-   if (classChainOffset && create)
+   if ((TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && create)
       {
       if (needClassChainRecord)
          {
@@ -1442,14 +1449,14 @@ TR_J9JITServerSharedCache::getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBl
    TR_ASSERT(!classChain, "Must always be NULL at JITServer");
    TR_ASSERT(_stream, "stream must be initialized by now");
 
-   uintptr_t classChainOffset = 0;
+   uintptr_t classChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
    ClientSessionData *clientData = TR::compInfoPT->getClientData();
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, clientData, _stream,
                                              JITServerHelpers::CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
                                              (void *)&classChainOffset);
    // Test if cached value of `classChainOffset` is initialized. Ask the client if it's not.
    // This situation is possible if we cache ClassInfo during a non-AOT compilation.
-   if (classChainOffset == 0)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
       {
       // Request the class name identifying loader if this client uses AOT cache
       // (even if the result of this specific compilation won't be stored in AOT cache)
@@ -1460,7 +1467,7 @@ TR_J9JITServerSharedCache::getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBl
       auto &className = std::get<1>(recv);
 
       // If we got a valid value back, cache that
-      if (classChainOffset)
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset)
          {
          OMR::CriticalSection getRemoteROMClass(clientData->getROMMapMonitor());
          auto it = clientData->getROMClassMap().find((J9Class *)clazz);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -897,8 +897,8 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
       return chainData;
       }
 
-   int32_t numSuperclasses = TR::Compiler->cls.classDepthOf(fe()->convertClassPtrToClassOffset(clazz));
-   int32_t numInterfaces = numInterfacesImplemented(clazz);
+   int32_t numSuperclasses = fe()->numSuperclasses(clazz);
+   int32_t numInterfaces = fe()->numInterfacesImplemented(clazz);
 
    LOG(3, "\tcreating chain now: 1 + 1 + %d superclasses + %d interfaces\n", numSuperclasses, numInterfaces);
    uintptr_t chainLength = (2 + numSuperclasses + numInterfaces) * sizeof(uintptr_t);
@@ -985,19 +985,6 @@ TR_J9SharedCache::getDebugCounterName(UDATA offset)
    //printf("\ngetDebugCounterName: Tried to find %p, name=%s (%p)\n", offset, (name ? name : ""), name);
 
    return name;
-   }
-
-uint32_t
-TR_J9SharedCache::numInterfacesImplemented(J9Class *clazz)
-   {
-   uint32_t count=0;
-   J9ITable *element = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
-   while (element != NULL)
-      {
-      count++;
-      element = TR::Compiler->cls.iTableNext(element);
-      }
-   return count;
    }
 
 bool

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -175,7 +175,7 @@ public:
 
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
       {
-      return rememberClass((J9Class *)classPtr, NULL, false) != 0;
+      return rememberClass((J9Class *)classPtr, NULL, false) != TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       }
 
    virtual uintptr_t rememberClass(TR_OpaqueClassBlock *classPtr,

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -388,8 +388,6 @@ private:
    void convertUnsignedOffsetToASCII(UDATA offset, char *myBuffer);
    void createClassKey(UDATA classOffsetInCache, char *key, uint32_t & keyLength);
 
-   uint32_t numInterfacesImplemented(J9Class *clazz);
-
    bool writeClassToChain(J9ROMClass *romClass, UDATA * & chainPtr);
    bool writeClassesToChain(J9Class *clazz, int32_t numSuperclasses, UDATA * & chainPtr);
    bool writeInterfacesToChain(J9Class *clazz, UDATA * & chainPtr);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -175,16 +175,16 @@ public:
 
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
       {
-      return rememberClass((J9Class *)classPtr, NULL, false) != NULL;
+      return rememberClass((J9Class *)classPtr, NULL, false) != 0;
       }
 
-   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *classPtr,
+   virtual uintptr_t rememberClass(TR_OpaqueClassBlock *classPtr,
                                     const AOTCacheClassChainRecord **classChainRecord = NULL)
       {
-      return (uintptr_t *)rememberClass((J9Class *)classPtr, classChainRecord, true);
+      return rememberClass((J9Class *)classPtr, classChainRecord, true);
       }
 
-   virtual uintptr_t *rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
+   virtual uintptr_t rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
                                     bool create = true);
 
    virtual UDATA rememberDebugCounterName(const char *name);
@@ -570,8 +570,8 @@ public:
    virtual void addHint(J9Method *, TR_SharedCacheHint) override;
    virtual bool isMostlyFull() override { TR_ASSERT_FATAL(false, "called"); return false;}
 
-   virtual uintptr_t *rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
-                                    bool create = true) override;
+   virtual uintptr_t rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
+                                   bool create = true) override;
 
    virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT_FATAL(false, "called"); return 0;}
    virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL;}

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -41,7 +41,7 @@ public:
    virtual bool isMostlyFull() { return false; }
 
    virtual bool canRememberClass(TR_OpaqueClassBlock *clazz) { return false; }
-   virtual uintptr_t *rememberClass(TR_OpaqueClassBlock *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL) { return NULL; }
+   virtual uintptr_t rememberClass(TR_OpaqueClassBlock *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL) { return 0; }
    virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *clazz, uintptr_t *chainData = NULL) { return false; }
 
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) { return NULL; }

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -41,7 +41,7 @@ public:
    virtual bool isMostlyFull() { return false; }
 
    virtual bool canRememberClass(TR_OpaqueClassBlock *clazz) { return false; }
-   virtual uintptr_t rememberClass(TR_OpaqueClassBlock *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL) { return 0; }
+   virtual uintptr_t rememberClass(TR_OpaqueClassBlock *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL) { return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET; }
    virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *clazz, uintptr_t *chainData = NULL) { return false; }
 
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
@@ -70,6 +70,10 @@ public:
 
    void setPersistentClassLoaderTable(TR_PersistentClassLoaderTable *table) { _persistentClassLoaderTable = table; }
    TR_PersistentClassLoaderTable *persistentClassLoaderTable() { return _persistentClassLoaderTable; }
+
+   // A uintptr_t value that can never represent a class chain in an SCC. Used to check the return value of rememberClass,
+   // and also useful to represent "class chain not present" in places where a class chain offset is optional.
+   static const uintptr_t INVALID_CLASS_CHAIN_OFFSET = 0;
 
 private:
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9416,7 +9416,7 @@ bool
 TR_J9SharedCacheVM::canRememberClass(TR_OpaqueClassBlock *classPtr)
    {
    if (_sharedCache)
-      return (_sharedCache->rememberClass((J9Class *)classPtr, NULL, false) != 0);
+      return (_sharedCache->rememberClass((J9Class *)classPtr, NULL, false) != TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET);
    return false;
    }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7321,6 +7321,19 @@ TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPo
    return returnValue; // 0 means failure
    }
 
+uint32_t
+TR_J9VMBase::numInterfacesImplemented(J9Class *clazz)
+   {
+   uint32_t count=0;
+   J9ITable *element = TR::Compiler->cls.iTableOf(convertClassPtrToClassOffset(clazz));
+   while (element != NULL)
+      {
+      count++;
+      element = TR::Compiler->cls.iTableNext(element);
+      }
+   return count;
+   }
+
 TR_EstimateCodeSize *
 TR_J9VMBase::getCodeEstimator(TR::Compilation *comp)
    {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9416,7 +9416,7 @@ bool
 TR_J9SharedCacheVM::canRememberClass(TR_OpaqueClassBlock *classPtr)
    {
    if (_sharedCache)
-      return (_sharedCache->rememberClass((J9Class *)classPtr, NULL, false) != NULL);
+      return (_sharedCache->rememberClass((J9Class *)classPtr, NULL, false) != 0);
    return false;
    }
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -399,6 +399,11 @@ public:
    // resolved interface calls are implemented in order to allow for such
    // transformations, this query should be defined as well.
 
+   // Get the length needed to contain the class chain associated with this class
+   uintptr_t necessaryClassChainLength(J9Class *clazz) { return 2 + numInterfacesImplemented(clazz) + numSuperclasses(clazz); }
+   uint32_t numInterfacesImplemented(J9Class *clazz);
+   uintptr_t numSuperclasses(J9Class *clazz) { return TR::Compiler->cls.classDepthOf(convertClassPtrToClassOffset(clazz)); }
+
 protected:
    // Shared logic for both TR_J9SharedCacheVM and TR_J9SharedCacheServerVM
    bool isAotResolvedDirectDispatchGuaranteed(TR::Compilation *comp);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -993,7 +993,7 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
    TR::Compilation *comp = TR::comp();
    if (comp && this->TR_ResolvedMethod::getRecognizedMethod() != TR::unknownMethod)
       {
-      if (0 != fej9->sharedCache()->rememberClass(containingClass()))
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != fej9->sharedCache()->rememberClass(containingClass()))
          {
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
@@ -1374,7 +1374,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
    uintptr_t classChainOffset = fej9->sharedCache()->rememberClass(definingClass);
-   if (0 == classChainOffset)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
       return false;
 
    bool inLocalList = false;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -993,7 +993,7 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
    TR::Compilation *comp = TR::comp();
    if (comp && this->TR_ResolvedMethod::getRecognizedMethod() != TR::unknownMethod)
       {
-      if (fej9->sharedCache()->rememberClass(containingClass()))
+      if (0 != fej9->sharedCache()->rememberClass(containingClass()))
          {
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
@@ -1372,13 +1372,10 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    J9UTF8 *className = J9ROMCLASS_CLASSNAME(definingClass->romClass);
    traceMsg(comp, "\tdefiningClass name %.*s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
-   void *classChain = NULL;
-
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
-   classChain = fej9->sharedCache()->rememberClass(definingClass);
-   if (!classChain)
+   uintptr_t classChainOffset = fej9->sharedCache()->rememberClass(definingClass);
+   if (0 == classChainOffset)
       return false;
-   uintptr_t classChainOffset = fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1378,6 +1378,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    classChain = fej9->sharedCache()->rememberClass(definingClass);
    if (!classChain)
       return false;
+   uintptr_t classChainOffset = fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;
@@ -1396,7 +1397,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
             if (isStatic)
                inLocalList = (definingClass->romClass == ((J9Class *)((*info)->_clazz))->romClass);
             else
-               inLocalList = (classChain == (*info)->_classChain &&
+               inLocalList = (classChainOffset == (*info)->_classChainOffset &&
                               cpIndex == (*info)->_cpIndex &&
                               ramMethod == (J9Method *)(*info)->_method);
 
@@ -1419,7 +1420,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
       return true;
       }
 
-   TR::AOTClassInfo *classInfo = new (comp->trHeapMemory()) TR::AOTClassInfo(fej9, (TR_OpaqueClassBlock *)definingClass, (void *) classChain, (TR_OpaqueMethodBlock *)ramMethod, cpIndex, reloKind);
+   TR::AOTClassInfo *classInfo = new (comp->trHeapMemory()) TR::AOTClassInfo(fej9, (TR_OpaqueClassBlock *)definingClass, classChainOffset, (TR_OpaqueMethodBlock *)ramMethod, cpIndex, reloKind);
    if (classInfo)
       {
       traceMsg(comp, "\tCreated new AOT class info %p\n", classInfo);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2049,6 +2049,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
    void *classChain = fej9->sharedCache()->rememberClass(definingClass, &classChainRecord);
    if (!classChain)
       return false;
+   uintptr_t classChainOffset = fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;
@@ -2068,7 +2069,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
                inLocalList = (TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) definingClass) ==
                               TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) ((*info)->_clazz)));
             else
-               inLocalList = (classChain == (*info)->_classChain &&
+               inLocalList = (classChainOffset == (*info)->_classChainOffset &&
                               cpIndex == (*info)->_cpIndex &&
                               ramMethod == (J9Method *)(*info)->_method);
 
@@ -2092,7 +2093,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
       }
 
    TR::AOTClassInfo *classInfo = new (comp->trHeapMemory()) TR::AOTClassInfo(
-      fej9, (TR_OpaqueClassBlock *)definingClass, (void *)classChain,
+      fej9, (TR_OpaqueClassBlock *)definingClass, classChainOffset,
       (TR_OpaqueMethodBlock *)ramMethod, cpIndex, reloKind, classChainRecord
    );
    if (classInfo)

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2047,7 +2047,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
    const AOTCacheClassChainRecord *classChainRecord = NULL;
    uintptr_t classChainOffset = fej9->sharedCache()->rememberClass(definingClass, &classChainRecord);
-   if (0 == classChainOffset)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
       return false;
 
    bool inLocalList = false;

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2046,10 +2046,9 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
    const AOTCacheClassChainRecord *classChainRecord = NULL;
-   void *classChain = fej9->sharedCache()->rememberClass(definingClass, &classChainRecord);
-   if (!classChain)
+   uintptr_t classChainOffset = fej9->sharedCache()->rememberClass(definingClass, &classChainRecord);
+   if (0 == classChainOffset)
       return false;
-   uintptr_t classChainOffset = fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 55; // ID: fyx74Hns1zMFiA0uP2Nr
+   static const uint16_t MINOR_NUMBER = 56; // ID: kkhDRhWae0gHBQ3ATWxV
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3117,28 +3117,19 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
          J9ROMClass *romClass = ((J9Class*)clazz)->romClass;
          if (sharedCache->isROMClassInSharedCache(romClass))
             {
-            uintptr_t *classChain = sharedCache->rememberClass(clazz);
-            if (classChain)
+            uintptr_t classChainOffset = sharedCache->rememberClass(clazz);
+            if (classChainOffset)
                {
-               uintptr_t cacheOffset = 0;
-               if (sharedCache->isPointerInSharedCache(classChain, &cacheOffset))
-                  {
-                  store->_csInfo.setClazz(0, cacheOffset);
-                  store->_csInfo._weight[0] = _csInfo._weight[indexMaxWeight];
-                  // I need to find the chain of the first class loaded by the class loader of this RAMClass
-                  // getClassChainOffsetIdentifyingLoader() fails the compilation if not found, hence we use a special implementation
-                  uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoaderNoThrow(clazz);
-                  // The chain that identifies the class loader is stored at index 1
-                  store->_csInfo.setClazz(1, classChainOffsetOfCLInSharedCache);
-                  if (classChainOffsetOfCLInSharedCache == 0)
-                     if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseIProfilerPersistence))
-                        TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "createPersistentCopy: Cannot store CallGraphEntry because classChain identifying classloader is 0");
-                  }
-               else
-                  {
+               store->_csInfo.setClazz(0, classChainOffset);
+               store->_csInfo._weight[0] = _csInfo._weight[indexMaxWeight];
+               // I need to find the chain of the first class loaded by the class loader of this RAMClass
+               // getClassChainOffsetIdentifyingLoader() fails the compilation if not found, hence we use a special implementation
+               uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoaderNoThrow(clazz);
+               // The chain that identifies the class loader is stored at index 1
+               store->_csInfo.setClazz(1, classChainOffsetOfCLInSharedCache);
+               if (classChainOffsetOfCLInSharedCache == 0)
                   if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseIProfilerPersistence))
-                     TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "createPersistentCopy: Cannot store CallGraphEntry because of race condition while storing chain");
-                  }
+                     TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "createPersistentCopy: Cannot store CallGraphEntry because classChain identifying classloader is 0");
                }
             else
                {

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3118,7 +3118,7 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
          if (sharedCache->isROMClassInSharedCache(romClass))
             {
             uintptr_t classChainOffset = sharedCache->rememberClass(clazz);
-            if (classChainOffset)
+            if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset)
                {
                store->_csInfo.setClazz(0, classChainOffset);
                store->_csInfo._weight[0] = _csInfo._weight[indexMaxWeight];
@@ -3127,7 +3127,7 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
                uintptr_t classChainOffsetOfCLInSharedCache = sharedCache->getClassChainOffsetIdentifyingLoaderNoThrow(clazz);
                // The chain that identifies the class loader is stored at index 1
                store->_csInfo.setClazz(1, classChainOffsetOfCLInSharedCache);
-               if (classChainOffsetOfCLInSharedCache == 0)
+               if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffsetOfCLInSharedCache)
                   if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseIProfilerPersistence))
                      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "createPersistentCopy: Cannot store CallGraphEntry because classChain identifying classloader is 0");
                }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -413,7 +413,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _totalInstanceSize(0),
    _constantPool(NULL),
    _classFlags(0),
-   _classChainOffsetIdentifyingLoader(0),
+   _classChainOffsetIdentifyingLoader(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET),
    _classNameIdentifyingLoader(),
    _aotCacheClassRecord(NULL),
    _arrayElementSize(0),
@@ -841,7 +841,7 @@ ClientSessionData::getClassRecord(ClientSessionData::ClassInfo &classInfo, bool 
       auto &name = classInfo._classNameIdentifyingLoader;
       if (name.empty())
          {
-         TR_ASSERT(!classInfo._classChainOffsetIdentifyingLoader,
+         TR_ASSERT(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classInfo._classChainOffsetIdentifyingLoader,
                    "Valid class chain offset but missing class name identifying loader");
          missingLoaderInfo = true;
          return NULL;

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -952,7 +952,7 @@ ClientSessionData::getMethodRecord(J9Method *method, J9Class *definingClass, JIT
    }
 
 const AOTCacheClassChainRecord *
-ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t *classChain,
+ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffset,
                                        const std::vector<J9Class *> &ramClassChain, JITServer::ServerStream *stream,
                                        bool &missingLoaderInfo)
    {
@@ -1043,7 +1043,7 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t *classChain,
    // Cache the new class chain record
    auto record = _aotCache->getClassChainRecord(classRecords, ramClassChain.size());
    OMR::CriticalSection cs(getClassChainDataMapMonitor());
-   auto result = getClassChainDataMap().insert({ clazz, { classChain, record } });
+   auto result = getClassChainDataMap().insert({ clazz, { classChainOffset, record } });
    if (!result.second)
       result.first->second._aotCacheClassChainRecord = record;
    return record;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -346,7 +346,7 @@ public:
 
    struct ClassChainData
       {
-      uintptr_t *_classChain;
+      uintptr_t _classChainOffset;
       const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
       };
 
@@ -477,7 +477,7 @@ public:
    const AOTCacheMethodRecord *getMethodRecord(J9Method *method, J9Class *definingClass, JITServer::ServerStream *stream);
    // If this function sets the missingLoaderInfo flag then a NULL result is due to missing class loader info; otherwise that
    // result is due to a failure to allocate.
-   const AOTCacheClassChainRecord *getClassChainRecord(J9Class *clazz, uintptr_t *classChain,
+   const AOTCacheClassChainRecord *getClassChainRecord(J9Class *clazz, uintptr_t classChainOffset,
                                                        const std::vector<J9Class *> &ramClassChain, JITServer::ServerStream *stream,
                                                        bool &missingLoaderInfo);
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -524,7 +524,7 @@ JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *recor
 
    // Create the class chain in the local SCC or find the existing one
    uintptr_t offset = _sharedCache->rememberClass((TR_OpaqueClassBlock *)ramClasses[0]);
-   if (0 == offset)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == offset)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -523,8 +523,8 @@ JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *recor
       }
 
    // Create the class chain in the local SCC or find the existing one
-   uintptr_t *chain = _sharedCache->rememberClass((TR_OpaqueClassBlock *)ramClasses[0]);
-   if (!chain)
+   uintptr_t offset = _sharedCache->rememberClass((TR_OpaqueClassBlock *)ramClasses[0]);
+   if (0 == offset)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
@@ -534,16 +534,7 @@ JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *recor
       return false;
       }
 
-   uintptr_t offset = (uintptr_t)-1;
-   if (!_sharedCache->isPointerInSharedCache(chain, &offset))
-      {
-      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
-            "ERROR: Failed to get SCC offset for class chain %p ID %zu for class %.*s ID %zu",
-            chain, record->id(), ROMCLASS_NAME(ramClasses[0]->romClass), record->list().ids()[0]
-         );
-      return false;
-      }
+   uintptr_t *chain = (uintptr_t *)_sharedCache->pointerFromOffsetInSharedCache(offset);
    uintptr_t chainLength = chain[0] / sizeof(chain[0]) - 1;
    uintptr_t *chainItems = chain + 1;
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -696,11 +696,15 @@ TR::SymbolValidationManager::addClassRecordWithChain(TR::ClassValidationRecordWi
    if (!_fej9->isPrimitiveClass(record->_class))
       {
       const AOTCacheClassChainRecord *classChainRecord = NULL;
-      record->_classChain = _fej9->sharedCache()->rememberClass(record->_class, &classChainRecord);
-      if (record->_classChain == NULL)
+      void *classChain = _fej9->sharedCache()->rememberClass(record->_class, &classChainRecord);
+      if (classChain == NULL)
          {
          _region.deallocate(record);
          return false;
+         }
+      else
+         {
+         record->_classChainOffset = _fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
          }
 
 #if defined(J9VM_OPT_JITSERVER)
@@ -1661,7 +1665,7 @@ void TR::ClassValidationRecordWithChain::printFields()
    {
    traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
    printClass(_class);
-   traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
+   traceMsg(TR::comp(), "\t_classChainOffset=%" OMR_PRIuPTR "\n", _classChainOffset);
    }
 
 bool TR::ClassByNameRecord::isLessThanWithinKind(SymbolValidationRecord *other)

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -251,7 +251,7 @@ TR::SymbolValidationManager::populateWellKnownClasses()
       int32_t len = (int32_t)strlen(name);
       TR_OpaqueClassBlock *wkClass = _fej9->getSystemClassFromClassName(name, len);
 
-      uintptr_t chainOffset = 0;
+      uintptr_t chainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       if (wkClass == NULL)
          {
          traceMsg(_comp, "well-known class %s not found\n", name);
@@ -272,7 +272,7 @@ TR::SymbolValidationManager::populateWellKnownClasses()
 #endif /* defined(J9VM_OPT_JITSERVER) */
          }
 
-      if (chainOffset == 0)
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == chainOffset)
          {
          traceMsg(_comp, "no class chain for well-known class %s\n", name);
          SVM_ASSERT_NONFATAL(
@@ -606,7 +606,7 @@ TR::SymbolValidationManager::getClassChainInfo(
       // primitive because primitives always satisfy isAlreadyValidated().
       const AOTCacheClassChainRecord *classChainRecord = NULL;
       info._baseComponentClassChainOffset = _fej9->sharedCache()->rememberClass(info._baseComponent, &classChainRecord);
-      if (info._baseComponentClassChainOffset == 0)
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == info._baseComponentClassChainOffset)
          {
          _region.deallocate(record);
          return false;
@@ -637,7 +637,7 @@ TR::SymbolValidationManager::appendClassChainInfoRecords(
       }
 
    // If necessary, remember to validate the class chain of the base component type
-   if (info._baseComponentClassChainOffset != 0)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != info._baseComponentClassChainOffset)
       {
       appendNewRecord(
          info._baseComponent,
@@ -695,7 +695,7 @@ TR::SymbolValidationManager::addClassRecordWithChain(TR::ClassValidationRecordWi
       {
       const AOTCacheClassChainRecord *classChainRecord = NULL;
       record->_classChainOffset = _fej9->sharedCache()->rememberClass(record->_class, &classChainRecord);
-      if (record->_classChainOffset == 0)
+      if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == record->_classChainOffset)
          {
          _region.deallocate(record);
          return false;
@@ -799,7 +799,7 @@ TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
 
    const AOTCacheClassChainRecord *classChainRecord = NULL;
    uintptr_t classChainOffset = _fej9->sharedCache()->rememberClass(clazz, &classChainRecord);
-   if (classChainOffset == 0)
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == classChainOffset)
       return false;
 
    if (!isAlreadyValidated(clazz))

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -803,9 +803,10 @@ TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
    void *classChain = _fej9->sharedCache()->rememberClass(clazz, &classChainRecord);
    if (classChain == NULL)
       return false;
+   uintptr_t classChainOffset = _fej9->sharedCache()->offsetInSharedCacheFromPointer(classChain);
 
    if (!isAlreadyValidated(clazz))
-      appendNewRecord(clazz, new (_region) ProfiledClassRecord(clazz, classChain, classChainRecord));
+      appendNewRecord(clazz, new (_region) ProfiledClassRecord(clazz, classChainOffset, classChainRecord));
 
    addMultipleArrayRecords(clazz, arrayDims);
    return true;
@@ -1691,7 +1692,7 @@ void TR::ProfiledClassRecord::printFields()
    traceMsg(TR::comp(), "ProfiledClassRecord\n");
    traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
    printClass(_class);
-   traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
+   traceMsg(TR::comp(), "\t_classChainOffset=%" OMR_PRIuPTR "\n", _classChainOffset);
    }
 
 bool TR::ClassFromCPRecord::isLessThanWithinKind(SymbolValidationRecord *other)

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -388,11 +388,11 @@ struct ConcreteSubClassFromClassRecord : public ClassValidationRecord
 
 struct ClassChainRecord : public SymbolValidationRecord
    {
-   ClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain,
+   ClassChainRecord(TR_OpaqueClassBlock *clazz, uintptr_t classChainOffset,
                     const AOTCacheClassChainRecord *aotCacheClassChainRecord = NULL)
       : SymbolValidationRecord(TR_ValidateClassChain),
         _class(clazz),
-        _classChain(classChain)
+        _classChainOffset(classChainOffset)
       {
 #if defined(J9VM_OPT_JITSERVER)
       _aotCacheClassChainRecord = aotCacheClassChainRecord;
@@ -409,7 +409,7 @@ struct ClassChainRecord : public SymbolValidationRecord
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR_OpaqueClassBlock *_class;
-   void *_classChain;
+   uintptr_t _classChainOffset;
 #if defined(J9VM_OPT_JITSERVER)
    const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -887,7 +887,7 @@ private:
    struct ClassChainInfo
       {
       ClassChainInfo()
-         : _baseComponent(NULL), _baseComponentClassChain(NULL), _arrayDims(0)
+         : _baseComponent(NULL), _baseComponentClassChainOffset(0), _arrayDims(0)
          {
 #if defined(J9VM_OPT_JITSERVER)
          _baseComponentAOTCacheClassChainRecord = NULL;
@@ -895,7 +895,7 @@ private:
          }
 
       TR_OpaqueClassBlock *_baseComponent;
-      void *_baseComponentClassChain;
+      uintptr_t _baseComponentClassChainOffset;
       int32_t _arrayDims;
 #if defined(J9VM_OPT_JITSERVER)
       const AOTCacheClassChainRecord *_baseComponentAOTCacheClassChainRecord;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -196,10 +196,10 @@ struct ClassByNameRecord : public ClassValidationRecordWithChain
 
 struct ProfiledClassRecord : public ClassValidationRecord
    {
-   ProfiledClassRecord(TR_OpaqueClassBlock *clazz, void *classChain,
+   ProfiledClassRecord(TR_OpaqueClassBlock *clazz, uintptr_t classChainOffset,
                        const AOTCacheClassChainRecord *aotCacheClassChainRecord = NULL)
       : ClassValidationRecord(TR_ValidateProfiledClass),
-        _class(clazz), _classChain(classChain)
+        _class(clazz), _classChainOffset(classChainOffset)
       {
 #if defined(J9VM_OPT_JITSERVER)
       _aotCacheClassChainRecord = aotCacheClassChainRecord;
@@ -216,7 +216,7 @@ struct ProfiledClassRecord : public ClassValidationRecord
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR_OpaqueClassBlock *_class;
-   void *_classChain;
+   uintptr_t _classChainOffset;
 #if defined(J9VM_OPT_JITSERVER)
    const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -158,7 +158,7 @@ struct ClassValidationRecord : public SymbolValidationRecord
 struct ClassValidationRecordWithChain : public ClassValidationRecord
    {
    ClassValidationRecordWithChain(TR_ExternalRelocationTargetKind kind, TR_OpaqueClassBlock *clazz)
-      : ClassValidationRecord(kind), _class(clazz), _classChainOffset(0)
+      : ClassValidationRecord(kind), _class(clazz), _classChainOffset(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET)
       {
 #if defined(J9VM_OPT_JITSERVER)
       _aotCacheClassChainRecord = NULL;
@@ -887,7 +887,7 @@ private:
    struct ClassChainInfo
       {
       ClassChainInfo()
-         : _baseComponent(NULL), _baseComponentClassChainOffset(0), _arrayDims(0)
+         : _baseComponent(NULL), _baseComponentClassChainOffset(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET), _arrayDims(0)
          {
 #if defined(J9VM_OPT_JITSERVER)
          _baseComponentAOTCacheClassChainRecord = NULL;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -158,7 +158,7 @@ struct ClassValidationRecord : public SymbolValidationRecord
 struct ClassValidationRecordWithChain : public ClassValidationRecord
    {
    ClassValidationRecordWithChain(TR_ExternalRelocationTargetKind kind, TR_OpaqueClassBlock *clazz)
-      : ClassValidationRecord(kind), _class(clazz), _classChain(NULL)
+      : ClassValidationRecord(kind), _class(clazz), _classChainOffset(0)
       {
 #if defined(J9VM_OPT_JITSERVER)
       _aotCacheClassChainRecord = NULL;
@@ -174,7 +174,7 @@ struct ClassValidationRecordWithChain : public ClassValidationRecord
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR_OpaqueClassBlock *_class;
-   void *_classChain;
+   uintptr_t _classChainOffset;
 #if defined(J9VM_OPT_JITSERVER)
    const AOTCacheClassChainRecord *_aotCacheClassChainRecord;
 #endif /* defined(J9VM_OPT_JITSERVER) */


### PR DESCRIPTION
The `rememberClass` function now returns the offset to the class chain that it creates or finds in the local SCC, instead of returning the chain directly. Instead of returning `NULL` when class remembering fails, it now returns the value `0`. The offset of a class chain can never be zero in the local SCC, because that offset is always encoded with `encodeOffsetFromEnd` by `isPointerInSharedCache`, which means that the resulting value will always be odd:

https://github.com/eclipse-openj9/openj9/blob/c6df01b2e48aafb5305d6f26ab649c7c20e6b2dc/runtime/compiler/env/J9SharedCache.hpp#L363-L364

Various structures that previously stored class chain pointers now instead store offsets instead.