### PR TITLE
DDR: always generate optional fields

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
@@ -276,8 +276,7 @@ public class StructureStubGenerator {
 
 		Collections.sort(fields);
 		for (FieldDescriptor fieldDescriptor : fields) {
-			if (fieldDescriptor.isPresent()
-					&& getOffsetConstant(fieldDescriptor).equals(fieldDescriptor.getName())
+			if (getOffsetConstant(fieldDescriptor).equals(fieldDescriptor.getName())
 					&& !PointerGenerator.omitFieldImplementation(structure, fieldDescriptor)) {
 				if (!headingPrinted) {
 					writer.println("\t// Offsets");
@@ -307,8 +306,7 @@ public class StructureStubGenerator {
 		Collections.sort(fields);
 		for (FieldDescriptor fieldDescriptor : fields) {
 			String fieldName = fieldDescriptor.getName();
-			if (fieldDescriptor.isPresent()
-					&& getOffsetConstant(fieldDescriptor).equals(fieldName)
+			if (getOffsetConstant(fieldDescriptor).equals(fieldName)
 					&& !PointerGenerator.omitFieldImplementation(structure, fieldDescriptor)) {
 				CTypeParser parser = new CTypeParser(fieldDescriptor.getType());
 


### PR DESCRIPTION
The test of whether a field is present must be deferred until a specific system dump is being accessed.

Structure stubs must include all fields optional or otherwise. The structure class generated dynamically will only include those fields actually present in the JVM that produced the system dump. Accesses to missing fields will trigger a `NoSuchFieldError` which will be replaced by `NoSuchFieldException` by the related pointer class.

Pointer classes must support the scenario where a field is not present in the executing JVM, but is present in a system dump being analyzed.