### PR TITLE
Fix javacore unmounted threads output

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5781,7 +5781,7 @@ continuationIteratorCallback(J9VMThread *vmThread, J9MM_IterateObjectDescriptor 
 		jcw->_OutputStream.writeCharacters("3XMVTHDINFO        \"");
 		jcw->_OutputStream.writeCharacters(threadName);
 		jcw->_OutputStream.writeCharacters("\" [");
-		jcw->_OutputStream.writeCharacters(isMounted ? "mounted" : "unmounted");
+		jcw->_OutputStream.writeCharacters(isMounted ? "unmounted carrier" : "unmounted");
 		jcw->_OutputStream.writeCharacters("] J9VMContinuation:");
 		jcw->_OutputStream.writePointer(continuation);
 		jcw->_OutputStream.writeCharacters(", java/lang/Thread:");
@@ -5826,8 +5826,9 @@ continuationIteratorCallback(J9VMThread *vmThread, J9MM_IterateObjectDescriptor 
 		if (j9sig_protect(protectedWalkJavaStack, &closure, handlerJavaThreadWalk, jcw, J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_RETURN, &sink) != 0) {
 			jcw->_OutputStream.writeCharacters("3XMTHREADINFO3           No Java callstack associated with this thread\n");
 		}
+		jcw->_OutputStream.writeCharacters("NULL\n");
 	}
-	jcw->_OutputStream.writeCharacters("NULL\n");
+
 	return JVMTI_ITERATION_CONTINUE;
 }
 #endif /* JAVA_SPEC_VERSION >= 21 */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5763,12 +5763,11 @@ regionIteratorCallback(J9JavaVM* virtualMachine, J9MM_IterateRegionDescriptor* r
 static jvmtiIterationControl
 continuationIteratorCallback(J9VMThread *vmThread, J9MM_IterateObjectDescriptor *object, void *userData)
 {
-	PORT_ACCESS_FROM_VMC(vmThread);
-	JavaCoreDumpWriter *jcw = (JavaCoreDumpWriter *)userData;
-	J9InternalVMFunctions *vmFuncs = vmThread->javaVM->internalVMFunctions;
-	j9object_t vthread = J9VMJDKINTERNALVMCONTINUATION_VTHREAD(vmThread, object->object);
 	J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, object->object);
 	if (NULL != continuation) {
+		PORT_ACCESS_FROM_VMC(vmThread);
+		JavaCoreDumpWriter *jcw = (JavaCoreDumpWriter *)userData;
+		j9object_t vthread = J9VMJDKINTERNALVMCONTINUATION_VTHREAD(vmThread, object->object);
 		j9object_t threadObj = vthread;
 		ContinuationState continuationState = *VM_ContinuationHelpers::getContinuationStateAddress(vmThread, object->object);
 		BOOLEAN isMounted = VM_ContinuationHelpers::isFullyMounted(continuationState);
@@ -5803,7 +5802,7 @@ continuationIteratorCallback(J9VMThread *vmThread, J9MM_IterateObjectDescriptor 
 		J9VMThread stackThread = {0};
 		J9VMEntryLocalStorage els = {0};
 
-		vmFuncs->copyFieldsFromContinuation(vmThread, &stackThread, &els, continuation);
+		vmThread->javaVM->internalVMFunctions->copyFieldsFromContinuation(vmThread, &stackThread, &els, continuation);
 		walkState.walkThread = &stackThread;
 
 		walkState.flags =

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5780,9 +5780,7 @@ continuationIteratorCallback(J9VMThread *vmThread, J9MM_IterateObjectDescriptor 
 		/* Write the first thread descriptor word. */
 		jcw->_OutputStream.writeCharacters("3XMVTHDINFO        \"");
 		jcw->_OutputStream.writeCharacters(threadName);
-		jcw->_OutputStream.writeCharacters("\" [");
-		jcw->_OutputStream.writeCharacters(isMounted ? "unmounted carrier" : "unmounted");
-		jcw->_OutputStream.writeCharacters("] J9VMContinuation:");
+		jcw->_OutputStream.writeCharacters("\" J9VMContinuation:");
 		jcw->_OutputStream.writePointer(continuation);
 		jcw->_OutputStream.writeCharacters(", java/lang/Thread:");
 		jcw->_OutputStream.writePointer(threadObj);


### PR DESCRIPTION
- Remove NULL line for unstarted/finished Continuations
- Remove unclear "mounted" state for swapped continuations where the unmounted carrier is printed.