### PR TITLE
Refactor J9JVMTI_HEAP_EVENT_STACK data parsing

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.hpp
+++ b/runtime/gc_base/ReferenceChainWalker.hpp
@@ -74,10 +74,15 @@ private:
 	bool _isProcessingOverflow; /**< Set when the queue is currently processing the overflow */
 	bool _isTerminating; /**< Set when no more callbacks should be queued */
 	bool _shouldPreindexInterfaceFields; /**< if true, indexes interface fields of the class being visited before class and superclass fields, otherwise, returns them in the order they appear in an object instance (CMVC 142897) */
+#if JAVA_SPEC_VERSION >= 19
+	bool _includeVThreadObject; /**< Set when VirtualThread object is needed by callback function */
+	J9Object *_vThreadObject; /**< Cached object ref of VirtualThread object */
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	MM_ReferenceChainWalkerMarkMap *_markMap;	/**< Mark Map created for Reference Chain Walker */
 	MM_Heap *_heap; /**< Cached pointer to the heap */
 	void *_heapBase; /**< Cached value of the heap base */
 	void *_heapTop; /**< Cached value of the heap top */
+
 
 	void clearQueue();
 	void pushObject(J9Object *obj);
@@ -235,6 +240,10 @@ public:
 		_isProcessingOverflow(false),
 		_isTerminating(false),
 		_shouldPreindexInterfaceFields(true),	/* default to behaviour required for Java6/heap11 */
+#if JAVA_SPEC_VERSION >= 19
+		_includeVThreadObject(false),
+		_vThreadObject(NULL),
+#endif /* JAVA_SPEC_VERSION >= 19 */
 		_markMap(NULL),
 		_heap(NULL),
 		_heapBase(NULL),
@@ -259,6 +268,10 @@ public:
 		completeScan();
 	}
 	
+#if JAVA_SPEC_VERSION >= 19
+	void includeVThreadObject() { _includeVThreadObject = true; }
+#endif /* JAVA_SPEC_VERSION >= 19 */
+
 	/**
 	 * Added to support bi-modal interface indexing in JVMTI (CMVC 142897).
 	 * Detail:  heap10 requires no pre-indexing in order to preserve Java5 behaviour but heap11 requires pre-indexing to pass a Java6 JCK

--- a/runtime/gc_include/HeapIteratorAPI.h
+++ b/runtime/gc_include/HeapIteratorAPI.h
@@ -164,6 +164,11 @@ typedef struct J9MM_HeapRootSlotDescriptor {
 	UDATA slotReachability; /**< Reachability of slot */
 } J9MM_HeapRootSlotDescriptor;
 
+typedef struct J9MM_StackSlotDescriptor {
+	J9VMThread *vmThread; /**< Thread containing the stack slot. */
+	J9StackWalkState *walkState; /**< WalkState that found the slot, or null if found directly in thread local tables. */
+} J9MM_StackSlotDescriptor;
+
 typedef jvmtiIterationControl (*rootIteratorCallBackFunc)(void* ptr, J9MM_HeapRootSlotDescriptor *rootDesc, void *userData);
 
 /**

--- a/runtime/gc_include/HeapIteratorAPI.h
+++ b/runtime/gc_include/HeapIteratorAPI.h
@@ -165,8 +165,8 @@ typedef struct J9MM_HeapRootSlotDescriptor {
 } J9MM_HeapRootSlotDescriptor;
 
 typedef struct J9MM_StackSlotDescriptor {
-	J9VMThread *vmThread; /**< Thread containing the stack slot. */
-	J9StackWalkState *walkState; /**< WalkState that found the slot, or null if found directly in thread local tables. */
+	J9VMThread *vmThread; /**< Thread containing the stack slot */
+	J9StackWalkState *walkState; /**< WalkState that found the slot, or null if found directly in thread local tables */
 } J9MM_StackSlotDescriptor;
 
 typedef jvmtiIterationControl (*rootIteratorCallBackFunc)(void* ptr, J9MM_HeapRootSlotDescriptor *rootDesc, void *userData);

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -118,7 +118,7 @@ static jvmtiError getArrayPrimitiveElements(J9JVMTIHeapData * iteratorData, jvmt
 static jvmtiIterationControl followReferencesCallback(j9object_t * slotPtr, j9object_t referrer, void *userData, IDATA type, IDATA referrerIndex, IDATA wasReportedBefore);
 static void mapEventType(J9JVMTIHeapData * data, IDATA type, jint index, j9object_t referrer, j9object_t object);
 static void jvmtiFollowRefs_getTags(J9JVMTIHeapData * iteratorData, j9object_t  referrer, j9object_t  object); 
-static UDATA jvmtiHeapFollowRefs_getStackData(J9JVMTIHeapData * iteratorData, J9StackWalkState *walkState);
+static UDATA jvmtiHeapFollowRefs_getStackData(J9JVMTIHeapData * iteratorData, J9MM_StackSlotDescriptor *stackSlotDescriptor);
 static IDATA heapReferenceFilter(J9JVMTIHeapData * iteratorData);
 
 
@@ -756,7 +756,7 @@ wrap_heapReferenceCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData)
         case JVMTI_HEAP_REFERENCE_JNI_LOCAL:
             if (iteratorData->referrer) {
                 /* fill in the stack local and jni local data */
-                if (jvmtiHeapFollowRefs_getStackData(iteratorData, (J9StackWalkState *) iteratorData->referrer) == 0)
+                if (jvmtiHeapFollowRefs_getStackData(iteratorData, (J9MM_StackSlotDescriptor *) iteratorData->referrer) == 0)
                     return JVMTI_ITERATION_IGNORE;
             } else {
 				/* No reference info available for heap roots, slime some bogus values 
@@ -840,55 +840,56 @@ wrap_heapReferenceCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData)
  *
  */
 static UDATA
-jvmtiHeapFollowRefs_getStackData(J9JVMTIHeapData * iteratorData, J9StackWalkState *walkState)
+jvmtiHeapFollowRefs_getStackData(J9JVMTIHeapData * iteratorData, J9MM_StackSlotDescriptor *stackSlotDescriptor)
 {
 	J9JVMTIHeapEvent * e = &iteratorData->event;
-	jint slot = (jint) walkState->slotIndex;
-	jint depth = (jint) walkState->framesWalked;
-	J9Method * ramMethod = walkState->method;
-	jmethodID method;
+	jint slot = -1;
+	jint depth = -1;
+	J9Method *ramMethod = NULL;
+	jmethodID method = (jmethodID) -1;
 	J9JVMTIObjectTag search;
-	J9JVMTIObjectTag * result;
+	J9JVMTIObjectTag *result;
 	jlong threadID;
+	J9StackWalkState *walkState = stackSlotDescriptor->walkState;
 
+	if (NULL != walkState) {
+		slot = (jint) walkState->slotIndex;
+		depth = (jint) walkState->framesWalked;
+		ramMethod = walkState->method;
 
-	/* Convert internal slot type to JVMTI type */
-	switch (walkState->slotType) {
-		case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
-			e->refKind = JVMTI_HEAP_REFERENCE_JNI_LOCAL;
-			break;
-		case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
-			e->refKind = JVMTI_HEAP_REFERENCE_STACK_LOCAL;
-			break;
-		default:
-			/* Do not callback with stack slot types other then JNI or STACK Local */
-			return 0;
-	}
+		/* Convert internal slot type to JVMTI type */
 
-	/* If there's no method, set slot, method and depth to -1 */
+		switch (walkState->slotType) {
+			case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
+				e->refKind = JVMTI_HEAP_REFERENCE_JNI_LOCAL;
+				break;
+			case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
+				e->refKind = JVMTI_HEAP_REFERENCE_STACK_LOCAL;
+				break;
+			default:
+				/* Do not callback with stack slot types other then JNI or STACK Local */
+				return 0;
+		}
 
-	if (ramMethod == NULL) {
-		slot = -1;
-		depth = -1;
-		method = (jmethodID) -1;
-	} else {
-		/* Cheating here - should be current thread, but the walk thread will do */
-		method = getCurrentMethodID(walkState->walkThread, ramMethod);
-		if (method == NULL) {
-			slot = -1;
-			depth = -1;
-			method = (jmethodID) -1;
+		/* If there's no method, slot, method and depth are set to -1 by default. */
+
+		if (NULL != ramMethod) {
+			/* Cheating here - should be current thread, but the walk thread will do. */
+			method = getCurrentMethodID(walkState->walkThread, ramMethod);
+			if (NULL == method) {
+				method = (jmethodID) -1;
+			}
 		}
 	}
 
 	/* Find thread tag */
 	
-	search.ref = (j9object_t ) walkState->walkThread->threadObject;
+	search.ref = (j9object_t)stackSlotDescriptor->vmThread->threadObject;
 	result = hashTableFind(iteratorData->env->objectTagTable, &search);
 
 	/* Figure out the Thread ID */
 
-	threadID = J9VMJAVALANGTHREAD_TID(iteratorData->currentThread, walkState->walkThread->threadObject);
+	threadID = J9VMJAVALANGTHREAD_TID(iteratorData->currentThread, stackSlotDescriptor->vmThread->threadObject);
 	
 
 	switch (e->refKind) {
@@ -897,7 +898,7 @@ jvmtiHeapFollowRefs_getStackData(J9JVMTIHeapData * iteratorData, J9StackWalkStat
 			e->refInfo.stack_local.thread_id = threadID;
 			e->refInfo.stack_local.depth = depth;
 			e->refInfo.stack_local.method = method;
-			e->refInfo.stack_local.location = (jlocation) walkState->bytecodePCOffset;
+			e->refInfo.stack_local.location = (jlocation) ((walkState) ? walkState->bytecodePCOffset : 0);
 			e->refInfo.stack_local.slot = slot;
 			break;
 
@@ -1096,7 +1097,7 @@ mapEventType(J9JVMTIHeapData * data, IDATA type, jint index, j9object_t referrer
 			break;
 
 		case J9GC_ROOT_TYPE_JNI_LOCAL:
-			event->type = J9JVMTI_HEAP_EVENT_ROOT;
+			event->type = J9JVMTI_HEAP_EVENT_STACK;
 			event->refKind = JVMTI_HEAP_REFERENCE_JNI_LOCAL;
 			event->hasRefInfo = TRUE;
 			break;

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -462,14 +462,14 @@ processObjectRef(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlo
 
 
 static jvmtiIterationControl
-processStackRoot(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, jvmtiHeapRootKind kind, J9MM_StackSlotDescriptor *stackSlotDescriptor)
+processStackRoot(J9JVMTIObjectIteratorData *data, J9JVMTIObjectTag *entry, jlong size, jlong classTag, jvmtiHeapRootKind kind, J9MM_StackSlotDescriptor *stackSlotDescriptor)
 {
 	jint slot = -1;
 	jint depth = -1;
 	J9Method *ramMethod = NULL;
 	jmethodID method = (jmethodID) -1;
-	J9JVMTIObjectTag search;
-	J9JVMTIObjectTag *result;
+	J9JVMTIObjectTag search = {NULL, 0};
+	J9JVMTIObjectTag *result = NULL;
 
 	if (NULL != stackSlotDescriptor->walkState) {
 		J9StackWalkState *walkState = stackSlotDescriptor->walkState;
@@ -477,23 +477,22 @@ processStackRoot(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlo
 		depth = (jint) walkState->framesWalked;
 		ramMethod = walkState->method;
 
-		/* Convert internal slot type to JVMTI type */
+		/* Convert internal slot type to JVMTI type. */
 
 		switch (walkState->slotType) {
-			case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
-				kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
-				break;
-			case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
-				kind = JVMTI_HEAP_ROOT_STACK_LOCAL;
-				break;
-			default:
-				kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
-				ramMethod = NULL;
-				break;
+		case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
+			kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
+			break;
+		case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
+			kind = JVMTI_HEAP_ROOT_STACK_LOCAL;
+			break;
+		default:
+			kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
+			ramMethod = NULL;
+			break;
 		}
 
 		/* If there's no method, slot, method and depth are set to -1 by default. */
-
 		if (NULL != ramMethod) {
 			/* Cheating here - should be current thread, but the walk thread will do. */
 			method = getCurrentMethodID(walkState->walkThread, ramMethod);

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -59,7 +59,7 @@ typedef struct J9JVMTIHeapEvent {
 } J9JVMTIHeapEvent;
 
 static jvmtiIterationControl processHeapRoot (J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, jvmtiHeapRootKind kind);
-static jvmtiIterationControl processStackRoot (J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, J9StackWalkState * walkState);
+static jvmtiIterationControl processStackRoot (J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, jvmtiHeapRootKind kind, J9MM_StackSlotDescriptor * walkState);
 static jvmtiIterationControl wrapHeapIterationCallback(J9JavaVM * vm, J9MM_IterateObjectDescriptor *objectDesc, void * userData);
 static J9JVMTIHeapEvent mapEventType (J9VMThread *vmThread, J9JVMTIObjectIteratorData * data, IDATA type, IDATA index, j9object_t referrer, j9object_t object);
 static jvmtiIterationControl wrapObjectIterationCallback (j9object_t *slotPtr, j9object_t referrer, void *userData, IDATA type, IDATA referrerIndex, IDATA wasReportedBefore);
@@ -309,7 +309,7 @@ mapEventType(J9VMThread *vmThread, J9JVMTIObjectIteratorData * data, IDATA type,
 			break;
 
 		case J9GC_ROOT_TYPE_JNI_LOCAL:
-			event.type = J9JVMTI_HEAP_EVENT_ROOT;
+			event.type = J9JVMTI_HEAP_EVENT_STACK;
 			event.rootKind = JVMTI_HEAP_ROOT_JNI_LOCAL;
 			break;
 
@@ -462,50 +462,50 @@ processObjectRef(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlo
 
 
 static jvmtiIterationControl
-processStackRoot(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, J9StackWalkState * walkState)
+processStackRoot(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlong size, jlong classTag, jvmtiHeapRootKind kind, J9MM_StackSlotDescriptor *stackSlotDescriptor)
 {
-	jvmtiHeapRootKind kind;
-	jint slot = (jint) walkState->slotIndex;
-	jint depth = (jint) walkState->framesWalked;
-	J9Method * ramMethod = walkState->method;
-	jmethodID method;
+	jint slot = -1;
+	jint depth = -1;
+	J9Method *ramMethod = NULL;
+	jmethodID method = (jmethodID) -1;
 	J9JVMTIObjectTag search;
-	J9JVMTIObjectTag * result;
+	J9JVMTIObjectTag *result;
 
-	/* Convert internal slot type to JVMTI type */
+	if (NULL != stackSlotDescriptor->walkState) {
+		J9StackWalkState *walkState = stackSlotDescriptor->walkState;
+		slot = (jint) walkState->slotIndex;
+		depth = (jint) walkState->framesWalked;
+		ramMethod = walkState->method;
 
-	switch (walkState->slotType) {
-		case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
-			kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
-			break;
-		case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
-			kind = JVMTI_HEAP_ROOT_STACK_LOCAL;
-			break;
-		default:
-			kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
-			ramMethod = NULL;
-			break;
-	}
+		/* Convert internal slot type to JVMTI type */
 
-	/* If there's no method, set slot, method and depth to -1 */
+		switch (walkState->slotType) {
+			case J9_STACKWALK_SLOT_TYPE_JNI_LOCAL:
+				kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
+				break;
+			case J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL:
+				kind = JVMTI_HEAP_ROOT_STACK_LOCAL;
+				break;
+			default:
+				kind = JVMTI_HEAP_ROOT_JNI_LOCAL;
+				ramMethod = NULL;
+				break;
+		}
 
-	if (ramMethod == NULL) {
-		slot = -1;
-		depth = -1;
-		method = (jmethodID) -1;
-	} else {
-		/* Cheating here - should be current thread, but the walk thread will do */
-		method = getCurrentMethodID(walkState->walkThread, ramMethod);
-		if (method == NULL) {
-			slot = -1;
-			depth = -1;
-			method = (jmethodID) -1;
+		/* If there's no method, slot, method and depth are set to -1 by default. */
+
+		if (NULL != ramMethod) {
+			/* Cheating here - should be current thread, but the walk thread will do. */
+			method = getCurrentMethodID(walkState->walkThread, ramMethod);
+			if (NULL == method) {
+				method = (jmethodID) -1;
+			}
 		}
 	}
 
 	/* Find thread tag */
 
-	search.ref = (j9object_t) walkState->walkThread->threadObject;
+	search.ref = (j9object_t)stackSlotDescriptor->vmThread->threadObject;
 	result = hashTableFind(data->env->objectTagTable, &search);
 	
 	/* Call the callback */
@@ -639,7 +639,7 @@ wrapObjectIterationCallback(j9object_t *slotPtr, j9object_t referrer, void *user
 				returnCode = processHeapRoot(iteratorData, result, objectSize, classTag, event.rootKind);
 				break;
 			case J9JVMTI_HEAP_EVENT_STACK:
-				returnCode = processStackRoot(iteratorData, result, objectSize, classTag, (J9StackWalkState *)  referrer);
+				returnCode = processStackRoot(iteratorData, result, objectSize, classTag, event.rootKind, (J9MM_StackSlotDescriptor *)referrer);
 				break;
 			case J9JVMTI_HEAP_EVENT_OBJECT:
 				returnCode = processObjectRef(iteratorData, result, objectSize, classTag, event.refKind, referrerTag, (jint)event.index);


### PR DESCRIPTION
Added new structure to hold JNI and Stack local referrer data. Update JNI locals found via jniLocalReferences table to be marked as Stack root.

Closes: #18416 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>