### PR TITLE
Disclaim memory for metadata segments

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -388,6 +388,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _sleepMsBeforeCheckpoint;
 #endif
 
+   static int32_t _minTimeBetweenMemoryDisclaims; // ms
+
    static int32_t _waitTimeToEnterIdleMode;
    static int32_t _waitTimeToEnterDeepIdleMode;
    static int32_t _waitTimeToExitStartupMode;
@@ -625,6 +627,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    bool isFSDNeeded(J9JavaVM *javaVM, J9HookInterface **vmHooks);
    FSDInitStatus initializeFSDIfNeeded(J9JavaVM *javaVM, J9HookInterface **vmHooks, bool &doAOT);
+
+   static bool disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig);
 
 #if defined(J9VM_OPT_JITSERVER)
    void setupJITServerOptions();

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -771,6 +771,11 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
          }
       }
 
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming) ||
+       !TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming))
+      {
+      TR::Options::disableMemoryDisclaimIfNeeded(_jitConfig);
+      }
    }
 
 void

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -435,6 +435,13 @@ TR::CRRuntime::prepareForCheckpoint()
       }
 #endif
 
+   // Make sure the limit for the ghost files is at least as big as the data cache size
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming))
+      {
+      U_32 ghostFileLimit = vm->jitConfig->dataCacheKB * 1024; // convert to bytes
+      vm->internalVMFunctions->setRequiredGhostFileLimit(vmThread, ghostFileLimit);
+      }
+
    setReadyForCheckpointRestore();
    }
 

--- a/runtime/compiler/runtime/DataCache.hpp
+++ b/runtime/compiler/runtime/DataCache.hpp
@@ -327,6 +327,7 @@ private:
    int32_t          _numAllocatedCaches;
    uint32_t         _flags;     // for configuration
    J9JITConfig     *_jitConfig;
+   bool             _disclaimEnabled; // If true, data cache segmnets can be disclaimed to a file or swap
 
    // Added as part of data cache reclamation
    const uint32_t _quantumSize;
@@ -337,6 +338,7 @@ private:
    TR_DataCache *allocateNewDataCache(uint32_t minimumSize);
    uint8_t *allocateDataCacheSpace(uint32_t size); // Made private for data cache reclamation.
    void freeDataCacheList(TR_DataCache *& head);
+   int disclaimSegment(J9MemorySegment *seg, bool canDisclaimOnSwap); // disclaim memory used for the indicated segment
 
    // Added as part of data cache reclamation
    void addToPool(Allocation *);
@@ -378,6 +380,7 @@ protected:
 
 public:
    void *operator new (size_t size, void * ptr) { return ptr; }
+   int32_t numAllocatedCaches() const { return _numAllocatedCaches; }
    TR_DataCache *reserveAvailableDataCache(J9VMThread *vmThread, uint32_t sizeHint);
    void makeDataCacheAvailable(TR_DataCache *dataCache); // put back the cache into the _activeDataCacheList
    uint8_t *allocateDataCacheRecord(uint32_t size, uint32_t allocType, uint32_t *allocSizePtr);
@@ -386,13 +389,10 @@ public:
    double computeDataCacheEfficiency();
    uint32_t getTotalSegmentMemoryAllocated() const { return _totalSegmentMemoryAllocated; }
    void freeDataCacheRecord(void *record);
-   void startupOver()
-      {
-      convertDataCachesToAllocations();
-      }
-
+   void startupOver() { convertDataCachesToAllocations(); }
    virtual void printStatistics();
-
+   bool isDisclaimEnabled() const { return _disclaimEnabled; }
+   int disclaimAllDataCaches();
 
    // static methods
    static TR_DataCacheManager* initialize(J9JITConfig * jitConfig);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4285,6 +4285,7 @@ typedef struct J9CRIUCheckpointState {
 #if defined(J9VM_OPT_CRAC_SUPPORT)
 	char *cracCheckpointToDir;
 #endif /* defined(J9VM_OPT_CRAC_SUPPORT) */
+	U_32 requiredGhostFileLimit;
 } J9CRIUCheckpointState;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
@@ -5068,6 +5069,7 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);
 	BOOLEAN (*isJVMInPortableRestoreMode)(struct J9VMThread *currentThread);
 	BOOLEAN (*isDebugOnRestoreEnabled)(struct J9VMThread *currentThread);
+	void (*setRequiredGhostFileLimit)(struct J9VMThread *currentThread, U_32 ghostFileLimit);
 	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);
 	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);
 	BOOLEAN (*runDelayedLockRelatedOperations)(struct J9VMThread *currentThread);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -585,6 +585,16 @@ BOOLEAN
 isDebugOnRestoreEnabled(J9VMThread *currentThread);
 
 /**
+ * @brief Sets the maximum size for the CRIU ghost files.
+ * If the new limit is smaller or equal to the previous limit,
+ * then this function does nothing.
+ * @param currentThread vmthread token
+ * @param ghostFileLimit the new size limit for ghost files
+ */
+void
+setRequiredGhostFileLimit(J9VMThread *currentThread, U_32 ghostFileLimit);
+
+/**
  * @brief JVM hooks to run before performing a JVM checkpoint
  *
  * @param currentThread vmthread token

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -415,6 +415,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	isNonPortableRestoreMode,
 	isJVMInPortableRestoreMode,
 	isDebugOnRestoreEnabled,
+	setRequiredGhostFileLimit,
 	runInternalJVMCheckpointHooks,
 	runInternalJVMRestoreHooks,
 	runDelayedLockRelatedOperations,

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2817,6 +2817,8 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 				}
 				vm->checkpointState.sleepMillisecondsForNotCheckpointSafe = sleepMillisecondsForNotCheckpointSafe;
 			}
+
+			vm->checkpointState.requiredGhostFileLimit = 1024 * 1024; /* 1 MB is the default ghost limit set by the CRIU library*/
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 			break;

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -342,6 +342,18 @@ J9MemorySegment * allocateFixedMemorySegmentInList(J9JavaVM *javaVM, J9MemorySeg
 	} else if (J9_ARE_ALL_BITS_SET(type, MEMORY_TYPE_VIRTUAL)) {
 
 		flags = J9PORT_VMEM_MEMORY_MODE_READ | J9PORT_VMEM_MEMORY_MODE_WRITE | J9PORT_VMEM_MEMORY_MODE_VIRTUAL;
+
+		/* DataCache and persistent memory segments can be marked as MEMORY_TYPE_DISCLAIMABLE_TO_FILE
+		 * to indicate the intent of allocating memory backed-up by a file.
+		 * This information is passed to the omr port library by setting the
+		 * flag OMRPORT_VMEM_MEMORY_MODE_SHARE_TMP_FILE_OPEN.
+		 * Note that when setting when the OMRPORT_VMEM_MEMORY_MODE_SHARE_TMP_FILE_OPEN bit,
+		 * we also have to set the OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN bit.
+		 */
+		if (J9_ARE_ALL_BITS_SET(type, MEMORY_TYPE_DISCLAIMABLE_TO_FILE)) {
+			flags |= (OMRPORT_VMEM_MEMORY_MODE_SHARE_TMP_FILE_OPEN | OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN);
+		}
+
 		if (J9_ARE_NO_BITS_SET(type, MEMORY_TYPE_UNCOMMITTED)) {
 			flags |= J9PORT_VMEM_MEMORY_MODE_COMMIT;
 		}


### PR DESCRIPTION
This commit will periodically disclaim memory for data cache (metadata) segments to a backing file. The points where the disclaim operations are issued are based on internal JIT heuristics, but the frequency cannot exceed certain values that are controlled by: `-Xjit:minTimeBetweenMemoryDisclaims=` (ms)
Disclaiming of metadata can be disabled with:
`-Xjit:disableDataCacheDisclaiming`
Disclaiming is performed only on Linux kernels >= 5.4