### PR TITLE
Initialize subclass as initial class before main method

### DIFF
--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -1874,7 +1874,7 @@ retry:
 
 		/* ensure that the class is initialized */
 		if (declaringClass->initializeStatus != J9ClassInitSucceeded && declaringClass->initializeStatus != (UDATA) vmThread) {
-			gpCheckInitialize(vmThread, declaringClass);
+			gpCheckInitialize(vmThread, clazz);
 		}
 
 		if (vmThread->currentException == NULL) {


### PR DESCRIPTION
Initialize subclass as initial class before main method to
match the RI and align with section 5.2 Java Virtual Machine
Startup in the spec.

Issue: https://github.com/eclipse-openj9/openj9/issues/19140
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>