### PR TITLE
(0.43) Remove javadoc tables used for code examples

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/JvmCpuMonitorMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/JvmCpuMonitorMXBean.java
@@ -63,9 +63,7 @@ import java.lang.management.PlatformManagedObject;
  *     <li>Collecting transaction metrics for a specific set of application threads over a specific duration.
  * </ol>
  * <br>
- * <table border="1">
- * <caption><b>Usage example for the {@link JvmCpuMonitorMXBean}</b></caption>
- * <tr> <td>
+ * <b>Usage example for the {@link JvmCpuMonitorMXBean}</b>
  * <pre>
  * {@code
  *   ...
@@ -84,8 +82,7 @@ import java.lang.management.PlatformManagedObject;
  *      // Exception Handling
  *   }
  * }
- * </pre></td></tr>
- * </table>
+ * </pre>
  */
 public interface JvmCpuMonitorMXBean extends PlatformManagedObject {
 	

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/OperatingSystemMXBean.java
@@ -23,18 +23,17 @@
 package com.ibm.lang.management;
 
 /**
- * OpenJ9 platform management extension interface for the Operating System on which the Java Virtual Machine is running.
+ * <p>OpenJ9 platform management extension interface for the Operating System on which the Java Virtual Machine is running.</p>
  * <br>
- * <table border="1">
- * <caption><b>Usage example for the {@link com.ibm.lang.management.OperatingSystemMXBean}</b></caption>
- * <tr> <td> <pre>
+ * <b>Usage example for the {@link com.ibm.lang.management.OperatingSystemMXBean}</b>
+ * <pre>
  * {@code
  * ...
  * com.ibm.lang.management.OperatingSystemMXBean osmxbean = null;
  * osmxbean = (com.ibm.lang.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
  * ...
  * }
- * </pre></td></tr></table>
+ * </pre>
  * <br>
  *
  * The following methods depend on certain information that is not available on z/OS;

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMXBean.java
@@ -49,9 +49,7 @@ import java.lang.management.*;
  *      </ul>
  * </ol>
  * <br>
- * <table border="1">
- * <caption><b>Usage example for the {@link GuestOSMXBean}</b></caption>
- * <tr> <td>
+ * <b>Usage example for the {@link GuestOSMXBean}</b>
  * <pre>
  * {@code
  *   ...
@@ -70,7 +68,7 @@ import java.lang.management.*;
  *	// Exception Handling
  *   }
  * }
- * </pre></td></tr></table>
+ * </pre>
  *
  * @since 1.7.1
  */

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/HypervisorMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/HypervisorMXBean.java
@@ -53,9 +53,8 @@ import java.lang.management.PlatformManagedObject;
  *          indeterminate.
  * </ul>
  * <br>
- * <table border="1">
- * <caption><b>Usage example for the {@link HypervisorMXBean}</b></caption>
- * <tr> <td> <pre>
+ * <b>Usage example for the {@link HypervisorMXBean}</b>
+ * <pre>
  * {@code
  *   ...
  *   try {
@@ -73,7 +72,7 @@ import java.lang.management.PlatformManagedObject;
  *	// Exception Handling
  *   }
  * }
- * </pre></td></tr></table>
+ * </pre>
  *
  * @since 1.7.1
  */

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
@@ -30,11 +30,10 @@ import java.lang.management.PlatformManagedObject;
  * <p>
  * This interface provides APIs to dynamically trigger dump agents. APIs are also available to
  * configure dump options.
- * This MXBean reuses the methods in com.ibm.jvm.Dump API 
+ * This MXBean reuses the methods in com.ibm.jvm.Dump API.
+ * </p>
  * <br>
- * <table border="1">
- * <caption><b>Usage example for the {@link OpenJ9DiagnosticsMXBean}</b></caption>
- * <tr> <td>
+ * <b>Usage example for the {@link OpenJ9DiagnosticsMXBean}</b>
  * <pre>
  * {@code
  *   ...
@@ -53,8 +52,7 @@ import java.lang.management.PlatformManagedObject;
  *      // Exception Handling
  *   }
  * }
- * </pre></td></tr>
- * </table>
+ * </pre>
  */
 public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	/**


### PR DESCRIPTION
The tables have no headers, which is an accessibility check violation.

Cherry pick https://github.com/eclipse-openj9/openj9/pull/18826 for 0.43