### PR TITLE
Misc. improvements to x86 inline object allocations

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -5579,7 +5579,7 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
                {
                static char *disableAlign = feGetEnv("TR_DisableAlignAlloc");
 
-               if (0 && !disableAlign && (node->getOpCodeValue() == TR::New) && (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()))
+               if (0 && !disableAlign && (node->getOpCodeValue() == TR::New) && (comp->getMethodHotness() >= hot))
                   {
                   TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6256,7 +6256,7 @@ static void genHeapAlloc(
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
          if ((node->getOpCodeValue() == TR::New) &&
-             (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()) &&
+             (comp->getMethodHotness() >= hot) &&
              !disableAllocationAlignment)
             {
             TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();
@@ -6634,7 +6634,7 @@ static void genHeapAlloc2(
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
          if ((node->getOpCodeValue() == TR::New) &&
-             (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()) &&
+             (comp->getMethodHotness() >= hot) &&
              !disableAllocationAlignment)
             {
             TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6150,7 +6150,7 @@ static void genHeapAlloc(
             }
          else
             {
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
          // Must be an unsigned comparison on sizes.
@@ -6541,7 +6541,7 @@ static void genHeapAlloc2(
             }
          else
             {
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
          // Must be an unsigned comparison on sizes.

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7762,11 +7762,13 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    startLabel->setStartInternalControlFlow();
    fallThru->setEndInternalControlFlow();
 
+   static char *enableTLHBatchClearing = feGetEnv("TR_EnableBatchClear");
+
 #ifdef J9VM_GC_NON_ZERO_TLH
    // If we can skip zero init, and it is not outlined new, we use the new TLH
    // same logic also appears later, but we need to do this before generate the helper call
    //
-   if (node->canSkipZeroInitialization() && !comp->getOption(TR_DisableDualTLH) && !comp->getOptions()->realTimeGC())
+   if (node->canSkipZeroInitialization() && (enableTLHBatchClearing || !comp->getOption(TR_DisableDualTLH)) && !comp->getOptions()->realTimeGC())
       {
       // For value types, it should use jitNewValue helper call which is set up before code gen
       if ((node->getOpCodeValue() == TR::New)
@@ -7875,7 +7877,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    bool shouldInitZeroSizedArrayHeader = true;
 
 #ifdef J9VM_GC_NON_ZERO_TLH
-   if (comp->getOption(TR_DisableDualTLH) || comp->getOptions()->realTimeGC())
+   if (!enableTLHBatchClearing || comp->getOptions()->realTimeGC())
       {
 #endif
       if (!maxZeroInitWordsPerIteration)


### PR DESCRIPTION
* Remove deprecated shouldAlignTLHAlloc() checks on TR::Nodes
* Ensure variable array sizes are compared as 32-bits for x86 inline allocations
* Add knobs to disable x86 object allocation features
* Misc. readability and formatting improvements to x86 inline allocation
* Perform zero initialization of TLH objects when batch clearing enabled