### PR TITLE
Optimize AsyncGetCallTrace methodID retention

### DIFF
--- a/runtime/j9vm/asgct.cpp
+++ b/runtime/j9vm/asgct.cpp
@@ -104,6 +104,7 @@ asyncFrameIterator(J9VMThread * currentThread, J9StackWalkState * walkState)
 		frame->lineno = (jint)walkState->bytecodePCOffset;
 	}
 	walkState->userData1 = (void*)(frame + 1);
+	declaringClass->classLoader->asyncGetCallTraceUsed = 1;
 	return J9_STACKWALK_KEEP_ITERATING;
 }
 
@@ -213,7 +214,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void *ucontext)
 		PORT_ACCESS_FROM_JAVAVM(BFUjavaVM);
 		ASGCT_parms parms = { trace, depth, ucontext, currentThread, num_frames, NULL, NULL, NULL, NULL, NULL, 0 };
 		UDATA result = 0;
-		BFUjavaVM->asyncGetCallTraceUsed = 1;
 		j9sig_protect(
 				protectedASGCT, (void*)&parms, 
 				emptySignalHandler, NULL,

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3468,6 +3468,7 @@ typedef struct J9ClassLoader {
 	omrthread_monitor_t hotFieldPoolMutex;
 	omrthread_rwmutex_t cpEntriesMutex;
 	UDATA initClassPathEntryCount;
+	UDATA asyncGetCallTraceUsed;
 } J9ClassLoader;
 
 #define J9CLASSLOADER_SHARED_CLASSES_ENABLED  8
@@ -6007,7 +6008,6 @@ typedef struct J9JavaVM {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	omrthread_monitor_t delayedLockingOperationsMutex;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-	UDATA asyncGetCallTraceUsed;
 	U_32 compatibilityFlags;
 } J9JavaVM;
 

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -378,7 +378,7 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 
 	if (NULL != classLoader->jniIDs) {
 		if (J9_ARE_NO_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_NEVER_KEEP_JNI_IDS)
-		&& (javaVM->asyncGetCallTraceUsed || J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ALWAYS_KEEP_JNI_IDS))
+		&& (classLoader->asyncGetCallTraceUsed || J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ALWAYS_KEEP_JNI_IDS))
 		) {
 			pool_state idWalkState;
 			J9GenericJNIID *jniID = pool_startDo(classLoader->jniIDs, &idWalkState);


### PR DESCRIPTION
Move the asyncGetCallTraceUsed flag from the J9JavaVM to J9ClassLoader so only methodIDs that have been handed out by AsyncGetCallTrace are retained.