### PR TITLE
(0.45) Remove generated MHProxy package entries

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2121,6 +2121,15 @@ UDATA
 hashClassTableDelete(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength);
 
 /**
+* @brief Remove package entry from hashClassTable
+* @param *classLoader
+* @param *romClass of package to be removed
+* @return UDATA 0 on success, 1 on failure
+*/
+UDATA
+hashClassTablePackageDelete(J9VMThread *vmThread, J9ClassLoader* classLoader, J9ROMClass* romClass);
+
+/**
 * @brief
 * @param *javaVM
 * @param initialSize

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -964,3 +964,5 @@ TraceEvent=Trc_VM_criu_after_dump Obsolete Overhead=1 Level=2 Template="After ch
 TraceEvent=Trc_VM_crac_checkpointTo NoEnv Overhead=1 Level=3 Template="-XX:CRaCCheckpointTo=%s"
 TraceEvent=Trc_VM_criu_after_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), restoreNanoTimeMonotonic (%lld), lastRestoreTimeInNanoseconds (%lld)"
 TraceEvent=Trc_VM_criu_process_restore_start_after_dump Overhead=1 Level=2 Template="After checkpoint criu_dump(), restorePid (%zu), processRestoreStartTimeInNanoseconds (%lld)"
+
+TraceEvent=Trc_VM_hashClassTablePackageDelete Overhead=1 Level=1 Template="hashClassTablePackageDelete %p (%.*s)"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -233,6 +233,9 @@ void sidecarExit(J9VMThread* shutdownThread);
 static jint runLoadStage (J9JavaVM *vm, IDATA flags);
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 static void freeClassNativeMemory (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
+#if JAVA_SPEC_VERSION >= 22
+static void vmHookAnonClassesUnload(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
+#endif /* JAVA_SPEC_VERSION >= 22 */
 #endif /* GC_DYNAMIC_CLASS_UNLOADING */
 static jint runShutdownStage (J9JavaVM* vm, IDATA stage, void* reserved, UDATA filterFlags);
 static jint modifyDllLoadTable (J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args);
@@ -7494,7 +7497,11 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	vmHooks = getVMHookInterface(vm);
-	if(0 != (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASS_UNLOAD, freeClassNativeMemory, OMR_GET_CALLSITE(), NULL)) {
+	if(0 != (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASS_UNLOAD, freeClassNativeMemory, OMR_GET_CALLSITE(), NULL)
+#if JAVA_SPEC_VERSION >= 22
+		|| 0 != (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_ANON_CLASSES_UNLOAD, vmHookAnonClassesUnload, OMR_GET_CALLSITE(), NULL)
+#endif /* JAVA_SPEC_VERSION >= 22 */
+	) {
 		goto error;
 	}
 #endif
@@ -8114,6 +8121,18 @@ freeClassNativeMemory(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 	omrthread_monitor_exit(vm->memberNameListsMutex);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 }
+
+#if JAVA_SPEC_VERSION >= 22
+static void
+vmHookAnonClassesUnload(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
+{
+	J9VMAnonymousClassesUnloadEvent * unloadedEvent = (J9VMAnonymousClassesUnloadEvent *)eventData;
+	J9VMThread * vmThread = unloadedEvent->currentThread;
+	for (J9Class* j9clazz = unloadedEvent->anonymousClassesToUnload; j9clazz; j9clazz = j9clazz->gcLink) {
+		hashClassTablePackageDelete(vmThread, j9clazz->classLoader, j9clazz->romClass);
+	}
+}
+#endif /* JAVA_SPEC_VERSION >= 22 */
 
 #endif /* GC_DYNAMIC_CLASS_UNLOADING */
 


### PR DESCRIPTION
from classHashTable when its associated rom class is unloaded. This will prevent errors that could occur when accessing the package entry with an invalid rom class.

Backport from: https://github.com/eclipse-openj9/openj9/pull/19159