### PR TITLE
Fix String creation to treat a modified UTF8 zero as ASCII

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1007,6 +1007,11 @@ public class Test_String {
 	public void test_lastIndexOf3() {
 		AssertJUnit.assertTrue("Returned incorrect index", hw1.lastIndexOf("World") == 5);
 		AssertJUnit.assertTrue("Found String outside of index", hw1.lastIndexOf("HeKKKKKKKK") == -1);
+
+		/* test https://github.com/eclipse-openj9/openj9/issues/19273 */
+		String s1 = "a";
+		String s2 = "b";
+		AssertJUnit.assertTrue("Incorrect index of \\u0000", (s1 + "\u0000" + s2).lastIndexOf("\u0000") == 1);
 	}
 
 	/**


### PR DESCRIPTION
Updates j9gc_createJavaLangString().

Fixes https://github.com/eclipse-openj9/openj9/issues/19273