### PR TITLE
Compile AIX jdk8 with xlclang 16.1

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -269,12 +269,7 @@ ppc64_aix:
     next: '--disable-warnings-as-errors'
   build_env:
     vars:
-      8: 'PATH+XLC=/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin'
-      11: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
-      17: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
-      21: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
-      22: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
-      next: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
+      all: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
 #========================================#
 # Linux x86 64bits
 #========================================#


### PR DESCRIPTION
Tested jdk8 via https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/488/ where all of sanity/extended.functional,sanity/extended.system,sanity.openjdk passed.
```
15:09:24  * Toolchain:      xlc (IBM XL C/C++)
15:09:24  * C Compiler:     Version 16.1.0 (at /opt/IBM/xlC/16.1.0/bin/xlclang)
15:09:24  * C++ Compiler:   Version 16.1.0 (at /opt/IBM/xlC/16.1.0/bin/xlclang++)
```