### PR TITLE
Possible fix for perf regression

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -480,7 +480,10 @@ final class J9VMInternals {
 	 */
 	static int fastIdentityHashCode(Object anObject) {
 		com.ibm.jit.JITHelpers h = jitHelpers;
-		if ((null == h) || h.isArray(anObject)) {
+		if (null == h) {
+			return identityHashCode(anObject); /* use early returns to make the JIT code faster */
+		}
+		if (h.isArray(anObject)) {
 			return identityHashCode(anObject); /* use early returns to make the JIT code faster */
 		}
 		if (h.is32Bit()) {


### PR DESCRIPTION
Change fastIdentityHashCode so the interpreter path is identical to what it was before #19172 was merged.

javanext/issues/438