### PR TITLE
(v0.44.0-release) CRIU adds unqualified exports java.base/jdk.crac when CRaC is enabled

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -171,6 +171,12 @@ final class J9VMInternals {
 			Runtime.getRuntime().addShutdownHook(new Thread(runnable, "CommonCleanerShutdown", true, false, false, null)); //$NON-NLS-1$
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
+/*[IF CRAC_SUPPORT]*/
+		if (openj9.internal.criu.InternalCRIUSupport.isCRaCSupportEnabled()) {
+			// export java.base/jdk.crac unconditionally
+			J9VMInternals.class.getModule().implAddExports("jdk.crac"); //$NON-NLS-1$
+		}
+/*[ENDIF] CRAC_SUPPORT */
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -67,9 +67,6 @@ exports jdk.internal.access to
 opens jdk.internal.access to
     openj9.criu;
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
-/*[IF CRAC_SUPPORT]*/
-exports jdk.crac;
-/*[ENDIF] CRAC_SUPPORT */
 exports jdk.internal.misc to
     openj9.criu;
 exports openj9.internal.criu to

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -210,6 +210,9 @@ throwExceptionHelper(J9VMThread * currentThread, UDATA errCode)
 			moduleName = J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND__MODULE;
 			messageNumber = J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND__ID;
 			break;
+		default:
+			Assert_SC_unreachable();
+			break;
 		}
 		msg = OMRPORTLIB->nls_lookup_message(OMRPORTLIB, J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, moduleName, messageNumber, NULL);
 		currentThread->javaVM->internalVMFunctions->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, msg);

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2336,3 +2336,52 @@ J9NLS_VM_CRIU_J9_GET_PROCESS_START_TIME_FAILURE.explanation=j9sysinfo_get_proces
 J9NLS_VM_CRIU_J9_GET_PROCESS_START_TIME_FAILURE.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_J9_GET_PROCESS_START_TIME_FAILURE.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_GENERAL_FAILURE=General failure
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_GENERAL_FAILURE.explanation=The specified modularity operation failed.
+J9NLS_VM_MODULARITY_GENERAL_FAILURE.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_GENERAL_FAILURE.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_PACKAGE_ALREADY_DEFINED=A package in the list has already been defined
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_PACKAGE_ALREADY_DEFINED.explanation=The specified module package has already been defined.
+J9NLS_VM_MODULARITY_PACKAGE_ALREADY_DEFINED.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_PACKAGE_ALREADY_DEFINED.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_MODULE_ALREADY_DEFINED=The module has already been defined
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_MODULE_ALREADY_DEFINED.explanation=The specified module has already been defined.
+J9NLS_VM_MODULARITY_MODULE_ALREADY_DEFINED.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_MODULE_ALREADY_DEFINED.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_HASH_OPERATION_FAILED=The modularity hash operation failed
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_HASH_OPERATION_FAILED.explanation=The modularity hash operation failed.
+J9NLS_VM_MODULARITY_HASH_OPERATION_FAILED.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_HASH_OPERATION_FAILED.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_DUPLICATED_PACKAGE_FOUND=The list contains duplicate packages
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_DUPLICATED_PACKAGE_FOUND.explanation=The list contains duplicate packages.
+J9NLS_VM_MODULARITY_DUPLICATED_PACKAGE_FOUND.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_DUPLICATED_PACKAGE_FOUND.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_MODULE_NOT_FOUND=The specified module was not found
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_MODULE_NOT_FOUND.explanation=The specified module was not found.
+J9NLS_VM_MODULARITY_MODULE_NOT_FOUND.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_MODULE_NOT_FOUND.user_response=Contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND=The specified package was not found
+# START NON-TRANSLATABLE
+J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.explanation=The specified package was not found.
+J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.system_action=The JVM will fail to start.
+J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.user_response=Contact your service representative.
+# END NON-TRANSLATABLE

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -84,7 +84,7 @@
 				</javac>
 			</then>
 			<else>
-				<property name="addExports" value="--add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+				<property name="addExports" value="--add-exports java.base/jdk.crac=ALL-UNNAMED --add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
 				<echo>===addExports:        ${addExports}</echo>
 				<echo>===enablePreview:     ${enablePreview}</echo>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">


### PR DESCRIPTION
`CRIU` adds unqualified `exports` `java.base/jdk.crac` when `CRaC` is enabled

Use `Module.implAddExports("jdk.crac")` to export `java.base/jdk.crac` unconditionally when the `CRaC` is enabled;
Refactored `throwExceptionHelper(currentThread, errCode)`;
Also fixed `addPackageDefinition()` usage in `JVM_AddModulePackage()`.

Cherry-Pick
* https://github.com/eclipse-openj9/openj9/pull/18959
* https://github.com/eclipse-openj9/openj9/pull/19019

Signed-off-by: Jason Feng <fengj@ca.ibm.com>