### PR TITLE
Eliminate VM_isClassLibraryClass messages for JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -269,12 +269,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             }
          }
          break;
-      case MessageType::VM_isClassLibraryClass:
-         {
-         bool rv = fe->isClassLibraryClass(std::get<0>(client->getRecvData<TR_OpaqueClassBlock*>()));
-         client->write(response, rv);
-         }
-         break;
       case MessageType::VM_isClassLibraryMethod:
          {
          auto tup = client->getRecvData<TR_OpaqueMethodBlock*, bool>();

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 61; // ID: 2WUGRj9RjAt4xrMCntc/
+   static const uint16_t MINOR_NUMBER = 62; // ID: TNff0n0QdLOhsH6CmQlT/
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -94,7 +94,6 @@ const char *messageNames[] =
    "ResolvedRelocatableMethod_fieldAttributes",
    "ResolvedRelocatableMethod_staticAttributes",
    "ResolvedRelocatableMethod_getFieldType",
-   "VM_isClassLibraryClass",
    "VM_isClassLibraryMethod",
    "VM_isClassArray",
    "VM_transformJlrMethodInvoke",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -103,7 +103,6 @@ enum MessageType : uint16_t
    ResolvedRelocatableMethod_getFieldType,
 
    // For TR_J9ServerVM methods
-   VM_isClassLibraryClass,
    VM_isClassLibraryMethod,
    VM_isClassArray,
    VM_transformJlrMethodInvoke,


### PR DESCRIPTION
After work to improve constant field folding, the number of VM_isClassLibraryClass messages increased a lot affecting the CPU overhead of the client.
This commit reimplements the `TR_J9ServerVM::isClassLibraryClass()` frontend query taking advantage of the caches maintained by JITServer and eliminating said messages completely.