### PR TITLE
(0.44) Update CRaC options

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/crac/Core.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Core.java
@@ -41,7 +41,12 @@ public class Core {
 	 */
 	public static Context<Resource> getGlobalContext() {
 		if ((globalContext == null) && InternalCRIUSupport.isCRaCSupportEnabled()) {
-			globalContext = new CRIUSupportContext<>();
+			try {
+				globalContext = new CRIUSupportContext<>();
+			} catch (IllegalArgumentException e) {
+				System.err.println("Invalid checkpoint directory supplied: " + InternalCRIUSupport.getCRaCCheckpointToDir()); //$NON-NLS-1$
+				throw e;
+			}
 		}
 		return (Context<Resource>)globalContext;
 	}
@@ -69,7 +74,10 @@ class CRIUSupportContext<R extends Resource> extends Context<R> {
 	// InternalCRIUSupport.getCRaCCheckpointToDir() is not null if
 	// InternalCRIUSupport.isCRaCSupportEnabled() returns true before creating CRIUSupportContext<>().
 	private final InternalCRIUSupport internalCRIUSupport = new InternalCRIUSupport(
-			Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir())).setLeaveRunning(false).setShellJob(true)
+			Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir()))
+			.setLeaveRunning(false)
+			.setShellJob(true)
+			.setTCPEstablished(true)
 			.setFileLocks(true);
 
 	@Override
@@ -111,6 +119,12 @@ class CRIUSupportContext<R extends Resource> extends Context<R> {
 	}
 
 	public void checkpointJVM() {
-		internalCRIUSupport.checkpointJVM();
+		try {
+			internalCRIUSupport.checkpointJVM();
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+
 	}
 }

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -22,6 +22,8 @@
  *******************************************************************************/
 package openj9.internal.criu;
 
+import com.ibm.oti.vm.VM;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -951,6 +953,42 @@ public final class InternalCRIUSupport {
 
 				J9InternalCheckpointHookAPI.registerPostRestoreHook(HookMode.SINGLE_THREAD_MODE, RESTORE_CLEAR_INETADDRESS_CACHE_PRIORITY, "Clear InetAddress cache on restore", InternalCRIUSupport::clearInetAddressCache); //$NON-NLS-1$
 				J9InternalCheckpointHookAPI.registerPostRestoreHook(HookMode.SINGLE_THREAD_MODE, RESTORE_ENVIRONMENT_VARIABLES_PRIORITY, "Restore system properties", InternalCRIUSupport::setRestoreJavaProperties); //$NON-NLS-1$
+
+				/* Add option overrides. */
+				Properties props = VM.internalGetProperties();
+
+				String unprivilegedOpt = props.getProperty("openj9.internal.criu.unprivilegedMode"); //$NON-NLS-1$
+				if (unprivilegedOpt != null) {
+						setUnprivileged(Boolean.parseBoolean(unprivilegedOpt));
+				}
+
+				String tcpEstablishedOpt = props.getProperty("openj9.internal.criu.tcpEstablished"); //$NON-NLS-1$
+				if (tcpEstablishedOpt != null) {
+					setTCPEstablished(Boolean.parseBoolean(tcpEstablishedOpt));
+				}
+
+				String ghostFileLimitOpt = props.getProperty("openj9.internal.criu.ghostFileLimit"); //$NON-NLS-1$
+				if (ghostFileLimitOpt != null) {
+					try {
+						setGhostFileLimit(Long.parseLong(ghostFileLimitOpt));
+					} catch (NumberFormatException e) {
+						System.err.println("Invalid value specified: `-Dopenj9.internal.criu.ghostFileLimit=" + ghostFileLimitOpt + "`."); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+
+				String logLevelOpt =  props.getProperty("openj9.internal.criu.logLevel"); //$NON-NLS-1$
+				if (logLevelOpt != null) {
+					try {
+						setLogLevel(Integer.parseInt(logLevelOpt));
+					} catch (NumberFormatException e) {
+						System.err.println("Invalid value specified: `-Dopenj9.internal.criu.logLevel=" + logLevelOpt + "` ."); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+
+				String logFileOpt =  props.getProperty("openj9.internal.criu.logFile"); //$NON-NLS-1$
+				if (logFileOpt != null) {
+					setLogFile(logFileOpt);
+				}
 
 				/* Add security provider hooks. */
 				SecurityProviders.registerResetCRIUState();


### PR DESCRIPTION
Add some error messages as org.crac eats exceptions making it very difficult to understand the issue at hand.

Add some properties to override default criu capabilities.

Original PR:
https://github.com/eclipse-openj9/openj9/pull/19046