### PR TITLE
Use non zero tlh for int and long to string

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -707,6 +707,8 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    //TR::java_lang_String_toUpperCaseCore,
    TR::java_lang_String_split_str_int,
    TR::java_math_BigDecimal_toString,
+   TR::java_lang_Integer_toString,
+   TR::java_lang_Long_toString,
    TR::java_lang_StringCoding_encode,
    TR::java_lang_StringCoding_decode,
    TR::java_lang_StringCoding_StringEncoder_encode,


### PR DESCRIPTION
Converting numbers to string does nor require zero memory allocation as it overwrite the whole memory. The Integer.toString is an intrinsic candidate which makes it safer to do this optimization. We inline the "getChars" method for both Integer and Long classes [here](https://github.com/eclipse-openj9/openj9/blob/0db560ffdcfc6bad37f6382fddf50fdb3f22b788/runtime/compiler/z/codegen/J9CodeGenerator.cpp#L3956) which does the to string conversion!
I looked into some real world applications and this change does not have a significant impact on nonZeroTLH utilization but since it is easy enough, I decided to raise this PR.
@r30shah Please let me know if this change looks okay to you.