### PR TITLE
Preventing flushForClassesUnload() to be called twice

### DIFF
--- a/runtime/vm/profilingbc.c
+++ b/runtime/vm/profilingbc.c
@@ -122,9 +122,7 @@ profilingBytecodeBufferFullHookRegistered(J9JavaVM* vm)
 
 #ifdef J9VM_GC_DYNAMIC_CLASS_UNLOADING
 	/* make sure that we flush any profiling data when a class is unloaded */
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, flushForClassesUnload, OMR_GET_CALLSITE(), iprofilerBufferSize)
-	|| (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_ANON_CLASSES_UNLOAD, flushForClassesUnload, OMR_GET_CALLSITE(), iprofilerBufferSize)
-	) {
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, flushForClassesUnload, OMR_GET_CALLSITE(), iprofilerBufferSize)) {
 		Trc_VM_profilingBytecodeBufferFullHookRegistered_ClassUnloadHookFailed();
 		Assert_VM_unreachable();
 	}


### PR DESCRIPTION
Currently flushForClassesUnload() is registred for J9HOOK_VM_CLASSES_UNLOAD and J9HOOK_VM_ANON_CLASSES_UNLOAD both. However it is not necessary, Anonymous classes are included to general classes unloaded report. So, there is enough to subscribe to J9HOOK_VM_CLASSES_UNLOAD only.