### PR TITLE
Avoid double module trace registration after CRIU move to java.base

### DIFF
--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -900,8 +900,6 @@ setupJNIFieldIDsAndCRIUAPI(JNIEnv *env, jclass *currentExceptionClass, IDATA *sy
 	PORT_ACCESS_FROM_VMC(currentThread);
 	IDATA libCRIUReturnCode = 0;
 
-	UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(vm));
-
 	criuJVMCheckpointExceptionClass = env->FindClass("openj9/internal/criu/JVMCheckpointException");
 	Assert_VM_criu_notNull(criuJVMCheckpointExceptionClass);
 	vmCheckpointState->criuJVMCheckpointExceptionClass = (jclass)env->NewGlobalRef(criuJVMCheckpointExceptionClass);


### PR DESCRIPTION
This patch fixes eclipse-openj9/openj9#18800.
When the CRIUSupport APIs were moved into java.base, the line that previously registered the j9criu module for tracing was not removed. Therefore, the j9vm module is being double registered, causing downstream effects in the tracing mechanism. This patch removes the registration during the CRIU API setup phase.

Issues: eclipse-openj9/openj9#18800
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>