### PR TITLE
Implement more robust deserializer reset detection

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1314,6 +1314,16 @@ public:
    bool methodCanBeJITServerAOTCacheLoaded(const char *methodSig, TR::Method::Type ty);
 
    bool methodCanBeRemotelyCompiled(const char *methodSig, TR::Method::Type ty);
+
+   /**
+   * @brief Notify every compilation thread that a JITServer AOT deserializer reset has occurred
+   *
+   * This function sets the _deserializerWasReset flag in every compilation thread. This function
+   * must be called with the appropriate deserializer monitors in hand. See
+   * JITServerAOTDeserializer::reset() for details.
+   *
+   */
+   void notifyCompilationThreadsOfDeserializerReset();
 #endif /* defined(J9VM_OPT_JITSERVER) */
    uint32_t getNumTotalCompilations() const { return _numSyncCompilations + _numAsyncCompilations; }
    uint32_t getNumCompsUsedForCompDensityCalculations() const { return _numCompsUsedForCompDensityCalculations; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1136,6 +1136,7 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
       {
       _classesThatShouldNotBeNewlyExtended = NULL;
       }
+   _deserializerWasReset = false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }
 
@@ -13463,5 +13464,16 @@ bool
 TR::CompilationInfo::methodCanBeRemotelyCompiled(const char *methodSig, TR::Method::Type ty)
    {
    return queryJITServerFilter(methodSig, ty, TR::Options::_JITServerRemoteExcludeFilters);
+   }
+
+void
+TR::CompilationInfo::notifyCompilationThreadsOfDeserializerReset()
+   {
+   for (int32_t i = getFirstCompThreadID(); i <= getLastCompThreadID(); i++)
+      {
+      TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
+      TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
+      curCompThreadInfoPT->setDeserializerWasReset();
+      }
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -513,6 +513,11 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    J9ROMClass               *getAndCacheRemoteROMClass(J9Class *clazz);
    J9ROMClass               *getRemoteROMClassIfCached(J9Class *clazz);
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() const { return _classesThatShouldNotBeNewlyExtended; }
+   bool                      getDeserializerWasReset() const { return _deserializerWasReset; }
+   // Called externally by a compilation thread that is resetting the JITServer AOT deserializer
+   void                      setDeserializerWasReset() { _deserializerWasReset = true; }
+   // Called by the current compilation thread at the beginning of a remote compilation to clear the _deserializerWasReset flag
+   void                      clearDeserializerWasReset() { _deserializerWasReset = false; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    protected:
@@ -537,6 +542,8 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;
+   // A flag notifying this thread that the JITServer AOT deserializer was reset.
+   bool _deserializerWasReset;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    }; // CompilationInfoPerThread

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -164,6 +164,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerPort(38400),
          _socketTimeoutMs(0),
          _clientUID(0),
+         _serverUID(0),
          _JITServerMetricsPort(38500),
          _requireJITServer(false),
          _localSyncCompiles(true),


### PR DESCRIPTION
Compilation threads must be able to detect whether or not a concurrent JITServer AOT cache deserializer reset has occurred during the course of deserializing a particular method. This check must be performed before any lookup or store operation involving the deserializer's internal caches. The methods of the deserializer now detect and report that such a reset has occurred by first acquiring the relevant deserializer monitor, checking the new _deserializerWasReset flag in the ongoing compilation's TR::CompilationInfoPerThread, and setting a &wasReset flag passed in to the method if such a reset occurred.

The _deserializerWasReset flag is set for every compilation thread by the thread doing the resetting, when it is guaranteed to have exclusive access to the deserializer's caches. Each compilation thread will reset its own flag at the start of a remote compilation, when they are guaranteed not to be processing JITServer AOT cache records from an old server connection.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18858