### PR TITLE
Set a higher ulimit -f setting for sigxfszHandlingTest

### DIFF
--- a/test/functional/cmdLineTests/sigxfszHandlingTest/runSIGXFSZTest.sh
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/runSIGXFSZTest.sh
@@ -26,7 +26,7 @@
 TEST_CMD=$1
 
 # Set the file size limit to raise SIGXFSZ signal
-ulimit -f 4000
+ulimit -f 6000
 
 # Print the value of the file size limit
 ulimit -f


### PR DESCRIPTION
VM changes seem to exceed the limit of 4000 and the SIGXFSZ signal occurs on Ubuntu before the test can run System.out.println().

Fixes https://github.com/eclipse-openj9/openj9/issues/19276

[Internal testing 1](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=68909) and [grinder](http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=68912)

[Internal testing 2](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/39520) and on the [same machine](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/39521/)
without this change it [failed](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/39519/)