### PR TITLE
Check if block frequency info exist before generating test

### DIFF
--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
@@ -53,7 +53,7 @@ class TR_JProfilingRecompLoopTest : public TR::Optimization
       }
    virtual int32_t perform();
    virtual const char *optDetailString() const throw();
-   void addRecompilationTests(TR::Compilation *comp, RecompilationTestLocationsInfo &testLocations);
+   void addRecompilationTests(TR::Compilation *comp, RecompilationTestLocationsInfo &testLocations, TR_BlockFrequencyInfo *bfi);
    bool isByteCodeInfoInCurrentTestLocationList(TR_ByteCodeInfo &bci, TR::list<TR_ByteCodeInfo, TR::Region&> &addedLocationBCIList);
    static int32_t maxLoopRecompilationThreshold;
    };


### PR DESCRIPTION
JProfilingValue: Check if the block frequency info exist before generating the test on whether or not the method is queued for recompilation.

JProfilingRecompLoopTest: Do not perform if the block frequency info does not exist because JProfilingRecompLoopTest relies on the counters created in the block frequency info.