### PR TITLE
Update TestThreadMXBean test for TotalThreadAllocatedBytes

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
@@ -93,7 +93,7 @@ public class TestThreadMXBean {
 		attribs.put("ThreadCpuTimeEnabled", new AttributeData(Boolean.TYPE.getName(), true, true, true));
 		attribs.put("ThreadCpuTimeSupported", new AttributeData(Boolean.TYPE.getName(), true, false, true));
 		attribs.put("TotalStartedThreadCount", new AttributeData(Long.TYPE.getName(), true, false, false));
-		if (VersionCheck.major() >= 21) {
+		if (VersionCheck.major() >= 11) {
 			attribs.put("TotalThreadAllocatedBytes", new AttributeData(Long.TYPE.getName(), true, false, false));
 		}
 	} // end static initializer
@@ -1568,7 +1568,7 @@ public class TestThreadMXBean {
 			numAttributes = 17;
 		} else {
 			numOperations = 20;
-			numAttributes = (VersionCheck.major() >= 21) ? 19 : 18;
+			numAttributes = (VersionCheck.major() >= 11) ? 19 : 18;
 		}
 		MBeanOperationInfo[] operations = mbi.getOperations();
 		AssertJUnit.assertNotNull(operations);


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/18877

jdk11 and jdk17 need to be promoted when this is merged.

Tested via grinders, which passed.
11: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3205/
17: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3206/
