### PR TITLE
Recognize java/lang/StringCoding.implEncodeAsciiArray

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1186,6 +1186,7 @@
    java_lang_StringCoding_StringDecoder_decode,
    java_lang_StringCoding_StringEncoder_encode,
    java_lang_StringCoding_implEncodeISOArray,
+   java_lang_StringCoding_implEncodeAsciiArray,
    java_lang_StringCoding_encode8859_1,
    java_lang_StringCoding_encodeASCII,
    java_lang_StringCoding_encodeUTF8,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2787,6 +2787,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_StringCoding_decode, "decode", "(Ljava/nio/charset/Charset;[BII)[C")},
       {x(TR::java_lang_StringCoding_encode, "encode", "(Ljava/nio/charset/Charset;[CII)[B")},
       {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
+      {x(TR::java_lang_StringCoding_implEncodeAsciiArray, "implEncodeAsciiArray", "([CI[BII)I")},
       {x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
       {x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
       {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[BZ)[B")},


### PR DESCRIPTION
implEncodeAsciiArray is equivalent to Java 11's US_ASCII.encodeASCII converter method. Acceleration for this routine already exists in OMR. This commit introduces this routine to the JIT compiler.