### PR TITLE
VMWare support is not open source, clarify Hypervisor/Guest MXBean

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMXBean.java
@@ -32,7 +32,7 @@ import java.lang.management.*;
  * <b>Where there are multiple levels of Hypervisor, only the top level Hypervisor information is returned.</b>
  * These are the supported Hypervisor and Guest Operating System combinations:
  * <ol>
- *      <li>Windows and Linux on VMWare ESXi.
+ *      <li>Windows and Linux on VMWare ESXi (IBM Java 8 only).
  *      <ul>
  *          <li><a href="http://www.vmware.com/support/developer/guest-sdk" target="_blank">VMware GuestSDK</a>
  *              (Generally packaged with VMWare tools) must be installed in the Guest Operating System.

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMemoryUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMemoryUsage.java
@@ -32,7 +32,7 @@ import com.ibm.virtualization.management.internal.GuestOSMemoryUsageUtil;
  * Memory usage statistics as seen by the Hypervisor Host.
  * The supported Operating System and Hypervisor combinations are:
  * <ol>
- *     <li>Linux and Windows on VMWare.
+ *     <li>Linux and Windows on VMWare (IBM Java 8 only).
  *     <li>AIX and Linux on PowerVM.
  *     <li>Linux and z/OS on z/VM.
  *     <li>Guest Operating System memory usage statistics are not available on Linux for PowerKVM.

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSProcessorUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSProcessorUsage.java
@@ -33,7 +33,7 @@ import com.ibm.virtualization.management.internal.GuestOSProcessorUsageUtil;
  * all physical CPUs assigned to the Guest by the Hypervisor Host.
  * The supported Operating System and Hypervisor combinations are:
  * <ol>
- *     <li>Linux and Windows on VMWare.
+ *     <li>Linux and Windows on VMWare (IBM Java 8 only).
  *     <li>AIX and Linux on PowerVM.
  *     <li>Linux and z/OS on z/VM.
  *     <li>Linux on PowerKVM.

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/HypervisorMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/HypervisorMXBean.java
@@ -32,7 +32,7 @@ import java.lang.management.PlatformManagedObject;
  * <b>Where there are multiple levels of Hypervisor, only the top level Hypervisor information is returned.</b>
  * The supported Hypervisors and the platforms on which they are supported:
  * <ol>
- *     <li>Linux and Windows on VMWare.
+ *     <li>Linux and Windows on VMWare (IBM Java 8 only).
  *     <li>Linux and Windows on KVM.
  *     <li>Windows on Hyper-V.
  *     <li>AIX and Linux on PowerVM.


### PR DESCRIPTION
Clarify the support statement for HypervisorMXBean and GuestMXBean given that VMWare support is not open source.