### PR TITLE
Override -XX:+ShowHiddenFrames option in getCallerClass API

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -64,6 +64,7 @@ public final class StackWalker {
 	/*[IF JAVA_SPEC_VERSION >= 22]*/
 	private static final int J9_DROP_METHOD_INFO       = 0x10;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
+	private static final int J9_GET_CALLER_CLASS       = 0x20;
 
 	/* Map the given options to the corresponding set of flags. */
 	private static int flagsFor(Set<Option> options) {
@@ -239,7 +240,7 @@ public final class StackWalker {
 		 * Get the top two stack frames: the client calling getCallerClass and
 		 * the client's caller. Ignore reflection and special frames.
 		 */
-		List<StackFrame> result = StackWalker.walkWrapperImpl(J9_RETAIN_CLASS_REFERENCE, "getCallerClass", //$NON-NLS-1$
+		List<StackFrame> result = StackWalker.walkWrapperImpl(J9_RETAIN_CLASS_REFERENCE | J9_GET_CALLER_CLASS, "getCallerClass", //$NON-NLS-1$
 				s -> s.limit(2).collect(Collectors.toList()));
 		if (result.size() < 2) {
 			/*[MSG "K0640", "getCallerClass() called from method with no caller"]*/

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -41,6 +41,7 @@ extern "C" {
 #if JAVA_SPEC_VERSION >= 22
 #define J9_DROP_METHOD_INFO       0x10
 #endif /* JAVA_SPEC_VERSION >= 22 */
+#define J9_GET_CALLER_CLASS       0x20
 
 #define J9_FRAME_VALID            0x80
 
@@ -109,9 +110,11 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 			| J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY;
 	/* Unless -XX:+ShowHiddenFrames or StackWalker.Option.SHOW_HIDDEN_FRAMES
 	 * has been specified, skip hidden method frames.
+	 * If this is called from getCallerClass() API, then always skip hidden frames.
 	 */
-	if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)
-			&& J9_ARE_NO_BITS_SET((UDATA)flags, J9_SHOW_HIDDEN_FRAMES)
+	if (J9_ARE_ANY_BITS_SET((UDATA)flags, J9_GET_CALLER_CLASS)
+	|| (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_SHOW_HIDDEN_FRAMES)
+		&& J9_ARE_NO_BITS_SET((UDATA)flags, J9_SHOW_HIDDEN_FRAMES))
 	) {
 		walkState->flags |= J9_STACKWALK_SKIP_HIDDEN_FRAMES;
 	}


### PR DESCRIPTION
Add J9_GET_CALLER_CLASS flag to identify StackWalker.getCallerClass().

Fixes: #18697 