### PR TITLE
Revert "Replace omrvm to javavm for RootScanner class"

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -421,7 +421,7 @@ MM_ReferenceChainWalker::scanContinuationObject(J9Object *objectPtr)
 void
 MM_ReferenceChainWalker::scanMixedObject(J9Object *objectPtr)
 {
-	GC_MixedObjectDeclarationOrderIterator objectIterator(_javaVM, objectPtr, _shouldPreindexInterfaceFields);
+	GC_MixedObjectDeclarationOrderIterator objectIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), objectPtr, _shouldPreindexInterfaceFields);
 
 	while (GC_SlotObject *slotObject = objectIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_FIELD, objectIterator.getIndex(), objectPtr);
@@ -434,7 +434,7 @@ MM_ReferenceChainWalker::scanMixedObject(J9Object *objectPtr)
 void
 MM_ReferenceChainWalker::scanPointerArrayObject(J9IndexableObject *objectPtr)
 {
-	GC_PointerArrayIterator pointerArrayIterator(_javaVM, (J9Object *)objectPtr);
+	GC_PointerArrayIterator pointerArrayIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9Object *)objectPtr);
 
 	while (GC_SlotObject *slotObject = pointerArrayIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_ARRAY, pointerArrayIterator.getIndex(), (J9Object *)objectPtr);
@@ -447,7 +447,7 @@ MM_ReferenceChainWalker::scanPointerArrayObject(J9IndexableObject *objectPtr)
 void
 MM_ReferenceChainWalker::scanReferenceMixedObject(J9Object *objectPtr)
 {
-	GC_MixedObjectDeclarationOrderIterator objectIterator(_javaVM, objectPtr, _shouldPreindexInterfaceFields);
+	GC_MixedObjectDeclarationOrderIterator objectIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), objectPtr, _shouldPreindexInterfaceFields);
 
 	while (GC_SlotObject *slotObject = objectIterator.nextSlot()) {
 		doFieldSlot(slotObject, J9GC_REFERENCE_TYPE_WEAK_REFERENCE, objectIterator.getIndex(), objectPtr);
@@ -462,7 +462,7 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 {
 	J9Object* referrer = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 
-	GC_ClassIteratorDeclarationOrder classIterator(_javaVM, clazz, _shouldPreindexInterfaceFields);
+	GC_ClassIteratorDeclarationOrder classIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz, _shouldPreindexInterfaceFields);
 	while (volatile j9object_t *slot = classIterator.nextSlot()) {
 		IDATA refType = classIterator.getSlotReferenceType();
 		IDATA index = classIterator.getIndex();
@@ -471,7 +471,7 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 		doSlot((j9object_t*)slot, refType, index, referrer);
 	}
 
-	GC_ClassIteratorClassSlots classIteratorClassSlots(_javaVM, clazz);
+	GC_ClassIteratorClassSlots classIteratorClassSlots(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
 	while (J9Class *classPtr = classIteratorClassSlots.nextSlot()) {
 		switch (classIteratorClassSlots.getState()) {
 		case classiteratorclassslots_state_constant_pool:

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -77,7 +77,7 @@ protected:
 	MM_EnvironmentBase *_env;
 	MM_GCExtensions *_extensions;
 	MM_CollectorLanguageInterfaceImpl *_clij;
-	J9JavaVM *_javaVM;
+	OMR_VM *_omrVM;
 
 	bool _stringTableAsRoot;  /**< Treat the string table as a hard root */
 	bool _jniWeakGlobalReferencesTableAsRoot;	/**< Treat JNI Weak References Table as a hard root */
@@ -198,7 +198,7 @@ protected:
 		_scanningEntity = scanningEntity;
 		
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 			_entityStartScanTime = omrtime_hires_clock();	
 			_entityIncrementStartTime = _entityStartScanTime;
 		}
@@ -231,7 +231,7 @@ protected:
 		Assert_MM_true(_scanningEntity == scannedEntity);
 		
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+ 			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
  			uint64_t entityEndScanTime = omrtime_hires_clock();
 			
 			_env->_rootScannerStats._statsUsed = true;
@@ -278,7 +278,7 @@ public:
 	reportScanningSuspended()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 			_entityIncrementEndTime = omrtime_hires_clock();
 			
 			updateScanStats(_entityIncrementEndTime);
@@ -292,7 +292,7 @@ public:
 	reportScanningResumed()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 			_entityIncrementStartTime = omrtime_hires_clock();
 			_entityIncrementEndTime = 0;	
 		}
@@ -304,7 +304,7 @@ public:
 		, _env(env)
 		, _extensions(MM_GCExtensions::getExtensions(env))
 		, _clij((MM_CollectorLanguageInterfaceImpl *)_extensions->collectorLanguageInterface)
-		, _javaVM((J9JavaVM *)env->getOmrVM()->_language_vm)
+		, _omrVM(env->getOmrVM())
 		, _stringTableAsRoot(true)
 		, _jniWeakGlobalReferencesTableAsRoot(false)
 		, _singleThread(singleThread)
@@ -328,7 +328,7 @@ public:
 	{
 		_typeId = __FUNCTION__;
 		
-		OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
+		OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 		_entityIncrementStartTime = omrtime_hires_clock();
 
 	}

--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -364,7 +364,7 @@ MM_MarkingSchemeRootClearer::iterateAllContinuationObjects(MM_EnvironmentBase *e
 void
 MM_MarkingSchemeRootClearer::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 {
-	J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+	J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 	_env->getGCEnvironment()->_markJavaStats._monitorReferenceCandidates += 1;
 
 	if (!_markingScheme->isMarked((omrobjectptr_t )monitor->userData)) {
@@ -372,15 +372,16 @@ MM_MarkingSchemeRootClearer::doMonitorReference(J9ObjectMonitor *objectMonitor, 
 		_env->getGCEnvironment()->_markJavaStats._monitorReferenceCleared += 1;
 		/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 		 * monitor is not internal to the GC */
-		_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 	}
 }
 
 MM_RootScanner::CompletePhaseCode
 MM_MarkingSchemeRootClearer::scanMonitorReferencesComplete(MM_EnvironmentBase *env)
 {
+	J9JavaVM *javaVM = (J9JavaVM *)env->getLanguageVM();
 	reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-	_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
+	javaVM->internalVMFunctions->objectMonitorDestroyComplete(javaVM, (J9VMThread *)env->getLanguageVMThread());
 	reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 	return complete_phase_OK;
 }

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -48,7 +48,7 @@
 #include "ScavengerRootClearer.hpp"
 
 void
-MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard *region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats)
+MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard* region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats)
 {
 	/* no list can possibly contain more reference objects than there are bytes in a region. */
 	const uintptr_t maxObjects = region->getSize();

--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -47,7 +47,7 @@ class MM_ScavengerRootClearer : public MM_RootScanner
 private:
 	MM_Scavenger *_scavenger;
 
-	void processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard *region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
+	void processReferenceList(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard* region, omrobjectptr_t headOfList, MM_ReferenceStats *referenceStats);
 	void scavengeReferenceObjects(MM_EnvironmentStandard *env, uintptr_t referenceObjectType);
 #if defined(J9VM_GC_FINALIZATION)
 	void scavengeUnfinalizedObjects(MM_EnvironmentStandard *env);
@@ -202,7 +202,7 @@ public:
 	doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 	{
 		bool const compressed = _extensions->compressObjectReferences();
-		J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		omrobjectptr_t objectPtr = (omrobjectptr_t )monitor->userData;
 		_env->getGCEnvironment()->_scavengerJavaStats._monitorReferenceCandidates += 1;
 		
@@ -217,7 +217,7 @@ public:
 				/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 				 * monitor is not internal to the GC
 				 */
-				_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+				static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 			}
 		}
 	}
@@ -226,7 +226,7 @@ public:
 	scanMonitorReferencesComplete(MM_EnvironmentBase *env)
 	{
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getOmrVMThread()->_language_vmthread);
+		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroyComplete(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)env->getOmrVMThread()->_language_vmthread);
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
@@ -52,10 +52,10 @@ void
 MM_RootScannerReadBarrierVerifier::scanClass(MM_EnvironmentBase *env)
 {
 	OMR_VMThread *omrVMThread = env->getOmrVMThread();
-	GC_SegmentIterator segmentIterator(_javaVM->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
+	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
 
 	while (J9MemorySegment *segment = segmentIterator.nextSegment()) {
-		GC_ClassHeapIterator classHeapIterator(_javaVM, segment);
+		GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm), segment);
 		J9Class *clazz = NULL;
 
 		while (NULL != (clazz = classHeapIterator.nextClass())) {

--- a/runtime/gc_realtime/RealtimeRootScanner.cpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.cpp
@@ -52,11 +52,11 @@ MM_RealtimeRootScanner::doClass(J9Class *clazz)
 {
 	GC_ClassIterator objectSlotIterator(_env, clazz);
 	volatile j9object_t *objectSlotPtr = NULL;
-	while ((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
+	while((objectSlotPtr = objectSlotIterator.nextSlot()) != NULL) {
 		/* discard volatile since we must be in stop-the-world mode */
 		doSlot((j9object_t*)objectSlotPtr);
 	}
-	GC_ClassIteratorClassSlots classSlotIterator(_javaVM, clazz);
+	GC_ClassIteratorClassSlots classSlotIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
 	J9Class *classPtr;
 	while (NULL != (classPtr = classSlotIterator.nextSlot())) {
 		doClassSlot(classPtr);
@@ -94,18 +94,18 @@ MM_RealtimeRootScanner::scanThreads(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_Threads);
 
-	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
+	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
 	StackIteratorData localData;
 
 	localData.rootScanner = this;
 	localData.env = env;
 
-	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
-		MM_EnvironmentRealtime *walkThreadEnv = MM_EnvironmentRealtime::getEnvironment(walkThread->omrVMThread);
+	while(J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
+		MM_EnvironmentRealtime* walkThreadEnv = MM_EnvironmentRealtime::getEnvironment(walkThread->omrVMThread);
 		if (GC_UNMARK == walkThreadEnv->_allocationColor) {
 			if (GC_UNMARK == MM_AtomicOperations::lockCompareExchangeU32(&walkThreadEnv->_allocationColor, GC_UNMARK, GC_MARK)) {
-				if (scanOneThread(env, walkThread, (void *)&localData)) {
-					vmThreadListIterator.reset(_javaVM->mainThread);
+				if (scanOneThread(env, walkThread, (void*) &localData)) {
+					vmThreadListIterator.reset(static_cast<J9JavaVM*>(_omrVM->_language_vm)->mainThread);
 				}
 			}
 		}
@@ -120,7 +120,7 @@ MM_RealtimeRootScanner::scanThreads(MM_EnvironmentBase *env)
  * been scanned in this cycle.
  **/
 bool
-MM_RealtimeRootScanner::scanOneThread(MM_EnvironmentBase *envBase, J9VMThread *walkThread, void *localData)
+MM_RealtimeRootScanner::scanOneThread(MM_EnvironmentBase *envBase, J9VMThread* walkThread, void* localData)
 {
 	MM_EnvironmentRealtime *env = MM_EnvironmentRealtime::getEnvironment(envBase);
 	
@@ -147,12 +147,12 @@ MM_RealtimeRootScanner::scanOneThread(MM_EnvironmentBase *envBase, J9VMThread *w
 }
 
 void
-MM_RealtimeRootScanner::scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread *walkThread, void *localData)
+MM_RealtimeRootScanner::scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread* walkThread, void* localData)
 {
 }
 
 void
-MM_RealtimeRootScanner::reportThreadCount(MM_EnvironmentBase *env)
+MM_RealtimeRootScanner::reportThreadCount(MM_EnvironmentBase* env)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 	j9tty_printf(PORTLIB, "Scanned %d threads for %s\n", _threadCount, scannerName());
@@ -170,7 +170,7 @@ MM_RealtimeRootScanner::scanAtomicRoots(MM_EnvironmentRealtime *env)
 
 	scanJNIGlobalReferences(env);
 
-	if (_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)){
+	if(_stringTableAsRoot && (!_nurseryReferencesOnly && !_nurseryReferencesPossibly)){
 		scanStringTable(env);
 	}
 }
@@ -179,7 +179,7 @@ void
 MM_RealtimeRootScanner::doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator)
 {
 	_env->getGCEnvironment()->_markJavaStats._stringConstantsCandidates += 1;
-	if (!_markingScheme->isMarked(*slotPtr)) {
+	if(!_markingScheme->isMarked(*slotPtr)) {
 		_env->getGCEnvironment()->_markJavaStats._stringConstantsCleared += 1;
 		stringTableIterator->removeSlot();
 	}
@@ -192,7 +192,7 @@ void
 MM_RealtimeRootScanner::doStringCacheTableSlot(J9Object **slotPtr) 
 {
 	J9Object *objectPtr = *slotPtr;
-	if ((NULL != objectPtr) && (!_markingScheme->isMarked(*slotPtr))) {
+	if((NULL != objectPtr) && (!_markingScheme->isMarked(*slotPtr))) {
 		*slotPtr = NULL;
 	}	
 }
@@ -286,9 +286,9 @@ void
 MM_RealtimeRootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 {
 	reportScanningStarted(RootScannerEntity_MonitorLookupCaches);
-	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
-	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
-		MM_EnvironmentRealtime *walkThreadEnv = MM_EnvironmentRealtime::getEnvironment(walkThread->omrVMThread);
+	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
+	while(J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
+		MM_EnvironmentRealtime* walkThreadEnv = MM_EnvironmentRealtime::getEnvironment(walkThread->omrVMThread);
 		if (FALSE == walkThreadEnv->_monitorCacheCleared) {
 			if (FALSE == MM_AtomicOperations::lockCompareExchangeU32(&walkThreadEnv->_monitorCacheCleared, FALSE, TRUE)) {
 				j9objectmonitor_t *objectMonitorLookupCache = walkThread->objectMonitorLookupCache;
@@ -297,7 +297,7 @@ MM_RealtimeRootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 					doMonitorLookupCacheSlot(&objectMonitorLookupCache[cacheIndex]);
 				}
 				if (condYield()) {
-					vmThreadListIterator.reset(_javaVM->mainThread);
+					vmThreadListIterator.reset(static_cast<J9JavaVM*>(_omrVM->_language_vm)->mainThread);
 				}
 			}
 		}

--- a/runtime/gc_realtime/RealtimeRootScanner.hpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.hpp
@@ -70,7 +70,7 @@ public:
 private:
 protected:
 public:
-	virtual void doClass(J9Class *clazz);
+	virtual void doClass(J9Class* clazz);
 
 #if defined(J9VM_GC_REALTIME) 
 	void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
@@ -78,8 +78,8 @@ public:
 #endif /* J9VM_GC_REALTIME */
 
 	virtual void scanThreads(MM_EnvironmentBase *env);
-	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread *walkThread, void *localData);
-	virtual void scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread *walkThread, void *localData);
+	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread* walkThread, void* localData);
+	virtual void scanOneThreadImpl(MM_EnvironmentRealtime *env, J9VMThread* walkThread, void* localData);
 	void reportThreadCount(MM_EnvironmentBase *env);
 	void scanAtomicRoots(MM_EnvironmentRealtime *env);
 

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1332,14 +1332,14 @@ private:
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCleared += 1;
 			/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 			 * monitor is not internal to the GC */
-			_javaVM->internalVMFunctions->objectMonitorDestroy(_javaVM, (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
+			static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);
 		}
 	}
 
 	virtual CompletePhaseCode scanMonitorReferencesComplete(MM_EnvironmentBase *envBase) {
 		MM_EnvironmentVLHGC* env = MM_EnvironmentVLHGC::getEnvironment(envBase);
 		reportScanningStarted(RootScannerEntity_MonitorReferenceObjectsComplete);
-		_javaVM->internalVMFunctions->objectMonitorDestroyComplete(_javaVM, (J9VMThread *)env->getLanguageVMThread());
+		((J9JavaVM *)env->getLanguageVM())->internalVMFunctions->objectMonitorDestroyComplete((J9JavaVM *)env->getLanguageVM(), (J9VMThread *)env->getLanguageVMThread());
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
 	}
@@ -1373,7 +1373,7 @@ private:
 		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCandidates += 1;
 		if (!_markingScheme->isMarked(objectPtr)) {
 			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCleared += 1;
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+			OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 			omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
 		}
     }


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#19141 due to https://github.com/eclipse-openj9/openj9/pull/19141#issuecomment-1998677574