### PR TITLE
AArch64: Remove obsolete JIT helper entries for arraycopy

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -611,14 +611,6 @@ JIT_HELPER(_nativeStaticHelper);
 JIT_HELPER(__arrayCopy);
 JIT_HELPER(__forwardArrayCopy);
 JIT_HELPER(__backwardArrayCopy);
-JIT_HELPER(__fwHalfWordArrayCopy);
-JIT_HELPER(__fwWordArrayCopy);
-JIT_HELPER(__fwDoubleWordArrayCopy);
-JIT_HELPER(__fwQuadWordArrayCopy);
-JIT_HELPER(__bwHalfWordArrayCopy);
-JIT_HELPER(__bwWordArrayCopy);
-JIT_HELPER(__bwDoubleWordArrayCopy);
-JIT_HELPER(__bwQuadWordArrayCopy);
 JIT_HELPER(_patchGCRHelper);
 JIT_HELPER(_fieldWatchHelper);
 
@@ -1616,14 +1608,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARM64arrayCopy,                         (void *) __arrayCopy,                      TR_Helper);
    SET(TR_ARM64forwardArrayCopy,                  (void *) __forwardArrayCopy,               TR_Helper);
    SET(TR_ARM64backwardArrayCopy,                 (void *) __backwardArrayCopy,              TR_Helper);
-   SET(TR_ARM64forwardQuadWordArrayCopy,          (void *) __fwQuadWordArrayCopy,            TR_Helper);
-   SET(TR_ARM64forwardDoubleWordArrayCopy,        (void *) __fwDoubleWordArrayCopy,          TR_Helper);
-   SET(TR_ARM64forwardWordArrayCopy,              (void *) __fwWordArrayCopy,                TR_Helper);
-   SET(TR_ARM64forwardHalfWordArrayCopy,          (void *) __fwHalfWordArrayCopy,            TR_Helper);
-   SET(TR_ARM64backwardQuadWordArrayCopy,         (void *) __bwQuadWordArrayCopy,            TR_Helper);
-   SET(TR_ARM64backwardDoubleWordArrayCopy,       (void *) __bwDoubleWordArrayCopy,          TR_Helper);
-   SET(TR_ARM64backwardWordArrayCopy,             (void *) __bwWordArrayCopy,                TR_Helper);
-   SET(TR_ARM64backwardHalfWordArrayCopy,         (void *) __bwHalfWordArrayCopy,            TR_Helper);
    SET(TR_ARM64PatchGCRHelper,                    (void *) _patchGCRHelper,                  TR_Helper);
 #if defined(OSX)
    SET(TR_ARM64fieldWatchHelper,                  (void *) _fieldWatchHelper,                TR_Helper);


### PR DESCRIPTION
This commit removes obsolete JIT helper entries for arraycopy.