### PR TITLE
jdk11 should create LATIN1 String constants

### DIFF
--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -576,7 +576,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			for (UDATA i = 0; i < unicodeLength; ++i) {
 				if (unicodeData[i] > 0x7F) {
 					isASCII = false;
-					if (J2SE_VERSION(vm) >= J2SE_V17) {
+					if (J2SE_VERSION(vm) >= J2SE_V11) {
 						for (UDATA j = i; j < unicodeLength; ++j) {
 							if (unicodeData[j] > 0xFF) {
 								isASCIIorLatin1 = false;
@@ -604,7 +604,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 					continue;
 				}
 				isASCII = false;
-				if (compressStrings && (J2SE_VERSION(vm) >= J2SE_V17)) {
+				if (compressStrings && (J2SE_VERSION(vm) >= J2SE_V11)) {
 					U_8 *dataTmp = data + i;
 					UDATA lengthTmp = length - i;
 					isASCIIorLatin1 = VM_VMHelpers::isLatin1String(dataTmp, lengthTmp);

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -932,8 +932,11 @@ public class Test_String {
 	 */
 	@Test
 	public void test_indexOf3() {
-		AssertJUnit.assertTrue("Failed to find string", hw1.indexOf("World") > 0);
-		AssertJUnit.assertTrue("Failed to find string", !(hw1.indexOf("ZZ") > 0));
+		AssertJUnit.assertEquals("Failed to find string 1", 5, hw1.indexOf("World"));
+		AssertJUnit.assertEquals("Failed to find string 2", -1, hw1.indexOf("ZZ"));
+		String needle = "\u00b0\u00b1";
+		String hay = new StringBuilder("a").append(needle).toString();
+		AssertJUnit.assertEquals("Failed to find string 3", 1, hay.indexOf(needle));
 	}
 
 	/**


### PR DESCRIPTION
LATIN1 String constants were only created in jdk17 and later. The JCL for jdk11 creates LATIN1 Strings and the VM needs to match.

Issue https://github.com/eclipse-openj9/openj9/issues/19334

Grinder showing the new test fails without this fix.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3482