### PR TITLE
Report exception class resolution failure in catch block

### DIFF
--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -491,11 +491,13 @@ isExceptionTypeCaughtByHandler(J9VMThread *currentThread, J9Class *thrownExcepti
 			syncDecompilationStackAfterReleasingVMAccess(currentThread, walkState, TRUE);
 		}
 		
-		/* If we were unable to load the class, then we can only say that the exception is not caught */
-
-		if (caughtExceptionClass == NULL) {
-			currentThread->currentException = NULL;
-			return FALSE;
+		/*
+		 * If the exception class in the catch block cannot be resolved,
+		 * instead of throwing the originally thrown exception,
+		 * we throw an exception related to the resolution failure.
+		 */
+		if (NULL == caughtExceptionClass) {
+			return TRUE;
 		}
 	}
 


### PR DESCRIPTION
Report exception class resolution failure in catch block
instead of the originally thrown exception to match the
RI.

Issue: https://github.com/eclipse-openj9/openj9/issues/19015
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>