### PR TITLE
Inline native call to java/lang/Class.getStackClass when possible

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -63,6 +63,7 @@
    java_lang_Class_isIdentity,
    java_lang_Class_getComponentType,
    java_lang_Class_getModifiersImpl,
+   java_lang_Class_getStackClass,
    java_lang_Class_getSuperclass,
    java_lang_Class_isAssignableFrom,
    java_lang_Class_isInstance,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2109,6 +2109,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Class_isInstance,           "isInstance",           "(Ljava/lang/Object;)Z")},
       {x(TR::java_lang_Class_isInterface,          "isInterface",          "()Z")},
       {x(TR::java_lang_Class_cast,                 "cast",                 "(Ljava/lang/Object;)Ljava/lang/Object;")},
+      {x(TR::java_lang_Class_getStackClass,        "getStackClass",        "(I)Ljava/lang/Class;")},
       {  TR::unknownMethod}
       };
 


### PR DESCRIPTION
Native call to java/lang/Class.getStackClass from the methods that are
being inlined in another method can be folded to load of JavaLangClass
from J9Class pointer when the inlined index of the caller of the
getStackClass is higher than the known constant argument to
getStackClass.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>