### PR TITLE
Add simple class name check in checkInnerClassAttrOfEnclosingClass()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -1499,11 +1499,13 @@ public Class<?> getDeclaringClass() {
  * when the enclosing class is the declaring class.
  */
 private void checkInnerClassAttrOfEnclosingClass() {
-	Class<?> enclosingClass = getEnclosingObjectClass();
-	if ((enclosingClass != null) && !enclosingClass.isClassAnEnclosedClass(this)) {
-		/*[MSG "K0555", "incompatible InnerClasses attribute between \"{0}\" and \"{1}\""]*/
-		throw new IncompatibleClassChangeError(
-				com.ibm.oti.util.Msg.getString("K0555", this.getName(), enclosingClass.getName())); //$NON-NLS-1$
+	if (getSimpleNameImpl() != null) {
+		Class<?> enclosingClass = getEnclosingObjectClass();
+		if ((enclosingClass != null) && !enclosingClass.isClassAnEnclosedClass(this)) {
+			/*[MSG "K0555", "incompatible InnerClasses attribute between \"{0}\" and \"{1}\""]*/
+			throw new IncompatibleClassChangeError(
+					com.ibm.oti.util.Msg.getString("K0555", this.getName(), enclosingClass.getName())); //$NON-NLS-1$
+		}
 	}
 }
 


### PR DESCRIPTION
Anon class (simple name is null) cannot be referenced by name from the inner class attribute of its enclosing class. In this case, there is no need to search for the class name in the inner class attribute.

Closes #19016