### PR TITLE
cmake: disable automatic dependency tracking for .nasm files

### DIFF
--- a/runtime/cmake/platform/os/win.cmake
+++ b/runtime/cmake/platform/os/win.cmake
@@ -20,34 +20,35 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ################################################################################
 
-# Note: we need to inject WIN32 et al, as OMR no longer uses them
+# Note: Define WIN32 etc. until OMR no longer uses them.
 
 list(APPEND OMR_PLATFORM_DEFINITIONS
-    -DWIN32
-    -D_WIN32
+	-DWIN32
+	-D_WIN32
 )
 if(OMR_ENV_DATA64)
-    list(APPEND OMR_PLATFORM_DEFINITIONS
-        -DWIN64
-        -D_WIN64
-    )
+	list(APPEND OMR_PLATFORM_DEFINITIONS
+		-DWIN64
+		-D_WIN64
+	)
 endif()
+
 list(APPEND OMR_PLATFORM_DEFINITIONS -DWINDOWS)
 
-# Set flags we use to build the interpreter
+# Set flags we use to build the interpreter.
 omr_stringify(CMAKE_J9VM_CXX_FLAGS
-    -O3
-    -fno-rtti
-    -fno-threadsafe-statics
-    -fno-strict-aliasing
-    -fno-exceptions
-    -fno-asynchronous-unwind-tables
-    -std=c++0x
-    -D_CRT_SUPPRESS_RESTRICT
-    -DVS12AndHigher
-    ${OMR_PLATFORM_DEFINITIONS}
+	-O3
+	-fno-rtti
+	-fno-threadsafe-statics
+	-fno-strict-aliasing
+	-fno-exceptions
+	-fno-asynchronous-unwind-tables
+	-std=c++0x
+	-D_CRT_SUPPRESS_RESTRICT
+	-DVS12AndHigher
+	${OMR_PLATFORM_DEFINITIONS}
 )
 
 if(OMR_ENV_DATA32)
-    set(CMAKE_J9VM_CXX_FLAGS "${CMAKE_J9VM_CXX_FLAGS} -m32")
+	set(CMAKE_J9VM_CXX_FLAGS "${CMAKE_J9VM_CXX_FLAGS} -m32")
 endif()

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -38,6 +38,12 @@ if(OMR_ARCH_X86)
 		endif()
 	endif()
 	enable_language(ASM_NASM)
+	if(OMR_OS_WINDOWS)
+		# On Windows, automatic dependency tracking for ASM_NASM files doesn't play
+		# nicely with fixpath.sh. Remove the nasm options that would produce *.d
+		# files: cmake silently treats missing *.d files as if they were empty.
+		set(CMAKE_DEPFILE_FLAGS_ASM_NASM "")
+	endif()
 	# We have to manually append "/" to the paths as NASM versions older than v2.14 requires trailing / in the directory paths.
 	set(asm_inc_dirs
 		"-I${j9vm_SOURCE_DIR}/oti/"


### PR DESCRIPTION
On Windows, automatic dependency tracking for `ASM_NASM` files doesn't play nicely with `fixpath.sh`. Remove the `nasm` options that would produce `*.d` files (`cmake` silently treats missing `*.d` files as if they were empty).

I tested this with cmake version 3.28.3 (the current default from cygwin setup) and with version 3.18.0 (built locally from source) which predates the introduction of automatic dependency tracking for `ASM_NASM` files.

Fixes #19410.