### PR TITLE
Z: Accelerate ArraysSupport.vectorizedHashCode

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -502,6 +502,16 @@ public:
    */
    void setSupportsInlineVectorizedMismatch() { _j9Flags.set(SupportsInlineVectorizedMismatch); }
 
+   /** \brief
+   *   Determines whether the code generator supports inlining of jdk/internal/util/ArraysSupport.vectorizedHashCode
+   */
+   bool getSupportsInlineVectorizedHashCode() { return _j9Flags.testAny(SupportsInlineVectorizedHashCode); }
+
+   /** \brief
+   *   The code generator supports inlining of jdk/internal/util/ArraysSupport.vectorizedHashCode
+   */
+   void setSupportsInlineVectorizedHashCode() { _j9Flags.set(SupportsInlineVectorizedHashCode); }
+
    /**
     * \brief
     *    The number of nodes between a monext and the next monent before
@@ -666,6 +676,7 @@ private:
       SupportsInlineEncodeASCII                           = 0x00000400,
       SavesNonVolatileGPRsForGC                           = 0x00000800,
       SupportsInlineVectorizedMismatch                    = 0x00001000,
+      SupportsInlineVectorizedHashCode                    = 0x00002000,
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -461,6 +461,7 @@
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,
    jdk_internal_util_ArraysSupport_vectorizedMismatch,
+   jdk_internal_util_ArraysSupport_vectorizedHashCode,
    jdk_internal_util_Preconditions_checkIndex,
 
    FirstVectorMethod,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4017,6 +4017,7 @@ void TR_ResolvedJ9Method::construct()
    static X ArraysSupportMethods [] =
       {
       {x(TR::jdk_internal_util_ArraysSupport_vectorizedMismatch, "vectorizedMismatch", "(Ljava/lang/Object;JLjava/lang/Object;JII)I")},
+      {x(TR::jdk_internal_util_ArraysSupport_vectorizedHashCode, "vectorizedHashCode", "(Ljava/lang/Object;IIII)I")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4870,6 +4870,14 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             return true;
             }
          break;
+      case TR::jdk_internal_util_ArraysSupport_vectorizedHashCode:
+         {
+         if (comp->cg()->getSupportsInlineVectorizedHashCode())
+            {
+            return true;
+            }
+         break;
+         }
       case TR::java_lang_StringLatin1_inflate:
          if (comp->cg()->getSupportsInlineStringLatin1Inflate())
             {

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -136,6 +136,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     * parameter passed to it.
     */
    static TR::Register *inlineStringHashCode(TR::Node *node, TR::CodeGenerator *cg, bool isCompressed);
+   static TR::Register *inlineVectorizedHashCode(TR::Node* node, TR::CodeGenerator* cg);
    static TR::Register *inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* inlineUTF16BEEncode    (TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineCRC32CUpdateBytes(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer);
@@ -345,7 +346,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
    static bool isZonedOperationAnEffectiveNop(TR::Node * node, int32_t shiftAmount, bool isTruncation, TR_PseudoRegister *srcReg, bool isSetSign, int32_t sign,TR::CodeGenerator * cg);
 
-   
+
    static TR::Register *BCDCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *BCDCHKEvaluatorImpl(TR::Node * node,
                                             TR::CodeGenerator * cg,
@@ -412,9 +413,9 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    /** \brief
     *     Helper to generate a VPSOP instruction.
     *
-    *  \param node 
+    *  \param node
     *     The node to which the instruction is associated.
-    *  \param cg 
+    *  \param cg
     *     The codegen object.
     *  \param setPrecision
     *     Determines whether the VPSOP instruction will set precision.
@@ -430,7 +431,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     *     Validate the input digits
     *  \param sign
     *     The new sign. Used if signOpType is SignOperationType::setSign. Possible values include:
-    *       - positive: 0xA, 0xC 
+    *       - positive: 0xA, 0xC
     *       - negative: 0xB, 0xD
     *       - unsigned: 0xF
     *  \param setConditionCode
@@ -496,13 +497,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
 /** \brief
     *  Generates Sequence to check and use Guarded Load for ArrayCopy
-    *  
+    *
     * \param node
     *     The arraycopy node.
     *
     *  \param cg
     *     The code generator used to generate the instructions.
-    * 
+    *
     *  \param byteSrcReg
     *     Register holding starting address of source
     *
@@ -511,16 +512,16 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     *
     *  \param byteLenReg
     *     Register holding number of bytes to copy
-    * 
+    *
     *  \param mergeLabel
     *     Label Symbol to merge from generated OOL sequence
-    * 
+    *
     *  \param srm
     *     Scratch Register Manager providing pool of scratch registers to use
-    * 
+    *
     *  \param isForward
     *     Boolean specifying if we need to copy elements in forward direction
-    * 
+    *
     */
    static void         genGuardedLoadOOL(TR::Node *node, TR::CodeGenerator *cg, TR::Register *byteSrcReg, TR::Register *byteDstReg, TR::Register *byteLenReg, TR::LabelSymbol *mergeLabel, TR_S390ScratchRegisterManager *srm, bool isForward);
    static void         genArrayCopyWithArrayStoreCHK(TR::Node *node, TR::Register *srcObjReg, TR::Register *dstObjReg, TR::Register *srcAddrReg, TR::Register *dstAddrReg, TR::Register *lengthReg, TR::CodeGenerator *cg);
@@ -535,14 +536,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    /*
     * Generate instructions for static/instance field access report.
     * @param dataSnippetRegister: Optional, can be used to pass the address of the snippet inside the register.
-    */ 
+    */
    static void generateTestAndReportFieldWatchInstructions(TR::CodeGenerator *cg, TR::Node *node, TR::Snippet *dataSnippet, bool isWrite, TR::Register *sideEffectRegister, TR::Register *valueReg, TR::Register *dataSnippetRegister);
 
 
    /*
     * Generate instructions to fill in the J9JITWatchedStaticFieldData.fieldAddress, J9JITWatchedStaticFieldData.fieldClass for static fields,
     * and J9JITWatchedInstanceFieldData.offset for instance fields at runtime. Used for fieldwatch support.
-    * @param dataSnippetRegister: Optional, can be used to pass the address of the snippet inside the register.  
+    * @param dataSnippetRegister: Optional, can be used to pass the address of the snippet inside the register.
     */
    static void generateFillInDataBlockSequenceForUnresolvedField (TR::CodeGenerator *cg, TR::Node *node, TR::Snippet *dataSnippet, bool isWrite, TR::Register *sideEffectRegister, TR::Register *dataSnippetRegister);
    static TR::Register *irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
`ArraysSupport.vectorizedHashCode` [1] is an intrinsic candidate introduced in JDK21. The hash function used is the same as the one used for hashing Strings, so this change leverages that by recognizing `ArraysSupport.vectorizedHashCode` and using the preexisting accelerated implementation of `String.hashCode`.

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk21/blob/openj9/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java#L200