### PR TITLE
jdk23 Blocker.begin() in Object.wait is only called for virtual threads

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Object.java
+++ b/jcl/src/java.base/share/classes/java/lang/Object.java
@@ -274,20 +274,27 @@ public final void wait(long time) throws InterruptedException {
  * @see			java.lang.Thread
  */
 public final void wait(long time, int frac) throws InterruptedException {
-/*[IF JAVA_SPEC_VERSION >= 19]*/
-/*[IF JAVA_SPEC_VERSION >= 23]*/
-	boolean blockerRC = Blocker.begin();
-/*[ELSE] JAVA_SPEC_VERSION >= 23 */
+/*[IF JAVA_SPEC_VERSION < 19]*/
+	waitImpl(time, frac);
+/*[ELSEIF JAVA_SPEC_VERSION < 23]*/
 	long blockerRC = Blocker.begin();
-/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 	try {
 		waitImpl(time, frac);
 	} finally {
 		Blocker.end(blockerRC);
 	}
-/*[ELSE] JAVA_SPEC_VERSION >= 19 */
-	waitImpl(time, frac);
-/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+/*[ELSE] JAVA_SPEC_VERSION < 23 */
+	if (!Thread.currentThread().isVirtual()) {
+		waitImpl(time, frac);
+	} else {
+		boolean blocking = Blocker.begin();
+		try {
+			waitImpl(time, frac);
+		} finally {
+			Blocker.end(blocking);
+		}
+	}
+/*[ENDIF] JAVA_SPEC_VERSION < 19 */
 }
 
 private final native void waitImpl(long time, int frac) throws InterruptedException;


### PR DESCRIPTION
Previous jdk23 builds were hanging, it's looking better with this change to match OpenJDK.
[8329593: Drop adjustments to target parallelism when virtual threads](https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/782/commits/e592d365bdcf133bc740531eba65f5bc01cedd0d)

Related to https://github.com/eclipse-openj9/openj9/pull/19374

Hanging builds https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-JDK23-with-System/5/

First PR build https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/517/