### PR TITLE
(0.44) Ignore extension classloader in JVM_LatestUserDefinedLoader on jdk8

### DIFF
--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -89,15 +89,8 @@ latestUserDefinedLoaderIterator(J9VMThread * currentThread, J9StackWalkState * w
 	J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 	J9ClassLoader * classLoader = currentClass->classLoader;
 
-	/* Ignore jdk/internal/loader/ClassLoaders$PlatformClassLoader (Java 9+).
-	 * In Java 9+, vm->extensionClassLoader is the PlatformClassLoader.
-	 */
-	BOOLEAN isPlatformClassLoader = FALSE;
-	if ((J2SE_VERSION(vm) >= J2SE_V11) && (classLoader == vm->extensionClassLoader)) {
-		isPlatformClassLoader = TRUE;
-	}
-
-	if ((classLoader != vm->systemClassLoader) && !isPlatformClassLoader) {
+	/* Ignore the system and extension/platform classloader. In jdk9+, vm->extensionClassLoader is the PlatformClassLoader. */
+	if ((classLoader != vm->systemClassLoader) && (classLoader != vm->extensionClassLoader)) {
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 		Assert_SunVMI_mustHaveVMAccess(currentThread);


### PR DESCRIPTION
The serialization filter may be loaded by the extension classloader and this loader needs to be ignored when determining the latest user defined loader. jdk9+ already does this, although for jdk9+ it's called the platform classloader.

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/18984 for 0.44