### PR TITLE
(0.44) Update OpenSSL to include the fix for CVE-2024-2511

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -137,7 +137,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=3.0.13'
+  extra_getsource_options: '--openssl-version=openssl-3.0.13+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Cherry pick https://github.com/eclipse-openj9/openj9/pull/19286 for 0.44