### PR TITLE
Make javaOffloadSwitch(On|Off)WithReason functions global

### DIFF
--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -45,13 +45,7 @@
 extern "C" {
 
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
-/**
- * Switch onto the zaap processor if not already running there.
- *
- * @param currentThread[in] the current J9VMThread
- * @param reason[in] the reason code
- */
-static void
+void
 javaOffloadSwitchOnWithReason(J9VMThread *currentThread, UDATA reason)
 {
 	J9JavaVM *vm = currentThread->javaVM;
@@ -64,13 +58,7 @@ javaOffloadSwitchOnWithReason(J9VMThread *currentThread, UDATA reason)
 	}
 }
 
-/**
- * Switch away from the zaap processor if running there.
- *
- * @param currentThread[in] the current J9VMThread
- * @param reason[in] the reason code
- */
-static void
+void
 javaOffloadSwitchOffWithReason(J9VMThread *currentThread, UDATA reason)
 {
 	J9JavaVM *vm = currentThread->javaVM;
@@ -81,8 +69,7 @@ javaOffloadSwitchOffWithReason(J9VMThread *currentThread, UDATA reason)
 		}
 	}
 }
-#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
-
+#endif /* defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) */
 
 /**
  * Get the array class for a J9Class.

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -557,6 +557,24 @@ freeAllStructFFITypes(J9VMThread *currentThread, void *cifNode);
 
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 
+/**
+ * Switch onto the zaap processor if not already running there.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param reason[in] the reason code
+ */
+void
+javaOffloadSwitchOnWithReason(J9VMThread *currentThread, UDATA reason);
+
+/**
+ * Switch away from the zaap processor if running there.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param reason[in] the reason code
+ */
+void
+javaOffloadSwitchOffWithReason(J9VMThread *currentThread, UDATA reason);
+
 #define JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, reason, length) \
 	do { \
 		if ((length) > J9_JNI_OFFLOAD_SWITCH_THRESHOLD) { \


### PR DESCRIPTION
Add declarations in `vm_internal.h` so they can also be used in `ArrayCopyHelpers.cpp`.
Fixes an oversight in #19263.