### PR TITLE
Use isNativeLoaded when checking if CRIU and CRaC are enabled

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -333,8 +333,7 @@ public final class InternalCRIUSupport {
 	 * @return TRUE if CRaC or CRIU support is enabled and the library is loaded, FALSE otherwise.
 	 */
 	public static boolean isCRaCorCRIUSupportEnabledAndNativeLoaded() {
-		init();
-		return (nativeLoaded && isCRaCorCRIUSupportEnabled());
+		return (isNativeLoaded() && isCRaCorCRIUSupportEnabled());
 	}
 
 	/**
@@ -343,8 +342,7 @@ public final class InternalCRIUSupport {
 	 * @return TRUE if CRIU support is enabled and the library is loaded, FALSE otherwise.
 	 */
 	public static boolean isCRIUSupportEnabledAndNativeLoaded() {
-		init();
-		return (nativeLoaded && isCRIUSupportEnabled());
+		return (isNativeLoaded() && isCRIUSupportEnabled());
 	}
 
 	/**


### PR DESCRIPTION
`InternalCRIUSupport`'s `isNativeLoaded` method has useful functionality but is currently dead code. This patch appropriately calls `isNativeLoaded` when checking in `isCRIUSupportEnabledAndNativeLoaded` and `isCRaCorCRIUSupportEnabledAndNativeLoaded`.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>