### PR TITLE
(0.44) Add missing critical section to deserializer reset

### DIFF
--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -102,6 +102,7 @@ JITServerAOTDeserializer::reset(TR::CompilationInfoPerThread *compInfoPT)
    OMR::CriticalSection cccs(_classChainMonitor);
    OMR::CriticalSection mcs(_methodMonitor);
    OMR::CriticalSection ccs(_classMonitor);
+   OMR::CriticalSection clcs(_classLoaderMonitor);
 
    // Notify each compilation thread that the deserializer was reset
    compInfoPT->getCompilationInfo()->notifyCompilationThreadsOfDeserializerReset();


### PR DESCRIPTION
A missing critical section has been added to `JITServerAOTDeserializer::reset()`.

Related: https://github.com/eclipse-openj9/openj9/issues/18990