### PR TITLE
Don't use non-ASCII characters in text files

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -353,7 +353,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 		<description>Set on double map. Allows LINUX systems to double map arrays that are stored as arraylets.
 When enabled, a contiguous block of memory is created for each array which data surpasses the size of a region. This contiguous block represents the array as
 if the data was stored in a contiguous region of memory. All of the array data will be stored at their own region (not with spine); hence, all arraylets
-become discontiguous whenever this flag is enabled. Since there won’t be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
+become discontiguous whenever this flag is enabled. Since there won't be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
 all data is stored in their own region. It additionaly reduces footprint, mainly for JNI primitive array critical.</description>
 		<ifRemoved></ifRemoved>
 		<requires>

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -57,7 +57,7 @@ j9vm_shadowed_option(J9VM_GC_DEBUG_ASSERTS "Specialized GC assertions are used i
 
 # When enabled, a contiguous block of memory is created for each array in which data surpasses the size of a region. This contiguous block represents the array as
 # if the data was stored in a contiguous region of memory. All of the array data is stored in a unique region (not with spine); hence, all arraylets
-# become discontiguous whenever this flag is enabled. Since there won’t be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
+# become discontiguous whenever this flag is enabled. Since there won't be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
 # all data is stored in a unique region. It additionaly reduces footprint, mainly for JNI primitive array critical.
 j9vm_shadowed_option(J9VM_GC_ENABLE_DOUBLE_MAP OMR_GC_DOUBLE_MAP_ARRAYLETS "Allows LINUX and OSX systems to double map arrays that are stored as arraylets.")
 j9vm_shadowed_option(J9VM_GC_LARGE_OBJECT_AREA "Enable large object area (LOA) support")

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6949,7 +6949,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
       // - The second compilation is queued only when this is the last thread waiting
       //   for the compilation of the method.
       // - If for any reason, the current compilation request is changed to a sync
-      //   compilation from an async compilation, it probably means we can’t do an
+      //   compilation from an async compilation, it probably means we can't do an
       //   async compilation. Don't queue the second async remote compilation.
       if (entry->hasChangedToLocalSyncComp() &&
           (entry->_numThreadsWaiting <= 1) &&

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -107,7 +107,7 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	 * try to mmap with huge pages with the respective file descriptor the mmap call
 	 * fails. It would only succeed if MAP_ANON flag was provided, but doing so ignores
 	 * the file descriptor which is the opposite of what we want. In a newer glibc
-	 * version (glibc 2.27 onwards) there’s a new function that does exactly what we
+	 * version (glibc 2.27 onwards) there's a new function that does exactly what we
 	 * want, and that's memfd_create(2); however that's only supported in glibc 2.27. We
 	 * also need to check if region size is a bigger or equal to multiple of page size.
 	 *

--- a/runtime/j9vm/asgct.cpp
+++ b/runtime/j9vm/asgct.cpp
@@ -39,14 +39,14 @@ enum {
 ticks_no_Java_frame         =  0, // new thread
 ticks_no_class_load         = -1, // jmethodIds are not available
 ticks_GC_active             = -2, // GC action
-ticks_unknown_not_Java      = -3, // ¯\_(ツ)_/¯
-ticks_not_walkable_not_Java = -4, // ¯\_(ツ)_/¯
-ticks_unknown_Java          = -5, // ¯\_(ツ)_/¯
-ticks_not_walkable_Java     = -6, // ¯\_(ツ)_/¯
-ticks_unknown_state         = -7, // ¯\_(ツ)_/¯
+ticks_unknown_not_Java      = -3,
+ticks_not_walkable_not_Java = -4,
+ticks_unknown_Java          = -5,
+ticks_not_walkable_Java     = -6,
+ticks_unknown_state         = -7,
 ticks_thread_exit           = -8, // dying thread
 ticks_deopt                 = -9, // mid-deopting code
-ticks_safepoint             = -10 // ¯\_(ツ)_/¯
+ticks_safepoint             = -10
 };
 
 typedef struct {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2939,15 +2939,15 @@ typedef struct J9Object {
 	 * The following diagram describes the metadata stored in the low order bit flags of an object class pointer:
 	 *
 	 * Bit   31                23                15                7 6 5 4 3 2 1 0
-	 *      ┌─────────────────────────────────────────────────────────────────────┐
-	 * Word │0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0│
-	 *      └──────────────────────────────────────────────────────┬─┬─┬─┬─┬─┬─┬─┬┘
-	 *                                                             │ │ │ │ │ │ │ │
-	 *                                                             └─┴┬┴─┘ │ │ │ └──► [1] Linked Free Header (Hole)
-	 *                                                                │    │ │ └────► [2] Object has been hashed and moved
-	 *                                                                │    │ └──────► [3] Slot contains forwarded pointer
-	 *                                                                │    └────────► [4] Object has been hashed
-	 *                                                                └─────────────► [5] Nursery age (0 - 14) or various remembered states
+	 *      +---------------------------------------------------------------------+
+	 * Word |0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0   0 0 0 0 0 0 0 0|
+	 *      +------------------------------------------------------+-+-+-+-+-+-+-++
+	 *                                                             | | | | | | | |
+	 *                                                             +-+++-+ | | | +--> [1] Linked Free Header (Hole)
+	 *                                                                |    | | +----> [2] Object has been hashed and moved
+	 *                                                                |    | +------> [3] Slot contains forwarded pointer
+	 *                                                                |    +--------> [4] Object has been hashed
+	 *                                                                +-------------> [5] Nursery age (0 - 14) or various remembered states
 	 *
 	 * [1] If bit is 0, the slot represents the start of object, ie object header, which depending of forwarded bit
 	 *     could be class slot or forwarded pointer.

--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -863,7 +863,7 @@ computeNPEMsgAtPC(J9VMThread *vmThread, J9ROMMethod *romMethod, J9ROMClass *romC
 			*npeMsg = getMsgWithAllocation(vmThread, "%lu", sipushIndex);
 			break;
 		}
-		
+
 		case JBldc:		/* Fall through case !!! */
 		case JBldcw:	/* Fall through case !!! */
 		case JBldc2dw:	/* Fall through case !!! */
@@ -970,7 +970,8 @@ computeNPEMsgAtPC(J9VMThread *vmThread, J9ROMMethod *romMethod, J9ROMClass *romC
 		case JBfload:	/* Fall through case !!! */
 		case JBdload:	/* Fall through case !!! */
 		case JBaload: {
-			/* The index is an unsigned byte that must be an index into the local variable array of the current frame (§2.6).
+			/* The index is an unsigned byte that must be an index into the
+			 * local variable array of the current frame (section 2.6).
 			 * The local variable at index must contain a reference.
 			 */
 			*npeMsg = getLocalsName(vmThread, romMethod, *(bcCurrentPtr + 1), npePC, temps);
@@ -1307,7 +1308,7 @@ getMsgWithAllocation(J9VMThread *vmThread, const char *msgTemplate, ...)
 	/* NULL check omitted since j9str_vprintf accepts NULL (as above) */
 	j9str_vprintf(resultMsg, msgLen, msgTemplate, args);
 	va_end(args);
-	
+
 	Trc_VM_GetMsgWithAllocation_Exit(vmThread, msgTemplate, resultMsg);
 
 	return resultMsg;


### PR DESCRIPTION
They are problematic on z/OS where conversion to EBCDIC will fail.