### PR TITLE
Remove generated MHProxy package entries

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2121,6 +2121,15 @@ UDATA
 hashClassTableDelete(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength);
 
 /**
+* @brief Remove package entry from hashClassTable
+* @param *classLoader
+* @param *romClass of package to be removed
+* @return UDATA 0 on success, 1 on failure
+*/
+UDATA
+hashClassTablePackageDelete(J9VMThread *vmThread, J9ClassLoader* classLoader, J9ROMClass* romClass);
+
+/**
 * @brief
 * @param *javaVM
 * @param initialSize

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -964,3 +964,5 @@ TraceEvent=Trc_VM_criu_after_dump Obsolete Overhead=1 Level=2 Template="After ch
 TraceEvent=Trc_VM_crac_checkpointTo NoEnv Overhead=1 Level=3 Template="-XX:CRaCCheckpointTo=%s"
 TraceEvent=Trc_VM_criu_after_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), restoreNanoTimeMonotonic (%lld), lastRestoreTimeInNanoseconds (%lld)"
 TraceEvent=Trc_VM_criu_process_restore_start_after_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), restorePid (%zu), processRestoreStartTimeInNanoseconds (%lld)"
+
+TraceEvent=Trc_VM_hashClassTablePackageDelete Overhead=1 Level=1 Template="hashClassTablePackageDelete %p (%.*s)"


### PR DESCRIPTION
from classHashTable when its associated rom class is unloaded. This will prevent errors that could occur when accessing the package entry with an invalid rom class.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18907