### PR TITLE
Only @Override getTotalThreadAllocatedBytes in OpenJ9 builds

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadMXBeanImpl.java
@@ -100,10 +100,12 @@ public final class ExtendedThreadMXBeanImpl extends ThreadMXBeanImpl implements 
 		return allocatedBytes;
 	}
 
+	/*[IF Sidecar18-SE-OpenJ9]*/
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
+	/*[ENDIF] Sidecar18-SE-OpenJ9 */
 	public long getTotalThreadAllocatedBytes() {
 		if (!isThreadAllocatedMemorySupported()) {
 			throw new UnsupportedOperationException();


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/pull/19436