### PR TITLE
set test_keep_reportdir to true for extended.functional

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -98,6 +98,7 @@ misc:
     sanity.openjdk: 'true'
     extended.openjdk: 'true'
     special.openjdk: 'true'
+    extended.functional: 'true'
   sdk_filename_template:
     default: "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}${SDK_FILE_EXT}"
 credentials:


### PR DESCRIPTION
This is to show junit report in the test builds for jtreg tests.

related: https://github.com/adoptium/aqa-tests/issues/5206