### PR TITLE
Define a base and derived deserializer class

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2121,7 +2121,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       {
       if (TR::Options::sharedClassCache())
          {
-         auto deserializer = new (PERSISTENT_NEW) JITServerAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
+         auto deserializer = new (PERSISTENT_NEW) JITServerLocalSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
          if (!deserializer)
             return -1;
          compInfo->setJITServerAOTDeserializer(deserializer);

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -31,24 +31,21 @@
 #include "infra/CriticalSection.hpp"
 #include "runtime/JITServerAOTDeserializer.hpp"
 
+#define RECORD_NAME(record) (int)(record)->nameLength(), (const char *)(record)->name()
+#define LENGTH_AND_DATA(str) J9UTF8_LENGTH(str), (const char *)J9UTF8_DATA(str)
+#define ROMCLASS_NAME(romClass) LENGTH_AND_DATA(J9ROMCLASS_CLASSNAME(romClass))
+#define ROMMETHOD_NAS(romMethod) \
+   LENGTH_AND_DATA(J9ROMMETHOD_NAME(romMethod)), LENGTH_AND_DATA(J9ROMMETHOD_SIGNATURE(romMethod))
 
 JITServerAOTDeserializer::JITServerAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable) :
-   _loaderTable(loaderTable), _sharedCache(loaderTable->getSharedCache()),
-   _classLoaderIdMap(decltype(_classLoaderIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
-   _classLoaderPtrMap(decltype(_classLoaderPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _loaderTable(loaderTable),
    _classLoaderMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassLoaderMonitor")),
-   _classIdMap(decltype(_classIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
-   _classPtrMap(decltype(_classPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassMonitor")),
-   _methodMap(decltype(_methodMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _methodMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerMethodMonitor")),
-   _classChainMap(decltype(_classChainMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classChainMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerClassChainMonitor")),
-   _wellKnownClassesMap(decltype(_wellKnownClassesMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _wellKnownClassesMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerWellKnownClassesMonitor")),
    _newKnownIds(decltype(_newKnownIds)::allocator_type(TR::Compiler->persistentAllocator())),
    _newKnownIdsMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerNewKnownIdsMonitor")),
-   _resetInProgress(false),
    _resetMonitor(TR::Monitor::create("JIT-JITServerAOTDeserializerResetMonitor")),
    _numCacheBypasses(0), _numCacheHits(0), _numCacheMisses(0), _numDeserializedMethods(0),
    _numDeserializationFailures(0), _numClassSizeMismatches(0), _numClassHashMismatches(0)
@@ -70,6 +67,60 @@ JITServerAOTDeserializer::~JITServerAOTDeserializer()
    TR::Monitor::destroy(_resetMonitor);
    }
 
+bool
+JITServerAOTDeserializer::deserializerWasReset(TR::Compilation *comp, bool &wasReset)
+   {
+   return comp->fej9vm()->_compInfoPT->getDeserializerWasReset() ? (wasReset = true) : false;
+   }
+
+bool
+JITServerAOTDeserializer::deserializationFailure(const SerializedAOTMethod *method,
+                                                 TR::Compilation *comp, bool wasReset)
+   {
+   ++_numDeserializationFailures;
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "ERROR: Failed to deserialize AOT method %s%s",
+         comp->signature(), wasReset ? " due to concurrent deserializer reset" : ""
+      );
+   return false;
+   }
+
+void
+JITServerAOTDeserializer::reset(TR::CompilationInfoPerThread *compInfoPT)
+   {
+   // We acquire all the locks one by one according to the lock hierarchy so other compilation threads
+   // can complete their deserializer operations, then be excluded from accessing the deserializer's caches
+   // until the reset is complete.
+   OMR::CriticalSection rcs(_resetMonitor);
+   OMR::CriticalSection nkcs(_newKnownIdsMonitor);
+   OMR::CriticalSection wkcs(_wellKnownClassesMonitor);
+   OMR::CriticalSection cccs(_classChainMonitor);
+   OMR::CriticalSection mcs(_methodMonitor);
+   OMR::CriticalSection ccs(_classMonitor);
+
+   // Notify each compilation thread that the deserializer was reset
+   compInfoPT->getCompilationInfo()->notifyCompilationThreadsOfDeserializerReset();
+   // This very thread is guaranteed not to be processing any AOT cache records from the old server,
+   // so we can clear its deserializer reset flag.
+   compInfoPT->clearDeserializerWasReset();
+
+   clearCachedData();
+   }
+
+std::vector<uintptr_t>
+JITServerAOTDeserializer::getNewKnownIds(TR::Compilation *comp)
+   {
+   OMR::CriticalSection cs(_newKnownIdsMonitor);
+   bool wasReset = false;
+   if (deserializerWasReset(comp, wasReset))
+      return std::vector<uintptr_t>();
+
+   std::vector<uintptr_t> result(_newKnownIds.begin(), _newKnownIds.end());
+   _newKnownIds.clear();
+   return result;
+   }
 
 bool
 JITServerAOTDeserializer::deserialize(SerializedAOTMethod *method, const std::vector<std::string> &records,
@@ -108,10 +159,8 @@ JITServerAOTDeserializer::deserialize(SerializedAOTMethod *method, const std::ve
    // concurrent reset), remember IDs of new records that were successfully cached so far.
    if (!wasReset)
       {
-      OMR::CriticalSection cs(_newKnownIdsMonitor);
-      // Check again that a reset operation has not started. Note that we need to read
-      // _resetInProgress after acquiring the monitor (it implies the required memory barrier).
-      if (!_resetInProgress)
+      OMR::CriticalSection cs(getNewKnownIdsMonitor());
+      if (!deserializerWasReset(comp, wasReset))
          _newKnownIds.insert(newIds.begin(), newIds.end());
       }
 
@@ -127,145 +176,6 @@ JITServerAOTDeserializer::deserialize(SerializedAOTMethod *method, const std::ve
    ++_numDeserializedMethods;
    return true;
    }
-
-
-// Invalidating classes and class loaders during GC can be done without locking since current thread
-// has exclusive VM access, and compilation threads have shared VM access during deserialization.
-static void
-assertExclusiveVmAccess(J9VMThread *vmThread)
-   {
-   TR_ASSERT((vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) && vmThread->omrVMThread->exclusiveCount,
-             "Must have exclusive VM access");
-   }
-
-void
-JITServerAOTDeserializer::invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader)
-   {
-   assertExclusiveVmAccess(vmThread);
-
-   auto p_it = _classLoaderPtrMap.find(loader);
-   if (p_it == _classLoaderPtrMap.end())// Not cached
-      return;
-
-   uintptr_t id = p_it->second;
-   auto i_it = _classLoaderIdMap.find(id);
-   TR_ASSERT(i_it != _classLoaderIdMap.end(), "Broken two-way map");
-
-   // Mark entry as unloaded, but keep the (still valid) SCC offset
-   i_it->second._loader = NULL;
-   _classLoaderPtrMap.erase(p_it);
-
-   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated class loader %p ID %zu", loader, id);
-   }
-
-void
-JITServerAOTDeserializer::invalidateClass(J9VMThread *vmThread, J9Class *ramClass)
-   {
-   assertExclusiveVmAccess(vmThread);
-
-   auto p_it = _classPtrMap.find(ramClass);
-   if (p_it == _classPtrMap.end())// Not cached
-      return;
-
-   uintptr_t id = p_it->second;
-   auto i_it = _classIdMap.find(id);
-   TR_ASSERT(i_it != _classIdMap.end(), "Broken two-way map");
-
-   if (i_it->second._ramClass)
-      {
-      // Class ID is valid. Keep the entry. Mark it as unloaded, but keep the (still valid) SCC offsets.
-      i_it->second._ramClass = NULL;
-      }
-   else
-      {
-      // Class ID is invalid. Remove the entry so that it can be replaced
-      // if a matching version of the class is ever loaded in the future.
-      _classIdMap.erase(i_it);
-      }
-
-   _classPtrMap.erase(p_it);
-   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated RAMClass %p ID %zu", ramClass, id);
-   }
-
-bool
-JITServerAOTDeserializer::deserializerWasReset(TR::Compilation *comp, bool &wasReset)
-   {
-   return comp->fej9vm()->_compInfoPT->getDeserializerWasReset() ? (wasReset = true) : false;
-   }
-
-void
-JITServerAOTDeserializer::reset(TR::CompilationInfoPerThread *compInfoPT)
-   {
-   // We acquire all the locks one by one according to the lock hierarchy so other compilation threads
-   // can complete their deserializer operations, then be excluded from accessing the deserializer's caches
-   // until the reset is complete.
-   OMR::CriticalSection rcs(_resetMonitor);
-   OMR::CriticalSection nkcs(_newKnownIdsMonitor);
-   OMR::CriticalSection wkcs(_wellKnownClassesMonitor);
-   OMR::CriticalSection cccs(_classChainMonitor);
-   OMR::CriticalSection mcs(_methodMonitor);
-   OMR::CriticalSection ccs(_classMonitor);
-
-   // Notify each compilation thread that the deserializer was reset
-   compInfoPT->getCompilationInfo()->notifyCompilationThreadsOfDeserializerReset();
-   // This very thread is guaranteed not to be processing any AOT cache records from the old server,
-   // so we can clear its deserializer reset flag.
-   compInfoPT->clearDeserializerWasReset();
-
-   _classLoaderIdMap.clear();
-   _classLoaderPtrMap.clear();
-
-   _classIdMap.clear();
-   _classPtrMap.clear();
-
-   _methodMap.clear();
-
-   _classChainMap.clear();
-
-   _wellKnownClassesMap.clear();
-
-   _newKnownIds.clear();
-   }
-
-
-std::vector<uintptr_t>
-JITServerAOTDeserializer::getNewKnownIds(TR::Compilation *comp)
-   {
-   OMR::CriticalSection cs(_newKnownIdsMonitor);
-   bool wasReset = false;
-   if (deserializerWasReset(comp, wasReset))
-      return std::vector<uintptr_t>();
-
-   std::vector<uintptr_t> result(_newKnownIds.begin(), _newKnownIds.end());
-   _newKnownIds.clear();
-   return result;
-   }
-
-
-void
-JITServerAOTDeserializer::printStats(FILE *f) const
-   {
-   fprintf(f,
-      "JITServer AOT cache statistics:\n"
-      "\tcache bypasses: %zu\n"
-      "\tcache hits: %zu\n"
-      "\tcache misses: %zu\n"
-      "\tdeserialized methods: %zu\n"
-      "\tdeserialization failures: %zu\n"
-      "\tclass size mismatches: %zu\n"
-      "\tclass hash mismatches: %zu\n",
-      _numCacheBypasses,
-      _numCacheHits,
-      _numCacheMisses,
-      _numDeserializedMethods,
-      _numDeserializationFailures,
-      _numClassSizeMismatches,
-      _numClassHashMismatches
-   );
-   }
-
 
 bool
 JITServerAOTDeserializer::cacheRecord(const AOTSerializationRecord *record, TR::Compilation *comp,
@@ -291,13 +201,27 @@ JITServerAOTDeserializer::cacheRecord(const AOTSerializationRecord *record, TR::
       }
    }
 
-
-#define RECORD_NAME(record) (int)(record)->nameLength(), (const char *)(record)->name()
-#define LENGTH_AND_DATA(str) J9UTF8_LENGTH(str), (const char *)J9UTF8_DATA(str)
-#define ROMCLASS_NAME(romClass) LENGTH_AND_DATA(J9ROMCLASS_CLASSNAME(romClass))
-#define ROMMETHOD_NAS(romMethod) \
-   LENGTH_AND_DATA(J9ROMMETHOD_NAME(romMethod)), LENGTH_AND_DATA(J9ROMMETHOD_SIGNATURE(romMethod))
-
+void
+JITServerAOTDeserializer::printStats(FILE *f) const
+   {
+   fprintf(f,
+      "JITServer AOT cache statistics:\n"
+      "\tcache bypasses: %zu\n"
+      "\tcache hits: %zu\n"
+      "\tcache misses: %zu\n"
+      "\tdeserialized methods: %zu\n"
+      "\tdeserialization failures: %zu\n"
+      "\tclass size mismatches: %zu\n"
+      "\tclass hash mismatches: %zu\n",
+      _numCacheBypasses,
+      _numCacheHits,
+      _numCacheMisses,
+      _numDeserializedMethods,
+      _numDeserializationFailures,
+      _numClassSizeMismatches,
+      _numClassHashMismatches
+   );
+   }
 
 bool
 JITServerAOTDeserializer::isClassMatching(const ClassSerializationRecord *record,
@@ -341,7 +265,6 @@ JITServerAOTDeserializer::isClassMatching(const ClassSerializationRecord *record
    return true;
 }
 
-
 // Atomically (w.r.t. exceptions) insert into two maps. id is the key in map0 and the value in map1.
 template<typename V0, typename K1> static void
 addToMaps(PersistentUnorderedMap<uintptr_t, V0> &map0,
@@ -361,11 +284,119 @@ addToMaps(PersistentUnorderedMap<uintptr_t, V0> &map0,
       }
    }
 
+// Find a cached entry for the given ID in the map
+template<typename V> V
+JITServerAOTDeserializer::findInMap(const PersistentUnorderedMap<uintptr_t, V> &map, uintptr_t id, TR::Monitor *monitor, TR::Compilation *comp, bool &wasReset)
+   {
+   OMR::CriticalSection cs(monitor);
+   if (deserializerWasReset(comp, wasReset))
+      return V();
+
+   auto it = map.find(id);
+   if (it != map.end())
+      return it->second;
+
+   // This record ID can only be missing from the cache if it was removed by a concurrent reset
+   // TODO: is this true any more? The deserializerWasReset above should guarantee that we haven't
+   // reset by this point.
+   wasReset = true;
+   return V();
+   }
+
+// Invalidating classes and class loaders during GC can be done without locking since current thread
+// has exclusive VM access, and compilation threads have shared VM access during deserialization.
+static void
+assertExclusiveVmAccess(J9VMThread *vmThread)
+   {
+   TR_ASSERT((vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) && vmThread->omrVMThread->exclusiveCount,
+             "Must have exclusive VM access");
+   }
+
+JITServerLocalSCCAOTDeserializer::JITServerLocalSCCAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable) :
+   JITServerAOTDeserializer(loaderTable),
+   _sharedCache(loaderTable->getSharedCache()),
+   _classLoaderIdMap(decltype(_classLoaderIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classLoaderPtrMap(decltype(_classLoaderPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classIdMap(decltype(_classIdMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classPtrMap(decltype(_classPtrMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _methodMap(decltype(_methodMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classChainMap(decltype(_classChainMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _wellKnownClassesMap(decltype(_wellKnownClassesMap)::allocator_type(TR::Compiler->persistentAllocator()))
+   { }
+
+void
+JITServerLocalSCCAOTDeserializer::clearCachedData()
+   {
+   _classLoaderIdMap.clear();
+   _classLoaderPtrMap.clear();
+
+   _classIdMap.clear();
+   _classPtrMap.clear();
+
+   _methodMap.clear();
+
+   _classChainMap.clear();
+
+   _wellKnownClassesMap.clear();
+
+   getNewKnownIds().clear();
+   }
+
+void
+JITServerLocalSCCAOTDeserializer::invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader)
+   {
+   assertExclusiveVmAccess(vmThread);
+
+   auto p_it = _classLoaderPtrMap.find(loader);
+   if (p_it == _classLoaderPtrMap.end())// Not cached
+      return;
+
+   uintptr_t id = p_it->second;
+   auto i_it = _classLoaderIdMap.find(id);
+   TR_ASSERT(i_it != _classLoaderIdMap.end(), "Broken two-way map");
+
+   // Mark entry as unloaded, but keep the (still valid) SCC offset
+   i_it->second._loader = NULL;
+   _classLoaderPtrMap.erase(p_it);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated class loader %p ID %zu", loader, id);
+   }
+
+void
+JITServerLocalSCCAOTDeserializer::invalidateClass(J9VMThread *vmThread, J9Class *ramClass)
+   {
+   assertExclusiveVmAccess(vmThread);
+
+   auto p_it = _classPtrMap.find(ramClass);
+   if (p_it == _classPtrMap.end())// Not cached
+      return;
+
+   uintptr_t id = p_it->second;
+   auto i_it = _classIdMap.find(id);
+   TR_ASSERT(i_it != _classIdMap.end(), "Broken two-way map");
+
+   if (i_it->second._ramClass)
+      {
+      // Class ID is valid. Keep the entry. Mark it as unloaded, but keep the (still valid) SCC offsets.
+      i_it->second._ramClass = NULL;
+      }
+   else
+      {
+      // Class ID is invalid. Remove the entry so that it can be replaced
+      // if a matching version of the class is ever loaded in the future.
+      _classIdMap.erase(i_it);
+      }
+
+   _classPtrMap.erase(p_it);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated RAMClass %p ID %zu", ramClass, id);
+   }
 
 bool
-JITServerAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
    {
-   OMR::CriticalSection cs(_classLoaderMonitor);
+   OMR::CriticalSection cs(getClassLoaderMonitor());
    if (deserializerWasReset(comp, wasReset))
       return false;
 
@@ -375,7 +406,7 @@ JITServerAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *reco
    isNew = true;
 
    // Lookup the class loader using the name of the first class that it loaded
-   auto result = _loaderTable->lookupClassLoaderAndChainAssociatedWithClassName(record->name(), record->nameLength());
+   auto result = getLoaderTable()->lookupClassLoaderAndChainAssociatedWithClassName(record->name(), record->nameLength());
    auto loader = (J9ClassLoader *)result.first;
    void *chain = result.second;
    if (!loader)
@@ -407,10 +438,10 @@ JITServerAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *reco
    }
 
 bool
-JITServerAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp,
-                                      bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp,
+                                              bool &isNew, bool &wasReset)
    {
-   OMR::CriticalSection cs(_classMonitor);
+   OMR::CriticalSection cs(getClassMonitor());
    if (deserializerWasReset(comp, wasReset))
       return false;
 
@@ -472,10 +503,10 @@ JITServerAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR
    }
 
 bool
-JITServerAOTDeserializer::cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp,
-                                      bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp,
+                                              bool &isNew, bool &wasReset)
 {
-   OMR::CriticalSection cs(_methodMonitor);
+   OMR::CriticalSection cs(getMethodMonitor());
    if (deserializerWasReset(comp, wasReset))
       return false;
 
@@ -506,10 +537,10 @@ JITServerAOTDeserializer::cacheRecord(const MethodSerializationRecord *record, T
    }
 
 bool
-JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp,
-                                      bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp,
+                                              bool &isNew, bool &wasReset)
    {
-   OMR::CriticalSection cs(_classChainMonitor);
+   OMR::CriticalSection cs(getClassChainMonitor());
    if (deserializerWasReset(comp, wasReset))
       return false;
 
@@ -582,10 +613,10 @@ JITServerAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *recor
    }
 
 bool
-JITServerAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord *record,
-                                      TR::Compilation *comp, bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord *record,
+                                              TR::Compilation *comp, bool &isNew, bool &wasReset)
    {
-   OMR::CriticalSection cs(_wellKnownClassesMonitor);
+   OMR::CriticalSection cs(getWellKnownClassesMonitor());
    if (deserializerWasReset(comp, wasReset))
       return false;
 
@@ -641,11 +672,11 @@ JITServerAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord 
 
 
 bool
-JITServerAOTDeserializer::cacheRecord(const ThunkSerializationRecord *record,
-                                      TR::Compilation *comp, bool &isNew, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::cacheRecord(const ThunkSerializationRecord *record,
+                                              TR::Compilation *comp, bool &isNew, bool &wasReset)
    {
    // Unlike the rest of the cacheRecord functions, we do not need to acquire a monitor here, as we can rely on
-   // the internal synchronization of getJ2IThunk and setJ2IThunk. We use a read barrier here for isResetInProgress.
+   // the internal synchronization of getJ2IThunk and setJ2IThunk. We use a read barrier here for deserializerWasReset().
    VM_AtomicSupport::readBarrier();
    if (deserializerWasReset(comp, wasReset))
       return false;
@@ -666,9 +697,9 @@ JITServerAOTDeserializer::cacheRecord(const ThunkSerializationRecord *record,
 
 
 J9ClassLoader *
-JITServerAOTDeserializer::getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffset, TR::Compilation *comp, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffset, TR::Compilation *comp, bool &wasReset)
    {
-   OMR::CriticalSection cs(_classLoaderMonitor);
+   OMR::CriticalSection cs(getClassLoaderMonitor());
    if (deserializerWasReset(comp, wasReset))
       return NULL;
 
@@ -689,7 +720,7 @@ JITServerAOTDeserializer::getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffse
 
    // Class loader was unloaded. Try to lookup a new version using the identifying class chain SCC offset.
    void *chain = _sharedCache->pointerFromOffsetInSharedCache(it->second._loaderChainSCCOffset);
-   auto loader = (J9ClassLoader *)_loaderTable->lookupClassLoaderAssociatedWithClassChain(chain);
+   auto loader = (J9ClassLoader *)getLoaderTable()->lookupClassLoaderAssociatedWithClassChain(chain);
    if (!loader)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -711,9 +742,9 @@ JITServerAOTDeserializer::getClassLoader(uintptr_t id, uintptr_t &loaderSCCOffse
    }
 
 J9Class *
-JITServerAOTDeserializer::getRAMClass(uintptr_t id, TR::Compilation *comp, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::getRAMClass(uintptr_t id, TR::Compilation *comp, bool &wasReset)
    {
-   OMR::CriticalSection cs(_classMonitor);
+   OMR::CriticalSection cs(getClassMonitor());
    if (deserializerWasReset(comp, wasReset))
       return NULL;
 
@@ -740,7 +771,7 @@ JITServerAOTDeserializer::getRAMClass(uintptr_t id, TR::Compilation *comp, bool 
 
    // Class was unloaded. Try to lookup a new version of its class loader using the identifying class chain SCC offset.
    void *chain = _sharedCache->pointerFromOffsetInSharedCache(it->second._loaderChainSCCOffset);
-   auto loader = (J9ClassLoader *)_loaderTable->lookupClassLoaderAssociatedWithClassChain(chain);
+   auto loader = (J9ClassLoader *)getLoaderTable()->lookupClassLoaderAssociatedWithClassChain(chain);
    if (!loader)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -786,37 +817,19 @@ JITServerAOTDeserializer::getRAMClass(uintptr_t id, TR::Compilation *comp, bool 
    return ramClass;
    }
 
-
-// Find a cached entry for the given ID in the map
-template<typename V> V
-JITServerAOTDeserializer::findInMap(const PersistentUnorderedMap<uintptr_t, V> &map, uintptr_t id, TR::Monitor *monitor, TR::Compilation *comp, bool &wasReset)
-   {
-   OMR::CriticalSection cs(monitor);
-   if (deserializerWasReset(comp, wasReset))
-      return V();
-
-   auto it = map.find(id);
-   if (it != map.end())
-      return it->second;
-
-   // This record ID can only be missing from the cache if it was removed by a concurrent reset
-   wasReset = true;
-   return V();
-   }
-
 uintptr_t
-JITServerAOTDeserializer::getSCCOffset(AOTSerializationRecordType type, uintptr_t id, TR::Compilation *comp, bool &wasReset)
+JITServerLocalSCCAOTDeserializer::getSCCOffset(AOTSerializationRecordType type, uintptr_t id, TR::Compilation *comp, bool &wasReset)
    {
    switch (type)
       {
       case ClassLoader:
          {
-         uintptr_t offset = findInMap(_classLoaderIdMap, id, _classLoaderMonitor, comp, wasReset)._loaderChainSCCOffset;
+         uintptr_t offset = findInMap(_classLoaderIdMap, id, getClassLoaderMonitor(), comp, wasReset)._loaderChainSCCOffset;
          return wasReset ? (uintptr_t)-1 : offset;
          }
       case Class:
          {
-         uintptr_t offset = findInMap(_classIdMap, id, _classMonitor, comp, wasReset)._romClassSCCOffset;
+         uintptr_t offset = findInMap(_classIdMap, id, getClassMonitor(), comp, wasReset)._romClassSCCOffset;
          // Check if this cached ID is for a valid class
          if ((offset == (uintptr_t)-1) && TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Mismatching class ID %zu", id);
@@ -824,17 +837,17 @@ JITServerAOTDeserializer::getSCCOffset(AOTSerializationRecordType type, uintptr_
          }
       case Method:
          {
-         uintptr_t offset = findInMap(_methodMap, id, _methodMonitor, comp, wasReset);
+         uintptr_t offset = findInMap(_methodMap, id, getMethodMonitor(), comp, wasReset);
          return wasReset ? (uintptr_t)-1 : offset;
          }
       case ClassChain:
          {
-         uintptr_t offset = findInMap(_classChainMap, id, _classChainMonitor, comp, wasReset);
+         uintptr_t offset = findInMap(_classChainMap, id, getClassChainMonitor(), comp, wasReset);
          return wasReset ? (uintptr_t)-1 : offset;
          }
       case WellKnownClasses:
          {
-         uintptr_t offset = findInMap(_wellKnownClassesMap, id, _wellKnownClassesMonitor, comp, wasReset);
+         uintptr_t offset = findInMap(_wellKnownClassesMap, id, getWellKnownClassesMonitor(), comp, wasReset);
          return wasReset ? (uintptr_t)-1 : offset;
          }
       default:
@@ -843,24 +856,9 @@ JITServerAOTDeserializer::getSCCOffset(AOTSerializationRecordType type, uintptr_
       }
    }
 
-
 bool
-JITServerAOTDeserializer::deserializationFailure(const SerializedAOTMethod *method,
-                                                 TR::Compilation *comp, bool wasReset)
-   {
-   ++_numDeserializationFailures;
-
-   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
-         "ERROR: Failed to deserialize AOT method %s%s",
-         comp->signature(), wasReset ? " due to concurrent deserializer reset" : ""
-      );
-   return false;
-   }
-
-bool
-JITServerAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp,
-                                           bool &wasReset, bool &usesSVM)
+JITServerLocalSCCAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp,
+                                                   bool &wasReset, bool &usesSVM)
    {
    //NOTE: Defining class chain record is validated by now; there is no corresponding SCC offset to be updated
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -31,8 +31,11 @@ class TR_PersistentClassLoaderTable;
 namespace TR { class Compilation; }
 namespace TR { class Monitor; }
 
-
-// This class implements deserialization of cached AOT methods received from JITServer.
+// This class defines the base interface for the deserialization of cached AOT methods received from a JITServer,
+// and initializes certain elements common to the implementations. Its derived classes contain the actual
+// deserialization implementation, and at most one of those implementations should be initialized at any one time.
+//
+// The following is a description of what the implementations all do:
 //
 // Deserialization involves looking up classes, methods etc. by name, and computing hashes of packed ROMClasses
 // (which can be a relatively heavy operation). To improve performance, the deserializer caches results of
@@ -41,9 +44,6 @@ namespace TR { class Monitor; }
 // The IDs of newly cached records are communicated back to the server (with subsequent compilation requests)
 // so that it doesn't keep sending records used by multiple methods (e.g. class and class chain records for
 // all well-known classes are referred to by any AOT method compiled with SVM).
-//
-// The deserializer cache stores pointers to "RAM" entities, which have to be invalidated when classes and
-// class loaders are unloaded, and SCC offsets to "ROM" entities, which always remain valid once cached.
 //
 // A JIT client can reconnect to a different JITServer instance after the previous instance fails or shuts down.
 // Since AOT cache record IDs are specific to a JITServer instance, the deserializer cache must be purged
@@ -54,6 +54,9 @@ namespace TR { class Monitor; }
 // If it was, the operations will set a bool &wasReset flag to notify the caller of that fact, so it can abort whatever it was doing.
 // The only exceptions are the invalidate* methods, which are called only when the current thread has exclusive VM access,
 // and so no compilation thread could possibly be attempting to reset the deserializer at the same time they are called.
+//
+// Certain functions in this class and in its subclasses take a bool &wasReset parameter. This is set to true when a concurrent reset
+// was detected before accessing the deserializer's cached data.
 class JITServerAOTDeserializer
    {
 public:
@@ -68,13 +71,14 @@ public:
                     TR::Compilation *comp, bool &usesSVM);
 
    // Invalidation functions called from class and class loader unload JIT hooks to invalidate RAMClass
-   // and class loader pointers cached by the deserializer. Note that cached SCC offsets stay valid.
-   void invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader);
-   void invalidateClass(J9VMThread *vmThread, J9Class *ramClass);
+   // and class loader pointers cached by the deserializer.
+   virtual void invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader) = 0;
+   virtual void invalidateClass(J9VMThread *vmThread, J9Class *ramClass) = 0;
 
    // Invalidates all cached serialization records. Must be called when the client
    // connects to a new server instance (e.g. upon receving a VM_getVMInfo message),
-   // before attempting to deserialize any method received from the new server instance.
+   // before attempting to deserialize any method received from the new server instance
+   // or otherwise use the cached data in the deserializer
    void reset(TR::CompilationInfoPerThread *compInfoPT);
 
    // IDs of records newly cached during deserialization of an AOT method are sent to the JITServer with
@@ -88,7 +92,118 @@ public:
 
    void printStats(FILE *f) const;
 
+protected:
+   bool deserializerWasReset(TR::Compilation *comp, bool &wasReset);
+   bool deserializationFailure(const SerializedAOTMethod *method, TR::Compilation *comp, bool wasReset);
+
+   // Returns true if ROMClass hash matches the one in the serialization record
+   bool isClassMatching(const ClassSerializationRecord *record, J9Class *ramClass, TR::Compilation *comp);
+
+   template<typename V> V
+   findInMap(const PersistentUnorderedMap<uintptr_t, V> &map, uintptr_t id, TR::Monitor *monitor, TR::Compilation *comp, bool &wasReset);
+
+   TR_PersistentClassLoaderTable *const getClassLoaderTable() const { return _loaderTable; }
+   TR::Monitor *const getClassLoaderMonitor() const { return _classLoaderMonitor; }
+   TR::Monitor *const getClassMonitor() const { return _classMonitor; }
+   TR::Monitor *const getMethodMonitor() const { return _methodMonitor; }
+   TR::Monitor *const getClassChainMonitor() const { return _classChainMonitor; }
+   TR::Monitor *const getWellKnownClassesMonitor() const { return _wellKnownClassesMonitor; }
+   TR::Monitor *const getNewKnownIdsMonitor() const { return _newKnownIdsMonitor; }
+   TR::Monitor *const getResetMonitor() const { return _resetMonitor; }
+
+   PersistentUnorderedSet<uintptr_t/*idAndType*/> &getNewKnownIds() { return _newKnownIds; }
+   TR_PersistentClassLoaderTable *getLoaderTable() const { return _loaderTable; }
+
 private:
+   // Clear the internal caches of the deserializer. Must be called with every monitor in hand
+   virtual void clearCachedData() = 0;
+
+   // Deserializes/validates and caches an AOT serialization record.
+   // Returns true if the record is valid (e.g. class was found and its hash matches),
+   // and sets isNew to true if the record was newly cached (not already known).
+   // Returns false if the record is invalid (e.g. ROMClass hash doesn't match)
+   // or not yet valid (e.g. class has not been loaded yet).
+   bool cacheRecord(const AOTSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+
+   // Cache a ClassLoaderSerializationRecord by looking up a class loader in the current JVM with a first-loaded class name
+   // that matches what was recorded during compilation. This will be used to find candidate J9Classes when deserializing other
+   // records, and isn't guranteed to have any particular relationship with the actual compile-time class loader.
+   virtual bool cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+   // Cache a ClassSerializationRecord by looking up a J9Class in the current JVM, using its associated ClassLoaderRecord, that
+   // has a name and ROM class hash that matches what was recorded at compile time. These are used to construct RAM class chains
+   // for class chain serialization records. The J9Classes found may not have any particular relationship with the ones recorded
+   // at compile time.
+   virtual bool cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+   // Cache a MethodSerializationRecord by looking up its defining J9Class using its (already-cached) defining
+   // ClassSerializationRecord. No extra guarantees are provided beyond what the associated ClassSerializationRecord provides.
+   virtual bool cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+   // Cache a ClassChainSerializationRecord by constructing a RAM class chain using its stored ClassSerializationRecord IDs.
+   // We then construct the actual RAM class chain of the first class in the ClassChainSerializationRecord, and make sure that
+   // the constructed and actual RAM class chains match. This ensures that the first class in the chain matches what was recorded
+   // at compile time, giving the same guarantees as J9SharedCache::classMatchesCachedVersion().
+   virtual bool cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+   // Cache a WellKnownClassesSerializationRecord. No extra guarantees are provided beyond what the associated
+   // ClassChainSerializationRecords of the individual well-known classes chains provide.
+   virtual bool cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+   // Deserialize a ThunkSerializationRecord by installing it in the JVM if one cannot be found through the compilation frontend.
+   // No special validation or caching needs to be performed.
+   virtual bool cacheRecord(const ThunkSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) = 0;
+
+   // Returns false on failure
+   virtual bool updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset, bool &usesSVM) = 0;
+
+   TR_PersistentClassLoaderTable *const _loaderTable;
+
+   // NOTE: Locking hierarchy used in this class and its derivatives follows cycle-free dependency order
+   // between serialization record types and guarantees that there are no deadlocks:
+   // - _resetMonitor < _wellKnownClassesMonitor < _classChainMonitor < _classMonitor;
+   // - _methodMonitor < _classMonitor;
+   // - remaining monitors are "leafs".
+
+   TR::Monitor *const _classLoaderMonitor;
+   TR::Monitor *const _classMonitor;
+   TR::Monitor *const _methodMonitor;
+   TR::Monitor *const _classChainMonitor;
+   TR::Monitor *const _wellKnownClassesMonitor;
+   TR::Monitor *const _newKnownIdsMonitor;
+   TR::Monitor *const _resetMonitor;
+
+   PersistentUnorderedSet<uintptr_t/*idAndType*/> _newKnownIds;
+
+   // Statistics
+   size_t _numCacheBypasses;
+   size_t _numCacheHits;
+   size_t _numCacheMisses;
+   size_t _numDeserializedMethods;
+   size_t _numDeserializationFailures;
+   size_t _numClassSizeMismatches;
+   size_t _numClassHashMismatches;
+   };
+
+// This deserializer implements the following scheme:
+//
+// 1. AOT cache serialization records are resolved into their corresponding "RAM" entities.
+// 2. The persistent representation of these RAM entities is found in the local SCC
+// 3. The RAM entities and their local SCC offsets are cached, to avoid deserializing the
+//    same record multiple times and to allow for the re-caching of classes and class
+//    loaders if they were invalidated and subsequently reloaded.
+// 4. The offsets in the cached AOT method are updated with the local SCC offsets.
+//
+// Methods deserialized with this deserializer must be relocated with a TR_J9SharedCache
+// in the frontend (i.e., with the shared cache not overridden in the frontend).
+class JITServerLocalSCCAOTDeserializer : public JITServerAOTDeserializer
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
+
+   JITServerLocalSCCAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable);
+
+   virtual void invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader) override;
+   virtual void invalidateClass(J9VMThread *vmThread, J9Class *ramClass) override;
+
+private:
+   virtual void clearCachedData() override;
+
    struct ClassLoaderEntry
       {
       J9ClassLoader *_loader;// NULL if class loader was unloaded
@@ -102,27 +217,12 @@ private:
       uintptr_t _loaderChainSCCOffset;
       };
 
-   bool deserializerWasReset(TR::Compilation *comp, bool &wasReset);
-
-   //NOTE: All the functions below that take a 'bool &wasReset' argument set it to true
-   //      if the operation failed due to a concurrent reset of the deserializer.
-
-   // Deserializes/validates and caches an AOT serialization record.
-   // Returns true if the record is valid (e.g. class was found and its hash matches),
-   // and sets isNew to true if the record was newly cached (not already known).
-   // Returns false if the record is invalid (e.g. ROMClass hash doesn't match)
-   // or not yet valid (e.g. class has not been loaded yet).
-   bool cacheRecord(const AOTSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-
-   // Returns true if ROMClass hash matches the one in the serialization record
-   bool isClassMatching(const ClassSerializationRecord *record, J9Class *ramClass, TR::Compilation *comp);
-
-   bool cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-   bool cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-   bool cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-   bool cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-   bool cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
-   bool cacheRecord(const ThunkSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset);
+   virtual bool cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
+   virtual bool cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
+   virtual bool cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
+   virtual bool cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
+   virtual bool cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
+   virtual bool cacheRecord(const ThunkSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
 
    // Returns the class loader for given class loader ID, either cached or
    // looked up using the cached SCC offset if the class loader was unloaded.
@@ -132,59 +232,26 @@ private:
    // looked up using the cached SCC offsets if the class was unloaded.
    J9Class *getRAMClass(uintptr_t id, TR::Compilation *comp, bool &wasReset);
 
+   virtual bool updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset, bool &usesSVM) override;
+
    // Returns -1 on failure
    uintptr_t getSCCOffset(AOTSerializationRecordType type, uintptr_t id, TR::Compilation *comp, bool &wasReset);
 
-   bool deserializationFailure(const SerializedAOTMethod *method, TR::Compilation *comp, bool wasReset);
-   // Returns false on failure
-   bool updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset, bool &usesSVM);
-
-   template<typename V> V
-   findInMap(const PersistentUnorderedMap<uintptr_t, V> &map, uintptr_t id, TR::Monitor *monitor, TR::Compilation *comp, bool &wasReset);
-
-   TR_PersistentClassLoaderTable *const _loaderTable;
    TR_J9SharedCache *const _sharedCache;
-
-   //NOTE: Locking hierarchy used in this class follows cycle-free dependency order
-   // between serialization record types and guarantees that there are no deadlocks:
-   // - _resetMonitor < _wellKnownClassesMonitor < _classChainMonitor < _classMonitor;
-   // - _methodMonitor < _classMonitor;
-   // - remaining monitors are "leafs".
 
    PersistentUnorderedMap<uintptr_t/*ID*/, ClassLoaderEntry> _classLoaderIdMap;
    // This map is needed for invalidating unloaded class loaders
    PersistentUnorderedMap<J9ClassLoader *, uintptr_t/*ID*/> _classLoaderPtrMap;
-   TR::Monitor *const _classLoaderMonitor;
 
    PersistentUnorderedMap<uintptr_t/*ID*/, ClassEntry> _classIdMap;
    // This map is needed for invalidating unloaded classes
    PersistentUnorderedMap<J9Class *, uintptr_t/*ID*/> _classPtrMap;
-   TR::Monitor *const _classMonitor;
 
    PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _methodMap;
-   TR::Monitor *const _methodMonitor;
 
    PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _classChainMap;
-   TR::Monitor *const _classChainMonitor;
 
    PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t/*SCC offset*/> _wellKnownClassesMap;
-   TR::Monitor *const _wellKnownClassesMonitor;
-
-   PersistentUnorderedSet<uintptr_t/*idAndType*/> _newKnownIds;
-   TR::Monitor *const _newKnownIdsMonitor;
-
-   volatile bool _resetInProgress;
-   TR::Monitor *const _resetMonitor;
-
-   // Statistics
-   size_t _numCacheBypasses;
-   size_t _numCacheHits;
-   size_t _numCacheMisses;
-   size_t _numDeserializedMethods;
-   size_t _numDeserializationFailures;
-   size_t _numClassSizeMismatches;
-   size_t _numClassHashMismatches;
    };
-
 
 #endif /* JITSERVER_AOT_DESERIALIZER_H */


### PR DESCRIPTION
The JITServerAOTDeserializer is now two classes. The base JITServerAOTDeserializer defines some common operations and functionality, and the derived JITServerLocalSCCAOTDeserializer implements the required deserialization and caching.