### PR TITLE
Correct condition for printing portable shared cache option help

### DIFF
--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -1256,13 +1256,13 @@ j9shr_dump_help(J9JavaVM* vm, UDATA more)
 	tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_EXELIB_INTERNAL_HELP_XXDISABLEUSEGCSTARTUPHINTS, NULL);
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, "%s", tmpcstr);
 
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_OPT_PORTABLE_SHARED_CACHE)
 	tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_EXELIB_INTERNAL_HELP_XXPORTABLESHAREDCACHE, NULL);
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, "%s", tmpcstr);
 
 	tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_EXELIB_INTERNAL_HELP_XXNOPORTABLESHAREDCACHE, NULL);
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, "%s", tmpcstr);
-#endif /* defined(J9VM_ARCH_X86) */
+#endif /* defined(J9VM_OPT_PORTABLE_SHARED_CACHE) */
 
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, "\n\n");
 }


### PR DESCRIPTION
Noticed while reviewing #19399; see https://github.com/eclipse-openj9/openj9/pull/19399#discussion_r1586793937.