### PR TITLE
Support for com.sun.management.ThreadMXBean.getThreadAllocatedBytes()

### DIFF
--- a/doc/release-notes/0.43/0.43.md
+++ b/doc/release-notes/0.43/0.43.md
@@ -93,6 +93,12 @@ In OpenJDK, these methods return <tt>0</tt> value in the case of the first call,
 The <tt>-XX:+CpuLoadCompatibility</tt> option is used to enable the OpenJDK behavior of the <tt>getProcessCpuLoad()</tt> and <tt>getSystemCpuLoad()</tt> methods in OpenJ9 so that these methods return <tt>0</tt> when called in OpenJ9 for the first time.
 </td>
 </tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/18202">#18202</a></td>
+<td valign="top">Support is added for the <tt>com.sun.management.ThreadMXBean.getThreadAllocatedBytes()</tt> API on z/OS&reg; platforms.</td>
+<td valign="top">All versions (z/OS)</td>
+<td valign="top">In the earlier release, support for the <tt>com.sun.management.ThreadMXBean.getThreadAllocatedBytes()</tt> API was added on all operating systems except z/OS platforms. In this release, the support for this API is added on z/OS platforms as well.</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Support for this API is added on z/OS platforms in this release

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com