### PR TITLE
Add Extension Class Loader to permanent roots

### DIFF
--- a/runtime/gc_api/HeapRootScanner.cpp
+++ b/runtime/gc_api/HeapRootScanner.cpp
@@ -108,7 +108,7 @@ MM_HeapRootScanner::doFinalizableObject(J9Object *objectPtr)
 void
 MM_HeapRootScanner::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 {
-	J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor *)objectMonitor->monitor;
+	J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor *)objectMonitor->monitor;
 	
 	void *userData = (void *)monitor->userData;
 	
@@ -173,6 +173,7 @@ MM_HeapRootScanner::scanClasses()
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	J9ClassLoader *sysClassLoader = _javaVM->systemClassLoader;
 	J9ClassLoader *appClassLoader = _javaVM->applicationClassLoader;
+	J9ClassLoader *extClassLoader = _javaVM->extensionClassLoader;
 	MM_GCExtensions::DynamicClassUnloading dynamicClassUnloadingFlag = (MM_GCExtensions::DynamicClassUnloading )_extensions->dynamicClassUnloading;
 #endif
 	
@@ -190,7 +191,8 @@ MM_HeapRootScanner::scanClasses()
 				/* if -Xnoclassgc, all classes are strong */
 				reachability = RootScannerEntityReachability_Strong;
 			} else {
-				if ((sysClassLoader == clazz->classLoader) || (appClassLoader == clazz->classLoader)) {
+				J9ClassLoader *classLoader = clazz->classLoader;
+				if ((classLoader == sysClassLoader) || (classLoader == appClassLoader) || (classLoader == extClassLoader)) {
 					reachability = RootScannerEntityReachability_Strong;
 				} else {
 					reachability = RootScannerEntityReachability_Weak;
@@ -264,9 +266,10 @@ MM_HeapRootScanner::scanClassLoaders()
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	J9ClassLoader *sysClassLoader = _javaVM->systemClassLoader;
 	J9ClassLoader *appClassLoader = _javaVM->applicationClassLoader;
+	J9ClassLoader *extClassLoader = _javaVM->extensionClassLoader;
 	MM_GCExtensions::DynamicClassUnloading dynamicClassUnloadingFlag = (MM_GCExtensions::DynamicClassUnloading )_extensions->dynamicClassUnloading;
 #endif
-	J9ClassLoader *classLoader;	
+	J9ClassLoader *classLoader = NULL;
 	GC_ClassLoaderIterator classLoaderIterator(_javaVM->classLoaderBlocks);
 	
 	reportScanningStarted(RootScannerEntity_ClassLoaders);
@@ -278,7 +281,7 @@ MM_HeapRootScanner::scanClassLoaders()
 			/* if -Xnoclassgc, all class loader refs are strong */
 			reachability = RootScannerEntityReachability_Strong;
 		} else {
-			if (classLoader == appClassLoader || classLoader == sysClassLoader) {
+			if ((classLoader == appClassLoader) || (classLoader == sysClassLoader) || (classLoader == extClassLoader)) {
 				reachability = RootScannerEntityReachability_Strong;
 			} else {
 				reachability = RootScannerEntityReachability_Weak;	
@@ -354,7 +357,7 @@ MM_HeapRootScanner::scanFinalizableObjects()
 	reportScanningStarted(RootScannerEntity_FinalizableObjects);
 	setReachability(RootScannerEntityReachability_Strong);
 	
-	GC_FinalizeListManager * finalizeListManager = _extensions->finalizeListManager;
+	GC_FinalizeListManager *finalizeListManager = _extensions->finalizeListManager;
 	{
 		/* walk finalizable objects created by the system class loader */
 		j9object_t systemObject = finalizeListManager->peekSystemFinalizableObject();

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -190,8 +190,8 @@ MM_RootScanner::scanContinuationObjectsComplete(MM_EnvironmentBase *env)
 void
 MM_RootScanner::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 {
-	J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
-	doSlot((J9Object **)& monitor->userData);
+	J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+	doSlot((J9Object **)&monitor->userData);
 }
 
 MM_RootScanner::CompletePhaseCode
@@ -205,9 +205,9 @@ MM_RootScanner::scanMonitorReferencesComplete(MM_EnvironmentBase *env)
  * @todo Provide function documentation
  */
 void
-MM_RootScanner::doMonitorLookupCacheSlot(j9objectmonitor_t* slotPtr)
+MM_RootScanner::doMonitorLookupCacheSlot(j9objectmonitor_t *slotPtr)
 {
-	if(0 != *slotPtr) {
+	if (0 != *slotPtr) {
 		*slotPtr = 0;
 	}
 }
@@ -279,7 +279,7 @@ MM_RootScanner::doVMClassSlot(J9Class *classPtr)
 void
 MM_RootScanner::doFieldSlot(GC_SlotObject *slotObject)
 {
-	J9Object* object = slotObject->readReferenceFromSlot();
+	J9Object *object = slotObject->readReferenceFromSlot();
 	doSlot(&object);
 	slotObject->writeReferenceToSlot(object);
 }
@@ -303,13 +303,13 @@ MM_RootScanner::scanClasses(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_Classes);
 
-	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
+	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
 
-	while(J9MemorySegment *segment = segmentIterator.nextSegment()) {
-		if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-			GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), segment);
+	while (J9MemorySegment *segment = segmentIterator.nextSegment()) {
+		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+			GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm), segment);
 			J9Class *clazz = NULL;
-			while(NULL != (clazz = classHeapIterator.nextClass())) {
+			while (NULL != (clazz = classHeapIterator.nextClass())) {
 				doClass(clazz);
 				if (shouldYieldFromClassScan(100000)) {
 					yield();
@@ -330,10 +330,10 @@ void
 MM_RootScanner::scanVMClassSlots(MM_EnvironmentBase *env)
 {
 	/* VM Class Slot Iterator */
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_VMClassSlots);
 
-		GC_VMClassSlotIterator classSlotIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
+		GC_VMClassSlotIterator classSlotIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
 		J9Class *classPtr;
 
 		while (NULL != (classPtr = classSlotIterator.nextSlot())) {
@@ -358,7 +358,7 @@ MM_RootScanner::doClassSlot(J9Class *classPtr)
  * @todo Provide function documentation
  */
 void
-MM_RootScanner::doStackSlot(J9Object **slotPtr, void *walkState, const void* stackLocation)
+MM_RootScanner::doStackSlot(J9Object **slotPtr, void *walkState, const void *stackLocation)
 {
 	/* ensure that this isn't a slot pointing into the gap (only matters for split heap VMs) */
 	if (!_extensions->heap->objectIsInGap(*slotPtr)) {
@@ -396,10 +396,13 @@ MM_RootScanner::scanPermanentClasses(MM_EnvironmentBase *env)
 	reportScanningStarted(RootScannerEntity_PermanentClasses);
 
 	/* Do systemClassLoader */
-	scanClassloader(env, static_cast<J9JavaVM*>(_omrVM->_language_vm)->systemClassLoader);
+	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->systemClassLoader);
 
 	/* Do applicationClassLoader */
-	scanClassloader(env, static_cast<J9JavaVM*>(_omrVM->_language_vm)->applicationClassLoader);
+	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->applicationClassLoader);
+
+	/* Do extensionClassLoader */
+	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->extensionClassLoader);
 
 	condYield();
 
@@ -455,13 +458,13 @@ MM_RootScanner::scanClassesComplete(MM_EnvironmentBase *env)
 void
 MM_RootScanner::scanClassLoaders(MM_EnvironmentBase *env)
 {
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_ClassLoaders);
 
 		J9ClassLoader *classLoader;
 
-		GC_ClassLoaderIterator classLoaderIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm)->classLoaderBlocks);
-		while((classLoader = classLoaderIterator.nextSlot()) != NULL) {
+		GC_ClassLoaderIterator classLoaderIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->classLoaderBlocks);
+		while ((classLoader = classLoaderIterator.nextSlot()) != NULL) {
 			doClassLoader(classLoader);
 		}
 
@@ -497,16 +500,16 @@ MM_RootScanner::scanThreads(MM_EnvironmentBase *env)
 	 * list is also locked.
 	 */
 
-	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
+	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
 	StackIteratorData localData;
 
 	localData.rootScanner = this;
 	localData.env = env;
 
-	while(J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
+	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-			if (scanOneThread(env, walkThread, (void*) &localData)) {
-				vmThreadListIterator.reset(static_cast<J9JavaVM*>(_omrVM->_language_vm)->mainThread);
+			if (scanOneThread(env, walkThread, (void *) &localData)) {
+				vmThreadListIterator.reset(static_cast<J9JavaVM *>(_omrVM->_language_vm)->mainThread);
 			}
 		}
 	}
@@ -528,11 +531,11 @@ MM_RootScanner::scanThreads(MM_EnvironmentBase *env)
  *   scan, allowing other threads to run and perhaps be created or terminated).
  **/
 bool
-MM_RootScanner::scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, void* localData)
+MM_RootScanner::scanOneThread(MM_EnvironmentBase *env, J9VMThread *walkThread, void *localData)
 {
 	GC_VMThreadIterator vmThreadIterator(walkThread);
 
-	while(J9Object **slot = vmThreadIterator.nextSlot()) {
+	while (J9Object **slot = vmThreadIterator.nextSlot()) {
 		doVMThreadSlot(slot, &vmThreadIterator);
 	}
 
@@ -557,7 +560,7 @@ MM_RootScanner::scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, v
  * @param walkThead the thread to be scanned
  **/
 void
-MM_RootScanner::scanSingleThread(MM_EnvironmentBase *env, J9VMThread* walkThread)
+MM_RootScanner::scanSingleThread(MM_EnvironmentBase *env, J9VMThread *walkThread)
 {
 	StackIteratorData localData;
 	localData.rootScanner = this;
@@ -572,10 +575,10 @@ MM_RootScanner::scanSingleThread(MM_EnvironmentBase *env, J9VMThread* walkThread
 void
 MM_RootScanner::scanFinalizableObjects(MM_EnvironmentBase *env)
 {
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_FinalizableObjects);
 
-		GC_FinalizeListManager * finalizeListManager = _extensions->finalizeListManager;
+		GC_FinalizeListManager *finalizeListManager = _extensions->finalizeListManager;
 		{
 			/* walk finalizable objects loaded by the system class loader */
 			j9object_t systemObject = finalizeListManager->peekSystemFinalizableObject();
@@ -615,13 +618,13 @@ void
 MM_RootScanner::scanJNIGlobalReferences(MM_EnvironmentBase *env)
 {
 	/* JNI Global References */
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_JNIGlobalReferences);
 
-		GC_JNIGlobalReferenceIterator jniGlobalReferenceIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm)->jniGlobalReferences);
+		GC_JNIGlobalReferenceIterator jniGlobalReferenceIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->jniGlobalReferences);
 		J9Object **slot;
 
-		while((slot = (J9Object **)jniGlobalReferenceIterator.nextSlot()) != NULL) {
+		while ((slot = (J9Object **)jniGlobalReferenceIterator.nextSlot()) != NULL) {
 			doJNIGlobalReferenceSlot(slot, &jniGlobalReferenceIterator);
 		}
 
@@ -641,7 +644,7 @@ MM_RootScanner::scanStringTable(MM_EnvironmentBase *env)
 
 	/* String Table */
 	for (uintptr_t tableIndex = 0; tableIndex < stringTable->getTableCount(); tableIndex++) {
-		if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 
 			if (isMetronomeGC) {
 				GC_StringTableIncrementalIterator stringTableIterator(stringTable->getTable(tableIndex));
@@ -667,7 +670,7 @@ MM_RootScanner::scanStringTable(MM_EnvironmentBase *env)
 		}
 	}
 
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		j9object_t *stringCacheTable = stringTable->getStringInternCache();
 		uintptr_t cacheTableIndex = 0;
 		for (; cacheTableIndex < MM_StringTable::getCacheSize(); cacheTableIndex++) {
@@ -727,8 +730,8 @@ MM_RootScanner::scanUnfinalizedObjects(MM_EnvironmentBase *env)
 
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
 	MM_UnfinalizedObjectList *unfinalizedObjectList = _extensions->unfinalizedObjectLists;
-	while(NULL != unfinalizedObjectList) {
-		if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	while (NULL != unfinalizedObjectList) {
+		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			J9Object *objectPtr = unfinalizedObjectList->getHeadOfList();
 			while (NULL != objectPtr) {
 				doUnfinalizedObject(objectPtr, unfinalizedObjectList);
@@ -749,7 +752,7 @@ MM_RootScanner::scanOwnableSynchronizerObjects(MM_EnvironmentBase *env)
 
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
 	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->getOwnableSynchronizerObjectLists();
-	while(NULL != ownableSynchronizerObjectList) {
+	while (NULL != ownableSynchronizerObjectList) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			J9Object *objectPtr = ownableSynchronizerObjectList->getHeadOfList();
 			while (NULL != objectPtr) {
@@ -770,7 +773,7 @@ MM_RootScanner::scanContinuationObjects(MM_EnvironmentBase *env)
 
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
 	MM_ContinuationObjectList *continuationObjectList = _extensions->getContinuationObjectLists();
-	while(NULL != continuationObjectList) {
+	while (NULL != continuationObjectList) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			J9Object *objectPtr = continuationObjectList->getHeadOfList();
 			while (NULL != objectPtr) {
@@ -794,7 +797,7 @@ void
 MM_RootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_MonitorLookupCaches);
-	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
+	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
 	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			j9objectmonitor_t *objectMonitorLookupCache = walkThread->objectMonitorLookupCache;
@@ -816,7 +819,7 @@ MM_RootScanner::scanMonitorReferences(MM_EnvironmentBase *env)
 	reportScanningStarted(RootScannerEntity_MonitorReferences);
 
 	J9ObjectMonitor *objectMonitor = NULL;
-	J9MonitorTableListEntry *monitorTableList = static_cast<J9JavaVM*>(_omrVM->_language_vm)->monitorTableList;
+	J9MonitorTableListEntry *monitorTableList = static_cast<J9JavaVM *>(_omrVM->_language_vm)->monitorTableList;
 	while (NULL != monitorTableList) {
 		J9HashTable *table = monitorTableList->monitorTable;
 		if (NULL != table) {
@@ -845,7 +848,7 @@ MM_RootScanner::scanJNIWeakGlobalReferences(MM_EnvironmentBase *env)
 		GC_JNIWeakGlobalReferenceIterator jniWeakGlobalReferenceIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm)->jniWeakGlobalReferences);
 		J9Object **slot;
 
-		while((slot = (J9Object **)jniWeakGlobalReferenceIterator.nextSlot()) != NULL) {
+		while ((slot = (J9Object **)jniWeakGlobalReferenceIterator.nextSlot()) != NULL) {
 			doJNIWeakGlobalReference(slot);
 		}
 
@@ -860,16 +863,16 @@ MM_RootScanner::scanJNIWeakGlobalReferences(MM_EnvironmentBase *env)
 void
 MM_RootScanner::scanRememberedSet(MM_EnvironmentBase *env)
 {
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_RememberedSet);
 
 		MM_SublistPuddle *puddle;
 		J9Object **slotPtr;
 		GC_RememberedSetIterator rememberedSetIterator(&_extensions->rememberedSet);
 
-		while((puddle = rememberedSetIterator.nextList()) != NULL) {
+		while ((puddle = rememberedSetIterator.nextList()) != NULL) {
 			GC_RememberedSetSlotIterator rememberedSetSlotIterator(puddle);
-			while((slotPtr = (J9Object **)rememberedSetSlotIterator.nextSlot()) != NULL) {
+			while ((slotPtr = (J9Object **)rememberedSetSlotIterator.nextSlot()) != NULL) {
 				doRememberedSetSlot(slotPtr, &rememberedSetSlotIterator);
 			}
 		}
@@ -886,21 +889,21 @@ MM_RootScanner::scanRememberedSet(MM_EnvironmentBase *env)
 void
 MM_RootScanner::scanJVMTIObjectTagTables(MM_EnvironmentBase *env)
 {
-	if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_JVMTIObjectTagTables);
 
-		J9JVMTIData * jvmtiData = J9JVMTI_DATA_FROM_VM(static_cast<J9JavaVM*>(_omrVM->_language_vm));
-		J9JVMTIEnv * jvmtiEnv;
-		J9Object **slotPtr;
+		J9JVMTIData *jvmtiData = J9JVMTI_DATA_FROM_VM(static_cast<J9JavaVM *>(_omrVM->_language_vm));
+		J9JVMTIEnv *jvmtiEnv = NULL;
+		J9Object **slotPtr = NULL;
 		if (NULL != jvmtiData) {
 			/* TODO: When JVMTI is supported in RTSJ, this structure needs to be locked
 			 * when it is being scanned
 			 */
 			GC_JVMTIObjectTagTableListIterator objectTagTableList(jvmtiData->environments);
-			while(NULL != (jvmtiEnv = (J9JVMTIEnv *)objectTagTableList.nextSlot())) {
+			while (NULL != (jvmtiEnv = (J9JVMTIEnv *)objectTagTableList.nextSlot())) {
 				if (NULL != jvmtiEnv->objectTagTable) {
 					GC_JVMTIObjectTagTableIterator objectTagTableIterator(jvmtiEnv->objectTagTable);
-					while(NULL != (slotPtr = (J9Object **)objectTagTableIterator.nextSlot())) {
+					while (NULL != (slotPtr = (J9Object **)objectTagTableIterator.nextSlot())) {
 						doJVMTIObjectTagSlot(slotPtr, &objectTagTableIterator);
 					}
 				}
@@ -964,7 +967,7 @@ MM_RootScanner::scanRoots(MM_EnvironmentBase *env)
 		}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
-		if(complete_phase_ABORT == scanClassesComplete(env)) {
+		if (complete_phase_ABORT == scanClassesComplete(env)) {
 			return ;
 		}
 	}
@@ -982,7 +985,7 @@ MM_RootScanner::scanRoots(MM_EnvironmentBase *env)
 
 /* In the RT configuration, We can skip scanning the string table because
    all interned strings are in immortal memory and will not move. */
-	if(_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)){
+	if (_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)){
 		scanStringTable(env);
 	}
 }
@@ -998,12 +1001,12 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 {
 	/* This may result in more marking, if aged soft references could not be enqueued. */
 	scanSoftReferenceObjects(env);
-	if(complete_phase_ABORT == scanSoftReferencesComplete(env)) {
+	if (complete_phase_ABORT == scanSoftReferencesComplete(env)) {
 		return ;
 	}
 
 	scanWeakReferenceObjects(env);
-	if(complete_phase_ABORT == scanWeakReferencesComplete(env)) {
+	if (complete_phase_ABORT == scanWeakReferencesComplete(env)) {
 		return ;
 	}
 
@@ -1013,7 +1016,7 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 	 * is moved to the finalizable list.
 	 */
 	scanUnfinalizedObjects(env);
-	if(complete_phase_ABORT == scanUnfinalizedObjectsComplete(env)) {
+	if (complete_phase_ABORT == scanUnfinalizedObjectsComplete(env)) {
 		return ;
 	}
 #endif /* J9VM_GC_FINALIZATION */
@@ -1024,7 +1027,7 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 	}
 
 	scanPhantomReferenceObjects(env);
-	if(complete_phase_ABORT == scanPhantomReferencesComplete(env)) {
+	if (complete_phase_ABORT == scanPhantomReferencesComplete(env)) {
 		return ;
 	}
 
@@ -1037,14 +1040,14 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 		return ;
 	}
 
-	if(!_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)) {
+	if (!_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)) {
 		scanStringTable(env);
 	}
 
 	scanOwnableSynchronizerObjects(env);
 	scanContinuationObjects(env);
 #if JAVA_SPEC_VERSION >= 19
-	J9JavaVM *vm = (J9JavaVM*)env->getOmrVM()->_language_vm;
+	J9JavaVM *vm = (J9JavaVM *)env->getOmrVM()->_language_vm;
 	J9JITConfig *jitConfig = vm->jitConfig;
 	if ((NULL != jitConfig) && (NULL != jitConfig->methodsToDelete)) {
 		iterateAllContinuationObjects(env);
@@ -1057,13 +1060,13 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 	 * from the remembered set.
 	 * This must after any other marking might occur, e.g. phantom references.
 	 */
-	if(_includeRememberedSetReferences && !_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
+	if (_includeRememberedSetReferences && !_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
 		scanRememberedSet(env);
 	}
 #endif /* J9VM_GC_MODRON_SCAVENGER */
 
 #if defined(J9VM_OPT_JVMTI)
-	if(_includeJVMTIObjectTagTables) {
+	if (_includeJVMTIObjectTagTables) {
 		scanJVMTIObjectTagTables(env);
 	}
 #endif /* J9VM_OPT_JVMTI */
@@ -1082,7 +1085,7 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 void
 MM_RootScanner::scanAllSlots(MM_EnvironmentBase *env)
 {
-	if(!_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
+	if (!_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
 		scanClasses(env);
 		scanVMClassSlots(env);
 	}
@@ -1095,7 +1098,7 @@ MM_RootScanner::scanAllSlots(MM_EnvironmentBase *env)
 #endif /* J9VM_GC_FINALIZATION */
 	scanJNIGlobalReferences(env);
 
-	if(!_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
+	if (!_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
 		scanStringTable(env);
 	}
 
@@ -1111,13 +1114,13 @@ MM_RootScanner::scanAllSlots(MM_EnvironmentBase *env)
 	scanJNIWeakGlobalReferences(env);
 
 #if defined(J9VM_GC_MODRON_SCAVENGER)
-	if(_includeRememberedSetReferences && !_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
+	if (_includeRememberedSetReferences && !_nurseryReferencesOnly && !_nurseryReferencesPossibly) {
 		scanRememberedSet(env);
 	}
 #endif /* J9VM_GC_MODRON_SCAVENGER */
 	
 #if defined(J9VM_OPT_JVMTI)
-	if(_includeJVMTIObjectTagTables) {
+	if (_includeJVMTIObjectTagTables) {
 		scanJVMTIObjectTagTables(env);
 	}
 #endif /* J9VM_OPT_JVMTI */

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -395,7 +395,7 @@ public:
 	}
 
 	/** General object slot handler to be reimplemented by specializing class. This handler is called for every reference to a J9Object. */
-	virtual void doSlot(J9Object** slotPtr) = 0;
+	virtual void doSlot(J9Object **slotPtr) = 0;
 
 	/** General class slot handler to be reimplemented by specializing class. This handler is called for every reference to a J9Class. */
 	virtual void doClassSlot(J9Class *classPtr);
@@ -407,7 +407,7 @@ public:
 	 * Scan object field
 	 * @param slotObject for field
 	 */
-	virtual void doFieldSlot(GC_SlotObject * slotObject);
+	virtual void doFieldSlot(GC_SlotObject *slotObject);
 	
 	virtual void scanRoots(MM_EnvironmentBase *env);
 	virtual void scanClearable(MM_EnvironmentBase *env);
@@ -425,11 +425,11 @@ public:
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 	virtual CompletePhaseCode scanClassesComplete(MM_EnvironmentBase *env);
 
- 	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, void* localData);
+	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread *walkThread, void *localData);
 	
 	virtual void scanClassLoaders(MM_EnvironmentBase *env);
 	virtual void scanThreads(MM_EnvironmentBase *env);
- 	virtual void scanSingleThread(MM_EnvironmentBase *env, J9VMThread* walkThread);
+	virtual void scanSingleThread(MM_EnvironmentBase *env, J9VMThread *walkThread);
 #if defined(J9VM_GC_FINALIZATION)
 	virtual void scanFinalizableObjects(MM_EnvironmentBase *env);
 	virtual void scanUnfinalizedObjects(MM_EnvironmentBase *env);

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -72,6 +72,15 @@ private:
 	fomrobject_t *setupReferenceObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason);
 	uintptr_t setupPointerArrayScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo, uintptr_t *slotsToDo);
 
+	/**
+	 * Set permanent ClassLoader Marked.
+	 *
+	 * @param env environment for calling thread
+	 * @param classLoader ClassLoader to be set marked
+	 */
+	void markPermanentClassloader(MM_EnvironmentBase *env, J9ClassLoader *classLoader);
+
+
 protected:
 
 public:
@@ -113,7 +122,11 @@ public:
 
 	void startRootListProcessing(MM_EnvironmentBase *env);
 
-	uintptr_t setupIndexableScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo, uintptr_t *sizeInElementsToDo, fomrobject_t **basePtr, uintptr_t *flags) { return 0; }
+	uintptr_t
+	setupIndexableScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo, uintptr_t *sizeInElementsToDo, fomrobject_t **basePtr, uintptr_t *flags)
+	{
+		return 0;
+	}
 
 	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr);
 	void scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
@@ -232,7 +245,7 @@ public:
 	void scanClass(MM_EnvironmentBase *env, J9Class *clazz);
 
 	bool processReference(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
-	void processReferenceList(MM_EnvironmentBase *env, MM_HeapRegionDescriptorStandard* region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
+	void processReferenceList(MM_EnvironmentBase *env, MM_HeapRegionDescriptorStandard *region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
 
 	void handleWorkPacketOverflowItem(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
 	{

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -79,14 +79,14 @@ MM_MetronomeDelegate::yieldWhenRequested(MM_EnvironmentBase *env)
  * C entrypoint for the newly created alarm thread.
  */
 int J9THREAD_PROC
-MM_MetronomeDelegate::metronomeAlarmThreadWrapper(void* userData)
+MM_MetronomeDelegate::metronomeAlarmThreadWrapper(void *userData)
 {
 	MM_MetronomeAlarmThread *alarmThread = (MM_MetronomeAlarmThread *)userData;
 	J9JavaVM *javaVM = (J9JavaVM *)alarmThread->getScheduler()->_extensions->getOmrVM()->_language_vm;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 	uintptr_t rc;
 
-	j9sig_protect(MM_MetronomeDelegate::signalProtectedFunction, (void*)userData,
+	j9sig_protect(MM_MetronomeDelegate::signalProtectedFunction, (void *)userData,
 		javaVM->internalVMFunctions->structuredSignalHandlerVM, javaVM,
 		J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION,
 		&rc);
@@ -100,7 +100,7 @@ MM_MetronomeDelegate::metronomeAlarmThreadWrapper(void* userData)
 }
 
 uintptr_t
-MM_MetronomeDelegate::signalProtectedFunction(J9PortLibrary *privatePortLibrary, void* userData)
+MM_MetronomeDelegate::signalProtectedFunction(J9PortLibrary *privatePortLibrary, void *userData)
 {
 	MM_MetronomeAlarmThread *alarmThread = (MM_MetronomeAlarmThread *)userData;
 	J9JavaVM *javaVM = (J9JavaVM *)alarmThread->getScheduler()->_extensions->getOmrVM()->_language_vm;
@@ -115,7 +115,7 @@ MM_MetronomeDelegate::signalProtectedFunction(J9PortLibrary *privatePortLibrary,
 	
 	alarmThread->run(env);
 	
-	javaVM->internalVMFunctions->DetachCurrentThread((JavaVM*)javaVM);
+	javaVM->internalVMFunctions->DetachCurrentThread((JavaVM *)javaVM);
 	
 	return 0;
 }
@@ -212,12 +212,12 @@ MM_MetronomeDelegate::allocateAndInitializeReferenceObjectLists(MM_EnvironmentBa
 {
 	const UDATA listCount = getReferenceObjectListCount(env);
 	Assert_MM_true(0 < listCount);
-	_extensions->referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate((sizeof(MM_ReferenceObjectList) * listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	_extensions->referenceObjectLists = (MM_ReferenceObjectList *)env->getForge()->allocate((sizeof(MM_ReferenceObjectList) *listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL == _extensions->referenceObjectLists) {
 		return false;
 	}
 	for (UDATA index = 0; index < listCount; index++) {
-		new(&_extensions->referenceObjectLists[index]) MM_ReferenceObjectList();
+		new (&_extensions->referenceObjectLists[index]) MM_ReferenceObjectList();
 	}
 	return true;
 }
@@ -227,7 +227,7 @@ MM_MetronomeDelegate::allocateAndInitializeUnfinalizedObjectLists(MM_Environment
 {
 	const UDATA listCount = getUnfinalizedObjectListCount(env);
 	Assert_MM_true(0 < listCount);
-	MM_UnfinalizedObjectList *unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate((sizeof(MM_UnfinalizedObjectList) * listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	MM_UnfinalizedObjectList *unfinalizedObjectLists = (MM_UnfinalizedObjectList *)env->getForge()->allocate((sizeof(MM_UnfinalizedObjectList) *listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL == unfinalizedObjectLists) {
 		return false;
 	}
@@ -236,8 +236,8 @@ MM_MetronomeDelegate::allocateAndInitializeUnfinalizedObjectLists(MM_Environment
 		/* add each list to the global list. we need to maintain the doubly linked list
 		 * to ensure uniformity with SE/Balanced.
 		 */
-		MM_UnfinalizedObjectList *previousUnfinalizedObjectList = (0 == index) ? NULL : &unfinalizedObjectLists[index-1];
-		MM_UnfinalizedObjectList *nextUnfinalizedObjectList = ((listCount - 1) == index) ? NULL : &unfinalizedObjectLists[index+1];
+		MM_UnfinalizedObjectList *previousUnfinalizedObjectList = (0 == index) ? NULL : &unfinalizedObjectLists[index - 1];
+		MM_UnfinalizedObjectList *nextUnfinalizedObjectList = ((listCount - 1) == index) ? NULL : &unfinalizedObjectLists[index + 1];
 
 		unfinalizedObjectLists[index].setNextList(nextUnfinalizedObjectList);
 		unfinalizedObjectLists[index].setPreviousList(previousUnfinalizedObjectList);
@@ -251,7 +251,7 @@ MM_MetronomeDelegate::allocateAndInitializeOwnableSynchronizerObjectLists(MM_Env
 {
 	const UDATA listCount = getOwnableSynchronizerObjectListCount(env);
 	Assert_MM_true(0 < listCount);
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate((sizeof(MM_OwnableSynchronizerObjectList) * listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectLists = (MM_OwnableSynchronizerObjectList *)env->getForge()->allocate((sizeof(MM_OwnableSynchronizerObjectList) *listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL == ownableSynchronizerObjectLists) {
 		return false;
 	}
@@ -260,8 +260,8 @@ MM_MetronomeDelegate::allocateAndInitializeOwnableSynchronizerObjectLists(MM_Env
 		/* add each list to the global list. we need to maintain the doubly linked list
 		 * to ensure uniformity with SE/Balanced.
 		 */
-		MM_OwnableSynchronizerObjectList *previousOwnableSynchronizerObjectList = (0 == index) ? NULL : &ownableSynchronizerObjectLists[index-1];
-		MM_OwnableSynchronizerObjectList *nextOwnableSynchronizerObjectList = ((listCount - 1) == index) ? NULL : &ownableSynchronizerObjectLists[index+1];
+		MM_OwnableSynchronizerObjectList *previousOwnableSynchronizerObjectList = (0 == index) ? NULL : &ownableSynchronizerObjectLists[index - 1];
+		MM_OwnableSynchronizerObjectList *nextOwnableSynchronizerObjectList = ((listCount - 1) == index) ? NULL : &ownableSynchronizerObjectLists[index + 1];
 
 		ownableSynchronizerObjectLists[index].setNextList(nextOwnableSynchronizerObjectList);
 		ownableSynchronizerObjectLists[index].setPreviousList(previousOwnableSynchronizerObjectList);
@@ -275,7 +275,7 @@ MM_MetronomeDelegate::allocateAndInitializeContinuationObjectLists(MM_Environmen
 {
 	const UDATA listCount = getContinuationObjectListCount(env);
 	Assert_MM_true(0 < listCount);
-	MM_ContinuationObjectList *continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate((sizeof(MM_ContinuationObjectList) * listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
+	MM_ContinuationObjectList *continuationObjectLists = (MM_ContinuationObjectList *)env->getForge()->allocate((sizeof(MM_ContinuationObjectList) *listCount), MM_AllocationCategory::FIXED, J9_GET_CALLSITE());
 	if (NULL == continuationObjectLists) {
 		return false;
 	}
@@ -284,8 +284,8 @@ MM_MetronomeDelegate::allocateAndInitializeContinuationObjectLists(MM_Environmen
 		/* add each list to the global list. we need to maintain the doubly linked list
 		 * to ensure uniformity with SE/Balanced.
 		 */
-		MM_ContinuationObjectList *previousContinuationObjectList = (0 == index) ? NULL : &continuationObjectLists[index-1];
-		MM_ContinuationObjectList *nextContinuationObjectList = ((listCount - 1) == index) ? NULL : &continuationObjectLists[index+1];
+		MM_ContinuationObjectList *previousContinuationObjectList = (0 == index) ? NULL : &continuationObjectLists[index - 1];
+		MM_ContinuationObjectList *nextContinuationObjectList = ((listCount - 1) == index) ? NULL : &continuationObjectLists[index + 1];
 
 		continuationObjectLists[index].setNextList(nextContinuationObjectList);
 		continuationObjectLists[index].setPreviousList(previousContinuationObjectList);
@@ -426,7 +426,7 @@ void
 MM_MetronomeDelegate::doAuxiliaryGCWork(MM_EnvironmentBase *env)
 {
 #if defined(J9VM_GC_FINALIZATION)
-	if(isFinalizationRequired()) {
+	if (isFinalizationRequired()) {
 		omrthread_monitor_enter(_javaVM->finalizeMainMonitor);
 		_javaVM->finalizeMainFlags |= J9_FINALIZE_FLAGS_MAIN_WAKE_UP;
 		omrthread_monitor_notify_all(_javaVM->finalizeMainMonitor);
@@ -437,7 +437,7 @@ MM_MetronomeDelegate::doAuxiliaryGCWork(MM_EnvironmentBase *env)
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 void
-MM_MetronomeDelegate::processDyingClasses(MM_EnvironmentRealtime *env, UDATA* classUnloadCountResult, UDATA* anonymousClassUnloadCountResult, UDATA* classLoaderUnloadCountResult, J9ClassLoader** classLoaderUnloadListResult)
+MM_MetronomeDelegate::processDyingClasses(MM_EnvironmentRealtime *env, UDATA *classUnloadCountResult, UDATA *anonymousClassUnloadCountResult, UDATA *classLoaderUnloadCountResult, J9ClassLoader **classLoaderUnloadListResult)
 {
 	J9ClassLoader *classLoader = NULL;
 	J9VMThread *vmThread = (J9VMThread *)env->getLanguageVMThread();
@@ -471,10 +471,10 @@ MM_MetronomeDelegate::processDyingClasses(MM_EnvironmentRealtime *env, UDATA* cl
 	classUnloadCount += anonymousClassUnloadCount;
 	
 	GC_ClassLoaderLinkedListIterator classLoaderIterator(env, _extensions->classLoaderManager);
-	while(NULL != (classLoader = (J9ClassLoader *)classLoaderIterator.nextSlot())) {
+	while (NULL != (classLoader = (J9ClassLoader *)classLoaderIterator.nextSlot())) {
 		if (0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
 			Assert_MM_true(NULL == classLoader->unloadLink);
-			if(_markingScheme->isMarked(classLoader->classLoaderObject) ) {
+			if (_markingScheme->isMarked(classLoader->classLoaderObject) ) {
 				classLoader->gcFlags &= ~J9_GC_CLASS_LOADER_SCANNED;
 			} else {
 				/* Anonymous classloader should not be unloaded */
@@ -521,7 +521,7 @@ MM_MetronomeDelegate::processDyingClasses(MM_EnvironmentRealtime *env, UDATA* cl
 }
 
 J9Class *
-MM_MetronomeDelegate::addDyingClassesToList(MM_EnvironmentRealtime *env, J9ClassLoader * classLoader, bool setAll, J9Class *classUnloadListStart, UDATA *classUnloadCountResult)
+MM_MetronomeDelegate::addDyingClassesToList(MM_EnvironmentRealtime *env, J9ClassLoader *classLoader, bool setAll, J9Class *classUnloadListStart, UDATA *classUnloadCountResult)
 {
 	J9VMThread *vmThread = (J9VMThread *)env->getLanguageVMThread();
 	J9Class *classUnloadList = classUnloadListStart;
@@ -530,10 +530,10 @@ MM_MetronomeDelegate::addDyingClassesToList(MM_EnvironmentRealtime *env, J9Class
 	if (NULL != classLoader) {
 		GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 		J9MemorySegment *segment = NULL;
-		while(NULL != (segment = segmentIterator.nextSegment())) {
+		while (NULL != (segment = segmentIterator.nextSegment())) {
 			GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 			J9Class *clazz = NULL;
-			while(NULL != (clazz = classHeapIterator.nextClass())) {
+			while (NULL != (clazz = classHeapIterator.nextClass())) {
 
 				J9CLASS_EXTENDED_FLAGS_CLEAR(clazz, J9ClassGCScanned);
 
@@ -688,7 +688,7 @@ MM_MetronomeDelegate::unloadDeadClassLoaders(MM_EnvironmentBase *envModron)
 		/* Determine if the classLoader needs to be enqueued for finalization (for shared library unloading),
 		 * otherwise add it to the list of classLoaders to be unloaded by cleanUpClassLoadersEnd.
 		 */
-		if(((NULL != classLoader->sharedLibraries)
+		if (((NULL != classLoader->sharedLibraries)
 		&& (0 != pool_numElements(classLoader->sharedLibraries)))
 		|| (_extensions->fvtest_forceFinalizeClassLoaders)) {
 			/* Attempt to enqueue the class loader for the finalizer */
@@ -892,7 +892,7 @@ MM_MetronomeDelegate::enableDoubleBarrier(MM_EnvironmentBase *env)
 	
 	/* First, enable the global double barrier flag so new threads will have the double barrier enabled. */
 	realtimeAccessBarrier->setDoubleBarrierActive();
-	while(J9VMThread* thread = vmThreadListIterator.nextVMThread()) {
+	while (J9VMThread* thread = vmThreadListIterator.nextVMThread()) {
 		/* Second, enable the double barrier on all threads individually. */
 		realtimeAccessBarrier->setDoubleBarrierActiveOnThread(MM_EnvironmentBase::getEnvironment(thread->omrVMThread));
 	}
@@ -902,11 +902,11 @@ MM_MetronomeDelegate::enableDoubleBarrier(MM_EnvironmentBase *env)
  * Disables the double barrier for the specified thread.
  */
 void
-MM_MetronomeDelegate::disableDoubleBarrierOnThread(MM_EnvironmentBase* env, OMR_VMThread* vmThread)
+MM_MetronomeDelegate::disableDoubleBarrierOnThread(MM_EnvironmentBase *env, OMR_VMThread *vmThread)
 {
 	/* This gets called on a per thread basis as threads get scanned. */
 	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(env);
-	MM_RealtimeAccessBarrier* realtimeAccessBarrier = (MM_RealtimeAccessBarrier*)extensions->accessBarrier;
+	MM_RealtimeAccessBarrier* realtimeAccessBarrier = (MM_RealtimeAccessBarrier *)extensions->accessBarrier;
 	realtimeAccessBarrier->setDoubleBarrierInactiveOnThread(MM_EnvironmentBase::getEnvironment(vmThread));
 }
 
@@ -915,13 +915,13 @@ MM_MetronomeDelegate::disableDoubleBarrierOnThread(MM_EnvironmentBase* env, OMR_
  * and disableDoubleBarrierOnThread has been called on each of them.
  */
 void
-MM_MetronomeDelegate::disableDoubleBarrier(MM_EnvironmentBase* env)
+MM_MetronomeDelegate::disableDoubleBarrier(MM_EnvironmentBase *env)
 {
 	/* The enabling of the double barrier must traverse all threads, but the double barrier gets disabled
 	 * on a per thread basis as threads get scanned, so no need to traverse all threads in this method.
 	 */
-	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(env);
-	MM_RealtimeAccessBarrier* realtimeAccessBarrier = (MM_RealtimeAccessBarrier*)extensions->accessBarrier;
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	MM_RealtimeAccessBarrier *realtimeAccessBarrier = (MM_RealtimeAccessBarrier *)extensions->accessBarrier;
 	realtimeAccessBarrier->setDoubleBarrierInactive();
 }
 
@@ -942,23 +942,23 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 	MM_GCExtensions* extensions = MM_GCExtensions::getExtensions(env);
 	GC_ClassLoaderLinkedListIterator classLoaderIterator(env, extensions->classLoaderManager);
 	
-	while((classLoader = (J9ClassLoader *)classLoaderIterator.nextSlot()) != NULL) {
+	while ((classLoader = (J9ClassLoader *)classLoaderIterator.nextSlot()) != NULL) {
 		if (0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
-			if(J9CLASSLOADER_ANON_CLASS_LOADER == (classLoader->flags & J9CLASSLOADER_ANON_CLASS_LOADER)) {
+			if (J9CLASSLOADER_ANON_CLASS_LOADER == (classLoader->flags & J9CLASSLOADER_ANON_CLASS_LOADER)) {
 				/* Anonymous classloader should be scanned on level of classes every time */
 				GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 				J9MemorySegment *segment = NULL;
-				while(NULL != (segment = segmentIterator.nextSegment())) {
+				while (NULL != (segment = segmentIterator.nextSegment())) {
 					GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 					J9Class *clazz = NULL;
-					while(NULL != (clazz = classHeapIterator.nextClass())) {
-						if((0 == (J9CLASS_EXTENDED_FLAGS(clazz) & J9ClassGCScanned)) && _markingScheme->isMarked(clazz->classObject)) {
+					while (NULL != (clazz = classHeapIterator.nextClass())) {
+						if ((0 == (J9CLASS_EXTENDED_FLAGS(clazz) & J9ClassGCScanned)) && _markingScheme->isMarked(clazz->classObject)) {
 							J9CLASS_EXTENDED_FLAGS_SET(clazz, J9ClassGCScanned);
 
 							/* Scan class */
 							GC_ClassIterator objectSlotIterator(env, clazz);
 							volatile j9object_t *objectSlotPtr = NULL;
-							while((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
+							while ((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
 								didWork |= _markingScheme->markObject(env, *objectSlotPtr);
 							}
 
@@ -973,7 +973,7 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 				}
 			} else {
 				/* Check if the class loader has not been scanned but the class loader is live */
-				if( !(classLoader->gcFlags & J9_GC_CLASS_LOADER_SCANNED) && _markingScheme->isMarked((J9Object *)classLoader->classLoaderObject)) {
+				if (!(classLoader->gcFlags & J9_GC_CLASS_LOADER_SCANNED) && _markingScheme->isMarked((J9Object *)classLoader->classLoaderObject)) {
 					/* Flag the class loader as being scanned */
 					classLoader->gcFlags |= J9_GC_CLASS_LOADER_SCANNED;
 
@@ -981,13 +981,13 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 					J9MemorySegment *segment = NULL;
 					J9Class *clazz;
 
-					while(NULL != (segment = segmentIterator.nextSegment())) {
+					while (NULL != (segment = segmentIterator.nextSegment())) {
 						GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
-						while(NULL != (clazz = classHeapIterator.nextClass())) {
+						while (NULL != (clazz = classHeapIterator.nextClass())) {
 							/* Scan class */
 							GC_ClassIterator objectSlotIterator(env, clazz);
 							volatile j9object_t *objectSlotPtr = NULL;
-							while((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
+							while ((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
 								didWork |= _markingScheme->markObject(env, *objectSlotPtr);
 							}
 
@@ -1058,11 +1058,11 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 bool
-MM_MetronomeDelegate::doTracing(MM_EnvironmentRealtime* env)
+MM_MetronomeDelegate::doTracing(MM_EnvironmentRealtime *env)
 {
 	/* TODO CRGTMP make class tracing concurrent */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	if(isDynamicClassUnloadingEnabled()) {	
+	if (isDynamicClassUnloadingEnabled()) {
 		return doClassTracing(env);
 	}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -1070,7 +1070,7 @@ MM_MetronomeDelegate::doTracing(MM_EnvironmentRealtime* env)
 }
 
 void
-MM_MetronomeDelegate::defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void* defaultMemorySpace)
+MM_MetronomeDelegate::defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void *defaultMemorySpace)
 {
 	J9JavaVM* vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
 	
@@ -1221,7 +1221,7 @@ MM_MetronomeDelegate::scanUnfinalizedObjects(MM_EnvironmentRealtime *env)
 	GC_FinalizableObjectBuffer buffer(_extensions);
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_UnfinalizedObjectList *unfinalizedObjectList = &_extensions->unfinalizedObjectLists[listIndex];
 			J9Object *object = unfinalizedObjectList->getPriorList();
 			UDATA objectsVisited = 0;
@@ -1371,7 +1371,7 @@ MM_MetronomeDelegate::scanWeakReferenceObjects(MM_EnvironmentRealtime *env)
 	const UDATA maxIndex = getReferenceObjectListCount(env);
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_extensions->referenceObjectLists[listIndex];
 			referenceObjectList->startWeakReferenceProcessing();
 			processReferenceList(env, NULL, referenceObjectList->getPriorWeakList(), &gcEnv->_markJavaStats._weakReferenceStats);
@@ -1389,7 +1389,7 @@ MM_MetronomeDelegate::scanSoftReferenceObjects(MM_EnvironmentRealtime *env)
 	const UDATA maxIndex = getReferenceObjectListCount(env);
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_extensions->referenceObjectLists[listIndex];
 			referenceObjectList->startSoftReferenceProcessing();
 			processReferenceList(env, NULL, referenceObjectList->getPriorSoftList(), &gcEnv->_markJavaStats._softReferenceStats);
@@ -1408,7 +1408,7 @@ MM_MetronomeDelegate::scanPhantomReferenceObjects(MM_EnvironmentRealtime *env)
 	const UDATA maxIndex = getReferenceObjectListCount(env);
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_extensions->referenceObjectLists[listIndex];
 			referenceObjectList->startPhantomReferenceProcessing();
 			processReferenceList(env, NULL, referenceObjectList->getPriorPhantomList(), &gcEnv->_markJavaStats._phantomReferenceStats);
@@ -1419,7 +1419,7 @@ MM_MetronomeDelegate::scanPhantomReferenceObjects(MM_EnvironmentRealtime *env)
 }
 
 void
-MM_MetronomeDelegate::processReferenceList(MM_EnvironmentRealtime *env, MM_HeapRegionDescriptorRealtime *region, J9Object* headOfList, MM_ReferenceStats *referenceStats)
+MM_MetronomeDelegate::processReferenceList(MM_EnvironmentRealtime *env, MM_HeapRegionDescriptorRealtime *region, J9Object *headOfList, MM_ReferenceStats *referenceStats)
 {
 	UDATA objectsVisited = 0;
 #if defined(J9VM_GC_FINALIZATION)
@@ -1495,18 +1495,19 @@ MM_MetronomeDelegate::markLiveObjectsRoots(MM_EnvironmentRealtime *env)
 
 	/* Mark root set classes */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	if(env->isMainThread()) {
-		/* TODO: This code belongs somewhere else? */
+	if (isDynamicClassUnloadingEnabled()) {
 		/* Setting the permanent class loaders to scanned without a locked operation is safe
 		 * Class loaders will not be rescanned until a thread synchronize is executed
 		 */
-		if(isDynamicClassUnloadingEnabled()) {
-			((J9ClassLoader *)_javaVM->systemClassLoader)->gcFlags |= J9_GC_CLASS_LOADER_SCANNED;
-			_markingScheme->markObject(env, (J9Object *)((J9ClassLoader *)_javaVM->systemClassLoader)->classLoaderObject);
-			if(_javaVM->applicationClassLoader) {
-				((J9ClassLoader *)_javaVM->applicationClassLoader)->gcFlags |= J9_GC_CLASS_LOADER_SCANNED;
-				_markingScheme->markObject(env, (J9Object *)((J9ClassLoader *)_javaVM->applicationClassLoader)->classLoaderObject);
-			}
+		if (env->isMainThread()) {
+			/* Mark systemClassLoader */
+			markPermanentClassloader(env, _javaVM->systemClassLoader);
+
+			/* Mark applicationClassLoader */
+			markPermanentClassloader(env, _javaVM->applicationClassLoader);
+
+			/* Mark extensionClassLoader */
+			markPermanentClassloader(env, _javaVM->extensionClassLoader);
 		}
 	}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -1575,6 +1576,15 @@ MM_MetronomeDelegate::markLiveObjectsRoots(MM_EnvironmentRealtime *env)
 	}
 
 	env->setRootScanner(NULL);
+}
+
+void
+MM_MetronomeDelegate::markPermanentClassloader(MM_EnvironmentRealtime *env, J9ClassLoader *classLoader)
+{
+	if (NULL != classLoader) {
+		classLoader->gcFlags |= J9_GC_CLASS_LOADER_SCANNED;
+		_markingScheme->markObject(env, classLoader->classLoaderObject);
+	}
 }
 
 void

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -55,13 +55,13 @@ private:
 
 public:
 	void yieldWhenRequested(MM_EnvironmentBase *env);
-	static int J9THREAD_PROC metronomeAlarmThreadWrapper(void* userData);
-	static uintptr_t signalProtectedFunction(J9PortLibrary *privatePortLibrary, void* userData);	
+	static int J9THREAD_PROC metronomeAlarmThreadWrapper(void *userData);
+	static uintptr_t signalProtectedFunction(J9PortLibrary *privatePortLibrary, void *userData);
 
 	MM_MetronomeDelegate(MM_EnvironmentBase *env) :
 		_extensions(MM_GCExtensions::getExtensions(env)),
 		_realtimeGC(NULL),
-		_javaVM((J9JavaVM*)env->getOmrVM()->_language_vm) {}
+		_javaVM((J9JavaVM *)env->getOmrVM()->_language_vm) {}
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
  	bool _unmarkedImpliesClasses; /**< if true the mark bit can be used to check is class alive or not */
@@ -120,7 +120,7 @@ public:
 	 * @param classLoaderUnloadCountResult[out] returns the number of class loaders about to be unloaded
 	 * @param classLoaderUnloadListResult[out] returns a linked list of class loaders about to be unloaded
 	 */
-	void processDyingClasses(MM_EnvironmentRealtime *env, UDATA* classUnloadCountResult, UDATA* anonymousClassUnloadCount, UDATA* classLoaderUnloadCountResult, J9ClassLoader** classLoaderUnloadListResult);
+	void processDyingClasses(MM_EnvironmentRealtime *env, UDATA *classUnloadCountResult, UDATA *anonymousClassUnloadCount, UDATA *classLoaderUnloadCountResult, J9ClassLoader **classLoaderUnloadListResult);
 	void processUnlinkedClassLoaders(MM_EnvironmentBase *env, J9ClassLoader *deadClassLoaders);
 	void updateClassUnloadStats(MM_EnvironmentBase *env, UDATA classUnloadCount, UDATA anonymousClassUnloadCount, UDATA classLoaderUnloadCount);
 
@@ -133,7 +133,7 @@ public:
 	 * @param classUnloadCountOut[out] number of classes dying added to the list
 	 * @return new root to list of dying classes
 	 */
-	J9Class *addDyingClassesToList(MM_EnvironmentRealtime *env, J9ClassLoader * classLoader, bool setAll, J9Class *classUnloadListStart, UDATA *classUnloadCountResult);
+	J9Class *addDyingClassesToList(MM_EnvironmentRealtime *env, J9ClassLoader *classLoader, bool setAll, J9Class *classUnloadListStart, UDATA *classUnloadCountResult);
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 	void yieldFromClassUnloading(MM_EnvironmentRealtime *env);
@@ -145,17 +145,17 @@ public:
 	UDATA getContinuationObjectListCount(MM_EnvironmentBase *env) { return _extensions->gcThreadCount; }
 	UDATA getReferenceObjectListCount(MM_EnvironmentBase *env) { return _extensions->gcThreadCount; }
 
-	void defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void* defaultMemorySpace);
-	MM_RealtimeAccessBarrier* allocateAccessBarrier(MM_EnvironmentBase *env);
+	void defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void *defaultMemorySpace);
+	MM_RealtimeAccessBarrier *allocateAccessBarrier(MM_EnvironmentBase *env);
 	void enableDoubleBarrier(MM_EnvironmentBase* env);
-	void disableDoubleBarrierOnThread(MM_EnvironmentBase* env, OMR_VMThread* vmThread);
-	void disableDoubleBarrier(MM_EnvironmentBase* env);
+	void disableDoubleBarrierOnThread(MM_EnvironmentBase *env, OMR_VMThread *vmThread);
+	void disableDoubleBarrier(MM_EnvironmentBase *env);
 
 	/* New methods */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	bool doClassTracing(MM_EnvironmentRealtime* env);
+	bool doClassTracing(MM_EnvironmentRealtime *env);
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
-	bool doTracing(MM_EnvironmentRealtime* env);
+	bool doTracing(MM_EnvironmentRealtime *env);
 
 	/*
 	 * These functions are used by classic Metronome gang-scheduling and
@@ -208,7 +208,7 @@ public:
 	scanPointerArraylet(MM_EnvironmentRealtime *env, fomrobject_t *arraylet)
 	{
 		fomrobject_t *startScanPtr = arraylet;
-		fomrobject_t *endScanPtr = (fomrobject_t*)((uintptr_t)startScanPtr + _javaVM->arrayletLeafSize);
+		fomrobject_t *endScanPtr = (fomrobject_t *)((uintptr_t)startScanPtr + _javaVM->arrayletLeafSize);
 		return scanPointerRange(env, startScanPtr, endScanPtr);
 	}
 
@@ -216,7 +216,7 @@ public:
 	scanObject(MM_EnvironmentRealtime *env, omrobjectptr_t objectPtr)
 	{
 		UDATA pointersScanned = 0;
-		switch(_extensions->objectModel.getScanType(objectPtr)) {
+		switch (_extensions->objectModel.getScanType(objectPtr)) {
 		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
@@ -250,20 +250,20 @@ public:
 		UDATA pointerField = 0;
 	
 		if (env->compressObjectReferences()) {
-			uint32_t *scanPtr = (uint32_t*)startScanPtr;
-			uint32_t *endPtr = (uint32_t*)endScanPtr;
+			uint32_t *scanPtr = (uint32_t *)startScanPtr;
+			uint32_t *endPtr = (uint32_t *)endScanPtr;
 			pointerField = endPtr - scanPtr;
-			while(scanPtr < endPtr) {
-				GC_SlotObject slotObject(_javaVM->omrVM, (fj9object_t*)scanPtr);
+			while (scanPtr < endPtr) {
+				GC_SlotObject slotObject(_javaVM->omrVM, (fj9object_t *)scanPtr);
 				_markingScheme->markObject(env, slotObject.readReferenceFromSlot());
 				scanPtr++;
 			}
 		} else {
-			uintptr_t *scanPtr = (uintptr_t*)startScanPtr;
-			uintptr_t *endPtr = (uintptr_t*)endScanPtr;
+			uintptr_t *scanPtr = (uintptr_t *)startScanPtr;
+			uintptr_t *endPtr = (uintptr_t *)endScanPtr;
 			pointerField = endPtr - scanPtr;
-			while(scanPtr < endPtr) {
-				GC_SlotObject slotObject(_javaVM->omrVM, (fj9object_t*)scanPtr);
+			while (scanPtr < endPtr) {
+				GC_SlotObject slotObject(_javaVM->omrVM, (fj9object_t *)scanPtr);
 				_markingScheme->markObject(env, slotObject.readReferenceFromSlot());
 				scanPtr++;
 			}
@@ -280,17 +280,17 @@ public:
 		bool const compressed = env->compressObjectReferences();
 		fj9object_t *scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 		UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
-		fj9object_t *endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
-		UDATA *descriptionPtr;
-		UDATA descriptionBits;
-		UDATA descriptionIndex;
+		fj9object_t *endScanPtr = (fj9object_t *)(((U_8 *)objectPtr) + objectSize);
+		UDATA *descriptionPtr = NULL;
+		UDATA descriptionBits = 0;
+		UDATA descriptionIndex = 0;
 #if defined(J9VM_GC_LEAF_BITS)
-		UDATA *leafPtr;
-		UDATA leafBits;
+		UDATA *leafPtr = NULL;
+		UDATA leafBits = 0;
 #endif /* J9VM_GC_LEAF_BITS */
 		
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-		if(isDynamicClassUnloadingEnabled()) {
+		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, objectPtr);
 		}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -300,7 +300,7 @@ public:
 		leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-		if(((UDATA)descriptionPtr) & 1) {
+		if (((UDATA)descriptionPtr) & 1) {
 			descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = ((UDATA)leafPtr) >> 1;
@@ -314,9 +314,9 @@ public:
 		descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
 		UDATA pointerFields = 0;
-		while(scanPtr < endScanPtr) {
+		while (scanPtr < endScanPtr) {
 			/* Determine if the slot should be processed */
-			if(descriptionBits & 1) {
+			if (descriptionBits & 1) {
 				pointerFields++;
 				GC_SlotObject slotObject(_javaVM->omrVM, scanPtr);
 #if defined(J9VM_GC_LEAF_BITS)
@@ -329,7 +329,7 @@ public:
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-			if(descriptionIndex-- == 0) {
+			if (descriptionIndex-- == 0) {
 				descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 				leafBits = *leafPtr++;
@@ -351,7 +351,7 @@ public:
 		bool const compressed = env->compressObjectReferences();
 		
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-		if(isDynamicClassUnloadingEnabled()) {
+		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, (J9Object *)objectPtr);
 		}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -380,9 +380,9 @@ public:
 				UDATA arrayletSize = _extensions->indexableObjectModel.arrayletSize(objectPtr, i);
 				/* need to check leaf pointer because this can be a partially allocated arraylet (not all leafs are allocated) */
 				GC_SlotObject slotObject(_javaVM->omrVM, GC_SlotObject::addToSlotAddress(arrayoid, i, compressed));
-				fj9object_t *startScanPtr = (fj9object_t*) (slotObject.readReferenceFromSlot());
+				fj9object_t *startScanPtr = (fj9object_t *) (slotObject.readReferenceFromSlot());
 				if (NULL != startScanPtr) {
-					fj9object_t *endScanPtr = (fj9object_t*)((uintptr_t)startScanPtr + arrayletSize);
+					fj9object_t *endScanPtr = (fj9object_t *)((uintptr_t)startScanPtr + arrayletSize);
 					if (i == (numArraylets - 1)) {
 						pointerFields += scanPointerRange(env, startScanPtr, endScanPtr);
 						if (canSetAsScanned) {
@@ -411,17 +411,17 @@ public:
 		bool const compressed = env->compressObjectReferences();
 		fj9object_t *scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 		UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
-		fj9object_t *endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
-		UDATA *descriptionPtr;
-		UDATA descriptionBits;
-		UDATA descriptionIndex;
+		fj9object_t *endScanPtr = (fj9object_t *)(((U_8 *)objectPtr) + objectSize);
+		UDATA *descriptionPtr = NULL;
+		UDATA descriptionBits = 0;
+		UDATA descriptionIndex = 0;
 #if defined(J9VM_GC_LEAF_BITS)
-		UDATA *leafPtr;
-		UDATA leafBits;
+		UDATA *leafPtr = NULL;
+		UDATA leafBits = 0;
 #endif /* J9VM_GC_LEAF_BITS */
 		
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-		if(isDynamicClassUnloadingEnabled()) {
+		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, objectPtr);
 		}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -431,7 +431,7 @@ public:
 		leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-		if(((UDATA)descriptionPtr) & 1) {
+		if (((UDATA)descriptionPtr) & 1) {
 			descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = ((UDATA)leafPtr) >> 1;
@@ -485,9 +485,9 @@ public:
 		}
 		
 		UDATA pointerFields = 0;
-		while(scanPtr < endScanPtr) {
+		while (scanPtr < endScanPtr) {
 			/* Determine if the slot should be processed */
-			if((descriptionBits & 1) && ((scanPtr != referentPtr.readAddressFromSlot()) || referentMustBeMarked)) {
+			if ((descriptionBits & 1) && ((scanPtr != referentPtr.readAddressFromSlot()) || referentMustBeMarked)) {
 				pointerFields++;
 				GC_SlotObject slotObject(_javaVM->omrVM, scanPtr);
 #if defined(J9VM_GC_LEAF_BITS)
@@ -500,7 +500,7 @@ public:
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-			if(descriptionIndex-- == 0) {
+			if (descriptionIndex-- == 0) {
 				descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 				leafBits = *leafPtr++;
@@ -547,7 +547,7 @@ private:
 	 * @param region[in] the region all the objects in the list belong to
 	 * @param headOfList[in] the first object in the linked list
 	 */
-	void processReferenceList(MM_EnvironmentRealtime *env, MM_HeapRegionDescriptorRealtime* region, J9Object* headOfList, MM_ReferenceStats *referenceStats);
+	void processReferenceList(MM_EnvironmentRealtime *env, MM_HeapRegionDescriptorRealtime *region, J9Object *headOfList, MM_ReferenceStats *referenceStats);
 
 	/**
 	 * Called by the root scanner to scan all SoftReference objects discovered by the mark phase,
@@ -562,6 +562,15 @@ private:
 	 * @param env[in] the current thread
 	 */
 	void scanPhantomReferenceObjects(MM_EnvironmentRealtime *env);
+
+	/**
+	 * Set permanent ClassLoader Marked.
+	 *
+	 * @param env environment for calling thread
+	 * @param classLoader ClassLoader to be set marked
+	 */
+	void markPermanentClassloader(MM_EnvironmentRealtime *env, J9ClassLoader *classLoader);
+
 
 	/*
 	 * Friends

--- a/runtime/gc_vlhgc/ClassLoaderRememberedSet.cpp
+++ b/runtime/gc_vlhgc/ClassLoaderRememberedSet.cpp
@@ -50,11 +50,11 @@ MM_ClassLoaderRememberedSet::MM_ClassLoaderRememberedSet(MM_EnvironmentBase *env
 }
 
 MM_ClassLoaderRememberedSet*
-MM_ClassLoaderRememberedSet::newInstance(MM_EnvironmentBase* env)
+MM_ClassLoaderRememberedSet::newInstance(MM_EnvironmentBase *env)
 {
-	MM_ClassLoaderRememberedSet* classLoaderRememberedSet = (MM_ClassLoaderRememberedSet*)env->getForge()->allocate(sizeof(MM_ClassLoaderRememberedSet), MM_AllocationCategory::REMEMBERED_SET, J9_GET_CALLSITE());
+	MM_ClassLoaderRememberedSet *classLoaderRememberedSet = (MM_ClassLoaderRememberedSet *)env->getForge()->allocate(sizeof(MM_ClassLoaderRememberedSet), MM_AllocationCategory::REMEMBERED_SET, J9_GET_CALLSITE());
 	if (classLoaderRememberedSet) {
-		new(classLoaderRememberedSet) MM_ClassLoaderRememberedSet(env);
+		new (classLoaderRememberedSet) MM_ClassLoaderRememberedSet(env);
 		if (!classLoaderRememberedSet->initialize(env)) {
 			classLoaderRememberedSet->kill(env);
 			classLoaderRememberedSet = NULL;
@@ -64,7 +64,7 @@ MM_ClassLoaderRememberedSet::newInstance(MM_EnvironmentBase* env)
 }
 
 bool
-MM_ClassLoaderRememberedSet::initialize(MM_EnvironmentBase* env)
+MM_ClassLoaderRememberedSet::initialize(MM_EnvironmentBase *env)
 {
 	if (!_lock.initialize(env, &_extensions->lnrlOptions, "MM_ClassLoaderRememberedSet:_lock")) {
 		return false;
@@ -75,7 +75,7 @@ MM_ClassLoaderRememberedSet::initialize(MM_EnvironmentBase* env)
 		if (NULL == _bitVectorPool) {
 			return false;
 		}
-		_bitsToClear = (UDATA*)pool_newElement(_bitVectorPool);
+		_bitsToClear = (UDATA *)pool_newElement(_bitVectorPool);
 		if (NULL == _bitsToClear) {
 			return false;
 		}
@@ -88,7 +88,7 @@ MM_ClassLoaderRememberedSet::initialize(MM_EnvironmentBase* env)
 }
 
 void
-MM_ClassLoaderRememberedSet::tearDown(MM_EnvironmentBase* env)
+MM_ClassLoaderRememberedSet::tearDown(MM_EnvironmentBase *env)
 {
 	if (NULL != _bitVectorPool) {
 		pool_kill(_bitVectorPool);
@@ -106,25 +106,25 @@ MM_ClassLoaderRememberedSet::kill(MM_EnvironmentBase *env)
 }
 
 void * 
-MM_ClassLoaderRememberedSet::poolAllocateHelper(void* userData, U_32 size, const char* callSite, U_32 memoryCategory, U_32 type, U_32* doInit)
+MM_ClassLoaderRememberedSet::poolAllocateHelper(void *userData, U_32 size, const char *callSite, U_32 memoryCategory, U_32 type, U_32 *doInit)
 {
 	/* We ignore the memoryCategory, type and doInit arguments */
-	MM_ClassLoaderRememberedSet *classLoaderRememberedSet = (MM_ClassLoaderRememberedSet*)userData;
-	MM_Forge* forge = classLoaderRememberedSet->_extensions->getForge();
+	MM_ClassLoaderRememberedSet *classLoaderRememberedSet = (MM_ClassLoaderRememberedSet *)userData;
+	MM_Forge *forge = classLoaderRememberedSet->_extensions->getForge();
 	return forge->allocate(size, MM_AllocationCategory::REMEMBERED_SET, callSite);
 }
 
 void 
-MM_ClassLoaderRememberedSet::poolFreeHelper(void* userData, void* address, U_32 type)
+MM_ClassLoaderRememberedSet::poolFreeHelper(void *userData, void *address, U_32 type)
 {
 	/* we ignore the type argument */
-	MM_ClassLoaderRememberedSet *classLoaderRememberedSet = (MM_ClassLoaderRememberedSet*)userData;
-	MM_Forge* forge = classLoaderRememberedSet->_extensions->getForge();
+	MM_ClassLoaderRememberedSet *classLoaderRememberedSet = (MM_ClassLoaderRememberedSet *)userData;
+	MM_Forge *forge = classLoaderRememberedSet->_extensions->getForge();
 	forge->free(address);
 }
 
 void
-MM_ClassLoaderRememberedSet::rememberInstance(MM_EnvironmentBase* env, J9Object* object) 
+MM_ClassLoaderRememberedSet::rememberInstance(MM_EnvironmentBase *env, J9Object *object)
 {
 	Assert_MM_true(NULL != object);
 	UDATA regionIndex = _regionManager->physicalTableDescriptorIndexForAddress(object);
@@ -150,7 +150,7 @@ MM_ClassLoaderRememberedSet::rememberInstance(MM_EnvironmentBase* env, J9Object*
 }
 
 void
-MM_ClassLoaderRememberedSet::rememberRegionInternal(MM_EnvironmentBase* env, UDATA regionIndex, volatile UDATA *gcRememberedSetAddress)
+MM_ClassLoaderRememberedSet::rememberRegionInternal(MM_EnvironmentBase *env, UDATA regionIndex, volatile UDATA *gcRememberedSetAddress)
 {
 	UDATA taggedRegionIndex = asTaggedRegionIndex(regionIndex);
 
@@ -177,7 +177,7 @@ MM_ClassLoaderRememberedSet::rememberRegionInternal(MM_EnvironmentBase* env, UDA
 }
 
 void
-MM_ClassLoaderRememberedSet::installBitVector(MM_EnvironmentBase* env, volatile UDATA *gcRememberedSetAddress)
+MM_ClassLoaderRememberedSet::installBitVector(MM_EnvironmentBase *env, volatile UDATA *gcRememberedSetAddress)
 {
 	_lock.acquire();
 	UDATA gcRememberedSet = *gcRememberedSetAddress;
@@ -191,7 +191,7 @@ MM_ClassLoaderRememberedSet::installBitVector(MM_EnvironmentBase* env, volatile 
 			Assert_MM_false(_extensions->tarokEnableIncrementalClassGC);
 			*gcRememberedSetAddress = UDATA_MAX;
 		} else {
-			volatile UDATA* bitVector = (volatile UDATA*)pool_newElement(_bitVectorPool);
+			volatile UDATA *bitVector = (volatile UDATA *)pool_newElement(_bitVectorPool);
 			if (NULL == bitVector) {
 				*gcRememberedSetAddress = UDATA_MAX;
 			} else {
@@ -205,7 +205,7 @@ MM_ClassLoaderRememberedSet::installBitVector(MM_EnvironmentBase* env, volatile 
 }
 
 void
-MM_ClassLoaderRememberedSet::setBit(MM_EnvironmentBase* env, volatile UDATA* bitVector, UDATA bit)
+MM_ClassLoaderRememberedSet::setBit(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit)
 {
 	UDATA wordIndex = bit / BITS_PER_UDATA;
 	UDATA bitIndex = bit % BITS_PER_UDATA;
@@ -220,7 +220,7 @@ MM_ClassLoaderRememberedSet::setBit(MM_EnvironmentBase* env, volatile UDATA* bit
 }
 
 bool
-MM_ClassLoaderRememberedSet::isBitSet(MM_EnvironmentBase* env, volatile UDATA* bitVector, UDATA bit)
+MM_ClassLoaderRememberedSet::isBitSet(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit)
 {
 	UDATA wordIndex = bit / BITS_PER_UDATA;
 	UDATA bitIndex = bit % BITS_PER_UDATA;
@@ -266,7 +266,7 @@ MM_ClassLoaderRememberedSet::isRememberedInternal(MM_EnvironmentBase *env, UDATA
 		isRemembered = true;
 	} else {
 		/* a bit vector is installed. Check to see if it's all zero */
-		volatile UDATA* bitVector = (volatile UDATA*)gcRememberedSet;
+		volatile UDATA *bitVector = (volatile UDATA *)gcRememberedSet;
 		for (UDATA i = 0; i < _bitVectorSize; i++) {
 			if (0 != bitVector[i]) {
 				isRemembered = true;
@@ -278,7 +278,7 @@ MM_ClassLoaderRememberedSet::isRememberedInternal(MM_EnvironmentBase *env, UDATA
 }
 
 bool
-MM_ClassLoaderRememberedSet::isInstanceRemembered(MM_EnvironmentBase *env, J9Object* object)
+MM_ClassLoaderRememberedSet::isInstanceRemembered(MM_EnvironmentBase *env, J9Object *object)
 {
 	bool isRemembered = false;
 	Assert_MM_true(NULL != object);
@@ -319,7 +319,7 @@ MM_ClassLoaderRememberedSet::isRegionRemembered(MM_EnvironmentBase *env, UDATA r
 		isRemembered = false;
 	} else {
 		/* this remembered set must be an inflated bit vector */
-		isRemembered = isBitSet(env, (volatile UDATA*)gcRememberedSet, regionIndex);
+		isRemembered = isBitSet(env, (volatile UDATA *)gcRememberedSet, regionIndex);
 	}
 	
 	return isRemembered;
@@ -344,7 +344,7 @@ MM_ClassLoaderRememberedSet::killRememberedSetInternal(MM_EnvironmentBase *env, 
 			/* inflated remembered set */
 			_lock.acquire();
 			Assert_MM_true(NULL != _bitVectorPool);
-			pool_removeElement(_bitVectorPool, (void*)gcRememberedSet);
+			pool_removeElement(_bitVectorPool, (void *)gcRememberedSet);
 			_lock.release();
 		}
 	}
@@ -372,15 +372,15 @@ MM_ClassLoaderRememberedSet::clearRememberedSets(MM_EnvironmentBase *env)
 	Assert_MM_true(NULL != _bitsToClear);
 	GC_ClassLoaderIterator classLoaderIterator(javaVM->classLoaderBlocks);
 	J9ClassLoader *classLoader = NULL;
-	while(NULL != (classLoader = classLoaderIterator.nextSlot())) {
-		if(J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
+	while (NULL != (classLoader = classLoaderIterator.nextSlot())) {
+		if (J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
 			/* Anonymous classloader should be scanned on level of classes every time */
 			GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 			J9MemorySegment *segment = NULL;
-			while(NULL != (segment = segmentIterator.nextSegment())) {
+			while (NULL != (segment = segmentIterator.nextSegment())) {
 				GC_ClassHeapIterator classHeapIterator(javaVM, segment);
 				J9Class *clazz = NULL;
-				while(NULL != (clazz = classHeapIterator.nextClass())) {
+				while (NULL != (clazz = classHeapIterator.nextClass())) {
 					/* class should not be unloaded otherwise gcLink is used to form list of unloaded classes */
 					Assert_MM_true(!J9_ARE_ANY_BITS_SET(clazz->classDepthAndFlags, J9AccClassDying));
 					clearRememberedSetsInternal(env, (volatile UDATA *)&clazz->gcLink);
@@ -409,7 +409,7 @@ MM_ClassLoaderRememberedSet::clearRememberedSetsInternal(MM_EnvironmentBase *env
 		}
 	} else {
 		/* a bit vector is installed */
-		volatile UDATA* bitVector = (volatile UDATA *)gcRememberedSet;
+		volatile UDATA *bitVector = (volatile UDATA *)gcRememberedSet;
 		for (UDATA i = 0; i < _bitVectorSize; i++) {
 			if ((0 != _bitsToClear[i]) && (0 != bitVector[i])) {
 				bitVector[i] &= ~_bitsToClear[i];
@@ -432,5 +432,10 @@ MM_ClassLoaderRememberedSet::setupBeforeGC(MM_EnvironmentBase *env)
 	if (NULL != javaVM->applicationClassLoader) {
 		killRememberedSet(env, javaVM->applicationClassLoader);
 		javaVM->applicationClassLoader->gcRememberedSet = UDATA_MAX;
+	}
+
+	if (NULL != javaVM->extensionClassLoader) {
+		killRememberedSet(env, javaVM->extensionClassLoader);
+		javaVM->extensionClassLoader->gcRememberedSet = UDATA_MAX;
 	}
 }

--- a/runtime/gc_vlhgc/ClassLoaderRememberedSet.hpp
+++ b/runtime/gc_vlhgc/ClassLoaderRememberedSet.hpp
@@ -51,20 +51,20 @@ private:
 	UDATA const _bitVectorSize; /**< The size of each bit vector in UDATAs */
 	J9Pool *_bitVectorPool; /**< A pool of bit vectors to associate with J9ClassLoaders */
 	MM_LightweightNonReentrantLock _lock; /**< A lock to protect _bitVectorPool */
-	UDATA * _bitsToClear; /**< A bit vector which is built up before a garbage collection */
+	UDATA *_bitsToClear; /**< A bit vector which is built up before a garbage collection */
 	
 private:
-	MM_ClassLoaderRememberedSet(MM_EnvironmentBase* env);
+	MM_ClassLoaderRememberedSet(MM_EnvironmentBase *env);
 	
 	/**
 	 * Allocation helper for J9Pool.
 	 */
-	static void * poolAllocateHelper(void* userData, U_32 size, const char* callSite, U_32 memoryCategory, U_32 type, U_32* doInit);
+	static void *poolAllocateHelper(void *userData, U_32 size, const char *callSite, U_32 memoryCategory, U_32 type, U_32 *doInit);
 
 	/**
 	 * Deallocation helper for J9Pool.
 	 */
-	static void poolFreeHelper(void* userData, void* address, U_32 type);
+	static void poolFreeHelper(void *userData, void *address, U_32 type);
 	
 	/**
 	 * Upgrade the specified class loader from a single remembered region to a full bit vector.
@@ -72,7 +72,7 @@ private:
 	 * @param env[in] the current thread
 	 * @param gcRememberedSetAddress[in/out] an address of gcRememberedSet slot
 	 */
-	void installBitVector(MM_EnvironmentBase* env, volatile UDATA *gcRememberedSetAddress);
+	void installBitVector(MM_EnvironmentBase *env, volatile UDATA *gcRememberedSetAddress);
 	
 	/**
 	 * Atomically set the specified bit in the specified bit vector.
@@ -80,7 +80,7 @@ private:
 	 * @param bitVector[in] the bitVector to modify
 	 * @param bit the index of the bit to set
 	 */
-	void setBit(MM_EnvironmentBase* env, volatile UDATA* bitVector, UDATA bit);
+	void setBit(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit);
 	
 	/**
 	 * Determine if the specified gcRememberedSet field value represents an overflowed set.
@@ -118,7 +118,7 @@ private:
 	 * @param bit the index of the bit to test
 	 * @return true if the bit is set, false otherwise 
 	 */
-	bool isBitSet(MM_EnvironmentBase* env, volatile UDATA* bitVector, UDATA bit);
+	bool isBitSet(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit);
 	
 	/**
 	 * Implementation helper for rememberInstance() based on region index.
@@ -127,7 +127,7 @@ private:
 	 * @param regionIndex[in] the region index to remember
 	 * @param gcRememberedSetAddress[in/out] an address of gcRememberedSet slot
 	 */
-	void rememberRegionInternal(MM_EnvironmentBase* env, UDATA regionIndex, volatile UDATA *gcRememberedSetAddress);
+	void rememberRegionInternal(MM_EnvironmentBase *env, UDATA regionIndex, volatile UDATA *gcRememberedSetAddress);
 
 	/**
 	 * Implementation helper for isRemembered().
@@ -164,18 +164,18 @@ private:
 
 protected:
 public:
-	static MM_ClassLoaderRememberedSet *newInstance(MM_EnvironmentBase* env);
+	static MM_ClassLoaderRememberedSet *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
 
 	/*
 	 * Initialize ClassLoaderRememberedSet
 	 */
-	bool initialize(MM_EnvironmentBase* env);
+	bool initialize(MM_EnvironmentBase *env);
 
 	/*
 	 * Teardown ClassLoaderRememberedSet
 	 */	
-	virtual void tearDown(MM_EnvironmentBase* env);
+	virtual void tearDown(MM_EnvironmentBase *env);
 
 	/**
 	 * Update the remembered set data for the specified object's class loader to record the object.
@@ -185,7 +185,7 @@ public:
 	 * @param env[in] the current thread
 	 * @param object[in] the object to remember
 	 */
-	void rememberInstance(MM_EnvironmentBase* env, J9Object* object);
+	void rememberInstance(MM_EnvironmentBase *env, J9Object *object);
 
 	/**
 	 * Determine if there are any instances of classes defined by specified class loader.
@@ -210,7 +210,7 @@ public:
 	 * @param object[in] the object to test
 	 * @return true if the object is properly remembered  
 	 */
-	bool isInstanceRemembered(MM_EnvironmentBase *env, J9Object* object);
+	bool isInstanceRemembered(MM_EnvironmentBase *env, J9Object *object);
 	
 	/**
 	 * Delete any resources associated with the remembered set for the specified class loader.

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -195,7 +195,7 @@ MM_ParallelGlobalMarkTask::cleanup(MM_EnvironmentBase *envBase)
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats.merge(&env->_markVLHGCStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.merge(&env->_workPacketStats);
 
-	if(!env->isMainThread()) {
+	if (!env->isMainThread()) {
 		env->_cycleState = NULL;
 	}
 
@@ -418,7 +418,7 @@ bool
 MM_GlobalMarkingScheme::isMarked(J9Object *objectPtr)
 {
 	bool shouldCheck = isHeapObject(objectPtr);
-	if(shouldCheck) {
+	if (shouldCheck) {
 		return _markMap->isBitSet(objectPtr);
 	}
 
@@ -435,7 +435,7 @@ MM_GlobalMarkingScheme::markObjectNoCheck(MM_EnvironmentVLHGC *env, J9Object *ob
 	}
 
 	/* mark successful - Attempt to add to the work stack */
-	if(!leafType) {
+	if (!leafType) {
 		env->_workStack.push(env, objectPtr);
 	}
 
@@ -480,7 +480,7 @@ MM_GlobalMarkingScheme::markObjectClass(MM_EnvironmentVLHGC *env, J9Object *obje
 {
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	_extensions->classLoaderRememberedSet->rememberInstance(env, objectPtr);
-	if(isDynamicClassUnloadingEnabled()) {
+	if (isDynamicClassUnloadingEnabled()) {
 		j9object_t classObject = (j9object_t)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->classObject;
 		Assert_MM_true(J9_INVALID_OBJECT != classObject);
 		markObjectNoCheck(env, classObject, false);
@@ -549,7 +549,7 @@ MM_GlobalMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obje
 
 	while (scanPtr < endScanPtr) {
 		/* Determine if the slot should be processed */
-		if(descriptionBits & 1) {
+		if (descriptionBits & 1) {
 			/* As this function can be invoked during concurrent mark the slot is
 			 * volatile so we must ensure that the compiler generates the correct
 			 * code if markObject() is inlined.
@@ -650,7 +650,7 @@ MM_GlobalMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Obj
 	leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-	if(((UDATA)descriptionPtr) & 1) {
+	if (((UDATA)descriptionPtr) & 1) {
 		descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits = ((UDATA)leafPtr) >> 1;
@@ -664,7 +664,7 @@ MM_GlobalMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Obj
 	descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
 	bool const compressed = env->compressObjectReferences();
-	while(scanPtr < endScanPtr) {
+	while (scanPtr < endScanPtr) {
 		/* Determine if the slot should be processed */
 		if ((descriptionBits & 1) && ((scanPtr != referentPtr.readAddressFromSlot()) || referentMustBeMarked)) {
 			/* As this function can be invoked during concurrent mark the slot is
@@ -687,7 +687,7 @@ MM_GlobalMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Obj
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-		if(descriptionIndex-- == 0) {
+		if (descriptionIndex-- == 0) {
 			descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = *leafPtr++;
@@ -748,7 +748,7 @@ MM_GlobalMarkingScheme::scanPointerArrayObject(MM_EnvironmentVLHGC *env, J9Index
 {
 	UDATA bytesScanned = 0;
 	UDATA workItem = (UDATA)env->_workStack.peek(env);
-	if( PACKET_ARRAY_SPLIT_TAG == (workItem & PACKET_ARRAY_SPLIT_TAG) ) {
+	if ( PACKET_ARRAY_SPLIT_TAG == (workItem & PACKET_ARRAY_SPLIT_TAG) ) {
 		env->_workStack.pop(env);
 		UDATA index = workItem >> PACKET_ARRAY_SPLIT_SHIFT;
 		bytesScanned = scanPointerArrayObjectSplit(env, objectPtr, index, reason);
@@ -916,11 +916,14 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 void
 MM_GlobalMarkingScheme::scanClassLoaderSlots(MM_EnvironmentVLHGC *env, J9ClassLoader *classLoader, ScanReason reason)
 {
-	if(NULL != classLoader){
+	if (NULL != classLoader){
 		/* This method should only be necessary for the system class loader and application class loader since they may not
 		 * necessarily have a class loader object but still need to keep their loaded classes alive
 		 */
-		Assert_MM_true((classLoader == _javaVM->systemClassLoader) || (classLoader == _javaVM->applicationClassLoader));
+		Assert_MM_true((classLoader == _javaVM->systemClassLoader)
+				|| (classLoader == _javaVM->applicationClassLoader)
+				|| (classLoader == _javaVM->extensionClassLoader));
+
 		if (NULL != classLoader->classLoaderObject) {
 			markObject(env, classLoader->classLoaderObject);
 		} else {
@@ -1174,7 +1177,7 @@ private:
 	}
 
 	virtual void doClassLoader(J9ClassLoader *classLoader) {
-		if(0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
+		if (0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
 			_markingScheme->markObject((MM_EnvironmentVLHGC *)_env, classLoader->classLoaderObject);
 		}
 	}
@@ -1209,7 +1212,7 @@ public:
 #endif /* J9VM_GC_FINALIZATION */
 		scanJNIGlobalReferences(env);
 
-		if(_stringTableAsRoot){
+		if (_stringTableAsRoot){
 			scanStringTable(env);
 		}
 	}
@@ -1324,7 +1327,7 @@ private:
 	virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator) {
 		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCandidates += 1;
-		if(!_markingScheme->isMarked((J9Object *)monitor->userData)) {
+		if (!_markingScheme->isMarked((J9Object *)monitor->userData)) {
 			monitorReferenceIterator->removeSlot();
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCleared += 1;
 			/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
@@ -1343,7 +1346,7 @@ private:
 
 	virtual void doJNIWeakGlobalReference(J9Object **slotPtr) {
 		J9Object *objectPtr = *slotPtr;
-		if(objectPtr && !_markingScheme->isMarked(objectPtr)) {
+		if (objectPtr && !_markingScheme->isMarked(objectPtr)) {
 			*slotPtr = NULL;
 		}
 	}
@@ -1351,7 +1354,7 @@ private:
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	virtual void doRememberedSetSlot(J9Object **slotPtr, GC_RememberedSetSlotIterator *rememberedSetSlotIterator) {
 		J9Object *objectPtr = *slotPtr;
-		if( (objectPtr == NULL) || !_markingScheme->isMarked(objectPtr)) {
+		if ( (objectPtr == NULL) || !_markingScheme->isMarked(objectPtr)) {
 			rememberedSetSlotIterator->removeSlot();
 		}
 	}
@@ -1359,7 +1362,7 @@ private:
 
 	virtual void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator) {
 		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._stringConstantsCandidates += 1;
-		if(!_markingScheme->isMarked(*slotPtr)) {
+		if (!_markingScheme->isMarked(*slotPtr)) {
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._stringConstantsCleared += 1;
 			stringTableIterator->removeSlot();
 		}
@@ -1381,7 +1384,7 @@ private:
 	 */
 	virtual void doStringCacheTableSlot(J9Object **slotPtr) {
 		J9Object *objectPtr = *slotPtr;
-		if((NULL != objectPtr) && (!_markingScheme->isMarked(*slotPtr))) {
+		if ((NULL != objectPtr) && (!_markingScheme->isMarked(*slotPtr))) {
 			*slotPtr = NULL;
 		}	
 	}
@@ -1394,7 +1397,7 @@ private:
 
 #if defined(J9VM_OPT_JVMTI)
 	virtual void doJVMTIObjectTagSlot(J9Object **slotPtr, GC_JVMTIObjectTagTableIterator *objectTagTableIterator) {
-		if(!_markingScheme->isMarked(*slotPtr)) {
+		if (!_markingScheme->isMarked(*slotPtr)) {
 			objectTagTableIterator->removeSlot();
 		}
 	}
@@ -1417,9 +1420,9 @@ MM_GlobalMarkingScheme::cleanCardTableForGlobalCollect(MM_EnvironmentVLHGC *env,
 
 	GC_HeapRegionIterator regionIterator(_heapRegionManager);
 	MM_HeapRegionDescriptor *region = NULL;
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->containsObjects()) {
-			if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 				_extensions->cardTable->cleanCardsInRegion(env, cardCleaner, region);
 			}
 		}
@@ -1435,9 +1438,9 @@ MM_GlobalMarkingScheme::initializeMarkMap(MM_EnvironmentVLHGC *env)
 {
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_extensions->getHeap()->getHeapRegionManager());
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->isCommitted()) {
-			if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 				if (region->_nextMarkMapCleared) {
 					region->_nextMarkMapCleared = false;
 					if (_extensions->tarokEnableExpensiveAssertions) {
@@ -1482,7 +1485,7 @@ void
 MM_GlobalMarkingScheme::markLiveObjectsRoots(MM_EnvironmentVLHGC *env)
 {
 	/* cleaning cards is now considered a root marking operation */
-	switch(env->_cycleState->_collectionType) {
+	switch (env->_cycleState->_collectionType) {
 	case MM_CycleState::CT_GLOBAL_MARK_PHASE:
 	{
 		if (0 == env->_cycleState->_currentIncrement) {
@@ -1514,14 +1517,15 @@ MM_GlobalMarkingScheme::markLiveObjectsRoots(MM_EnvironmentVLHGC *env)
 		
 	/* Mark root set classes */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	if(isDynamicClassUnloadingEnabled()) {
+	if (isDynamicClassUnloadingEnabled()) {
 		/* TODO: This code belongs somewhere else? */
 		/* Setting the permanent class loaders to scanned without a locked operation is safe
 		 * Class loaders will not be rescanned until a thread synchronize is executed
 		 */
-		if(env->isMainThread()) {
+		if (env->isMainThread()) {
 			scanClassLoaderSlots(env, _javaVM->systemClassLoader);
 			scanClassLoaderSlots(env, _javaVM->applicationClassLoader);
+			scanClassLoaderSlots(env, _javaVM->extensionClassLoader);
 		}
 	}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -1552,7 +1556,7 @@ MM_GlobalMarkingScheme::markLiveObjectsComplete(MM_EnvironmentVLHGC *env)
 		env->_cycleState->_referenceObjectOptions |= MM_CycleState::references_clear_weak;
 		MM_HeapRegionDescriptorVLHGC *region = NULL;
 		GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
-		while(NULL != (region = regionIterator.nextRegion())) {
+		while (NULL != (region = regionIterator.nextRegion())) {
 			if (region->containsObjects()) {
 				region->getReferenceObjectList()->startSoftReferenceProcessing();
 				region->getReferenceObjectList()->startWeakReferenceProcessing();
@@ -1694,10 +1698,10 @@ MM_GlobalMarkingScheme::scanSoftReferenceObjects(MM_EnvironmentVLHGC *env)
 
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->containsObjects()) {
 			if (!region->getReferenceObjectList()->wasSoftListEmpty()) {
-				if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+				if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 					processReferenceList(env, region->getReferenceObjectList()->getPriorSoftList(), &env->_markVLHGCStats._softReferenceStats);
 				}
 			}
@@ -1716,7 +1720,7 @@ MM_GlobalMarkingScheme::scanPhantomReferenceObjects(MM_EnvironmentVLHGC *env)
 	if (env->_currentTask->synchronizeGCThreadsAndReleaseSingleThread(env, UNIQUE_ID)) {
 		MM_HeapRegionDescriptorVLHGC *region = NULL;
 		GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
-		while(NULL != (region = regionIterator.nextRegion())) {
+		while (NULL != (region = regionIterator.nextRegion())) {
 			if (region->containsObjects()) {
 				region->getReferenceObjectList()->startPhantomReferenceProcessing();
 			}
@@ -1726,10 +1730,10 @@ MM_GlobalMarkingScheme::scanPhantomReferenceObjects(MM_EnvironmentVLHGC *env)
 	
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->containsObjects()) {
 			if (!region->getReferenceObjectList()->wasPhantomListEmpty()) {
-				if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+				if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 					processReferenceList(env, region->getReferenceObjectList()->getPriorPhantomList(), &env->_markVLHGCStats._phantomReferenceStats);
 				}
 			}

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -114,7 +114,7 @@ MM_ParallelWriteOnceCompactTask::cleanup(MM_EnvironmentBase *envBase)
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._compactStats.merge(&env->_compactVLHGCStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._irrsStats.merge(&env->_irrsStats);
 
-	if(!env->isMainThread()) {
+	if (!env->isMainThread()) {
 		env->_cycleState = NULL;
 	}
 
@@ -462,7 +462,7 @@ MM_WriteOnceCompactor::initRegionCompactDataForCompactSet(MM_EnvironmentVLHGC *e
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			void *lowAddress = region->getLowAddress();
 			region->_compactData._compactDestination = NULL;
@@ -1549,12 +1549,12 @@ MM_WriteOnceCompactor::flushRememberedSetIntoCardTable(MM_EnvironmentVLHGC *env)
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		if (NULL != region->getMemoryPool()) {
-			if(region->_compactData._shouldCompact) {
-				if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+			if (region->_compactData._shouldCompact) {
+				if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 					Assert_MM_true(region->getRememberedSetCardList()->isAccurate());
 					UDATA card = 0;
 					GC_RememberedSetCardListCardIterator rsclCardIterator(region->getRememberedSetCardList());
-					while(0 != (card = rsclCardIterator.nextReferencingCard(env))) {
+					while (0 != (card = rsclCardIterator.nextReferencingCard(env))) {
 						/* For Marking purposes we do not need to track references within Collection Set */
 						MM_HeapRegionDescriptorVLHGC *targetRegion = _interRegionRememberedSet->tableDescriptorForRememberedSetCard(card);
 						if ((!targetRegion->_compactData._shouldCompact) && (targetRegion->containsObjects())) {
@@ -1681,7 +1681,7 @@ public:
 		Assert_MM_unreachable();
 	}
 	virtual void scanFinalizableObjects(MM_EnvironmentBase *env) {
-		if(_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
+		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			reportScanningStarted(RootScannerEntity_FinalizableObjects);
 			_compactScheme->fixupFinalizableObjects(MM_EnvironmentVLHGC::getEnvironment(env));
 			reportScanningEnded(RootScannerEntity_FinalizableObjects);
@@ -1701,7 +1701,7 @@ MM_WriteOnceCompactor::fixupRoots(MM_EnvironmentVLHGC *env)
 	 */
 	GC_ClassLoaderIterator classLoaderIterator(_javaVM->classLoaderBlocks);
 	J9ClassLoader *classLoader = NULL;
-	while((classLoader = classLoaderIterator.nextSlot()) != NULL) {
+	while ((classLoader = classLoaderIterator.nextSlot()) != NULL) {
 		if (0 == (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
 			/* TODO: we could optimize this by only examining class loaders in fixup regions */
 			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
@@ -1717,7 +1717,9 @@ MM_WriteOnceCompactor::fixupRoots(MM_EnvironmentVLHGC *env)
 					}
 				} else { 
 					/* Only system/app classloaders can have a null classloader object (only during early bootstrap) */
-					Assert_MM_true((classLoader == _javaVM->systemClassLoader) || (classLoader == _javaVM->applicationClassLoader));
+					Assert_MM_true((classLoader == _javaVM->systemClassLoader)
+							|| (classLoader == _javaVM->applicationClassLoader)
+							|| (classLoader == _javaVM->extensionClassLoader));
 				}
 			}
 		}
@@ -1823,7 +1825,7 @@ public:
 
 	virtual void doClassLoader(J9ClassLoader *classLoader)
 	{
-		if(J9_GC_CLASS_LOADER_DEAD != (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
+		if (J9_GC_CLASS_LOADER_DEAD != (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
 			doSlot(&classLoader->classLoaderObject);
 		}
 	}
@@ -1877,7 +1879,7 @@ MM_WriteOnceCompactor::verifyHeap(MM_EnvironmentVLHGC *env, bool beforeCompactio
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		void *lowAddress = region->getLowAddress();
 		void *highAddress = region->getHighAddress();
 		MM_HeapMapIterator markedObjectIterator(_extensions,
@@ -1919,7 +1921,7 @@ MM_WriteOnceCompactor::recycleFreeRegionsAndFixFreeLists(MM_EnvironmentVLHGC *en
 	/* try walking the regions and recycling any regions with free pools */
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			MM_MemoryPool *regionPool = region->getMemoryPool();
 			Assert_MM_true(NULL != regionPool);
@@ -1964,7 +1966,7 @@ MM_WriteOnceCompactor::fixupArrayletLeafRegionSpinePointers()
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		J9IndexableObject *spine = region->_allocateData.getSpine();
 		
 		if (NULL != spine) {
@@ -1979,7 +1981,7 @@ MM_WriteOnceCompactor::fixupArrayletLeafRegionSpinePointers()
 				 * this method) so we can't assert anything about the state of the previous region.
 				 */
 				Assert_MM_true( newSpineRegion->containsObjects() );
-				if(spineRegion != newSpineRegion) {
+				if (spineRegion != newSpineRegion) {
 					/* we need to move the leaf to another region's leaf list since its spine has moved */
 					region->_allocateData.removeFromArrayletLeafList();
 					region->_allocateData.addToArrayletLeafList(newSpineRegion);
@@ -1997,7 +1999,7 @@ MM_WriteOnceCompactor::fixupArrayletLeafRegionContentsAndObjectLists(MM_Environm
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldFixup) {  
 			Assert_MM_true(region->isArrayletLeaf());
 			J9Object* spineObject = (J9Object*)region->_allocateData.getSpine();
@@ -2073,7 +2075,7 @@ MM_WriteOnceCompactor::clearMarkMapCompactSet(MM_EnvironmentVLHGC *env, MM_MarkM
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 				markMap->setBitsForRegion(env, region, true);
@@ -2090,7 +2092,7 @@ MM_WriteOnceCompactor::planCompaction(MM_EnvironmentVLHGC *env, UDATA *objectCou
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 				Assert_MM_true(0 == region->_criticalRegionsInUse);
@@ -2384,7 +2386,7 @@ MM_WriteOnceCompactor::setupMoveWorkStack(MM_EnvironmentVLHGC *env)
 	_moveFinished = false;
 	_rebuildFinished = false;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			if (NULL == endOfQueue) {
 				endOfQueue = region;
@@ -2419,7 +2421,7 @@ MM_WriteOnceCompactor::popWork(MM_EnvironmentVLHGC *env)
 				MM_HeapRegionDescriptorVLHGC *region = NULL;
 				GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 				UDATA compactRegions = 0;
-				while(NULL != (region = regionIterator.nextRegion())) {
+				while (NULL != (region = regionIterator.nextRegion())) {
 					if (region->_compactData._shouldCompact) {
 						compactRegions += 1;
 					}
@@ -2523,7 +2525,7 @@ MM_WriteOnceCompactor::popRebuildWork(MM_EnvironmentVLHGC *env)
 				/* ensure that none of the regions in the compact set are still in a work list and that no regions are blocked */
 				MM_HeapRegionDescriptorVLHGC *region = NULL;
 				GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-				while(NULL != (region = regionIterator.nextRegion())) {
+				while (NULL != (region = regionIterator.nextRegion())) {
 					if (region->_compactData._shouldCompact) {
 						Assert_MM_true(NULL == region->_compactData._nextInWorkList);
 						Assert_MM_true(NULL == region->_compactData._blockedList);
@@ -2786,15 +2788,15 @@ MM_WriteOnceCompactor::rememberClassLoaders(MM_EnvironmentVLHGC *env)
 	if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		GC_ClassLoaderIterator classLoaderIterator(_javaVM->classLoaderBlocks);
 		J9ClassLoader *classLoader = NULL;
-		while((classLoader = classLoaderIterator.nextSlot()) != NULL) {
-			if(J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
+		while ((classLoader = classLoaderIterator.nextSlot()) != NULL) {
+			if (J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
 				/* Anonymous classloader should be scanned on level of classes */
 				GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 				J9MemorySegment *segment = NULL;
-				while(NULL != (segment = segmentIterator.nextSegment())) {
+				while (NULL != (segment = segmentIterator.nextSegment())) {
 					GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 					J9Class *clazz = NULL;
-					while(NULL != (clazz = classHeapIterator.nextClass())) {
+					while (NULL != (clazz = classHeapIterator.nextClass())) {
 						Assert_MM_true(!J9_ARE_ANY_BITS_SET(clazz->classDepthAndFlags, J9AccClassDying));
 						Assert_MM_true(!J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(clazz), J9ClassGCScanned));
 						J9Object* classObject = clazz->classObject;
@@ -2827,17 +2829,17 @@ MM_WriteOnceCompactor::rebuildNextMarkMapFromClassLoaders(MM_EnvironmentVLHGC *e
 	if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		GC_ClassLoaderIterator classLoaderIterator(_javaVM->classLoaderBlocks);
 		J9ClassLoader *classLoader = NULL;
-		while((classLoader = classLoaderIterator.nextSlot()) != NULL) {
-			if(J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
+		while ((classLoader = classLoaderIterator.nextSlot()) != NULL) {
+			if (J9_ARE_ANY_BITS_SET(classLoader->flags, J9CLASSLOADER_ANON_CLASS_LOADER)) {
 				/* Anonymous classloader should be scanned on level of classes */
 				GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 				J9MemorySegment *segment = NULL;
-				while(NULL != (segment = segmentIterator.nextSegment())) {
+				while (NULL != (segment = segmentIterator.nextSegment())) {
 					GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 					J9Class *clazz = NULL;
-					while(NULL != (clazz = classHeapIterator.nextClass())) {
+					while (NULL != (clazz = classHeapIterator.nextClass())) {
 						Assert_MM_true(!J9_ARE_ANY_BITS_SET(clazz->classDepthAndFlags, J9AccClassDying));
-						if(J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(clazz), J9ClassGCScanned)) {
+						if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(clazz), J9ClassGCScanned)) {
 							J9Object* classObject = clazz->classObject;
 							Assert_MM_true(NULL != classObject);
 							_nextMarkMap->atomicSetBit(classObject);
@@ -2869,7 +2871,7 @@ MM_WriteOnceCompactor::clearClassLoaderRememberedSetsForCompactSet(MM_Environmen
 	classLoaderRememberedSet->resetRegionsToClear(env);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->_compactData._shouldCompact) {
 			classLoaderRememberedSet->prepareToClearRememberedSetForRegion(env, region);
 		}


### PR DESCRIPTION
Extension Cladss Loader can not be unloaded and can be treated as a permanent root the same way as System and Application Class Loaders.