### PR TITLE
Fix JITServer AOT cache compilation retry logic

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2995,7 +2995,7 @@ remoteCompilationEnd(J9VMThread *vmThread, TR::Compilation *comp, TR_ResolvedMet
 
             // Relocation failed, fail compilation
             // attempt to recompile in non-AOT mode
-            entry->_doNotUseAotCodeFromSharedCache = true;
+            entry->_doNotAOTCompile = true;
             entry->_doNotLoadFromJITServerAOTCache = true;
             entry->_compErrCode = returnCode;
 

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -77,7 +77,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails &details, vo
    _unloadedMethod = false;
    _doAotLoad = false;
    _useAotCompilation = false;
-   _doNotUseAotCodeFromSharedCache = false;
+   _doNotAOTCompile = false;
    _tryCompilingAgain = false;
    _async = false;
    _changedFromAsyncToSync = false;

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -123,7 +123,8 @@ struct TR_MethodToBeCompiled
                                            // need to have vmaccess for accessing this flag
    bool                   _doAotLoad;// used for AOT shared cache
    bool                   _useAotCompilation;// used for AOT shared cache
-   bool                   _doNotUseAotCodeFromSharedCache;
+   bool                   _doNotAOTCompile; // Set when we want to forbid all future compilation attempts
+                                            // from being AOT compilations (loads or stores).
    bool                   _tryCompilingAgain;
 
    bool                   _async;           // flag for async compilation; used to print in vlog


### PR DESCRIPTION
When checking for the eligibility of a method to be JITServer AOT cache stored or loaded, we now check that the flag `_doNotAOTCompile` is not set in all cases. (This flag was also renamed, from the somewhat misleading `_doNotUseAotCodeFromSharedCache`). This has the effect of ensuring that when any unrecoverable AOT-related method compilation failures occur, JITServer clients will not request that those methods be JITServer AOT cache compiled during a subsequent compilation attempt.