### PR TITLE
Disclaim IProfiler memory

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -175,8 +175,8 @@ int32_t J9::Options::_iProfilerMemoryConsumptionLimit=32*1024*1024;
 #else
 int32_t J9::Options::_iProfilerMemoryConsumptionLimit=18*1024*1024;
 #endif
-int32_t J9::Options::_iProfilerBcHashTableSize = 34501; // prime number; Note: 131049 * 8 fits in 1 segment of persistent memory
-int32_t J9::Options::_iProfilerMethodHashTableSize = 12007; // 32707 could be another good value for larger apps
+int32_t J9::Options::_iProfilerBcHashTableSize = 131049; // prime number; Note: 131049 * 8 fits in 1 segment of persistent memory
+int32_t J9::Options::_iProfilerMethodHashTableSize = 32707; // 32707 could be another good value for larger apps
 
 int32_t J9::Options::_IprofilerOffSubtractionFactor = 500;
 int32_t J9::Options::_IprofilerOffDivisionFactor = 16;

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -326,7 +326,7 @@ PersistentAllocator::allocateFromSegmentLocked(size_t allocSize)
       {
       PORT_ACCESS_FROM_JAVAVM(&_javaVM);
       defaultPageSize = j9vmem_supported_page_sizes()[0];
-      segmentSize = OMR::align(segmentSize, defaultPageSize); // Round up to a multiple of default page size if needed
+      segmentSize = OMR::align(segmentSize, (size_t)defaultPageSize); // Round up to a multiple of default page size if needed
       }
 #endif // LINUX
       segment = _segmentAllocator.allocate(segmentSize, std::nothrow);
@@ -742,8 +742,6 @@ PersistentAllocator::disclaimAllSegments()
             fprintf(stderr, "Disclaimed persistent memory segment %p of size %zu. Present pages =%d swapped=%d fileMapped=%d\n",
                     &segment, segLength, numPresentPages, swappedCount, filePageCount);
 #endif
-            if (verbose)
-               TR_VerboseLog::writeLine(TR_Vlog_PERF, "madvise disclaimed persistent segment at address %p size=%zu", segment.heapBase, segLength);
             numSegDisclaimed++;
             }
          }

--- a/runtime/compiler/env/PersistentAllocatorKit.hpp
+++ b/runtime/compiler/env/PersistentAllocatorKit.hpp
@@ -39,14 +39,16 @@ namespace J9
 
 struct PersistentAllocatorKit
    {
-   PersistentAllocatorKit(size_t const minimumSegmentSize, J9JavaVM &javaVM) :
+   PersistentAllocatorKit(size_t const minimumSegmentSize, J9JavaVM &javaVM, uint32_t memType = 0) :
       minimumSegmentSize(minimumSegmentSize),
-      javaVM(javaVM)
+      javaVM(javaVM),
+      memoryType(memType)
       {
       }
 
    size_t const minimumSegmentSize;
    J9JavaVM &javaVM;
+   uint32_t memoryType; // extra flags to be passed to the persistent allocator
    };
 
 }

--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -37,7 +37,11 @@
 JITServerIProfiler *
 JITServerIProfiler::allocate(J9JITConfig *jitConfig)
    {
-   JITServerIProfiler * profiler = new (PERSISTENT_NEW) JITServerIProfiler(jitConfig);
+   // The global persistent allocator will be used to allocate the singleton JITServerIProfiler object.
+   // All other allocations for data structures used by JITServerIProfiler will be done using
+   // the per-client persistent allocator.
+   TR_IProfiler::setAllocator(&TR::Compiler->persistentAllocator());
+   JITServerIProfiler * profiler = new JITServerIProfiler(jitConfig);
    return profiler;
    }
 
@@ -215,7 +219,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
          if (!clientData && entry)
             {
             uint8_t bytecode = *(uint8_t *)(methodStart + byteCodeIndex);
-            fprintf(stderr, "Error cached IP data for method %p bcIndex %u bytecode=%x: ipdata is empty but we have a cached entry=%p\n", 
+            fprintf(stderr, "Error cached IP data for method %p bcIndex %u bytecode=%x: ipdata is empty but we have a cached entry=%p\n",
                method, byteCodeIndex, bytecode, entry);
             }
 
@@ -259,12 +263,12 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
          // this method contains empty data
          if (usePersistentCache && !clientSessionData->cacheIProfilerInfo(method, byteCodeIndex, NULL, isCompiled))
             _statsIProfilerInfoCachingFailures++;
-         else if (!usePersistentCache && !compInfoPT->cacheIProfilerInfo(method, byteCodeIndex, NULL))   
+         else if (!usePersistentCache && !compInfoPT->cacheIProfilerInfo(method, byteCodeIndex, NULL))
             _statsIProfilerInfoCachingFailures++;
          }
       return NULL;
       }
-   
+
    uintptr_t methodStart = TR::Compiler->mtd.bytecodeStart(method);
 
    if (doCache)
@@ -285,7 +289,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             entry->deserialize(storage);
             // Add the entry to the cache if allowed
             // Note that it's possible that the method got unloaded since we last talked
-            // to the client and the unload event was communicated through another compilation 
+            // to the client and the unload event was communicated through another compilation
             // request which is going to be handled by another thread
             //
             // Interfaces are weird; we may have to add 2 to the bci that is going to be the key
@@ -294,7 +298,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             if (storage->ID == TR_IPBCD_CALL_GRAPH)
                {
                U_8* pc = (U_8*)entry->getPC();
-               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method); 
+               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method);
                TR_ASSERT(bci < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
                if (*pc == JBinvokeinterface2)
                   {
@@ -307,7 +311,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
                {
                // If caching failed we must delete the entry allocated with persistent memory
                _statsIProfilerInfoCachingFailures++;
-               jitPersistentFree(entry);
+               comp->trMemory()->freeMemory(entry, persistentAlloc);
                // should we break here or keep going?
                }
             else if (!usePersistentCache && !compInfoPT->cacheIProfilerInfo(method, bci, entry))
@@ -331,7 +335,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
          entry = clientSessionData->getCachedIProfilerInfo(method, byteCodeIndex, &methodInfoPresent);
       else
          entry = compInfoPT->getCachedIProfilerInfo(method, byteCodeIndex, &methodInfoPresent);
-      } 
+      }
    else // No caching
       {
       // Did the client sent an entire method? Such a waste
@@ -351,7 +355,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             if (storage->ID == TR_IPBCD_CALL_GRAPH)
                {
                U_8* pc = (U_8*)entry->getPC();
-               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method); 
+               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method);
                TR_ASSERT(bci < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
                if (*pc == JBinvokeinterface2)
                   {
@@ -377,7 +381,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             entry->deserialize(storage);
          }
       }
-  
+
    return entry;
    }
 
@@ -434,7 +438,7 @@ JITServerIProfiler::validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR
                {
                TR_IPBCDataFourBytes *concreteEntry = entry->asIPBCDataFourBytes();
                TR_ASSERT(concreteEntry, "Cached IP entry is not of type TR_IPBCDataFourBytes");
-               uint32_t sentData = ((TR_IPBCDataFourBytesStorage *)clientData)->data; 
+               uint32_t sentData = ((TR_IPBCDataFourBytesStorage *)clientData)->data;
                uint32_t foundData = (uint32_t)concreteEntry->getData();
                if (sentData != foundData)
                   {
@@ -464,14 +468,14 @@ JITServerIProfiler::validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR
                // Check that the dominant target is the same in both cases
                CallSiteProfileInfo *csInfoServer = concreteEntry->getCGData();
                CallSiteProfileInfo *csInfoClient = &(((TR_IPBCDataCallGraphStorage *)clientData)->_csInfo);
-              
+
                int32_t sumW;
                int32_t maxW;
                uintptr_t domClazzClient = csInfoClient->getDominantClass(sumW, maxW);
                uintptr_t domClazzServer = csInfoServer->getDominantClass(sumW, maxW);
-               
+
                   if(!fromPerCompilationCache && isCompiledWhenProfiling)
-                     TR_ASSERT(domClazzClient == domClazzServer, "Missmatch dominant class client=%p server=%p", (void*)domClazzClient, (void*)domClazzServer);            
+                     TR_ASSERT(domClazzClient == domClazzServer, "Missmatch dominant class client=%p server=%p", (void*)domClazzClient, (void*)domClazzServer);
                }
                break;
             default:
@@ -498,7 +502,7 @@ JITServerIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
        bytecode == JBinvokeinterface2)
       return;
 
-   bool sendRemoteMessage = false; 
+   bool sendRemoteMessage = false;
    bool createNewEntry = false;
    bool methodInfoPresentInPersistent = false;
    ClientSessionData *clientData = TR::compInfoPT->getClientData(); // Find clientSessionData
@@ -574,7 +578,7 @@ JITServerIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
       }
    }
 
-void 
+void
 JITServerIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp)
    {
    // resolvedMethodSymbol is only used for debugging on the client, so we don't have to send it
@@ -592,7 +596,9 @@ JITServerIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, 
 JITClientIProfiler *
 JITClientIProfiler::allocate(J9JITConfig *jitConfig)
    {
-   JITClientIProfiler * profiler = new (PERSISTENT_NEW) JITClientIProfiler(jitConfig);
+   // Create a dedicated persistent allocator to be used by the IProfiler
+   TR_IProfiler::setAllocator(TR_IProfiler::createPersistentAllocator(jitConfig));
+   JITClientIProfiler * profiler = new JITClientIProfiler(jitConfig);
    return profiler;
    }
 
@@ -607,7 +613,7 @@ JITClientIProfiler::JITClientIProfiler(J9JITConfig *jitConfig)
  * Given a method, use the bytecodeIterator to walk over its bytecodes and determine
  * the bytecodePCs that have IProfiler information. Create a sorted array with such
  * bytecodePCs
- * 
+ *
  * @param pcEntries An array that needs to be populated (in sorted fashion)
  * @param numEntries (output) Returns the number of entries in the array
  * @param bcIterator The bytecodeIterator (must be allocated by the caller)

--- a/runtime/compiler/runtime/JITServerIProfiler.hpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.hpp
@@ -49,7 +49,7 @@ struct TR_ContiguousIPMethodHashTableEntry
 
 /**
  * @class JITServerIProfiler
- * @brief Class for manipulating IProfiler data at the server side 
+ * @brief Class for manipulating IProfiler data at the server side
  *
  * This class is an extension of the TR_IProfiler class so that the server
  * can intercept IProfiler requests from the JIT compiler and redirect them
@@ -71,7 +71,7 @@ struct TR_ContiguousIPMethodHashTableEntry
  * object while the global IProfile cache is stored in `struct J9MethodInfo`
  * which is part of `ClientSessionData` (thus, the global cache is more like
  * a collection of caches, one for each method).
- * As a RAS feature, caching can be disabled if the environment variable 
+ * As a RAS feature, caching can be disabled if the environment variable
  * TR_DisableIPCaching is set.
  * Another RAS feature is the validation of the cached data. For a build with
  * assumes enabled (or for a debug build) every time the server uses a cached
@@ -83,8 +83,6 @@ struct TR_ContiguousIPMethodHashTableEntry
 class JITServerIProfiler : public TR_IProfiler
    {
 public:
-
-   TR_PERSISTENT_ALLOC(TR_Memory::IProfiler);
    static JITServerIProfiler * allocate(J9JITConfig *jitConfig);
    JITServerIProfiler(J9JITConfig *);
 
@@ -100,7 +98,7 @@ public:
 
    virtual int32_t getMaxCallCount() override;
    virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *) override;
-   
+
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp) override;
 
    TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptr_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
@@ -123,10 +121,10 @@ private:
 
 /**
  * @class JITClientIProfiler
- * @brief Class for manipulating IProfiler data at the client side 
+ * @brief Class for manipulating IProfiler data at the client side
  *
  * This class is an extension of the TR_IProfiler and has the ability of
- * serializing the entire IProfile data for a given method and send it to 
+ * serializing the entire IProfile data for a given method and send it to
  * server.
  */
 
@@ -134,14 +132,13 @@ class JITClientIProfiler : public TR_IProfiler
    {
 public:
 
-   TR_PERSISTENT_ALLOC(TR_Memory::IProfiler);
    static JITClientIProfiler * allocate(J9JITConfig *jitConfig);
    JITClientIProfiler(J9JITConfig *);
-   // NOTE: since the JITClient can act as a regular JVM compiling methods 
+   // NOTE: since the JITClient can act as a regular JVM compiling methods
    // locally, we must not change the behavior of functions used in TR_IProfiler
    // Thus, any virtual function here must call the corresponding method in
    // the base class. It may be better not to override any methods though
- 
+
    bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITServer::ClientStream *client, bool usePersistentCache, bool isCompiled);
    std::string serializeIProfilerMethodEntry(TR_OpaqueMethodBlock *omb);
 


### PR DESCRIPTION
This commit allocates memory for IProfiler data using a dedicated persistent memory allocator. 
This allocator is instructed to use mmap and to back the allocator memory by a file or swap.
Heuristics dictate when to issue the disclaim operations.
The disclaim can be disabled with -Xjit:disableIprofilerDataDisclaiming
