### PR TITLE
JDK23 adds java.lang.Access.allowSecurityManager()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -522,14 +522,17 @@ final class Access implements JavaLangAccess {
 		return mod.implAddEnableNativeAccess();
 	}
 
-/*[IF (JAVA_SPEC_VERSION >= 23) & !INLINE-TYPES]*/
-	// This API should be enabled for INLINE-TYPES later.
-	// https://github.com/eclipse-openj9/openj9/issues/19144
+/*[IF JAVA_SPEC_VERSION >= 23]*/
 	@Override
 	public boolean addEnableNativeAccess(ModuleLayer moduleLayer, String moduleName) {
 		return moduleLayer.addEnableNativeAccess(moduleName);
 	}
-/*[ENDIF] (JAVA_SPEC_VERSION >= 23) & !INLINE-TYPES */
+
+	@Override
+	public boolean allowSecurityManager() {
+		return System.allowSecurityManager();
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 
 	public long findNative(ClassLoader loader, String entryName) {
 		return ClassLoader.findNative(loader, entryName);

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1226,6 +1226,12 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
+/*[IF JAVA_SPEC_VERSION >= 23]*/
+static boolean allowSecurityManager() {
+	return !throwUOEFromSetSM;
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
+
 /**
  * Sets the active security manager. Note that once
  * the security manager has been set, it can not be


### PR DESCRIPTION
`JDK23` adds `java.lang.Access.allowSecurityManager()`

Removed `!INLINE-TYPES` since `valhalla` is still in JDK 22 level.

closes https://github.com/eclipse-openj9/openj9/issues/19208

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk/tree/openj9-staging

Signed-off-by: Jason Feng <fengj@ca.ibm.com>