### PR TITLE
Fix JLM_Tests build on vmfarm

### DIFF
--- a/test/functional/JLM_Tests/testng.xml
+++ b/test/functional/JLM_Tests/testng.xml
@@ -22,7 +22,6 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="JLM_Tests_Suite" parallel="none" verbose="2">
 	<listeners>
 		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer" />


### PR DESCRIPTION
Fix JLM_Tests build on vmfarm by removing the DOCTYPE
declaration in testng.xml, which avoids a network issue
when retrieving testng-1.0.dtd.

Issue: https://github.com/eclipse-openj9/openj9/issues/18998
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>