### PR TITLE
[Verifier] Prevent displaying the garbage type on the empty stack

### DIFF
--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -222,8 +222,8 @@ pushLiveStackToVerificationTypeBuffer(StackMapFrame* stackMapFrame, J9BytecodeVe
 	U_16 maxLocals = methodInfo->maxLocals;
 	IDATA lastIndex = 0;
 	IDATA slot = 0;
-
-	IDATA errorPositionInclusive = 1;
+	/* Don't print anything on the empty stack. */
+	IDATA errorPositionInclusive = (BCV_ERR_STACK_UNDERFLOW == verifyData->errorDetailCode) ? 0 : 1;
 	IDATA wideType = DATATYPE_1_SLOT;
 	BOOLEAN result = TRUE;
 	BOOLEAN nonTopFound = FALSE;


### PR DESCRIPTION
The changes aim to rectify the situation when there is
literally no valid type data to be displayed on the empty
stack after a bunch of manipulations (e.g. pop) to prevent
any garbage data from being decoded in the error message
framework so as to match the RI's behavior.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>