### PR TITLE
Remove the need for numerous '--add-exports=openj9.dtfj' options

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/SetupConfig.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/SetupConfig.java
@@ -68,6 +68,12 @@ public class SetupConfig {
 		if (ddrInstance == null) {
 			if (coreFile != null) {
 				try {
+					/*
+					 * In modular VMs, the static initializer of ImageFactory
+					 * exports the packages to which we need access.
+					 */
+					Class.forName("com.ibm.dtfj.image.j9.ImageFactory");
+
 					DDROutputStream ps = getPrintStream();
 					ddrInstance = new DDRInteractive(coreFile, ps);
 					log.info("Created new DDR Interactive instance using core file : "

--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -158,23 +158,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 				<classpath refid="tck.class.path" />
 			</common-elements>
 			<modular-elements>
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.corereaders=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.corereaders.memory=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.corereaders.osthread=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.events=ALL-UNNAMED" />
 				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive.annotations=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.util=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.view.dtfj.image=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.gc=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.walkers=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.generated=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.helper=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.tools.ddrinteractive=ALL-UNNAMED" />
-				<jvmarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.types=ALL-UNNAMED" />
 			</modular-elements>
 		</java-wrapper>
 	</target>


### PR DESCRIPTION
Loading ImageFactory will export most of the packages needed.

Tested in https://openj9-jenkins.osuosl.org/job/Grinder/3194.