### PR TITLE
(0.45) Fixup stack references of unmounted continuation for scavenge backout

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -1028,6 +1028,11 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 		return ;
 	}
 
+	/* Just completed last phase that may have done any object scanning (or copied objects if a copying collector).
+	 * Collectors have a chance to invoke specific processing and checks.
+	 */
+	completedObjectScanPhasesCheckpoint();
+
 	/*
 	 * clear the following private references once resurrection is completed 
 	 */

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -506,6 +506,11 @@ public:
 #endif /* J9VM_GC_FINALIZATION */
 
 	/**
+	 * During clearabble processing, invoke specific processing/checks after last known phase that scans (and copies) objects.
+	 */
+	virtual void completedObjectScanPhasesCheckpoint() {}
+
+	/**
 	 * @todo Provide function documentation
 	 */
 	virtual void doOwnableSynchronizerObject(J9Object *objectPtr, MM_OwnableSynchronizerObjectList *list);

--- a/runtime/gc_glue_java/ScavengerBackOutScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerBackOutScanner.hpp
@@ -46,7 +46,6 @@ private:
 	void backoutUnfinalizedObjects(MM_EnvironmentStandard *env);
 	void backoutFinalizableObjects(MM_EnvironmentStandard *env);
 #endif
-	void backoutContinuationObjects(MM_EnvironmentStandard *env);
 
 public:
 	MM_ScavengerBackOutScanner(MM_EnvironmentBase *env, bool singleThread, MM_Scavenger *scavenger)
@@ -118,12 +117,11 @@ public:
 
 	/* empty, move ownable synchronizer backout processing in scanAllSlots() */
 	virtual void scanOwnableSynchronizerObjects(MM_EnvironmentBase *env) {}
-	virtual void scanContinuationObjects(MM_EnvironmentBase *env)
-	{
-		reportScanningStarted(RootScannerEntity_ContinuationObjects);
-		backoutContinuationObjects(MM_EnvironmentStandard::getEnvironment(env));
-		reportScanningEnded(RootScannerEntity_ContinuationObjects);
-	}
+	/**
+	 * empty, move continuation backout processing in scanAllSlots(), scavenger abort would never happen after continuationObjectList processing
+	 * so only need to backout list._head from _priorHead
+	 */
+	virtual void scanContinuationObjects(MM_EnvironmentBase *env) {}
 };
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -653,6 +653,17 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 		if (NULL != finalizeLinkAddress) {
 			barrier->setFinalizeLink(objectPtr, barrier->getFinalizeLink(fwdObjectPtr));
 		}
+
+		/* fixup the references in the continuation native StackSlots */
+		switch (_extensions->objectModel.getScanType(forwardedClass)) {
+
+		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
+			scanContinuationNativeSlots(MM_EnvironmentStandard::getEnvironment(env), objectPtr, SCAN_REASON_BACKOUT);
+			break;
+		default:
+			break;
+		}
+
 	}
 }
 

--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -286,6 +286,11 @@ public:
 		_scavenger->pruneRememberedSet(MM_EnvironmentStandard::getEnvironment(env));
 		reportScanningEnded(RootScannerEntity_RememberedSet);
 	}
+
+	virtual void completedObjectScanPhasesCheckpoint() {
+		Assert_MM_false(_extensions->isScavengerBackOutFlagRaised());
+	}
+
 };
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #endif /* SCAVENGERROOTCLEARER_HPP_ */


### PR DESCRIPTION
Due to no completeScan for scavenge backout(there are no need to fixup the references for regular objects in evacurated regions), the native stack references of unmounted continuation Objects might still point to the reversedForwardedObject in survior or tenure regions, it would cause the Assertion in following global GC.

 - scanContinuationNativeSlots for the continuation Objects during reverseForwardedObject.
 - there is no need backoutContinuationObjects processing, instead, just backout continuation list in new regions.
 - -Xgc:fvtest=forceScavengerBackout (for testing/debug only) is triggered wrong location(should not be triggered after continuationObjects processing, there is no more new allocation needed and no possible backout in real cases), do not use -Xgc:fvtest=forceScavengerBackout option for testing until further
 update.
 - new mehtod completedObjectScanPhasesCheckpoint() for future asserting no more abort Case happened after unfinalized/phantom processing in scavenge clearable phase.

Port of https://github.com/eclipse-openj9/openj9/pull/19341