### PR TITLE
Cache Invocation API function descriptors in libjvm31 wrapper

### DIFF
--- a/runtime/j9vm31/j9cel4ro64.h
+++ b/runtime/j9vm31/j9cel4ro64.h
@@ -46,6 +46,12 @@ extern "C" {
 #define J9_CEL4RO64_RETCODE_ERROR_FAILED_QUERY_TARGET_FUNC       0x5
 #define J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND   0x6
 
+/* Locally allocated control block lengths. */
+/*   For use with j9_cel4ro64_call_function - Sufficient space for 10 arguments. */
+#define MAX_LOCAL_CONTROL_BLOCK_LENGTH_FOR_CALL sizeof(J9_CEL4RO64_controlBlock) + sizeof(uint64_t) * 10 + sizeof(uint32_t)
+/*   For use with j9_cel4ro64_load_query_function_descriptor - Sufficient space for 48 total chars for module/function names. */
+#define MAX_LOCAL_CONTROL_BLOCK_LENGTH_FOR_QUERY sizeof(J9_CEL4RO64_infoBlock) + 2 * sizeof(int32_t) + 48
+
 /* Fixed length Control Block structure RO64_CB */
 typedef struct J9_CEL4RO64_controlBlock {
 	uint32_t version;            /**< (Input) A integer which contains the version of RO64_INFO. */
@@ -143,6 +149,20 @@ uint32_t
 j9_cel4ro64_load_query_call_function(
 	const char* moduleName, const char* functionName, J9_CEL4RO64_ArgType *argTypes,
 	uint64_t *argValues, uint32_t numArgs, J9_CEL4RO64_ArgType returnType, void *returnStorage);
+
+/**
+ * A helper routine to allocate the CEL4RO64 control blocks and related structures
+ * for target shared library and function. Returns the 64-bit function descriptor
+ * in returnStorage parameter.
+ * @param[in] moduleName The name of the target library to load.
+ * @param[in] functionName The name of the target function to lookup.
+ * @param[in] returnStorage The storage location to store the target function descriptor.
+ *
+ * @return The return code of the CEL4RO64 call - 0 implies success.
+ */
+uint32_t
+j9_cel4ro64_load_query_function_descriptor(
+	const char* moduleName, const char* functionName, void *returnStorage);
 
 /**
  * A helper routine to confirm LE support of CEL4RO64

--- a/runtime/j9vm31/jniinv.cpp
+++ b/runtime/j9vm31/jniinv.cpp
@@ -65,8 +65,23 @@ JNI_GetDefaultJavaVMInitArgs(void * vm_args)
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_uint32_ptr };
 	uint64_t argValues[NUM_ARGS] = { (uint64_t)vm_args };
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "JNI_GetDefaultJavaVMInitArgs",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t GetDefaultJavaVMInitArgsFD = 0; /* Cached value of GetDefaultJavaVMInitArgs function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == GetDefaultJavaVMInitArgsFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "JNI_GetDefaultJavaVMInitArgs", &GetDefaultJavaVMInitArgsFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "JNI_GetDefaultJavaVMInitArgs function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			GetDefaultJavaVMInitArgsFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -117,8 +132,23 @@ JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args)
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
 	uint64_t argValues[NUM_ARGS] = { (uint64_t)&JavaVM64Result, (uint64_t)&JNIEnv64Result, (uint64_t)vm_args };
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "JNI_CreateJavaVM",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t JNI_CreateJavaVMFD = 0; /* Cached value of JNI_CreateJavaVM function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == JNI_CreateJavaVMFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "JNI_CreateJavaVM", &JNI_CreateJavaVMFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "JNI_CreateJavaVM function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			JNI_CreateJavaVMFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -153,8 +183,23 @@ JNI_GetCreatedJavaVMs(JavaVM **vmBuf, jsize bufLen, jsize *nVMs)
 
 	uint64_t argValues[NUM_ARGS] = { (uint64_t)tempJavaVM64Buffer, bufLen, (uint64_t)nVMs };
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "JNI_GetCreatedJavaVMs",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t JNI_GetCreatedJavaVMsFD = 0; /* Cached value of JNI_GetCreatedJavaVMs function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == JNI_GetCreatedJavaVMsFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "JNI_GetCreatedJavaVMs", &JNI_GetCreatedJavaVMsFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "JNI_GetCreatedJavaVMs function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			JNI_GetCreatedJavaVMsFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -179,8 +224,24 @@ DestroyJavaVM(JavaVM *vm)
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64 };
 	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm)};
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJ9VM29_NAME, "DestroyJavaVM",
+
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t DestroyJavaVMFD = 0; /* Cached value of DestroyJavaVM function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == DestroyJavaVMFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJ9VM29_NAME, "DestroyJavaVM", &DestroyJavaVMFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "DestroyJavaVM function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			DestroyJavaVMFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -207,14 +268,27 @@ AttachCurrentThread(JavaVM *vm, void **penv, void *args)
 	jint returnValue = JNI_ERR;
 	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
 
+	static uint64_t AttachCurrentThreadFD = 0; /* Cached value of AttachCurrentThread function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == AttachCurrentThreadFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJ9VM29_NAME, "AttachCurrentThread", &AttachCurrentThreadFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "AttachCurrentThread function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
 	/* Zero initialize reservedNamePadding in JavaVMAttachArgs. */
 	JavaVMAttachArgs *vmAttachArgs = ((JavaVMAttachArgs *) args);
 	if (NULL != vmAttachArgs) {
 		vmAttachArgs->reservedNamePadding = NULL;
 	}
 
-	cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJ9VM29_NAME, "AttachCurrentThread",
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			AttachCurrentThreadFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -239,8 +313,23 @@ DetachCurrentThread(JavaVM *vm) {
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64 };
 	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm) };
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJ9VM29_NAME, "DetachCurrentThread",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t DetachCurrentThreadFD = 0; /* Cached value of DetachCurrentThread function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == DetachCurrentThreadFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJ9VM29_NAME, "DetachCurrentThread", &DetachCurrentThreadFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "DetachCurrentThread function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			DetachCurrentThreadFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -258,8 +347,23 @@ GetEnv(JavaVM *vm, void **penv, jint version)
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_jint };
 	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm), (uint64_t)&JNIEnv64Result, version };
 	jint returnValue = JNI_ERR;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJ9VM29_NAME, "GetEnv",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t GetEnvFD = 0; /* Cached value of GetEnv function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == GetEnvFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJ9VM29_NAME, "GetEnv", &GetEnvFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "GetEnv function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			GetEnvFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
@@ -288,14 +392,27 @@ AttachCurrentThreadAsDaemon(JavaVM *vm, void **penv, void *args)
 	jint returnValue = JNI_ERR;
 	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
 
+	static uint64_t AttachCurrentThreadAsDaemonFD = 0; /* Cached value of AttachCurrentThreadAsDaemon function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == AttachCurrentThreadAsDaemonFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJ9VM29_NAME, "AttachCurrentThreadAsDaemon", &AttachCurrentThreadAsDaemonFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "AttachCurrentThreadAsDaemon function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
 	/* Zero initialize reservedNamePadding in JavaVMAttachArgs. */
 	JavaVMAttachArgs *vmAttachArgs = ((JavaVMAttachArgs *) args);
 	if (NULL != vmAttachArgs) {
 		vmAttachArgs->reservedNamePadding = NULL;
 	}
 
-	cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJ9VM29_NAME, "AttachCurrentThreadAsDaemon",
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			AttachCurrentThreadAsDaemonFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {

--- a/runtime/j9vm31/jnimisc.cpp
+++ b/runtime/j9vm31/jnimisc.cpp
@@ -362,8 +362,23 @@ GetStringPlatform(JNIEnv* env, jstring instr, char* outstr, jint outlen, const c
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jint, CEL4RO64_type_uint32_ptr };
 	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), instr, (uint64_t)outstr, outlen, (uint64_t)encoding };
 	jint returnValue = NULL;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "GetStringPlatform",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t GetStringPlatformFD = 0; /* Cached value of GetStringPlatform function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == GetStringPlatformFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "GetStringPlatform", &GetStringPlatformFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "GetStringPlatform function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			GetStringPlatformFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
 		fprintf(stderr, "GetStringPlatform failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
@@ -379,8 +394,23 @@ GetStringPlatformLength(JNIEnv* env, jstring instr, jint* outlen, const char* en
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
 	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), instr, (uint64_t)outlen, (uint64_t)encoding };
 	jint returnValue = NULL;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "GetStringPlatformLength",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t GetStringPlatformLengthFD = 0; /* Cached value of GetStringPlatformLength function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == GetStringPlatformLengthFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "GetStringPlatformLength", &GetStringPlatformLengthFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "GetStringPlatformLength function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			GetStringPlatformLengthFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
 		fprintf(stderr, "GetStringPlatformLength failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
@@ -396,8 +426,23 @@ NewStringPlatform(JNIEnv* env, const char* instr, jstring* outstr, const char* e
 	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
 	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)instr, (uint64_t)outstr, (uint64_t)encoding };
 	jint returnValue = NULL;
-	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
-			LIBJVM_NAME, "NewStringPlatform",
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	static uint64_t NewStringPlatformFD = 0; /* Cached value of NewStringPlatform function descriptor. */
+
+	/* Lazy initialization of function descriptor on first invocation. */
+	if (0 == NewStringPlatformFD) {
+		cel4ro64ReturnCode = j9_cel4ro64_load_query_function_descriptor(
+			LIBJVM_NAME, "NewStringPlatform", &NewStringPlatformFD);
+
+		if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+			fprintf(stderr, "NewStringPlatform function query failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+			return JNI_ERR;
+		}
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_call_function(
+			NewStringPlatformFD,
 			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
 	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
 		fprintf(stderr, "NewStringPlatform failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));


### PR DESCRIPTION
The existing implementation for various Invocation APIs and *StringPlatform* functions calls CEL4RO64 to load and query the target function on each invocation. By caching the target function pointer, we avoid the redundant load/queries.

Also, reduce malloc/free usage on common CEL4RO64 call and query paths.