### PR TITLE
Update JVMTI InterruptThread for virtual threads

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5928,6 +5928,9 @@ typedef struct J9JavaVM {
 	jmethodID addOpens;
 	jmethodID addUses;
 	jmethodID addProvides;
+#if JAVA_SPEC_VERSION >= 19
+       jmethodID vThreadInterrupt;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 	UDATA addModulesCount;
 	UDATA safePointState;
 	UDATA safePointResponseCount;


### PR DESCRIPTION
JVMTI InterruptThread needs to invoke j.l.VirtualThread.interrupt()
to interrupt a virtual thread as per the RI.

Related: #18810