### PR TITLE
JDK23 adds Access.addEnableNativeAccess(moduleLayer, moduleName)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -522,6 +522,15 @@ final class Access implements JavaLangAccess {
 		return mod.implAddEnableNativeAccess();
 	}
 
+/*[IF (JAVA_SPEC_VERSION >= 23) & !INLINE-TYPES]*/
+	// This API should be enabled for INLINE-TYPES later.
+	// https://github.com/eclipse-openj9/openj9/issues/19144
+	@Override
+	public boolean addEnableNativeAccess(ModuleLayer moduleLayer, String moduleName) {
+		return moduleLayer.addEnableNativeAccess(moduleName);
+	}
+/*[ENDIF] (JAVA_SPEC_VERSION >= 23) & !INLINE-TYPES */
+
 	public long findNative(ClassLoader loader, String entryName) {
 		return ClassLoader.findNative(loader, entryName);
 	}

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -344,18 +344,26 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 	jvm_add_exports(jvm
 		JVM_RegisterLambdaProxyClassForArchiving
 		JVM_LookupLambdaProxyClassFromArchive
-		JVM_IsCDSDumpingEnabled
 	)
+	if(JAVA_SPEC_VERSION LESS 23)
+		jvm_add_exports(jvm
+			JVM_IsCDSDumpingEnabled
+		)
+	endif()
 endif()
 
 if(NOT JAVA_SPEC_VERSION LESS 16)
 	jvm_add_exports(jvm
 		JVM_DefineArchivedModules
 		JVM_GetRandomSeedForDumping
-		JVM_IsSharingEnabled
 		JVM_LogLambdaFormInvoker
-		JVM_IsDumpingClassList
 	)
+	if(JAVA_SPEC_VERSION LESS 23)
+		jvm_add_exports(jvm
+			JVM_IsDumpingClassList
+			JVM_IsSharingEnabled
+		)
+	endif()
 endif()
 
 if(JAVA_SPEC_VERSION LESS 17)
@@ -443,6 +451,12 @@ else()
 	jvm_add_exports(jvm
 		JVM_ExpandStackFrameInfo
 		JVM_VirtualThreadDisableSuspend
+	)
+endif()
+
+if(NOT JAVA_SPEC_VERSION LESS 23)
+	jvm_add_exports(jvm
+		JVM_GetCDSConfigStatus
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -378,16 +378,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<!-- Additions for Java 15 (General) -->
 		<export name="JVM_RegisterLambdaProxyClassForArchiving"/>
 		<export name="JVM_LookupLambdaProxyClassFromArchive"/>
-		<export name="JVM_IsCDSDumpingEnabled"/>
+		<export name="JVM_IsCDSDumpingEnabled">
+			<exclude-if condition="spec.java23"/>
+		</export>
 	</exports>
 
 	<exports group="jdk16">
 		<!-- Additions for Java 16 (General) -->
 		<export name="JVM_DefineArchivedModules"/>
 		<export name="JVM_GetRandomSeedForDumping"/>
-		<export name="JVM_IsSharingEnabled"/>
+		<export name="JVM_IsDumpingClassList">
+			<exclude-if condition="spec.java23"/>
+		</export>
+		<export name="JVM_IsSharingEnabled">
+			<exclude-if condition="spec.java23"/>
+		</export>
 		<export name="JVM_LogLambdaFormInvoker"/>
-		<export name="JVM_IsDumpingClassList"/>
 	</exports>
 
 	<exports group="jdk17">
@@ -451,5 +457,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<!-- Additions for Java 22 (General) -->
 		<export name="JVM_ExpandStackFrameInfo"/>
 		<export name="JVM_VirtualThreadDisableSuspend"/>
+	</exports>
+
+	<exports group="jdk23">
+		<!-- Additions for Java 23 (General) -->
+		<export name="JVM_GetCDSConfigStatus"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1688,12 +1688,14 @@ JVM_LookupLambdaProxyClassFromArchive(JNIEnv *env, jclass arg1, jstring arg2, jo
 	return NULL;
 }
 
+#if JAVA_SPEC_VERSION < 23
 JNIEXPORT jboolean JNICALL
 JVM_IsCDSDumpingEnabled(JNIEnv *env)
 {
 	/* OpenJ9 does not support -Xshare:dump, so we return false unconditionally. */
 	return JNI_FALSE;
 }
+#endif /* JAVA_SPEC_VERSION < 23 */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
 #if JAVA_SPEC_VERSION >= 16
@@ -1705,13 +1707,20 @@ JVM_GetRandomSeedForDumping()
 	return 0;
 }
 
+#if JAVA_SPEC_VERSION < 23
+JNIEXPORT jboolean JNICALL
+JVM_IsDumpingClassList(JNIEnv *env)
+{
+	return JNI_FALSE;
+}
+
 JNIEXPORT jboolean JNICALL
 JVM_IsSharingEnabled(JNIEnv *env)
 {
 	/* OpenJ9 does not support CDS, so we return false unconditionally. */
 	return JNI_FALSE;
 }
-
+#endif /* JAVA_SPEC_VERSION < 23 */
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 JNIEXPORT jboolean JNICALL

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -60,12 +60,6 @@ JVM_LogLambdaFormInvoker(JNIEnv *env, jstring str)
 {
 	Assert_SC_true(!"JVM_LogLambdaFormInvoker unimplemented");
 }
-
-JNIEXPORT jboolean JNICALL
-JVM_IsDumpingClassList(JNIEnv *env)
-{
-	return JNI_FALSE;
-}
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 11
@@ -750,5 +744,14 @@ JVM_VirtualThreadDisableSuspend(
 	 */
 }
 #endif /* JAVA_SPEC_VERSION >= 22 */
+
+#if JAVA_SPEC_VERSION >= 23
+JNIEXPORT jint JNICALL
+JVM_GetCDSConfigStatus()
+{
+	/* OpenJ9 does not support CDS, so we return 0 to indicate that there is no CDS config available. */
+	return 0;
+}
+#endif /* JAVA_SPEC_VERSION >= 23 */
 
 } /* extern "C" */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -85,6 +85,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk22">
 				<include-if condition="spec.java22"/>
 			</group>
+			<group name="jdk23">
+				<include-if condition="spec.java23"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -372,16 +372,16 @@ _IF([JAVA_SPEC_VERSION == 15],
 	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6)])
-_IF([JAVA_SPEC_VERSION >= 15],
+_IF([(15 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
-_IF([JAVA_SPEC_VERSION >= 16],
+_IF([(16 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
+	[_X(JVM_IsDumpingClassList, JNICALL, false, jboolean, JNIEnv *env)])
+_IF([(16 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
 	[_X(JVM_IsSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_DefineArchivedModules, JNICALL, false, void, JNIEnv *env, jobject obj1, jobject obj2)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_LogLambdaFormInvoker, JNICALL, false, void, JNIEnv *env, jstring str)])
-_IF([JAVA_SPEC_VERSION >= 16],
-	[_X(JVM_IsDumpingClassList, JNICALL, false, jboolean, JNIEnv *env)])
 _X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)
 _X(AsyncGetCallTrace, JNICALL, false, void, void *trace, jint depth, void *ucontext)
 _IF([JAVA_SPEC_VERSION >= 17],
@@ -434,3 +434,5 @@ _IF([JAVA_SPEC_VERSION == 22],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean enter)])
 _IF([JAVA_SPEC_VERSION >= 23],
 	[_X(JVM_VirtualThreadDisableSuspend, JNICALL, false, void, JNIEnv *env, jclass clz, jboolean enter)])
+_IF([JAVA_SPEC_VERSION >= 23],
+	[_X(JVM_GetCDSConfigStatus, JNICALL, false, jint, void)])


### PR DESCRIPTION
`JDK23` adds `Access.addEnableNativeAccess(moduleLayer, moduleName)`

Also added `JVM_GetCDSConfigStatus()` stub method that returns false unconditionally since OpenJ9 doesn't support `CDS`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/755

Related to
* https://github.com/eclipse-openj9/openj9/issues/19144

Signed-off-by: Jason Feng <fengj@ca.ibm.com>