### PR TITLE
Add AOTCachePersistenceFailure, associated compErrCode

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1606,7 +1606,7 @@ J9::Compilation::addSerializationRecord(const AOTCacheRecord *record, uintptr_t 
       // Otherwise, we can simply stop maintaining AOT cache records for this compilation and continue
       // with the compilation without subsequently storing it in the AOT cache.
       if (useServerOffsets)
-         failCompilation<J9::PersistenceFailure>("Serialization record at offset %zu must not be NULL", reloDataOffset);
+         failCompilation<J9::AOTCachePersistenceFailure>("Serialization record at offset %zu must not be NULL", reloDataOffset);
       else
          _aotCacheStore = false;
       }
@@ -1635,7 +1635,7 @@ J9::Compilation::addThunkRecord(const AOTCacheThunkRecord *record)
       // Otherwise, we can simply stop maintaining AOT cache records for this compilation and continue
       // with the compilation without subsequently storing it in the AOT cache.
       if (useServerOffsets)
-         failCompilation<J9::PersistenceFailure>("Thunk record must not be NULL");
+         failCompilation<J9::AOTCachePersistenceFailure>("Thunk record must not be NULL");
       else
          _aotCacheStore = false;
       }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2256,6 +2256,9 @@ bool TR::CompilationInfo::shouldRetryCompilation(J9VMThread *vmThread, TR_Method
             case compilationAotPatchedCPConstant:
             case compilationAotHasInvokeSpecialInterface:
             case compilationAotClassChainPersistenceFailure:
+#if defined(J9VM_OPT_JITSERVER)
+            case compilationAOTCachePersistenceFailure:
+#endif /* defined (J9VM_OPT_JITSERVER)*/
             case compilationSymbolValidationManagerFailure:
             case compilationAOTNoSupportForAOTFailure:
             case compilationAOTRelocationRecordGenerationFailure:
@@ -11424,6 +11427,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTDeserializerReset &e)
       {
       _methodBeingCompiled->_compErrCode = aotDeserializerReset;
+      }
+   catch (const J9::AOTCachePersistenceFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAOTCachePersistenceFailure;
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    catch (...)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -213,6 +213,7 @@ const char *compilationErrorNames[]={
    "compilationStreamInterrupted",                         // compilationFirstJITServerFailure + 4 = 52
    "aotCacheDeserializationFailure",                       // compilationFirstJITServerFailure + 5 = 53
    "aotDeserializerReset",                                 // compilationFirstJITServerFailure + 6 = 54
+   "compilationAOTCachePersistenceFailure",                // compilationFirstJITServerFailure + 7 = 55
 #endif /* defined(J9VM_OPT_JITSERVER) */
    "compilationMaxError"
 };

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -83,6 +83,7 @@ typedef enum {
    compilationStreamInterrupted                         = compilationFirstJITServerFailure + 4, // 52
    aotCacheDeserializationFailure                       = compilationFirstJITServerFailure + 5, // 53
    aotDeserializerReset                                 = compilationFirstJITServerFailure + 6, // 54
+   compilationAOTCachePersistenceFailure                = compilationFirstJITServerFailure + 7, // 55
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    /* must be the last one */

--- a/runtime/compiler/exceptions/PersistenceFailure.hpp
+++ b/runtime/compiler/exceptions/PersistenceFailure.hpp
@@ -49,6 +49,16 @@ struct ClassChainPersistenceFailure : public virtual PersistenceFailure
    virtual const char* what() const throw() { return "Class chain persistence failure"; }
    };
 
+/**
+ * JITServer AOT cache Persistence Failure exception type.
+ *
+ * Thrown when an error related to creating AOT cache serialization records occurs.
+ */
+struct AOTCachePersistenceFailure : public virtual PersistenceFailure
+   {
+   virtual const char* what() const throw() { return "AOT cache persistence failure"; }
+   };
+
 }
 
 #endif // PERSISTENCE_FAILURE


### PR DESCRIPTION
This compilation failure type is thrown if errors related to creating JITServer AOT cache serialization records occur during compilation. Formerly, this type of failure did not have a specific exception associated to it, and would be reported as a generic compilationFailure.