### PR TITLE
Implement a deserializer and shared cache interface that ignores the local SCC

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2319,6 +2319,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationStreamVersionIncompatible:
             case compilationStreamLostMessage:
             case aotCacheDeserializationFailure:
+            case aotDeserializerReset:
 #endif
             case compilationInterrupted:
             case compilationCodeReservationFailure:
@@ -11695,6 +11696,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTCacheDeserializationFailure &e)
       {
       // error code was already set in remoteCompile()
+      }
+   catch (const J9::AOTDeserializerReset &e)
+      {
+      _methodBeingCompiled->_compErrCode = aotDeserializerReset;
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    catch (...)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -212,6 +212,7 @@ const char *compilationErrorNames[]={
    "compilationStreamVersionIncompatible",                 // compilationFirstJITServerFailure + 3 = 51
    "compilationStreamInterrupted",                         // compilationFirstJITServerFailure + 4 = 52
    "aotCacheDeserializationFailure",                       // compilationFirstJITServerFailure + 5 = 53
+   "aotDeserializerReset",                                 // compilationFirstJITServerFailure + 6 = 54
 #endif /* defined(J9VM_OPT_JITSERVER) */
    "compilationMaxError"
 };

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -82,6 +82,7 @@ typedef enum {
    compilationStreamVersionIncompatible                 = compilationFirstJITServerFailure + 3, // 51
    compilationStreamInterrupted                         = compilationFirstJITServerFailure + 4, // 52
    aotCacheDeserializationFailure                       = compilationFirstJITServerFailure + 5, // 53
+   aotDeserializerReset                                 = compilationFirstJITServerFailure + 6, // 54
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    /* must be the last one */

--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -382,6 +382,20 @@ TR_PersistentClassLoaderTable::lookupClassLoaderAndChainAssociatedWithClassName(
    return { info->_loader, info->_chain };
    }
 
+void *
+TR_PersistentClassLoaderTable::lookupClassLoaderAssociatedWithClassName(const uint8_t *data, size_t length) const
+   {
+   assertCurrentThreadCanRead();
+
+   NameKey key { data, length };
+   size_t index;
+   TR_ClassLoaderInfo *prev;
+   TR_ClassLoaderInfo *info = lookup<Name>(_nameTable, index, prev, &key);
+   if (!info)
+      return NULL;
+   return info->_loader;
+   }
+
 const J9UTF8 *
 TR_PersistentClassLoaderTable::lookupClassNameAssociatedWithClassLoader(void *loader) const
    {

--- a/runtime/compiler/env/ClassLoaderTable.hpp
+++ b/runtime/compiler/env/ClassLoaderTable.hpp
@@ -46,6 +46,7 @@ public:
    // in order to support AOT method serialization (and caching at JITServer) and deserialization.
    std::pair<void *, void *>// loader, chain
    lookupClassLoaderAndChainAssociatedWithClassName(const uint8_t *data, size_t length) const;
+   void *lookupClassLoaderAssociatedWithClassName(const uint8_t *data, size_t length) const;
    const J9UTF8 *lookupClassNameAssociatedWithClassLoader(void *loader) const;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    void removeClassLoader(J9VMThread *vmThread, void *loader);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -46,6 +46,7 @@
 #include "control/CompilationThread.hpp" // for TR::compInfoPT
 #include "control/JITServerHelpers.hpp"
 #include "runtime/JITClientSession.hpp"
+#include "runtime/JITServerAOTDeserializer.hpp"
 #endif
 
 #define LOG(logLevel, format, ...)               \
@@ -149,7 +150,10 @@ TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
    _numDigitsForCacheOffsets = 8;
 
 #if defined(J9VM_OPT_JITSERVER)
-   TR_ASSERT_FATAL(_sharedCacheConfig || _compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER, "Must have _sharedCacheConfig");
+   TR_ASSERT_FATAL(_sharedCacheConfig || _compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+                                      || (_compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT
+                                          && _compInfo->getPersistentInfo()->getJITServerUseAOTCache()),
+                  "Must have _sharedCacheConfig");
 #else
    TR_ASSERT_FATAL(_sharedCacheConfig, "Must have _sharedCacheConfig");
 #endif
@@ -1565,6 +1569,110 @@ TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, const char *key
 
    _stream->write(JITServer::MessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
    return std::get<0>(_stream->read<const void *>());
+   }
+
+TR_J9DeserializerSharedCache::TR_J9DeserializerSharedCache(TR_J9VMBase *fe, JITServerNoSCCAOTDeserializer *deserializer)
+   : TR_J9SharedCache(fe)
+   {
+   _deserializer = deserializer;
+   }
+
+J9ROMClass *
+TR_J9DeserializerSharedCache::romClassFromOffsetInSharedCache(uintptr_t offset)
+   {
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   bool wasReset = false;
+   auto romClass = _deserializer->romClassFromOffsetInSharedCache(offset, comp, wasReset);
+   if (wasReset)
+      comp->failCompilation<J9::AOTDeserializerReset>(
+         "Deserializer reset during relocation of method %s", comp->signature());
+   TR_ASSERT_FATAL(romClass, "ROM class for offset %zu could not be found",
+                   offset,
+                   JITServerNoSCCAOTDeserializer::offsetId(offset),
+                   JITServerNoSCCAOTDeserializer::offsetType(offset));
+   return romClass;
+   }
+
+void *
+TR_J9DeserializerSharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
+   {
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   bool wasReset = false;
+   auto ptr = _deserializer->pointerFromOffsetInSharedCache(offset, comp, wasReset);
+   if (wasReset)
+      comp->failCompilation<J9::AOTDeserializerReset>(
+         "Deserializer reset during relocation of method %s", comp->signature());
+   TR_ASSERT_FATAL(ptr, "Pointer for offset %zu ID %zu type %u could not be found",
+                   offset,
+                   JITServerNoSCCAOTDeserializer::offsetId(offset),
+                   JITServerNoSCCAOTDeserializer::offsetType(offset));
+   return ptr;
+   }
+
+void *
+TR_J9DeserializerSharedCache::lookupClassLoaderAssociatedWithClassChain(void *chainData)
+   {
+   // We return chainData directly because the only thing this function can be called on is the result of
+   // TR_J9DeserializerSharedCache::pointerFromOffsetInSharedCache(), and that will return a (J9ClassLoader *)
+   // directly when given a class loader offset.
+   return chainData;
+   }
+
+bool
+TR_J9DeserializerSharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
+   {
+   // During deserialization, we find a matching J9Class for the first entry of the chainData, meaning that
+   // its ROM class chain matches what was recorded during compilation. This provides the same guarantees
+   // that TR_J9SharedCache::validateClassChain() does, which is what TR_J9SharedCache::validateClassChain()
+   // uses to verify that the given clazz matches chainData. Thus we only have to check that that cached J9Class
+   // is equal to the one we are trying to validate.
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   bool wasReset = false;
+   auto ramClass = _deserializer->classFromOffset(chainData[1], comp, wasReset);
+   if (wasReset)
+      comp->failCompilation<J9::AOTDeserializerReset>(
+         "Deserializer reset during relocation of method %s", comp->signature());
+   TR_ASSERT_FATAL(ramClass, "RAM class for offset %zu ID %zu type %zu could not be found",
+                   chainData[1],
+                   JITServerNoSCCAOTDeserializer::offsetId(chainData[1]),
+                   JITServerNoSCCAOTDeserializer::offsetType(chainData[1]));
+   return ramClass == clazz;
+   }
+
+TR_OpaqueClassBlock *
+TR_J9DeserializerSharedCache::lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader)
+   {
+   // The base TR_J9SharedCache::lookupClassFromChainAndLoader(), when given a class chain and class loader, will look in the loader
+   // a J9Class correspoding to the first class in the chain. If one could be found, it then verifies that the class matches the cached version.
+   // We do not need to perform that checking here, because during deserialization we will have already resolved the first class in the chain to
+   // a J9Class and verified that it matches. Thus we can simply return that cached first J9Class.
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   bool wasReset = false;
+   auto clazz = _deserializer->classFromOffset(chainData[1], comp, wasReset);
+   if (wasReset)
+      comp->failCompilation<J9::AOTDeserializerReset>(
+         "Deserializer reset during relocation of method %s", comp->signature());
+   TR_ASSERT_FATAL(clazz, "Class for offset %zu could not be found",
+                   chainData[1],
+                   JITServerNoSCCAOTDeserializer::offsetId(chainData[1]),
+                   JITServerNoSCCAOTDeserializer::offsetType(chainData[1]));
+   return reinterpret_cast<TR_OpaqueClassBlock *>(clazz);
+   }
+
+J9ROMMethod *
+TR_J9DeserializerSharedCache::romMethodFromOffsetInSharedCache(uintptr_t offset)
+   {
+   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   bool wasReset = false;
+   auto romMethod = _deserializer->romMethodFromOffsetInSharedCache(offset, comp, wasReset);
+   if (wasReset)
+      comp->failCompilation<J9::AOTDeserializerReset>(
+         "Deserializer reset during relocation of method %s", comp->signature());
+   TR_ASSERT_FATAL(romMethod, "ROM method for offset %zu ID %zu type %zu could not be found",
+                   offset,
+                   JITServerNoSCCAOTDeserializer::offsetId(offset),
+                   JITServerNoSCCAOTDeserializer::offsetType(offset));
+   return romMethod;
    }
 
 #endif

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -148,6 +148,16 @@ class AOTCacheDeserializationFailure : public virtual RuntimeFailure
    {
    virtual const char *what() const throw() { return "AOT cache deserialization failure"; }
    };
+
+/**
+ * JITServer AOT Deserializer Reset exception type.
+ *
+ * Thrown when a concurrent JITServer AOT deserializer reset has been detected.
+ */
+class AOTDeserializerReset : public virtual RuntimeFailure
+   {
+   virtual const char *what() const throw() { return "AOT deserializer reset"; }
+   };
 #endif /* defined(J9VM_OPT_JITSERVER) */
 }
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -984,6 +984,9 @@ JITServerNoSCCAOTDeserializer::invalidateMethod(J9Method *method)
    TR_ASSERT(i_it != _methodIdMap.end(), "Broken two-way map");
 
    i_it->second = NULL;
+
+   _methodPtrMap.erase(p_it);
+
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Invalidated RAMMethod %p ID %zu", method, id);
    }

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -898,3 +898,66 @@ JITServerLocalSCCAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, 
 
    return true;
    }
+
+JITServerNoSCCAOTDeserializer::JITServerNoSCCAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable) :
+   JITServerAOTDeserializer(loaderTable)
+   { }
+
+
+void
+JITServerNoSCCAOTDeserializer::invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader)
+   {
+   }
+
+void
+JITServerNoSCCAOTDeserializer::invalidateClass(J9VMThread *vmThread, J9Class *ramClass)
+   {
+   }
+
+void
+JITServerNoSCCAOTDeserializer::clearCachedData()
+   {
+   getNewKnownIds().clear();
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const ClassSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const MethodSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const ClassChainSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const WellKnownClassesSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::cacheRecord(const ThunkSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset)
+   {
+   return false;
+   }
+
+bool
+JITServerNoSCCAOTDeserializer::updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset, bool &usesSVM)
+   {
+   return false;
+   }

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -295,11 +295,17 @@ private:
 
    virtual bool updateSCCOffsets(SerializedAOTMethod *method, TR::Compilation *comp, bool &wasReset, bool &usesSVM) override;
 
+   bool revalidateClassChain(uintptr_t *classChain, TR::Compilation *comp, bool &wasReset);
+   void getRAMClassChain(TR::Compilation *comp, J9Class *clazz, J9Class **chainBuffer, size_t &chainLength);
+
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }
 
    static uintptr_t encodeClassOffset(uintptr_t id)
       { return AOTSerializationRecord::idAndType(id, AOTSerializationRecordType::Class); }
+
+   static uintptr_t encodeClassChainOffset(uintptr_t id)
+      { return AOTSerializationRecord::idAndType(id, AOTSerializationRecordType::ClassChain); }
 
    PersistentUnorderedMap<uintptr_t/*ID*/, J9ClassLoader *> _classLoaderIdMap;
    PersistentUnorderedMap<J9ClassLoader *, uintptr_t/*ID*/> _classLoaderPtrMap;
@@ -310,6 +316,7 @@ private:
    PersistentUnorderedMap<uintptr_t/*ID*/, J9Method *> _methodIdMap;
    PersistentUnorderedMap<J9Method *, uintptr_t> _methodPtrMap;
 
+   PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t * /*deserializer chain*/> _classChainMap;
    };
 
 #endif /* JITSERVER_AOT_DESERIALIZER_H */

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -269,6 +269,7 @@ public:
 
    virtual void invalidateClassLoader(J9VMThread *vmThread, J9ClassLoader *loader) override;
    virtual void invalidateClass(J9VMThread *vmThread, J9Class *ramClass) override;
+   void invalidateMethod(J9Method *method);
 
    static uintptr_t offsetId(uintptr_t offset)
       { return AOTSerializationRecord::getId(offset); }
@@ -305,6 +306,9 @@ private:
 
    PersistentUnorderedMap<uintptr_t/*ID*/, ClassEntry> _classIdMap;
    PersistentUnorderedMap<J9Class *, uintptr_t/*ID*/> _classPtrMap;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, J9Method *> _methodIdMap;
+   PersistentUnorderedMap<J9Method *, uintptr_t> _methodPtrMap;
 
    };
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -276,6 +276,13 @@ public:
       { return AOTSerializationRecord::getType(offset); }
 
 private:
+   struct ClassEntry
+      {
+      // NULL if class ID is invalid (was not found or its hash didn't match), or class was unloaded
+      J9Class *_ramClass;
+      uintptr_t _classLoaderId;
+      };
+
    virtual void clearCachedData() override;
 
    virtual bool cacheRecord(const ClassLoaderSerializationRecord *record, TR::Compilation *comp, bool &isNew, bool &wasReset) override;
@@ -290,8 +297,14 @@ private:
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }
 
+   static uintptr_t encodeClassOffset(uintptr_t id)
+      { return AOTSerializationRecord::idAndType(id, AOTSerializationRecordType::Class); }
+
    PersistentUnorderedMap<uintptr_t/*ID*/, J9ClassLoader *> _classLoaderIdMap;
    PersistentUnorderedMap<J9ClassLoader *, uintptr_t/*ID*/> _classLoaderPtrMap;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, ClassEntry> _classIdMap;
+   PersistentUnorderedMap<J9Class *, uintptr_t/*ID*/> _classPtrMap;
 
    };
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -298,6 +298,8 @@ private:
    bool revalidateClassChain(uintptr_t *classChain, TR::Compilation *comp, bool &wasReset);
    void getRAMClassChain(TR::Compilation *comp, J9Class *clazz, J9Class **chainBuffer, size_t &chainLength);
 
+   bool revalidateWellKnownClasses(uintptr_t *wellKnownClassesChain, TR::Compilation *comp, bool &wasReset);
+
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }
 
@@ -317,6 +319,8 @@ private:
    PersistentUnorderedMap<J9Method *, uintptr_t> _methodPtrMap;
 
    PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t * /*deserializer chain*/> _classChainMap;
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, uintptr_t * /*deserializer chain offsets*/> _wellKnownClassesMap;
    };
 
 #endif /* JITSERVER_AOT_DESERIALIZER_H */

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -263,6 +263,8 @@ private:
 class JITServerNoSCCAOTDeserializer : public JITServerAOTDeserializer
    {
 public:
+   friend class TR_J9DeserializerSharedCache;
+
    TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
 
    JITServerNoSCCAOTDeserializer(TR_PersistentClassLoaderTable *loaderTable);
@@ -299,6 +301,11 @@ private:
    void getRAMClassChain(TR::Compilation *comp, J9Class *clazz, J9Class **chainBuffer, size_t &chainLength);
 
    bool revalidateWellKnownClasses(uintptr_t *wellKnownClassesChain, TR::Compilation *comp, bool &wasReset);
+
+   J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset, TR::Compilation *comp, bool &wasReset);
+   void *pointerFromOffsetInSharedCache(uintptr_t offset, TR::Compilation *comp, bool &wasReset);
+   J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset, TR::Compilation *comp, bool &wasReset);
+   J9Class *classFromOffset(uintptr_t offset, TR::Compilation *comp, bool &wasReset);
 
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -303,6 +303,9 @@ private:
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }
 
+   static uintptr_t encodeOffset(const SerializedSCCOffset &serializedOffset)
+      { return AOTSerializationRecord::idAndType(serializedOffset.recordId(), serializedOffset.recordType()); }
+
    static uintptr_t encodeClassOffset(uintptr_t id)
       { return AOTSerializationRecord::idAndType(id, AOTSerializationRecordType::Class); }
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -289,6 +289,10 @@ private:
 
    static uintptr_t encodeOffset(const AOTSerializationRecord *record)
       { return AOTSerializationRecord::idAndType(record->id(), record->type()); }
+
+   PersistentUnorderedMap<uintptr_t/*ID*/, J9ClassLoader *> _classLoaderIdMap;
+   PersistentUnorderedMap<J9ClassLoader *, uintptr_t/*ID*/> _classLoaderPtrMap;
+
    };
 
 #endif /* JITSERVER_AOT_DESERIALIZER_H */


### PR DESCRIPTION
The new `JITServerNoSCCAOTDeserializer` will deserialize methods received from the JITServer AOT cache without consulting the local SCC. It does this by following the procedure that the `JITServerLocalSCCAOTDeserializer` does, roughly - it resolves each type of record into a corresponding dynamic JVM entity, does a certain amount of validation of those entities, and caches those entities. In contrast to the existing deserializer, it will not store a persistent representation of those entities in the local SCC, and instead of updating the offsets in the relocation records of methods with local SCC offsets, it will instead update them with the `idAndType` of the serialization record associated to those offsets.

The `TR_J9DeserializerSharedCache` is a `TR_J9SharedCache` derived class that ignores the local SCC entirely, even if it exists. Instead, it will consult the deserializer caches for information during relocation. These SCC methods will check for a concurrent reset of the deserializer and abort compilation if one was detected. Methods deserialized with `JITServerNoSCCAOTDeserializer` must be relocated with this new shared cache interface, as that deserializer updates the relocation records of methods with offsets that only it understands, and not local SCC offsets.