### PR TITLE
Exclude JLM_Tests for FIPS

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -62,6 +62,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_interface</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -133,6 +140,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_class</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -196,6 +210,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_IBMinternal</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -228,6 +249,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testSoftMxLocal</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode119</variation>
@@ -1318,6 +1346,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test>
 		<testCaseName>testCRaCMXBean</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- exclude `JLM_Tests_interface`, `JLM_Tests_IBMinternal`, `testCRaCMXBean`,`JLM_Tests_class`,`testSoftMxLocal` for FIPS.

related:[github_ibm/runtimes/backlog/issues/1371](https://github.ibm.com/runtimes/backlog/issues/1371)