### PR TITLE
Skip zero init when copied array is the result of StringBuilder.toString

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -174,6 +174,8 @@
    java_lang_String_init_String,
    java_lang_String_init_int_String_int_String_String,
    java_lang_String_init_int_int_char_boolean,
+   java_lang_String_init_StringBuilder,
+   java_lang_String_init_AbstractStringBuilder_Void,
 
    java_lang_String_trim,
    java_lang_String_charAt,
@@ -1227,6 +1229,8 @@
    java_util_Arrays_copyOfRange_boolean,
    java_util_Arrays_copyOfRange_Object1,
    java_util_Arrays_copyOfRange_Object2,
+
+   java_util_Arrays_copyOfRangeByte,
 
    sun_nio_ch_NativeThread_current,
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2733,6 +2733,8 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_util_Arrays_copyOfRange_double, "copyOfRange",     "([DII)[D")},
       {x(TR::java_util_Arrays_copyOfRange_Object1,"copyOfRange",     "([Ljava/lang/Object;II)[Ljava/lang/Object;")},
       {x(TR::java_util_Arrays_copyOfRange_Object2,"copyOfRange",     "([Ljava/lang/Object;IILjava/lang/Class;)[Ljava/lang/Object;")},
+
+      {x(TR::java_util_Arrays_copyOfRangeByte, "copyOfRangeByte",    "([BII)[B")},
       {  TR::unknownMethod}
       };
 
@@ -2742,7 +2744,9 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_init_String,         "<init>",              "(Ljava/lang/String;)V")},
       {x(TR::java_lang_String_init_String_char,    "<init>",              "(Ljava/lang/String;C)V")},
       {x(TR::java_lang_String_init_int_String_int_String_String, "<init>","(ILjava/lang/String;ILjava/lang/String;Ljava/lang/String;)V")},
-      {x(TR::java_lang_String_init_int_int_char_boolean, "<init>",       "(II[CZ)V")},
+      {x(TR::java_lang_String_init_int_int_char_boolean,       "<init>",  "(II[CZ)V")},
+      {x(TR::java_lang_String_init_StringBuilder,              "<init>",  "(Ljava/lang/StringBuilder;)V")},
+      {x(TR::java_lang_String_init_AbstractStringBuilder_Void, "<init>",  "(Ljava/lang/AbstractStringBuilder;Ljava/lang/Void;)V")},
       {  TR::java_lang_String_init,          6,    "<init>", (int16_t)-1,    "*"},
       {x(TR::java_lang_String_charAt,              "charAt",              "(I)C")},
       {x(TR::java_lang_String_charAtInternal_I,    "charAtInternal",      "(I)C")},

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6817,6 +6817,38 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
    genFlush(0);
    }
 
+/**
+ * Check the call chain for the following pattern: StringBuilder.toString() -> String<init>(StringBuilder)
+ *                -> String<init>(AbstractStringBuilder, Void) -> Arrays.copyOfRange([BII)
+ *
+ * @param comp the compilation class.
+ * @return true if the call chain matches the expected stack or false otherwise.
+ */
+static bool isCallChainFromStringBuilderToStringToArraysCopyOfRange(TR::Compilation *comp)
+   {
+   if(comp->getInlineDepth() < 4)
+      return false;
+
+   int32_t callerIndex = comp->getCurrentInlinedCallSite()->_byteCodeInfo.getCallerIndex();
+   if(comp->getInlinedResolvedMethodSymbol(callerIndex)->getRecognizedMethod() != TR::java_util_Arrays_copyOfRange_byte)
+      return false;
+
+   callerIndex = comp->getInlinedCallSite(callerIndex)._byteCodeInfo.getCallerIndex();
+   if(comp->getInlinedResolvedMethodSymbol(callerIndex)->getRecognizedMethod() != TR::java_lang_String_init_AbstractStringBuilder_Void)
+      return false;
+
+   callerIndex = comp->getInlinedCallSite(callerIndex)._byteCodeInfo.getCallerIndex();
+   if(comp->getInlinedResolvedMethodSymbol(callerIndex)->getRecognizedMethod() != TR::java_lang_String_init_StringBuilder)
+      return false;
+
+   callerIndex = comp->getInlinedCallSite(callerIndex)._byteCodeInfo.getCallerIndex();
+   TR::ResolvedMethodSymbol *caller = callerIndex > -1 ? comp->getInlinedResolvedMethodSymbol(callerIndex) : comp->getOptimizer()->getMethodSymbol();
+   if(caller->getRecognizedMethod() != TR::java_lang_StringBuilder_toString)
+      return false;
+
+   return true;
+   }
+
 void
 TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
    {
@@ -6851,6 +6883,16 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
            break;
         }
      }
+
+   // Special case for handling Arrays.copyOfRangeByte when called from StringBuilder.toString method
+   // The call chain is: StringBuilder.toString() -> String<init>(StringBuilder) -> String<init>(AbstractStringBuilder, Void)
+   //                                                             -> Arrays.copyOfRange([BII) -> Arrays.copyOfRangeByte([BII)
+   if (!comp()->isPeekingMethod() && !generateArraylets
+       && _methodSymbol->getRecognizedMethod() == TR::java_util_Arrays_copyOfRangeByte
+       && isCallChainFromStringBuilderToStringToArraysCopyOfRange(comp()))
+      {
+      node->setCanSkipZeroInitialization(true);
+      }
 
    bool separateInitializationFromAllocation;
    switch (_methodSymbol->getRecognizedMethod())


### PR DESCRIPTION
StringBuilder.toString calls String(StringBuilder) which calls String(AbstractStringBuilder, void)
which calls Array.copyOfRange which calls
Array.copyOfRangeByte.
In this chain we can skip Zero alloc.