### PR TITLE
Allow SCC to be overridden during relocation

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1383,6 +1383,7 @@ public:
 
    virtual TR_J9SharedCache *sharedCache() { return _sharedCache; }
    virtual void              freeSharedCache();
+   virtual void              setSharedCache(TR_J9SharedCache *sharedCache) { _sharedCache = sharedCache; }
 
    const char *getByteCodeName(uint8_t opcode);
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -242,7 +242,9 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
                                                     TR::Options *options,
                                                     TR::Compilation *comp,
                                                     TR_ResolvedMethod *resolvedMethod,
-                                                    uint8_t *existingCode)
+                                                    uint8_t *existingCode,
+                                                    TR_J9SharedCache *cacheOverride
+                                                    )
    {
    _currentThread = vmThread;
    _fe = theFE;
@@ -268,7 +270,7 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
    TR_ASSERT(_options, "Options were not correctly initialized.");
    _reloLogger->setupOptions(_options);
 
-   TR_RelocationRuntime::IsRelocating startRelocating(this);
+   TR_RelocationRuntime::IsRelocating startRelocating(this, cacheOverride);
 
    uint8_t *tempCodeStart, *tempDataStart;
    uint8_t *oldDataStart, *oldCodeStart, *newCodeStart;


### PR DESCRIPTION
An alternate SCC frontend may now be passed to the relocation runtime, which will be used for the duration of relocation. This isn't directly useful, but #18301 will need this to override the shared class cache interface used during relocation.