### PR TITLE
JDK23 adds JavaLangAccess.initialSystemErr()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -46,6 +46,9 @@ import com.ibm.oti.reflect.TypeAnnotationParser;
 import java.io.InputStream;
 /*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 import java.io.IOException;
+/*[IF JAVA_SPEC_VERSION >= 23]*/
+import java.io.PrintStream;
+/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 import java.lang.module.ModuleDescriptor;
 import java.net.URL;
 import java.net.URI;
@@ -561,6 +564,13 @@ final class Access implements JavaLangAccess {
 	@Override
 	public int stringSize(long x) {
 		return Long.stringSize(x);
+	}
+
+	/*[IF !INLINE-TYPES]*/
+	@Override
+	/*[ENDIF] !INLINE-TYPES */
+	public PrintStream initialSystemErr() {
+		return System.initialErr;
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 


### PR DESCRIPTION
`JDK23` adds `JavaLangAccess.initialSystemErr()`

Decorated `@OverRide` with `!INLINE-TYPES` because `Valhalla` extension repo doesn't have latest openjdk update yet.

This fixes JDK23 abuild failure - https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/660/consoleFull

Signed-off-by: Jason Feng <fengj@ca.ibm.com>