### PR TITLE
Print footprint statistics using verbose #METHOD STATS

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11422,6 +11422,28 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                TR_VerboseLog::write(" queueTime=%zuus", currentTime - _methodBeingCompiled->_entryTime);
 
             TR_VerboseLog::writeLine("");
+
+            if (TR::Options::getVerboseOption(TR_VerboseJitMemory))
+               {
+               OMR::CodeGenerator::MethodStats methodStats;
+               compiler->cg()->getMethodStats(methodStats);
+
+               TR_VerboseLog::writeLineLocked(TR_Vlog_METHOD_STATS, "%s j9m=%p "
+                                                                    "codeSize=%iB warmBlocks=%iB coldBlocks=%iB "
+                                                                    "prologue=%iB snippets=%iB outOfLine=%iB "
+                                                                    "unaccounted=%iB blocksInColdCache=%iB "
+                                                                    "overestimateInColdCache=%iB",
+                                                                     compiler->signature(), method,
+                                                                     methodStats.codeSize,
+                                                                     methodStats.warmBlocks,
+                                                                     methodStats.coldBlocks,
+                                                                     methodStats.prologue,
+                                                                     methodStats.snippets,
+                                                                     methodStats.outOfLine,
+                                                                     methodStats.unaccounted,
+                                                                     methodStats.blocksInColdCache,
+                                                                     methodStats.overestimateInColdCache);
+               }
             }
 
          char compilationAttributes[40] = { 0 };


### PR DESCRIPTION
Depends on: https://github.com/eclipse/omr/pull/7309