### PR TITLE
(0.44) AttachAPI jcmd supports VMID query via Java process display names

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -106,23 +106,26 @@ public class AttachHandler extends Thread {
 	private static int numberOfTargets;
 	/**
 	 * As of Java 9, a VM cannot attach to itself unless explicitly enabled.
-	 * Grab the setting before the application has a chance to change it,
-	 * but parse it lazily because we rarely need the value.
+	 * Grab the setting before the application has a chance to change it.
 	 */
-	public final static String allowAttachSelf =
-			VM.internalGetProperties().getProperty("jdk.attach.allowAttachSelf" //$NON-NLS-1$
-/*[IF JAVA_SPEC_VERSION >= 9]*/
-					, "false" //$NON-NLS-1$
-/*[ELSE] JAVA_SPEC_VERSION >= 9 */
-					, "true" //$NON-NLS-1$
-/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
-					);
+	public static final boolean selfAttachAllowed;
 
 	/* only the attach handler thread uses syncFileLock */
 	/* [PR Jazz 30075] Make syncFileLock an instance variable since it is accessed only by the attachHandler singleton. */
 	FileLock syncFileLock;
 
 	static volatile Thread fileAccessTimeUpdaterThread;
+
+	static {
+		String allowAttachSelf = VM.internalGetProperties().getProperty("jdk.attach.allowAttachSelf" //$NON-NLS-1$
+		/*[IF JAVA_SPEC_VERSION >= 9]*/
+				, "false" //$NON-NLS-1$
+		/*[ELSE] JAVA_SPEC_VERSION >= 9 */
+				, "true" //$NON-NLS-1$
+		/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
+		);
+		selfAttachAllowed = "".equals(allowAttachSelf) || Boolean.parseBoolean(allowAttachSelf); //$NON-NLS-1$
+	}
 
 	/**
 	 * Keep the constructor private

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -473,9 +473,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				}
 
 				if (descriptor.id().equals(AttachHandler.getVmId())) {
-					String allowAttachSelf_Value = AttachHandler.allowAttachSelf;
-					boolean selfAttachAllowed = "".equals(allowAttachSelf_Value) || Boolean.parseBoolean(allowAttachSelf_Value); //$NON-NLS-1$
-					if (!selfAttachAllowed) {
+					if (!AttachHandler.selfAttachAllowed) {
 						/*[MSG "K0646", "Late attach connection to self disabled. Set jdk.attach.allowAttachSelf=true"]*/
 						throw new IOException(getString("K0646")); //$NON-NLS-1$
 					}

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -351,6 +351,43 @@ public class TestJcmd extends AttachApiTest {
 		}
 	}
 
+	private static final String DISPLAYNAME_GC_CLASS_HISTOGRAM = "TargetVM_GC.class_histogram_all";
+
+	private void testDisplayNameHelper(String targetName) throws IOException {
+		TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null, DISPLAYNAME_GC_CLASS_HISTOGRAM,
+				Collections.singletonList("-Xmx10M"), Collections.emptyList());
+		tgt.syncWithTarget();
+		String targetId = tgt.targetId;
+		assertNotNull(targetId, ERROR_TARGET_NOT_LAUNCH);
+
+		List<String> args = new ArrayList<>();
+		args.add(targetName);
+		args.add(GC_CLASS_HISTOGRAM);
+		args.add("all");
+		List<String> jcmdOutput = runCommandAndLogOutput(args);
+		String expectedString = commandExpectedOutputs.getOrDefault(GC_CLASS_HISTOGRAM,
+				"Test error: expected output not defined");
+		log("Expected string: " + expectedString);
+		Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+		assertTrue(searchResult.isPresent(), "Expected string not found: " + expectedString);
+		log(EXPECTED_STRING_FOUND);
+	}
+
+	@Test
+	public void testMatchDisplayNameFully() throws IOException {
+		testDisplayNameHelper(DISPLAYNAME_GC_CLASS_HISTOGRAM);
+	}
+
+	@Test
+	public void testMatchDisplayNamePartially() throws IOException {
+		testDisplayNameHelper(DISPLAYNAME_GC_CLASS_HISTOGRAM.substring(1, DISPLAYNAME_GC_CLASS_HISTOGRAM.length() - 2));
+	}
+
+	@Test
+	public void testAllVMID() throws IOException {
+		testDisplayNameHelper("0");
+	}
+
 	@BeforeMethod
 	protected void setUp(Method testMethod) {
 		testName = testMethod.getName();


### PR DESCRIPTION
`AttachAPI` `jcmd` supports `VMID` query via Java process display names

Allow `jcmd` to accept the full/partial display name, and find its corresponding `VMIDs`;
Also accept `pid 0`, and send the `jcmd` command to all Java processes detected by current `jcmd`;
Add tests.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/19069

Signed-off-by: Jason Feng <fengj@ca.ibm.com>