### PR TITLE
Cache compInfoPT in JITServer deserializer SCC interface

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1200,9 +1200,6 @@ public:
    JITServerAOTDeserializer *getJITServerAOTDeserializer() const { return _JITServerAOTDeserializer; }
    void setJITServerAOTDeserializer(JITServerAOTDeserializer *deserializer) { _JITServerAOTDeserializer = deserializer; }
 
-   TR_J9DeserializerSharedCache *getDeserializerSharedCache() const { return _deserializerSharedCache; }
-   void setDeserializerSharedCache(TR_J9DeserializerSharedCache *deserializerSharedCache) { _deserializerSharedCache = deserializerSharedCache; }
-
    bool methodCanBeJITServerAOTCacheStored(const char *methodSig, TR::Method::Type ty);
    bool methodCanBeJITServerAOTCacheLoaded(const char *methodSig, TR::Method::Type ty);
 
@@ -1460,7 +1457,6 @@ private:
    JITServerSharedROMClassCache *_sharedROMClassCache;
    JITServerAOTCacheMap *_JITServerAOTCacheMap;
    JITServerAOTDeserializer *_JITServerAOTDeserializer;
-   TR_J9DeserializerSharedCache *_deserializerSharedCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2970,7 +2970,13 @@ remoteCompilationEnd(J9VMThread *vmThread, TR::Compilation *comp, TR_ResolvedMet
             TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
             TR_J9SharedCache *cacheOverride = NULL;
             if (comp->isDeserializedAOTMethod() && compInfo->getPersistentInfo()->getJITServerAOTCacheIgnoreLocalSCC())
-               cacheOverride = compInfo->getDeserializerSharedCache();
+               {
+               auto deserializerSCC = fe->deserializerSharedCache();
+               // This should be extremely rare
+               if (!deserializerSCC)
+                  comp->failCompilation<TR::CompilationException>("Deserializer was not allocated in compilation thread");
+               cacheOverride = deserializerSCC;
+               }
             metaData = entry->_compInfoPT->reloRuntime()->prepareRelocateAOTCodeAndData(
                vmThread, fe, comp->cg()->getCodeCache(), (J9JITDataCacheHeader *)dataCacheStr.data(),
                method, false, comp->getOptions(), comp, compilee, (uint8_t *)codeCacheStr.data(), cacheOverride

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2120,38 +2120,27 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
    // Create AOT deserializer at the client if using JITServer with AOT cache
    if ((persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT) && persistentInfo->getJITServerUseAOTCache())
       {
+      JITServerAOTDeserializer *deserializer = NULL;
       if (persistentInfo->getJITServerAOTCacheIgnoreLocalSCC())
          {
-         auto deserializer = new (PERSISTENT_NEW) JITServerNoSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
-         if (!deserializer)
-            {
-            fprintf(stderr, "Could not create JITServer AOT deserializer\n");
-            return -1;
-            }
-         compInfo->setJITServerAOTDeserializer(deserializer);
-         auto deserializerSharedCache = new (PERSISTENT_NEW) TR_J9DeserializerSharedCache(vm, deserializer);
-         if (!deserializerSharedCache)
-            {
-            fprintf(stderr, "Could not create JITServer AOT deserializer cache\n");
-            return -1;
-            }
-         compInfo->setDeserializerSharedCache(deserializerSharedCache);
+         deserializer = new (PERSISTENT_NEW) JITServerNoSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
          }
       else if (TR::Options::sharedClassCache())
          {
-         auto deserializer = new (PERSISTENT_NEW) JITServerLocalSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
-         if (!deserializer)
-            {
-            fprintf(stderr, "Could not create JITServer AOT deserializer\n");
-            return -1;
-            }
-         compInfo->setJITServerAOTDeserializer(deserializer);
+         deserializer = new (PERSISTENT_NEW) JITServerLocalSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
          }
       else
          {
          fprintf(stderr, "Disabling JITServer AOT cache since AOT compilation and JITServerAOTCacheIgnoreLocalSCC are disabled\n");
          persistentInfo->setJITServerUseAOTCache(false);
          }
+
+      if (persistentInfo->getJITServerUseAOTCache() && !deserializer)
+         {
+         fprintf(stderr, "Could not create JITServer AOT deserializer\n");
+         return -1;
+         }
+      compInfo->setJITServerAOTDeserializer(deserializer);
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1652,16 +1652,15 @@ TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, const char *key
    return std::get<0>(_stream->read<const void *>());
    }
 
-TR_J9DeserializerSharedCache::TR_J9DeserializerSharedCache(TR_J9VMBase *fe, JITServerNoSCCAOTDeserializer *deserializer)
-   : TR_J9SharedCache(fe)
+TR_J9DeserializerSharedCache::TR_J9DeserializerSharedCache(TR_J9VMBase *fe, JITServerNoSCCAOTDeserializer *deserializer, TR::CompilationInfoPerThread *compInfoPT)
+   : TR_J9SharedCache(fe), _deserializer(deserializer), _compInfoPT(compInfoPT)
    {
-   _deserializer = deserializer;
    }
 
 J9ROMClass *
 TR_J9DeserializerSharedCache::romClassFromOffsetInSharedCache(uintptr_t offset)
    {
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    bool wasReset = false;
    auto romClass = _deserializer->romClassFromOffsetInSharedCache(offset, comp, wasReset);
    if (wasReset)
@@ -1677,7 +1676,7 @@ TR_J9DeserializerSharedCache::romClassFromOffsetInSharedCache(uintptr_t offset)
 void *
 TR_J9DeserializerSharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
    {
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    bool wasReset = false;
    auto ptr = _deserializer->pointerFromOffsetInSharedCache(offset, comp, wasReset);
    if (wasReset)
@@ -1707,7 +1706,7 @@ TR_J9DeserializerSharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *c
    // that TR_J9SharedCache::validateClassChain() does, which is what TR_J9SharedCache::validateClassChain()
    // uses to verify that the given clazz matches chainData. Thus we only have to check that that cached J9Class
    // is equal to the one we are trying to validate.
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    bool wasReset = false;
    auto ramClass = _deserializer->classFromOffset(chainData[1], comp, wasReset);
    if (wasReset)
@@ -1727,7 +1726,7 @@ TR_J9DeserializerSharedCache::lookupClassFromChainAndLoader(uintptr_t *chainData
    // a J9Class correspoding to the first class in the chain. If one could be found, it then verifies that the class matches the cached version.
    // We do not need to perform that checking here, because during deserialization we will have already resolved the first class in the chain to
    // a J9Class and verified that it matches. Thus we can simply return that cached first J9Class.
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    bool wasReset = false;
    auto clazz = _deserializer->classFromOffset(chainData[1], comp, wasReset);
    if (wasReset)
@@ -1743,7 +1742,7 @@ TR_J9DeserializerSharedCache::lookupClassFromChainAndLoader(uintptr_t *chainData
 J9ROMMethod *
 TR_J9DeserializerSharedCache::romMethodFromOffsetInSharedCache(uintptr_t offset)
    {
-   TR::Compilation *comp = TR::compInfoPT->getCompilation();
+   TR::Compilation *comp = _compInfoPT->getCompilation();
    bool wasReset = false;
    auto romMethod = _deserializer->romMethodFromOffsetInSharedCache(offset, comp, wasReset);
    if (wasReset)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -714,7 +714,7 @@ class TR_J9DeserializerSharedCache : public TR_J9SharedCache
 public:
    TR_ALLOC(TR_Memory::SharedCache)
 
-   TR_J9DeserializerSharedCache(TR_J9VMBase *fe, JITServerNoSCCAOTDeserializer *deserializer);
+   TR_J9DeserializerSharedCache(TR_J9VMBase *fe, JITServerNoSCCAOTDeserializer *deserializer, TR::CompilationInfoPerThread *compInfoPT);
 
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) override;
    virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) override;
@@ -766,6 +766,7 @@ public:
 
 private:
    JITServerNoSCCAOTDeserializer *_deserializer;
+   TR::CompilationInfoPerThread *_compInfoPT;
    };
 
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1357,6 +1357,10 @@ public:
 
    TR_J9SharedCache *     _sharedCache;
 
+#if defined(J9VM_OPT_JITSERVER)
+   TR_J9DeserializerSharedCache *_deserializerSharedCache;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    static int32_t *       staticDFPHWAvailField;
    static bool            cachedStaticDFPAvailField;
 
@@ -1384,6 +1388,10 @@ public:
    virtual TR_J9SharedCache *sharedCache() { return _sharedCache; }
    virtual void              freeSharedCache();
    virtual void              setSharedCache(TR_J9SharedCache *sharedCache) { _sharedCache = sharedCache; }
+
+#if defined(J9VM_OPT_JITSERVER)
+   TR_J9DeserializerSharedCache *deserializerSharedCache() const { return _deserializerSharedCache; }
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    const char *getByteCodeName(uint8_t opcode);
 


### PR DESCRIPTION
The `TR::CompilationInfoPerThread` is now cached in `TR_J9DeserializerSharedCache` to avoid the use of `TR::compInfoPT`. The handling of the `TR_J9DeserializerSharedCache` object itself has changed to accommodate this - there is now a `_deserializerSharedCache` in `TR_J9VMBase` (to have these objects be exclusive to one compilation thread) and the `_deserializerSharedCache` in `TR::CompilationInfo` has been removed.

Related: https://github.com/eclipse-openj9/openj9/issues/18990