### PR TITLE
Skip zero initialization for Unsafe.allocateUninitializedArray0

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -455,6 +455,7 @@
 
    sun_misc_Unsafe_ensureClassInitialized,
    sun_misc_Unsafe_allocateInstance,
+   sun_misc_Unsafe_allocateUninitializedArray0,
 
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3008,8 +3008,9 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::sun_misc_Unsafe_storeFence,    "storeFence", "()V")},
       {x(TR::sun_misc_Unsafe_fullFence,     "fullFence",  "()V")},
 
-      {x(TR::sun_misc_Unsafe_ensureClassInitialized,     "ensureClassInitialized", "(Ljava/lang/Class;)V")},
-      {x(TR::sun_misc_Unsafe_allocateInstance,           "allocateInstance",       "(Ljava/lang/Class;)Ljava/lang/Object;")},
+      {x(TR::sun_misc_Unsafe_ensureClassInitialized,      "ensureClassInitialized",      "(Ljava/lang/Class;)V")},
+      {x(TR::sun_misc_Unsafe_allocateInstance,            "allocateInstance",            "(Ljava/lang/Class;)Ljava/lang/Object;")},
+      {x(TR::sun_misc_Unsafe_allocateUninitializedArray0, "allocateUninitializedArray0", "(Ljava/lang/Class;I)Ljava/lang/Object;")},
       {x(TR::jdk_internal_misc_Unsafe_copyMemory0,   "copyMemory0", "(Ljava/lang/Object;JLjava/lang/Object;JJ)V")},
       {  TR::unknownMethod}
       };

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -711,6 +711,7 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    TR::java_lang_StringCoding_decode,
    TR::java_lang_StringCoding_StringEncoder_encode,
    TR::java_lang_StringCoding_StringDecoder_decode,
+   TR::sun_misc_Unsafe_allocateUninitializedArray0,
    //TR::java_lang_StringBuilder_ensureCapacityImpl,
    //TR::java_lang_StringBuffer_ensureCapacityImpl,
    //TR::java_util_Arrays_copyOf,


### PR DESCRIPTION
The Unsafe.allocateUninitializedArray0 does not require zero init. This change skip zero initialization for Unsafe.allocateUninitializedArray0.