### PR TITLE
Fix fatal assertion in class loader table during class unload

### DIFF
--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -456,7 +456,7 @@ TR_PersistentClassLoaderTable::removeClassLoader(J9VMThread *vmThread, void *loa
             loader, nameLength, (const char *)name, info->_chain
          );
 
-      if (!_sharedCache || !_sharedCache->isPointerInSharedCache(nameStr))
+      if (!_sharedCache || !_sharedCache->isPtrToROMClassesSectionInSharedCache(nameStr))
          _persistentMemory->freePersistentMemory(nameStr);
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */


### PR DESCRIPTION
When removing entries from the class loader table during class unloading, the current implementation uses the wrong shared cache API `isPointerInSharedCache()` (which is only intended for the metadata section of the SCC) to check whether the class loader identifying name string is stored in the SCC or in the persistent allocator heap. This can result in a fatal assertion when using both the JITServer AOT cache and the local SCC, as well as memory corruption since SCC memory ranges get added to the persistent allocator free lists. This commit fixes the issue by using the correct API `isPtrToROMClassesSectionInSharedCache()`.