### PR TITLE
Avoid testing xmac jdk22+ on sw.os.mac.10_15

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -393,6 +393,9 @@ x86-64_mac:
     build: 'ci.role.build && hw.arch.x86 && sw.os.mac.10_15'
   build_env:
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
+  extra_test_labels:
+    22: '!sw.os.mac.10_15'
+    next: '!sw.os.mac.10_15'
 #========================================#
 # Mac M1 Aarch64
 #========================================#


### PR DESCRIPTION
jdk21+ only supports macOS 11+. Since there is no test issue for jdk21 at the moment, jdk21 isn't excluded for testing on 10.15 machines in order to have more test machines available.

Closes https://github.com/eclipse-openj9/openj9/issues/18909