### PR TITLE
Support ignoring the client's local SCC when compiling a JITServer AOT cache store

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -375,13 +375,15 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &getSerializationRecords() { return _serializationRecords; }
    // Adds an AOT cache record and the corresponding offset into AOT relocation data to the list that
    // will be used when the result of this out-of-process compilation is serialized and stored in
-   // JITServer AOT cache. If record is NULL, fails serialization by setting _aotCacheStore to false.
+   // JITServer AOT cache. If record is NULL, fails serialization by setting _aotCacheStore to false if we are not
+   // ignoring the client's SCC, and otherwise fails the compilation entirely.
    void addSerializationRecord(const AOTCacheRecord *record, uintptr_t reloDataOffset);
 
    UnorderedSet<const AOTCacheThunkRecord *> &getThunkRecords() { return _thunkRecords; }
    // Adds an AOT cache thunk record to the set of thunks that this compilation depends on, and also adds it
    // to the list of records that this compilation depends on if the thunk record is new. If the record is NULL,
-   // fails serialization by setting _aotCacheStore to false.
+   // fails serialization by setting _aotCacheStore to false if we are not ignoring the client's SCC, and otherwise
+   // fails the compilation entirely.
    void addThunkRecord(const AOTCacheThunkRecord *record);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -533,6 +533,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                TR_RelocationRuntime::fillAOTHeader(javaVM, fe, &vmInfo._aotHeader);
                }
             }
+         vmInfo._useServerOffsets = false;
          vmInfo._inSnapshotMode = fe->inSnapshotMode();
          vmInfo._isPortableRestoreMode = fe->isPortableRestoreModeEnabled();
          vmInfo._isSnapshotModeEnabled = fe->isSnapshotModeEnabled();

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -622,10 +622,14 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          }
 
       if (_vm->sharedCache())
+         {
          // Set/update stream pointer in shared cache.
          // Note that if remote-AOT is enabled, even regular J9_SERVER_VM will have a shared cache
          // This behaviour is consistent with non-JITServer
          ((TR_J9JITServerSharedCache *) _vm->sharedCache())->setStream(stream);
+         // Also cache this compilation thread
+         ((TR_J9JITServerSharedCache *) _vm->sharedCache())->setCompInfoPT(this);
+         }
 
       //if (seqNo == 501)
       //   throw JITServer::StreamFailure(); // stress testing

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -43,7 +43,6 @@
 #include "runtime/IProfiler.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #if defined(J9VM_OPT_JITSERVER)
-#include "control/CompilationThread.hpp" // for TR::compInfoPT
 #include "control/JITServerHelpers.hpp"
 #include "runtime/JITClientSession.hpp"
 #endif
@@ -1417,9 +1416,8 @@ TR_J9SharedCache::storeWellKnownClasses(J9VMThread *vmThread, uintptr_t *classCh
 
 #if defined(J9VM_OPT_JITSERVER)
 TR_J9JITServerSharedCache::TR_J9JITServerSharedCache(TR_J9VMBase *fe)
-   : TR_J9SharedCache(fe)
+   : TR_J9SharedCache(fe), _stream(NULL), _compInfoPT(NULL)
    {
-   _stream = NULL;
    }
 
 uintptr_t
@@ -1429,7 +1427,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    TR_ASSERT(_stream, "stream must be initialized by now");
 
    uintptr_t clientClassChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool needClassChainRecord = comp->isAOTCacheStore();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && needClassChainRecord;
@@ -1505,7 +1503,7 @@ J9SharedClassCacheDescriptor *
 TR_J9JITServerSharedCache::getCacheDescriptorList()
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
    TR_ASSERT_FATAL(!useServerOffsets, "Unsupported when ignoring the client SCC");
@@ -1518,7 +1516,7 @@ bool
 TR_J9JITServerSharedCache::isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
 
@@ -1544,7 +1542,7 @@ TR_J9JITServerSharedCache::isClassInSharedCache(TR_OpaqueClassBlock *clazz, uint
 bool
 TR_J9JITServerSharedCache::isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset)
    {
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
 
@@ -1576,7 +1574,7 @@ TR_J9JITServerSharedCache::getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBl
    TR_ASSERT(!classChain, "Must always be NULL at JITServer");
    TR_ASSERT(_stream, "stream must be initialized by now");
 
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
 
@@ -1625,7 +1623,7 @@ void
 TR_J9JITServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
    if (vmInfo->_hasSharedClassCache)
       {
       _stream->write(JITServer::MessageType::SharedCache_addHint, method, theHint);
@@ -1638,7 +1636,7 @@ const void *
 TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
    bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
    TR_ASSERT_FATAL(!useServerOffsets, "Unsupported when ignoring the client SCC");

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1428,10 +1428,11 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    TR_ASSERT_FATAL(classChainRecord || !create, "Must pass classChainRecord if creating class chain at JITServer");
    TR_ASSERT(_stream, "stream must be initialized by now");
 
-   uintptr_t classChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
+   uintptr_t clientClassChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
    TR::Compilation *comp = TR::compInfoPT->getCompilation();
    ClientSessionData *clientData = comp->getClientData();
-   bool needClassChainRecord = create && comp->isAOTCacheStore();
+   bool needClassChainRecord = comp->isAOTCacheStore();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && needClassChainRecord;
    const AOTCacheClassChainRecord *record = NULL;
 
    // Check if the class chain is already cached
@@ -1441,69 +1442,132 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
       auto it = cache.find(clazz);
       if (it != cache.end())
          {
-         classChainOffset = it->second._classChainOffset;
+         clientClassChainOffset = it->second._classChainOffset;
          record = it->second._aotCacheClassChainRecord;
          }
       }
 
-   // If the class chain is cached and the AOT cache record is either cached or not needed, return the cached values
-   if ((TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && (record || !needClassChainRecord))
+   // If ignoring the client's offsets, we only need to consult the cached class chain record
+   if (useServerOffsets && record)
       {
       if (classChainRecord)
          *classChainRecord = record;
-      return classChainOffset;
+      return record->data().idAndType();
+      }
+
+   // If the class chain is cached and the AOT cache record is either cached or not needed, return the cached values
+   if (!useServerOffsets && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != clientClassChainOffset) && (record || !needClassChainRecord))
+      {
+      if (classChainRecord)
+         *classChainRecord = record;
+      return clientClassChainOffset;
       }
 
    // Request missing class chain information from the client
-   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create, needClassChainRecord);
+   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create, !useServerOffsets, needClassChainRecord);
    auto recv = _stream->read<uintptr_t, std::vector<J9Class *>, std::vector<J9Class *>,
                              std::vector<JITServerHelpers::ClassInfoTuple>>();
-   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset)
-      TR_ASSERT_FATAL(std::get<0>(recv) == classChainOffset, "Received mismatching class chain offset: %" OMR_PRIuPTR " != %" OMR_PRIuPTR,
-                      std::get<0>(recv), classChainOffset);
-   classChainOffset = std::get<0>(recv);
+   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != clientClassChainOffset)
+      TR_ASSERT_FATAL(std::get<0>(recv) == clientClassChainOffset, "Received mismatching class chain offset: %" OMR_PRIuPTR " != %" OMR_PRIuPTR,
+                      std::get<0>(recv), clientClassChainOffset);
+   clientClassChainOffset = std::get<0>(recv);
    auto &ramClassChain = std::get<1>(recv);
    auto &uncachedRAMClasses = std::get<2>(recv);
    auto &uncachedClassInfos = std::get<3>(recv);
 
    // Cache the result if the class chain was succesfully created at the client
-   if ((TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classChainOffset) && create)
+   if (create)
       {
       if (needClassChainRecord)
          {
          JITServerHelpers::cacheRemoteROMClassBatch(clientData, uncachedRAMClasses, uncachedClassInfos);
-         // This call will cache both the class chain and the AOT cache record in the client session
+         // This call will cache both the class chain and the AOT cache record in the client session.
+         // The clientClassChainOffset can be invalid - we will attempt to re-cache it if necessary.
          bool missingLoaderInfo = false;
-         record = clientData->getClassChainRecord(clazz, classChainOffset, ramClassChain, _stream, missingLoaderInfo);
+         record = clientData->getClassChainRecord(clazz, clientClassChainOffset, ramClassChain, _stream, missingLoaderInfo);
          if (classChainRecord)
             *classChainRecord = record;
          }
-      else
+      else if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != clientClassChainOffset)
          {
          OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
-         cache.insert({ clazz, { classChainOffset, NULL } });
+         cache.insert({ clazz, { clientClassChainOffset, NULL } });
          }
       }
 
-   return classChainOffset;
+   if (useServerOffsets)
+      return record ? record->data().idAndType() : TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
+   else
+      return clientClassChainOffset;
    }
 
 J9SharedClassCacheDescriptor *
 TR_J9JITServerSharedCache::getCacheDescriptorList()
    {
-   auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
+   TR_ASSERT_FATAL(!useServerOffsets, "Unsupported when ignoring the client SCC");
+
+   auto *vmInfo = clientData->getOrCacheVMInfo(_stream);
    return vmInfo->_j9SharedClassCacheDescriptorList;
+   }
+
+bool
+TR_J9JITServerSharedCache::isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
+
+   if (useServerOffsets)
+      {
+      bool missingLoaderInfo = false;
+      auto classRecord = clientData->getClassRecord(reinterpret_cast<J9Class *>(clazz), _stream, missingLoaderInfo);
+      if (classRecord)
+         {
+         if (cacheOffset)
+            *cacheOffset = classRecord->data().idAndType();
+         return true;
+         }
+      return false;
+      }
+   else
+      {
+      J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fe()->getPersistentClassPointerFromClassPointer(clazz));
+      return isROMClassInSharedCache(romClass, cacheOffset);
+      }
    }
 
 bool
 TR_J9JITServerSharedCache::isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset)
    {
-   // TODO: The definingClass parameter of this method is currently unused, but it will become necessary when AOT cache stores are
-   // allowed at the server without a client SCC.
-   J9ROMMethod *romMethod = fe()->getROMMethodFromRAMMethod(reinterpret_cast<J9Method *>(method));
-   // We use isROMStructureInSharedCache directly because we want to forbid
-   // isROMMethodInSharedCache from being used at the server
-   return isROMStructureInSharedCache(romMethod, cacheOffset);
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
+
+   if (useServerOffsets)
+      {
+      auto record = clientData->getMethodRecord(reinterpret_cast<J9Method *>(method),
+                                                reinterpret_cast<J9Class *>(definingClass),
+                                                _stream);
+      if (record)
+         {
+         if (cacheOffset)
+            *cacheOffset = record->data().idAndType();
+         return true;
+         }
+      return false;
+      }
+   else
+      {
+      J9ROMMethod *romMethod = fe()->getROMMethodFromRAMMethod(reinterpret_cast<J9Method *>(method));
+      // We use isROMStructureInSharedCache directly because we want to forbid
+      // isROMMethodInSharedCache from being used at the server
+      return isROMStructureInSharedCache(romMethod, cacheOffset);
+      }
    }
 
 uintptr_t
@@ -1512,8 +1576,20 @@ TR_J9JITServerSharedCache::getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBl
    TR_ASSERT(!classChain, "Must always be NULL at JITServer");
    TR_ASSERT(_stream, "stream must be initialized by now");
 
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
+
+   if (useServerOffsets)
+      {
+      bool missingLoaderInfo = false;
+      auto classRecord = clientData->getClassRecord(reinterpret_cast<J9Class *>(clazz), _stream, missingLoaderInfo);
+      if (classRecord)
+         return AOTSerializationRecord::idAndType(classRecord->data().classLoaderId(), AOTSerializationRecordType::ClassLoader);
+      return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
+      }
+
    uintptr_t classChainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
-   ClientSessionData *clientData = TR::compInfoPT->getClientData();
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, clientData, _stream,
                                              JITServerHelpers::CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
                                              (void *)&classChainOffset);
@@ -1557,10 +1633,16 @@ TR_J9JITServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint
       }
    }
 
+// TODO: need to do well-known classes, and the stuff that the AOT file wraps
 const void *
 TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   ClientSessionData *clientData = comp->getClientData();
+   bool useServerOffsets = clientData->useServerOffsets(_stream) && comp->isAOTCacheStore();
+   TR_ASSERT_FATAL(!useServerOffsets, "Unsupported when ignoring the client SCC");
+
    std::string dataStr((const char *)descriptor->address, descriptor->length);
 
    _stream->write(JITServer::MessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -37,6 +37,7 @@ class TR_J9VMBase;
 class TR_ResolvedMethod;
 namespace TR { class CompilationInfo; }
 #if defined(J9VM_OPT_JITSERVER)
+namespace TR { class CompilationInfoPerThread; }
 namespace JITServer { class ServerStream; }
 #endif
 
@@ -663,6 +664,7 @@ public:
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
 
    void setStream(JITServer::ServerStream *stream) { _stream = stream; }
+   void setCompInfoPT(TR::CompilationInfoPerThread *compInfoPT) { _compInfoPT = compInfoPT; }
    virtual const void *storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor) override;
 
 private:
@@ -685,6 +687,7 @@ private:
       }
 
    JITServer::ServerStream *_stream;
+   TR::CompilationInfoPerThread *_compInfoPT;
    };
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -643,6 +643,7 @@ public:
    virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT_FATAL(false, "called"); return 0;}
    virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL;}
 
+   virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL) override;
    virtual bool isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset = NULL) override;
    virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }
    virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod) override { TR_ASSERT_FATAL(false, "called"); return TR_SharedCache::INVALID_ROM_METHOD_OFFSET; }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 56; // ID: kkhDRhWae0gHBQ3ATWxV
+   static const uint16_t MINOR_NUMBER = 57; // ID: S/lCtmSB049jvzhogWYP
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1049,6 +1049,13 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffse
    return record;
    }
 
+const AOTCacheWellKnownClassesRecord *
+ClientSessionData::getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
+                                             size_t length, uintptr_t includedClasses)
+   {
+   return _aotCache->getWellKnownClassesRecord(chainRecords, length, includedClasses);
+   }
+
 bool
 ClientSessionData::useServerOffsets(JITServer::ServerStream *stream)
    {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1049,6 +1049,13 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffse
    return record;
    }
 
+bool
+ClientSessionData::useServerOffsets(JITServer::ServerStream *stream)
+   {
+   auto *vmInfo = getOrCacheVMInfo(stream);
+   return vmInfo->_useServerOffsets;
+   }
+
 
 ClientSessionHT*
 ClientSessionHT::allocate()

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -320,6 +320,9 @@ public:
       UDATA _vmindexOffset;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
       bool _useAOTCache;
+      // Should we use server offsets (idAndType of AOT cache serialization records) instead of
+      // local SCC offsets during AOT cache compilations?
+      bool _useServerOffsets;
       TR_AOTHeader _aotHeader;
       TR_OpaqueClassBlock *_JavaLangObject;
       TR_OpaqueClassBlock *_JavaStringObject;
@@ -484,6 +487,7 @@ public:
    JITServerAOTCache::KnownIdSet &getAOTCacheKnownIds() { return _aotCacheKnownIds; }
    TR::Monitor *getAOTCacheKnownIdsMonitor() const { return _aotCacheKnownIdsMonitor; }
 
+   bool useServerOffsets(JITServer::ServerStream *stream);
 private:
    void destroyMonitors();
 
@@ -570,6 +574,7 @@ private:
 
    std::string _aotCacheName;
    JITServerAOTCache *volatile _aotCache;
+   bool _useServerOffsets;
    const AOTCacheAOTHeaderRecord *volatile _aotHeaderRecord;
 
    JITServerAOTCache::KnownIdSet _aotCacheKnownIds;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -483,6 +483,8 @@ public:
    const AOTCacheClassChainRecord *getClassChainRecord(J9Class *clazz, uintptr_t classChainOffset,
                                                        const std::vector<J9Class *> &ramClassChain, JITServer::ServerStream *stream,
                                                        bool &missingLoaderInfo);
+   const AOTCacheWellKnownClassesRecord *getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
+                                                       size_t length, uintptr_t includedClasses);
 
    JITServerAOTCache::KnownIdSet &getAOTCacheKnownIds() { return _aotCacheKnownIds; }
    TR::Monitor *getAOTCacheKnownIdsMonitor() const { return _aotCacheKnownIdsMonitor; }

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -67,6 +67,7 @@ public:
    //NOTE: 0 signifies an invalid record ID
    uintptr_t id() const { return getId(_idAndType); }
    AOTSerializationRecordType type() const { return getType(_idAndType); }
+   uintptr_t idAndType() const { return _idAndType; }
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
 
    static const AOTSerializationRecord *get(const std::string &str)

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -288,7 +288,18 @@ TR::SymbolValidationManager::populateWellKnownClasses()
 #if defined(J9VM_OPT_JITSERVER)
    if (clientData)
       {
-      // This is an out-of-process compilation; check the cache in the client session first
+      // This is an out-of-process compilation.
+
+      // If we're ignoring the client's SCC, we can skip client consultation here
+      if (aotCacheStore && clientData->useServerOffsets(_comp->getStream()))
+         {
+         // getWellKnownClassesRecord expects the number of well-known classes, not the number of elements in the object
+         _aotCacheWellKnownClassesRecord = clientData->getWellKnownClassesRecord(classChainRecords, _wellKnownClasses.size(), includedClasses);
+         // TODO: I think _wellKnownClassChainOffsets can remain NULL
+         return;
+         }
+
+      // Otherwise check the cache in the client session first
       _wellKnownClassChainOffsets = clientData->getCachedWellKnownClassChainOffsets(
          includedClasses, _wellKnownClasses.size(), classChainOffsets + 1, _aotCacheWellKnownClassesRecord
       );


### PR DESCRIPTION
A new `_useServerOffsets` field in `VMInfo` has been added. It will be set when a client wants its local SCC (whether or not it exists) to be ignored during JITServer AOT cache compilations. Currently the client always sets this field to false.

The methods of `TR_J9JITServerSharedCache` and the handling of the well-known classes object in the SVM and AOT relocation header initialization have been modified so that it we are compiling an AOT cache store and are ignoring the client's local SCC, we now consult the JITServer AOT cache and use the `idAndType` of its records in place of local SCC offsets.

Various client-server messages have been modified to accommodate the changes in server compilation. The client will either test for a local SCC before accessing it, or the server will send an explicit boolean parameter indicating that a local SCC offset is required.
