### PR TITLE
Add class loader lookup method to SCC interface

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -563,6 +563,12 @@ TR_J9SharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
    }
 
 void *
+TR_J9SharedCache::lookupClassLoaderAssociatedWithClassChain(void *chainData)
+   {
+   return persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(chainData);
+   }
+
+void *
 TR_J9SharedCache::romStructureFromOffsetInSharedCache(uintptr_t offset)
    {
    void *romStructure = NULL;

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -196,6 +196,14 @@ public:
       return classMatchesCachedVersion((J9Class *) classPtr, chainData);
       }
 
+   /**
+    * \brief Converts a pointer to a class chain associated to a class loader in the SCC into a J9ClassLoader,
+    *        if it can be found in the running JVM.
+    *
+    * \param[in] chainData The pointer to convert, which should have come from pointerFromOffsetInSharedCache().
+    * \return A pointer. Raises a fatal assertion before returning NULL if the pointer is invalid.
+    */
+   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData);
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader);
 
    /**
@@ -608,6 +616,7 @@ public:
 
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override { TR_ASSERT_FATAL(false, "called"); return false;}
 
+   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) override { TR_ASSERT_FATAL(false, "called"); return NULL; }
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader) override { TR_ASSERT_FATAL(false, "called"); return NULL;}
 
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { TR_ASSERT_FATAL(false, "called"); }

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -67,6 +67,7 @@ public:
    virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) { return false; }
    virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) { return false; }
 
+   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) {return NULL; }
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *loader) { return NULL; }
 
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) { return 0; }

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3177,7 +3177,7 @@ TR_IPBCDataCallGraph::loadFromPersistentCopy(TR_IPBCDataStorageHeader * storage,
          if (classChainIdentifyingLoader)
             {
             TR::VMAccessCriticalSection criticalSection(comp->fej9());
-            J9ClassLoader *classLoader = (J9ClassLoader *)sharedCache->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+            J9ClassLoader *classLoader = (J9ClassLoader *)sharedCache->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
             if (classLoader)
                {
                TR_OpaqueClassBlock *j9class = sharedCache->lookupClassFromChainAndLoader(classChain, classLoader);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3298,7 +3298,7 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
 
       void *classChainIdentifyingLoader = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainIdentifyingLoaderOffsetInSharedCache(reloTarget));
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classChainIdentifyingLoader %p\n", classChainIdentifyingLoader);
-      J9ClassLoader *classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+      J9ClassLoader *classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
 
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classLoader %p\n", classLoader);
 
@@ -3807,7 +3807,7 @@ TR_RelocationRecordValidateArbitraryClass::applyRelocation(TR_RelocationRuntime 
    void *classChainIdentifyingLoader = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainIdentifyingLoaderOffset(reloTarget));
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tpreparePrivateData: classChainIdentifyingLoader %p\n", classChainIdentifyingLoader);
 
-   J9ClassLoader *classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+   J9ClassLoader *classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
    RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tpreparePrivateData: classLoader %p\n", classLoader);
 
    if (classLoader)
@@ -5640,7 +5640,7 @@ TR_RelocationRecordPointer::preparePrivateData(TR_RelocationRuntime *reloRuntime
       J9ClassLoader *classLoader = NULL;
       void *classChainIdentifyingLoader = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainIdentifyingLoaderOffsetInSharedCache(reloTarget));
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classChainIdentifyingLoader %p\n", classChainIdentifyingLoader);
-      classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+      classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classLoader %p\n", classLoader);
 
       if (classLoader != NULL)

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1217,7 +1217,7 @@ TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_
 bool
 TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated)
    {
-   J9ClassLoader *classLoader = (J9ClassLoader *) _fej9->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+   J9ClassLoader *classLoader = (J9ClassLoader *) _fej9->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
    if (classLoader == NULL)
       return false;
 


### PR DESCRIPTION
The `lookupClassLoaderAssociatedWithClassChain(void *chain)` method attempts to find a `J9ClassLoader *` whose class chain (i.e., the class chain of its first loaded class) matches the given class chain. This new method is roughly analogous to the already-existing

```
   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader);
```

in the shared cache interface, which also looks up a dynamic JVM entity after being given some persistent data. For now, all it does is query the `persistentClassLoaderTable()` for the class loader associated to the class chain.

This is needed for #18301, since part of that PR involves overriding `void *pointerFromOffsetInSharedCache(uintptr_t offset)` so that instead of returning the class chain associated to a class loader when given an offset to a class loader chain, we will instead return the `J9ClassLoader *` directly. (See item (3) "Temporarily override..." and the subsequent paragraph in https://github.com/eclipse-openj9/openj9/issues/16721#issuecomment-1921857539 for why we'll do this). Thus we will need this overridable method in the SCC interface so we can return the loader we are given from that query, instead of consulting the class loader table.

Technically I could create a derived class of the persistent class loader table and return that when `sharedClassCache()->persistentClassLoaderTable()` is called, but this seemed simpler, as this query is the only time the relo runtime needs to consult the persistent class loader table.
