### PR TITLE
Avoid heap walk and GC for MemberName fix-up on class redefinition

### DIFF
--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -649,6 +649,7 @@ if(J9VM_OPT_OPENJDK_METHODHANDLE)
 		Java_java_lang_invoke_MethodHandleNatives_setCallSiteTargetVolatile
 		Java_java_lang_invoke_MethodHandleNatives_getNamedCon
 		Java_java_lang_invoke_MethodHandleNatives_registerNatives
+		Java_java_lang_invoke_MethodHandleNatives_markClassForMemberNamePruning
 	)
 	if(JAVA_SPEC_VERSION EQUAL 8)
 		omr_add_exports(jclse Java_java_lang_invoke_MethodHandleNatives_getConstant)

--- a/runtime/jcl/uma/java_lang_invoke_MethodHandleNatives_exports.xml
+++ b/runtime/jcl/uma/java_lang_invoke_MethodHandleNatives_exports.xml
@@ -40,4 +40,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<export name="Java_java_lang_invoke_MethodHandleNatives_getConstant">
 		<exclude-if condition="spec.java9"/>
 	</export>
+	<export name="Java_java_lang_invoke_MethodHandleNatives_markClassForMemberNamePruning" />
 </exports>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -89,6 +89,7 @@
 #define J9ClassHasOffloadAllowSubtasksNatives 0x200000
 #define J9ClassIsPrimitiveValueType 0x400000
 #define J9ClassAllowsNonAtomicCreation 0x800000
+#define J9ClassNeedToPruneMemberNames 0x1000000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 
@@ -3251,6 +3252,13 @@ typedef struct J9ClassLocation {
 #define LOAD_LOCATION_CLASSPATH 2
 #define LOAD_LOCATION_MODULE 3
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+typedef struct J9MemberNameListNode {
+	jobject memberName;
+	struct J9MemberNameListNode *next;
+} J9MemberNameListNode;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
 typedef struct J9Class {
 	UDATA eyecatcher;
 	struct J9ROMClass* romClass;
@@ -3314,6 +3322,10 @@ typedef struct J9Class {
 #endif /* JAVA_SPEC_VERSION >= 11 */
 	struct J9FlattenedClassCache* flattenedClassCache;
 	struct J9ClassHotFieldsInfo* hotFieldsInfo;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	/* A linked list of weak global references to every resolved MemberName whose clazz is this class. */
+	J9MemberNameListNode *memberNames;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 } J9Class;
 
 /* Interface classes can never be instantiated, so the following fields in J9Class will not be used:
@@ -3406,6 +3418,10 @@ typedef struct J9ArrayClass {
 	/* Added temporarily for consistency */
 	UDATA flattenedElementSize;
 	struct J9ClassHotFieldsInfo* hotFieldsInfo;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	/* A linked list of weak global references to every resolved MemberName whose clazz is this class. */
+	J9MemberNameListNode *memberNames;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 } J9ArrayClass;
 
 
@@ -6025,6 +6041,14 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t delayedLockingOperationsMutex;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	U_32 compatibilityFlags;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	/* Protects access globally to memberNameListNodePool, J9Class::memberNames
+	 * (for every class), and all nodes in each of those lists.
+	 */
+	omrthread_monitor_t memberNameListsMutex;
+	/* Pool for allocating J9MemberNameListNode. */
+	struct J9Pool *memberNameListNodePool;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 } J9JavaVM;
 
 #define J9VM_PHASE_STARTUP  1

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1017,6 +1017,7 @@ void JNICALL Java_java_lang_invoke_MethodHandleNatives_registerNatives(JNIEnv *e
 #if JAVA_SPEC_VERSION == 8
 jint JNICALL Java_java_lang_invoke_MethodHandleNatives_getConstant(JNIEnv *env, jclass clazz, jint kind);
 #endif /* JAVA_SPEC_VERSION == 8 */
+void JNICALL Java_java_lang_invoke_MethodHandleNatives_markClassForMemberNamePruning(JNIEnv *env, jclass clazz, jclass c);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 /* java_lang_invoke_VarHandle.c */

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2249,9 +2249,8 @@ fixJNIRefs (J9VMThread * currentThread, J9HashTable* classHashTable, BOOLEAN fas
  * vmtarget is temporarily repurposed as the next pointer for an intrusive
  * linked list of all MemberName objects to fix up. This list allows the same
  * MemberNames to be processed again by fixMemberNames() without needing to
- * iterate over all objects a second time and without needing to identify the
- * same MemberNames after java/lang/Class instances and JNI method/field IDs
- * have been updated.
+ * identify the same MemberNames after java/lang/Class instances and JNI
+ * method/field IDs have been updated.
  *
  * For MemberNames representing methods (MN_IS_METHOD, MN_IS_CONSTRUCTOR),
  * vmindex is temporarily set to point to the corresponding J9JNIMethodID,

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3240,7 +3240,7 @@ fail:
 			 *            + J9ClassIsPrimitiveValueType
 			 *           + J9ClassAllowsNonAtomicCreation
 			 *
-			 *         + Unused
+			 *         + J9ClassNeedToPruneMemberNames
 			 *        + Unused
 			 *       + Unused
 			 *      + Unused

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -977,6 +977,18 @@ freeJavaVM(J9JavaVM * vm)
 		vm->realtimeSizeClasses = NULL;
 	}
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	if (NULL != vm->memberNameListsMutex) {
+		omrthread_monitor_destroy(vm->memberNameListsMutex);
+		vm->memberNameListsMutex = NULL;
+	}
+
+	if (NULL != vm->memberNameListNodePool) {
+		pool_kill(vm->memberNameListNodePool);
+		vm->memberNameListNodePool = NULL;
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	{
 		J9Pool *hookRecords = vm->checkpointState.hookRecords;
@@ -7155,6 +7167,18 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	/* Default to using lazy in all but realtime */
 	vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_LAZY_SYMBOL_RESOLUTION;
 
+	/* Initialize the pool and mutex for per-class MemberName lists. */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	vm->memberNameListNodePool = pool_new(sizeof(J9MemberNameListNode), 0, 0, 0, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM, POOL_FOR_PORT(portLibrary));
+	if (NULL == vm->memberNameListNodePool) {
+		goto error;
+	}
+
+	if (0 != omrthread_monitor_init_with_name(&vm->memberNameListsMutex, 0, "MemberName lists mutex")) {
+		goto error;
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
 	/* Scans cmd-line arguments in order */
 	if (JNI_OK != processVMArgsFromFirstToLast(vm)) {
 		goto error;
@@ -8049,8 +8073,10 @@ static void
 freeClassNativeMemory(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
 {
 	J9VMClassUnloadEvent * data = eventData;
+	J9VMThread *currentThread = data->currentThread;
+	J9JavaVM *vm = currentThread->javaVM;
 	J9Class * clazz = data->clazz;
-	PORT_ACCESS_FROM_VMC(data->currentThread);
+	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	/* Free the ID table for this class, but do not free any of the IDs.  They will be freed by killing their
 		pools when the class loader is unloaded.
@@ -8064,6 +8090,29 @@ freeClassNativeMemory(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 		j9mem_free_memory(J9INTERFACECLASS_METHODORDERING(clazz));
 		J9INTERFACECLASS_SET_METHODORDERING(clazz, NULL);
 	}
+
+	/* Free the MemberName list. */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	omrthread_monitor_enter(vm->memberNameListsMutex);
+
+	if (NULL != clazz->memberNames) {
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		J9MemberNameListNode *node = clazz->memberNames;
+		clazz->memberNames = NULL;
+		while (NULL != node) {
+			J9MemberNameListNode *next = node->next;
+			/* The weak JNI ref must have been cleared by now. Otherwise, the
+			 * MemberName is still live, and this class should be too.
+			 */
+			Assert_VM_true(NULL == J9_JNI_UNWRAP_REFERENCE(node->memberName));
+			vmFuncs->j9jni_deleteGlobalRef((JNIEnv*)currentThread, node->memberName, JNI_TRUE);
+			pool_removeElement(vm->memberNameListNodePool, node);
+			node = next;
+		}
+	}
+
+	omrthread_monitor_exit(vm->memberNameListsMutex);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 }
 
 #endif /* GC_DYNAMIC_CLASS_UNLOADING */


### PR DESCRIPTION
In class redefinition the affected `MemberName` objects were previously identified by iterating over all objects in the heap. The heap walk also necessitated a GC cycle to eliminate dead objects, which could otherwise cause the fix-up to crash.

This heap walk and GC cycle were causing a significant performance regression in redefinition for builds using OpenJDK `MethodHandle`s (i.e. Java 17+) vs. ones using J9 `MethodHandle`s. The regression was especially drastic in fast HCR mode, where no other heap walk is necessary and therefore the time taken for redefinition should be largely independent of the number of objects in the heap.

Now instead each `J9Class` has a list of JNI weak global references to all of the `MemberName` objects that are resolved (i.e. have `vmtarget` set) to a member of that class (as determined by the `clazz` field). Redefinition uses these lists to identify the affected `MemberName`s without inspecting any other objects, and in particular without walking the heap. Because the heap walk is no longer needed, neither is the GC cycle, and both are eliminated.

The use of weak references ensures that these lists don't prevent `MemberName` objects from being reclaimed, and in particular that they don't prevent class unloading.

When a `MemberName` is reclaimed, its corresponding weak reference is cleared, and both that reference and its linked list node become unnecessary. To avoid leaking this memory, such entries are removed just prior to the addition of a `MemberName`, but only if it can be expected that there are any. To this end, the VM now provides an implementation of a native method `MethodHandleNatives.markClassForMemberNamePruning()`, which is expected to (exist and) be called when a `MemberName` that is on a per-class list becomes unreachable (really, phantom reachable), such as from a cleaning action or finalizer.

Without this adjustment to the Java sources, the mechanism implemented in this commit will still work, but the `MemberName` list will leak memory if many `MemberName`s for the same class are created and then reclaimed.

Issue: #19152 
Issue: #19153