### PR TITLE
Relax condition on JITServer rememberClass assert (0.44)

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1469,7 +1469,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChai
    _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create, !useServerOffsets, needClassChainRecord);
    auto recv = _stream->read<uintptr_t, std::vector<J9Class *>, std::vector<J9Class *>,
                              std::vector<JITServerHelpers::ClassInfoTuple>>();
-   if (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != clientClassChainOffset)
+   if (!useServerOffsets && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != clientClassChainOffset))
       TR_ASSERT_FATAL(std::get<0>(recv) == clientClassChainOffset, "Received mismatching class chain offset: %" OMR_PRIuPTR " != %" OMR_PRIuPTR,
                       std::get<0>(recv), clientClassChainOffset);
    clientClassChainOffset = std::get<0>(recv);


### PR DESCRIPTION
When ignoring the client's SCC, if a server performs an AOT compilation that is not an AOT cache compilation for a client (possible if the client has a valid local SCC) it may cache valid class chain offsets for classes in the client's session data. If the server then performs an AOT cache store for that client, it may receive an invalid class chain from the client for a class that already has a valid cached class chain offset, since the client will be ignoring its local SCC for such a compilation. This situation is valid, and should not trigger the fatal assert in TR_J9JITServerSharedCache::rememberClass() that detects a mismatch between the cached and received class chain offset. That fatal assert is now disabled for AOT cache stores when the server is ignoring the client's SCC.

This fixes an unnecessary crash that could occur in the situation outlined above.