### PR TITLE
TR_J9ServerMethod: change type of cpIndex to match usage

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1452,11 +1452,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          break;
       case MessageType::get_params_to_construct_TR_j9method:
          {
-         auto recv = client->getRecvData<J9Class *, uintptr_t>();
+         auto recv = client->getRecvData<J9Class *, int32_t>();
          J9Class * aClazz = std::get<0>(recv);
-         uintptr_t cpIndex = std::get<1>(recv);
+         int32_t cpIndex = std::get<1>(recv);
          J9ROMClass * romClass = aClazz->romClass;
-         uintptr_t realCPIndex = jitGetRealCPIndex(fe->vmThread(), romClass, cpIndex);
+         uintptr_t realCPIndex = jitGetRealCPIndex(fe->vmThread(), romClass, (uintptr_t)(intptr_t)cpIndex);
          J9ROMMethodRef * romRef = &J9ROM_CP_BASE(romClass, J9ROMMethodRef)[realCPIndex];
          J9ROMClassRef * classRef = &J9ROM_CP_BASE(romClass, J9ROMClassRef)[romRef->classRefCPIndex];
          J9ROMNameAndSignature * nameAndSignature = J9ROMMETHODREF_NAMEANDSIGNATURE(romRef);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2635,7 +2635,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::validateMethodFieldAttributes(const TR_
    return equal;
    }
 
-TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClazz, uintptr_t cpIndex)
+TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClazz, int32_t cpIndex)
    : TR_J9Method()
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -337,6 +337,6 @@ protected:
 class TR_J9ServerMethod : public TR_J9Method
    {
 public:
-   TR_J9ServerMethod(TR_FrontEnd *trvm, TR_Memory *, J9Class * aClazz, uintptr_t cpIndex);
+   TR_J9ServerMethod(TR_FrontEnd *trvm, TR_Memory *, J9Class * aClazz, int32_t cpIndex);
    };
 #endif // J9METHODSERVER_H

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 60; // ID: rCSONLnFpNx1aQQmficD
+   static const uint16_t MINOR_NUMBER = 61; // ID: 2WUGRj9RjAt4xrMCntc/
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
Otherwise gcc 13 reports a narrowing warning on line 2676 of `j9methodServer.cpp`.
The only use of the constructor provides an argument of type `int32_t`.