### PR TITLE
Add ThreadMXBean.getTotalThreadAllocatedBytes() impl, and jdk8 support

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadMXBeanImpl.java
@@ -104,6 +104,27 @@ public final class ExtendedThreadMXBeanImpl extends ThreadMXBeanImpl implements 
 	 * {@inheritDoc}
 	 */
 	@Override
+	public long getTotalThreadAllocatedBytes() {
+		if (!isThreadAllocatedMemorySupported()) {
+			throw new UnsupportedOperationException();
+		}
+		if (!isThreadAllocatedMemoryEnabled()) {
+			return -1;
+		}
+		long total = 0;
+		long[] allocatedBytes = getThreadAllocatedBytes(getAllThreadIds());
+		for (long threadAllocated : allocatedBytes) {
+			if (threadAllocated != -1) {
+				total += threadAllocated;
+			}
+		}
+		return total;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public long[] getThreadCpuTime(long[] threadIds) {
 		long[] result = new long[threadIds.length];
 		for (int i = 0; i < threadIds.length; i++) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
@@ -93,7 +93,7 @@ public class TestThreadMXBean {
 		attribs.put("ThreadCpuTimeEnabled", new AttributeData(Boolean.TYPE.getName(), true, true, true));
 		attribs.put("ThreadCpuTimeSupported", new AttributeData(Boolean.TYPE.getName(), true, false, true));
 		attribs.put("TotalStartedThreadCount", new AttributeData(Long.TYPE.getName(), true, false, false));
-		if (VersionCheck.major() >= 11) {
+		if (!isIBMJava8) {
 			attribs.put("TotalThreadAllocatedBytes", new AttributeData(Long.TYPE.getName(), true, false, false));
 		}
 	} // end static initializer
@@ -1568,7 +1568,7 @@ public class TestThreadMXBean {
 			numAttributes = 17;
 		} else {
 			numOperations = 20;
-			numAttributes = (VersionCheck.major() >= 11) ? 19 : 18;
+			numAttributes = 19;
 		}
 		MBeanOperationInfo[] operations = mbi.getOperations();
 		AssertJUnit.assertNotNull(operations);


### PR DESCRIPTION
To match OpenJDK.
https://github.com/ibmruntimes/openj9-openjdk-jdk8/commit/5b83d98d6fc1

This should be merged at the same time as jdk8 acceptance is promoted.

Doc issue https://github.com/eclipse-openj9/openj9-docs/issues/1326