### PR TITLE
Add "-Wc,list(),offset,gonumber" compile options on z/OS

### DIFF
--- a/runtime/cmake/platform/os/zos.cmake
+++ b/runtime/cmake/platform/os/zos.cmake
@@ -25,4 +25,7 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
 
 set(CMAKE_IMPORT_LIBRARY_PREFIX "lib")
 
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS "\"-Wc,inline(auto,noreport,600,5000)\"")
+list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+    "\"-Wc,inline(auto,noreport,600,5000)\""
+    "\"-Wc,list(),offset,gonumber\""
+)


### PR DESCRIPTION
In order to create compiler pseudo assembly listing .lst files.

https://www.ibm.com/docs/en/zos/2.4.0?topic=options-list-nolist
https://www.ibm.com/docs/en/zos/2.4.0?topic=options-offset-nooffset
https://www.ibm.com/docs/en/zos/2.4.0?topic=options-gonumber-nogonumber