### PR TITLE
Fix JNI argument setup when ref count is not 1

### DIFF
--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -422,7 +422,7 @@ J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol 
       TR::Node * n = self()->getChild(i);
       if (n->getDataType() == TR::Address)
          {
-         if (n->getOpCode().hasSymbolReference() && n->getSymbol()->isAutoOrParm())
+         if (n->getOpCode().hasSymbolReference() && n->getSymbol()->isAutoOrParm() && n->getReferenceCount() == 1)
             {
             n->decReferenceCount();
             self()->setAndIncChild(i, TR::Node::createWithSymRef(n, TR::loadaddr, 0, n->getSymbolReference()));


### PR DESCRIPTION
The JNI argument setup in processJNICall() will add another level of indirection for object arguments by placing the argument into a stack slot and passing a pointer to the slot as the JNI argument. Is some cases the argument object is already a load of a stack slot, in which case we try and avoid creating a new temporary stack slot to hold the argument value. But in such cases it's possible that the slot has since been overwritten with some other value causing an incorrect argument to be passed to the JNI method. This fix will only allow using an existing stack slot (auto) when the reference count is 1 because only then can we be assured that the slot has not been overwritten.