### PR TITLE
Add var handle method type lookup table walking

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3582,6 +3582,9 @@ typedef struct J9ROMClass {
 #endif /* JAVA_SPEC_VERSION >= 11 */
 #define J9ROMCLASS_OPTIONALINFO(base) SRP_GET((base)->optionalInfo, U_32*)
 #define J9ROMCLASS_CALLSITEDATA(base) SRP_GET((base)->callSiteData, U_8*)
+#if defined(J9VM_OPT_METHOD_HANDLE)
+#define J9ROMCLASS_VARHANDLEMETHODTYPELOOKUPTABLE(base) SRP_GET((base)->varHandleMethodTypeLookupTable, U_16*)
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 #define J9ROMCLASS_STATICSPLITMETHODREFINDEXES(base) SRP_GET((base)->staticSplitMethodRefIndexes, U_16*)
 #define J9ROMCLASS_SPECIALSPLITMETHODREFINDEXES(base) SRP_GET((base)->specialSplitMethodRefIndexes, U_16*)
 


### PR DESCRIPTION
The content of the `varHandleMethodTypeLookupTable` is now walked in `allSlotsInROMClassDo`.

The relevant section of the ROM class writer code is here, I believe:

https://github.com/eclipse-openj9/openj9/blob/6a6d7afd73759f7bf4c786055bcb02bb35343030/runtime/bcutil/ROMClassWriter.cpp#L887-L910

I think the individual slots are `"cpIndex"`, but I'm unsure. I also made up the new section name `"varHandleMethodTypeLookupTable"`.

I also updated some of the documentation surrounding `JITServerHelpers::packROMClass`.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18957