### PR TITLE
AttachAPI updates control file access time for long running applications

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -36,11 +36,11 @@ import java.util.Objects;
  *
  */
 public abstract class CommonDirectory {
-	private static final String ATTACH_LOCK = "_attachlock"; //$NON-NLS-1$
+	static final String ATTACH_LOCK = "_attachlock"; //$NON-NLS-1$
 	private static final String COM_IBM_TOOLS_ATTACH_DIRECTORY = "com.ibm.tools.attach.directory"; //$NON-NLS-1$
 	private static final int COMMON_DIRECTORY_PERMISSIONS = 01777; /* allow anyone to create directories, but only owner can delete */
 	private static final int COMMON_LOCK_FILE_PERMISSIONS = 0666; /* allow anyone to create and use the file */
-	private static final String CONTROLLER_LOCKFILE = "_controller"; //$NON-NLS-1$
+	static final String CONTROLLER_LOCKFILE = "_controller"; //$NON-NLS-1$
 	static final String CONTROLLER_NOTIFIER = "_notifier"; //$NON-NLS-1$
 	static final int SEMAPHORE_OKAY = 0;
 	private static final String TRASH_PREFIX = ".trash_"; //$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
@@ -79,10 +79,13 @@ public class IPC {
 	public static final String PROPERTY_DIAGNOSTICS_ERRORTYPE = OPENJ9_DIAGNOSTICS_PREFIX + "errortype"; //$NON-NLS-1$
 	public static final String PROPERTY_DIAGNOSTICS_ERRORMSG = OPENJ9_DIAGNOSTICS_PREFIX + "errormsg"; //$NON-NLS-1$
 	/**
+	 * True if operating system is Linux.
+	 */
+	public static final boolean isLinux;
+	/**
 	 * True if operating system is Windows.
 	 */
 	public static final boolean isWindows;
-
 	/**
 	 * True if operating system is z/OS.
 	 */
@@ -101,22 +104,26 @@ public class IPC {
 		String osName = props.getProperty("os.name"); //$NON-NLS-1$
 		boolean tempIsZos = false;
 		boolean tempIsWindows = false;
+		boolean tempIsLinux = false;
 		if (null != osName) {
 			if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
 				tempIsZos = true;
 			} else if (osName.startsWith("Windows")) { //$NON-NLS-1$
 				tempIsWindows = true;
+			} else if (osName.startsWith("Linux")) { //$NON-NLS-1$
+				tempIsLinux = true;
 			}
 		}
 		isZOS = tempIsZos;
 		isWindows = tempIsWindows;
+		isLinux = tempIsLinux;
 
 		String propUseFileLockWatchdog = props.getProperty(COM_IBM_TOOLS_ATTACH_USE_FILELOCK_WATCHDOG);
 		if (propUseFileLockWatchdog == null) {
 			// no system property com.ibm.tools.attach.useFileLockWatchdog is specified
 			useFileLockWatchdog = !isZOS;
 		} else {
-			useFileLockWatchdog = "true".equalsIgnoreCase(propUseFileLockWatchdog);
+			useFileLockWatchdog = "true".equalsIgnoreCase(propUseFileLockWatchdog); //$NON-NLS-1$
 		}
 	}
 


### PR DESCRIPTION
`AttachAPI` updates control file access time for long running applications 

Added a system property `com.ibm.tools.attach.fileAccessUpdateTime` for `sleepDays` which has a default value `8` (days);
Added a daemon thread to update `AttachAPI` control files every `sleepDays`.

close https://github.com/eclipse-openj9/openj9/issues/18720

Signed-off-by: Jason Feng <fengj@ca.ibm.com>