### PR TITLE
Heuristics to minimize performance impact of `-XX:+DebugOnRestore`

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4167,6 +4167,9 @@ TR::CompilationInfoPerThread::processEntries()
             {
             // Compilation request extracted; go work on it
             TR_ASSERT(entry, "Attempting to process NULL entry");
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+            entry->_checkpointInProgress = compInfo->getCRRuntime()->isCheckpointInProgress();
+#endif
             processEntry(*entry, scratchSegmentCache);
             break;
             }
@@ -8262,7 +8265,8 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
          regionSegmentProvider,
          dispatchRegion,
          trMemory,
-         TR::CompileIlGenRequest(entry->getMethodDetails())
+         TR::CompileIlGenRequest(entry->getMethodDetails()),
+         entry->_checkpointInProgress
          );
    if (TR::Options::getVerboseOption(TR_VerboseCompilationDispatch))
       TR_VerboseLog::writeLineLocked(TR_Vlog_DISPATCH,
@@ -8545,7 +8549,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   aotCompilationReUpgradedToWarm = true;
                   }
                }
-
 
             TR_PersistentCHTable *cht = that->_compInfo.getPersistentInfo()->getPersistentCHTable();
             if (cht && !cht->isActive())
@@ -10565,7 +10568,8 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                jitMethodTranslated(vmThread, method, startPC);
 #if defined(J9VM_OPT_CRIU_SUPPORT)
                if (jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)
-                   && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+                   && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
+                   && (!compInfo->getCRRuntime()->isCheckpointInProgress() || comp->getOption(TR_FullSpeedDebug)))
                   {
                   if (comp->getRecompilationInfo() && comp->getRecompilationInfo()->getJittedBodyInfo())
                      {

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -101,7 +101,8 @@ struct CompileParameters
          TR::SegmentAllocator &scratchSegmentProvider,
          TR::Region &dispatchRegion,
          TR_Memory &trMemory,
-         const TR::CompileIlGenRequest &ilGenRequest
+         const TR::CompileIlGenRequest &ilGenRequest,
+         bool checkpointInProgress
       ) :
       _compilationInfo(compilationInfo),
       _vm(vm),
@@ -111,7 +112,8 @@ struct CompileParameters
       _scratchSegmentProvider(scratchSegmentProvider),
       _dispatchRegion(dispatchRegion),
       _trMemory(trMemory),
-      _ilGenRequest(ilGenRequest)
+      _ilGenRequest(ilGenRequest),
+      _checkpointInProgress(checkpointInProgress)
       {}
 
    TR_Memory *trMemory() { return &_trMemory; }
@@ -125,6 +127,7 @@ struct CompileParameters
    TR::Region           &_dispatchRegion;
    TR_Memory            &_trMemory;
    TR::CompileIlGenRequest  _ilGenRequest;
+   bool _checkpointInProgress;
    };
 
 #if defined(TR_HOST_S390)

--- a/runtime/compiler/control/CompileBeforeCheckpoint.cpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.cpp
@@ -134,26 +134,6 @@ TR::CompileBeforeCheckpoint::queueMethodsForCompilationBeforeCheckpoint()
       }
    }
 
-static void resetFSD(TR::Options *options)
-   {
-   options->setOption(TR_EnableHCR);
-
-   options->setOption(TR_FullSpeedDebug, false);
-   options->setOption(TR_DisableDirectToJNI, false);
-
-   options->setReportByteCodeInfoAtCatchBlock(false);
-   options->setOption(TR_DisableGuardedCountingRecompilations, false);
-
-   options->setOption(TR_DisableProfiling, false);
-
-   options->setOption(TR_DisableNewInstanceImplOpt, false);
-
-   options->setDisabled(OMR::redundantGotoElimination, false);
-   options->setDisabled(OMR::loopReplicator, false);
-
-   options->setOption(TR_DisableMethodHandleThunks, false);
-   }
-
 void
 TR::CompileBeforeCheckpoint::compileMethodsBeforeCheckpoint()
    {
@@ -162,19 +142,6 @@ TR::CompileBeforeCheckpoint::compileMethodsBeforeCheckpoint()
    /* If running portable CRIU, don't bother compiling proactively */
    if (!javaVM->internalVMFunctions->isNonPortableRestoreMode(_vmThread))
       return;
-
-   /* Proactive compilation should not be FSD compiles */
-   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(_vmThread))
-      {
-      resetFSD(TR::Options::getCmdLineOptions());
-      resetFSD(TR::Options::getAOTCmdLineOptions());
-      _compInfo->getCRRuntime()->setCanPerformRemoteCompilationInCRIUMode(false);
-      _compInfo->getPersistentInfo()->setClientUID(0);
-      _compInfo->getPersistentInfo()->setServerUID(0);
-      _fej9->getJ9JITConfig()->clientUID = 0;
-      _fej9->getJ9JITConfig()->serverUID = 0;
-      J9::PersistentInfo::_remoteCompilationMode = JITServer::NONE;
-      }
 
    /* Release the Comp Monitor, since compileMethod should be called without it
     * in hand. If running in sync mode, having the monitor in hand before
@@ -190,8 +157,6 @@ TR::CompileBeforeCheckpoint::compileMethodsBeforeCheckpoint()
 
    /* Reacquire the Comp Monitor */
    _compInfo->acquireCompMonitor(_vmThread);
-
-   /* TODO un-reset FSD in case the JVM runs in debug mode post restore */
    }
 
 #endif

--- a/runtime/compiler/control/CompileBeforeCheckpoint.hpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.hpp
@@ -62,7 +62,7 @@ class CompileBeforeCheckpoint
     *
     * @param j9method the J9Method
     */
-   void queueMethodForCompilationBeforeCheckpoint(J9Method *j9method);
+   void queueMethodForCompilationBeforeCheckpoint(J9Method *j9method, bool recomp = false);
 
    /**
     * @brief Iterates over the list of methods to be compiled proactively

--- a/runtime/compiler/control/CompileBeforeCheckpoint.hpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.hpp
@@ -23,15 +23,15 @@
 #ifndef TR_COMPILEBEFORECHECKPOINT_INCL
 #define TR_COMPILEBEFORECHECKPOINT_INCL
 
-#if defined(J9VM_OPT_CRIU_SUPPORT)
+#include "j9cfg.h"
 
-#include <set>
-#include "infra/TRlist.hpp"
+#if defined(J9VM_OPT_CRIU_SUPPORT)
 
 namespace TR { class Region; }
 namespace TR { class CompilationInfo; }
 class TR_J9VMBase;
 struct J9VMThread;
+struct J9Method;
 
 namespace TR
 {
@@ -39,26 +39,40 @@ namespace TR
 class CompileBeforeCheckpoint
    {
    public:
-      typedef std::set<TR_OpaqueMethodBlock*,
-                       std::less<TR_OpaqueMethodBlock*>,
-                       TR::typed_allocator<TR_OpaqueMethodBlock*, TR::Region&>
-                      > TR_MethodsSet;
 
-      CompileBeforeCheckpoint(TR::Region &region, J9VMThread *vmThread, TR_J9VMBase *fej9, TR::CompilationInfo *compInfo);
+   CompileBeforeCheckpoint(TR::Region &region, J9VMThread *vmThread, TR_J9VMBase *fej9, TR::CompilationInfo *compInfo);
 
-      void collectAndCompileMethodsBeforeCheckpoint();
-      void addMethodForCompilationBeforeCheckpoint(TR_OpaqueMethodBlock *method) { return addMethodToList(method); }
+   /**
+    * @brief API to trigger compilation in the pre-checkpoint hook.
+    *
+    *        This method is called with the Comp Monitor in hand.
+    */
+   void compileMethodsBeforeCheckpoint();
 
    private:
-      void addMethodToList(TR_OpaqueMethodBlock *method);
-      void collectMethodsForCompilationBeforeCheckpoint() {};
-      void queueMethodsForCompilationBeforeCheckpoint();
 
-      TR::Region &_region;
-      J9VMThread *_vmThread;
-      TR_J9VMBase *_fej9;
-      TR::CompilationInfo *_compInfo;
-      TR_MethodsSet _methodsSet;
+   /**
+    * @brief Queue the specified method for compilation
+    *
+    *        This method is called with the CR Runtime Monitor in hand. However,
+    *        it releases it before actually queueing the method for compilation
+    *        and reacquires it before returning.
+    *
+    * @param j9method the J9Method
+    */
+   void queueMethodForCompilationBeforeCheckpoint(J9Method *j9method);
+
+   /**
+    * @brief Iterates over the list of methods to be compiled proactively
+    *
+    *        This method is called with VMAccess in hand.
+    */
+   void queueMethodsForCompilationBeforeCheckpoint();
+
+   TR::Region &_region;
+   J9VMThread *_vmThread;
+   TR_J9VMBase *_fej9;
+   TR::CompilationInfo *_compInfo;
    };
 
 }

--- a/runtime/compiler/control/CompileBeforeCheckpoint.hpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.hpp
@@ -27,11 +27,13 @@
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 
+struct J9JavaVM;
+struct J9VMThread;
+struct J9Method;
+
 namespace TR { class Region; }
 namespace TR { class CompilationInfo; }
 class TR_J9VMBase;
-struct J9VMThread;
-struct J9Method;
 
 namespace TR
 {

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -3237,10 +3237,6 @@ static bool updateCHTable(J9VMThread * vmThread, J9Class  * cl)
    return !updateFailed;
    }
 
-void turnOffInterpreterProfiling(J9JITConfig *jitConfig);
-
-
-
 /**
  * @brief  A function to get the available virtual memory.
  *
@@ -4001,28 +3997,6 @@ int32_t returnIprofilerState()
 #define TEST_verbose 0
 #define TEST_events  0
 #define TEST_records 0
-
-void turnOffInterpreterProfiling(J9JITConfig *jitConfig)
-   {
-   // Turn off interpreter profiling
-   //
-   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling))
-      {
-      if (interpreterProfilingState != IPROFILING_STATE_OFF)
-         {
-         interpreterProfilingState = IPROFILING_STATE_OFF;
-         J9HookInterface ** hook = jitConfig->javaVM->internalVMFunctions->getVMHookInterface(jitConfig->javaVM);
-         (*hook)->J9HookUnregister(hook, J9HOOK_VM_PROFILING_BYTECODE_BUFFER_FULL, jitHookBytecodeProfiling, NULL);
-
-         PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-         if (TR::Options::getCmdLineOptions()->getOption(TR_VerboseInterpreterProfiling))
-            {
-            TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
-            TR_VerboseLog::writeLineLocked(TR_Vlog_IPROFILER,"t=%6u IProfiler stopped", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
-            }
-         }
-      }
-   }
 
 /// The following two methods (stopInterpreterProfiling and restartInterpreterProfiling)
 /// are used when we disable/enable JIT compilation at runtime
@@ -7576,3 +7550,27 @@ int32_t waitJITServerTermination(J9JITConfig *jitConfig)
 #endif /* J9VM_OPT_JITSERVER */
 
 } /* extern "C" */
+
+#if defined(J9VM_INTERP_PROFILING_BYTECODES)
+void turnOffInterpreterProfiling(J9JITConfig *jitConfig)
+   {
+   // Turn off interpreter profiling
+   //
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling))
+      {
+      if (interpreterProfilingState != IPROFILING_STATE_OFF)
+         {
+         interpreterProfilingState = IPROFILING_STATE_OFF;
+         J9HookInterface ** hook = jitConfig->javaVM->internalVMFunctions->getVMHookInterface(jitConfig->javaVM);
+         (*hook)->J9HookUnregister(hook, J9HOOK_VM_PROFILING_BYTECODE_BUFFER_FULL, jitHookBytecodeProfiling, NULL);
+
+         PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+         if (TR::Options::getCmdLineOptions()->getOption(TR_VerboseInterpreterProfiling))
+            {
+            TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
+            TR_VerboseLog::writeLineLocked(TR_Vlog_IPROFILER,"t=%6u IProfiler stopped", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
+            }
+         }
+      }
+   }
+#endif /* defined(J9VM_INTERP_PROFILING_BYTECODES) */

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -6772,7 +6772,12 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
             // fprintf(stderr, "samplingPeriod=%u numProcs=%u numActiveThreads=%u samplingFrequency=%d\n", samplingPeriod, compInfo->getNumTargetCPUs(), numActiveThreads, jitConfig->samplingFrequency);
 
             // compute jit state
-            jitStateLogic(jitConfig, compInfo, diffTime); // Update JIT state before going to sleep
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+            if (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(samplerThread))
+#endif
+               {
+               jitStateLogic(jitConfig, compInfo, diffTime); // Update JIT state before going to sleep
+               }
 
             // detect high code cache occupancy
             TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -192,8 +192,11 @@ TR_OptimizationPlan *J9::CompilationStrategy::processEvent(TR_MethodEvent *event
          break;
       case TR_MethodEvent::CompilationBeforeCheckpoint:
          {
-         // use the counts to determine the first level of compilation
-         hotnessLevel = self()->getInitialOptLevel(event->_j9method);
+         J9Method *method = event->_j9method;
+         bool jninative = J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccNative);
+
+         // use the counts to determine the first level of compilation if not JNI
+         hotnessLevel = jninative ? TR_Hotness::cold : self()->getInitialOptLevel(method);
          plan = TR_OptimizationPlan::alloc(hotnessLevel);
          *newPlanCreated = true;
          }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3735,31 +3735,31 @@ J9::Options::closeLogFileForClientOptions()
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 void
-J9::Options::resetFSDOptions()
+J9::Options::setFSDOptions(bool flag)
    {
    // TODO: Need to handle if these options were set/unset as part of
    // the post restore options processing.
 
-   setOption(TR_EnableHCR);
+   self()->setOption(TR_EnableHCR, !flag);
 
-   setOption(TR_FullSpeedDebug, false);
-   setOption(TR_DisableDirectToJNI, false);
+   self()->setOption(TR_FullSpeedDebug, flag);
+   self()->setOption(TR_DisableDirectToJNI, flag);
 
-   setReportByteCodeInfoAtCatchBlock(false);
-   setOption(TR_DisableProfiling, false);
-   setOption(TR_DisableNewInstanceImplOpt, false);
-   setDisabled(OMR::redundantGotoElimination, false);
-   setDisabled(OMR::loopReplicator, false);
-   setOption(TR_DisableMethodHandleThunks, false);
+   self()->setReportByteCodeInfoAtCatchBlock(flag);
+   self()->setOption(TR_DisableProfiling, flag);
+   self()->setOption(TR_DisableNewInstanceImplOpt, flag);
+   self()->setDisabled(OMR::redundantGotoElimination, flag);
+   self()->setDisabled(OMR::loopReplicator, flag);
+   self()->setOption(TR_DisableMethodHandleThunks, flag);
    }
 
 void
-J9::Options::resetFSDOptionsForAll()
+J9::Options::setFSDOptionsForAll(bool flag)
    {
-   resetFSDOptions();
+   setFSDOptions(flag);
    for (auto optionSet = _optionSets; optionSet; optionSet = optionSet->getNext())
       {
-      optionSet->getOptions()->resetFSDOptions();
+      optionSet->getOptions()->setFSDOptions(flag);
       }
    }
 
@@ -3775,8 +3775,8 @@ J9::Options::resetFSD(J9JavaVM *vm, J9VMThread *vmThread, bool &doAOT)
        && !vm->internalVMFunctions->isCheckpointAllowed(vmThread)
        && vm->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
       {
-      getCmdLineOptions()->resetFSDOptionsForAll();
-      getAOTCmdLineOptions()->resetFSDOptionsForAll();
+      getCmdLineOptions()->setFSDOptionsForAll(false);
+      getAOTCmdLineOptions()->setFSDOptionsForAll(false);
       }
 
    return fsdStatusJIT;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3281,7 +3281,11 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
                j9nls_printf( PORTLIB, J9NLS_WARNING,  J9NLS_RELOCATABLE_CODE_NOT_AVAILABLE_WITH_FSD_JVMPI);
             }
          }
-      else // do AOT
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+      else if (!javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+#else
+      else
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
          {
          // Turn off Iprofiler for the warm runs, but not if we cache only bootstrap classes
          // This is because we may be missing IProfiler information for non-bootstrap classes

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -643,9 +643,33 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+   /**
+    * \brief Static method used to reset FSD post-restore
+    *
+    * \param vm the J9JavaVM
+    * \param vmThread the J9VMThread
+    * \param[out] doAOT a boolean to indicate whether AOT should be disabled
+    *                   after the call to this method
+    *
+    * \return The FSDInitStatus indicating the FSD Status
+    */
    static FSDInitStatus resetFSD(J9JavaVM *vm, J9VMThread *vmThread, bool &doAOT);
-   void resetFSDOptions();
-   void resetFSDOptionsForAll();
+
+   /**
+    * \brief Method to enable or disable FSD options for the given TR::Options
+    *        object
+    *
+    * \param flag true results in FSD enabled; false results in FSD disabled.
+    */
+   void setFSDOptions(bool flag);
+
+   /**
+    * \brief Method to enable or disable FSD options for the given TR::Options
+    *        and all subsets
+    *
+    * \param flag true results in FSD enabled; false results in FSD disabled.
+    */
+   void setFSDOptionsForAll(bool flag);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
    private:

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -89,6 +89,8 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails &details, vo
    _weight = 0;
    _jitStateWhenQueued = UNDEFINED_STATE;
 
+   _checkpointInProgress = false;
+
 #if defined(J9VM_OPT_JITSERVER)
    _remoteCompReq = false;
    _shouldUpgradeOutOfProcessCompilation = false;
@@ -146,7 +148,7 @@ TR_MethodToBeCompiled::setAotCodeToBeRelocated(const void *m)
    }
 
 #if defined(J9VM_OPT_JITSERVER)
-uint64_t 
+uint64_t
 TR_MethodToBeCompiled::getClientUID() const
    {
    return _stream->getClientId();

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -153,6 +153,8 @@ struct TR_MethodToBeCompiled
    uint8_t                _weight; // Up to 256 levels of weight
    uint8_t                _jitStateWhenQueued;
 
+   bool                   _checkpointInProgress;
+
 #if defined(J9VM_OPT_JITSERVER)
    // Comp request should be sent remotely to JITServer
    bool _remoteCompReq;

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -732,7 +732,7 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
    TR::Options::FSDInitStatus fsdStatus = TR::Options::resetFSD(vm, _vmThread, doAOT);
    disableAOT = !doAOT;
 
-   if (fsdStatus == TR::Options::FSDInitStatus::FSDInit_Error)
+   if (fsdStatus != TR::Options::FSDInitStatus::FSDInit_NotInitialized)
       {
       invalidateAll = true;
       disableAOT = true;

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -87,7 +87,8 @@ TR::CRRuntime::CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo) 
    _checkpointStatus(TR_CheckpointStatus::NO_CHECKPOINT_IN_PROGRESS),
    _failedComps(),
    _forcedRecomps(),
-   _impMethodForCR()
+   _impMethodForCR(),
+   _proactiveCompEnv()
    {
    // TR::CompilationInfo is initialized in the JIT_INITIALIZED bootstrap
    // stage, whereas J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED is set in the
@@ -310,6 +311,49 @@ TR::CRRuntime::triggerRecompilationForPreCheckpointGeneratedFSDBodies(J9VMThread
       }
    }
 
+void
+TR::CRRuntime::setupEnvForProactiveCompilation(J9JavaVM *javaVM, J9VMThread *vmThread, TR_J9VMBase *fej9)
+   {
+   /* Proactive compilation should not be FSD compiles */
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+      {
+      TR::Options::getCmdLineOptions()->setFSDOptionsForAll(false);
+      TR::Options::getAOTCmdLineOptions()->setFSDOptionsForAll(false);
+#if defined(J9VM_OPT_JITSERVER)
+      _proactiveCompEnv._canDoRemoteComp = _compInfo->getCRRuntime()->canPerformRemoteCompilationInCRIUMode();
+      _proactiveCompEnv._clientUID = _compInfo->getPersistentInfo()->getClientUID();
+      _proactiveCompEnv._serverUID = _compInfo->getPersistentInfo()->getServerUID();
+      _proactiveCompEnv._remoteCompMode = J9::PersistentInfo::_remoteCompilationMode;
+
+      setCanPerformRemoteCompilationInCRIUMode(false);
+      getCompInfo()->getPersistentInfo()->setClientUID(0);
+      getCompInfo()->getPersistentInfo()->setServerUID(0);
+      fej9->getJ9JITConfig()->clientUID = 0;
+      fej9->getJ9JITConfig()->serverUID = 0;
+      J9::PersistentInfo::_remoteCompilationMode = JITServer::NONE;
+#endif // if defined(J9VM_OPT_JITSERVER)
+      }
+   }
+
+void
+TR::CRRuntime::teardownEnvForProactiveCompilation(J9JavaVM *javaVM, J9VMThread *vmThread, TR_J9VMBase *fej9)
+   {
+   /* Proactive compilation should not be FSD compiles */
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+      {
+      TR::Options::getCmdLineOptions()->setFSDOptionsForAll(true);
+      TR::Options::getAOTCmdLineOptions()->setFSDOptionsForAll(true);
+#if defined(J9VM_OPT_JITSERVER)
+      setCanPerformRemoteCompilationInCRIUMode(_proactiveCompEnv._canDoRemoteComp);
+      getCompInfo()->getPersistentInfo()->setClientUID(_proactiveCompEnv._clientUID);
+      getCompInfo()->getPersistentInfo()->setServerUID(_proactiveCompEnv._serverUID);
+      fej9->getJ9JITConfig()->clientUID = _proactiveCompEnv._clientUID;
+      fej9->getJ9JITConfig()->serverUID = _proactiveCompEnv._serverUID;
+      J9::PersistentInfo::_remoteCompilationMode = _proactiveCompEnv._remoteCompMode;
+#endif // if defined(J9VM_OPT_JITSERVER)
+      }
+   }
+
 /* IMPORTANT: There should be no return, or C++ exception thrown, after
  *            releasing the Comp Monitor below until it is re-acquired.
  *            The Comp Monitor may be acquired in an OMR::CriticalSection
@@ -344,32 +388,7 @@ bool TR::CRRuntime::compileMethodsForCheckpoint(J9VMThread *vmThread)
    /* Indicate to compilation threads that they should compile methods for checkpoint/restore */
    setCompileMethodsForCheckpoint();
 
-   /* Queue compilation of interpreted methods */
-   try
-      {
-      TR_J9VMBase *fej9 = TR_J9VMBase::get(getJITConfig(), vmThread);
-
-      TR::RawAllocator rawAllocator(getJITConfig()->javaVM);
-      J9::SegmentAllocator segmentAllocator(MEMORY_TYPE_JIT_SCRATCH_SPACE | MEMORY_TYPE_VIRTUAL, *getJITConfig()->javaVM);
-      J9::SystemSegmentProvider regionSegmentProvider(
-         1 << 20,
-         1 << 20,
-         TR::Options::getScratchSpaceLimit(),
-         segmentAllocator,
-         rawAllocator
-         );
-      TR::Region compForCheckpointRegion(regionSegmentProvider, rawAllocator);
-
-      TR::CompileBeforeCheckpoint compileBeforeCheckpoint(compForCheckpointRegion, vmThread, fej9, getCompInfo());
-      compileBeforeCheckpoint.compileMethodsBeforeCheckpoint();
-      }
-   catch (const std::exception &e)
-      {
-      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Failed to collect methods for compilation before checkpoint");
-      }
-
-   /* Determine whether to wait on the CR Monitor. */
+   /* Wait until existing compilations are done before modifying the env */
    while (getCompInfo()->getMethodQueueSize() && !shouldCheckpointBeInterrupted())
       {
       releaseCompMonitorUntilNotifiedOnCRMonitor();
@@ -381,6 +400,50 @@ bool TR::CRRuntime::compileMethodsForCheckpoint(J9VMThread *vmThread)
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
          TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Aborting; checkpoint is interrupted");
       return false;
+      }
+
+      {
+      J9JavaVM *javaVM = getJITConfig()->javaVM;
+      TR_J9VMBase *fej9 = TR_J9VMBase::get(getJITConfig(), vmThread);
+
+      SetupEnvForProactiveComp setupProactiveCompEnv(this, javaVM, vmThread, fej9);
+
+      /* Queue compilation of interpreted methods */
+      try
+         {
+         TR::RawAllocator rawAllocator(javaVM);
+         J9::SegmentAllocator segmentAllocator(MEMORY_TYPE_JIT_SCRATCH_SPACE | MEMORY_TYPE_VIRTUAL, *javaVM);
+         J9::SystemSegmentProvider regionSegmentProvider(
+            1 << 20,
+            1 << 20,
+            TR::Options::getScratchSpaceLimit(),
+            segmentAllocator,
+            rawAllocator
+            );
+         TR::Region compForCheckpointRegion(regionSegmentProvider, rawAllocator);
+
+         TR::CompileBeforeCheckpoint compileBeforeCheckpoint(compForCheckpointRegion, vmThread, fej9, getCompInfo());
+         compileBeforeCheckpoint.compileMethodsBeforeCheckpoint();
+         }
+      catch (const std::exception &e)
+         {
+         if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Failed to collect methods for compilation before checkpoint");
+         }
+
+      /* Determine whether to wait on the CR Monitor. */
+      while (getCompInfo()->getMethodQueueSize() && !shouldCheckpointBeInterrupted())
+         {
+         releaseCompMonitorUntilNotifiedOnCRMonitor();
+         }
+
+      /* Abort if checkpoint should be interrupted. */
+      if (shouldCheckpointBeInterrupted())
+         {
+         if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Aborting; checkpoint is interrupted");
+         return false;
+         }
       }
 
    if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))

--- a/runtime/compiler/runtime/CRRuntime.hpp
+++ b/runtime/compiler/runtime/CRRuntime.hpp
@@ -127,10 +127,12 @@ class CRRuntime
    /* The following methods should be only be invoked with the CR Runtime
     * Monitor in hand.
     */
-   void pushFailedCompilation(J9Method *method)    { pushMemoizedCompilation(_failedComps, method);   }
-   J9Method * popFailedCompilation()               { return popMemoizedCompilation(_failedComps);     }
-   void pushForcedRecompilation(J9Method *method)  { pushMemoizedCompilation(_forcedRecomps, method); }
-   J9Method * popForcedRecompilation()             { return popMemoizedCompilation(_forcedRecomps);   }
+   void pushFailedCompilation(J9Method *method)    { pushMemoizedCompilation(_failedComps, method);    }
+   J9Method * popFailedCompilation()               { return popMemoizedCompilation(_failedComps);      }
+   void pushForcedRecompilation(J9Method *method)  { pushMemoizedCompilation(_forcedRecomps, method);  }
+   J9Method * popForcedRecompilation()             { return popMemoizedCompilation(_forcedRecomps);    }
+   void pushImportantMethodForCR(J9Method *method) { pushMemoizedCompilation(_impMethodForCR, method); }
+   J9Method * popImportantMethodForCR()            { return popMemoizedCompilation(_impMethodForCR);   }
 
    /**
     * @brief Remove appropriate methods from all of the memoized lists. This
@@ -303,16 +305,6 @@ class CRRuntime
    void purgeMemoizedCompilation(TR_MemoizedCompilations& list);
 
    /**
-    * @brief Trigger compilation of any compilations that failed pre-checkpoint;
-    *        specifically, any compilations added to the _failedComps list.
-    *
-    *        This method is called with the CR Runtime Monitor in hand.
-    *
-    * @param vmThread the J9VMThread
-    */
-   void triggerCompilationOfFailedCompilationsPreCheckpoint(J9VMThread *vmThread);
-
-   /**
     * @brief Trigger recompilation of the compilations that were generated with
     *        FSD enabled pre-checkpoint; specifically, any compilations added to
     *        the _forcedRecomps list.
@@ -338,6 +330,7 @@ class CRRuntime
 
    TR_MemoizedCompilations _failedComps;
    TR_MemoizedCompilations _forcedRecomps;
+   TR_MemoizedCompilations _impMethodForCR;
 
    bool _vmMethodTraceEnabled;
    bool _vmExceptionEventsHooked;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -790,4 +790,7 @@ private:
    static int32_t                  _STATS_IPEntryRead;
    static int32_t                  _STATS_IPEntryChoosePersistent;
    };
+
+void turnOffInterpreterProfiling(J9JITConfig *jitConfig);
+
 #endif


### PR DESCRIPTION
This PR includes several heuristics to minimize the performance impact of `-XX:+DebugOnRestore`:
- Generate FSD compilations pre-checkpoint
- Compile "important" methods pre-checkpoint
  - "important" methods are those that are in the SCC, that would have
    been loaded at scount=20
  - These "important" methods are compiled without FSD enabled
- Compile failed compilations pre-checkpoint as opposed to post-restore
- Reset environment after proactive compilation 
- Don't change JVM Phase pre-checkpoint
- Enable IProfiling during startup; because SCC validation occurs post
  restore, there is no persistent IProfiling data to pull from
- Turn off IProfiling on restore so that the normal heuristics can turn
  it back on post-startup
- Trigger recomps pre-checkpoint 

Parent issue https://github.com/eclipse-openj9/openj9/issues/18866