### PR TITLE
JDK21 adds PinnedThreadPrinter.printStackTrace(out, reason, printAll)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
+++ b/jcl/src/java.base/share/classes/java/lang/PinnedThreadPrinter.java
@@ -27,9 +27,7 @@ import java.lang.StackWalker.StackFrame;
 import java.lang.StackWalker.StackFrameImpl;
 import java.util.List;
 import java.util.stream.Collectors;
-/*[IF JAVA_SPEC_VERSION >= 22]*/
 import jdk.internal.vm.Continuation;
-/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
 /**
  * Prints the stack trace of a pinned thread that is attempting to yield.
@@ -57,10 +55,8 @@ final class PinnedThreadPrinter {
 		}
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 22]*/
 	static void printStackTrace(PrintStream out, Continuation.Pinned reason, boolean printAll) {
 		out.println(Thread.currentThread() + " reason:" + reason); //$NON-NLS-1$
 		printStackTraceHelper(out, printAll);
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 }


### PR DESCRIPTION
`JDK21` adds `PinnedThreadPrinter.printStackTrace(out, reason, printAll)`

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/150

Signed-off-by: Jason Feng <fengj@ca.ibm.com>