### PR TITLE
Modify SCC frontend to take method parameter

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -222,13 +222,14 @@ protected:
    uintptr_t offsetInSharedCacheFromClass(TR_SharedCache *sharedCache, TR_OpaqueClassBlock *clazz);
 
    /**
-    * @brief Same circumstance as offsetInSharedCacheFromROMClass above
+    * @brief Same circumstance as offsetInSharedCacheFromClass above
     *
     * @param sharedCache pointer to the TR_SharedCache object
-    * @param romMethod J9ROMMethod * whose offset in the SCC is required
+    * @param method J9Method * whose J9ROMMethod offset in the SCC is required
+    * @param definingClass the defining J9Class * of method
     * @return The offset into the SCC of romMethod
     */
-   uintptr_t offsetInSharedCacheFromROMMethod(TR_SharedCache *sharedCache, J9ROMMethod *romMethod);
+   uintptr_t offsetInSharedCacheFromMethod(TR_SharedCache *sharedCache, TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass);
 
    /**
     * @brief Wrapper around TR_J9SharedCache::offsetInSharedCacheFromPointer for

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -57,7 +57,8 @@ public:
    virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL) { return false; }
 
    virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
-   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod) { return 0; }
+   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod) { return INVALID_ROM_METHOD_OFFSET; }
+   virtual bool isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset = NULL) { return false; }
    virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL) { return false; }
    virtual bool isROMMethodOffsetInSharedCache(uintptr_t offset, J9ROMMethod **romMethodPtr = NULL) { return false; }
 
@@ -76,6 +77,10 @@ public:
    // A uintptr_t value that can never represent a class chain in an SCC. Used to check the return value of rememberClass,
    // and also useful to represent "class chain not present" in places where a class chain offset is optional.
    static const uintptr_t INVALID_CLASS_CHAIN_OFFSET = 0;
+
+   // A uintptr_t value that can never represent a ROM method in an SCC. Used to check the return value of isMethodInSharedCache
+   // and related methods.
+   static const uintptr_t INVALID_ROM_METHOD_OFFSET = 1;
 
 private:
 


### PR DESCRIPTION
The new `isMethodInSharedCache` method in the shared class cache API will determine whether or not the `J9ROMMethod` underlying a `J9Method` is in the SCC, and will return its offset to the caller through the `uintptr_t *offset` input if so. I added an `INVALID_ROM_METHOD_OFFSET` constant to parallel `INVALID_CLASS_CHAIN_OFFSET` as well, but it isn't used much at the moment.

The `isROMMethodInSharedCache` and `offsetInSharedCacheFromROMMethod` methods are now forbidden from being called at the server. These should only be called at a client, when working directly with the underlying shared classes implementation.

In future, as part of #18301, I will be overriding `isMethodInSharedCache` at the server so we can look up the offset of the server's `AOTCacheMethodRecord` using the `J9Method *` and the (currently unused) `J9Class *` inputs.