### PR TITLE
Fix JLM_Tests build for windows

### DIFF
--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -51,9 +51,9 @@
 			<then>
 				<property name="excludeTestCRaCMXBean" value="org/openj9/test/java/lang/management/TestCRaCMXBean.java"/>
 				<property name="replaceTestng" value="testng.xml" />
-				<exec executable="awk" input="${src}/../testng.xml" output="${build}/testng.xml">
-					<arg value="/&lt;test name=&quot;testCRaCMXBean&quot;&gt;/,/&lt;\/test&gt;/{next} 1"/>
-				</exec>
+				<xslt in="testng.xml" out="${build}/testng.xml" style="testng_filter.xsl">
+					<param name="testName" expression="testCRaCMXBean"/>
+				</xslt>
 			</then>
 		</if>
 	</target>

--- a/test/functional/JLM_Tests/testng.xml
+++ b/test/functional/JLM_Tests/testng.xml
@@ -22,7 +22,7 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="JLM_Tests_Suite" parallel="none" verbose="2">
 	<listeners>
 		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer" />

--- a/test/functional/JLM_Tests/testng_filter.xsl
+++ b/test/functional/JLM_Tests/testng_filter.xsl
@@ -1,0 +1,36 @@
+<!--
+Copyright IBM Corp. and others 2024
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:param name="testName"/>
+    <!--
+    This template matches any attribute or node and copies it to the output xml file,
+    and only applies if there is not a more specific match,
+    such as a template that matches <test> elements with the name $testName.
+    -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <!-- This template finds <test> elements with the name $testName and excludes them from the output xml file. -->
+    <xsl:template match="test[@name=$testName]"/>
+</xsl:stylesheet>


### PR DESCRIPTION
Fix JLM_Tests build for windows by excluding tests in
testng.xml with xslt instead of awk, which is not
accessible on the windows machines.

Issue: https://github.com/eclipse-openj9/openj9/issues/18998
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>