### PR TITLE
Add explicit well-known classes SCC handling

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -152,6 +152,12 @@ J9::AheadOfTimeCompile::offsetInSharedCacheFromPointer(TR_SharedCache *sharedCac
    }
 
 uintptr_t
+J9::AheadOfTimeCompile::offsetInSharedCacheFromWellKnownClasses(TR_SharedCache *sharedCache, void *wellKnownClassesPtr)
+   {
+   return offsetInSharedCacheFromPointer(sharedCache, wellKnownClassesPtr);
+   }
+
+uintptr_t
 J9::AheadOfTimeCompile::offsetInSharedCacheFromClass(TR_SharedCache *sharedCache, TR_OpaqueClassBlock *clazz)
    {
    uintptr_t offset = 0;
@@ -2455,7 +2461,7 @@ void J9::AheadOfTimeCompile::processRelocations()
          TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
          void *offsets = const_cast<void *>(svm->wellKnownClassChainOffsets());
          uintptr_t *wkcOffsetAddr = (uintptr_t *)relocationDataCursor;
-         *wkcOffsetAddr = self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
+         *wkcOffsetAddr = self()->offsetInSharedCacheFromWellKnownClasses(fej9->sharedCache(), offsets);
 #if defined(J9VM_OPT_JITSERVER)
          self()->addWellKnownClassesSerializationRecord(svm->aotCacheWellKnownClassesRecord(), wkcOffsetAddr);
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -242,6 +242,15 @@ protected:
    uintptr_t offsetInSharedCacheFromPointer(TR_SharedCache *sharedCache, void *ptr);
 
    /**
+    * @brief Same circumstance as offsetinSharedCacheFromClass above.
+    *
+    * @param sharedCache pointer to the TR_SharedCache object
+    * @param wellKnownClassesPtr well-known classes pointer whose offset in the SCC is required
+    * @return The offset into the SCC of wellKnownClassesPtr
+    */
+   uintptr_t offsetInSharedCacheFromWellKnownClasses(TR_SharedCache *sharedCache, void *wellKnownClassesPtr);
+
+   /**
     * @brief Initialization of relocation record headers for whom data for the fields are acquired
     *        in a manner that is common on all platforms
     *

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -38,6 +38,7 @@
 #include "env/VerboseLog.hpp"
 #include "exceptions/PersistenceFailure.hpp"
 #include "infra/CriticalSection.hpp"
+#include "infra/String.hpp"
 #include "runtime/CodeRuntime.hpp"
 #include "runtime/IProfiler.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
@@ -1385,6 +1386,27 @@ TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, const char *key, const J
 #else
    return NULL;
 #endif
+   }
+
+void
+TR_J9SharedCache::buildWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses)
+   {
+   TR::snprintfNoTrunc(buffer, size, "AOTWellKnownClasses:%x", includedClasses);
+   }
+
+const void *
+TR_J9SharedCache::storeWellKnownClasses(J9VMThread *vmThread, uintptr_t *classChainOffsets, size_t classChainOffsetsSize, unsigned int includedClasses)
+   {
+   char key[128];
+   buildWellKnownClassesSCCKey(key, sizeof(key), includedClasses);
+
+   J9SharedDataDescriptor dataDescriptor;
+   dataDescriptor.address = (U_8*)classChainOffsets;
+   dataDescriptor.length = classChainOffsetsSize * sizeof (classChainOffsets[0]);
+   dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
+   dataDescriptor.flags = 0;
+
+   return storeSharedData(vmThread, key, &dataDescriptor);
    }
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -338,7 +338,40 @@ public:
 
    uintptr_t getClassChainOffsetIdentifyingLoaderNoThrow(TR_OpaqueClassBlock *clazz);
 
+   /**
+    * \brief Store the given well-known classes object in the SCC
+    *
+    * A word of caution: there is an important difference in the encoding of a well-known classes object
+    * (the classChainOffsets parameter to this function) compared to a class chain. A class chain is a
+    * (uintptr_t *classChain) value whose first element is the total size of classChain in bytes, with
+    * subsequent elements being offsets to ROM classes. A well-known classes object is a
+    * (uintptr_t *classChainOffsets) value whose first element is the number of subsequent elements,
+    * with subsequent elements being offsets to class chains.
+    *
+    * \param[in] vmThread VM thread
+    * \param[in] classChainOffsets The well-known classes object
+    * \param[in] classChainOffsetsSize The number of elements in classChainOffsets
+    * \param[in] includedClasses An encoding of the well-known classes object, where the ith bit is set
+    *                            exactly when the well-known class at index i of the names[] array of
+    *                            TR::SymbolValidationManager::populateWellKnownClasses() is included in
+    *                            the object.
+    * \return Returns a pointer to the data stored in the local SCC, or NULL if the data could not be stored.
+    */
+   virtual const void *storeWellKnownClasses(J9VMThread *vmThread, uintptr_t *classChainOffsets, size_t classChainOffsetsSize, unsigned int includedClasses);
    virtual const void *storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor);
+
+   /**
+    * \brief Fill the given buffer with the SCC key for the well-known classes object with the given
+    *        includedClasses
+    *
+    * \param[out] buffer The buffer to fill with the SCC key
+    * \param[out] size The size of buffer
+    * \param[in] includedClasses An encoding of the well-known classes object, where the ith bit is set
+    *                            exactly when the well-known class at index i of the names[] array of
+    *                            TR::SymbolValidationManager::populateWellKnownClasses() is included in
+    *                            the object.
+    */
+   static void buildWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses);
 
    enum TR_J9SharedCacheDisabledReason
       {

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -605,15 +605,8 @@ JITServerAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord 
          return false;
       }
 
-   // Get the key that it will be stored under in the local SCC
-   char key[128];
-   TR::SymbolValidationManager::getWellKnownClassesSCCKey(key, sizeof(key), record->includedClasses());
-   J9SharedDataDescriptor desc = { .address = (uint8_t *)chainOffsets,
-                                   .length = (1 + record->list().length()) * sizeof(chainOffsets[0]),
-                                   .type = J9SHR_DATA_TYPE_JITHINT };
-
    // Store the "well-known classes" object in the local SCC or find the existing one
-   const void *wkcOffsets = _sharedCache->storeSharedData(comp->j9VMThread(), key, &desc);
+   const void *wkcOffsets = _sharedCache->storeWellKnownClasses(comp->j9VMThread(), chainOffsets, 1 + record->list().length(), record->includedClasses());
    if (!wkcOffsets)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -29,7 +29,6 @@
 #include "compile/J9Compilation.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
-#include "infra/String.hpp"
 #include "runtime/RelocationRuntime.hpp"
 #include "runtime/SymbolValidationManager.hpp"
 
@@ -196,12 +195,6 @@ TR::SymbolValidationManager::getSystemClassNotWorthRemembering(int idx)
    }
 
 void
-TR::SymbolValidationManager::getWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses)
-   {
-   TR::snprintfNoTrunc(buffer, size, "AOTWellKnownClasses:%x", includedClasses);
-   }
-
-void
 TR::SymbolValidationManager::populateWellKnownClasses()
    {
 #define REQUIRED_WELL_KNOWN_CLASS_COUNT 0
@@ -304,20 +297,7 @@ TR::SymbolValidationManager::populateWellKnownClasses()
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-   char key[128];
-   getWellKnownClassesSCCKey(key, sizeof(key), includedClasses);
-
-   J9SharedDataDescriptor dataDescriptor;
-   dataDescriptor.address = (U_8*)classChainOffsets;
-   dataDescriptor.length = (1 + _wellKnownClasses.size()) * sizeof (classChainOffsets[0]);
-   dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
-   dataDescriptor.flags = 0;
-
-   _wellKnownClassChainOffsets =
-      _fej9->sharedCache()->storeSharedData(
-         _vmThread,
-         key,
-         &dataDescriptor);
+   _wellKnownClassChainOffsets = _fej9->sharedCache()->storeWellKnownClasses(_vmThread, classChainOffsets, 1 + _wellKnownClasses.size(), includedClasses);
 
 #if defined(J9VM_OPT_JITSERVER)
    if (_wellKnownClassChainOffsets && clientData)

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -724,7 +724,6 @@ public:
 
    #define WELL_KNOWN_CLASS_COUNT 9
 
-   static void getWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses);
    void populateWellKnownClasses();
    bool validateWellKnownClasses(const uintptr_t *wellKnownClassChainOffsets);
    bool isWellKnownClass(TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
A new storeWellKnownClasses method in J9SharedCache is now responsible for storing a well-known classes object in the SCC.

The J9::AheadOfTimeCompile::offsetInSharedCacheFromPointer has been renamed offsetInSharedCacheFromWellKnownClasses, as getting the offset of the well-known classes object stored in the SVM is currently its sole responsibility.