### PR TITLE
(0.44) JIT must narrow byte/short/char before storing

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1838,6 +1838,11 @@ static bool isSignatureTypeBool(const char *fieldSignature, int32_t len)
    return len == 1 && fieldSignature[0] == 'Z';
    }
 
+static bool isSignatureTypeChar(const char *fieldSignature, int32_t len)
+   {
+   return len == 1 && fieldSignature[0] == 'C';
+   }
+
 static bool isSignatureReturnTypeBool(const char *methodSignature, int32_t len)
    {
    TR_ASSERT(len > 1, "Method signature is unexpectedly short %d", len);
@@ -1862,6 +1867,25 @@ J9::SymbolReferenceTable::isStaticTypeBool(TR::SymbolReference *symRef)
    dumpOptDetails(comp(), "got static signature as %.*s\n", len, fieldSignature);
    return isSignatureTypeBool(fieldSignature, len);
    }
+
+bool
+J9::SymbolReferenceTable::isFieldTypeChar(TR::SymbolReference *symRef)
+   {
+   int32_t len;
+   const char *fieldSignature = symRef->getOwningMethod(comp())->fieldSignatureChars(symRef->getCPIndex(), len);
+   dumpOptDetails(comp(), "got field signature as %.*s\n", len, fieldSignature);
+   return isSignatureTypeChar(fieldSignature, len);
+   }
+
+bool
+J9::SymbolReferenceTable::isStaticTypeChar(TR::SymbolReference *symRef)
+   {
+   int32_t len;
+   const char *fieldSignature = symRef->getOwningMethod(comp())->staticSignatureChars(symRef->getCPIndex(), len);
+   dumpOptDetails(comp(), "got static signature as %.*s\n", len, fieldSignature);
+   return isSignatureTypeChar(fieldSignature, len);
+   }
+
 
 bool
 J9::SymbolReferenceTable::isReturnTypeBool(TR::SymbolReference *symRef)

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -443,7 +443,9 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    List<TR::SymbolReference> *dynamicMethodSymrefsByCallSiteIndex(int32_t index);
    bool isFieldClassObject(TR::SymbolReference *symRef);
    bool isFieldTypeBool(TR::SymbolReference *symRef);
+   bool isFieldTypeChar(TR::SymbolReference *symRef);
    bool isStaticTypeBool(TR::SymbolReference *symRef);
+   bool isStaticTypeChar(TR::SymbolReference *symRef);
    bool isReturnTypeBool(TR::SymbolReference *symRef);
 
    /*

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -205,6 +205,7 @@ private:
    void         storeFlattenableInstance(int32_t);
    void         storeFlattenableInstanceWithHelper(int32_t);
    void         storeStatic(int32_t);
+   TR::Node*    narrowIntStoreIfRequired(TR::Node *value, TR::SymbolReference *symRef);
    void         storeAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
    void         storeArrayElement(TR::DataType dt){ storeArrayElement(dt, comp()->il.opCodeForIndirectArrayStore(dt)); }
    void         storeArrayElement(TR::DataType dt, TR::ILOpCodes opCode, bool checks = true);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6232,6 +6232,11 @@ TR_J9ByteCodeIlGenerator::genWithField(TR::SymbolReference * symRef, TR_OpaqueCl
    TR::Node *newFieldValue = pop();
    TR::Node *originalObject = pop();
 
+   if (symRef->getSymbol()->getType().isIntegral())
+      {
+      newFieldValue = narrowIntStoreIfRequired(newFieldValue, symRef);
+      }
+
    /*
     * Insert nullchk for the original object as requested by the JVM spec.
     * Especially in case of value type class with a single field, the nullchk is still
@@ -6998,6 +7003,48 @@ TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
    storeInstance(symRef);
    }
 
+TR::Node*
+TR_J9ByteCodeIlGenerator::narrowIntStoreIfRequired(TR::Node *value, TR::SymbolReference *symRef)
+   {
+   TR::DataType type = symRef->getSymbol()->getDataType();
+
+   // Per the JVM spec, putstatic/putfield/withfield opcodes must adhere to field type compatibility.
+   // Integer values on the stack must be narrowed when stored into smaller types like bool, byte,
+   // char, and short fields. For byte and short fields, narrowing involves conversion from integer
+   // to byte/short, then back to integer. For bool and char types, which are unsigned, narrowing
+   // entails ANDing the value with a mask matching the type width.
+
+   switch (type)
+      {
+      case TR::Int8:
+         if (symRefTab()->isStaticTypeBool(symRef))
+            {
+            value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 1));
+            }
+         else
+            {
+            value = TR::Node::create(TR::i2b, 1, value);
+            value = TR::Node::create(TR::b2i, 1, value);
+            }
+         break;
+      case TR::Int16:
+         if (symRefTab()->isStaticTypeChar(symRef))
+            {
+            value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 0xffff));
+            }
+         else
+            {
+            value = TR::Node::create(TR::i2s, 1, value);
+            value = TR::Node::create(TR::s2i, 1, value);
+            }
+         break;
+      default:
+         break;
+      }
+
+   return value;
+   }
+
 void
 TR_J9ByteCodeIlGenerator::storeInstance(TR::SymbolReference * symRef)
    {
@@ -7019,8 +7066,8 @@ TR_J9ByteCodeIlGenerator::storeInstance(TR::SymbolReference * symRef)
       }
    else
       {
-      if (type == TR::Int8 && symRefTab()->isFieldTypeBool(symRef))
-         value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 1));
+      if (type.isIntegral())
+         value = narrowIntStoreIfRequired(value, symRef);
       node = TR::Node::createWithSymRef(comp()->il.opCodeForIndirectStore(type), 2, 2, addressNode, value, symRef);
       }
 
@@ -7303,8 +7350,9 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
    TR::Node * node;
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
-   if (type == TR::Int8 && symRefTab()->isStaticTypeBool(symRef))
-      value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 1));
+
+   if (type.isIntegral())
+      value = narrowIntStoreIfRequired(value, symRef);
 
    if ((type == TR::Address && _generateWriteBarriersForGC) || _generateWriteBarriersForFieldWatch)
       {


### PR DESCRIPTION
This commit ensures compliance with JVM spec regarding the handling of putstatic/putfield/withfield opcodes. This involves correctly narrowing integer values when storing them into fields of smaller types such as bool, byte, char, and short. For byte and short fields, narrowing involves conversion from integer to byte/short, then back to integer. For bool and char types, which are unsigned, narrowing entails ANDing the value with a mask matching the type width.

Issue: #16498

Port of https://github.com/eclipse-openj9/openj9/pull/18904 for 0.44