### PR TITLE
Periodically issue malloc_trim at JITServer client

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <limits.h>
+#include <malloc.h>
 #include <stdarg.h>
 #include "bcnames.h"
 #include "jithash.h"
@@ -6723,6 +6724,16 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
                }
 
 #if defined(J9VM_OPT_JITSERVER)
+#if defined(LINUX)
+            static uint64_t lastMallocTrimTime = 0;
+            if ((TR::Options::_jitserverMallocTrimInterval > 0) &&
+               (persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT) &&
+               (crtTime > lastMallocTrimTime + TR::Options::_jitserverMallocTrimInterval))
+               {
+               malloc_trim(0);
+               lastMallocTrimTime = crtTime;
+               }
+#endif /* defined(LINUX) */
             if (persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT &&
                 TR::Options::_lowCompDensityModeEnterThreshold > 0 && // A value of 0 disables this feature
                 !TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug) && // FSD interferes with recompilations in LPQ

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -137,6 +137,7 @@ int32_t J9::Options::_highActiveThreadThreshold = -1;
 int32_t J9::Options::_veryHighActiveThreadThreshold = -1;
 int32_t J9::Options::_aotCachePersistenceMinDeltaMethods = 200;
 int32_t J9::Options::_aotCachePersistenceMinPeriodMs = 10000; // ms
+int32_t J9::Options::_jitserverMallocTrimInterval = 1000 * 30; // 30000ms = 30s
 int32_t J9::Options::_lowCompDensityModeEnterThreshold = 4; // Maximum number of compilations per 10 min of CPU required to enter low compilation density mode. Use 0 to disable feature
 int32_t J9::Options::_lowCompDensityModeExitThreshold = 15; // Minimum number of compilations per 10 min of CPU required to exit low compilation density mode
 int32_t J9::Options::_lowCompDensityModeExitLPQSize = 120;  // Minimum number of compilations in LPQ to take us out of low compilation density mode
@@ -1062,6 +1063,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::JITServerAOTCacheLoadLimitOption, 1, 0, "P%s"},
    {"jitserverAOTCacheStoreExclude=", "D{regex}\tdo not store methods matching regex in the JITServer AOT cache",
         TR::Options::JITServerAOTCacheStoreLimitOption, 1, 0, "P%s"},
+   {"jitserverMallocTrimInterval=", "M<nnn>\tmiminum time between two consecutive JITServer client malloc_trim invocations (ms)",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_jitserverMallocTrimInterval, 0, "F%d", NOT_IN_SUBSET },
 #endif /* defined(J9VM_OPT_JITSERVER) */
    {"jProfilingEnablementSampleThreshold=", "M<nnn>\tNumber of global samples to allow generation of JProfiling bodies",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_jProfilingEnablementSampleThreshold, 0, "F%d", NOT_IN_SUBSET },

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -376,6 +376,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static const uint32_t DEFAULT_JITSERVER_TIMEOUT = 30000; // ms
    static int32_t _aotCachePersistenceMinDeltaMethods;
    static int32_t _aotCachePersistenceMinPeriodMs;
+   static int32_t _jitserverMallocTrimInterval;
    static int32_t _lowCompDensityModeEnterThreshold;
    static int32_t _lowCompDensityModeExitThreshold;
    static int32_t _lowCompDensityModeExitLPQSize;


### PR DESCRIPTION
JITServer clients will now periodically call `malloc_trim(0)`, at a configurable interval set by the new option
`-Xjit:jitserverMallocTrimInterval=<time in ms>`. The default is every 30s (30000ms). Setting the interval to 0 will disable the feature entirely.