### PR TITLE
Fix compile error for JAVA_SPEC_VERSION < 19

### DIFF
--- a/runtime/jvmti/jvmtiThread.cpp
+++ b/runtime/jvmti/jvmtiThread.cpp
@@ -510,9 +510,9 @@ done:
 				rc = JVMTI_ERROR_INTERNAL;
 			}
 		}
-	}
-exit:
+exit:;
 #endif /* JAVA_SPEC_VERSION >= 19 */
+	}
 
 	TRACE_JVMTI_RETURN(jvmtiInterruptThread);
 }


### PR DESCRIPTION
Introduced in https://github.com/eclipse-openj9/openj9/pull/18964.