### PR TITLE
add native tag to tests

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -370,6 +370,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<types>
+			<type>native</type>
+		</types>
 	</test>
 	<!-- jit.test.tr start here -->
 	<test>

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1082,6 +1082,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<features>
 			<feature>AOT:nonapplicable</feature>
 		</features>
+		<types>
+			<type>native</type>
+		</types>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -1234,6 +1237,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<features>
 			<feature>AOT:nonapplicable</feature>
 		</features>
+		<types>
+			<type>native</type>
+		</types>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/UnsafeTest/playlist.xml
+++ b/test/functional/UnsafeTest/playlist.xml
@@ -79,5 +79,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<types>
+			<type>native</type>
+		</types>
 	</test>
 </playlist>


### PR DESCRIPTION
Close https://github.com/eclipse-openj9/openj9/issues/19390

Added native tag to the following tests:
- JCL_Test
- JCL_Test_none_SCC
- jit_jar
- UnsafeTests