### PR TITLE
Set default values for implicit value classes

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -331,6 +331,7 @@ static const struct { \
 
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 #define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) J9_VALUETYPE_FLATTENED_SIZE(clazz)
+/* TODO replace with J9_IS_J9CLASS_ALLOW_DEFAULT_VALUE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassAllowsInitialDefaultValue)*/
 #define J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsPrimitiveValueType)
 #define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -87,7 +87,9 @@
 #define J9ClassHasIdentity 0x80000
 #define J9ClassEnsureHashed 0x100000
 #define J9ClassHasOffloadAllowSubtasksNatives 0x200000
+/* TODO J9ClassAllowsInitialDefaultValue replaces J9ClassIsPrimitiveValueType for lw5 */
 #define J9ClassIsPrimitiveValueType 0x400000
+#define J9ClassAllowsInitialDefaultValue 0x400000
 #define J9ClassAllowsNonAtomicCreation 0x800000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4216,7 +4216,7 @@ done:
 		j9object_t cls = *(j9object_t*)_sp;
 		j9object_t result = NULL;
 
-		/* TODO (#14073): update this function to have the same behavior as OpenJDK when cls is null or not a vlauetype (currently OpenJDK segfaults in both those scenarios) */
+		/* TODO (#14073): update this function to have the same behavior as OpenJDK when cls is null or not a valuetype (currently OpenJDK segfaults in both those scenarios) */
 		if (NULL != cls) {
 			J9Class *j9clazz = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, cls);
 			if (J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(j9clazz)) {


### PR DESCRIPTION
Reuse value for J9ClassIsPrimitiveValueType to J9ClassAllowsInitialDefaultValue for lw5.
Set J9ClassAllowsInitialDefaultValue when class has an ImplicitCreation attribute set
to indicate that default values should be set during initialization.

Related https://github.com/eclipse-openj9/openj9/issues/17234