### PR TITLE
Delete only datasets created from JVM crashes 

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
@@ -184,7 +184,7 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
 
                                     // Cleanup zOS datasets 
                                     if (nodeLabels.contains('sw.os.zos')) {
-                                        listcat = sh(script: "tso listcat | grep '${env.USER}' | cut -d. -f 2-", returnStdout: true).trim()
+                                        listcat = sh(script: "tso listcat | grep '${env.USER}' | grep 'JVM' | cut -d. -f 2-", returnStdout: true).trim()
                                         listcat.split('\n').each {
                                             sh "tso delete ${it}"
                                         }


### PR DESCRIPTION
The Cleanup-Nodes.groovy script tries to delete all datasets in the zos system including some important ones needed for compiles.
This way we can ensure we delete the ones from jvm crashes alone.