### PR TITLE
Refactor SFFF for InterpreterEmulator and record/replay InterpreterEmulator constants

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -205,7 +205,8 @@ J9::Compilation::Compilation(int32_t id,
    _serializationRecords(decltype(_serializationRecords)::allocator_type(heapMemoryRegion)),
    _thunkRecords(decltype(_thunkRecords)::allocator_type(heapMemoryRegion)),
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   _osrProhibitedOverRangeOfTrees(false)
+   _osrProhibitedOverRangeOfTrees(false),
+   _wasFearPointAnalysisDone(false)
    {
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
@@ -1576,6 +1577,15 @@ bool
 J9::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
    {
    return self()->getOption(TR_EnableFieldWatch);
+   }
+
+bool
+J9::Compilation::canAddOSRAssumptions()
+   {
+   return self()->supportsInduceOSR()
+      && self()->isOSRTransitionTarget(TR::postExecutionOSR)
+      && self()->getOSRMode() == TR::voluntaryOSR
+      && !self()->wasFearPointAnalysisDone();
    }
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -409,6 +409,21 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
     */
    bool canAddOSRAssumptions();
 
+   /**
+    * \brief Determine whether fear points may be placed (almost) anywhere.
+    *
+    * If the result is true, then prior to fear point analysis, the compiler
+    * must ensure that OSR induction remains possible at every OSR yield point.
+    * As such, fear points may be placed almost anywhere in the method.
+    *
+    * \warning This does not allow fear points to be placed on the taken side
+    * of a guard (except after an OSR yield point, e.g. a cold call). That
+    * restriction is due to a limitation of the fear point analysis.
+    *
+    * \return true if fear points may be placed (almost) anywhere
+    */
+   bool isFearPointPlacementUnrestricted() { return false; }
+
    // Flag to record whether fear-point analysis has already been done.
    void setFearPointAnalysisDone() { _wasFearPointAnalysisDone = true; }
    bool wasFearPointAnalysisDone() { return _wasFearPointAnalysisDone; }

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -395,6 +395,24 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
 
+   /**
+    * \brief Determine whether it's currently expected to be possible to add
+    * OSR assumptions and corresponding fear points somewhere in the method.
+    *
+    * The result is independent of any particular program point. Even if the
+    * result is true, there may still be restrictions on the placement of fear
+    * points. However, if the result is false, then no fear points can be
+    * placed and no new assumptions can be made.
+    *
+    * \param comp the compilation object
+    * \return true if it's possible in general to add assumptions, false otherwise
+    */
+   bool canAddOSRAssumptions();
+
+   // Flag to record whether fear-point analysis has already been done.
+   void setFearPointAnalysisDone() { _wasFearPointAnalysisDone = true; }
+   bool wasFearPointAnalysisDone() { return _wasFearPointAnalysisDone; }
+
    // Flag to record if any optimization has prohibited OSR over a range of trees
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
@@ -530,6 +548,7 @@ private:
 
    TR::SymbolValidationManager *_symbolValidationManager;
    bool _osrProhibitedOverRangeOfTrees;
+   bool _wasFearPointAnalysisDone;
    };
 
 }

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1980,8 +1980,23 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
    TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
    if (resolved && isFinal && type == TR::Address)
       {
-      knownObjectIndex = TR::TransformUtil::knownObjectFromFinalStatic(
-         comp(), owningMethod, cpIndex, dataAddress);
+      TR_OpaqueClassBlock *declaringClass =
+         owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
+
+      TR::Symbol::RecognizedField recField = sym->getRecognizedField();
+      TR_YesNoMaybe canFold =
+         TR::TransformUtil::canFoldStaticFinalField(
+            comp(), declaringClass, recField, owningMethod, cpIndex);
+
+      if (canFold == TR_yes)
+         {
+         TR::AnyConst value = TR::AnyConst::makeAddress(0);
+         bool gotValue = TR::TransformUtil::staticFinalFieldValue(
+            comp(), owningMethod, cpIndex, dataAddress, TR::Address, recField, &value);
+
+         if (gotValue && value.isKnownObject())
+            knownObjectIndex = value.getKnownObjectIndex();
+         }
       }
 
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, knownObjectIndex);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2705,27 +2705,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, knot->getExistingIndexAt(objectPointerReference));
          }
          break;
-      case MessageType::KnownObjectTable_symbolReferenceTableCreateKnownObject:
-         {
-         auto recv = client->getRecvData<void *, TR_ResolvedMethod *, int32_t>();
-         void *dataAddress = std::get<0>(recv);
-         TR_ResolvedMethod *owningMethod = std::get<1>(recv);
-         int32_t cpIndex = std::get<2>(recv);
-
-         TR::KnownObjectTable::Index knotIndex =
-            TR::TransformUtil::knownObjectFromFinalStatic(
-               comp, owningMethod, cpIndex, dataAddress);
-
-         uintptr_t *objectPointerReference = NULL;
-         if (knotIndex != TR::KnownObjectTable::UNKNOWN)
-            {
-            objectPointerReference =
-               comp->getKnownObjectTable()->getPointerLocation(knotIndex);
-            }
-
-         client->write(response, knotIndex, objectPointerReference);
-         }
-         break;
       case MessageType::KnownObjectTable_mutableCallSiteEpoch:
          {
          auto recv = client->getRecvData<uintptr_t*, bool>();

--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -526,10 +526,15 @@ J9::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
 void
 J9::KnownObjectTable::addStableArray(Index index, int32_t stableArrayRank)
    {
-   uintptr_t    object = self()->getPointer(index);
-   TR_J9VMBase *j9fe = (TR_J9VMBase*)self()->fe();
-   J9Class      *clazz  = (J9Class*)j9fe->getObjectClass(object);
-   TR_ASSERT_FATAL((clazz->romClass->modifiers & J9AccClassArray), "addStableArray can only be called for arrays\n");
+   TR_J9VMBase *fej9 = static_cast<TR_J9VMBase*>(fe());
+   TR_OpaqueClassBlock *clazz =
+      fej9->getObjectClassFromKnownObjectIndex(comp(), index);
+
+   // Null is only possible on failure to get VM access. Most of the time we
+   // should find the class successfully anyway, so check only in that case.
+   TR_ASSERT_FATAL(
+      clazz == NULL || fej9->isClassArray(clazz),
+      "addStableArray can only be called for arrays");
 
    if (_stableArrayRanks[index] < stableArrayRank)
       {

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -344,9 +344,6 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
          }
       }
 
-   _staticFieldReferenceEncountered = false;
-   _staticMethodInvokeEncountered = false;
-
    // Allocate zero-length bit vectors before walker so that the bit vectors can grow on the right
    // stack memory region
    //

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -34,8 +34,11 @@
 #include "ilgen/IlGen.hpp"
 #include "infra/Checklist.hpp"
 #include "infra/Link.hpp"
+#include "infra/map.hpp"
+#include "infra/set.hpp"
 #include "infra/Stack.hpp"
 #include "env/VMJ9.h"
+#include "optimizer/CallInfo.hpp"
 
 class TR_InlineBlocks;
 class TR_PersistentClassInfo;
@@ -147,6 +150,11 @@ private:
    bool         runMacro(TR::SymbolReference *);
    bool         runFEMacro(TR::SymbolReference *);
    TR::Node *    genInvoke(TR::SymbolReference *, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver = NULL);
+   TR::Node *    genInvokeInner(
+      TR::SymbolReference *,
+      TR::Node *indirectCallFirstChild,
+      TR::Node *invokedynamicReceiver,
+      TR::KnownObjectTable::Index *requiredKoi);
 
    TR::Node *    genInvokeDirect(TR::SymbolReference *symRef){ return genInvoke(symRef, NULL); }
    TR::Node *    genInvokeWithVFTChild(TR::SymbolReference *);
@@ -374,6 +382,10 @@ private:
 
    bool hasFPU();
 
+   bool pushRequiredConst(TR::KnownObjectTable::Index *koi);
+   void markRequiredKnownObjectIndex(TR::Node *node, TR::KnownObjectTable::Index koi);
+   void assertFoldedAllRequiredConsts();
+
    // data
    //
    TR::SymbolReferenceTable *         _symRefTab;
@@ -424,6 +436,9 @@ private:
    static const int32_t              _numDecFormatRenames = 9;
    static struct methodRenamePair    _decFormatRenames[_numDecFormatRenames];
    TR::SymbolReference               *_decFormatRenamesDstSymRef[_numDecFormatRenames];
+
+   const TR::map<int32_t, TR::RequiredConst> * const _requiredConsts; // from current inline call target
+   TR::set<int32_t>                 *_foldedRequiredConsts; // to make sure none were missed
    };
 
 #endif

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -408,12 +408,6 @@ private:
    TR_BitVector                     *_invokeDynamicCalls;
    TR_BitVector                     *_ilGenMacroInvokeExactCalls;
 
-   // TenantScope field support, set to 'true' if a get/put static is encountered
-   // when option TR_DisableMultiTenancy is on and current method contains static
-   // field and method reference/invoke, skip compilation for such method
-   bool                              _staticFieldReferenceEncountered;
-   bool                              _staticMethodInvokeEncountered;
-
    TR_OpaqueClassBlock              *_invokeSpecialInterface;
    TR_BitVector                     *_invokeSpecialInterfaceCalls;
    bool                              _invokeSpecialSeen;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2809,8 +2809,6 @@ TR_J9ByteCodeIlGenerator::genInvokeStatic(int32_t cpIndex)
    if (comp()->getOption(TR_TraceILGen))
       traceMsg(comp(), "  genInvokeStatic(%d) // %s\n", cpIndex, comp()->getDebug()->getName(methodSymRef));
 
-   _staticMethodInvokeEncountered = true;
-
    if (runMacro(methodSymRef))
       {
       if (comp()->compileRelocatableCode())
@@ -5193,7 +5191,6 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
    if (_generateReadBarriersForFieldWatch && comp()->compileRelocatableCode())
       comp()->failCompilation<J9::AOTNoSupportForAOTFailure>("NO support for AOT in field watch");
 
-   _staticFieldReferenceEncountered = true;
    TR::SymbolReference * symRef = symRefTab()->findOrCreateStaticSymbol(_methodSymbol, cpIndex, false);
    if (comp()->getOption(TR_TraceILGen))
       traceMsg(comp(), "load static symref %d created with knownObjectIndex %d", symRef->getReferenceNumber(), symRef->getKnownObjectIndex());
@@ -7354,7 +7351,6 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
    if (_generateWriteBarriersForFieldWatch && comp()->compileRelocatableCode())
       comp()->failCompilation<J9::AOTNoSupportForAOTFailure>("NO support for AOT in field watch");
 
-   _staticFieldReferenceEncountered = true;
    TR::Node * value = pop();
 
    TR_ResolvedJ9Method * owningMethod = static_cast<TR_ResolvedJ9Method*>(_methodSymbol->getResolvedMethod());

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 59; // ID: h4Ihmr7j+jt8ie/rpCIX
+   static const uint16_t MINOR_NUMBER = 60; // ID: rCSONLnFpNx1aQQmficD
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -250,7 +250,6 @@ const char *messageNames[] =
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
-   "KnownObjectTable_symbolReferenceTableCreateKnownObject",
    "KnownObjectTable_mutableCallSiteEpoch",
    "KnownObjectTable_dereferenceKnownObjectField",
    "KnownObjectTable_dereferenceKnownObjectField2",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -275,7 +275,6 @@ enum MessageType : uint16_t
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
    // for KnownObjectTable outside J9::KnownObjectTable class
-   KnownObjectTable_symbolReferenceTableCreateKnownObject,
    KnownObjectTable_mutableCallSiteEpoch,
    KnownObjectTable_dereferenceKnownObjectField,
    KnownObjectTable_dereferenceKnownObjectField2,

--- a/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
+++ b/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
@@ -186,6 +186,10 @@ void TR_HCRGuardAnalysis::initializeGenAndKillSetInfo()
             }
          else
             {
+            TR_ASSERT_FATAL(
+               !comp()->isFearPointPlacementUnrestricted(),
+               "unexpected uninducible OSR yield point");
+
             isGen = true;
             isKill = false;
             }

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -257,6 +257,27 @@ void InterpreterEmulator::mergeOperandArray(OperandArray *first, OperandArray *s
       }
    }
 
+/**
+ * \brief Add a required constant with \p value at the current bytecode index.
+ *
+ * There must not already be one.
+ *
+ * \param value the constant value
+ * \return a reference to the created TR::RequiredConst
+ */
+TR::RequiredConst &
+InterpreterEmulator::addRequiredConst(TR::AnyConst value)
+   {
+   TR::Region &stackRegion = comp()->trMemory()->currentStackRegion();
+   auto insertResult = _calltarget->_requiredConsts.insert(
+      std::make_pair(_bcIndex, TR::RequiredConst(value, stackRegion)));
+
+   auto it = insertResult.first;
+   bool isNewEntry = insertResult.second;
+   TR_ASSERT_FATAL(isNewEntry, "multiple required consts at bcIndex %d", _bcIndex);
+   return it->second; // value
+   }
+
 void
 InterpreterEmulator::maintainStackForIf(TR_J9ByteCode bc)
    {
@@ -410,6 +431,12 @@ InterpreterEmulator::maintainStackForGetField()
             debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
                   newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
                   fieldOffset, baseObjectIndex, baseObjectAddress);
+
+            if (resultIndex != TR::KnownObjectTable::UNKNOWN)
+               {
+               auto value = TR::AnyConst::makeKnownObject(resultIndex);
+               addRequiredConst(value);
+               }
             }
          }
       }
@@ -766,7 +793,10 @@ InterpreterEmulator::maintainStackForGetStatic()
          comp(), owningMethod, cpIndex, dataAddress, TR::Address, recField, &value);
 
       if (gotValue && value.isKnownObject())
+         {
          knownObjectIndex = value.getKnownObjectIndex();
+         addRequiredConst(value);
+         }
       }
 
    if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
@@ -1082,6 +1112,35 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
       default:
          break;
       }
+
+   if (result != NULL)
+      {
+      if (result->asIconst() != NULL)
+         {
+         auto value = TR::AnyConst::makeInt32(result->asIconst()->intValue);
+         addRequiredConst(value);
+         }
+      else if (result->asKnownObject() != NULL)
+         {
+         auto i = result->asKnownObject()->getKnownObjectIndex();
+         auto value = TR::AnyConst::makeKnownObject(i);
+         addRequiredConst(value);
+         }
+      else if (result->asMutableCallsiteTargetOperand() != NULL)
+         {
+         // These are handled differently, so nothing to do here.
+         }
+      else
+         {
+         TR::StringBuf buf(comp()->trMemory()->currentStackRegion());
+         result->printToString(&buf);
+         TR_ASSERT_FATAL(
+            false,
+            "failed to record required constant call result: %s",
+            buf.text());
+         }
+      }
+
    return result;
    }
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -437,6 +437,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
        */
       void mergeOperandArray(OperandArray *first, OperandArray *second);
 
+      TR::RequiredConst &addRequiredConst(TR::AnyConst value);
 
       TR_LogTracer *_tracer;
       TR_EstimateCodeSize *_ecs;

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1061,6 +1061,10 @@ static TR_YesNoMaybe safeToAddFearPointAt(TR::Optimization* opt, TR::TreeTop* tt
       return TR_yes;
       }
 
+   TR_ASSERT_FATAL(
+      !comp->isFearPointPlacementUnrestricted(),
+      "unrestricted fear point placement should have prevented prohibition");
+
    // Look for an OSR point dominating tt in block
    TR::Block* block = tt->getEnclosingBlock();
    TR::TreeTop* firstTT = block->getEntry();
@@ -2316,6 +2320,10 @@ void J9::TransformUtil::removePotentialOSRPointHelperCalls(TR::Compilation* comp
  */
 void J9::TransformUtil::prohibitOSROverRange(TR::Compilation* comp, TR::TreeTop* start, TR::TreeTop* end)
    {
+   TR_ASSERT_FATAL(
+      !comp->isFearPointPlacementUnrestricted(),
+      "disallowed attempt to prohibit OSR");
+
    TR_ASSERT(start->getEnclosingBlock() == end->getEnclosingBlock(), "Does not support range across blocks");
    TR_ASSERT(comp->supportsInduceOSR() && comp->isOSRTransitionTarget(TR::postExecutionOSR) && comp->getOSRMode() == TR::voluntaryOSR,
              "prohibitOSROverRange only works in certain modes");

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -27,6 +27,7 @@
 #include "control/CompilationRuntime.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #include "env/CompilerEnv.hpp"
+#include "il/AnyConst.hpp"
 #include "il/Block.hpp"
 #include "il/Block_inlines.hpp"
 #include "il/Node.hpp"
@@ -896,34 +897,34 @@ J9::TransformUtil::foldStaticFinalFieldAssumingProtection(TR::Compilation *comp,
    return false;
    }
 
-/** \brief
- *     Compile time query that answers if a direct load for static can be folded by compiler.
- *
- *  \param comp
- *     The compilation object.
- *
- *  \param node
- *     The node which is a load of a static final field.
- *
- *  \return
- *    True TR_yes if the field is allowlisted and can be folded.
- *    True TR_maybe if the field is a generic static final and can be folded with protection.
- *    True TR_no if the field is cannot be folded due to being unresolved, already been written post initialization, or owning class uninitialized, etc.
- */
 TR_YesNoMaybe
 J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node)
    {
    TR_ASSERT(node->getOpCode().isLoadVarDirect() && node->isLoadOfStaticFinalField(), "Expecting direct load of static final field on %s %p", node->getOpCode().getName(), node);
    TR::SymbolReference *symRef = node->getSymbolReference();
    TR::Symbol           *sym    = node->getSymbol();
-   TR_J9VMBase *fej9 = comp->fej9();
 
    if (symRef->isUnresolved()
        || !sym->isStaticField()
        || !sym->isFinal())
       return TR_no;
 
-   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, symRef->getCPIndex(), true);
+   TR_ResolvedMethod *owningMethod = symRef->getOwningMethod(comp);
+   TR_OpaqueClassBlock* declaringClass = owningMethod->getClassFromFieldOrStatic(comp, symRef->getCPIndex(), true);
+   TR::Symbol::RecognizedField recField = sym->getRecognizedField();
+   return TR::TransformUtil::canFoldStaticFinalField(
+      comp, declaringClass, recField, owningMethod, symRef->getCPIndex());
+   }
+
+TR_YesNoMaybe
+J9::TransformUtil::canFoldStaticFinalField(
+   TR::Compilation *comp,
+   TR_OpaqueClassBlock *declaringClass,
+   TR::Symbol::RecognizedField recField,
+   TR_ResolvedMethod *owningMethod,
+   int32_t cpIndex)
+   {
+   TR_J9VMBase *fej9 = comp->fej9();
 
    // Can't trust final statics unless class init is finished
    //
@@ -938,10 +939,58 @@ J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node
    if (len == 16 && !strncmp(name, "java/lang/System", 16))
       return TR_no;
 
+   // Static initializer can produce different values in different runs
+   // so for AOT we cannot allow this transformation. However for String
+   // we will embed some bits in the aotMethodHeader for this method.
+   // The string compression enabled bit is set in staticFinalFieldValue().
+   if (comp->compileRelocatableCode())
+      {
+      if (recField == TR::Symbol::Java_lang_String_enableCompression)
+         return TR_yes;
+      else
+         return TR_no;
+      }
+
+   // in Java 17 and above, it is not possible to remove the final attribute of a field
+   // to make it writable via reflection.
+#if JAVA_SPEC_VERSION >= 17
+   // In classes with version 53 and later, putstatic can write to static final
+   // fields only during class initialization.
+   //
+   // We can also trust our own JCL classes not to use putstatic to modify
+   // static final fields after initialization.
+   //
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(declaringClass);
+   if (romClass->majorVersion >= 53 || fej9->isClassLibraryClass(declaringClass))
+      {
+      // Both putstatic and reflection have been ruled out, so fields declared
+      // in declaringClass must not be modified. We do not support modifying
+      // them using Unsafe.
+      //
+      // For the time being, limit aggressive folding here to static final
+      // fields with declared type VarHandle.
+      //
+      static const bool disableAggressiveVarHandleSFFF =
+         feGetEnv("TR_disableAggressiveVarHandleSFFF17") != NULL;
+
+      if (!disableAggressiveVarHandleSFFF && cpIndex >= 0)
+         {
+         int32_t len;
+         const char *sig = owningMethod->fieldSignatureChars(cpIndex, len);
+         const char *vhSig = "Ljava/lang/invoke/VarHandle;";
+         if (len == (int32_t)strlen(vhSig) && !strncmp(sig, vhSig, len))
+            return TR_yes;
+         }
+      }
+#endif
+
    if (!comp->getOption(TR_RestrictStaticFieldFolding) ||
-       sym->getRecognizedField() == TR::Symbol::assertionsDisabled ||
+       recField == TR::Symbol::assertionsDisabled ||
        J9::TransformUtil::foldFinalFieldsIn(declaringClass, name, len, true, comp))
       return TR_yes;
+
+   if (TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+      return TR_no;
 
    return TR_maybe;
    }
@@ -1054,8 +1103,7 @@ static TR_YesNoMaybe safeToAddFearPointAt(TR::Optimization* opt, TR::TreeTop* tt
 
 static bool isVarHandleFolding(TR::Compilation* comp, TR_OpaqueClassBlock* declaringClass, char* fieldSignature, int32_t fieldSigLength)
    {
-   if (comp->getMethodSymbol()->hasMethodHandleInvokes()
-       && !TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+   if (comp->getMethodSymbol()->hasMethodHandleInvokes())
       {
       if (fieldSigLength == 28 && !strncmp(fieldSignature, "Ljava/lang/invoke/VarHandle;", 28))
          return true;
@@ -1098,6 +1146,13 @@ bool J9::TransformUtil::attemptGenericStaticFinalFieldFolding(TR::Optimization* 
    return J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(opt, currentTree, node, false);
    }
 
+bool J9::TransformUtil::canDoGuardedStaticFinalFieldFolding(
+   TR::Compilation *comp)
+   {
+   return !comp->getOption(TR_DisableGuardedStaticFinalFieldFolding)
+      && comp->canAddOSRAssumptions();
+   }
+
 /** \brief
  *     Try to fold static final field with protection
  *
@@ -1132,14 +1187,7 @@ bool J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(TR::Optimization* opt
       return false;
       }
 
-   if (comp->getOption(TR_DisableGuardedStaticFinalFieldFolding))
-      {
-      return false;
-      }
-
-   if (!comp->supportsInduceOSR()
-       || !comp->isOSRTransitionTarget(TR::postExecutionOSR)
-       || comp->getOSRMode() != TR::voluntaryOSR)
+   if (!TR::TransformUtil::canDoGuardedStaticFinalFieldFolding(comp))
       {
       return false;
       }
@@ -1147,8 +1195,7 @@ bool J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(TR::Optimization* opt
    int32_t cpIndex = symRef->getCPIndex();
    TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, cpIndex);
    if (J9::TransformUtil::canFoldStaticFinalField(comp, node) != TR_maybe
-       || !declaringClass
-       || TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+       || !declaringClass)
       {
       return false;
       }
@@ -1234,37 +1281,12 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
        || symRef->hasKnownObjectIndex())
       return false;
 
-   // Static initializer can produce different values in different runs
-   // so for AOT we cannot allow this transformation. However for String
-   // we will embed some bits in the aotMethodHeader for this method
-   if (comp->compileRelocatableCode())
-      {
-      if (sym->getRecognizedField() == TR::Symbol::Java_lang_String_enableCompression)
-         {
-         // Add the flags in TR_AOTMethodHeader
-         TR_AOTMethodHeader *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
-         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesEnableStringCompressionFolding;
-         TR_ASSERT(node->getDataType() == TR::Int32, "Java_lang_String_enableCompression must be Int32");
-         bool fieldValue = ((TR_J9VM *) comp->fej9())->dereferenceStaticFinalAddress(sym->castToStaticSymbol()->getStaticAddress(), TR::Int32).dataInt32Bit != 0;
-         bool compressionEnabled = comp->fej9()->isStringCompressionEnabledVM();
-         TR_ASSERT((fieldValue && compressionEnabled) || (!fieldValue && !compressionEnabled),
-            "java/lang/String.enableCompression and javaVM->strCompEnabled must be in sync");
-         if (fieldValue)
-            aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_StringCompressionEnabled;
-         }
-      else
-         {
-         return false;
-         }
-      }
-
    // Note that the load type can differ from the symbol type, eg. Java uses
    // integer loads for the sub-integer types.  The sub-integer types are
    // included below just for completeness, but we likely never hit them.
    //
    TR::DataType loadType = node->getDataType();
    bool typeIsConstible = false;
-   bool symrefIsImprovable  = false;
    switch (loadType)
       {
       case TR::Int8:
@@ -1276,100 +1298,203 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
          typeIsConstible = true;
          break;
       case TR::Address:
-         symrefIsImprovable = !symRef->hasKnownObjectIndex();
          break;
       default:
-         break;
+         return false;
       }
 
+   TR_ResolvedMethod *owningMethod = symRef->getOwningMethod(comp);
    TR::StaticSymbol *staticSym = sym->castToStaticSymbol();
-   TR_StaticFinalData data = ((TR_J9VM *) comp->fej9())->dereferenceStaticFinalAddress(staticSym->getStaticAddress(), loadType);
+   int32_t cpIndex = symRef->getCPIndex();
+   void *staticAddr = staticSym->getStaticAddress();
+   TR::Symbol::RecognizedField recField = sym->getRecognizedField();
+   TR::AnyConst value = TR::AnyConst::makeAddress(0);
+   bool gotValue = TR::TransformUtil::staticFinalFieldValue(
+      comp, owningMethod, cpIndex, staticAddr, loadType, recField, &value);
+
+   if (!gotValue)
+      return false;
+
    if (typeIsConstible)
       {
       if (performTransformation(comp, "O^O foldStaticFinalField: turn [%p] %s %s into load const\n", node, node->getOpCode().getName(), symRef->getName(comp->getDebug())))
          {
-         TR::VMAccessCriticalSection isConsitble(comp->fej9());
          prepareNodeToBeLoadConst(node);
          switch (loadType)
             {
             case TR::Int8:
                TR::Node::recreate(node, TR::bconst);
-               node->setByte(data.dataInt8Bit);
+               node->setByte(value.getInt8());
                break;
             case TR::Int16:
                TR::Node::recreate(node, TR::sconst);
-               node->setShortInt(data.dataInt16Bit);
+               node->setShortInt(value.getInt16());
                break;
             case TR::Int32:
                TR::Node::recreate(node, TR::iconst);
-               node->setInt(data.dataInt32Bit);
+               node->setInt(value.getInt32());
                break;
             case TR::Int64:
                TR::Node::recreate(node, TR::lconst);
-               node->setLongInt(data.dataInt64Bit);
+               node->setLongInt(value.getInt64());
                break;
             case TR::Float:
                TR::Node::recreate(node, TR::fconst);
-               node->setFloat(data.dataFloat);
+               node->setFloat(value.getFloat());
                break;
             case TR::Double:
                TR::Node::recreate(node, TR::dconst);
-               node->setDouble(data.dataDouble);
+               node->setDouble(value.getDouble());
                break;
             default:
-               TR_ASSERT(0, "Unexpected type %s", loadType.toString());
+               TR_ASSERT_FATAL(false, "Unexpected type %s", loadType.toString());
                break;
             }
-         }
-      TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.const/(%s)/%s/(%s)",
-                                                         comp->signature(),
-                                                         comp->getHotnessName(comp->getMethodHotness()),
-                                                         symRef->getName(comp->getDebug())));
-      return true;
-      }
-   else if (data.dataAddress == 0) // Seems ok just to check for a static to be NULL without vm access
-      {
-      switch (staticSym->getRecognizedField())
-         {
-         // J9VMInternals.jitHelpers is initialized after the class has been
-         // initialized via an Unsafe helper - don't fold null in to improve perf
-         case TR::Symbol::Java_lang_J9VMInternals_jitHelpers:
-            return false;
-         default:
-            if (performTransformation(comp, "O^O transformDirectLoad: [%p] field is null - change to aconst NULL\n", node))
-               {
-               prepareNodeToBeLoadConst(node);
-               TR::Node::recreate(node, TR::aconst);
-               node->setAddress(0);
-               node->setIsNull(true);
-               node->setIsNonNull(false);
-               TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.null/(%s)/%s/(%s)", comp->signature(), comp->getHotnessName(comp->getMethodHotness()), symRef->getName(comp->getDebug())));
-               return true;
-               }
-         }
-      }
-   else if (symrefIsImprovable)
-      {
-      uintptr_t *refLocation = (uintptr_t*)staticSym->getStaticAddress();
-      TR::SymbolReference *improvedSymRef = comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(node->getSymbolReference(), refLocation);
-      if (improvedSymRef->hasKnownObjectIndex()
-         && performTransformation(comp, "O^O transformDirectLoad: [%p] use object-specific symref #%d (=obj%d) for %s %s\n",
-            node,
-            improvedSymRef->getReferenceNumber(),
-            improvedSymRef->getKnownObjectIndex(),
-            node->getOpCode().getName(),
-            symRef->getName(comp->getDebug())))
-         {
-         node->setSymbolReference(improvedSymRef);
-         bool isNull = comp->getKnownObjectTable()->isNull(improvedSymRef->getKnownObjectIndex());
-         node->setIsNull(isNull);
-         node->setIsNonNull (!isNull);
-         TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.knownObject/(%s)/%s/(%s)", comp->signature(), comp->getHotnessName(comp->getMethodHotness()), symRef->getName(comp->getDebug())));
+
+         TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.const/(%s)/%s/(%s)",
+                                                            comp->signature(),
+                                                            comp->getHotnessName(comp->getMethodHotness()),
+                                                            symRef->getName(comp->getDebug())));
          return true;
          }
       }
+   else if (value.isAddress() && value.getAddress() == 0)
+      {
+      if (performTransformation(comp, "O^O transformDirectLoad: [%p] field is null - change to aconst NULL\n", node))
+         {
+         prepareNodeToBeLoadConst(node);
+         TR::Node::recreate(node, TR::aconst);
+         node->setAddress(0);
+         TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.null/(%s)/%s/(%s)", comp->signature(), comp->getHotnessName(comp->getMethodHotness()), symRef->getName(comp->getDebug())));
+         return true;
+         }
+      }
+   else if (value.isKnownObject())
+      {
+      TR::KnownObjectTable::Index koi = value.getKnownObjectIndex();
+      if (!performTransformation(comp, "O^O transformDirectLoad: mark n%un [%p] as obj%d\n",
+            node->getGlobalIndex(),
+            node,
+            koi))
+         return false;
+
+      TR::SymbolReference *improvedSymRef =
+         comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(
+            node->getSymbolReference(), koi);
+
+      node->setSymbolReference(improvedSymRef);
+      node->setIsNull(false);
+      node->setIsNonNull(true);
+      TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "foldFinalField.knownObject/(%s)/%s/(%s)", comp->signature(), comp->getHotnessName(comp->getMethodHotness()), symRef->getName(comp->getDebug())));
+      return true;
+      }
 
    return false; // Indicates we did nothing
+   }
+
+bool
+J9::TransformUtil::staticFinalFieldValue(
+   TR::Compilation *comp,
+   TR_ResolvedMethod *owningMethod,
+   int32_t cpIndex,
+   void *staticAddr,
+   TR::DataType loadType,
+   TR::Symbol::RecognizedField recField,
+   TR::AnyConst *outValue)
+   {
+   TR_J9VM *fej9 = (TR_J9VM *)comp->fej9();
+   TR_StaticFinalData data = fej9->dereferenceStaticFinalAddress(staticAddr, loadType);
+
+   if (comp->compileRelocatableCode())
+      {
+      TR_ASSERT_FATAL(
+         recField == TR::Symbol::Java_lang_String_enableCompression,
+         "folding unexpected static final in AOT");
+
+      // Add the flags in TR_AOTMethodHeader
+      TR_AOTMethodHeader *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
+      aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesEnableStringCompressionFolding;
+      TR_ASSERT_FATAL(loadType == TR::Int32, "Java_lang_String_enableCompression must be Int32");
+      bool fieldValue = data.dataInt32Bit != 0;
+      bool compressionEnabled = comp->fej9()->isStringCompressionEnabledVM();
+      TR_ASSERT_FATAL(
+         fieldValue == compressionEnabled,
+         "java/lang/String.enableCompression and javaVM->strCompEnabled must be in sync");
+      if (fieldValue)
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_StringCompressionEnabled;
+      }
+
+   switch (loadType)
+      {
+      case TR::Int8:
+         *outValue = TR::AnyConst::makeInt8(data.dataInt8Bit);
+         return true;
+
+      case TR::Int16:
+         *outValue = TR::AnyConst::makeInt16(data.dataInt16Bit);
+         return true;
+
+      case TR::Int32:
+         *outValue = TR::AnyConst::makeInt32(data.dataInt32Bit);
+         return true;
+
+      case TR::Int64:
+         *outValue = TR::AnyConst::makeInt64(data.dataInt64Bit);
+         return true;
+
+      case TR::Float:
+         *outValue = TR::AnyConst::makeFloat(data.dataFloat);
+         return true;
+
+      case TR::Double:
+         *outValue = TR::AnyConst::makeDouble(data.dataDouble);
+         return true;
+
+      case TR::Address:
+         // address logic follows
+         break;
+
+      default:
+         return false;
+      }
+
+   if (data.dataAddress == 0)
+      {
+      // J9VMInternals.jitHelpers is initialized after the class has been
+      // initialized via an Unsafe helper - don't fold null in to improve perf
+      if (recField == TR::Symbol::Java_lang_J9VMInternals_jitHelpers)
+         return false;
+
+      *outValue = TR::AnyConst::makeAddress(0);
+      return true;
+      }
+
+   // The value is a known object.
+   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
+   if (knot == NULL)
+      return false;
+
+   uintptr_t *refLocation = (uintptr_t*)staticAddr;
+   TR::KnownObjectTable::Index koi = knot->getOrCreateIndexAt(refLocation);
+   if (koi == TR::KnownObjectTable::UNKNOWN)
+      return false;
+
+   // It's possible to get the null index if the field was mutated between
+   // dereferenceStaticFinalAddress() and getOrCreateIndexAt(). This will be
+   // exceedingly rare for any field that should be folded. In this case, just
+   // give up to avoid setting *outValue to the null index.
+   if (knot->isNull(koi))
+      return false;
+
+   if (cpIndex >= 0)
+      {
+      int32_t stableArrayRank = isArrayWithStableElements(cpIndex, owningMethod, comp);
+      if (stableArrayRank > 0)
+         knot->addStableArray(koi, stableArrayRank);
+      }
+
+   *outValue = TR::AnyConst::makeKnownObject(koi);
+   return true;
    }
 
 bool
@@ -2579,97 +2704,4 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
 #else
    return false;
 #endif
-   }
-
-TR::KnownObjectTable::Index
-J9::TransformUtil::knownObjectFromFinalStatic(
-   TR::Compilation *comp,
-   TR_ResolvedMethod *owningMethod,
-   int32_t cpIndex,
-   void *dataAddress)
-   {
-   if (comp->compileRelocatableCode())
-      return TR::KnownObjectTable::UNKNOWN;
-
-   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
-   if (knot == NULL)
-      return TR::KnownObjectTable::UNKNOWN;
-
-#if defined(J9VM_OPT_JITSERVER)
-   if (comp->isOutOfProcessCompilation())
-      {
-      TR_ResolvedJ9JITServerMethod *serverMethod = static_cast<TR_ResolvedJ9JITServerMethod*>(owningMethod);
-      TR_ResolvedMethod *clientMethod = serverMethod->getRemoteMirror();
-
-      auto stream = TR::CompilationInfo::getStream();
-      stream->write(JITServer::MessageType::KnownObjectTable_symbolReferenceTableCreateKnownObject, dataAddress, clientMethod, cpIndex);
-
-      auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t*>();
-      TR::KnownObjectTable::Index knownObjectIndex = std::get<0>(recv);
-      uintptr_t *objectPointerReference = std::get<1>(recv);
-
-      if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
-         {
-         knot->updateKnownObjectTableAtServer(knownObjectIndex, objectPointerReference);
-         }
-
-      return knownObjectIndex;
-      }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-
-   TR::VMAccessCriticalSection getObjectReferenceLocation(comp);
-   TR_J9VMBase *fej9 = comp->fej9();
-
-   // Could return the null index when the reference is null, but current
-   // callers aren't interested in it.
-   if (*((uintptr_t*)dataAddress) == 0)
-      return TR::KnownObjectTable::UNKNOWN;
-
-   TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp, cpIndex);
-   if (!declaringClass || !fej9->isClassInitialized(declaringClass))
-      return TR::KnownObjectTable::UNKNOWN;
-
-   static const char *foldVarHandle = feGetEnv("TR_FoldVarHandleWithoutFear");
-
-   bool canFoldVarHandleWithoutFear = false;
-
-   // in Java 17 and above, it is not possible to remove the final attribute of a field
-   // to make it writable via reflection.
-#if JAVA_SPEC_VERSION >= 17
-   canFoldVarHandleWithoutFear = true;
-#endif
-
-   int32_t clazzNameLength = 0;
-   char *clazzName = fej9->getClassNameChars(declaringClass, clazzNameLength);
-   bool createKnownObject = false;
-
-   if (J9::TransformUtil::foldFinalFieldsIn(declaringClass, clazzName, clazzNameLength, true, comp))
-      {
-      createKnownObject = true;
-      }
-   else if ((foldVarHandle || canFoldVarHandleWithoutFear)
-            && (clazzNameLength != 16 || strncmp(clazzName, "java/lang/System", 16)))
-      {
-      TR_OpaqueClassBlock *varHandleClass =  fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", 26);
-      TR_OpaqueClassBlock *objectClass = TR::Compiler->cls.objectClass(comp, *((uintptr_t*)dataAddress));
-
-      if (varHandleClass != NULL
-          && objectClass != NULL
-          && fej9->isInstanceOf(objectClass, varHandleClass, true, true))
-         {
-         createKnownObject = true;
-         }
-      }
-
-   if (!createKnownObject)
-      return TR::KnownObjectTable::UNKNOWN;
-
-   TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt((uintptr_t*)dataAddress);
-
-   int32_t stableArrayRank = isArrayWithStableElements(cpIndex, owningMethod, comp);
-
-   if (stableArrayRank > 0)
-      knot->addStableArray(index, stableArrayRank);
-
-   return index;
    }

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -36,6 +36,7 @@ namespace J9 { typedef J9::TransformUtil TransformUtilConnector; }
 #include "optimizer/Optimization.hpp"
 #include "control/RecompilationInfo.hpp"
 
+namespace TR { class AnyConst; }
 namespace TR { class Compilation; }
 namespace TR { class Node; }
 namespace TR { class Block; }
@@ -278,6 +279,31 @@ public:
     */
    static TR_YesNoMaybe canFoldStaticFinalField(TR::Compilation *comp, TR::Node *node);
 
+   /**
+    * \brief
+    *    Determine whether a static final field can be folded without a node.
+    *
+    *    The caller must have already checked that the field in question is
+    *    both static and final.
+    *
+    *    If a node is available, prefer
+    *    canFoldStaticFinalField(TR::Compilation*, TR::Node*).
+    *
+    * \param comp the compilation object
+    * \param declaringClass the class that declares the field
+    * \param recField the corresponding recognized field, or UnknownField
+    * \param owningMethod the owning method of the field reference
+    * \param cpIndex the constant pool index of the field reference
+    * \return TR_yes if the field is reliable, TR_maybe if it can be folded
+    *         with OSR protection, or TR_no if it should not be folded.
+    */
+   static TR_YesNoMaybe canFoldStaticFinalField(
+      TR::Compilation *comp,
+      TR_OpaqueClassBlock *declaringClass,
+      TR::Symbol::RecognizedField recField,
+      TR_ResolvedMethod *owningMethod,
+      int32_t cpIndex);
+
    static bool transformIndirectLoadChain(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, TR::KnownObjectTable::Index baseKnownObject, TR::Node **removedNode);
    static bool transformIndirectLoadChainAt(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, uintptr_t *baseReferenceLocation, TR::Node **removedNode);
    static bool transformIndirectLoadChainImpl( TR::Compilation *, TR::Node *node, TR::Node *baseExpression, void *baseAddress, int32_t baseStableArrayRank, TR::Node **removedNode);
@@ -377,26 +403,46 @@ public:
     */
    static bool refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* treetop, TR::Node* node, TR::KnownObjectTable::Index mnIndex, bool trace = false);
 
-   /*
+   /**
     * \brief
-    *    Determine the known-object index to use for a reference-typed final
-    *    static field that is foldable in the walker.
+    *    Determine whether it's currently expected that it's possible to fold
+    *    static final fields with OSR protection somewhere in the method.
     *
-    *    The caller must check in advance that the field is a final reference.
-    *    This method does not verify.
+    *    The result is independent of any particular program point. Even if the
+    *    result is true, folding might still be impossible at certain points
+    *    due to restrictions on the placement of fear points. However, if the
+    *    result is false, then such folding cannot be done anywhere.
     *
     * \param comp the compilation object
-    * \param owningMethod the owning method of the static field reference
-    * \param cpIndex the constant pool index of the static field reference
-    * \param dataAddress The static field address from \c staticAttributes()
-    *
-    * \return the known object index, or \c UNKNOWN if disallowed
+    * \return true if it's possible in general to fold, false otherwise
     */
-   static TR::KnownObjectTable::Index knownObjectFromFinalStatic(
+   static bool canDoGuardedStaticFinalFieldFolding(TR::Compilation *comp);
+
+   /**
+    * \brief
+    *    Get the value of a static final field.
+    *
+    *    canFoldStaticFinalField() must have already run for the given field in
+    *    the current compilation, and it must have produced a result of TR_yes
+    *    or TR_maybe.
+    *
+    * \param[in] comp the compilation object
+    * \param[in] owningMethod the owning method of the field reference
+    * \param[in] cpIndex the constant pool index of the field reference
+    * \param[in] staticAddr the address of the static field
+    * \param[in] loadType the type that a direct load of the static field would have
+    * \param[in] recField the corresponding recognized field, or UnknownField
+    * \param[out] outValue the resulting value
+    * \return true for success, or (rarely) false for failure
+    */
+   static bool staticFinalFieldValue(
       TR::Compilation *comp,
       TR_ResolvedMethod *owningMethod,
       int32_t cpIndex,
-      void *dataAddress);
+      void *staticAddr,
+      TR::DataType loadType,
+      TR::Symbol::RecognizedField recField,
+      TR::AnyConst *outValue);
 
 protected:
    /**

--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -277,6 +277,8 @@ int32_t TR_OSRGuardInsertion::perform()
    cleanUpPotentialOSRPointHelperCalls();
    cleanUpOSRFearPoints();
 
+   comp()->setFearPointAnalysisDone(); // It's no longer possible to create fear points.
+
    return 0;
    }
 

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -219,7 +219,8 @@ int32_t TR_StringPeepholes::perform()
    static char *skipitAtWarm = feGetEnv("TR_noPeepholeAtWarm");
    if (comp()->getOption(TR_DisableStringPeepholes)
        || (!comp()->fej9()->doStringPeepholing() && !comp()->getOption(TR_UseSymbolValidationManager))
-       || (skipitAtWarm && comp()->getMethodHotness()==warm))
+       || (skipitAtWarm && comp()->getMethodHotness() == warm)
+       || comp()->isFearPointPlacementUnrestricted())
       return 1;
 
    process(comp()->getStartTree(), NULL);


### PR DESCRIPTION
This series consists of some initial preparations for expanded static final field folding (SFFF) in `InterpreterEmulator`, primarily in the two ways mentioned in the title. Brief summary of each commit:
- Make `KnownObjectTable::addStableArray()` safe to call on the server: *needed for the following refactoring*
- Refactor static final field folding for reuse in `InterpreterEmulator`: *exposes SFFF logic that will facilitate later guarded/speculative folding in inliner*
- Declare `isFearPointPlacementUnrestricted()`: *names a concept that will be needed later for early guarded folding*
- Delete unused flags in the IL generator held over from multitenancy: *minor cleanup prior to record/replay*
- Record/replay `InterpreterEmulator` constants: *ensures consistency between inliner and IL, which will become more important later with expanded folding, and which will also inform the placement of fear points for guarded folding*

This PR depends on https://github.com/eclipse/omr/pull/7282