### PR TITLE
Correctly initialize walkState values when calling walkStackFrames

### DIFF
--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -102,6 +102,7 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 	J9StackWalkState *walkState = vmThread->stackWalkState;
 
 	Assert_JCL_notNull (stackWalkerMethod);
+	/* Consume thread's stateWalkState, push a new entry to thread for use during Java callout. */
 	memset(&newWalkState, 0, sizeof(J9StackWalkState));
 	newWalkState.previous = walkState;
 	vmThread->stackWalkState = &newWalkState;
@@ -146,6 +147,8 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 	if (NULL == walkerMethodChars) { /* native out of memory exception pending */
 		return NULL;
 	}
+	/* Ensure userData1/2 used by stackFrameFilter function is set properly. */
+	walkState->userData1 = NULL;
 	walkState->userData2 = (void *)walkerMethodChars;
 	UDATA walkStateResult = vm->walkStackFrames(vmThread, walkState);
 	Assert_JCL_true(walkStateResult == J9_STACKWALK_RC_NONE);

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -148,12 +148,11 @@ Java_java_lang_StackWalker_walkWrapperImpl(JNIEnv *env, jclass clazz, jint flags
 		return NULL;
 	}
 	/* Ensure userData1/2 used by stackFrameFilter function is set properly. */
-	walkState->userData1 = NULL;
+	walkState->userData1 = (void *)(UDATA)flags;
 	walkState->userData2 = (void *)walkerMethodChars;
 	UDATA walkStateResult = vm->walkStackFrames(vmThread, walkState);
 	Assert_JCL_true(walkStateResult == J9_STACKWALK_RC_NONE);
 	walkState->flags |= J9_STACKWALK_RESUME;
-	walkState->userData1 = (void *)(UDATA)flags;
 	if (J9SF_FRAME_TYPE_END_OF_STACK != walkState->pc) {
 		/* indicate the we have the topmost client method's frame */
 		walkState->userData1 = (void *)((UDATA)walkState->userData1 | J9_FRAME_VALID);
@@ -213,11 +212,12 @@ Java_java_lang_StackWalker_walkContinuationImpl(JNIEnv *env, jclass clazz, jint 
 	walkState.frameWalkFunction = stackFrameFilter;
 
 	/* walking unmounted Continuation will not require skipping StackWalker methods */
+	walkState.userData1 = (void *)(UDATA)flags;
 	walkState.userData2 = NULL;
 	UDATA walkStateResult = vm->walkStackFrames(vmThread, &walkState);
 	Assert_JCL_true(walkStateResult == J9_STACKWALK_RC_NONE);
 	walkState.flags |= J9_STACKWALK_RESUME;
-	walkState.userData1 = (void *)(UDATA)flags;
+
 	if (J9SF_FRAME_TYPE_END_OF_STACK != walkState.pc) {
 		/* indicate the we have the topmost client method's frame */
 		walkState.userData1 = (void *)((UDATA)walkState.userData1 | J9_FRAME_VALID);


### PR DESCRIPTION
After a thread's stackWalkState is used, we don't reset the fields to 0 but expects future code uses to set the parameters to the expected value before calling walkStackFrames.
This change fixes walkWrapperImpl where userData1 is not properly set.

Fixes: #18696 
Fixes: #18961 