### PR TITLE
Disable temporary SCC layer if ignoring local SCC

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -72,6 +72,15 @@ shouldEnableJITServerAOTCacheLayer(J9JavaVM* vm, U_64 runtimeFlags)
 		return FALSE;
 	}
 
+	// If we are ignoring the local SCC (tested by looking for an explicit
+	// -XX:+JITServerAOTCacheIgnoreLocalSCC, since it is disabled by default),
+	// then we do not need the layer.
+	argIndex1 = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:+JITServerAOTCacheIgnoreLocalSCC", NULL);
+	argIndex2 = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:-JITServerAOTCacheIgnoreLocalSCC", NULL);
+	if (argIndex1 > argIndex2) {
+		return FALSE;
+	}
+
 	argIndex1 = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:+JITServerAOTCacheUseTemporaryLayer", NULL);
 	argIndex2 = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:-JITServerAOTCacheUseTemporaryLayer", NULL);
 	// We skip a couple of checks if the layer is explicitly requested - useful


### PR DESCRIPTION
If a JITServer AOT cache client is ignoring its local SCC for AOT cache compilations, then the temporary writable SCC layer that might otherwise be created (if the client has a readonly local SCC and is running in containers) is redundant and does not in fact need to be created.

Related: https://github.com/eclipse-openj9/openj9/issues/18990