### PR TITLE
(0.44) Correct memorypool usage calculating for GMP case

### DIFF
--- a/runtime/gc_vlhgc/HeapRegionManagerVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionManagerVLHGC.hpp
@@ -40,10 +40,10 @@ public:
 	 */
 	virtual bool enableRegionsInTable(MM_EnvironmentBase *env, MM_MemoryHandle *handle);
 
-	virtual MM_HeapMemorySnapshot* getHeapMemorySnapshot(MM_GCExtensionsBase *extensions, MM_HeapMemorySnapshot* snapshot, bool gcEnd);
+	virtual MM_HeapMemorySnapshot *getHeapMemorySnapshot(MM_GCExtensionsBase *extensions, MM_HeapMemorySnapshot *snapshot, bool gcEnd);
 
-	static MM_HeapRegionManagerVLHGC *newInstance(MM_EnvironmentBase *env, UDATA regionSize, UDATA tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
-	MM_HeapRegionManagerVLHGC(MM_EnvironmentBase *env, UDATA regionSize, UDATA tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
+	static MM_HeapRegionManagerVLHGC *newInstance(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
+	MM_HeapRegionManagerVLHGC(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
 
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);


### PR DESCRIPTION
There was a gcEnd condition check patch for calculating memorypool usage at the end of GC due to the increment logic age for regions happened after getHeapMemorySnapshot(), but incrementing region's age has been updated to be called before getHeapMemorySnapshot(), condition check for gcEnd is unnecessory, also the condition check would cause incorrect memory usages for eden, reserved and survivor pools in Global Marking Phase case.

-cleanup the format base on the coding standard
 UDATA to uintptr_t
 "<type>*" to "<type> *"

Port of https://github.com/eclipse-openj9/openj9/pull/19063 to 0.44