### PR TITLE
Remove flushCaches param from acquireExclusiveVMAccessForGC

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -699,20 +699,20 @@ MM_MemorySubSpaceTarok::replenishAllocationContextFailed(MM_EnvironmentBase *env
 	Assert_MM_true(NULL != collector);
 
 	allocateDescription->saveObjects(env);
-	if(!env->acquireExclusiveVMAccessForGC(collector, true, true)) {
+	if (!env->acquireExclusiveVMAccessForGC(collector, true)) {
 		allocateDescription->restoreObjects(env);
 		/* don't have exclusive access - another thread beat us to the GC.  retry the allocate using the standard locking path */
 		result = context->allocate(env, objectAllocationInterface, allocateDescription, allocationType);
 
-		if(NULL == result) {
+		if (NULL == result) {
 			allocateDescription->saveObjects(env);
 			/* still can't satisfy - grab exclusive at all costs and retry the allocate */
-			if(!env->acquireExclusiveVMAccessForGC(collector)) {
+			if (!env->acquireExclusiveVMAccessForGC(collector)) {
 				allocateDescription->restoreObjects(env);
 				/* now that we have exclusive, see if there is memory to satisfy the allocate (since we might not be the first to get in here) */
 				result = lockedAllocate(env, context, objectAllocationInterface, allocateDescription, allocationType);
 
-				if(NULL != result) {
+				if (NULL != result) {
 					/* Satisfied the allocate after having grabbed exclusive access to perform a GC (without actually performing the GC).  Raise
 					 * an event for tracing / verbose to report the occurrence.
 					 */


### PR DESCRIPTION
OMR's acquireExclusiveVMAccessForGC is about to stop calling
flushCachesForGC, so it will lose a parameter that controls it.

This change just removes that actual argument at the call site,
what is safe to due, since that actual value is exactly what
the default value is.