### PR TITLE
Check normalizedNaN flag on (d/f)bits2(l/i) nodes

### DIFF
--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -223,7 +223,7 @@ bool TR_DynamicLiteralPool::visitTreeTop(TR::TreeTop * tt, TR::Node *grandParent
          addNewAloadChild(node);
          }
       // add extra aload child for float conversions
-      else if (opCodeValue==TR::fbits2i || opCodeValue==TR::dbits2l)
+      else if ((opCodeValue==TR::fbits2i || opCodeValue==TR::dbits2l) && node->normalizeNanValues())
          {
          addNewAloadChild(node);
          }


### PR DESCRIPTION
In DynamicLiteralPool optimization, we add `aload` node denoting the address of literal base as a child of certain nodes when certain constant normalization is needed. For example, when OpenJ9 recognizes and inlines `floatToIntBits` or `doubleToLongBits`, it uses the fbits2i and dbits2l nodes respectively. Java specification requires those method to return normalize/canonical NaN value if the floating point operand is NaN. Dynamic Literal Pool optimization would attach an aload node denoting address of literal pool base to such nodes. In case when we are inlining `floatToRawIntBits` / `doubleToRawLongBits` , we are not required to return the normalize for of NaN for all NaN operands and simply return the raw bits representing floating point value. In such case, DynamicLiteralPool optimization do not need to attach extra child to node for literal base. This commit checks if normalization is required or not for such operation before attaching extra node for literal base.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18874