### PR TITLE
Support transition to debug interpreter on restore

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2394,3 +2394,10 @@ J9NLS_VM_DEPRECATED_OPTION.explanation=The command line option is deprecated.
 J9NLS_VM_DEPRECATED_OPTION.system_action=The JVM will print a deprecation warning.
 J9NLS_VM_DEPRECATED_OPTION.user_response=Remove the command line option from the command line.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED=The check for the transition to the debug interpreter failed
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.explanation=checkTransitionToDebugInterpreter failed.
+J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.user_response=View CRIU documentation to determine how to resolve the error.
+# END NON-TRANSLATABLE

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -761,6 +761,24 @@
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
   </test>
+
+  <test id="Test checkTransitionToDebugInterpreter with env var file">
+    <!-- The transition to the debug interpreter currently only works with -Xint, which will be removed when the jit changes are completed. -->
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+DebugOnRestore -Xint" $MAINCLASS_ENVVAR_TEST$ testCheckTransitionToDebugInterpreterWithEnvVarFile 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
+
   <test id="Restore trace options test with no trace options specified before checkpoint - 1">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $MAINCLASS_OPTIONSFILE_TEST$ TraceOptionsTest1 1 false false</command>
     <output type="success" caseSensitive="no" regex="no">Killed</output>
@@ -895,6 +913,23 @@
     <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
     <output type="failure" caseSensitive="yes" regex="no">Dump option unrecognized: -Xdump:nofailover</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+  </test>
+
+  <test id="Test checkTransitionToDebugInterpreter with options file">
+    <!-- The transition to the debug interpreter currently only works with -Xint, which will be removed when the jit changes are completed. -->
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+DebugOnRestore -Xint" $MAINCLASS_OPTIONSFILE_TEST$ testCheckTransitionToDebugInterpreterWithOptionsFile 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="success" caseSensitive="yes" regex="no">Post-checkpoint</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
     <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
     <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/EnvVarFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/EnvVarFileTest.java
@@ -83,6 +83,9 @@ public class EnvVarFileTest {
 		case "EnvVarFileTest16":
 			envVarFileTest16();
 			break;
+		case "testCheckTransitionToDebugInterpreterWithEnvVarFile":
+			testCheckTransitionToDebugInterpreterWithEnvVarFile();
+			break;
 		default:
 			throw new RuntimeException("incorrect parameters");
 		}
@@ -404,4 +407,15 @@ public class EnvVarFileTest {
 		System.out.println("Post-checkpoint");
 	}
 
+	static void testCheckTransitionToDebugInterpreterWithEnvVarFile() {
+		String optionsContents = RESTORE_ENV_VAR + "=-XX:+DebugInterpreter";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+	}
 }

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -71,6 +71,9 @@ public class OptionsFileTest {
 		case "JitOptionsTest":
 			jitOptionsTest(args);
 			break;
+		case "testCheckTransitionToDebugInterpreterWithOptionsFile":
+			testCheckTransitionToDebugInterpreterWithOptionsFile();
+			break;
 		default:
 			throw new RuntimeException("incorrect parameters");
 		}
@@ -332,4 +335,15 @@ public class OptionsFileTest {
 		}
 	}
 
+	static void testCheckTransitionToDebugInterpreterWithOptionsFile() {
+		String optionsContents = "-XX:+DebugInterpreter";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+	}
 }


### PR DESCRIPTION
Support transition to debug interpreter on restore when
the transition is requested with an env var file or an
options file.
    
Issue: https://github.com/eclipse-openj9/openj9/issues/17642
Co-authored-by: Tobi Ajila <atobia@ca.ibm.com>
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>