### PR TITLE
Ensure Client UID is different on restore

### DIFF
--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -336,8 +336,20 @@ J9::OptionsPostRestore::processJitServerOptions()
          GET_OPTION_VALUE_RESTORE_ARGS(_argIndexJITServerAOTCacheName, '=', &name);
          _compInfo->getPersistentInfo()->setJITServerAOTCacheName(name);
          }
+
+      uint64_t oldClientUID = _compInfo->getPersistentInfo()->getClientUID();
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "oldClientUID = %llu", oldClientUID);
+
       // Re-compute client UID post restore
       uint64_t clientUID = JITServerHelpers::generateUID();
+      while(clientUID == oldClientUID)
+         clientUID = JITServerHelpers::generateUID();
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "clientUID = %llu", clientUID);
+
       _jitConfig->clientUID = clientUID;
       _compInfo->getPersistentInfo()->setClientUID(clientUID);
       _compInfo->getPersistentInfo()->setServerUID(0);


### PR DESCRIPTION
Ensure the new Client UID generated in the post restore options processing code is different from the UID generated pre-checpoint. Also Print out the old and new Client UIDs.

This may fix https://github.com/eclipse-openj9/openj9/issues/17474, but at the very least it'll add a few more diagnostics to help with it if it doesn't.