### PR TITLE
[FFI_JDK21/Test] Enable the downcall tests for primitives on z/OS

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -144,9 +144,13 @@ public final class UpcallLinker {
 	 * @return a factory instance that wraps up the upcall specific code
 	 */
 	public static UpcallStubFactory makeFactory(MethodType methodType, FunctionDescriptor descriptor, LinkerOptions options) {
+		/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
+		throw new InternalError("Upcall is not yet implemented"); //$NON-NLS-1$
+		/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 */
 		return (target, arena) -> {
 			return UpcallLinker.make(target, methodType, descriptor, arena, options);
 		};
+		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 }

--- a/test/TestConfig/resources/excludes/latest_exclude_21.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_21.txt
@@ -31,6 +31,18 @@ org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrong
 org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost NA generic-all
 org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost2 NA generic-all
 
+org.openj9.test.jep442.downcall.InvalidDownCallTests:test_heapSegmentForStructArgument javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.InvalidDownCallTests:test_invalidMemoryLayoutForMemAddr javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.InvalidDownCallTests:test_invalidMemoryLayoutForReturnType javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_memoryAllocFreeFromDefaultLib_1 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_printfFromDefaultLibWithMemAddr_1 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_printfFromDefaultLibWithMemAddr_LinkerOption_1 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_strlenFromDefaultLibWithMemAddr_1 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_memoryAllocFreeFromDefaultLib_2 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_printfFromDefaultLibWithMemAddr_2 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_printfFromDefaultLibWithMemAddr_LinkerOption_2 javanext/issues/441 zos_390-64
+org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_strlenFromDefaultLibWithMemAddr_2 javanext/issues/441 zos_390-64
+
 # Exclude Java 19 Thread related failures
 
 org.openj9.test.java.lang.Test_ThreadGroup:test_activeCount NA generic-all

--- a/test/functional/Java21Only/build.xml
+++ b/test/functional/Java21Only/build.xml
@@ -34,7 +34,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<property name="build" location="bin" />
 	<property name="LIB" value="asm,testng,jcommander" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
-	<property name="TestUtilities" location="../TestUtilities/src"/>
+	<property name="TestUtilities" location="../TestUtilities/src" />
+	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -52,6 +53,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${TestUtilities}" />
+			<src path="${transformerListener}" />
 			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar" />

--- a/test/functional/Java21Only/playlist.xml
+++ b/test/functional/Java21Only/playlist.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-		<platformRequirements>bits.64,^arch.arm,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^arch.riscv,^os.sunos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -44,6 +44,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<versions>
 			<version>21</version>

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/InvalidDownCallTests.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/InvalidDownCallTests.java
@@ -114,6 +114,7 @@ public class InvalidDownCallTests {
 		}
 	}
 
+	@Test
 	public void test_nullSegmentForPtrArgument() throws Throwable {
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
 		MemorySegment functionSymbol = nativeLibLookup.find("validateNullAddrArgument").get();
@@ -154,6 +155,7 @@ public class InvalidDownCallTests {
 		fail("Failed to throw out IllegalArgumentException in the case of the heap segment");
 	}
 
+	@Test
 	public void test_heapSegmentForStructArgument() throws Throwable {
 		GroupLayout structLayout = MemoryLayout.structLayout(JAVA_INT.withName("elem1"), JAVA_INT.withName("elem2"));
 		VarHandle intHandle1 = structLayout.varHandle(PathElement.groupElement("elem1"));

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/MultiThreadingTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/MultiThreadingTests2.java
@@ -44,7 +44,7 @@ import static java.lang.foreign.ValueLayout.*;
  * verifies the downcalls with the shared downcall handlder (cached as soft reference in OpenJDK)
  * in multithreading.
  */
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity", "disabled.os.zos" })
 public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 	private volatile Throwable initException;
 

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
@@ -52,7 +52,7 @@ import static java.lang.foreign.ValueLayout.*;
  * [2] the test suite is mainly intended for the following Clinker API:
  * MethodHandle downcallHandle(MemorySegment symbol, FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity", "disabled.os.zos" })
 public class StructTests1 {
 	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
 	private static Linker linker = Linker.nativeLinker();

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
@@ -52,7 +52,7 @@ import static java.lang.foreign.ValueLayout.*;
  * [2] the test suite is mainly intended for the following Clinker API:
  * MethodHandle downcallHandle(FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity", "disabled.os.zos" })
 public class StructTests2 {
 	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
 	private static Linker linker = Linker.nativeLinker();

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/UnionStructTests.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/UnionStructTests.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.*;
  * The test suite is mainly intended for the following Linker API:
  * MethodHandle downcallHandle(MemorySegment symbol, FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity", "disabled.os.zos" })
 public class UnionStructTests {
 	private static Linker linker = Linker.nativeLinker();
 

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/UnionTests.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/UnionTests.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.*;
  * The test suite is mainly intended for the following Linker API:
  * MethodHandle downcallHandle(MemorySegment symbol, FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity", "disabled.os.zos" })
 public class UnionTests {
 	private static Linker linker = Linker.nativeLinker();
 

--- a/test/functional/Java21Only/testng_210.xml
+++ b/test/functional/Java21Only/testng_210.xml
@@ -24,6 +24,9 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Java21 only test suite" parallel="none" verbose="2">
+	<listeners>
+		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer" />
+	</listeners>
 	<test name="Jep442Tests_testLinkerFfi_DownCall">
 		<classes>
 			<class name="org.openj9.test.jep442.downcall.InvalidDownCallTests"/>


### PR DESCRIPTION
The changes only enable the downcall specific tests for primitives
on z/OS to ensure FFI functionally works as expected given the
related code issues with the remaining test cases have not yet been
resolved on z/OS.

Related: [Internal 441](https://github.ibm.com/runtimes/javanext/issues/441)

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>