### PR TITLE
(0.44) Recognize StringCoding.implEncodeAsciiArray() as a converter method

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1186,6 +1186,7 @@
    java_lang_StringCoding_StringDecoder_decode,
    java_lang_StringCoding_StringEncoder_encode,
    java_lang_StringCoding_implEncodeISOArray,
+   java_lang_StringCoding_implEncodeAsciiArray,
    java_lang_StringCoding_encode8859_1,
    java_lang_StringCoding_encodeASCII,
    java_lang_StringCoding_encodeUTF8,

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -438,6 +438,7 @@ J9::Compilation::isConverterMethod(TR::RecognizedMethod rm)
       case TR::java_lang_String_decodeUTF8_UTF16:
       case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
+      case TR::java_lang_StringCoding_implEncodeAsciiArray:
       case TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII:
       case TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS:
       case TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS:
@@ -477,6 +478,7 @@ J9::Compilation::canTransformConverterMethod(TR::RecognizedMethod rm)
          return genTRxx || self()->cg()->getSupportsArrayTranslateTROTNoBreak() || genSIMD;
 
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
+      case TR::java_lang_StringCoding_implEncodeAsciiArray:
       case TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8:
          return genTRxx || self()->cg()->getSupportsArrayTranslateTRTO() || genSIMD;
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2808,6 +2808,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_StringCoding_decode, "decode", "(Ljava/nio/charset/Charset;[BII)[C")},
       {x(TR::java_lang_StringCoding_encode, "encode", "(Ljava/nio/charset/Charset;[CII)[B")},
       {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
+      {x(TR::java_lang_StringCoding_implEncodeAsciiArray, "implEncodeAsciiArray", "([CI[BII)I")},
       {x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
       {x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
       {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[BZ)[B")},


### PR DESCRIPTION
implEncodeAsciiArray is equivalent to Java 11's US_ASCII.encodeASCII converter method. Acceleration
for this routine was added in OMR PR 7271. This commit introduces this API and enables the acceleration the JIT compiler.

Double delivery of https://github.com/eclipse-openj9/openj9/pull/18983/ and https://github.com/eclipse-openj9/openj9/pull/19025/
Related to https://github.com/eclipse-openj9/openj9-omr/pull/199