### PR TITLE
Recompile the outermost method in JIT dump when compilation crashes

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -629,7 +629,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                // request the compilation
                jitDumpRecompileWithTracing(
                   crashedThread,
-                  (J9Method *)(comp->getCurrentMethod()->getPersistentIdentifier()),
+                  (J9Method *)(comp->getMethodBeingCompiled()->getPersistentIdentifier()),
                   compInfo,
                   (TR_Hotness)comp->getOptLevel(),
                   comp->isProfilingCompilation(),


### PR DESCRIPTION
Previously the JIT dump would recompile the "current method," which is sensitive to ongoing IL generation. If the compiler crashed during IL generation for an inlined method, then only that inlined method would be recompiled.

Now the JIT dump will always recompile the outermost method so that there will be a chance of reproducing IL generator crashes even if they are related to inlining.