### PR TITLE
(0.44.0) Add dedicated health port for JITServer

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -127,7 +127,10 @@ enum ExternalOptions
    XXminusIProfileDuringStartupPhase           = 71,
    XXplusJITServerAOTCacheIgnoreLocalSCC       = 72,
    XXminusJITServerAOTCacheIgnoreLocalSCC      = 73,
-   TR_NumExternalOptions                       = 74
+   XXplusHealthProbes                          = 74,
+   XXminusHealthProbes                         = 75,
+   XXJITServerHealthProbePortOption            = 76,
+   TR_NumExternalOptions                       = 77
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -178,6 +178,9 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::XXminusJITServerAOTCacheDelayMethodRelocation:
          case J9::ExternalOptions::XXplusJITServerAOTCacheIgnoreLocalSCC:
          case J9::ExternalOptions::XXminusJITServerAOTCacheIgnoreLocalSCC:
+         case J9::ExternalOptions::XXplusHealthProbes:
+         case J9::ExternalOptions::XXminusHealthProbes:
+         case J9::ExternalOptions::XXJITServerHealthProbePortOption:
             {
             // do nothing, consume them to prevent errors
             FIND_AND_CONSUME_RESTORE_ARG(OPTIONAL_LIST_MATCH, optString, 0);

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -166,6 +166,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _clientUID(0),
          _serverUID(0),
          _JITServerMetricsPort(38500),
+         _JITServerHealthPort(38600),
          _requireJITServer(false),
          _localSyncCompiles(true),
          _JITServerUseAOTCache(false),
@@ -354,6 +355,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setServerUID(uint64_t val) { _serverUID = val; }
    uint32_t getJITServerMetricsPort() const { return _JITServerMetricsPort; }
    void setJITServerMetricsPort(uint32_t port) { _JITServerMetricsPort = port; }
+   uint32_t getJITServerHealthPort() const { return _JITServerHealthPort; }
+   void setJITServerHealthPort(uint32_t port) { _JITServerHealthPort = port; }
    bool getRequireJITServer() const { return _requireJITServer; }
    void setRequireJITServer(bool requireJITServer) { _requireJITServer = requireJITServer; }
    bool isLocalSyncCompiles() const { return _localSyncCompiles; }
@@ -461,6 +464,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint64_t    _clientUID;
    uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
    uint32_t    _JITServerMetricsPort; // Port for receiving http metrics requests from Prometheus; only used at server
+   uint32_t    _JITServerHealthPort; // Port for receiving readiness/liveness probes from Kubernetes; only used at server
    bool        _requireJITServer;
    bool        _localSyncCompiles;
    bool        _JITServerUseAOTCache;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 57; // ID: S/lCtmSB049jvzhogWYP
+   static const uint16_t MINOR_NUMBER = 58; // ID: jdaegRYmBxGBJ/FG0fcY
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/LoadSSLLibs.cpp
+++ b/runtime/compiler/net/LoadSSLLibs.cpp
@@ -108,6 +108,9 @@ OEVP_DigestFinal_ex_t * OEVP_DigestFinal_ex = NULL;
 OEVP_sha256_t * OEVP_sha256 = NULL;
 
 OERR_print_errors_fp_t * OERR_print_errors_fp = NULL;
+OERR_peek_error_t * OERR_peek_error = NULL;
+OERR_get_error_t * OERR_get_error = NULL;
+OERR_error_string_n_t * OERR_error_string_n = NULL;
 
 int OSSL102_OOPENSSL_init_ssl(uint64_t opts, const void * settings)
    {
@@ -380,6 +383,9 @@ void dbgPrintSymbols()
    printf(" EVP_sha256 %p\n", OEVP_sha256);
 
    printf(" ERR_print_errors_fp %p\n", OERR_print_errors_fp);
+   printf(" ERR_peek_error %p\n", OERR_peek_error);
+   printf(" ERR_get_error %p\n", OERR_get_error);
+   printf(" ERR_error_string_n %p\n", OERR_error_string_n);
 
    printf("=============================================================\n\n");
    }
@@ -515,6 +521,9 @@ bool loadLibsslAndFindSymbols()
    OEVP_sha256 = (OEVP_sha256_t *)findLibsslSymbol(handle, "EVP_sha256");
 
    OERR_print_errors_fp = (OERR_print_errors_fp_t *)findLibsslSymbol(handle, "ERR_print_errors_fp");
+   OERR_peek_error = (OERR_peek_error_t *)findLibsslSymbol(handle, "ERR_peek_error");
+   OERR_get_error = (OERR_get_error_t *)findLibsslSymbol(handle, "ERR_get_error");
+   OERR_error_string_n = (OERR_error_string_n_t *)findLibsslSymbol(handle, "ERR_error_string_n");
 
    if (
        (OOpenSSL_version == NULL) ||
@@ -582,7 +591,10 @@ bool loadLibsslAndFindSymbols()
        (OEVP_DigestFinal_ex == NULL) ||
        (OEVP_sha256 == NULL) ||
 
-       (OERR_print_errors_fp == NULL)
+       (OERR_print_errors_fp == NULL) ||
+       (OERR_peek_error == NULL) ||
+       (OERR_get_error == NULL) ||
+       (OERR_error_string_n == NULL)
       )
       {
       printf("#JITServer: Failed to load all the required OpenSSL symbols\n");

--- a/runtime/compiler/net/LoadSSLLibs.hpp
+++ b/runtime/compiler/net/LoadSSLLibs.hpp
@@ -102,6 +102,9 @@ typedef int OEVP_DigestFinal_ex_t(EVP_MD_CTX *ctx, unsigned char *md, unsigned i
 typedef const EVP_MD * OEVP_sha256_t(void);
 
 typedef void OERR_print_errors_fp_t(FILE *fp);
+typedef unsigned long OERR_peek_error_t();
+typedef unsigned long OERR_get_error_t();
+typedef void OERR_error_string_n_t(unsigned long e, char *buf, size_t len);
 
 extern "C" OOpenSSL_version_t * OOpenSSL_version;
 
@@ -174,6 +177,9 @@ extern "C" OEVP_DigestFinal_ex_t * OEVP_DigestFinal_ex;
 extern "C" OEVP_sha256_t * OEVP_sha256;
 
 extern "C" OERR_print_errors_fp_t * OERR_print_errors_fp;
+extern "C" OERR_peek_error_t * OERR_peek_error;
+extern "C" OERR_get_error_t * OERR_get_error;
+extern "C" OERR_error_string_n_t * OERR_error_string_n;
 
 namespace JITServer
 {

--- a/runtime/compiler/runtime/MetricsServer.cpp
+++ b/runtime/compiler/runtime/MetricsServer.cpp
@@ -859,11 +859,11 @@ MetricsServer::serveMetricsRequests()
       } // end while (!getMetricsThreadExitFlag())
 
    // The following piece of code will be executed only if the server shuts down properly
-   closeSocket(0);
    if (_sslCtx)
       {
       (*OSSL_CTX_free)(_sslCtx);
       }
+   closeSocket(0);
    }
 
 std::string

--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -60,13 +60,13 @@ public class JITServerTest {
 	private static final String JITSERVER_PORT_OPTION_FORMAT_STRING = "-XX:JITServerPort=%d";
 	private final String aotCacheOption = "-XX:+JITServerUseAOTCache";
 
-        private static final String CLIENT_EXE = System.getProperty("CLIENT_EXE");
-        // This handy regex pattern uses positive lookahead to match a string containing either zero or an even number of " (double quote) characters.
-        // If a character is followed by this pattern it means that the character itself is not in a quoted string, otherwise it would be followed by
-        // an odd number of " characters. Note that this doesn't handle ' (single quote) characters.
-        private static final String QUOTES_LOOKAHEAD_PATTERN = "(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
-        // We want to split the client program string on whitespace, unless the space appears in a quoted string.
-        private static final String SPLIT_ARGS_PATTERN = "\\s+" + QUOTES_LOOKAHEAD_PATTERN;
+	private static final String CLIENT_EXE = System.getProperty("CLIENT_EXE");
+	// This handy regex pattern uses positive lookahead to match a string containing either zero or an even number of " (double quote) characters.
+	// If a character is followed by this pattern it means that the character itself is not in a quoted string, otherwise it would be followed by
+	// an odd number of " characters. Note that this doesn't handle ' (single quote) characters.
+	private static final String QUOTES_LOOKAHEAD_PATTERN = "(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
+    // We want to split the client program string on whitespace, unless the space appears in a quoted string.
+    private static final String SPLIT_ARGS_PATTERN = "\\s+" + QUOTES_LOOKAHEAD_PATTERN;
 
 	JITServerTest() {
 		AssertJUnit.assertEquals("Tests have only been validated on Linux. Other platforms are currently unsupported.", "Linux", System.getProperty("os.name"));
@@ -91,9 +91,9 @@ public class JITServerTest {
 
 		clientBuilder = new ProcessBuilder(stripQuotesFromEachArg(String.join(" ", CLIENT_EXE, portOption, "-XX:+UseJITServer", CLIENT_PROGRAM).split(SPLIT_ARGS_PATTERN)));
 		if (CLIENT_PROGRAM.contains(aotCacheOption))
-                        serverBuilder = new ProcessBuilder(stripQuotesFromEachArg(String.join(" ", SERVER_EXE, portOption, aotCacheOption).split(SPLIT_ARGS_PATTERN)));
-                else
-			serverBuilder = new ProcessBuilder(stripQuotesFromEachArg(String.join(" ", SERVER_EXE, portOption).split(SPLIT_ARGS_PATTERN)));
+			serverBuilder = new ProcessBuilder(stripQuotesFromEachArg(String.join(" ", SERVER_EXE, portOption, "-XX:-JITServerHealthProbes", aotCacheOption).split(SPLIT_ARGS_PATTERN)));
+		else
+			serverBuilder = new ProcessBuilder(stripQuotesFromEachArg(String.join(" ", SERVER_EXE, portOption, "-XX:-JITServerHealthProbes").split(SPLIT_ARGS_PATTERN)));
 
 		// Redirect stderr to stdout, one log for each of the client and server is sufficient.
 		clientBuilder.redirectErrorStream(true);

--- a/test/functional/cmdLineTests/criu/criuJitServerScript.sh
+++ b/test/functional/cmdLineTests/criu/criuJitServerScript.sh
@@ -50,6 +50,7 @@ echo "export LD_BIND_NOT=on";
 export LD_BIND_NOT=on
 
 JITSERVER_PORT=$(random_port)
+HEALTH_PORT=$(random_port)
 JITSERVER_SSL="-XX:JITServerSSLRootCerts"
 if grep -q -- "$JITSERVER_SSL" <<< "$APP_ARGS"; then
     echo "Generate SSL certificates"
@@ -59,7 +60,7 @@ if grep -q -- "$JITSERVER_SSL" <<< "$APP_ARGS"; then
     fi
 fi
 
-JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT $SSL_OPTS"
+JITSERVER_OPTIONS="-XX:JITServerPort=$JITSERVER_PORT -XX:JITServerHealthProbePort=$HEALTH_PORT $SSL_OPTS"
 
 echo "Starting $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS"
 $TEST_JDK_BIN/jitserver $JITSERVER_OPTIONS &

--- a/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
+++ b/test/functional/cmdLineTests/jitserver/jitserverArgumentTesting.xml
@@ -34,7 +34,7 @@
 	<variable name="DEFAULT_JITSERVER_OPTIONS" value="-Xjit" />
 
 	<test id="Test default configuration">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
 		<output type="success" caseSensitive="no" regex="no">Connected to a server</output>
@@ -46,7 +46,7 @@
 	</test>
 
 	<test id="Test JITServer disabled">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$DISABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$DISABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
@@ -57,7 +57,7 @@
 	</test>
 
 	<test id="Test bad port">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ -XX:JITServerPort=38399" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ -XX:JITServerPort=38399" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
@@ -68,7 +68,7 @@
 	</test>
 
 	<test id="Test bad hostname">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ -XX:JITServerAddress=bad.address" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ -XX:JITServerAddress=bad.address" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="failure" caseSesnsitive="no" regex="no">Connected to a server</output>
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
@@ -79,7 +79,7 @@
 	</test>
 
 	<test id="Test Metrics">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" true</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" true false</command>
 		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="success" caseSensitive="no" regex="no">jitserver_cpu_utilization</output>
 		<output type="success" caseSensitive="no" regex="no">jitserver_available_memory</output>
@@ -93,8 +93,19 @@
 		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
 	</test>
 
+	<test id="Test Health Port">
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$" false true</command>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output type="failure" caseSenstive="no" regex="no">Connection refused</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(Fatal|Unhandled) Exception</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER EXISTS</output>
+		<output type="success" caseSensitive="yes" regex="no">JITSERVER STILL EXISTS</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER DOES NOT EXIST</output>
+		<output type="failure" caseSensitive="yes" regex="no">JITSERVER NO LONGER EXISTS</output>
+	</test>
+
 	<test id="Test SSL success condition">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL1$" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL1$" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
 		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
@@ -108,7 +119,7 @@
 	</test>
 
 	<test id="Test SSL Failure Case with mismatched certificate">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL2$" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL2$" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
 		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>
@@ -122,7 +133,7 @@
 	</test>
 
 	<test id="Test SSL Failure Case with connection to Non-SSL Server">
-		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL3$" false</command>
+		<command>bash $SCRIPPATH$ $TEST_RESROOT$ $TEST_JDK_BIN$ "$DEFAULT_JITSERVER_OPTIONS$" "$ENABLE_JITSERVER$ $JITSERVER_CLIENT_OPTS$ $NO_LOCAL_SYNC_COMPILE$ $JITSERVER_SSL3$" false false</command>
 		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
 		<output type="required" caseSensitive="no" regex="no">JITServer Client Mode.</output>
 		<output type="success" caseSensitive="no" regex="no">Successfully initialized SSL context</output>


### PR DESCRIPTION
Kubernetes can use liveness and readiness probes to check
a pod's health. For a TCP port, the kubelet attempts to open a
socket to the container on the specified port. If a connection
can be established, the container is considered healthy.

The JITServer did not have a dedicated port for health probes;
instead, the main communication port (default 38400) could be
used for this purpose. However, this solution is not ideal
when communication between the client and server is encrypted
with OpenSSL. Starting with OpenSSL 3.0, if one of the participants
closes the connection without notifying the other party, the
OpenSSL library will log error messages like:
"A0F04FE4FE7F0000:error:0A000126:SSL routines:ssl3_read_n:unexpected eof while reading:ssl/record/rec_layer_s3.c:320"
Since the health probes are sent periodically, over time, the log
of the JITServer container could be flooded with such messages.
While the error is benign in nature, these messages are annoying
and can create concerns for end-users.

This commit adds a dedicated health port for JITServer, where
communication is never encrypted. By default, the JITServer will
open a health port and the value of this port is 38600.
The following options were added:
-XX:JITServerHealthProbePort=NNN # change the health port value
-XX:-JITServerHealthProbes # disable the dedicated health port
-XX:+JITServerHealthProbes # enable the dedicated health port

Issue: https://github.com/OpenLiberty/open-liberty/issues/27665