### PR TITLE
Update struct support in embedded libffi

### DIFF
--- a/runtime/libffi/z/ffi64.c
+++ b/runtime/libffi/z/ffi64.c
@@ -2,9 +2,9 @@
    ffi64.c - Copyright (c) 2000, 2007 Software AG
              Copyright (c) 2008 Red Hat, Inc
              Copyright IBM Corp. 2016
- 
+
    S390 Foreign Function Interface
- 
+
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
    ``Software''), to deal in the Software without restriction, including
@@ -12,10 +12,10 @@
    distribute, sublicense, and/or sell copies of the Software, and to
    permit persons to whom the Software is furnished to do so, subject to
    the following conditions:
- 
+
    The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
- 
+
    THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND, EXPRESS
    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -28,24 +28,24 @@
 /*                          Includes                                  */
 /*                          --------                                  */
 /*====================================================================*/
- 
+
 #include <ffi.h>
 #include <ffi_common.h>
- 
+
 #include <stdlib.h>
 #include <stdio.h>
- 
+
 /*====================== End of Includes =============================*/
- 
+
 /*====================================================================*/
 /*                           Defines                                  */
 /*                           -------                                  */
 /*====================================================================*/
 
-/* Maximum number of GPRs available for argument passing.  */ 
+/* Maximum number of GPRs available for argument passing.  */
 #define MAX_GPRARGS 3
 
-/* Maximum number of FPRs available for argument passing.  */ 
+/* Maximum number of FPRs available for argument passing.  */
 #define MAX_FPRARGS 4
 
 /* Round to multiple of 16.  */
@@ -100,28 +100,28 @@ typedef struct ffi_cel4ro31_control_block {
 } ffi_cel4ro31_control_block;
 
 /*===================== End of Defines ===============================*/
- 
+
 /*====================================================================*/
 /*                          Prototypes                                */
 /*                          ----------                                */
 /*====================================================================*/
- 
+
 /*Making it extern to call this from sysvz.S*/
 #pragma map(ffi_prep_args, "PREPARGS")
 void ffi_prep_args (unsigned char *, extended_cif *);
-void ffi_closure_helper_SYSV (ffi_closure *, unsigned long *, 
+void ffi_closure_helper_SYSV (ffi_closure *, unsigned long *,
 			 unsigned long long *, unsigned long *);
 
 /*====================== End of Prototypes ===========================*/
- 
+
 /*====================================================================*/
 /*                          Externals                                 */
 /*                          ---------                                 */
 /*====================================================================*/
- 
+
 
 #pragma map(ffi_call_SYSV, "FFISYS")
-extern void ffi_call_SYSV(void (*fn)(void), extended_cif *, 
+extern void ffi_call_SYSV(void (*fn)(void), extended_cif *,
 			  unsigned, unsigned *, unsigned, unsigned, unsigned);
 
 extern void ffi_closure_SYSV(void);
@@ -145,7 +145,7 @@ typedef void celqgipb_cwi_func(uint32_t*, ffi_cel4ro31_control_block**, uint32_t
 #define FFI390_CEL4RO31_CEEPCB_3164_MASK 0x4
 
 /*====================== End of Externals ============================*/
- 
+
 /*====================================================================*/
 /*                                                                    */
 /* Name     - ffi_check_struct_type.                                  */
@@ -154,7 +154,7 @@ typedef void celqgipb_cwi_func(uint32_t*, ffi_cel4ro31_control_block**, uint32_t
 /*            general purpose or floating point register.             */
 /*                                                                    */
 /*====================================================================*/
- 
+
 static int
 ffi_check_struct_type (ffi_type *arg)
 {
@@ -162,7 +162,7 @@ ffi_check_struct_type (ffi_type *arg)
 
   /* If the struct has just one element, look at that element
      to find out whether to consider the struct as floating point.  */
-  while (arg->type == FFI_TYPE_STRUCT 
+  while (arg->type == FFI_TYPE_STRUCT
          && arg->elements[0] && !arg->elements[1])
     arg = arg->elements[0];
 
@@ -172,17 +172,17 @@ ffi_check_struct_type (ffi_type *arg)
   {
     case 1:
     case 2:
-      return FFI_TYPE_UINT32; 
+      return FFI_TYPE_UINT32;
     case 4:
       if (arg->type == FFI_TYPE_FLOAT)
        	return FFI_TYPE_FLOAT;
       else
-       	return FFI_TYPE_UINT32; 
+        return FFI_TYPE_UINT32;
     case 8:
       if (arg->type == FFI_TYPE_DOUBLE)
        	return FFI_TYPE_DOUBLE;
       else
-       	return FFI_TYPE_UINT64; 
+        return FFI_TYPE_UINT64;
     default:
       break;
   }
@@ -632,7 +632,7 @@ ffi_call_CEL4RO31(void (*fn)(void), extended_cif *ecif)
 /* has been allocated for the function's arguments.                   */
 /*                                                                    */
 /*====================================================================*/
- 
+
 void
 ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 {
@@ -641,29 +641,29 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 
      ------------------------------------ <- Low Addresses
        Guard Page (4KB)
-     ------------------------------------ 
+     ------------------------------------
        Stack Frame for Called functions
      ------------------------------------ <- Stack Ptr (r4)
        Backchain                            |+2048
      ------------------------------------   |
        Environment                          |
      ------------------------------------   |
-       Entry Point                          |  Savearea 
+       Entry Point                          |  Savearea
      ------------------------------------   |  48 bytes
        Return Address                       |
      ------------------------------------   |
        R8 - R15                             |
      ------------------------------------ <-
        Reserved (8 bytes)                   +2096
-     ------------------------------------ 
+     ------------------------------------
        Debug Area (4 bytes)                 +2104
-     ------------------------------------ 
+     ------------------------------------
        Arg area prefix (4 bytes)            +2108
-     ------------------------------------ 
+     ------------------------------------
        Argument area: Parm1 ... ParmN       +2112
-     ------------------------------------ 
+     ------------------------------------
        Local (automatic storage)
-      Saved FPRs   Saved  ARs   Saved VRs 
+      Saved FPRs   Saved  ARs   Saved VRs
      ------------------------------------ <- High Addresses
   */
 
@@ -677,8 +677,8 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 #endif
   /* If we returning a structure larger than 12bytes,
      we set the first parameter register
-     to the address of where we are returning this structure.  
-   */  
+     to the address of where we are returning this structure.
+   */
 
   if (ecif->cif->flags == FFI_TYPE_STRUCT &&
       (ecif->cif->rtype->size > 12)){
@@ -686,7 +686,7 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 
   }
    /*Now for the arguments.  */
- 
+
   for (type_ptr = ecif->cif->arg_types, i = ecif->cif->nargs;
        i > 0;
        i--, type_ptr++, p_argv++)
@@ -695,18 +695,15 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
       int type = (*type_ptr)->type;
       int size = (*type_ptr)->size;
 
-     /*  Check how a structure type is passed.   */
-      if (type == FFI_TYPE_STRUCT) {
-				memcpy(arg_ptr, (char*)p_argv, (*type_ptr)->size);
-				arg_ptr += (*type_ptr)->size;
-				continue;
-      }
-
      /*  Now handle all primitive int/pointer/float data types.  */
-      switch (type) 
+      switch (type)
 	{
-#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE 
-	  case FFI_TYPE_LONGDOUBLE: 
+	  case FFI_TYPE_STRUCT:
+	    memcpy(arg_ptr, *p_argv, size);
+	    break;
+
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+	  case FFI_TYPE_LONGDOUBLE:
 	    *(long double *) arg_ptr = * (long double *) (*p_argv);
 	    break;
 #endif
@@ -715,15 +712,15 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 	  case FFI_TYPE_COMPLEX:
 	    *(double *) arg_ptr = * (double *) (*p_argv);
 	    break;
-	
+
 	  case FFI_TYPE_FLOAT:
 	    *(float *) arg_ptr = * (float *) (*p_argv);
 	    break;
 
 	  case FFI_TYPE_POINTER:
-	    *(void **) arg_ptr = * (void**) (* p_argv); 
+	    *(void **) arg_ptr = * (void**) (* p_argv);
 	    break;
- 
+
 	  case FFI_TYPE_SINT64:
 	    *(signed long long *) arg_ptr = * (signed long long *) (* p_argv);
 	    break;
@@ -731,37 +728,32 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 	  case FFI_TYPE_UINT64:
 	    *(unsigned long long *) arg_ptr = * (unsigned long long *) (* p_argv);
 	    break;
- 
+
 	  case FFI_TYPE_UINT32:
 	    *(unsigned int *) arg_ptr = * (unsigned int *) (*p_argv);
 	    break;
- 
+
 	  case FFI_TYPE_SINT32:
 	  case FFI_TYPE_INT:
 	    *(signed int *) arg_ptr = * (signed int *) (*p_argv);
 	    break;
- 
+
 	  case FFI_TYPE_UINT16:
 	    *(unsigned short *) arg_ptr = * (unsigned short *) (* p_argv);
-			arg_ptr += 2;
 	    break;
- 
+
 	  case FFI_TYPE_SINT16:
 	    *(signed short *) arg_ptr = * (signed short *) (* p_argv);
-			arg_ptr += 2;
 	    break;
 
 	  case FFI_TYPE_UINT8:
 	    *(unsigned char *) arg_ptr = * (unsigned char *) (* p_argv);
-		arg_ptr += 3;
 	    break;
- 
+
 	  case FFI_TYPE_SINT8:
 	    *(signed char *) arg_ptr = * (signed char*) (* p_argv);
-
-			arg_ptr += 3;
 	    break;
- 
+
 	  default:
 	    FFI_ASSERT (0);
 	    break;
@@ -773,7 +765,7 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 }
 
 /*======================== End of Routine ============================*/
- 
+
 /*====================================================================*/
 /*                                                                    */
 /* Name     - ffi_prep_cif_machdep.                                   */
@@ -781,7 +773,7 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 /* Function - Perform machine dependent CIF processing.               */
 /*                                                                    */
 /*====================================================================*/
- 
+
 ffi_status
 ffi_prep_cif_machdep(ffi_cif *cif)
 {
@@ -800,16 +792,16 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 
   /* 64-bit XPLINK handling below */
 
-  /* Determine return value handling.  
-     Integral values <=4bytes are widened and put in GPR3
-     Integral values >4bytes and <=8bytes are widened and put in
-     GPR2 (left most 32-bits) and GPR3 (right most 32-bits)
-     Floating point values, including complex type, are returned in 
+  /* Determine return value handling.
+     Integral values <=8bytes are widened and put in GPR3
+     Integral values >8bytes and <=16bytes are widened and put in
+     GPR2 (left most 64-bits) and GPR3 (right most 64-bits)
+     Floating point values, including complex type, are returned in
      FPR0, FPR2, FPR4, FPR6 (as many registers as required)
-     Aggregates size of <=4 are returned GPR1 (left adjusted)
-     Aggregates size between 5bytes-8bytes are returned in GPR1 and 
+     Aggregates size of <=8 are returned GPR1 (left adjusted)
+     Aggregates size between 9bytes-16bytes are returned in GPR1 and
      GPR2 (left adjusted)
-     Aggregates size between 9bytes-12bytes are returned in GPR1, GPR2,
+     Aggregates size between 17bytes-24bytes are returned in GPR1, GPR2,
      and GPR3 (left adjusted)
      Anything greater in size and anyother type is returned in a buffer,
      the buffer is passed in as hidden first argument.
@@ -825,13 +817,11 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       /* Structures are returned in GPR or buffer depending on size.  */
       case FFI_TYPE_STRUCT:
 	struct_size = cif->rtype->size;
-	if (struct_size <= 8)
-	  cif->flags = FFI390_RET_INT64;
-	else if (struct_size <= 12)
+        if (struct_size <= 24)
 	  cif->flags = FFI390_RET_STRUCT;
 	else
-	  n_ov = struct_size;
-	break; 
+          n_gpr++;
+	break;
 
       /* Floating point and complex values are returned in fpr0, 2, 4, 6 */
       case FFI_TYPE_FLOAT:
@@ -866,14 +856,14 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 
 
 
- 
+
       default:
         FFI_ASSERT (0);
         break;
     }
 
   /* Now for the arguments.  */
- 
+
   for (ptr = cif->arg_types, i = cif->nargs;
        i > 0;
        i--, ptr++)
@@ -881,7 +871,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       int type = (*ptr)->type;
 
       /* Check how a structure type is passed.  */
-      if (type == FFI_TYPE_STRUCT) 
+      if (type == FFI_TYPE_STRUCT)
 	{
 		type = ffi_check_struct_type (*ptr);
 
@@ -892,18 +882,18 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	}
 
       /* Now handle all primitive int/float data types.  */
-      switch (type) 
+      switch (type)
       {
        	/* The first MAX_FPRARGS floating point arguments
-	     go in FPRs, the rest overflow to the stack.  */ 
-	
+	     go in FPRs, the rest overflow to the stack.  */
+
 	case FFI_TYPE_LONGDOUBLE:
 	  if (n_fpr < MAX_FPRARGS)
 	    n_fpr+=2;
 	  else
 	    n_ov += sizeof(long double) / sizeof(long);
-	  break; 
-	
+	  break;
+
 	case FFI_TYPE_COMPLEX:
        	case FFI_TYPE_DOUBLE:
        	case FFI_TYPE_FLOAT:
@@ -911,13 +901,13 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	    n_fpr++;
 	  else
 	    n_ov += sizeof (double) / sizeof (long);
-	  break; 
-	  
+	  break;
+
 	  /* On 31-bit machines, 64-bit integers are passed in GPR pairs,
 	     if one is still available, or else on the stack.  If only one
-	     register is free, skip the register (it won't be used for any 
-	     subsequent argument either).  */ 
-	
+	     register is free, skip the register (it won't be used for any
+	     subsequent argument either).  */
+
 	case FFI_TYPE_UINT64:
        	case FFI_TYPE_SINT64:
 	  if (n_gpr == MAX_GPRARGS-1)
@@ -926,12 +916,12 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	    n_gpr += 2;
 	  else
 	    n_ov += 2;
-	  break; 
-	  
+	  break;
+
 	  /* Everything else is passed in GPRs (until MAX_GPRARGS
-	     have been used) or overflows to the stack.  */ 
-	
-	default: 
+	     have been used) or overflows to the stack.  */
+
+	default:
 	  if (n_gpr < MAX_GPRARGS)
 	    n_gpr++;
 	  else
@@ -947,12 +937,12 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 
   cif->bytes = ROUND_SIZE ((n_ov * sizeof (long)) + (n_fpr * sizeof (long long)) + (n_gpr * sizeof (long)) ) + struct_size;
 /*  printf("prep_cif_machdep_cif_bytes: %d n_gpr=%d n_ov=%d n_fpr=%d\n",cif->bytes,n_gpr,n_ov,n_fpr); */
- 
+
   return FFI_OK;
 }
- 
+
 /*======================== End of Routine ============================*/
- 
+
 /*====================================================================*/
 /*                                                                    */
 /* Name     - ffi_call.                                               */
@@ -960,7 +950,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 /* Function - Call the FFI routine.                                   */
 /*                                                                    */
 /*====================================================================*/
- 
+
 void
 ffi_call(ffi_cif *cif,
 	 void (*fn)(void),
@@ -969,7 +959,7 @@ ffi_call(ffi_cif *cif,
 {
   int ret_type = cif->flags;
   extended_cif ecif;
- 
+
   ecif.cif    = cif;
   ecif.avalue = avalue;
   ecif.rvalue = rvalue;
@@ -980,14 +970,17 @@ ffi_call(ffi_cif *cif,
   /*    if (ret_type == FFI_TYPE_STRUCT)
 	ecif.rvalue = alloca (cif->rtype->size);
       else
-   */   
+   */
 	ret_type = FFI_TYPE_VOID;
-    } 
+    }
 
   switch (cif->abi)
     {
       case FFI_SYSV:
-        ffi_call_SYSV(fn, &ecif, cif->flags, ecif.rvalue, cif->bytes, cif->nargs, (*cif->arg_types)->size);
+        if (cif->arg_types != NULL)
+          ffi_call_SYSV(fn, &ecif, cif->flags, ecif.rvalue, cif->bytes, cif->nargs, (*cif->arg_types)->size);
+        else
+          ffi_call_SYSV(fn, &ecif, cif->flags, ecif.rvalue, cif->bytes, cif->nargs, 0);
 #ifdef FFI_DEBUG
 	printf("called_ffi_call_sysv nargs=%d\n",cif->nargs);
 #endif
@@ -1000,7 +993,7 @@ ffi_call(ffi_cif *cif,
         break;
     }
 }
- 
+
 /*======================== End of Routine ============================*/
 
 /*====================================================================*/
@@ -1010,7 +1003,7 @@ ffi_call(ffi_cif *cif,
 /* Function - Call a FFI closure target function.                     */
 /*                                                                    */
 /*====================================================================*/
- 
+
 void
 ffi_closure_helper_SYSV (ffi_closure *closure,
 			 unsigned long *p_gpr,
@@ -1034,8 +1027,8 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 
   p_arg = avalue = alloca (closure->cif->nargs * sizeof (void *));
 
-  /* If we returning a structure, pass the structure address 
-     directly to the target function.  Otherwise, have the target 
+  /* If we returning a structure, pass the structure address
+     directly to the target function.  Otherwise, have the target
      function store the return value to the GPR save area.  */
 
   if (closure->cif->flags == FFI_TYPE_STRUCT)
@@ -1064,7 +1057,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 	  else
 	    type = ffi_check_struct_type (*ptr);
 
-	  /* If we pass the struct via pointer, remember to 
+	  /* If we pass the struct via pointer, remember to
 	     retrieve the pointer later.  */
 	  if (type == FFI_TYPE_POINTER)
 	    deref_struct_pointer = 1;
@@ -1079,23 +1072,23 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 #endif
 
       /* Now handle all primitive int/float data types.  */
-      switch (type) 
+      switch (type)
 	{
 	  case FFI_TYPE_DOUBLE:
 	    if (n_fpr < MAX_FPRARGS)
 	      *p_arg = &p_fpr[n_fpr++];
 	    else
-	      *p_arg = &p_ov[n_ov], 
+	      *p_arg = &p_ov[n_ov],
 	      n_ov += sizeof (double) / sizeof (long);
 	    break;
-	
+
 	  case FFI_TYPE_FLOAT:
 	    if (n_fpr < MAX_FPRARGS)
 	      *p_arg = &p_fpr[n_fpr++];
 	    else
 	      *p_arg = (char *)&p_ov[n_ov++] + sizeof (long) - 4;
 	    break;
- 
+
 	  case FFI_TYPE_UINT64:
 	  case FFI_TYPE_SINT64:
 #ifdef __s390x__
@@ -1112,7 +1105,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 	      *p_arg = &p_ov[n_ov], n_ov += 2;
 #endif
 	    break;
- 
+
 	  case FFI_TYPE_INT:
 	  case FFI_TYPE_UINT32:
 	  case FFI_TYPE_SINT32:
@@ -1121,7 +1114,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 	    else
 	      *p_arg = (char *)&p_ov[n_ov++] + sizeof (long) - 4;
 	    break;
- 
+
 	  case FFI_TYPE_UINT16:
 	  case FFI_TYPE_SINT16:
 	    if (n_gpr < MAX_GPRARGS)
@@ -1137,7 +1130,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 	    else
 	      *p_arg = (char *)&p_ov[n_ov++] + sizeof (long) - 1;
 	    break;
- 
+
 	  default:
 	    FFI_ASSERT (0);
 	    break;
@@ -1205,7 +1198,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
         break;
     }
 }
- 
+
 /*======================== End of Routine ============================*/
 
 /*====================================================================*/
@@ -1215,7 +1208,7 @@ ffi_closure_helper_SYSV (ffi_closure *closure,
 /* Function - Prepare a FFI closure.                                  */
 /*                                                                    */
 /*====================================================================*/
- 
+
 ffi_status
 ffi_prep_closure_loc (ffi_closure *closure,
 		      ffi_cif *cif,
@@ -1241,14 +1234,14 @@ ffi_prep_closure_loc (ffi_closure *closure,
   *(short *)&closure->tramp [8] = 0x07f1;   /* br %r1 */
   *(long  *)&closure->tramp[16] = (long)codeloc;
   *(long  *)&closure->tramp[24] = (long)&ffi_closure_SYSV;
-#endif 
- 
+#endif
+
   closure->cif = cif;
   closure->user_data = user_data;
   closure->fun = fun;
- 
+
   return FFI_OK;
 }
 
 /*======================== End of Routine ============================*/
- 
+


### PR DESCRIPTION
Adds support for passing struct type arguments and receiving struct type returns in libffi
    - Struct arguments are now properly loaded into registers and the argument area in sys64z.s
    - Struct returns are now appropriately handled in sys64z.s
    - Doesn't pad argument buffer in ffi_prep_args to save space.

    Signed-off-by: Austin Wells <austin.wells@mail.utoronto.ca>