### PR TITLE
[FFI/Jtreg_JDK22] Change the value of the heap address identifier

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -94,7 +94,7 @@ public class InternalDowncallHandler {
 	/* The identifier denotes the passed-in argument is a heap segment which helps
 	 * extract the address from the heap argument's base object in native.
 	 */
-	private static final long DOWNCALL_HEAP_ARGUMENT_ID = 0x1;
+	private static final long DOWNCALL_HEAP_ARGUMENT_ID = 0xFFFFFFFFFFFFFFFFL;
 
 	/* The ThreadLocal holds the information of the heap argument which includes
 	 * the base object array, the offset array plus the current heap argument index

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6064,7 +6064,7 @@ typedef struct J9JavaVM {
 
 #if JAVA_SPEC_VERSION >= 16
 #if JAVA_SPEC_VERSION >= 22
-#define J9_FFI_DOWNCALL_HEAP_ARGUMENT_ID 0x1
+#define J9_FFI_DOWNCALL_HEAP_ARGUMENT_ID J9CONST_U64(0xFFFFFFFFFFFFFFFF)
 #endif /* JAVA_SPEC_VERSION >= 22 */
 
 /* The mask for the signature type identifier */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5288,7 +5288,7 @@ done:
 				/* ffi_call expects the address of the pointer is the address of the stackslot. */
 				pointerValues[i] = (U_64)ffiArgs[i];
 #if JAVA_SPEC_VERSION >= 22
-				if ((U_64)J9_FFI_DOWNCALL_HEAP_ARGUMENT_ID == pointerValues[i]) {
+				if (J9_FFI_DOWNCALL_HEAP_ARGUMENT_ID == pointerValues[i]) {
 					j9object_t heapBase = (j9object_t)J9JAVAARRAYOFOBJECT_LOAD(
 							_currentThread,
 							J9_JNI_UNWRAP_REFERENCE(_sp + 11), /* The heap base array. */


### PR DESCRIPTION
The tiny changes modify the constant used to
identify the heap address in downcall to avoid
any potential conflict with the address value
passed to downcall.

Fixes: #18999

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>