### PR TITLE
Enable JIT breakpoint on macOS

### DIFF
--- a/runtime/compiler/env/J9DebugEnv.cpp
+++ b/runtime/compiler/env/J9DebugEnv.cpp
@@ -32,7 +32,7 @@
 #include "thrtypes.h"
 
 
-#if defined(LINUX) || defined(AIXPPC)
+#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
 #include <signal.h>
 #endif
 
@@ -40,7 +40,7 @@ void
 J9::DebugEnv::breakPoint()
    {
 
-#if defined(LINUX) || defined(AIXPPC)
+#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
    raise(SIGTRAP);
 #elif defined(_MSC_VER)
    DebugBreak();


### PR DESCRIPTION
This commit enables JIT breakpoint on macOS.