### PR TITLE
(0.44) Fix intermittent LogGeneratedClassesTest failures

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -231,7 +231,7 @@ public final class InternalCRIUSupport {
 
 	private static native String[] getRestoreSystemProperites();
 
-	static {
+	private static void initializeUnsafe() {
 		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 			try {
 				Field f = Unsafe.class.getDeclaredField("theUnsafe"); //$NON-NLS-1$
@@ -807,6 +807,10 @@ public final class InternalCRIUSupport {
 	private void registerRestoreEnvVariables() {
 		if (this.envFile == null) {
 			return;
+		}
+
+		if (unsafe == null) {
+			initializeUnsafe();
 		}
 
 		J9InternalCheckpointHookAPI.registerPostRestoreHook(HookMode.SINGLE_THREAD_MODE, RESTORE_ENVIRONMENT_VARIABLES_PRIORITY,


### PR DESCRIPTION
Fix intermittent LogGeneratedClassesTest failures by
removing use of lambda expression in static block of
InternalCRIUSupport, which avoids the unexpected
creation of lambda class files for InternalCRIUSupport
during the test.

Port-of: https://github.com/eclipse-openj9/openj9/pull/18968
Issue: https://github.com/eclipse-openj9/openj9/issues/18556
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>