### PR TITLE
Protect JITServer code with `#if defined(J9VM_OPT_JITSERVER)`

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7949,7 +7949,9 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       _compInfo.acquireCompMonitor(vmThread);
       bool checkpointInProgress = _compInfo.isCheckpointInProgress();
       _compInfo.releaseCompMonitor(vmThread);
+#if defined(J9VM_OPT_JITSERVER)
       eligibleForRemoteAOTNoSCCCompile = eligibleForRemoteAOTNoSCCCompile && !checkpointInProgress;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 #endif
 
       bool sharedClassTest = eligibleForRelocatableCompile

--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -236,7 +236,11 @@ TR_PersistentClassLoaderTable::associateClassLoaderWithClass(J9VMThread *vmThrea
    // If we are using the JITServer AOT cache and ignoring the local SCC, we need to remember the name of clazz
    // with or without chain. Otherwise (not using AOT cache or not ignoring the local SCC) there is no point in continuing
    // without a chain.
-   if (!chain && (!useAOTCache || !_persistentMemory->getPersistentInfo()->getJITServerAOTCacheIgnoreLocalSCC()))
+   if (!chain
+#if defined(J9VM_OPT_JITSERVER)
+       && (!useAOTCache || !_persistentMemory->getPersistentInfo()->getJITServerAOTCacheIgnoreLocalSCC())
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      )
       return;
    TR_ASSERT(!_sharedCache || !chain || _sharedCache->isPointerInSharedCache(chain), "Class chain must be in SCC");
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1995,8 +1995,10 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 #if (defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_AARCH64))
 				IDATA argIndexXXPortableSharedCache = 0;
 				IDATA argIndexXXNoPortableSharedCache = 0;
+#if defined(J9VM_OPT_JITSERVER)
 				IDATA argIndexXXJITServerAOTCache = 0;
 				IDATA argIndexXXNoJITServerAOTCache = 0;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 #endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_AARCH64) */
 
 				vm->sharedClassPreinitConfig = NULL;


### PR DESCRIPTION
This fixes a build break on platforms that don't have JITServer enabled by default.