### PR TITLE
Detach copy-cache size bounds from TLH size bounds for Balanced

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -261,7 +261,7 @@ MM_CopyForwardScheme::initialize(MM_EnvironmentVLHGC *env)
 	UDATA minCacheCount = threadCount * cachesPerThread;
 	
 	/* Estimate how many caches we might need to describe the entire heap */
-	UDATA heapCaches = extensions->memoryMax / extensions->tlhMaximumSize;
+	UDATA heapCaches = extensions->memoryMax / extensions->scavengerScanCacheMaximumSize;
 
 	/* use whichever value is higher */
 	UDATA totalCacheCount = OMR_MAX(minCacheCount, heapCaches);
@@ -297,8 +297,8 @@ MM_CopyForwardScheme::initialize(MM_EnvironmentVLHGC *env)
 	}
 
 	/* Set the min/max sizes for copy scan cache allocation when allocating a general purpose area (does not include non-standard sized objects) */
-	_minCacheSize = _extensions->tlhMinimumSize;
-	_maxCacheSize = _extensions->tlhMaximumSize;
+	_minCacheSize = _extensions->scavengerScanCacheMinimumSize;
+	_maxCacheSize = _extensions->scavengerScanCacheMaximumSize;
 
 	/* Cached pointer to the inter region remembered set */
 	_interRegionRememberedSet = MM_GCExtensions::getExtensions(env)->interRegionRememberedSet;

--- a/runtime/gc_vlhgc/CopyScanCacheChunkVLHGCInHeap.cpp
+++ b/runtime/gc_vlhgc/CopyScanCacheChunkVLHGCInHeap.cpp
@@ -31,7 +31,7 @@
 uintptr_t
 MM_CopyScanCacheChunkVLHGCInHeap::numberOfCachesInChunk(MM_EnvironmentVLHGC *env)
 {
-	uintptr_t tlhMinimumSize = MM_GCExtensions::getExtensions(env)->tlhMinimumSize;
+	uintptr_t tlhMinimumSize = MM_GCExtensions::getExtensions(env)->scavengerScanCacheMinimumSize;
 	uintptr_t sizeToAllocate = sizeof(MM_CopyScanCacheChunkVLHGCInHeap);
 	uintptr_t numberOfCaches = 1;
 


### PR DESCRIPTION
For Balanced GC, min/max copy-cache size bounds used by GC threads for Copy-Forward caches are currently identical to min/max TLH size bounds used by mutator threads. This is rigid and problematic if we want to increase TLH sizes for large systems with large allocation rate, since too large copy-cache sizes may lead to suboptimal parallelism in GC.

Gencon's Scavenge already uses separate bounds, and this change will make Copy-Forward to use the same bounds as Scavenge (and also be able to use separate options to change the default values).

Default max size will remain unchanged - 128KB.
Default min size will increase to 8K from 768bytes, but this is a good change since 8K is already a tuned value, while too low value may cause too much activity/contention on the scan queue.