### PR TITLE
(v0.44.0-release) Exclude JLM_Tests for FIPS

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -62,6 +62,13 @@
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_interface</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -133,6 +140,13 @@
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_class</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -196,6 +210,13 @@
 	</test>
 	<test>
 		<testCaseName>JLM_Tests_IBMinternal</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -228,6 +249,13 @@
 	</test>
 	<test>
 		<testCaseName>testSoftMxLocal</testCaseName>
+		<disables>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/1371</comment>
+				<impl>openj9</impl>
+				<testflag>FIPS140_2</testflag>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode119</variation>


### PR DESCRIPTION
-exclude `JLM_Tests_interface`, `JLM_Tests_IBMinternal`,`JLM_Tests_class`,`testSoftMxLocal` for FIPS.

related:github_ibm/runtimes/backlog#1371