### PR TITLE
Fix transformIndexOfKnownString to handle 8bit characters properly

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -389,8 +389,7 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
             else
                {
                uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
-               uint8_t chByte  = *((uint8_t*)element);
-               ch = chByte;
+               ch  = *((uint8_t*)element);
                }
             }
          else
@@ -426,8 +425,7 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
          else
             {
             uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, start + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
-            int8_t chByte  = *((uint8_t*)element);
-            ch = chByte;
+            ch  = *((uint8_t*)element);
             }
          }
       else
@@ -464,8 +462,7 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
             else
                {
                uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
-               int8_t chByte  = *((uint8_t*)element);
-               ch = chByte;
+               ch  = *((uint8_t*)element);
                }
             }
          else


### PR DESCRIPTION
Avoid sign extension when assigning an 8bit value to an int32_t variable.

Issue: https://github.com/eclipse-openj9/openj9/issues/18974