### PR TITLE
Enable per-connection JITServer AOT cache disabling

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7940,6 +7940,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             && persistentInfo->getJITServerUseAOTCache() // Ideally we would check if the options allow us to use the AOT cache for this method
             && persistentInfo->getJITServerAOTCacheIgnoreLocalSCC() // Need to be using the new implementation
             && !entry->_doNotLoadFromJITServerAOTCache
+            && !persistentInfo->doNotRequestJITServerAOTCacheStore()
             && !_compInfo.getLowCompDensityMode() // AOT req is sent to JITServer and we don't want to send JITServer any messages in this mode
             && !cannotDoRemoteCompilation; // Make sure remote compilations are possible (no strong guarantees)
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -226,7 +226,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          {
          uint64_t serverUID = std::get<0>(client->getRecvData<uint64_t>());
          uint64_t previousUID = compInfo->getPersistentInfo()->getServerUID();
+         bool hasEverConnectedToServer = compInfo->getPersistentInfo()->hasEverConnectedToServer();
          compInfo->getPersistentInfo()->setServerUID(serverUID);
+         compInfo->getPersistentInfo()->setHasEverConnectedToServer();
 
          auto unloadedClasses = comp->getPersistentInfo()->getUnloadedClassAddresses();
          std::vector<TR_AddressRange> ranges;
@@ -245,7 +247,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             }
 
          // This is a connection to a new server after a previous disconnection
-         if ((0 != previousUID) && (previousUID != serverUID))
+         if (hasEverConnectedToServer && (previousUID != serverUID))
             {
             // Reset AOT deserializer (cached serialization records are now invalid)
             auto deserializer = compInfo->getJITServerAOTDeserializer();

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -175,6 +175,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerAOTCacheDir(),
          _JITServerAOTCacheDelayMethodRelocation(false),
          _JITServerAOTCacheIgnoreLocalSCC(false),
+         _doNotRequestJITServerAOTCacheLoad(false),
+         _doNotRequestJITServerAOTCacheStore(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -373,6 +375,10 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerAOTCacheDelayMethodRelocation(bool b) { _JITServerAOTCacheDelayMethodRelocation = b; }
    bool getJITServerAOTCacheIgnoreLocalSCC() const { return _JITServerAOTCacheIgnoreLocalSCC; }
    void setJITServerAOTCacheIgnoreLocalSCC(bool b) { _JITServerAOTCacheIgnoreLocalSCC = b; }
+   bool doNotRequestJITServerAOTCacheLoad() const { return _doNotRequestJITServerAOTCacheLoad; }
+   void setDoNotRequestJITServerAOTCacheLoad(bool b) { _doNotRequestJITServerAOTCacheLoad = b; }
+   bool doNotRequestJITServerAOTCacheStore() const { return _doNotRequestJITServerAOTCacheStore; }
+   void setDoNotRequestJITServerAOTCacheStore(bool b) { _doNotRequestJITServerAOTCacheStore = b; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -472,8 +478,12 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    bool        _JITServerUseAOTCachePersistence; // Whether to persist the JITServer AOT caches at the server
    std::string _JITServerAOTCacheDir;  // Directory where the JITServer persistent AOT caches are located
    bool        _JITServerAOTCacheDelayMethodRelocation; // At the client, whether to delay deserialized method relocation or not
-    // At the client, whether or not to use the new AOT cache implementation (with serialization record IDs as SCC offsets)
+   // At the client, whether or not to use the new AOT cache implementation (with serialization record IDs as SCC offsets)
    bool        _JITServerAOTCacheIgnoreLocalSCC;
+   // True if the client should not request AOT cache loads during this server connection
+   bool        _doNotRequestJITServerAOTCacheLoad;
+   // True if the client should not request AOT cache stores during this server connection
+   bool        _doNotRequestJITServerAOTCacheStore;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -165,6 +165,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _socketTimeoutMs(0),
          _clientUID(0),
          _serverUID(0),
+         _hasEverConnectedToServer(false),
          _JITServerMetricsPort(38500),
          _JITServerHealthPort(38600),
          _requireJITServer(false),
@@ -355,6 +356,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setClientUID(uint64_t val) { _clientUID = val; }
    uint64_t getServerUID() const { return _serverUID; }
    void setServerUID(uint64_t val) { _serverUID = val; }
+   bool hasEverConnectedToServer() const { return _hasEverConnectedToServer; }
+   void setHasEverConnectedToServer() { _hasEverConnectedToServer = true; }
    uint32_t getJITServerMetricsPort() const { return _JITServerMetricsPort; }
    void setJITServerMetricsPort(uint32_t port) { _JITServerMetricsPort = port; }
    uint32_t getJITServerHealthPort() const { return _JITServerHealthPort; }
@@ -469,6 +472,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    uint64_t    _clientUID;
    uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
+   bool        _hasEverConnectedToServer; // At the client, true if the client has connected to a server at some point in the past
    uint32_t    _JITServerMetricsPort; // Port for receiving http metrics requests from Prometheus; only used at server
    uint32_t    _JITServerHealthPort; // Port for receiving readiness/liveness probes from Kubernetes; only used at server
    bool        _requireJITServer;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 58; // ID: jdaegRYmBxGBJ/FG0fcY
+   static const uint16_t MINOR_NUMBER = 59; // ID: h4Ihmr7j+jt8ie/rpCIX
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -30,6 +30,7 @@ const char *messageNames[] =
    "compilationFailure",
    "AOTCache_storedAOTMethod",
    "AOTCache_serializedAOTMethod",
+   "AOTCache_failure",
    "mirrorResolvedJ9Method",
    "get_params_to_construct_TR_j9method",
    "getUnloadedClassRangesAndCHTable",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -34,6 +34,7 @@ enum MessageType : uint16_t
    compilationFailure,
    AOTCache_storedAOTMethod, // Final response to a compilation request that was an AOT cache store that ignored the client SCC
    AOTCache_serializedAOTMethod,// Final response to a compilation request that was an AOT cache hit
+   AOTCache_failure,// Final response to a compilation request that could not be completed due to AOT cache failure
    mirrorResolvedJ9Method,
    get_params_to_construct_TR_j9method,
    getUnloadedClassRangesAndCHTable,


### PR DESCRIPTION
If a JITServer client uses `-XX:+JITServerAOTCacheIgnoreLocalSCC`, servers that client connects to will now

1. Fail a compilation completely if the client requests an AOT cache store and the server cannot set up the compilation as an AOT cache store or load, and

2. Report the state of the server's AOT cache if (1) occurs, so the client will not continue to send AOT cache requests to that server if those requests could not possibly be fulfilled.

The client tracks the state of the current server's AOT cache with the persistent info properties `doNotRequestJITServerAOTCacheStore()` and `doNotRequestJITServerAOTCacheLoad()`. Since a particular server's cache will never become able to complete AOT cache loads or stores partway through a connection (e.g., the server's cache never shrinks in size, so AOT cache stores will never succeed once it is full) these properties remain true once set for the duration of the connection with a particular server. They are reset whenever a client connects to a new server.

These changes are necessary to prevent a crash at the client from occurring if the client is running with `-XX:+JITServerUseAOTCache -XX:+JITServerAOTCacheIgnoreLocalSCC` and connects to a server that is *not* running `-XX:+JITServerUseAOTCache` (or, more generally, has an AOT cache in which methods or records cannot be stored).

This PR also fixes a bug that prevented the deserializer from being reset when a client connected to a new server after a previous disconnection.

Related: https://github.com/eclipse-openj9/openj9/issues/18990