### PR TITLE
DDR: correct some operations for signed types

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I16.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I16.java
@@ -21,284 +21,278 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.types;
 
-
 public class I16 extends IScalar {
-	
+
 	// Constants
 	public static final int SIZEOF = 2;
 	public static final long MASK = 0xFFFFL;
 	public static final I16 MIN = new I16(0x8000L);
 	public static final I16 MAX = new I16(0x7FFFL);
-	
+
 	// Constructors
 	public I16(long value) {
 		super(value & MASK);
 	}
-	
+
 	public I16(Scalar parameter) {
 		super(parameter);
 	}
-	
+
 	// API
-	
+
 	// ADD
-	
+
 	public I16 add(int number) {
 		return new I16(data + number);
 	}
-	
+
 	public I32 add(U8 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U8 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public I32 add(U16 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U16 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public U32 add(U32 parameter) {
 		return new U32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U32 parameter) {
 		return new U32(this).eq(parameter);
 	}
-	
+
 	public U64 add(U64 parameter) {
 		return new U64(this).add(parameter);
 	}
-	
+
 	public boolean eq(U64 parameter) {
 		return new U64(this).eq(parameter);
 	}
-	
+
 	public UDATA add(UDATA parameter) {
 		return new UDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(UDATA parameter) {
 		return new UDATA(this).eq(parameter);
 	}
-	
+
 	public I32 add(I8 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public I16 add(I16 parameter) {
 		return new I16(data + parameter.data);
 	}
-	
+
 	public I32 add(I32 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(I32 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public I64 add(I64 parameter) {
 		return new I64(this).add(parameter);
 	}
-	
+
 	public boolean eq(I64 parameter) {
 		return new I64(this).eq(parameter);
 	}
-	
+
 	public IDATA add(IDATA parameter) {
 		return new IDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(IDATA parameter) {
 		return new IDATA(this).eq(parameter);
 	}
 	//SUB
-	
+
 	public I16 sub(int number) {
 		return new I16(data - number);
 	}
-	
+
 	public I32 sub(U8 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I32 sub(U16 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public U32 sub(U32 parameter) {
 		return new U32(this).sub(parameter);
 	}
-	
+
 	public U64 sub(U64 parameter) {
 		return new U64(this).sub(parameter);
 	}
-	
+
 	public UDATA sub(UDATA parameter) {
 		return new UDATA(this).sub(parameter);
 	}
-	
+
 	public I32 sub(I8 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I16 sub(I16 parameter) {
 		return new I16(data - parameter.data);
 	}
-	
+
 	public I32 sub(I32 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I64 sub(I64 parameter) {
 		return new I64(this).sub(parameter);
 	}
-	
+
 	public IDATA sub(IDATA parameter) {
 		return new IDATA(this).sub(parameter);
 	}
 
-	
 	public long longValue() {
 		return (short) data;
 	}
-	
+
 	public int intValue() {
 		return (short) data;
 	}
-	
+
 	// bitOr
-	
+
 	public I16 bitOr(int number) {
 		return new I16(data | number);
 	}
-	
+
 	public I16 bitOr(long number) {
 		return new I16(data | number);
 	}
-	
+
 	public I32 bitOr(U8 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I32 bitOr(U16 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public U32 bitOr(U32 parameter) {
 		return new U32(this).bitOr(parameter);
 	}
-	
+
 	public U64 bitOr(U64 parameter) {
 		return new U64(this).bitOr(parameter);
 	}
-	
+
 	public UDATA bitOr(UDATA parameter) {
 		return new UDATA(this).bitOr(parameter);
 	}
-	
+
 	public I32 bitOr(I8 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I16 bitOr(I16 parameter) {
 		return new I16(data | parameter.data);
 	}
-	
+
 	public I32 bitOr(I32 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I64 bitOr(I64 parameter) {
 		return new I64(this).bitOr(parameter);
 	}
-	
+
 	public IDATA bitOr(IDATA parameter) {
 		return new IDATA(this).bitOr(parameter);
 	}
-	
+
 	// bitAnd
-	
+
 	public I16 bitAnd(int number) {
 		return new I16(data & number);
 	}
-	
+
 	public I16 bitAnd(long number) {
 		return new I16(data & number);
 	}
-	
+
 	public I32 bitAnd(U8 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I32 bitAnd(U16 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public U32 bitAnd(U32 parameter) {
 		return new U32(this).bitAnd(parameter);
 	}
-	
+
 	public U64 bitAnd(U64 parameter) {
 		return new U64(this).bitAnd(parameter);
 	}
-	
+
 	public UDATA bitAnd(UDATA parameter) {
 		return new UDATA(this).bitAnd(parameter);
 	}
-	
+
 	public I32 bitAnd(I8 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I16 bitAnd(I16 parameter) {
 		return new I16(data & parameter.data);
 	}
-	
+
 	public I32 bitAnd(I32 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I64 bitAnd(I64 parameter) {
 		return new I64(this).bitAnd(parameter);
 	}
-	
+
 	public IDATA bitAnd(IDATA parameter) {
 		return new IDATA(this).bitAnd(parameter);
 	}
-	
+
 	// leftShift
 	public I16 leftShift(int i) {
 		return new I16(data << i);
 	}
-	
+
 	// rightShift
 	public I16 rightShift(int i) {
-		long newData = data >>> i;
-		if ((data & 0x8000) != 0) {
-			newData |= (0xFFFF << (Math.max(0, 16 - i)));
-		}
-		return new I16(newData);
+		return new I16(intValue() >> i);
 	}
-	
+
 	// bitNot
 	public I16 bitNot() {
 		return new I16(~data);
 	}
-	
+
 	public I16 mult(int parameter) {
 		return new I16(data * parameter);
 	}
-	
+
 	@Override
-	public int sizeof()
-	{
+	public int sizeof() {
 		return SIZEOF;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I32.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I32.java
@@ -22,18 +22,18 @@
 package com.ibm.j9ddr.vm29.types;
 
 public class I32 extends IDATA {
-	
+
 	// Constants
 	public static final int SIZEOF = 4;
 	public static final long MASK = 0xFFFFFFFFL;
 	public static final I32 MIN = new I32(0x80000000L);
 	public static final I32 MAX = MIN.sub(0x7FFFFFFFL);
-	
+
 	// Constructors
 	public I32(long value) {
 		super(value & MASK);
 	}
-	
+
 	public I32(Scalar parameter) {
 		super(parameter);
 	}
@@ -44,15 +44,15 @@ public class I32 extends IDATA {
 	public I32 add(long number) {
 		return new I32(data + number);
 	}
-	
+
 	public I32 add(U8 parameter) {
-		return add (new I32(parameter));
+		return add(new I32(parameter));
 	}
-	
+
 	public I32 add(U16 parameter) {
-		return add (new I32(parameter));
+		return add(new I32(parameter));
 	}
-	
+
 	public I32 add(U32 parameter) {
 		return new I32(this).add(parameter);
 	}
@@ -60,19 +60,19 @@ public class I32 extends IDATA {
 	public boolean eq(U32 parameter) {
 		return new U32(this).eq(parameter);
 	}
-	
+
 	public U64 add(U64 parameter) {
 		return new U64(this).add(parameter);
 	}
-	
+
 	public boolean eq(U64 parameter) {
 		return new U64(this).eq(parameter);
 	}
-	
+
 	public UDATA add(UDATA parameter) {
 		return new UDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(UDATA parameter) {
 		return new UDATA(this).eq(parameter);
 	}
@@ -80,65 +80,65 @@ public class I32 extends IDATA {
 	public I32 add(I8 parameter) {
 		return add(new I32(parameter));
 	}
-	
+
 	public I32 add(I16 parameter) {
 		return add(new I32(parameter));
 	}
-	
+
 	public I32 add(I32 parameter) {
 		return new I32(data + parameter.data);
 	}
-	
+
 	public I64 add(I64 parameter) {
 		return new I64(this).add(parameter);
 	}
-	
+
 	public IDATA add(IDATA parameter) {
 		return new IDATA(this).add(parameter);
 	}
 
 	//SUB
-	
+
 	public I32 sub(long number) {
 		return new I32(data - number);
 	}
-	
+
 	public I32 sub(U8 parameter) {
-		return sub (new I32(parameter));
+		return sub(new I32(parameter));
 	}
-	
+
 	public I32 sub(U16 parameter) {
-		return sub (new I32(parameter));
+		return sub(new I32(parameter));
 	}
-	
+
 	public I32 sub(U32 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public U64 sub(U64 parameter) {
 		return new U64(this).sub(parameter);
 	}
-	
+
 	public UDATA sub(UDATA parameter) {
 		return new UDATA(this).sub(parameter);
 	}
-	
+
 	public I32 sub(I8 parameter) {
 		return sub(new I32(parameter));
 	}
-	
+
 	public I32 sub(I16 parameter) {
 		return sub(new I32(parameter));
 	}
-	
+
 	public I32 sub(I32 parameter) {
 		return new I32(data - parameter.data);
 	}
-	
+
 	public I64 sub(I64 parameter) {
 		return new I64(this).sub(parameter);
 	}
-	
+
 	public IDATA sub(IDATA parameter) {
 		return new IDATA(this).sub(parameter);
 	}
@@ -150,83 +150,83 @@ public class I32 extends IDATA {
 	public long longValue() {
 		return (int) data;
 	}
-	
+
 	// bitOr
 
 	public I32 bitOr(int number) {
 		return new I32(data | number);
 	}
-	
+
 	public I32 bitOr(long number) {
 		return new I32(data | number);
 	}
-	
+
 	public I32 bitOr(U8 parameter) {
-		return bitOr (new I32(parameter));
+		return bitOr(new I32(parameter));
 	}
-	
+
 	public I32 bitOr(U16 parameter) {
-		return bitOr (new I32(parameter));
+		return bitOr(new I32(parameter));
 	}
-	
+
 	public I32 bitOr(U32 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public U64 bitOr(U64 parameter) {
 		return new U64(this).bitOr(parameter);
 	}
-	
+
 	public UDATA bitOr(UDATA parameter) {
 		return new UDATA(this).bitOr(parameter);
 	}
-	
+
 	public I32 bitOr(I8 parameter) {
 		return bitOr(new I32(parameter));
 	}
-	
+
 	public I32 bitOr(I16 parameter) {
 		return bitOr(new I32(parameter));
 	}
-	
+
 	public I32 bitOr(I32 parameter) {
 		return new I32(data | parameter.data);
 	}
-	
+
 	public I64 bitOr(I64 parameter) {
 		return new I64(this).bitOr(parameter);
 	}
-	
+
 	public IDATA bitOr(IDATA parameter) {
 		return new IDATA(this).bitOr(parameter);
 	}
-	
+
 	// bitXor
-	
+
 	public I32 bitXor(int number) {
 		return new I32(data ^ number);
 	}
-	
+
 	public I32 bitXor(long number) {
 		return new I32(data ^ number);
 	}
-	
+
 	public I32 bitXor(Scalar parameter) {
 		return bitXor(new I32(parameter));
 	}
-	
+
 	public I32 bitXor(I32 parameter) {
 		return new I32(data ^ parameter.data);
 	}
-	
+
 	public U32 bitXor(U32 parameter) {
 		return new U32(this).bitXor(parameter);
 	}
-	
+
 	public UDATA bitXor(UDATA parameter) {
 		return new UDATA(this).bitXor(parameter);
 	}
-	
+
 	public IDATA bitXor(IDATA parameter) {
 		return new IDATA(this).bitXor(parameter);
 	}
@@ -234,87 +234,83 @@ public class I32 extends IDATA {
 	public U64 bitXor(U64 parameter) {
 		return new U64(this).bitXor(parameter);
 	}
-	
+
 	public I64 bitXor(I64 parameter) {
 		return new I64(this).bitXor(parameter);
 	}
-	
+
 	// bitAnd
-	
+
 	public I32 bitAnd(int number) {
 		return new I32(data & number);
 	}
-	
+
 	public I32 bitAnd(long number) {
 		return new I32(data & number);
 	}
-	
+
 	public I32 bitAnd(U8 parameter) {
-		return bitAnd (new I32(parameter));
+		return bitAnd(new I32(parameter));
 	}
-	
+
 	public I32 bitAnd(U16 parameter) {
-		return bitAnd (new I32(parameter));
+		return bitAnd(new I32(parameter));
 	}
-	
+
 	public I32 bitAnd(U32 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public U64 bitAnd(U64 parameter) {
 		return new U64(this).bitAnd(parameter);
 	}
-	
+
 	public UDATA bitAnd(UDATA parameter) {
 		return new UDATA(this).bitAnd(parameter);
 	}
-	
+
 	public I32 bitAnd(I8 parameter) {
 		return bitAnd(new I32(parameter));
 	}
-	
+
 	public I32 bitAnd(I16 parameter) {
 		return bitAnd(new I32(parameter));
 	}
-	
+
 	public I32 bitAnd(I32 parameter) {
 		return new I32(data & parameter.data);
 	}
-	
+
 	public I64 bitAnd(I64 parameter) {
 		return new I64(this).bitAnd(parameter);
 	}
-	
+
 	public IDATA bitAnd(IDATA parameter) {
 		return new IDATA(this).bitAnd(parameter);
 	}
-	
+
 	// leftShift
 	public I32 leftShift(int i) {
 		return new I32(data << i);
 	}
-	
+
 	// rightShift
 	public I32 rightShift(int i) {
-		long newData = data >>> i;
-		if ((data & 0x80000000) != 0) {
-			newData |= (0xFFFFFFFF << (Math.max(0, 32 - i)));
-		}
-		return new I32(newData);
+		return new I32(intValue() >> i);
 	}
-	
+
 	// bitNot
 	public I32 bitNot() {
 		return new I32(~data);
 	}
-	
+
 	public I32 mult(int parameter) {
 		return new I32(data * parameter);
 	}
-	
+
 	@Override
-	public int sizeof()
-	{
+	public int sizeof() {
 		return SIZEOF;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
@@ -24,7 +24,7 @@ package com.ibm.j9ddr.vm29.types;
 import com.ibm.j9ddr.InvalidDataTypeException;
 
 public class I64 extends IDATA {
-	
+
 	// Constants
 	public static final int SIZEOF = 8;
 	public static final long MASK = 0xFFFFFFFFFFFFFFFFL;
@@ -38,13 +38,13 @@ public class I64 extends IDATA {
 		// will truncate the value to 32 bits: we need all 64-bits here.
 		this.data = value;
 	}
-	
+
 	public I64(Scalar parameter) {
 		super(parameter);
 	}
 
 	// API
-	
+
 	// ADD
 	public I64 add(int number) {
 		return new I64(data + number);
@@ -57,43 +57,43 @@ public class I64 extends IDATA {
 	public I64 add(U8 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public I64 add(U16 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public I64 add(U32 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public U64 add(U64 parameter) {
 		return new U64(this).add(new I64(parameter));
 	}
-	
+
 	public boolean eq(U64 parameter) {
 		return new U64(this).eq(new I64(parameter));
 	}
-	
+
 	public I64 add(I8 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public I64 add(I16 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public I64 add(I32 parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	public I64 add(I64 parameter) {
 		return new I64(data + parameter.data);
 	}
-	
+
 	public I64 add(IDATA parameter) {
 		return add(new I64(parameter));
 	}
-	
+
 	//SUB
 	public I64 sub(int number) {
 		return new I64(data - number);
@@ -106,15 +106,15 @@ public class I64 extends IDATA {
 	public I64 sub(U8 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public I64 sub(U16 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public I64 sub(U32 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public U64 sub(U64 parameter) {
 		return new U64(this).sub(new I64(parameter));
 	}
@@ -122,19 +122,19 @@ public class I64 extends IDATA {
 	public I64 sub(I8 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public I64 sub(I16 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public I64 sub(I32 parameter) {
 		return sub(new I64(parameter));
 	}
-	
+
 	public I64 sub(I64 parameter) {
 		return new I64(data - parameter.data);
 	}
-	
+
 	public I64 sub(IDATA parameter) {
 		return sub(new I64(parameter));
 	}
@@ -150,8 +150,6 @@ public class I64 extends IDATA {
 	}
 
 	public long longValue() {
-		// When working with 32-bit core files, IDATA.longValue() will
-		// truncate the value to 32 bits: we must return all 64-bits here.
 		return data;
 	}
 
@@ -160,130 +158,130 @@ public class I64 extends IDATA {
 	public I64 bitOr(int number) {
 		return new I64(data | number);
 	}
-	
+
 	public I64 bitOr(long number) {
 		return new I64(data | number);
 	}
-	
+
 	public I64 bitOr(U8 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(U16 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(U32 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public U64 bitOr(U64 parameter) {
 		return new U64(this).bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(I8 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(I16 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(I32 parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	public I64 bitOr(I64 parameter) {
 		return new I64(data | parameter.data);
 	}
-	
+
 	public I64 bitOr(IDATA parameter) {
 		return bitOr(new I64(parameter));
 	}
-	
+
 	// bitXor
-	
+
 	public I64 bitXor(int number) {
 		return new I64(data ^ number);
 	}
-	
+
 	public I64 bitXor(long number) {
 		return new I64(data ^ number);
 	}
-		
+
 	public I64 bitXor(Scalar parameter) {
 		return bitXor(new I64(parameter));
 	}
-	
+
 	public I64 bitXor(I64 parameter) {
 		return new I64(data ^ parameter.data);
 	}
-	
+
 	public U64 bitXor(U64 parameter) {
 		return new U64(this).bitXor(parameter);
 	}
-	
+
 	// bitAnd
-	
+
 	public I64 bitAnd(int number) {
 		return new I64(data & number);
 	}
-	
+
 	public I64 bitAnd(long number) {
 		return new I64(data & number);
 	}
-	
+
 	public I64 bitAnd(U8 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(U16 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(U32 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public U64 bitAnd(U64 parameter) {
 		return new U64(this).bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(I8 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(I16 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(I32 parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	public I64 bitAnd(I64 parameter) {
 		return new I64(data & parameter.data);
 	}
-	
+
 	public I64 bitAnd(IDATA parameter) {
 		return bitAnd(new I64(parameter));
 	}
-	
+
 	// leftShift
 	public I64 leftShift(int i) {
 		return new I64(data << i);
 	}
-	
+
 	// rightShift
 	public I64 rightShift(int i) {
 		return new I64(data >> i);
 	}
-	
+
 	// bitNot
 	public I64 bitNot() {
 		return new I64(~data);
 	}
-	
+
 	public I64 mult(int parameter) {
 		return new I64(data * parameter);
 	}
@@ -292,19 +290,17 @@ public class I64 extends IDATA {
 		return new I64(data * parameter);
 	}
 
-	public boolean lt(I64 parameter)
-	{
+	public boolean lt(I64 parameter) {
 		return this.data < parameter.data;
 	}
-	
-	public boolean gt(I64 parameter)
-	{
+
+	public boolean gt(I64 parameter) {
 		return this.data > parameter.data;
 	}
-	
+
 	@Override
-	public int sizeof()
-	{
+	public int sizeof() {
 		return SIZEOF;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I8.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I8.java
@@ -21,9 +21,8 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.types;
 
-
 public class I8 extends IScalar {
-	
+
 	// Constants
 	public static final int SIZEOF = 1;
 	public static final long MASK = 0xFFL;
@@ -34,271 +33,266 @@ public class I8 extends IScalar {
 	public I8(long value) {
 		super(value & MASK);
 	}
-	
+
 	public I8(Scalar parameter) {
 		super(parameter);
 	}
-	
+
 	// API
-	
+
 	// ADD
-	
+
 	public I8 add(int number) {
 		return new I8(data + number);
 	}
-	
+
 	public I32 add(U8 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U8 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public I32 add(U16 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U16 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public U32 add(U32 parameter) {
 		return new U32(this).add(parameter);
 	}
-	
+
 	public boolean eq(U32 parameter) {
 		return new U32(this).eq(parameter);
 	}
-	
+
 	public U64 add(U64 parameter) {
 		return new U64(this).add(parameter);
 	}
-	
+
 	public boolean eq(U64 parameter) {
 		return new U64(this).eq(parameter);
 	}
-	
+
 	public UDATA add(UDATA parameter) {
 		return new UDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(UDATA parameter) {
 		return new UDATA(this).eq(parameter);
 	}
-	
+
 	public I8 add(I8 parameter) {
 		return new I8(data + parameter.data);
 	}
-	
+
 	public I32 add(I16 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public I32 add(I32 parameter) {
 		return new I32(this).add(parameter);
 	}
-	
+
 	public boolean eq(I32 parameter) {
 		return new I32(this).eq(parameter);
 	}
-	
+
 	public I64 add(I64 parameter) {
 		return new I64(this).add(parameter);
 	}
-	
+
 	public boolean eq(I64 parameter) {
 		return new I64(this).eq(parameter);
 	}
-	
+
 	public IDATA add(IDATA parameter) {
 		return new IDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(IDATA parameter) {
 		return new IDATA(this).eq(parameter);
 	}
 	//SUB
-	
+
 	public I8 sub(int number) {
 		return new I8(data - number);
 	}
-	
+
 	public I32 sub(U8 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I32 sub(U16 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public U32 sub(U32 parameter) {
 		return new U32(this).sub(parameter);
 	}
-	
+
 	public U64 sub(U64 parameter) {
 		return new U64(this).sub(parameter);
 	}
-	
+
 	public UDATA sub(UDATA parameter) {
 		return new UDATA(this).sub(parameter);
 	}
-	
+
 	public I8 sub(I8 parameter) {
 		return new I8(data - parameter.data);
 	}
-	
+
 	public I32 sub(I16 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I32 sub(I32 parameter) {
 		return new I32(this).sub(parameter);
 	}
-	
+
 	public I64 sub(I64 parameter) {
 		return new I64(this).sub(parameter);
 	}
-	
+
 	public IDATA sub(IDATA parameter) {
 		return new IDATA(this).sub(parameter);
 	}
 
-	
 	public long longValue() {
 		return (byte) data;
 	}
-	
+
 	public int intValue() {
 		return (byte) data;
 	}
-	
+
 	// bitOr
-	
+
 	public I8 bitOr(int number) {
 		return new I8(data | number);
 	}
-	
+
 	public I8 bitOr(long number) {
 		return new I8(data | number);
 	}
-	
+
 	public I32 bitOr(U8 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I32 bitOr(U16 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public U32 bitOr(U32 parameter) {
 		return new U32(this).bitOr(parameter);
 	}
-	
+
 	public U64 bitOr(U64 parameter) {
 		return new U64(this).bitOr(parameter);
 	}
-	
+
 	public UDATA bitOr(UDATA parameter) {
 		return new UDATA(this).bitOr(parameter);
 	}
-	
+
 	public I8 bitOr(I8 parameter) {
 		return new I8(data | parameter.data);
 	}
-	
+
 	public I32 bitOr(I16 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I32 bitOr(I32 parameter) {
 		return new I32(this).bitOr(parameter);
 	}
-	
+
 	public I64 bitOr(I64 parameter) {
 		return new I64(this).bitOr(parameter);
 	}
-	
+
 	public IDATA bitOr(IDATA parameter) {
 		return new IDATA(this).bitOr(parameter);
 	}
-	
+
 	// bitAnd
-	
+
 	public I8 bitAnd(int number) {
 		return new I8(data & number);
 	}
-	
+
 	public I8 bitAnd(long number) {
 		return new I8(data & number);
 	}
-	
+
 	public I32 bitAnd(U8 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I32 bitAnd(U16 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public U32 bitAnd(U32 parameter) {
 		return new U32(this).bitAnd(parameter);
 	}
-	
+
 	public U64 bitAnd(U64 parameter) {
 		return new U64(this).bitAnd(parameter);
 	}
-	
+
 	public UDATA bitAnd(UDATA parameter) {
 		return new UDATA(this).bitAnd(parameter);
 	}
-	
+
 	public I8 bitAnd(I8 parameter) {
 		return new I8(data & parameter.data);
 	}
-	
+
 	public I32 bitAnd(I16 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I32 bitAnd(I32 parameter) {
 		return new I32(this).bitAnd(parameter);
 	}
-	
+
 	public I64 bitAnd(I64 parameter) {
 		return new I64(this).bitAnd(parameter);
 	}
-	
+
 	public IDATA bitAnd(IDATA parameter) {
 		return new IDATA(this).bitAnd(parameter);
 	}
-	
+
 	// leftShift
 	public I8 leftShift(int i) {
 		return new I8(data << i);
 	}
-	
+
 	// rightShift
 	public I8 rightShift(int i) {
-		long newData = data >>> i;
-		if ((data & 0x8000) != 0) {
-			newData |= (0xFFFF << (Math.max(0, 16 - i)));
-		}
-		return new I8(newData);
+		return new I8(intValue() >> i);
 	}
-	
+
 	// bitNot
 	public I8 bitNot() {
 		return new I8(~data);
 	}
-	
+
 	public I8 mult(int parameter) {
 		return new I8(data * parameter);
 	}
-	
+
 	@Override
-	public int sizeof()
-	{
+	public int sizeof() {
 		return SIZEOF;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/IDATA.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/IDATA.java
@@ -27,90 +27,104 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 
 public class IDATA extends IScalar {
 	// Constants
-	public static final int SIZEOF = J9BuildFlags.env_data64 ? 8 : 4;;
-	public static final long MASK = SIZEOF == 8 ? 0xFFFFFFFFFFFFFFFFL : 0xFFFFFFFFL;
-	public static final IDATA MIN = SIZEOF == 8 ? new IDATA(0x8000000000000000L) : new IDATA(0x80000000L);
-	public static final IDATA MAX = SIZEOF == 8 ? new IDATA(0x7FFFFFFFFFFFFFFFL) : new IDATA(0x7FFFFFFFL);
+	public static final int SIZEOF;
+	public static final long MASK;
+	public static final IDATA MIN;
+	public static final IDATA MAX;
+
+	static {
+		if (J9BuildFlags.env_data64) {
+			SIZEOF = 8;
+			MASK = 0xFFFFFFFFFFFFFFFFL;
+			MIN = new IDATA(0x8000000000000000L);
+			MAX = new IDATA(0x7FFFFFFFFFFFFFFFL);
+		} else {
+			SIZEOF = 4;
+			MASK = 0xFFFFFFFFL;
+			MIN = new IDATA(0x80000000L);
+			MAX = new IDATA(0x7FFFFFFFL);
+		}
+	}
 
 	// Constructors
 	public IDATA(long value) {
 		super(value & MASK);
 	}
-	
+
 	public IDATA(Scalar parameter) {
 		super(parameter);
 	}
-	
+
 	// API
 
 	// ADD
-	
+
 	public IDATA add(U8 parameter) {
 		return add(new IDATA(parameter));
 	}
-	
+
 	public IDATA add(U16 parameter) {
 		return add(new IDATA(parameter));
 	}
-	
+
 	public IDATA add(U32 parameter) {
 		return add(new IDATA(parameter));
 	}
-	
+
 	public boolean eq(U32 parameter) {
 		return eq(new IDATA(parameter));
 	}
-	
+
 	public UDATA add(UDATA parameter) {
 		return new UDATA(this).add(parameter);
 	}
-	
+
 	public boolean eq(UDATA parameter) {
 		return new UDATA(this).eq(parameter);
 	}
-	
+
 	public IDATA add(IScalar parameter) {
 		return add(new IDATA(parameter));
 	}
-	
+
 	public IDATA add(IDATA parameter) {
 		return new IDATA(data + parameter.data);
 	}
-	
+
 	public I64 add(I64 parameter) {
 		return new I64(this).add(parameter);
 	}
-	
+
 	//SUB
-	
+
 	public IDATA sub(U8 parameter) {
 		return sub(new IDATA(parameter));
 	}
-	
+
 	public IDATA sub(U16 parameter) {
 		return sub(new IDATA(parameter));
 	}
-	
+
 	public IDATA sub(U32 parameter) {
 		return sub(new IDATA(parameter));
 	}
-	
+
 	public UDATA sub(UDATA parameter) {
 		return new UDATA(this).sub(parameter);
 	}
-	
+
 	public IDATA sub(IScalar parameter) {
 		return sub(new IDATA(parameter));
 	}
-	
+
 	public IDATA sub(IDATA parameter) {
 		return new IDATA(data - parameter.data);
 	}
-	
+
 	public IDATA sub(long parameter) {
 		return new IDATA(data - parameter);
 	}
-	
+
 	public I64 sub(I64 parameter) {
 		return new I64(this).sub(parameter);
 	}
@@ -132,47 +146,47 @@ public class IDATA extends IScalar {
 			return data;
 		}
 	}
-	
+
 	// bitOr
-	
+
 	public IDATA bitOr(int parameter) {
 		return new IDATA(data | parameter);
 	}
-	
+
 	public IDATA bitOr(U8 parameter) {
 		return bitOr(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitOr(U16 parameter) {
 		return bitOr(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitOr(U32 parameter) {
 		return bitOr(new IDATA(parameter));
 	}
-	
+
 	public UDATA bitOr(UDATA parameter) {
 		return new UDATA(this).bitOr(parameter);
 	}
-	
+
 	public IDATA bitOr(IScalar parameter) {
 		return bitOr(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitOr(IDATA parameter) {
 		return new IDATA(data | parameter.data);
 	}
-	
+
 	public I64 bitOr(I64 parameter) {
 		return new I64(this).bitOr(parameter);
 	}
-	
+
 	// bitXor
-	
+
 	public IDATA bitXor(int parameter) {
 		return new IDATA(data ^ parameter);
 	}
-	
+
 	public IDATA bitXor(long parameter) {
 		return new IDATA(data ^ parameter);
 	}
@@ -180,116 +194,107 @@ public class IDATA extends IScalar {
 	public IDATA bitXor(Scalar parameter) {
 		return bitXor(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitXor(IDATA parameter) {
 		return new IDATA(data ^ parameter.data);
 	}
-	
+
 	public UDATA bitXor(UDATA parameter) {
 		return new UDATA(this).bitXor(parameter);
 	}
-	
+
 	public I64 bitXor(I64 parameter) {
 		return new I64(this).bitXor(parameter);
 	}
-	
+
 	public U64 bitXor(U64 parameter) {
 		return new U64(this).bitXor(parameter);
 	}
-	
+
 	// bitAnd
-	
+
 	public IDATA bitAnd(int parameter) {
 		return new IDATA(data & parameter);
 	}
-	
+
 	public IDATA bitAnd(U8 parameter) {
 		return bitAnd(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitAnd(U16 parameter) {
 		return bitAnd(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitAnd(U32 parameter) {
 		return bitAnd(new IDATA(parameter));
 	}
-	
+
 	public UDATA bitAnd(UDATA parameter) {
 		return new UDATA(this).bitAnd(parameter);
 	}
-	
+
 	public IDATA bitAnd(IScalar parameter) {
 		return bitAnd(new IDATA(parameter));
 	}
-	
+
 	public IDATA bitAnd(IDATA parameter) {
 		return new IDATA(data & parameter.data);
 	}
-	
+
 	public I64 bitAnd(I64 parameter) {
 		return new I64(this).bitAnd(parameter);
 	}
-	
+
 	// leftShift
 	public IDATA leftShift(int i) {
 		return new IDATA(data << i);
 	}
-	
+
 	public IDATA rightShift(int i) {
-		if (SIZEOF == 4) {
-			long newData = data >>> i;
-			if ((data & 0x80000000) != 0) {
-				newData |= (0xFFFFFFFF << (Math.max(0, 32 - i)));
-			}
-			return new IDATA(newData);
-		} else {
-			return new IDATA(data >> i);
-		}
+		return new IDATA(longValue() >> i);
 	}
-	
+
 	// bitNot
 	public IDATA bitNot() {
 		return new IDATA(~data);
 	}
-	
+
 	public IDATA mult(int parameter) {
 		return new IDATA(data * parameter);
 	}
-	
+
 	/* mod */
 	public IDATA mod(int parameter) {
 		return mod((long) parameter);
 	}
-	
+
 	public IDATA mod(long parameter) {
-		return new IDATA(data % parameter);
+		return new IDATA(longValue() % parameter);
 	}
-	
+
 	public IDATA mod(Scalar parameter) {
 		return mod(parameter.longValue());
 	}
-	
+
 	public IDATA div(long parameter) {
-		return new IDATA(data/parameter);
+		return new IDATA(longValue() / parameter);
 	}
-	
+
 	public IDATA div(Scalar parameter) {
 		return div(parameter.longValue());
 	}
-	
+
 	@Override
-	public int sizeof()
-	{
+	public int sizeof() {
 		return SIZEOF;
 	}
-	
-	public static IDATA cast(AbstractPointer ptr)
-	{
+
+	public static IDATA cast(AbstractPointer ptr) {
 		if (ptr != null) {
 			return new IDATA(ptr.getAddress());
 		} else {
 			return new IDATA(0);
 		}
 	}
+
 }


### PR DESCRIPTION
For negative values, the `div()`, `mod()`, and `rightShift()` methods would sometimes return bad values.

For example, -10 is represented as 0xFFFFFFF6L in the data field of an `I32` object (or in a `IDATA` object for 32-bit dumps).
* `div(5)` would return 0x33333331(858993457) instead of -2
* `mod(5)` would return 1 instead of 0
* `rightShift(0)` would return -1 instead of -10