### PR TITLE
Pass NULL as threadObject to walkContinuationStackFrames in GC

### DIFF
--- a/runtime/gc_structs/VMThreadStackSlotIterator.cpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.cpp
@@ -148,8 +148,8 @@ GC_VMThreadStackSlotIterator::scanContinuationSlots(
 
 #if JAVA_SPEC_VERSION >= 19
 	J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(vmThread, continuationObjectPtr);
-	j9object_t threadObject = VM_ContinuationHelpers::getThreadObjectForContinuation(vmThread, continuation, continuationObjectPtr);
-	vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuation, threadObject, &stackWalkState);
+	/* pass NULL as threadObject to avoid to retrieve threadObject via const pool api, since we don't need it for this case */
+	vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuation, NULL, &stackWalkState);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 }
 


### PR DESCRIPTION
GC Thread scanContinuationNativeSlots via walkContinuationStackFrames(), new threadObject parameter is required for calling walkContinuationStackFrames, retrieving the virtual thread Object during GC might trigger a read barrier in concurrent scavenger mode, because threadObject is not neccessary for GC case, so pass NULL as threadObject for call function walkContinuationStackFrames() to aviod the potential assertion.

fix: https://github.com/eclipse-openj9/openj9/issues/19486

Signed-off-by: hulin <linhu@ca.ibm.com>