### PR TITLE
ScopedMemoryAccess closeScope0 synchronization

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6053,6 +6053,10 @@ typedef struct J9JavaVM {
 	/* Pool for allocating J9MemberNameListNode. */
 	struct J9Pool *memberNameListNodePool;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+#if JAVA_SPEC_VERSION >= 22
+	omrthread_monitor_t closeScopeMutex;
+	UDATA closeScopeNotifyCount;
+#endif /* JAVA_SPEC_VERSION >= 22 */
 } J9JavaVM;
 
 #define J9VM_PHASE_STARTUP  1

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1025,6 +1025,13 @@ freeJavaVM(J9JavaVM * vm)
 	}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+#if JAVA_SPEC_VERSION >= 22
+	if (NULL != vm->closeScopeMutex) {
+		omrthread_monitor_destroy(vm->closeScopeMutex);
+		vm->closeScopeMutex = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 22 */
+
 	j9mem_free_memory(vm);
 
 	if (NULL != tmpLib->self_handle) {

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -99,6 +99,10 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 		omrthread_monitor_init_with_name(&vm->delayedLockingOperationsMutex, 0, "Delayed locking operations mutex") ||
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+#if JAVA_SPEC_VERSION >= 22
+		omrthread_monitor_init_with_name(&vm->closeScopeMutex, 0, "ScopedMemoryAccess closeScope0 mutex") ||
+#endif /* JAVA_SPEC_VERSION >= 22 */
+
 		initializeMonitorTable(vm)
 	)
 	{


### PR DESCRIPTION
There are gaps where async exceptions are not processed in time (e.g.
JIT compiled code in a loop). Threads will wait in `closeScope0` until
`J9VMThread->scopedError` (async exception) is transferred to
`J9VMThread->currentException`. The wait prevents a `MemorySession` to be
closed until no more operations are being performed on it.

Related: https://github.com/eclipse-openj9/openj9/issues/13211