### PR TITLE
Methods to access class depth and flags

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1311,14 +1311,20 @@ J9::SymbolReferenceTable::findOrCreateClassFlagsSymbolRef()
 TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateClassAndDepthFlagsSymbolRef()
    {
-   if (!element(isClassAndDepthFlagsSymbol))
+   return self()->findOrCreateClassDepthAndFlagsSymbolRef();
+   }
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateClassDepthAndFlagsSymbolRef()
+   {
+   if (!element(isClassDepthAndFlagsSymbol))
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
       TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Int32);
-      element(isClassAndDepthFlagsSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), isClassAndDepthFlagsSymbol, sym);
-      element(isClassAndDepthFlagsSymbol)->setOffset(fej9->getOffsetOfClassAndDepthFlags());
+      element(isClassDepthAndFlagsSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), isClassDepthAndFlagsSymbol, sym);
+      element(isClassDepthAndFlagsSymbol)->setOffset(fej9->getOffsetOfClassDepthAndFlags());
       }
-   return element(isClassAndDepthFlagsSymbol);
+   return element(isClassDepthAndFlagsSymbol);
    }
 
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -244,6 +244,7 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateDescriptionWordFromPtrSymbolRef();
    TR::SymbolReference * findOrCreateClassFlagsSymbolRef();
    TR::SymbolReference * findOrCreateClassAndDepthFlagsSymbolRef();
+   TR::SymbolReference * findOrCreateClassDepthAndFlagsSymbolRef();
    TR::SymbolReference * findOrCreateArrayComponentTypeAsPrimitiveSymbolRef();
    TR::SymbolReference * findOrCreateMethodTypeCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateIncompatibleReceiverSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1603,7 +1603,7 @@ UDATA TR_J9VMBase::getOffsetOfClassFromJavaLangClassField()
 
 UDATA TR_J9VMBase::getOffsetOfRamStaticsFromClassField()            {return offsetof(J9Class, ramStatics);}
 UDATA TR_J9VMBase::getOffsetOfIsArrayFieldFromRomClass()            {return offsetof(J9ROMClass, modifiers);}
-UDATA TR_J9VMBase::getOffsetOfClassAndDepthFlags()                  {return offsetof(J9Class, classDepthAndFlags);}
+UDATA TR_J9VMBase::getOffsetOfClassDepthAndFlags()                  {return offsetof(J9Class, classDepthAndFlags);}
 UDATA TR_J9VMBase::getOffsetOfClassFlags()                          {return offsetof(J9Class, classFlags);}
 UDATA TR_J9VMBase::getOffsetOfArrayComponentTypeField()             {return offsetof(J9ArrayClass, componentType);}
 UDATA TR_J9VMBase::constReleaseVMAccessOutOfLineMask()              {return J9_PUBLIC_FLAGS_VMACCESS_RELEASE_BITS;}
@@ -7408,7 +7408,7 @@ TR_J9VM::transformJavaLangClassIsArray(TR::Compilation * comp, TR::Node * callNo
    // treetop
    //   iushr
    //    iand
-   //     iloadi <classAndDepthFlags>
+   //     iloadi <ClassDepthAndFlags>
    //       aloadi <classFromJavaLangClass>
    //        aload <parm 1>         <= jlClass
    //    iconst J9AccClassArray
@@ -7437,11 +7437,11 @@ TR_J9VM::transformJavaLangClassIsArray(TR::Compilation * comp, TR::Node * callNo
 
    if (comp->target().is32Bit())
       {
-      classFlag = TR::Node::createWithSymRef(callNode, TR::iloadi, 1, vftLoad, symRefTab->findOrCreateClassAndDepthFlagsSymbolRef());
+      classFlag = TR::Node::createWithSymRef(callNode, TR::iloadi, 1, vftLoad, symRefTab->findOrCreateClassDepthAndFlagsSymbolRef());
       }
    else
       {
-      classFlag = TR::Node::createWithSymRef(callNode, TR::lloadi, 1, vftLoad, symRefTab->findOrCreateClassAndDepthFlagsSymbolRef());
+      classFlag = TR::Node::createWithSymRef(callNode, TR::lloadi, 1, vftLoad, symRefTab->findOrCreateClassDepthAndFlagsSymbolRef());
       classFlag = TR::Node::create(callNode, TR::l2i, 1, classFlag);
       }
 
@@ -8317,13 +8317,13 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
          case TR::com_ibm_jit_JITHelpers_getClassDepthAndFlagsFromJ9Class32:
             {
             loadOp = TR::iloadi;
-            newSymRef = comp->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef();
+            newSymRef = comp->getSymRefTab()->findOrCreateClassDepthAndFlagsSymbolRef();
             break;
             }
          case TR::com_ibm_jit_JITHelpers_getClassDepthAndFlagsFromJ9Class64:
             {
             loadOp = TR::lloadi;
-            newSymRef = comp->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef();
+            newSymRef = comp->getSymRefTab()->findOrCreateClassDepthAndFlagsSymbolRef();
             break;
             }
          case TR::com_ibm_jit_JITHelpers_getComponentTypeFromJ9Class32:

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2902,13 +2902,56 @@ TR_J9VMBase::testIsClassIdentityType(TR::Node *j9ClassRefNode)
    }
 
 TR::Node *
+TR_J9VMBase::loadClassDepthAndFlags(TR::Node *j9ClassRefNode)
+   {
+   TR::SymbolReference *classDepthAndFlagsSymRef = TR::comp()->getSymRefTab()->findOrCreateClassDepthAndFlagsSymbolRef();
+
+   TR::Node *classFlagsNode = NULL;
+
+   if (TR::comp()->target().is32Bit())
+      {
+      classFlagsNode = TR::Node::createWithSymRef(TR::iloadi, 1, 1, j9ClassRefNode, classDepthAndFlagsSymRef);
+      }
+   else
+      {
+      classFlagsNode = TR::Node::createWithSymRef(TR::lloadi, 1, 1, j9ClassRefNode, classDepthAndFlagsSymRef);
+      classFlagsNode = TR::Node::create(TR::l2i, 1, classFlagsNode);
+      }
+
+   return classFlagsNode;
+   }
+
+TR::Node *
+TR_J9VMBase::testAreSomeClassDepthAndFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest)
+   {
+   TR::Node *classFlags = loadClassDepthAndFlags(j9ClassRefNode);
+   TR::Node *maskedFlags = TR::Node::create(TR::iand, 2, classFlags, TR::Node::iconst(j9ClassRefNode, flagsToTest));
+
+   return maskedFlags;
+   }
+
+TR::Node *
+TR_J9VMBase::testIsClassArrayType(TR::Node *j9ClassRefNode)
+   {
+   return testAreSomeClassDepthAndFlagsSet(j9ClassRefNode, getFlagValueForArrayCheck());
+   }
+
+TR::Node *
+TR_J9VMBase::loadArrayClassComponentType(TR::Node *j9ClassRefNode)
+   {
+   TR::SymbolReference *arrayCompSymRef = TR::comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef();
+   TR::Node *arrayCompClass = TR::Node::createWithSymRef(TR::aloadi, 1, 1, j9ClassRefNode, arrayCompSymRef);
+
+   return arrayCompClass;
+   }
+
+TR::Node *
 TR_J9VMBase::checkSomeArrayCompClassFlags(TR::Node *arrayBaseAddressNode, TR::ILOpCodes ifCmpOp, uint32_t flagsToTest)
    {
    TR::SymbolReference *vftSymRef = TR::comp()->getSymRefTab()->findOrCreateVftSymbolRef();
-   TR::SymbolReference *arrayCompSymRef = TR::comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef();
-
    TR::Node *vft = TR::Node::createWithSymRef(TR::aloadi, 1, 1, arrayBaseAddressNode, vftSymRef);
-   TR::Node *arrayCompClass = TR::Node::createWithSymRef(TR::aloadi, 1, 1, vft, arrayCompSymRef);
+
+   TR::Node *arrayCompClass = loadArrayClassComponentType(vft);
    TR::Node *maskedFlagsNode = testAreSomeClassFlagsSet(arrayCompClass, flagsToTest);
    TR::Node *ifNode = TR::Node::createif(ifCmpOp, maskedFlagsNode, TR::Node::iconst(arrayBaseAddressNode, 0));
 
@@ -7414,8 +7457,8 @@ TR_J9VM::transformJavaLangClassIsArray(TR::Compilation * comp, TR::Node * callNo
    //    iconst J9AccClassArray
    //   iconst shiftAmount
 
-   int andMask = comp->fej9()->getFlagValueForArrayCheck();
-   TR::Node * classFlag, *jlClass, * andConstNode;
+   int flagMask = comp->fej9()->getFlagValueForArrayCheck();
+   TR::Node * classFlagNode, *jlClass;
    TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
 
    jlClass = callNode->getFirstChild();
@@ -7435,26 +7478,16 @@ TR_J9VM::transformJavaLangClassIsArray(TR::Compilation * comp, TR::Node * callNo
 
    TR::Node * vftLoad = TR::Node::createWithSymRef(callNode, TR::aloadi, 1, jlClass, comp->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef());
 
-   if (comp->target().is32Bit())
-      {
-      classFlag = TR::Node::createWithSymRef(callNode, TR::iloadi, 1, vftLoad, symRefTab->findOrCreateClassDepthAndFlagsSymbolRef());
-      }
-   else
-      {
-      classFlag = TR::Node::createWithSymRef(callNode, TR::lloadi, 1, vftLoad, symRefTab->findOrCreateClassDepthAndFlagsSymbolRef());
-      classFlag = TR::Node::create(callNode, TR::l2i, 1, classFlag);
-      }
+   classFlagNode = testIsClassArrayType(vftLoad);
 
    // Decrement the ref count of jlClass since the call is going to be transmuted and its first child is not needed anymore
    callNode->getAndDecChild(0);
    TR::Node::recreate(callNode, TR::iushr);
    callNode->setNumChildren(2);
 
-   andConstNode = TR::Node::create(callNode, TR::iconst, 0, andMask);
-   TR::Node * andNode   = TR::Node::create(TR::iand, 2, classFlag, andConstNode);
-   callNode->setAndIncChild(0, andNode);
+   callNode->setAndIncChild(0, classFlagNode);
 
-   int32_t shiftAmount = trailingZeroes(andMask);
+   int32_t shiftAmount = trailingZeroes(flagMask);
    callNode->setAndIncChild(1, TR::Node::iconst(callNode, shiftAmount));
    }
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -686,7 +686,7 @@ public:
    virtual uintptr_t         getConstantPoolFromClass(TR_OpaqueClassBlock *);
 
    virtual uintptr_t         getOffsetOfIsArrayFieldFromRomClass();
-   virtual uintptr_t         getOffsetOfClassAndDepthFlags();
+   virtual uintptr_t         getOffsetOfClassDepthAndFlags();
    virtual uintptr_t         getOffsetOfClassFlags();
    virtual uintptr_t         getOffsetOfArrayComponentTypeField();
    virtual uintptr_t         getOffsetOfIndexableSizeField();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1291,6 +1291,44 @@ public:
    TR::Node * testIsClassIdentityType(TR::Node *j9ClassRefNode);
 
    /**
+    * \brief Generate IL to load the value of the \c componentType field of the specified
+    *        \ref J9ArrayClass.  The class must be a \ref J9ArrayClass or garbage will be loaded.
+    *        IL might load this field unconditionally, but must only dereference the loaded value
+    *        if the class actually is an array class.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return A \ref TR::Node that loads the value of the \c componentType field
+    */
+   TR::Node * loadArrayClassComponentType(TR::Node *j9ClassRefNode);
+
+   /**
+    * \brief Generate IL to load the value of the \c classDepthAndFlags field of the
+    *        specified \ref J9Class.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return A \ref TR::Node that loads the value of the \c classDepthAndFlags field
+    */
+   TR::Node * loadClassDepthAndFlags(TR::Node *j9ClassRefNode);
+
+   /**
+    * \brief Generate IL to load the \c classDepthAndFlags field of the specified
+    *        \ref J9Class, and apply the mask specified by \c flagsToTest.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \param flagsToTest Flags to use as a mask for the \ref classAndFlags field
+    * \return A \ref TR::Node that produces the result of loading \c classDepthAndFlags
+    *         and applying the \c flagsToTest mask to it.
+    */
+   TR::Node * testAreSomeClassDepthAndFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
+
+   /**
+    * \brief Generate IL to test whether the specified \ref J9Class is an array class.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return A \ref TR::Node that will evaluate to zero if the specified \ref J9Class
+    *         is not an array class, or the value of
+    *         \c TR::Compiler->cls.flagValueForArrayCheck (which is non-zero) if it is
+    *         an array class.
+    */
+   TR::Node * testIsClassArrayType(TR::Node *j9ClassRefNode);
+
+   /**
     * \brief Test whether any of the specified flags is set on the array's component class
     * \param arrayBaseAddressNode A node representing a reference to the array base address
     * \param ifCmpOp If comparison opCode such as ificmpeq or ificmpne

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2157,7 +2157,7 @@ TR_J9ByteCodeIlGenerator::inlineJitCheckIfFinalizeObject(TR::Block *firstBlock)
 
             TR::Node *classDepthAndFlagsNode = TR::Node::createWithSymRef(loadOp, 1, 1,
                                               vftLoad,
-                                              comp()->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
+                                              comp()->getSymRefTab()->findOrCreateClassDepthAndFlagsSymbolRef());
             TR::Node *andConstNode = TR::Node::create(classDepthAndFlagsNode, is64bit ? TR::lconst : TR::iconst, 0);
             if (is64bit)
                andConstNode->setLongInt(fej9()->getFlagValueForFinalizerCheck());

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4606,20 +4606,12 @@ break
       TR::Node* obj = callNode->getChild(1);
       TR::Node* vftLoad = TR::Node::createWithSymRef(callNode, TR::aloadi, 1, obj, symRefTab()->findOrCreateVftSymbolRef());
 
-      if (comp()->target().is32Bit())
-         {
-         resultNode = TR::Node::createWithSymRef(callNode, TR::iloadi, 1, vftLoad, symRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
-         }
-      else
-         {
-         resultNode = TR::Node::createWithSymRef(callNode, TR::lloadi, 1, vftLoad, symRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
-         resultNode = TR::Node::create(callNode, TR::l2i, 1, resultNode);
-         }
-
       int32_t andMask = comp()->fej9()->getFlagValueForArrayCheck();
+      resultNode = comp()->fej9()->testIsClassArrayType(vftLoad);
+
       int32_t shiftAmount = trailingZeroes(andMask);
-      resultNode  = TR::Node::create(callNode, TR::iand, 2, resultNode, TR::Node::iconst(callNode, andMask));
       resultNode  = TR::Node::create(callNode, TR::iushr, 2, resultNode, TR::Node::iconst(callNode, shiftAmount));
+
       // Handle NullCHK
       if (callNodeTreeTop->getNode()->getOpCode().isNullCheck())
          TR::Node::recreate(callNodeTreeTop->getNode(), TR::treetop);

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -4179,7 +4179,7 @@ static bool isFinalizableInlineTest(TR::Compilation *comp, TR::Node *candidate, 
 
       if[i/l]cmpne                                      <root>
          [i/l]and                                       <r1>
-            [i/l]loadi <classAndDepthFlags>             <r11/loadNode>
+            [i/l]loadi <classDepthAndFlags>             <r11/loadNode>
                aloadi <vft-symbol>                      <vftLoad>
                   ...                                   <ref>
             [i/l]const <FlagValueForFinalizerCheck>     <r12>
@@ -4190,7 +4190,7 @@ static bool isFinalizableInlineTest(TR::Compilation *comp, TR::Node *candidate, 
       ificmpne                                          <root>
          iand                                           <r1>
             l2i                                         <r11>
-               lloadi <classAndDepthFlags>              <loadNode>
+               lloadi <classDepthAndFlags>              <loadNode>
                   aloadi <vft-symbol>                   <vftLoad>
                      ...                                <ref>
             iconst <FlagValueForFinalizerCheck>         <r12>

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -940,19 +940,9 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
    // If we need conversion or java/lang/Class is not loaded yet, we generate old sequence of tests
    if (conversionNeeded || javaLangClass == NULL)
       {
-      TR::Node *isArrayField = NULL;
-      if (comp()->target().is32Bit())
-         {
-         isArrayField = TR::Node::createWithSymRef(TR::iloadi, 1, 1, vftLoad, comp()->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
-         }
-      else
-         {
-         isArrayField = TR::Node::createWithSymRef(TR::lloadi, 1, 1, vftLoad, comp()->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
-         isArrayField = TR::Node::create(TR::l2i, 1, isArrayField);
-         }
-      TR::Node *andConstNode = TR::Node::create(isArrayField, TR::iconst, 0, TR::Compiler->cls.flagValueForArrayCheck(comp()));
-      TR::Node * andNode   = TR::Node::create(TR::iand, 2, isArrayField, andConstNode);
-      TR::Node *isArrayNode = TR::Node::createif(TR::ificmpeq, andNode, andConstNode, NULL);
+      TR::Node *testIsArrayFlag = comp()->fej9()->testIsClassArrayType(vftLoad);
+      TR::Node *flagConstNode = TR::Node::create(testIsArrayFlag, TR::iconst, 0, TR::Compiler->cls.flagValueForArrayCheck(comp()));
+      TR::Node *isArrayNode = TR::Node::createif(TR::ificmpeq, testIsArrayFlag, flagConstNode, NULL);
       isArrayTreeTop = TR::TreeTop::create(comp(), isArrayNode, NULL, NULL);
       isArrayBlock = TR::Block::createEmptyBlock(vftLoad, comp(), indirectAccessBlock->getFrequency());
       isArrayBlock->append(isArrayTreeTop);


### PR DESCRIPTION
There are several places in the JIT compiler that generate IL to access the `classDepthAndFlags` field of `j9class`.  This introduces methods in `TR_J9VMBase` to do that, as has previously been done with some methods that generate IL to access the `classFlags` field.

This change also deals with some typos in methods that refer to `classDepthAndFlags` incorrectly as `classAndDepthFlags`.  One instance, `J9::SymbolReferenceTable::findOrCreateClassAndDepthFlagsSymbolRef`, will remain while it's still in use upstream in `J9_PROJECT_SPECIFIC` code in OMR.

Depends on OMR pull request eclipse/omr#7330