### PR TITLE
JDK23 update Blocker.begin()/end()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -206,7 +206,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava21.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava22.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=22"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
@@ -234,7 +234,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava21.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava23.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=23"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>

--- a/jcl/src/java.base/share/classes/java/lang/Object.java
+++ b/jcl/src/java.base/share/classes/java/lang/Object.java
@@ -275,7 +275,11 @@ public final void wait(long time) throws InterruptedException {
  */
 public final void wait(long time, int frac) throws InterruptedException {
 /*[IF JAVA_SPEC_VERSION >= 19]*/
+/*[IF JAVA_SPEC_VERSION >= 23]*/
+	boolean blockerRC = Blocker.begin();
+/*[ELSE] JAVA_SPEC_VERSION >= 23 */
 	long blockerRC = Blocker.begin();
+/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 	try {
 		waitImpl(time, frac);
 	} finally {


### PR DESCRIPTION
JDK23 update `Blocker.begin()/end()`

Updated `jpp_configuration.xml to refer rt-compressed.sunJava22.jar` & `rt-compressed.sunJava23.jar`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/782

Signed-off-by: Jason Feng <fengj@ca.ibm.com>