### PR TITLE
Add VM.internalGetProperties() helper method

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
@@ -49,11 +49,10 @@ import com.ibm.oti.vm.VMLangAccess;
 public final class Util {
 
 	private static final Charset defaultEncoding;
-	private static final VMLangAccess vmLangAccess;
+	private static final VMLangAccess vmLangAccess = VM.getVMLangAccess();
 
 	static {
-		vmLangAccess = VM.getVMLangAccess();
-		String encoding = vmLangAccess.internalGetProperties().getProperty("os.encoding"); //$NON-NLS-1$
+		String encoding = VM.internalGetProperties().getProperty("os.encoding"); //$NON-NLS-1$
 		Charset charset = null;
 		if (encoding != null) {
 			try {

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
@@ -24,6 +24,7 @@ package com.ibm.oti.vm;
 
 import com.ibm.oti.util.Msg;
 import com.ibm.oti.util.Util;
+import java.util.Properties;
 
 /*[IF JAVA_SPEC_VERSION >= 9]
 import jdk.internal.misc.Unsafe;
@@ -615,5 +616,25 @@ public static ConstantPool getConstantPoolFromAnnotationBytes(Class<?> clazz, by
 	}
 	Object internalCP = getVMLangAccess().createInternalConstantPool(ramCPAddr);
 	return getVMLangAccess().getConstantPool(internalCP);
+}
+
+/**
+ * Answers the system properties without any security checks.
+ *
+ *  Important notes similar to VMLangAccess.internalGetProperties():
+ *  1. This API must NOT be exposed to application code directly or indirectly;
+ *  2. This method can only be used to retrieve system properties for internal usage,
+ *      i.e., there is no security exception expected;
+ *  3. If there is an application caller in the call stack, AND the application caller(s)
+ *      have to be checked for permission to retrieve the system properties specified,
+ *      then this API should NOT be used even though the immediate caller is in the bootstrap path.
+ *
+ * Note that this is not a copy so changes made to the returned Properties object will be reflected
+ * in subsequent calls to System.getProperty() and System.getProperties().
+ *
+ * @return the system properties
+ */
+public static Properties internalGetProperties() {
+	return getVMLangAccess().internalGetProperties();
 }
 }

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -98,7 +98,7 @@ public final class AccessControlContext {
 static int debugSetting() {
 	if (debugSetting != -1) return debugSetting;
 	debugSetting = 0;
-	String value = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("java.security.debug"); //$NON-NLS-1$
+	String value = com.ibm.oti.vm.VM.internalGetProperties().getProperty("java.security.debug"); //$NON-NLS-1$
 	if (value == null) return debugSetting;
 	StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(value));
 	tokenizer.resetSyntax();

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Advertisement.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Advertisement.java
@@ -103,7 +103,7 @@ public final class Advertisement {
 	private static StringBuilder createAdvertContent(String vmId, String displayName) {
 		StringBuilder contentBuffer = new StringBuilder(512); 
 		addKeyAsciiValue(contentBuffer, KEY_VERSION, "0.1"); //$NON-NLS-1$
-		addKeyValue(contentBuffer, KEY_USER_ID, com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("user.name")); //$NON-NLS-1$
+		addKeyValue(contentBuffer, KEY_USER_ID, com.ibm.oti.vm.VM.internalGetProperties().getProperty("user.name")); //$NON-NLS-1$
 		/* CMVC 161414 - PIDs and UIDs are long */
 		addKeyAsciiValue(contentBuffer, KEY_USER_UID ,Long.toString(IPC.getUid()));
 		addKeyAsciiValue(contentBuffer, KEY_PROCESS_ID, Long.toString(IPC.getProcessId()));

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
@@ -22,10 +22,12 @@
  *******************************************************************************/
 package openj9.internal.tools.attach.target;
 
+import com.ibm.oti.vm.VM;
+
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -35,7 +37,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Properties;
-
 import java.util.ServiceLoader;
 
 /*[IF JAVA_SPEC_VERSION >= 9]*/
@@ -227,8 +228,8 @@ final class Attachment extends Thread implements Response {
 							+ " " + attachError); //$NON-NLS-1$
 				}
 			} else if (cmd.startsWith(Command.GET_SYSTEM_PROPERTIES)) {
-				Properties internalProperties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();
-				String argumentString = String.join(" ", com.ibm.oti.vm.VM.getVMArgs()); //$NON-NLS-1$
+				Properties internalProperties = VM.internalGetProperties();
+				String argumentString = String.join(" ", VM.getVMArgs()); //$NON-NLS-1$
 				Properties newProperties = (Properties) internalProperties.clone();
 				newProperties.put("sun.jvm.args", argumentString); //$NON-NLS-1$
 				replyWithProperties(newProperties);
@@ -468,7 +469,7 @@ final class Attachment extends Thread implements Response {
 	}
 
 	static String saveLocalConnectorAddress() {
-		Properties systemProperties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();
+		Properties systemProperties = VM.internalGetProperties();
 		String addr;
 		synchronized (systemProperties) {
 			addr = systemProperties.getProperty(LOCAL_CONNECTOR_ADDRESS);

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -93,7 +93,7 @@ public abstract class CommonDirectory {
 
 	private static void initialize() {
 		/* Set the common directory used by all VMs.  Defaults to /tmp/.com_ibm_tools_attach */
-		String ipcDirProperty = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty(COM_IBM_TOOLS_ATTACH_DIRECTORY, 
+		String ipcDirProperty = com.ibm.oti.vm.VM.internalGetProperties().getProperty(COM_IBM_TOOLS_ATTACH_DIRECTORY,
 				(new File(systemTmpDir,".com_ibm_tools_attach")).getPath()); //$NON-NLS-1$
 		/*[PR CMVC 165300 restriction on embedded blanks was unnecessary. Also, trailing separators were redundant. ]*/
 		if (LOGGING_DISABLED != loggingStatus) {

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
@@ -97,7 +97,7 @@ public class IPC {
 	public static final boolean useFileLockWatchdog;
 
 	static {
-		Properties props = VM.getVMLangAccess().internalGetProperties();
+		Properties props = VM.internalGetProperties();
 		String osName = props.getProperty("os.name"); //$NON-NLS-1$
 		boolean tempIsZos = false;
 		boolean tempIsWindows = false;
@@ -345,7 +345,7 @@ public class IPC {
 		String tmpDir = getTempDirImpl();
 		if (null == tmpDir) {
 			logMessage("Could not get system temporary directory. Trying " + JAVA_IO_TMPDIR); //$NON-NLS-1$
-			tmpDir = VM.getVMLangAccess().internalGetProperties().getProperty(JAVA_IO_TMPDIR);
+			tmpDir = VM.internalGetProperties().getProperty(JAVA_IO_TMPDIR);
 		}
 		return tmpDir;
 	}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
@@ -72,7 +72,7 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 	 */
 	@Override
 	public String getName() {
-		return com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().
+		return com.ibm.oti.vm.VM.internalGetProperties().
 /*[IF JAVA_SPEC_VERSION < 21]*/
 				getProperty("java.compiler"); //$NON-NLS-1$
 /*[ELSE] JAVA_SPEC_VERSION < 21 */

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -88,7 +88,7 @@ public final class ManagementUtils {
 	public static final boolean VERBOSE_MODE;
 
 	static {
-		Properties properties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();
+		Properties properties = com.ibm.oti.vm.VM.internalGetProperties();
 		String thisOs = properties.getProperty("os.name"); //$NON-NLS-1$
 
 		isUnix = "aix".equalsIgnoreCase(thisOs) //$NON-NLS-1$

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
@@ -72,7 +72,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 		}
 
 		checkMonitorPermission();
-		return VM.getVMLangAccess().internalGetProperties().getProperty("sun.boot.class.path"); //$NON-NLS-1$
+		return VM.internalGetProperties().getProperty("sun.boot.class.path"); //$NON-NLS-1$
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -90,7 +90,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 		}
 
 		/* add configurable model numbers if any */
-		String emuHwProperty = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("com.ibm.lang.management.OperatingSystemMXBean.zos.emulatedHardwareModels"); //$NON-NLS-1$
+		String emuHwProperty = VM.internalGetProperties().getProperty("com.ibm.lang.management.OperatingSystemMXBean.zos.emulatedHardwareModels"); //$NON-NLS-1$
 
 		if (null != emuHwProperty) {
 			for (String emuHw : emuHwProperty.split("[;,]")) { //$NON-NLS-1$
@@ -518,7 +518,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	@Override
 	public final boolean isHardwareEmulated() throws UnsupportedOperationException {
 		if (HwEmulResult.UNKNOWN == isHwEmulated) {
-			String osName = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("os.name"); //$NON-NLS-1$
+			String osName = VM.internalGetProperties().getProperty("os.name"); //$NON-NLS-1$
 			String hwModel = getHardwareModel();
 
 			if ((null != osName) && (null != hwModel)) {

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
@@ -513,8 +513,9 @@ public class Dump {
 	}
 
 	private static void checkLegacySecurityPermssion() throws SecurityException {
-		if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
-			.internalGetProperties().getProperty(LEGACY_DUMP_PERMISSION_PROPERTY)))) {
+		if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM //$NON-NLS-1$
+				.internalGetProperties().getProperty(LEGACY_DUMP_PERMISSION_PROPERTY)))
+		) {
 			checkDumpSecurityPermssion();
 		}
 	}

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
@@ -67,22 +67,23 @@ public class Log {
 	 * directly.
 	 * @throws SecurityException
 	 */
-    private static void checkLegacySecurityPermssion() throws SecurityException {
-    	if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
-    		.internalGetProperties().getProperty(LEGACY_LOG_PERMISSION_PROPERTY)))) {
-    		checkLogSecurityPermssion();
-    	}
-    }
-	
-    private static void checkLogSecurityPermssion() throws SecurityException {
+	private static void checkLegacySecurityPermssion() throws SecurityException {
+		if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM //$NON-NLS-1$
+				.internalGetProperties().getProperty(LEGACY_LOG_PERMISSION_PROPERTY)))
+		) {
+			checkLogSecurityPermssion();
+		}
+	}
+
+	private static void checkLogSecurityPermssion() throws SecurityException {
 		/* Check the caller has LogPermission. */
 		@SuppressWarnings("removal")
 		SecurityManager manager = System.getSecurityManager();
-		if( manager != null ) {
+		if (manager != null) {
 			manager.checkPermission(LOG_PERMISSION);
 		}
-    }
-    
+	}
+
 	/*
 	 * Log should not be instantiated.
 	 */

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
@@ -281,8 +281,9 @@ public final class Trace {
 	 * @throws SecurityException
 	 */
 	private static void checkLegacySecurityPermssion() throws SecurityException {
-		if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess() //$NON-NLS-1$
-				.internalGetProperties().getProperty(LEGACY_TRACE_PERMISSION_PROPERTY)))) {
+		if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM //$NON-NLS-1$
+				.internalGetProperties().getProperty(LEGACY_TRACE_PERMISSION_PROPERTY)))
+		) {
 			checkTraceSecurityPermssion();
 		}
 	}

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactoryImpl.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactoryImpl.java
@@ -53,7 +53,7 @@ final class SharedClassHelperFactoryImpl extends SharedAbstractHelperFactory imp
 	private static SharedClassFilter getGlobalSharingFilter() {
 		if (globalSharingFilter == null) {
 			try {
-				String className = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty(GLOBAL_SHARING_FILTER);
+				String className = com.ibm.oti.vm.VM.internalGetProperties().getProperty(GLOBAL_SHARING_FILTER);
 				if (null != className) {
 					Class<?> filterClass = Class.forName(className);
 					globalSharingFilter = SharedClassFilter.class.cast(filterClass.getDeclaredConstructor().newInstance());


### PR DESCRIPTION
Add `VM.internalGetProperties()` helper method

It is equivalent to `VM.getVMLangAccess().internalGetProperties()`;
Updated all references.

Related to 
* https://github.com/eclipse-openj9/openj9/pull/18996

Signed-off-by: Jason Feng <fengj@ca.ibm.com>