### PR TITLE
Array base offset zero

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3310,6 +3310,11 @@ initializeIndexableObjectHeaderSizes(J9JavaVM* vm)
 #else /* defined(J9VM_ENV_DATA64) */
 	setIndexableObjectHeaderSizeWithoutDataAddress(vm);
 #endif /* defined(J9VM_ENV_DATA64) */
+	if (MM_GCExtensions::getExtensions(vm)->isVirtualLargeObjectHeapEnabled) {
+		vm->unsafeIndexableHeaderSize = 0;
+	} else {
+		vm->unsafeIndexableHeaderSize = vm->contiguousIndexableHeaderSize;
+	}
 }
 
 #if defined(J9VM_ENV_DATA64)

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -38,6 +38,7 @@
 #include "ArrayCopyHelpers.hpp"
 #include "AtomicSupport.hpp"
 #include "ObjectMonitor.hpp"
+#include "UnsafeAPI.hpp"
 #include "VMHelpers.hpp"
 
 extern "C" {
@@ -572,7 +573,7 @@ copyMemory(J9VMThread* currentThread, j9object_t sourceObject, UDATA sourceOffse
 		UDATA destOffset, UDATA actualSize)
 {
 	/* Because array data is always 8-aligned, only the alignment of the offsets (and byte size) need be considered */
-	UDATA const headerSize = J9VMTHREAD_CONTIGUOUS_INDEXABLE_HEADER_SIZE(currentThread);
+	UDATA const headerSize = VM_UnsafeAPI::arrayBase(currentThread);
 	UDATA logElementSize = determineCommonAlignment(sourceOffset, destOffset, actualSize);
 	UDATA sourceIndex = (sourceOffset - headerSize) >> logElementSize;
 	UDATA destIndex = (destOffset - headerSize) >> logElementSize;
@@ -595,7 +596,7 @@ static VMINLINE void
 copyMemoryByte(J9VMThread* currentThread, j9object_t sourceObject, UDATA sourceOffset, j9object_t destObject,
 		UDATA destOffset)
 {
-	UDATA const headerSize = J9VMTHREAD_CONTIGUOUS_INDEXABLE_HEADER_SIZE(currentThread);
+	UDATA const headerSize = VM_UnsafeAPI::arrayBase(currentThread);
 	UDATA sourceIndex = sourceOffset - headerSize;
 	UDATA destIndex = destOffset - headerSize;
 
@@ -695,7 +696,7 @@ illegal:
 		if (!J9ROMCLASS_IS_PRIMITIVE_TYPE(((J9ArrayClass*)clazz)->componentType->romClass)) {
 			goto illegal;
 		}
-		offset -= J9VMTHREAD_CONTIGUOUS_INDEXABLE_HEADER_SIZE(currentThread);
+		offset -= VM_UnsafeAPI::arrayBase(currentThread);
 		VM_ArrayCopyHelpers::primitiveArrayFill(currentThread, object, (UDATA)offset, actualSize, (U_8)value);
 	}
 	vmFuncs->internalExitVMToJNI(currentThread);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5541,6 +5541,7 @@ typedef struct J9VMThread {
 	j9object_t scopedError;
 	j9object_t closeScopeObj;
 #endif /* JAVA_SPEC_VERSION >= 22 */
+	UDATA unsafeIndexableHeaderSize;
 } J9VMThread;
 
 #define J9VMTHREAD_ALIGNMENT  0x100
@@ -5604,6 +5605,7 @@ typedef struct J9VMThread {
 #define J9VMTHREAD_OBJECT_HEADER_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
 #define J9VMTHREAD_CONTIGUOUS_INDEXABLE_HEADER_SIZE(vmThread) ((vmThread)->contiguousIndexableHeaderSize)
 #define J9VMTHREAD_DISCONTIGUOUS_INDEXABLE_HEADER_SIZE(vmThread) ((vmThread)->discontiguousIndexableHeaderSize)
+#define J9VMTHREAD_UNSAFE_INDEXABLE_HEADER_SIZE(vmThread) ((vmThread)->unsafeIndexableHeaderSize)
 
 typedef struct JFRState {
 	char *jfrFileName;
@@ -6147,6 +6149,7 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t closeScopeMutex;
 	UDATA closeScopeNotifyCount;
 #endif /* JAVA_SPEC_VERSION >= 22 */
+	UDATA unsafeIndexableHeaderSize;
 } J9JavaVM;
 
 #define J9VM_PHASE_STARTUP  1

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4249,7 +4249,7 @@ done:
 
 			if (J9CLASS_IS_ARRAY(receiverClass)) {
 				I_64 arrayDataSize = J9INDEXABLEOBJECT_SIZE(_currentThread, receiver) * J9ARRAYCLASS_GET_STRIDE(receiverClass);
-				I_64 headerSize = J9VMTHREAD_CONTIGUOUS_INDEXABLE_HEADER_SIZE(_currentThread);
+				I_64 headerSize = J9VMTHREAD_UNSAFE_INDEXABLE_HEADER_SIZE(_currentThread);
 				returnDoubleFromINL(REGISTER_ARGS, arrayDataSize + headerSize, 2);
 			} else {
 				I_64 headerSize = (I_64)J9VMTHREAD_OBJECT_HEADER_SIZE(_currentThread);

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -194,6 +194,7 @@ allocateVMThread(J9JavaVM *vm, omrthread_t osThread, UDATA privateFlags, void *m
 
 	newThread->contiguousIndexableHeaderSize = vm->contiguousIndexableHeaderSize;
 	newThread->discontiguousIndexableHeaderSize = vm->discontiguousIndexableHeaderSize;
+	newThread->unsafeIndexableHeaderSize = vm->unsafeIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
 	newThread->isIndexableDataAddrPresent = vm->isIndexableDataAddrPresent;
 #endif /* defined(J9VM_ENV_DATA64) */


### PR DESCRIPTION
Set unsafe header offsets to zero when large offheap arrays are enabled.

Replace assertation with exception in `compareAndExchangeObject` due
avoid trace header includes in UnsafeAPI.hpp as that file is used in
various modules.
