### PR TITLE
Add j9protos.h to StringTable.hpp

### DIFF
--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -20,16 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include "StringTable.hpp"
+
 #include "hashtable_api.h"
 #include "j2sever.h"
 #include "j9consts.h"
-#include "j9protos.h"
 #include "objhelp.h"
-#include "ModronAssertions.h"
 
 #include "EnvironmentBase.hpp"
 #include "GCExtensions.hpp"
-#include "StringTable.hpp"
 #include "VMHelpers.hpp"
 
 /* the following is all zeros except the least significant bit */

--- a/runtime/gc_base/StringTable.hpp
+++ b/runtime/gc_base/StringTable.hpp
@@ -30,6 +30,7 @@
 
 #include "BaseVirtual.hpp"
 
+#include "j9protos.h"
 #include "ModronAssertions.h"
 
 class MM_EnvironmentBase;


### PR DESCRIPTION
This patch fixes a include-order dependency in StringTable.cpp. StringTable.hpp relies on j9protos.h which it transitively has access to through the include order in StringTable.cpp. This patch includes j9protos.h explicitly in StringTable.hpp and alters StringTable.cpp includes to conform to the OMR coding standards.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>