### PR TITLE
Delay AOT validation until restore under -XX:+DebugOnRestore

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2025,6 +2025,8 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
 #endif
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+   bool debugOnRestoreEnabled = javaVM->internalVMFunctions->isDebugOnRestoreEnabled(curThread);
+
    /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be
     * limited to the same processor features as those used in Portable AOT mode. This
     * is because, the restore run may not be on the same machine as the one that created
@@ -2049,38 +2051,14 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
          validateSCC = false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      if (debugOnRestoreEnabled)
+         validateSCC = false;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
       if (validateSCC)
          {
-         /* If AOT Shared Classes is turned ON, perform compatibility checks for AOT Shared Classes
-          *
-          * This check has to be done after latePostProcessJIT so that all the necessary JIT options
-          * can be set
-          */
-         TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, curThread);
-         if (!compInfo->reloRuntime()->validateAOTHeader(fe, curThread))
-            {
-            TR_ASSERT_FATAL(static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader != TR_yes,
-                            "aotValidHeader is TR_yes after failing to validate AOT header\n");
-
-            /* If this is the second run, then failing to validate AOT header will cause aotValidHeader
-             * to be TR_no, in which case the SCC is not valid for use. However, if this is the first
-             * run, then aotValidHeader will be TR_maybe; try to store the AOT Header in this case.
-             */
-            if (static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_no
-                || !compInfo->reloRuntime()->storeAOTHeader(fe, curThread))
-               {
-               static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader = TR_no;
-               TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
-               TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
-               TR::Options::setSharedClassCache(false);
-               TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
-               }
-            }
-         else
-            {
-            TR::Compiler->relocatableTarget.cpu = TR::CPU::customize(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(curThread));
-            jitConfig->relocatableTargetProcessor = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
-            }
+         TR_J9SharedCache::validateAOTHeader(jitConfig, curThread, compInfo);
          }
 
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))
@@ -2107,6 +2085,17 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
 #endif /* defined(J9VM_OPT_JITSERVER) */
          }
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      else if (debugOnRestoreEnabled)
+         {
+         javaVM->sharedClassConfig->runtimeFlags &= ~J9SHR_RUNTIMEFLAG_ENABLE_AOT;
+         TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
+         TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
+         TR::Options::setSharedClassCache(false);
+         TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_HEADER_VALIDATION_DELAYED);
+         TR_J9SharedCache::setAOTHeaderValidationDelayed();
+         }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
       if (javaVM->sharedClassConfig->runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_READONLY)
          {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -103,6 +103,8 @@ public:
    virtual void addHint(TR_ResolvedMethod *, TR_SharedCacheHint);
    virtual bool isMostlyFull();
 
+   static void validateAOTHeader(J9JITConfig *jitConfig, J9VMThread *vmThread, TR::CompilationInfo *compInfo);
+
    /**
     * \brief Converts a shared cache offset, calculated from the end of the SCC, into the
     *        metadata section of the SCC into a pointer.
@@ -400,13 +402,20 @@ public:
       // The following are probably equivalent to SHARED_CACHE_FULL -
       // they could have failed because of no space but no error code is returned.
       SHARED_CACHE_CLASS_CHAIN_STORE_FAILED,
-      AOT_HEADER_STORE_FAILED
+      AOT_HEADER_STORE_FAILED,
+      AOT_HEADER_VALIDATION_DELAYED
       };
 
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { _sharedCacheState = state; }
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { return _sharedCacheState; }
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo);
    static void setStoreSharedDataFailedLength(UDATA length) {_storeSharedDataFailedLength = length; }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   static void setAOTHeaderValidationDelayed() { _aotHeaderValidationDelayed = true; }
+   static void resetAOTHeaderValidationDelayed() { _aotHeaderValidationDelayed = false; }
+   static bool aotHeaderValidationDelayed() { return _aotHeaderValidationDelayed; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
 
@@ -613,6 +622,9 @@ private:
    static TR_J9SharedCacheDisabledReason _sharedCacheState;
    static TR_YesNoMaybe                  _sharedCacheDisabledBecauseFull;
    static UDATA                          _storeSharedDataFailedLength;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   static bool                           _aotHeaderValidationDelayed;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
    };
 
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -814,6 +814,12 @@ TR_J9VMBase::TR_J9VMBase(
 #if defined(J9VM_OPT_JITSERVER)
       || (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
 #endif /* defined(J9VM_OPT_JITSERVER) */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      || (vmThread
+          && jitConfig->javaVM->sharedClassConfig
+          && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
+          && jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
       )
       // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
       {


### PR DESCRIPTION
Under -XX:+DebugOnRestore, the JIT generates FSD code. This is problematic for AOT as either:

1. An existing SCC will fail validation, since the AOT code therein will not have been generated with FSD, or
2. An unpopulated SCC will contain FSD code, which will be useless for any JVM that does not have FSD enabled

This commit delays AOT validation until after restore; this ensures that AOT code from the SCC can be loaded post-restore, and that any code added to the SCC is maximally sharable.

Parent issue: https://github.com/eclipse-openj9/openj9/issues/18866