### PR TITLE
AArch64: Fix BNDCHKwithSpineCHK

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -7922,7 +7922,7 @@ J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGe
             if (indexReg)
                generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, loadOrStoreReg, loadOrStoreReg, arrayletOffsetReg);
             else
-               addConstant32(cg, node, loadOrStoreReg, loadOrStoreReg, arrayletOffsetVal);
+               addConstant64(cg, node, loadOrStoreReg, loadOrStoreReg, arrayletOffsetVal);
             }
 
          if (indexReg)


### PR DESCRIPTION
This commit fixes BNDCHKwithSpineCHK for AArch64.
Address calculation must use the 64-bit instruction.