### PR TITLE
Extend arraycmp length child

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -3139,7 +3139,7 @@ J9::ValuePropagation::transformVTObjectEqNeCompare(TR_OpaqueClassBlock *containi
        * n101n        aladd
        * n36n           aload  ACMPWideFieldsPrimitive.VALUE1 QWideFieldsPrimitive;
        * n99n           ==>lconst 4
-       * n98n         iconst 12
+       * n98n         lconst 12
        * n102n      iconst 0
        */
       int32_t totalFieldSize = 0;
@@ -3151,7 +3151,7 @@ J9::ValuePropagation::transformVTObjectEqNeCompare(TR_OpaqueClassBlock *containi
          totalFieldSize += TR::DataType::getSize(fieldEntry._datatype);
          }
 
-      TR::Node *totalFieldSizeNode = TR::Node::iconst(callNode, totalFieldSize);
+      TR::Node *totalFieldSizeNode = TR::Node::lconst(callNode, totalFieldSize);
 
       TR::Node * lhsOffsetNode = NULL;
       TR::Node * rhsOffsetNode = NULL;


### PR DESCRIPTION
Change all uses of arraycmp to take a 64 bit length child instead of 32 bits.

Relies on https://github.com/eclipse/omr/pull/7313