### PR TITLE
jdk8 Ignore "allow" and "disallow" set in java.security.manager

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -289,6 +289,10 @@ public abstract class ClassLoader {
 		System.initSecurityManager(applicationClassLoader);
 		jdk.internal.misc.VM.initLevel(3);
 		/*[ELSE] JAVA_SPEC_VERSION >= 9 */
+		String smvalue = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
+		if ("allow".equals(smvalue) || "disallow".equals(smvalue)) { //$NON-NLS-1$ //$NON-NLS-2$
+			System.internalGetProperties().remove("java.security.manager"); //$NON-NLS-1$
+		}
 		applicationClassLoader = sun.misc.Launcher.getLauncher().getClassLoader();
 		/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1184,6 +1184,7 @@ static void checkTmpDir() {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 }
 
+/*[IF JAVA_SPEC_VERSION >= 9]*/
 static void initSecurityManager(ClassLoader applicationClassLoader) {
 	String javaSecurityManager = internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 	if (null == javaSecurityManager) {
@@ -1219,6 +1220,7 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 		}
 	}
 }
+/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
 /**
  * Sets the active security manager. Note that once


### PR DESCRIPTION
This was previously attempted via
https://github.com/eclipse-openj9/openj9/pull/18402 but it didn't work for jdk8.

Fixes https://github.com/eclipse-openj9/openj9/issues/18900

Doc issue https://github.com/eclipse-openj9/openj9-docs/issues/1279

Created a jdk8 and 11 build with this change at https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/490/
Manually checked jdk8 and it's working.