### PR TITLE
Modify ROMclass packing to normalize more

### DIFF
--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1245,6 +1245,7 @@ ROMClassWriter::writeMethods(Cursor *cursor, Cursor *lineNumberCursor, Cursor *v
 	 *  - allSlotsInROMMethodsSectionDo() in util/romclasswalk.c
 	 *  - dbgNextROMMethod() in dbgext/j9dbgext.c
 	 *  - createBreakpointedMethod() in jvmti/jvmtiHelpers.cpp
+	 *  - JITServerHelpers::packROMClass() in compiler/control/JITServerHelpers.cpp
 	 * All the above are involved in walking or walking over ROMMethods.
 	 *
 	 */

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -95,7 +95,7 @@ public:
    // structures used for packing). This function should be used with TR::StackMemoryRegion.
    // If passed non-zero expectedSize, and it doesn't match the resulting packedSize
    // (which is returned to the caller by reference), this function returns NULL.
-   static J9ROMClass *packROMClass(J9ROMClass *romClass, TR_Memory *trMemory, size_t &packedSize, size_t expectedSize = 0);
+   static J9ROMClass *packROMClass(J9ROMClass *romClass, TR_Memory *trMemory, TR_J9VMBase *fej9, size_t &packedSize, size_t expectedSize = 0);
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory, bool serializeClass);
    static void freeRemoteROMClass(J9ROMClass *romClass, TR_PersistentMemory *persistentMemory);

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -306,7 +306,7 @@ JITServerAOTDeserializer::isClassMatching(const ClassSerializationRecord *record
    TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
 
    size_t packedSize;
-   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass(ramClass->romClass, comp->trMemory(),
+   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass(ramClass->romClass, comp->trMemory(), comp->fej9(),
                                                                packedSize, record->romClassSize());
    if (!packedROMClass)
       {


### PR DESCRIPTION
When ROM classes are packed to be sent to the JITServer, we now perform two additional transformations, in addition to the existing string inlining:

1. The return bytecodes in the ROM class are fixed up if the class is not shared.
2. Any inlined debug info is stripped from the ROM class

Both of these are necessary to ensure that the packed representations of shared and non-shared versions of the same ROM class are identical. Otherwise, the difference in representations will cause them to have different hashes, and that will effectively prevent us from sharing code between JITServer clients that have different mixes of shared and non-shared classes.