### PR TITLE
Allow loader data without local offsets

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -896,8 +896,7 @@ ClientSessionData::getClassRecord(J9Class *clazz, JITServer::ServerStream *strea
       auto recv = stream->read<uintptr_t, std::string>();
       uintptr_t offset = std::get<0>(recv);
       auto &name = std::get<1>(recv);
-
-      if (offset)
+      if (!name.empty())
          {
          OMR::CriticalSection cs(getROMMapMonitor());
          auto it = getROMClassMap().find((J9Class *)clazz);


### PR DESCRIPTION
Class chain offsets do not necessarily need to be present when fetching class loader data from the client in getClassRecord. We only really care about the name of the loader at this point, since that is what is used to create the server ClassLoader record. The server already tolerates not having the local class chain offset cached - if it ever requires that information, say during compilation, it will request the offset from the client again.