### PR TITLE
Replace omrvm to javavm for RootScanner class

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -421,7 +421,7 @@ MM_ReferenceChainWalker::scanContinuationObject(J9Object *objectPtr)
 void
 MM_ReferenceChainWalker::scanMixedObject(J9Object *objectPtr)
 {
-	GC_MixedObjectDeclarationOrderIterator objectIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), objectPtr, _shouldPreindexInterfaceFields);
+	GC_MixedObjectDeclarationOrderIterator objectIterator(_javaVM, objectPtr, _shouldPreindexInterfaceFields);
 
 	while (GC_SlotObject *slotObject = objectIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_FIELD, objectIterator.getIndex(), objectPtr);
@@ -434,7 +434,7 @@ MM_ReferenceChainWalker::scanMixedObject(J9Object *objectPtr)
 void
 MM_ReferenceChainWalker::scanPointerArrayObject(J9IndexableObject *objectPtr)
 {
-	GC_PointerArrayIterator pointerArrayIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9Object *)objectPtr);
+	GC_PointerArrayIterator pointerArrayIterator(_javaVM, (J9Object *)objectPtr);
 
 	while (GC_SlotObject *slotObject = pointerArrayIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_ARRAY, pointerArrayIterator.getIndex(), (J9Object *)objectPtr);
@@ -447,7 +447,7 @@ MM_ReferenceChainWalker::scanPointerArrayObject(J9IndexableObject *objectPtr)
 void
 MM_ReferenceChainWalker::scanReferenceMixedObject(J9Object *objectPtr)
 {
-	GC_MixedObjectDeclarationOrderIterator objectIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), objectPtr, _shouldPreindexInterfaceFields);
+	GC_MixedObjectDeclarationOrderIterator objectIterator(_javaVM, objectPtr, _shouldPreindexInterfaceFields);
 
 	while (GC_SlotObject *slotObject = objectIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_WEAK_REFERENCE, objectIterator.getIndex(), objectPtr);
@@ -462,7 +462,7 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 {
 	J9Object* referrer = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 
-	GC_ClassIteratorDeclarationOrder classIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz, _shouldPreindexInterfaceFields);
+	GC_ClassIteratorDeclarationOrder classIterator(_javaVM, clazz, _shouldPreindexInterfaceFields);
 	while (volatile j9object_t *slot = classIterator.nextSlot()) {
 		IDATA refType = classIterator.getSlotReferenceType();
 		IDATA index = classIterator.getIndex();
@@ -471,7 +471,7 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 		doSlot((j9object_t*)slot, refType, index, referrer);
 	}
 
-	GC_ClassIteratorClassSlots classIteratorClassSlots(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
+	GC_ClassIteratorClassSlots classIteratorClassSlots(_javaVM, clazz);
 	while (J9Class *classPtr = classIteratorClassSlots.nextSlot()) {
 		switch (classIteratorClassSlots.getState()) {
 		case classiteratorclassslots_state_constant_pool:

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -87,7 +87,6 @@ MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 {
 	if (NULL != classLoader->moduleHashTable) {
 		J9HashTableState moduleWalkState;
-		J9JavaVM *javaVM = static_cast<J9JavaVM*>(_omrVM->_language_vm);
 		J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
 		while (NULL != modulePtr) {
 			J9Module * const module = *modulePtr;
@@ -102,8 +101,8 @@ MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 			modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 		}
 
-		if (classLoader == javaVM->systemClassLoader) {
-			doSlot(&javaVM->unamedModuleForSystemLoader->moduleObject);
+		if (classLoader == _javaVM->systemClassLoader) {
+			doSlot(&_javaVM->unamedModuleForSystemLoader->moduleObject);
 		}
 	}
 }
@@ -303,11 +302,11 @@ MM_RootScanner::scanClasses(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_Classes);
 
-	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
+	GC_SegmentIterator segmentIterator(_javaVM->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
 
 	while (J9MemorySegment *segment = segmentIterator.nextSegment()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-			GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm), segment);
+			GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 			J9Class *clazz = NULL;
 			while (NULL != (clazz = classHeapIterator.nextClass())) {
 				doClass(clazz);
@@ -333,7 +332,7 @@ MM_RootScanner::scanVMClassSlots(MM_EnvironmentBase *env)
 	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_VMClassSlots);
 
-		GC_VMClassSlotIterator classSlotIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
+		GC_VMClassSlotIterator classSlotIterator(_javaVM);
 		J9Class *classPtr;
 
 		while (NULL != (classPtr = classSlotIterator.nextSlot())) {
@@ -396,13 +395,13 @@ MM_RootScanner::scanPermanentClasses(MM_EnvironmentBase *env)
 	reportScanningStarted(RootScannerEntity_PermanentClasses);
 
 	/* Do systemClassLoader */
-	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->systemClassLoader);
+	scanClassloader(env, _javaVM->systemClassLoader);
 
 	/* Do applicationClassLoader */
-	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->applicationClassLoader);
+	scanClassloader(env, _javaVM->applicationClassLoader);
 
 	/* Do extensionClassLoader */
-	scanClassloader(env, static_cast<J9JavaVM *>(_omrVM->_language_vm)->extensionClassLoader);
+	scanClassloader(env, _javaVM->extensionClassLoader);
 
 	condYield();
 
@@ -422,7 +421,7 @@ MM_RootScanner::scanClassloader(MM_EnvironmentBase *env, J9ClassLoader *classLoa
 		GC_ClassLoaderSegmentIterator segmentIterator(classLoader, MEMORY_TYPE_RAM_CLASS);
 		while (NULL != (segment = segmentIterator.nextSegment())) {
 			if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-				GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), segment);
+				GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 				while (NULL != (clazz = classHeapIterator.nextClass())) {
 					doClass(clazz);
 					if (shouldYieldFromClassScan(100000)) {
@@ -463,7 +462,7 @@ MM_RootScanner::scanClassLoaders(MM_EnvironmentBase *env)
 
 		J9ClassLoader *classLoader;
 
-		GC_ClassLoaderIterator classLoaderIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->classLoaderBlocks);
+		GC_ClassLoaderIterator classLoaderIterator(_javaVM->classLoaderBlocks);
 		while ((classLoader = classLoaderIterator.nextSlot()) != NULL) {
 			doClassLoader(classLoader);
 		}
@@ -500,7 +499,7 @@ MM_RootScanner::scanThreads(MM_EnvironmentBase *env)
 	 * list is also locked.
 	 */
 
-	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
+	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
 	StackIteratorData localData;
 
 	localData.rootScanner = this;
@@ -509,7 +508,7 @@ MM_RootScanner::scanThreads(MM_EnvironmentBase *env)
 	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			if (scanOneThread(env, walkThread, (void *) &localData)) {
-				vmThreadListIterator.reset(static_cast<J9JavaVM *>(_omrVM->_language_vm)->mainThread);
+				vmThreadListIterator.reset(_javaVM->mainThread);
 			}
 		}
 	}
@@ -621,7 +620,7 @@ MM_RootScanner::scanJNIGlobalReferences(MM_EnvironmentBase *env)
 	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_JNIGlobalReferences);
 
-		GC_JNIGlobalReferenceIterator jniGlobalReferenceIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm)->jniGlobalReferences);
+		GC_JNIGlobalReferenceIterator jniGlobalReferenceIterator(_javaVM->jniGlobalReferences);
 		J9Object **slot;
 
 		while ((slot = (J9Object **)jniGlobalReferenceIterator.nextSlot()) != NULL) {
@@ -797,7 +796,7 @@ void
 MM_RootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_MonitorLookupCaches);
-	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM *>(_omrVM->_language_vm));
+	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
 	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			j9objectmonitor_t *objectMonitorLookupCache = walkThread->objectMonitorLookupCache;
@@ -819,7 +818,7 @@ MM_RootScanner::scanMonitorReferences(MM_EnvironmentBase *env)
 	reportScanningStarted(RootScannerEntity_MonitorReferences);
 
 	J9ObjectMonitor *objectMonitor = NULL;
-	J9MonitorTableListEntry *monitorTableList = static_cast<J9JavaVM *>(_omrVM->_language_vm)->monitorTableList;
+	J9MonitorTableListEntry *monitorTableList = _javaVM->monitorTableList;
 	while (NULL != monitorTableList) {
 		J9HashTable *table = monitorTableList->monitorTable;
 		if (NULL != table) {
@@ -845,7 +844,7 @@ MM_RootScanner::scanJNIWeakGlobalReferences(MM_EnvironmentBase *env)
 	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_JNIWeakGlobalReferences);
 
-		GC_JNIWeakGlobalReferenceIterator jniWeakGlobalReferenceIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm)->jniWeakGlobalReferences);
+		GC_JNIWeakGlobalReferenceIterator jniWeakGlobalReferenceIterator(_javaVM->jniWeakGlobalReferences);
 		J9Object **slot;
 
 		while ((slot = (J9Object **)jniWeakGlobalReferenceIterator.nextSlot()) != NULL) {
@@ -892,7 +891,7 @@ MM_RootScanner::scanJVMTIObjectTagTables(MM_EnvironmentBase *env)
 	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		reportScanningStarted(RootScannerEntity_JVMTIObjectTagTables);
 
-		J9JVMTIData *jvmtiData = J9JVMTI_DATA_FROM_VM(static_cast<J9JavaVM *>(_omrVM->_language_vm));
+		J9JVMTIData *jvmtiData = J9JVMTI_DATA_FROM_VM(_javaVM);
 		J9JVMTIEnv *jvmtiEnv = NULL;
 		J9Object **slotPtr = NULL;
 		if (NULL != jvmtiData) {
@@ -1047,8 +1046,7 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 	scanOwnableSynchronizerObjects(env);
 	scanContinuationObjects(env);
 #if JAVA_SPEC_VERSION >= 19
-	J9JavaVM *vm = (J9JavaVM *)env->getOmrVM()->_language_vm;
-	J9JITConfig *jitConfig = vm->jitConfig;
+	J9JITConfig *jitConfig = _javaVM->jitConfig;
 	if ((NULL != jitConfig) && (NULL != jitConfig->methodsToDelete)) {
 		iterateAllContinuationObjects(env);
 	}

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -77,7 +77,7 @@ protected:
 	MM_EnvironmentBase *_env;
 	MM_GCExtensions *_extensions;
 	MM_CollectorLanguageInterfaceImpl *_clij;
-	OMR_VM *_omrVM;
+	J9JavaVM *_javaVM;
 
 	bool _stringTableAsRoot;  /**< Treat the string table as a hard root */
 	bool _jniWeakGlobalReferencesTableAsRoot;	/**< Treat JNI Weak References Table as a hard root */
@@ -198,7 +198,7 @@ protected:
 		_scanningEntity = scanningEntity;
 		
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			_entityStartScanTime = omrtime_hires_clock();	
 			_entityIncrementStartTime = _entityStartScanTime;
 		}
@@ -231,7 +231,7 @@ protected:
 		Assert_MM_true(_scanningEntity == scannedEntity);
 		
 		if (_extensions->rootScannerStatsEnabled) {
- 			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
  			uint64_t entityEndScanTime = omrtime_hires_clock();
 			
 			_env->_rootScannerStats._statsUsed = true;
@@ -278,7 +278,7 @@ public:
 	reportScanningSuspended()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			_entityIncrementEndTime = omrtime_hires_clock();
 			
 			updateScanStats(_entityIncrementEndTime);
@@ -292,7 +292,7 @@ public:
 	reportScanningResumed()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			_entityIncrementStartTime = omrtime_hires_clock();
 			_entityIncrementEndTime = 0;	
 		}
@@ -304,7 +304,7 @@ public:
 		, _env(env)
 		, _extensions(MM_GCExtensions::getExtensions(env))
 		, _clij((MM_CollectorLanguageInterfaceImpl *)_extensions->collectorLanguageInterface)
-		, _omrVM(env->getOmrVM())
+		, _javaVM((J9JavaVM *)env->getOmrVM()->_language_vm)
 		, _stringTableAsRoot(true)
 		, _jniWeakGlobalReferencesTableAsRoot(false)
 		, _singleThread(singleThread)
@@ -328,7 +328,7 @@ public:
 	{
 		_typeId = __FUNCTION__;
 		
-		OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+		OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 		_entityIncrementStartTime = omrtime_hires_clock();
 
 	}

--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -364,7 +364,7 @@ MM_MarkingSchemeRootClearer::iterateAllContinuationObjects(MM_EnvironmentBase *e
 void
 MM_MarkingSchemeRootClearer::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 {
-	J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+	J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 	_env->getGCEnvironment()->_markJavaStats._monitorReferenceCandidates += 1;
 
 	if (!_markingScheme->isMarked((omrobjectptr_t )monitor->userData)) {
@@ -372,16 +372,15 @@ MM_MarkingSchemeRootClearer::doMonitorReference(J9ObjectMonitor *objectMonitor, 
 		_env->getGCEnvironment()->_markJavaStats._monitorReferenceCleared += 1;
 		/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 		 * monitor is not internal to the GC */
-		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+		_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 	}
 }
 
 MM_RootScanner::CompletePhaseCode
 MM_MarkingSchemeRootClearer::scanMonitorReferencesComplete(MM_EnvironmentBase *env)
 {
-	J9JavaVM *javaVM = (J9JavaVM *)env->getLanguageVM();
 	reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-	javaVM->internalVMFunctions->objectMonitorDestroyComplete(javaVM, (J9VMThread *)env->getLanguageVMThread());
+	_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
 	reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 	return complete_phase_OK;
 }

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -48,7 +48,7 @@
 #include "ScavengerRootClearer.hpp"
 
 void
-MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard* region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats)
+MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard *region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats)
 {
 	/* no list can possibly contain more reference objects than there are bytes in a region. */
 	const uintptr_t maxObjects = region->getSize();

--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -47,7 +47,7 @@ class MM_ScavengerRootClearer : public MM_RootScanner
 private:
 	MM_Scavenger *_scavenger;
 
-	void processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard* region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
+	void processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard *region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
 	void scavengeReferenceObjects(MM_EnvironmentStandard *env, uintptr_t referenceObjectType);
 #if defined(J9VM_GC_FINALIZATION)
 	void scavengeUnfinalizedObjects(MM_EnvironmentStandard *env);
@@ -202,7 +202,7 @@ public:
 	doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 	{
 		bool const compressed = _extensions->compressObjectReferences();
-		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		omrobjectptr_t objectPtr = (omrobjectptr_t )monitor->userData;
 		_env->getGCEnvironment()->_scavengerJavaStats._monitorReferenceCandidates += 1;
 		
@@ -217,7 +217,7 @@ public:
 				/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 				 * monitor is not internal to the GC
 				 */
-				static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+				_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 			}
 		}
 	}
@@ -226,7 +226,7 @@ public:
 	scanMonitorReferencesComplete(MM_EnvironmentBase *env)
 	{
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroyComplete(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)env->getOmrVMThread()->_language_vmthread);
+		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getOmrVMThread()->_language_vmthread);
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
@@ -52,10 +52,10 @@ void
 MM_RootScannerReadBarrierVerifier::scanClass(MM_EnvironmentBase *env)
 {
 	OMR_VMThread *omrVMThread = env->getOmrVMThread();
-	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
+	GC_SegmentIterator segmentIterator(_javaVM->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
 
 	while (J9MemorySegment *segment = segmentIterator.nextSegment()) {
-		GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm), segment);
+		GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
 		J9Class *clazz = NULL;
 
 		while (NULL != (clazz = classHeapIterator.nextClass())) {

--- a/runtime/gc_realtime/RealtimeMarkingSchemeRootClearer.hpp
+++ b/runtime/gc_realtime/RealtimeMarkingSchemeRootClearer.hpp
@@ -63,7 +63,7 @@ public:
 	 * This should not be called
 	 */
 	virtual void
-	doSlot(J9Object** slot)
+	doSlot(J9Object **slot)
 	{
 		Assert_MM_unreachable();
 	}
@@ -83,12 +83,12 @@ public:
 	virtual void
 	doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 	{
-		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		if (!_markingScheme->isMarked((J9Object *)monitor->userData)) {
 			monitorReferenceIterator->removeSlot();
 			/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 			 * monitor is not internal to the GC */
-			static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+			_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 		}
 	}
 	
@@ -106,13 +106,13 @@ public:
 			reportScanningStarted(RootScannerEntity_MonitorReferences);
 		
 			J9ObjectMonitor *objectMonitor = NULL;
-			J9MonitorTableListEntry *monitorTableList = static_cast<J9JavaVM*>(_omrVM->_language_vm)->monitorTableList;
+			J9MonitorTableListEntry *monitorTableList = _javaVM->monitorTableList;
 			while (NULL != monitorTableList) {
 				J9HashTable *table = monitorTableList->monitorTable;
 				if (NULL != table) {
 					GC_HashTableIterator iterator(table);
 					iterator.disableTableGrowth();
-					while (NULL != (objectMonitor = (J9ObjectMonitor*)iterator.nextSlot())) {
+					while (NULL != (objectMonitor = (J9ObjectMonitor *)iterator.nextSlot())) {
 						doMonitorReference(objectMonitor, &iterator);
 						if (shouldYieldFromMonitorScan()) {
 							yield();
@@ -130,7 +130,7 @@ public:
 	virtual CompletePhaseCode scanMonitorReferencesComplete(MM_EnvironmentBase *envBase) {
 		MM_EnvironmentRealtime *env = MM_EnvironmentRealtime::getEnvironment(envBase);
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		((J9JavaVM *)env->getLanguageVM())->internalVMFunctions->objectMonitorDestroyComplete((J9JavaVM *)env->getLanguageVM(), (J9VMThread *)env->getLanguageVMThread());
+		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}

--- a/runtime/gc_realtime/RealtimeRootScanner.hpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.hpp
@@ -70,7 +70,7 @@ public:
 private:
 protected:
 public:
-	virtual void doClass(J9Class* clazz);
+	virtual void doClass(J9Class *clazz);
 
 #if defined(J9VM_GC_REALTIME) 
 	void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
@@ -78,8 +78,8 @@ public:
 #endif /* J9VM_GC_REALTIME */
 
 	virtual void scanThreads(MM_EnvironmentBase *env);
-	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, void* localData);
-	virtual void scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread* walkThread, void* localData);
+	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread *walkThread, void *localData);
+	virtual void scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread *walkThread, void *localData);
 	void reportThreadCount(MM_EnvironmentBase *env);
 	void scanAtomicRoots(MM_EnvironmentRealtime *env);
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3801,12 +3801,12 @@ private:
 	virtual void doSlot(J9Object **slotPtr) {
 		if (NULL != *slotPtr) {
 			/* we don't have the context of this slot so just relocate the object into the same node where we found it */
-			MM_AllocationContextTarok *reservingContext = _copyForwardScheme->getContextForHeapAddress(*slotPtr);
+			MM_AllocationContextTarok *reservingContext = _copyForwardScheme->getContextForHeapAddress(* slotPtr);
 			_copyForwardScheme->copyAndForward(MM_EnvironmentVLHGC::getEnvironment(_env), reservingContext, slotPtr);
 		}
 	}
 
-	virtual void doStackSlot(J9Object **slotPtr, void *walkState, const void* stackLocation) {
+	virtual void doStackSlot(J9Object **slotPtr, void *walkState, const void *stackLocation) {
 		if (_copyForwardScheme->isHeapObject(*slotPtr)) {
 			/* heap object - validate and mark */
 			Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::COULD_BE_FORWARDED, *slotPtr, stackLocation, walkState).validate(_env));
@@ -3821,7 +3821,7 @@ private:
 	}
 
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator) {
-		if (_copyForwardScheme->isHeapObject(*slotPtr)) {
+		if (_copyForwardScheme->isHeapObject(* slotPtr)) {
 			/* we know that threads are bound to nodes so relocalize this object into the node of the thread which directly references it */
 			J9VMThread *thread = vmThreadIterator->getVMThread();
 			MM_AllocationContextTarok *reservingContext = (MM_AllocationContextTarok *)MM_EnvironmentVLHGC::getEnvironment(thread)->getAllocationContext();
@@ -4015,7 +4015,7 @@ private:
 	}
 
 	virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator) {
-		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		MM_EnvironmentVLHGC::getEnvironment(_env)->_copyForwardStats._monitorReferenceCandidates += 1;
 		J9Object *objectPtr = (J9Object *)monitor->userData;
 		if (!_copyForwardScheme->isLiveObject(objectPtr)) {
@@ -4031,15 +4031,15 @@ private:
 				/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 				 * monitor is not internal to the GC
 				 */
-				static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+				_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 			}
 		}
 	}
 
 	virtual CompletePhaseCode scanMonitorReferencesComplete(MM_EnvironmentBase *envBase) {
-		MM_EnvironmentVLHGC* env = MM_EnvironmentVLHGC::getEnvironment(envBase);
+		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		((J9JavaVM *)env->getLanguageVM())->internalVMFunctions->objectMonitorDestroyComplete((J9JavaVM *)env->getLanguageVM(), (J9VMThread *)env->getLanguageVMThread());
+		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}
@@ -4081,7 +4081,7 @@ private:
 			if (NULL == objectPtr) {
 				Assert_MM_mustBeClass(_extensions->objectModel.getPreservedClass(&forwardedHeader));
 				env->_copyForwardStats._doubleMappedArrayletsCleared += 1;
-				OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+				OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 				omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
 			}
 		}

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1332,14 +1332,14 @@ private:
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCleared += 1;
 			/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 			 * monitor is not internal to the GC */
-			static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+			_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 		}
 	}
 
 	virtual CompletePhaseCode scanMonitorReferencesComplete(MM_EnvironmentBase *envBase) {
 		MM_EnvironmentVLHGC* env = MM_EnvironmentVLHGC::getEnvironment(envBase);
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		((J9JavaVM *)env->getLanguageVM())->internalVMFunctions->objectMonitorDestroyComplete((J9JavaVM *)env->getLanguageVM(), (J9VMThread *)env->getLanguageVMThread());
+		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}
@@ -1373,7 +1373,7 @@ private:
 		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCandidates += 1;
 		if (!_markingScheme->isMarked(objectPtr)) {
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCleared += 1;
-			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
 		}
     }


### PR DESCRIPTION
Currently RootScanner class stores omrvm. However it is always used to get javavm. So, reasonable solution to store javavm instead to avoid multiple casts.
This PR does not have any functional change.