### PR TITLE
Revert "In PR testing redefine `all` to exclude UNB platforms"

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -121,7 +121,7 @@ SPECS = ['ppc64_aix' : CURRENT_RELEASES,
 
 // SHORT_NAMES is used for PullRequest triggers
 // TODO Combine SHORT_NAMES and SPECS
-SHORT_NAMES = ['all' : ['ppc64le_linux', 's390x_linux', 'ppc64_aix', 'x86-64_windows', 'x86-32_windows', 'aarch64_linux'],
+SHORT_NAMES = ['all' : ['ppc64le_linux', 's390x_linux', 'x86-64_linux', 'ppc64_aix', 'x86-64_windows', 'x86-32_windows', 'x86-64_mac', 'aarch64_linux', 'aarch64_mac'],
             'aix' : ['ppc64_aix'],
             'zlinux' : ['s390x_linux'],
             'zlinuxgcc11' : ['s390x_linux_gcc11'],


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#18325