### PR TITLE
Fix compile errors with JIT server disabled

### DIFF
--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -27,6 +27,7 @@
 #include "control/CompilationController.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationStrategy.hpp"
+#include "control/CompilationThread.hpp"
 #include "control/CompileBeforeCheckpoint.hpp"
 #include "control/Options.hpp"
 #include "control/OptionsPostRestore.hpp"
@@ -41,6 +42,7 @@
 #include "infra/CriticalSection.hpp"
 #include "infra/Monitor.hpp"
 #include "runtime/CRRuntime.hpp"
+#include "runtime/IProfiler.hpp"
 #include "runtime/J9VMAccess.hpp"
 
 #if defined(J9VM_OPT_JITSERVER)


### PR DESCRIPTION
Add required includes to avoid uses of incomplete types `TR::CompilationInfoPerThread` and `TR_IProfiler`.