### PR TITLE
JITServer AOT cache array class support

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -962,20 +962,17 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // Get defining class chain record to use as a part of the key to lookup or store the method in AOT cache
          JITServerHelpers::cacheRemoteROMClassBatch(clientSession, uncachedRAMClasses, uncachedClassInfos);
          bool missingLoaderInfo = false;
-         bool referencesArrayClass = false;
-         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChainOffset, ramClassChain, stream, missingLoaderInfo, referencesArrayClass);
+         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChainOffset, ramClassChain,
+                                                                        stream, missingLoaderInfo);
          if (!_definingClassChainRecord)
             {
             if (TR::Options::getVerboseOption(TR_VerboseJITServer))
                TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "clientUID %llu failed to get defining class chain record for %p due to %s; "
-                  "method %p won't be loaded from or stored in AOT cache",
-                  (unsigned long long)clientId,
-                  clazz,
-                  missingLoaderInfo ? "missing class loader info" :
-                     (referencesArrayClass ? "unsupported reference to array class" : "the AOT cache size limit"),
-                  ramMethod
+                  "method %p won't be loaded from or stored in AOT cache", (unsigned long long)clientId, clazz,
+                  missingLoaderInfo ? "missing class loader info" : "the AOT cache size limit", ramMethod
                );
+
             if (aotCacheLoad)
                aotCache->incNumCacheMisses();
             _aotCacheStore = false;

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -146,6 +146,14 @@ public:
    // Helper routine to generate a unique ID for the client or server
    static uint64_t generateUID();
 
+   static uint32_t getFullClassNameLength(const J9ROMClass *romClass, const J9ROMClass *baseComponent,
+                                          uint32_t numDimensions);
+   // Writes the full class name (array class signature for arrays, class name otherwise) into the result buffer.
+   // The buffer length must be at least getFullClassNameLength(romClass, baseComponent, numDimensions).
+   // The baseComponent ROMClass and numDimensions correspond to the result of TR_J9VM::getBaseComponentClass().
+   static void getFullClassName(uint8_t *result, uint32_t length, const J9ROMClass *romClass,
+                                const J9ROMClass *baseComponent, uint32_t numDimensions);
+
 private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1525,8 +1525,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
          // This call will cache both the class chain and the AOT cache record in the client session.
          // The clientClassChainOffset can be invalid - we will attempt to re-cache it if necessary.
          bool missingLoaderInfo = false;
-         bool referencesArrayClass = false;
-         record = clientData->getClassChainRecord(clazz, clientClassChainOffset, ramClassChain, _stream, missingLoaderInfo, referencesArrayClass);
+         record = clientData->getClassChainRecord(clazz, clientClassChainOffset, ramClassChain, _stream, missingLoaderInfo);
          if (classChainRecord)
             *classChainRecord = record;
          }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -834,49 +834,60 @@ ClientSessionData::getOrCreateAOTCache(JITServer::ServerStream *stream)
    }
 
 const AOTCacheClassRecord *
-ClientSessionData::getClassRecord(ClientSessionData::ClassInfo &classInfo, bool &missingLoaderInfo)
+ClientSessionData::getClassRecord(ClassInfo &classInfo, bool &missingLoaderInfo, J9Class *&uncachedBaseComponent)
 {
-   if (!classInfo._aotCacheClassRecord)
-      {
-      auto &name = classInfo._classNameIdentifyingLoader;
-      if (name.empty())
-         {
-         TR_ASSERT(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classInfo._classChainOffsetIdentifyingLoader,
-                   "Valid class chain offset but missing class name identifying loader");
-         missingLoaderInfo = true;
-         return NULL;
-         }
+   TR_ASSERT(getROMMapMonitor()->owned_by_self(), "Must hold ROMMapMonitor");
 
-      auto classLoaderRecord = _aotCache->getClassLoaderRecord((const uint8_t *)name.data(), name.size());
-      if (!classLoaderRecord)
+   if (classInfo._aotCacheClassRecord)
+      return classInfo._aotCacheClassRecord;
+
+   const J9ROMClass *baseComponent = NULL;
+   if (classInfo._numDimensions)
+      {
+      auto it = getROMClassMap().find((J9Class *)classInfo._baseComponentClass);
+      if (it == getROMClassMap().end())
          {
+         uncachedBaseComponent = (J9Class *)classInfo._baseComponentClass;
          return NULL;
          }
-      classInfo._aotCacheClassRecord = _aotCache->getClassRecord(classLoaderRecord, classInfo._romClass);
-      if (classInfo._aotCacheClassRecord)
-         {
-         // The name string is no longer needed; free the memory used by it by setting it to an empty string
-         std::string().swap(classInfo._classNameIdentifyingLoader);
-         }
+      baseComponent = it->second._romClass;
       }
 
+   auto &name = classInfo._classNameIdentifyingLoader;
+   if (name.empty())
+      {
+      TR_ASSERT(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != classInfo._classChainOffsetIdentifyingLoader,
+                "Valid class chain offset but missing class name identifying loader");
+      missingLoaderInfo = true;
+      return NULL;
+      }
+
+   auto classLoaderRecord = _aotCache->getClassLoaderRecord((const uint8_t *)name.data(), name.size());
+   if (!classLoaderRecord)
+      return NULL; // Reached AOT cache size limit
+
+   classInfo._aotCacheClassRecord = _aotCache->getClassRecord(classLoaderRecord, classInfo._romClass,
+                                                              baseComponent, classInfo._numDimensions);
+   if (!classInfo._aotCacheClassRecord)
+      return NULL; // Reached AOT cache size limit
+
+   // The name string is no longer needed; free the memory used by it by setting it to an empty string
+   std::string().swap(classInfo._classNameIdentifyingLoader);
    return classInfo._aotCacheClassRecord;
 }
 
 const AOTCacheClassRecord *
-ClientSessionData::getClassRecord(J9Class *clazz, bool &missingLoaderInfo, bool &uncachedClass)
+ClientSessionData::getClassRecord(J9Class *clazz, bool &missingLoaderInfo,
+                                  bool &uncachedClass, J9Class *&uncachedBaseComponent)
    {
    TR_ASSERT(getROMMapMonitor()->owned_by_self(), "Must hold ROMMapMonitor");
 
    auto it = getROMClassMap().find(clazz);
-   if (it == getROMClassMap().end())
-      {
-      uncachedClass = true;
-      return NULL;
-      }
+   if (it != getROMClassMap().end())
+      return getClassRecord(it->second, missingLoaderInfo, uncachedBaseComponent);
 
-   auto record = getClassRecord(it->second, missingLoaderInfo);
-   return record;
+   uncachedClass = true;
+   return NULL;
    }
 
 const AOTCacheClassRecord *
@@ -884,9 +895,36 @@ ClientSessionData::getClassRecord(J9Class *clazz, JITServer::ServerStream *strea
    {
    const AOTCacheClassRecord *record = NULL;
    bool uncachedClass = false;
+   J9Class *uncachedBaseComponent = NULL;
       {
       OMR::CriticalSection cs(getROMMapMonitor());
-      record = getClassRecord(clazz, missingLoaderInfo, uncachedClass);
+      record = getClassRecord(clazz, missingLoaderInfo, uncachedClass, uncachedBaseComponent);
+      }
+   if (record)
+      return record;
+
+   if (uncachedClass)
+      {
+      // Request and cache class info from the client
+      JITServerHelpers::ClassInfoTuple classInfoTuple;
+      auto romClass = JITServerHelpers::getRemoteROMClass(clazz, stream, _persistentMemory, classInfoTuple);
+      JITServerHelpers::cacheRemoteROMClassOrFreeIt(this, clazz, romClass, classInfoTuple);
+
+      OMR::CriticalSection cs(getROMMapMonitor());
+      record = getClassRecord(clazz, missingLoaderInfo, uncachedClass, uncachedBaseComponent);
+      TR_ASSERT(!uncachedClass, "Class %p must be already cached", clazz);
+      }
+
+   if (uncachedBaseComponent)
+      {
+      // Request and cache base component class info from the client
+      JITServerHelpers::ClassInfoTuple classInfoTuple;
+      auto romClass = JITServerHelpers::getRemoteROMClass(uncachedBaseComponent, stream, _persistentMemory, classInfoTuple);
+      JITServerHelpers::cacheRemoteROMClassOrFreeIt(this, uncachedBaseComponent, romClass, classInfoTuple);
+
+      OMR::CriticalSection cs(getROMMapMonitor());
+      record = getClassRecord(clazz, missingLoaderInfo, uncachedClass, uncachedBaseComponent);
+      TR_ASSERT(!uncachedClass && !uncachedBaseComponent, "Class %p and base component must be already cached", clazz);
       }
 
    if (missingLoaderInfo)
@@ -903,7 +941,7 @@ ClientSessionData::getClassRecord(J9Class *clazz, JITServer::ServerStream *strea
          TR_ASSERT(it != getROMClassMap().end(), "Class %p must be already cached", clazz);
          it->second._classChainOffsetIdentifyingLoader = offset;
          it->second._classNameIdentifyingLoader = name;
-         record = getClassRecord(it->second, missingLoaderInfo);
+         record = getClassRecord(it->second, missingLoaderInfo, uncachedBaseComponent);
          TR_ASSERT(!missingLoaderInfo, "Class %p cannot have missing loader info as we've just received it from the client", clazz);
          }
       else if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -913,17 +951,6 @@ ClientSessionData::getClassRecord(J9Class *clazz, JITServer::ServerStream *strea
             (unsigned long long)_clientUID, clazz
          );
          }
-      }
-   else if (uncachedClass)
-      {
-      // Request and cache class info from the client
-      JITServerHelpers::ClassInfoTuple classInfoTuple;
-      auto romClass = JITServerHelpers::getRemoteROMClass(clazz, stream, _persistentMemory, classInfoTuple);
-      JITServerHelpers::cacheRemoteROMClassOrFreeIt(this, clazz, romClass, classInfoTuple);
-
-      OMR::CriticalSection cs(getROMMapMonitor());
-      record = getClassRecord(clazz, missingLoaderInfo, uncachedClass);
-      TR_ASSERT(!uncachedClass, "Class %p cannot be uncached", clazz);
       }
 
    return record;
@@ -953,9 +980,8 @@ ClientSessionData::getMethodRecord(J9Method *method, J9Class *definingClass, JIT
 
 const AOTCacheClassChainRecord *
 ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffset,
-                                       const std::vector<J9Class *> &ramClassChain, JITServer::ServerStream *stream,
-                                       bool &missingLoaderInfo,
-                                       bool &referencesArrayClass)
+                                       const std::vector<J9Class *> &ramClassChain,
+                                       JITServer::ServerStream *stream, bool &missingLoaderInfo)
    {
    TR_ASSERT(!ramClassChain.empty() && (ramClassChain.size() <= TR_J9SharedCache::maxClassChainLength),
              "Invalid class chain length: %zu", ramClassChain.size());
@@ -971,7 +997,8 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffse
    const AOTCacheClassRecord *classRecords[TR_J9SharedCache::maxClassChainLength] = {0};
    size_t uncachedIndexes[TR_J9SharedCache::maxClassChainLength] = {0};
    std::vector<J9Class *> uncachedRAMClasses;
-   uncachedRAMClasses.reserve(ramClassChain.size());
+   uncachedRAMClasses.reserve(ramClassChain.size() + 1); // Extra slot for possibly uncached base component class
+   J9Class *baseComponent = NULL;
    size_t missingLoaderRecordIndexes[TR_J9SharedCache::maxClassChainLength] = {0};
    size_t numMissingLoaderRecords = 0;
 
@@ -983,57 +1010,82 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffse
          {
          bool missingLoaderRecord = false;
          bool uncachedClass = false;
-         if (!(classRecords[i] = getClassRecord(ramClassChain[i], missingLoaderRecord, uncachedClass)))
+         J9Class *uncachedBaseComponent = NULL;
+         classRecords[i] = getClassRecord(ramClassChain[i], missingLoaderRecord, uncachedClass, uncachedBaseComponent);
+
+         if (!classRecords[i])
             {
-            if (missingLoaderRecord)
-               {
-               missingLoaderRecordIndexes[numMissingLoaderRecords++] = i;
-               }
-            else if (uncachedClass)
+            if (uncachedClass)
                {
                uncachedIndexes[uncachedRAMClasses.size()] = i;
                uncachedRAMClasses.push_back(ramClassChain[i]);
                }
+            else if (uncachedBaseComponent)
+               {
+               TR_ASSERT_FATAL(!baseComponent && (i == 0), "Only root class can be an array");
+               baseComponent = uncachedBaseComponent;
+               // The corner case of missing both the base component class and the class loader info is still handled
+               // correctly by requesting the class loader info in the getClassRecord(ramClassChain[0], ...) call below.
+               }
+            else if (missingLoaderRecord)
+               {
+               missingLoaderRecordIndexes[numMissingLoaderRecords++] = i;
+               }
             else
                {
-               // Either the class was an array or there was an allocation failure
-               auto it = getROMClassMap().find(ramClassChain[i]);
-               if (it != getROMClassMap().end())
-                  referencesArrayClass = J9ROMCLASS_IS_ARRAY(it->second._romClass);
-               return NULL;
+               return NULL; // Reached AOT cache size limit
                }
             }
          }
       }
+
+   size_t numUncachedClasses = uncachedRAMClasses.size();
+   if (baseComponent)
+      uncachedRAMClasses.push_back(baseComponent);
 
    if (!uncachedRAMClasses.empty())
       {
       // Request uncached classes from the client and cache them
       stream->write(JITServer::MessageType::AOTCache_getROMClassBatch, uncachedRAMClasses);
       auto recv = stream->read<std::vector<JITServerHelpers::ClassInfoTuple>>();
-      auto classInfoTuples = std::get<0>(recv);
+      auto &classInfoTuples = std::get<0>(recv);
       JITServerHelpers::cacheRemoteROMClassBatch(this, uncachedRAMClasses, classInfoTuples);
+
+      // Get root class record if its base component class was previously uncached
+      if (baseComponent)
+         {
+         classRecords[0] = getClassRecord(ramClassChain[0], stream, missingLoaderInfo);
+         if (!classRecords[0])
+            return NULL; // Missing class loader info or reached AOT cache size limit
+         baseComponent = NULL;
+         }
 
       // Get class records for newly cached classes, remembering classes with missing class loader info
       OMR::CriticalSection cs(getROMMapMonitor());
-      for (size_t i = 0; i < uncachedRAMClasses.size(); ++i)
+      for (size_t i = 0; i < numUncachedClasses; ++i)
          {
+         size_t idx = uncachedIndexes[i];
          bool missingLoaderRecord = false;
          bool uncachedClass = false;
-         if (!(classRecords[uncachedIndexes[i]] = getClassRecord(uncachedRAMClasses[i], missingLoaderRecord, uncachedClass)))
+         J9Class *uncachedBaseComponent = NULL;
+         classRecords[idx] = getClassRecord(uncachedRAMClasses[i], missingLoaderRecord,
+                                            uncachedClass, uncachedBaseComponent);
+
+         if (!classRecords[idx])
             {
             TR_ASSERT(!uncachedClass, "Class %p must be already cached", uncachedRAMClasses[i]);
-            if (missingLoaderRecord)
+            if (uncachedBaseComponent)
                {
-               missingLoaderRecordIndexes[numMissingLoaderRecords++] = uncachedIndexes[i];
+               TR_ASSERT_FATAL(!baseComponent && (idx == 0), "Only root class can be an array");
+               baseComponent = uncachedBaseComponent;
+               }
+            else if (missingLoaderRecord)
+               {
+               missingLoaderRecordIndexes[numMissingLoaderRecords++] = idx;
                }
             else
                {
-               // Either the class was an array or there was an allocation failure
-               auto it = getROMClassMap().find(uncachedRAMClasses[i]);
-               if (it != getROMClassMap().end())
-                  referencesArrayClass = J9ROMCLASS_IS_ARRAY(it->second._romClass);
-               return NULL;
+               return NULL; // Reached AOT cache size limit
                }
             }
          }
@@ -1043,8 +1095,17 @@ ClientSessionData::getClassChainRecord(J9Class *clazz, uintptr_t classChainOffse
    for (size_t i = 0; i < numMissingLoaderRecords; ++i)
       {
       size_t idx = missingLoaderRecordIndexes[i];
-      if (!(classRecords[idx] = getClassRecord(ramClassChain[idx], stream, missingLoaderInfo)))
-         return NULL;
+      classRecords[idx] = getClassRecord(ramClassChain[idx], stream, missingLoaderInfo);
+      if (!classRecords[idx])
+         return NULL; // Missing class loader info or reached AOT cache size limit
+      }
+
+   // Get root class record if its base component class is uncached
+   if (baseComponent)
+      {
+      classRecords[0] = getClassRecord(ramClassChain[0], stream, missingLoaderInfo);
+      if (!classRecords[0])
+         return NULL; // Missing class loader info or reached AOT cache size limit
       }
 
    // Cache the new class chain record

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -167,7 +167,8 @@ public:
 
    static const char *getRecordName() { return "class"; }
    static AOTCacheClassRecord *create(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
-                                      const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+                                      const JITServerROMClassHash &hash, const J9ROMClass *romClass,
+                                      const J9ROMClass *baseComponent, uint32_t numDimensions);
    void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
 
 private:
@@ -176,10 +177,11 @@ private:
    friend AOTCacheClassRecord *AOTCacheRecord::readRecord<>(FILE *f, const JITServerAOTCacheReadContext &context);
 
    AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
-                       const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+                       const JITServerROMClassHash &hash, const J9ROMClass *romClass, const J9ROMClass *baseComponent,
+                       uint32_t numDimensions, uint32_t nameLength);
    AOTCacheClassRecord(const JITServerAOTCacheReadContext &context, const ClassSerializationRecord &header);
 
-   static size_t size(size_t nameLength)
+   static size_t size(uint32_t nameLength)
       {
       return offsetof(AOTCacheClassRecord, _data) + ClassSerializationRecord::size(nameLength);
       }
@@ -414,7 +416,8 @@ public:
    // space. The getThunkRecord method instead has an accompanying createAndStoreThunk method that will create and store
    // a new thunk record if there is sufficient space.
    const AOTCacheClassLoaderRecord *getClassLoaderRecord(const uint8_t *name, size_t nameLength);
-   const AOTCacheClassRecord *getClassRecord(const AOTCacheClassLoaderRecord *loaderRecord, const J9ROMClass *romClass);
+   const AOTCacheClassRecord *getClassRecord(const AOTCacheClassLoaderRecord *loaderRecord, const J9ROMClass *romClass,
+                                             const J9ROMClass *baseComponent, uint32_t numDimensions);
    const AOTCacheMethodRecord *getMethodRecord(const AOTCacheClassRecord *definingClassRecord,
                                                uint32_t index, const J9ROMMethod *romMethod);
    const AOTCacheClassChainRecord *getClassChainRecord(const AOTCacheClassRecord *const *classRecords, size_t length);

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -29,6 +29,7 @@
 
 struct JITServerAOTCacheReadContext;
 
+
 enum AOTSerializationRecordType
    {
    // Used for class loader identification (by name of the first loaded class).
@@ -147,18 +148,19 @@ public:
    uintptr_t classLoaderId() const { return _classLoaderId; }
    const JITServerROMClassHash &hash() const { return _hash; }
    uint32_t romClassSize() const { return _romClassSize; }
-   size_t nameLength() const { return _nameLength; }
+   uint32_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
 
 private:
    friend class AOTCacheRecord;
    friend class AOTCacheClassRecord;
 
-   ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
-                            const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+   ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId, const JITServerROMClassHash &hash,
+                            const J9ROMClass *romClass, const J9ROMClass *baseComponent,
+                            uint32_t numDimensions, uint32_t nameLength);
    ClassSerializationRecord();
 
-   static size_t size(size_t nameLength)
+   static size_t size(uint32_t nameLength)
       {
       return sizeof(ClassSerializationRecord) + OMR::alignNoCheck(nameLength, sizeof(size_t));
       }

--- a/runtime/compiler/runtime/JITServerROMClassHash.cpp
+++ b/runtime/compiler/runtime/JITServerROMClassHash.cpp
@@ -19,20 +19,39 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
+
 #include "j9.h"
+#include "AtomicSupport.hpp"
+#include "control/JITServerHelpers.hpp"
+#include "env/StackMemoryRegion.hpp"
+#include "env/TRMemory.hpp"
 #include "net/LoadSSLLibs.hpp"
 #include "runtime/JITServerROMClassHash.hpp"
+#include "runtime/JITServerAOTSerializationRecords.hpp"
 
 
-JITServerROMClassHash::JITServerROMClassHash(const J9ROMClass *romClass)
+JITServerROMClassHash::JITServerROMClassHash(const JITServerROMClassHash &objectArrayHash,
+                                             const JITServerROMClassHash &baseComponentHash, size_t numDimensions)
+   {
+   size_t data[ROMCLASS_HASH_WORDS * 2 + 1];
+   memcpy(data, objectArrayHash._data, sizeof(_data));
+   memcpy(data + ROMCLASS_HASH_WORDS, baseComponentHash._data, sizeof(_data));
+   data[ROMCLASS_HASH_WORDS * 2] = numDimensions;
+
+   init(data, sizeof(data));
+   }
+
+
+void
+JITServerROMClassHash::init(const void *data, size_t size)
    {
    EVP_MD_CTX *ctx = OEVP_MD_CTX_new();
    if (!ctx)
-      throw std::bad_alloc();//The only possible error is memory allocation failure
+      throw std::bad_alloc(); // The only possible error is memory allocation failure
    if (!OEVP_DigestInit_ex(ctx, OEVP_sha256(), NULL))
-      throw std::bad_alloc();//The only possible error is memory allocation failure
+      throw std::bad_alloc(); // The only possible error is memory allocation failure
 
-   int success = OEVP_DigestUpdate(ctx, romClass, romClass->romSize);
+   int success = OEVP_DigestUpdate(ctx, data, size);
    TR_ASSERT(success, "EVP_DigestUpdate() failed");
    unsigned int hashSize = 0;
    success = OEVP_DigestFinal_ex(ctx, (uint8_t *)_data, &hashSize);
@@ -41,6 +60,17 @@ JITServerROMClassHash::JITServerROMClassHash(const J9ROMClass *romClass)
 
    OEVP_MD_CTX_free(ctx);
    }
+
+void
+JITServerROMClassHash::init(const J9ROMClass *romClass, TR_Memory &trMemory, TR_J9VMBase *fej9)
+   {
+   TR::StackMemoryRegion region(trMemory);
+   size_t packedSize = 0;
+   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass((J9ROMClass *)romClass, &trMemory, fej9, packedSize, 0);
+
+   init(packedROMClass, packedSize);
+   }
+
 
 const char *
 JITServerROMClassHash::toString(char *buffer, size_t size) const
@@ -51,4 +81,27 @@ JITServerROMClassHash::toString(char *buffer, size_t size) const
    for (size_t i = 0; i < sizeof(_data); ++i)
       s += sprintf(s, "%02x", ((uint8_t *)_data)[i]);
    return buffer;
+   }
+
+
+volatile bool JITServerROMClassHash::_cachedObjectArrayHash = false;
+JITServerROMClassHash JITServerROMClassHash::_objectArrayHash;
+
+const JITServerROMClassHash &
+JITServerROMClassHash::getObjectArrayHash(const J9ROMClass *objectArrayROMClass, TR_Memory &trMemory, TR_J9VMBase *fej9)
+   {
+   if (_cachedObjectArrayHash)
+      {
+      TR_ASSERT(_objectArrayHash == JITServerROMClassHash(objectArrayROMClass, trMemory, fej9),
+                "Mismatching cached object array ROMClass hash");
+      return _objectArrayHash;
+      }
+
+   // There is no need to synchronize writes into _objectArrayHash since the only existing
+   // call site of this function in JITServerAOTDeserializer::isClassMatching() is always
+   // inside a critical section of the same monitor JITServerAOTDeserializer::_classMonitor.
+   _objectArrayHash.init(objectArrayROMClass, trMemory, fej9);
+   VM_AtomicSupport::writeBarrier();
+   _cachedObjectArrayHash = true;
+   return _objectArrayHash;
    }


### PR DESCRIPTION
~~This draft PR implements object array class support for JITServer AOT cache. Currently untested.~~

This PR enables AOT cache serialization and load for methods that refer to array classes in their relocation and validation records, specifically object arrays and multidimensional primitive arrays. Since such classes share the same ROMClass named `[L`, we disambiguate them in the AOT cache by using the full array class signature instead of the ROMClass name. We build the ROMClass hash for an array class by combining the ROMClass hash of the `[L` object array class, the ROMClass hash of the base component class, and the number of array dimensions.