### PR TITLE
Added fast implementation of StringLatin1.inflate

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -97,6 +97,13 @@ J9::Power::CodeGenerator::initialize()
       !TR::Compiler->om.canGenerateArraylets())
       cg->setSupportsInlineStringIndexOf();
 
+   static bool disableStringInflateIntrinsic = feGetEnv("TR_DisableStringInflateIntrinsic") != NULL;
+   if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) &&
+      comp->target().is64Bit() &&
+      !TR::Compiler->om.canGenerateArraylets() &&
+      !disableStringInflateIntrinsic)
+      cg->setSupportsInlineStringLatin1Inflate();
+
    if (!comp->getOption(TR_DisableReadMonitors))
       cg->setSupportsReadOnlyLocks();
 


### PR DESCRIPTION
Adds support for replacing calls to StringLatin1.inflate with hand tuned assembly that takes advantage of vector instructions and wider loads and stores.

StringLatin1.inflate is recognized and intentionally prevented from being inlined. During codegen, the call is changed to custom assembly instead of generating a callout.

Changes apply to 64 bit Big/Little endian on Power 8 and later.

New behavior can be disabled with the TR_DisableStringInflateIntrinsic environment variable.

These changes use the `vmrghb` and `vmrglb` instructions so they are dependent on this OMR PR that adds support for them:
https://github.com/eclipse/omr/pull/7329