### PR TITLE
(0.45) Update zlib version in doc to match version used

### DIFF
--- a/longabout.html
+++ b/longabout.html
@@ -189,7 +189,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <p>
-<h4>zlib 1.2.13</h4>
+<h4>zlib 1.3</h4>
   (C) 1995-2023 Jean-loup Gailly and Mark Adler
 <p>
   This software is provided 'as-is', without any express or implied

--- a/runtime/include/about.html
+++ b/runtime/include/about.html
@@ -40,7 +40,7 @@ License 2.0 still apply to any source code in the Content and such source code m
 Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you
 should look to the Redistributor's license for terms and conditions of use.</p>
 
-<h3>zlib 1.2.13</h3>
+<h3>zlib 1.3</h3>
 
 <p>zlib general purpose compression library obtained from https://zlib.net/</p>
 

--- a/runtime/zlib/about.html
+++ b/runtime/zlib/about.html
@@ -39,13 +39,13 @@ License 2.0 still apply to any source code in the Content and such source code m
 Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you
 should look to the Redistributor's license for terms and conditions of use.</p>
 
-<h3>zlib 1.2.13</h3>
+<h3>zlib 1.3</h3>
 
 <p>zlib general purpose compression library obtained from http://zlib.net/</p>
 
 <p>The software is modified from the original version.</p>
 
-<p>Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler</p>
+<p>Copyright (C) 1995-2023 Jean-loup Gailly and Mark Adler</p>
 
 <p>This software is
 provided 'as-is', without any express or implied warranty. In no event will the


### PR DESCRIPTION
zlib was updated via https://github.com/eclipse-openj9/openj9/pull/18137 but the doc was not updated to match.

Cherry pick of https://github.com/eclipse-openj9/openj9/pull/19451