### PR TITLE
AttachAPI Jcmd retry attaching in case of SocketException

### DIFF
--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -319,7 +319,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 	 * @throws IOException in case of a communication error
 	 */
 	public Properties executeDiagnosticCommand(String diagnosticCommand) throws IOException {
-		IPC.logMessage("enter executeDiagnosticCommand ", diagnosticCommand); //$NON-NLS-1$
+		IPC.logMessage("OpenJ9VirtualMachine enter executeDiagnosticCommand ", diagnosticCommand); //$NON-NLS-1$
 		AttachmentConnection.streamSend(commandStream, Command.ATTACH_DIAGNOSTICS_PREFIX + diagnosticCommand);
 		return IPC.receiveProperties(responseStream, true);
 	}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
@@ -52,7 +52,7 @@ public class AttacherDiagnosticsProvider {
 	 * @throws IOException in case of a communication error
 	 */
 	public Properties executeDiagnosticCommand(String diagnosticCommand) throws IOException {
-		IPC.logMessage("enter executeDiagnosticCommand ", diagnosticCommand); //$NON-NLS-1$
+		IPC.logMessage("AttacherDiagnosticsProvider enter executeDiagnosticCommand ", diagnosticCommand); //$NON-NLS-1$
 		checkAttached();
 		Properties info = vm.executeDiagnosticCommand(diagnosticCommand);
 		DiagnosticProperties.dumpPropertiesIfDebug("Properties from target:", info); //$NON-NLS-1$

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -157,6 +157,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames AttachAPISanity \
 	-groups $(TEST_GROUP) \
@@ -181,6 +182,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames AttachAPISanity \
@@ -207,6 +209,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachAPI \
 	-groups $(TEST_GROUP) \
@@ -235,6 +238,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachAPI \
 	-groups $(TEST_GROUP) \
@@ -284,6 +288,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachAPIEnabling \
@@ -315,6 +320,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachErrorHandling \
 	-groups $(TEST_GROUP) \
@@ -345,6 +351,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachErrorHandling \
 	-groups $(TEST_GROUP) \
@@ -370,6 +377,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestSunAttachClasses \
 	-groups $(TEST_GROUP) \
@@ -399,6 +407,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	-Djdk.attach.allowAttachSelf=true \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestSunAttachClasses \
@@ -427,6 +436,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestManagementAgent \
 	-groups $(TEST_GROUP) \
@@ -452,6 +462,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestManagementAgent \
 	-groups $(TEST_GROUP) \
@@ -477,6 +488,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJps \
@@ -501,6 +513,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJps \
@@ -526,6 +539,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJstack \
@@ -550,6 +564,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED \
@@ -576,6 +591,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJmap \
@@ -600,6 +616,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	--add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED \
@@ -627,6 +644,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJcmd \
@@ -648,6 +666,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJcmd \
@@ -672,6 +691,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJstat \
 	-groups $(TEST_GROUP) \
@@ -692,6 +712,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJstat \
 	-groups $(TEST_GROUP) \

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -26,6 +26,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Collections;
@@ -54,7 +55,9 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		// Allow jps to be attached on z/OS, like other platforms
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-J-Dcom.ibm.tools.attach.enable=yes"));
+		List<String> args = new ArrayList<>();
+		args.add("-J-Dcom.ibm.tools.attach.enable=yes"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		assertTrue(TEST_PROCESS_ID_MISSING, StringUtilities.searchSubstring(vmId, jpsOutput).isPresent());
 		assertTrue("jps is missing", StringUtilities.searchSubstring(JPS_Class, jpsOutput).isPresent()); //$NON-NLS-1$
 		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
@@ -65,7 +68,9 @@ public class TestJps extends AttachApiTest {
 	public void testJpsPackageName() throws IOException {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-l")); //$NON-NLS-1$
+		List<String> args = new ArrayList<>();
+		args.add("-l"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		Optional<String> searchResult = StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
 		assertTrue(WRONG_PKG_NAME + searchResult.get(), searchResult.get().contains(TargetVM.class.getPackage().getName()));
@@ -78,8 +83,9 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr2 = new TargetManager(TARGET_VM_CLASS, "SomeRandomId"); //$NON-NLS-1$
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr1.syncWithTarget());
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr2.syncWithTarget());
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-q")); //$NON-NLS-1$
-		
+		List<String> args = new ArrayList<>();
+		args.add("-q"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		boolean searchResult = StringUtilities.contains(vmId, jpsOutput);
 		assertTrue(TEST_PROCESS_ID_MISSING + ": " + vmId, searchResult); //$NON-NLS-1$
 		
@@ -99,7 +105,9 @@ public class TestJps extends AttachApiTest {
 		List<String> targetArgs = Arrays.asList("foo", "bar");  //$NON-NLS-1$//$NON-NLS-2$
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-m")); //$NON-NLS-1$
+		List<String> args = new ArrayList<>();
+		args.add("-m"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		String needle = tgtMgr.targetId + " TargetVM";
 		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
@@ -114,7 +122,9 @@ public class TestJps extends AttachApiTest {
 		List<String> vmArgs = Collections.singletonList("-Dfoo=bar"); //$NON-NLS-1$
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, null, vmArgs, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-v")); //$NON-NLS-1$
+		List<String> args = new ArrayList<>();
+		args.add("-v"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		String needle = tgtMgr.targetId + " TargetVM";
 		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
@@ -129,7 +139,9 @@ public class TestJps extends AttachApiTest {
 		List<String> targetArgs = Arrays.asList("foo", "bar");  //$NON-NLS-1$//$NON-NLS-2$
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
-		List<String> jpsOutput = runCommandAndLogOutput(Collections.singletonList("-ml")); //$NON-NLS-1$
+		List<String> args = new ArrayList<>();
+		args.add("-ml"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommandAndLogOutput(args);
 		String needle = tgtMgr.targetId + " org.openj9.test.attachAPI.TargetVM";
 		Optional<String> searchResult = StringUtilities.searchPrefixSubstring(needle, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());

--- a/test/functional/Java9andUp/playlist.xml
+++ b/test/functional/Java9andUp/playlist.xml
@@ -474,6 +474,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.logging=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJava9AttachAPI \
 	-groups $(TEST_GROUP) \

--- a/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/AttachApiTest.java
+++ b/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/AttachApiTest.java
@@ -223,6 +223,8 @@ public abstract class AttachApiTest {
 	}
 
 	protected List<String> runCommandAndLogOutput(List<String> commandLineOptions) throws IOException {
+		// this api is used by jcmd and jps
+		commandLineOptions.add("-J-Dcom.ibm.tools.attach.logging=yes");
 		List<String> jpsOutput = runCommand(commandLineOptions);
 		StringWriter buff = new StringWriter();
 		PrintWriter buffWriter = new PrintWriter(buff);

--- a/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/TargetManager.java
@@ -71,7 +71,7 @@ public class TargetManager {
 	private String targetVmid;
 	public static final String TARGETVM_START = "targetvm_start";
 	public static final String TARGETVM_STOP = "targetvm_stop";
-	private static boolean doLogging = false;
+	private static boolean doLogging = true; // enable doLogging by default
 	private static final String DEFAULT_IPC_DIR = ".com_ibm_tools_attach";
 	public TargetStatus targetVmStatus;
 	private boolean active = true;

--- a/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/TargetVM.java
+++ b/test/functional/TestUtilitiesJ9/src/org/openj9/test/attachAPI/TargetVM.java
@@ -25,13 +25,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Properties;
-
+import org.testng.log4testng.Logger;
 
 public class TargetVM {
 
 	public static final String WAITING_FOR_INITIALIZATION = "STATUS_WAIT_INITIALIZATION"; //$NON-NLS-1$
 	private static final String propertyKey = "j9vm.test.attach.testproperty2"; //$NON-NLS-1$
 	private static final String propertyValue = "5678def"; //$NON-NLS-1$
+	private static final Logger logger = Logger.getLogger(TargetVM.class);
 
 	/**
 	 * @param args
@@ -42,12 +43,17 @@ public class TargetVM {
 		Properties p = new Properties();
 		p.setProperty(propertyKey, propertyValue);
 		/* use the object so the code cannot be reordered */
+		String logMsg;
 		if (!propertyValue.equals(p.getProperty(propertyKey))) {
-			System.err.println("This should never happen"); //$NON-NLS-1$
+			logMsg = "This should never happen";
+			System.err.println(logMsg); //$NON-NLS-1$
+			logger.error(logMsg);
 		}
 		BufferedReader inRdr = new BufferedReader(new InputStreamReader(
 				System.in));
-		System.err.println(new java.util.Date() + " : TargetVM starting");
+		logMsg = new java.util.Date() + " : TargetVM starting";
+		System.err.println(logMsg);
+		logger.info(logMsg);
 		long pid = 0;
 		try {
 			pid = TargetManager.getProcessId();
@@ -63,35 +69,51 @@ public class TargetVM {
 				System.out.flush();
 				System.out.println("failed");
 				System.err.println("initialization failed");
+				logger.error("TargetVM initialization failed, exit before sleep 10s");
 				Thread.sleep(10000); /*
 									 * give the launching process a chance to
 									 * connect
 									 */
 				return;
 			}
+			logMsg = "before waitForTermination()";
+			System.out.println(logMsg);
+			logger.info(logMsg);
 			String cmd = "";
 			cmd = waitForTermination(inRdr, pid, cmd);
 			if (null == cmd) {
-				System.out.println(pid + " stdin closed unexpectedly");
+				logMsg = pid + " stdin closed unexpectedly";
 			} else {
-				System.out.println(new java.util.Date() + " : " + pid + " terminated by \"" + cmd + "\"");
+				logMsg = new java.util.Date() + " : " + pid + " terminated by \"" + cmd + "\"";
 			}
+			System.out.println(logMsg);
+			logger.info(logMsg);
 			/* force a reference to keep the Properties object alive */
 			if (!propertyValue.equals(p.getProperty(propertyKey))) {
-				System.err.println("This should never happen"); //$NON-NLS-1$
+				logMsg = "This should never happen";
+				System.err.println(logMsg); //$NON-NLS-1$
+				logger.error(logMsg);
 			}
 		} catch (Throwable e) {
-			System.out.println(pid + " failed");
-			System.err.println(pid + " failed");
-			System.err.println("Throwable: " + e.getMessage());
+			logMsg = pid + " failed";
+			logger.error(logMsg);
+			System.out.println(logMsg);
+			System.err.println(logMsg);
+			logMsg = "Throwable: " + e.getMessage();
+			System.err.println(logMsg);
+			logger.error(logMsg);
 			e.printStackTrace(System.err);
 		} finally {
 			System.out.flush();
 			System.err.flush();
-			System.out.println(new java.util.Date() + " : terminated from System.out");
+			logMsg = new java.util.Date() + " : terminated from System.out";
+			System.out.println(logMsg);
+			logger.info(logMsg);
 			System.out.flush();
 			System.out.close();
-			System.err.println(new java.util.Date() + " : terminated from System.err");
+			logMsg = new java.util.Date() + " : terminated from System.err";
+			logger.error(logMsg);
+			System.err.println(logMsg);
 			System.err.flush();
 			System.err.close();
 		}
@@ -100,8 +122,10 @@ public class TargetVM {
 	private static String waitForTermination(BufferedReader inRdr, long pid,
 			String cmd) throws IOException {
 		while ((null != cmd) && !cmd.contains(TargetManager.TARGETVM_STOP)) {
-			System.out.println(new java.util.Date() + " : waitForTermination: " + pid + " received \"" + cmd + "\"");
+			String logMsg = new java.util.Date() + " : waitForTermination: " + pid + " received \"" + cmd + "\"";
+			System.out.println(logMsg);
 			System.out.flush();
+			logger.info(logMsg);
 			cmd = inRdr.readLine();
 		}
 		return cmd;


### PR DESCRIPTION
`AttachAPI Jcmd` retry attaching in case of `SocketException`

`AttachAPI Jcmd` retry attaching in case of `SocketException` on `Windows` platform;
Retry time is `3` by default or a value specified via a system property `com.ibm.tools.attach.retry`;
Enabled `-Dcom.ibm.tools.attach.logging=yes` for `AttachAPI` utility tests;
Also enabled `TargetManager.doLogging`.

closes https://github.com/eclipse-openj9/openj9/issues/19165

Signed-off-by: Jason Feng <fengj@ca.ibm.com>