### PR TITLE
Allow JITServer communication and health port 0

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2283,7 +2283,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
             }
          else
             {
-            compInfo->getPersistentInfo()->setJITServerHealthPort(0); // This means don't open dedicated port for health probes
+            compInfo->getPersistentInfo()->setJITServerUseHealthPort(false);
             }
 
          // Check if we should open the port for the MetricsServer

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -167,6 +167,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _serverUID(0),
          _hasEverConnectedToServer(false),
          _JITServerMetricsPort(38500),
+         _JITServerUseHealthPort(true),
          _JITServerHealthPort(38600),
          _requireJITServer(false),
          _localSyncCompiles(true),
@@ -360,6 +361,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setHasEverConnectedToServer() { _hasEverConnectedToServer = true; }
    uint32_t getJITServerMetricsPort() const { return _JITServerMetricsPort; }
    void setJITServerMetricsPort(uint32_t port) { _JITServerMetricsPort = port; }
+   bool getJITServerUseHealthPort() const { return _JITServerUseHealthPort; }
+   void setJITServerUseHealthPort(bool b) { _JITServerUseHealthPort = b; }
    uint32_t getJITServerHealthPort() const { return _JITServerHealthPort; }
    void setJITServerHealthPort(uint32_t port) { _JITServerHealthPort = port; }
    bool getRequireJITServer() const { return _requireJITServer; }
@@ -474,6 +477,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint64_t    _serverUID; // At the client, this represents the UID of the server the client is connected to
    bool        _hasEverConnectedToServer; // At the client, true if the client has connected to a server at some point in the past
    uint32_t    _JITServerMetricsPort; // Port for receiving http metrics requests from Prometheus; only used at server
+   bool        _JITServerUseHealthPort; // True if the server should open _JITServerHealthPort
    uint32_t    _JITServerHealthPort; // Port for receiving readiness/liveness probes from Kubernetes; only used at server
    bool        _requireJITServer;
    bool        _localSyncCompiles;


### PR DESCRIPTION
The `-XX:JITServerPort=<port>` and `-XX:JITServerHeathProbePort=<port>` options both now support the port value 0. When this port is specified, a random unassigned port will be assigned to the relevant socket, and this bound port will be reported in the JITServer verbose log.

This behaviour when port 0 is specified matches that of the underlying `bind()` network function.

Related: https://github.com/eclipse-openj9/openj9/issues/14706