### PR TITLE
Support persistent class loader name tracking in all cases when JITServer AOT cache is active

### DIFF
--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -380,6 +380,18 @@ TR_PersistentClassLoaderTable::lookupClassLoaderAndChainAssociatedWithClassName(
    return { info->_loader, info->_chain };
    }
 
+const J9UTF8 *
+TR_PersistentClassLoaderTable::lookupClassNameAssociatedWithClassLoader(void *loader) const
+   {
+   assertCurrentThreadCanRead();
+
+   size_t index;
+   TR_ClassLoaderInfo *prev;
+   TR_ClassLoaderInfo *info = lookup<Loader>(_loaderTable, index, prev, loader);
+   if (!info)
+      return NULL;
+   return info->_nameStr;
+   }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 

--- a/runtime/compiler/env/ClassLoaderTable.hpp
+++ b/runtime/compiler/env/ClassLoaderTable.hpp
@@ -46,6 +46,7 @@ public:
    // in order to support AOT method serialization (and caching at JITServer) and deserialization.
    std::pair<void *, void *>// loader, chain
    lookupClassLoaderAndChainAssociatedWithClassName(const uint8_t *data, size_t length) const;
+   const J9UTF8 *lookupClassNameAssociatedWithClassLoader(void *loader) const;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    void removeClassLoader(J9VMThread *vmThread, void *loader);
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -388,6 +388,14 @@ JITServerAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *reco
          );
       return false;
       }
+   else if (!chain)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "ERROR: Found class loader but not chain for first loaded class %.*s", RECORD_NAME(record)
+         );
+      return false;
+      }
 
    uintptr_t offset = _sharedCache->offsetInSharedCacheFromPointer(chain);
    addToMaps(_classLoaderIdMap, _classLoaderPtrMap, it, record->id(), { loader, offset }, loader);


### PR DESCRIPTION
The persistent class loader table will now track the name of the first-loaded class of particular class loaders whenever `getJITServerUseAOTCache()` is true, including when a local SCC is not present. If the ROM class of the first-loaded class happens to be shared, the table will save a pointer to its name in the local SCC. Otherwise, we create a persistent copy of the name.

A query function `lookupClassNameAssociatedWithClassLoader` has been added to look up only the class name associated to a class loader. Presently it is unused, but it will be useful in https://github.com/eclipse-openj9/openj9/pull/18301.

The `isROMClassInSharedCache` query function is now public. I was a little too ambitious making it private in https://github.com/eclipse-openj9/openj9/pull/18821 - it's still sometimes useful as a query, but only for lower-level ROM class processing when there is local SCC guaranteed to be present.