### PR TITLE
JDK22+ print deprecation warning messages

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2385,3 +2385,12 @@ J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.explanation=The specified package was not 
 J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.system_action=The JVM will fail to start.
 J9NLS_VM_MODULARITY_PACKAGE_NOT_FOUND.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_DEPRECATED_OPTION=%s warning: Option %s was deprecated in JDK 22 and will likely be removed in a future release.
+# START NON-TRANSLATABLE
+J9NLS_VM_DEPRECATED_OPTION.sample_input_1=Eclipse OpenJ9 VM
+J9NLS_VM_DEPRECATED_OPTION.sample_input_2=-Xdebug
+J9NLS_VM_DEPRECATED_OPTION.explanation=The command line option is deprecated.
+J9NLS_VM_DEPRECATED_OPTION.system_action=The JVM will print a deprecation warning.
+J9NLS_VM_DEPRECATED_OPTION.user_response=Remove the command line option from the command line.
+# END NON-TRANSLATABLE

--- a/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/deprecatedvmoptions.xml
+++ b/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/deprecatedvmoptions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright IBM Corp. and others 2024
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="DeprecatedVMOptions Command-Line Option Tests" timeout="2400">
+
+ <variable name="XDEBUG" value="-Xdebug" />
+ <variable name="XNOAGENT" value="-Xnoagent" />
+
+ <test id="test -Xdebug">
+  <command>$EXE$ $XDEBUG$ -version</command>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+  <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">JVMJ9VM246W(.)*-Xdebug</output>
+  <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
+ </test>
+
+ <test id="test -Xnoagent">
+  <command>$EXE$ $XNOAGENT$ -version</command>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+  <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">JVMJ9VM246W(.)*-Xnoagent</output>
+  <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
+ </test>
+
+ <test id="test -Xdebug -Xnoagent">
+  <command>$EXE$ $XDEBUG$ $XNOAGENT$ -version</command>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+  <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">JVMJ9VM246W(.)*-Xdebug</output>
+  <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">JVMJ9VM246W(.)*-Xnoagent</output>
+  <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
+ </test>
+</suite>

--- a/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/playlist.xml
+++ b/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/playlist.xml
@@ -58,4 +58,25 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTester_deprecatedvmoptions</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)deprecatedvmoptions.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+		<versions>
+			<version>22+</version>
+		</versions>
+	</test>
 </playlist>


### PR DESCRIPTION
`JDK22+` print deprecation warning messages

Deprecation warning messages are printed when `-Xdebug/-Xnoagent` are specified at `JDK22+` command line options;
Added a test.

Note: 
JDK22 RI `java -debug -Xdebug -Xnoagent -version` output:
```
Warning: -debug option is deprecated and may be removed in a future release.
OpenJDK 64-Bit Server VM warning: Option -Xdebug was deprecated in JDK 22 and will likely be removed in a future release.
OpenJDK 64-Bit Server VM warning: Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.
```

OpenJ9 JVM already prints a deprecation warning message for `-debug`
```
Warning: -debug option is deprecated and may be removed in a future release.
```
which is from JCL native.

close https://github.com/eclipse-openj9/openj9/issues/18403

Signed-off-by: Jason Feng <fengj@ca.ibm.com>