### PR TITLE
Improve x86 inline object allocations

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -5579,7 +5579,7 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
                {
                static char *disableAlign = feGetEnv("TR_DisableAlignAlloc");
 
-               if (0 && !disableAlign && (node->getOpCodeValue() == TR::New) && (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()))
+               if (0 && !disableAlign && (node->getOpCodeValue() == TR::New) && (comp->getMethodHotness() >= hot))
                   {
                   TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -4255,7 +4255,7 @@ TR::Register *J9::Power::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node *node, 
          }
       depIndex = numberOfRegisterCandidate(cg, depNode, TR_GPR) + numberOfRegisterCandidate(cg, depNode, TR_FPR) +
                  numberOfRegisterCandidate(cg, depNode, TR_CCR) + numberOfRegisterCandidate(cg, depNode, TR_VRF) +
-	         numberOfRegisterCandidate(cg, depNode, TR_VSX_SCALAR) + numberOfRegisterCandidate(cg, depNode, TR_VSX_VECTOR);
+                 numberOfRegisterCandidate(cg, depNode, TR_VSX_SCALAR) + numberOfRegisterCandidate(cg, depNode, TR_VSX_VECTOR);
       }
 
    doneLabel = generateLabelSymbol(cg);
@@ -5536,7 +5536,6 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
       if (usingTLH)
          {
          bool sizeInReg = (isVariableLen || (allocSize > UPPER_IMMED));
-         bool shouldAlignToCacheBoundary = false;
          int32_t instanceBoundaryForAlignment = 64;
 
          static bool verboseDualTLH = feGetEnv("TR_verboseDualTLH") != NULL;
@@ -5572,78 +5571,14 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
          //TODO: This code is never executed, check if this can be deleted now.
          if (!cg->isDualTLH())
             {
-            //All of this code never gets executed because of the 0 && in
-            //the inside if statement. Candidate for deletion
+            iCursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, resReg,
+                  TR::MemoryReference::createWithDisplacement(cg, metaReg, offsetof(J9VMThread, heapAlloc), TR::Compiler->om.sizeofReferenceAddress()), iCursor);
 
-            if (!isVariableLen)
-               {
-               static char *disableAlign = feGetEnv("TR_DisableAlignAlloc");
-
-               if (0 && !disableAlign && (node->getOpCodeValue() == TR::New) && (comp->getMethodHotness() >= hot))
-                  {
-                  TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();
-
-                  TR::Node *classChild = node->getFirstChild();
-                  char * className = NULL;
-                  TR_OpaqueClassBlock *clazz = NULL;
-
-                  if (classChild && classChild->getSymbolReference() && !classChild->getSymbolReference()->isUnresolved())
-                     {
-                     TR::SymbolReference *symRef = classChild->getSymbolReference();
-                     TR::Symbol *sym = symRef->getSymbol();
-
-                     if (sym && sym->getKind() == TR::Symbol::IsStatic && sym->isClassObject())
-                        {
-                        TR::StaticSymbol * staticSym = symRef->getSymbol()->castToStaticSymbol();
-                        void * staticAddress = staticSym->getStaticAddress();
-                        if (symRef->getCPIndex() >= 0)
-                           {
-                           if (!staticSym->addressIsCPIndexOfStatic() && staticAddress)
-                              {
-                              int32_t len;
-                              className = TR::Compiler->cls.classNameChars(comp, symRef, len);
-                              clazz = (TR_OpaqueClassBlock *) staticAddress;
-                              }
-                           }
-                        }
-                     }
-
-                  int32_t instanceSizeForAlignment = 56;
-                  static char *alignSize = feGetEnv("TR_AlignInstanceSize");
-                  static char *alignBoundary = feGetEnv("TR_AlignInstanceBoundary");
-
-                  if (alignSize)
-                     instanceSizeForAlignment = atoi(alignSize);
-                  if (alignBoundary)
-                     instanceBoundaryForAlignment = atoi(alignBoundary);
-
-                  if (clazz && !cg->getCurrentEvaluationBlock()->isCold() && TR::Compiler->cls.classInstanceSize(clazz) >= instanceSizeForAlignment)
-                     {
-                     shouldAlignToCacheBoundary = true;
-
-                     iCursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, temp1Reg,
-                           TR::MemoryReference::createWithDisplacement(cg, metaReg, offsetof(J9VMThread, heapAlloc), TR::Compiler->om.sizeofReferenceAddress()), iCursor);
-
-                     iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, resReg, temp1Reg, instanceBoundaryForAlignment - 1, iCursor);
-                     if (comp->target().is64Bit())
-                        iCursor = generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldicr, node, resReg, resReg, 0, int64_t(-instanceBoundaryForAlignment), iCursor);
-                     else
-                        iCursor = generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, resReg, resReg, 0, -instanceBoundaryForAlignment, iCursor);
-                     }
-                  }
-               }
-
-            if (!shouldAlignToCacheBoundary)
-               {
-               iCursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, resReg,
-                     TR::MemoryReference::createWithDisplacement(cg, metaReg, offsetof(J9VMThread, heapAlloc), TR::Compiler->om.sizeofReferenceAddress()), iCursor);
-               }
             iCursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, heapTopReg,
                   TR::MemoryReference::createWithDisplacement(cg, metaReg, offsetof(J9VMThread, heapTop), TR::Compiler->om.sizeofReferenceAddress()), iCursor);
 
             if (needZeroInit)
                iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, zeroReg, 0, iCursor);
-
             }
          else
             {
@@ -5815,15 +5750,9 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
          else
             iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, temp2Reg, resReg, allocSize, iCursor);
 
-         //TODO: shouldAlignToCacheBoundary is never true, check its effects here.
-         int32_t padding = shouldAlignToCacheBoundary ? instanceBoundaryForAlignment : 0;
-
-         if (!isVariableLen && ((uint32_t) allocSize + padding) > maxSafeSize)
+         if (!isVariableLen && ((uint32_t) allocSize) > maxSafeSize)
             {
-            if (!shouldAlignToCacheBoundary)
-               iCursor = generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, condReg, temp2Reg, resReg, iCursor);
-            else
-               iCursor = generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, condReg, temp2Reg, temp1Reg, iCursor);
+            iCursor = generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, condReg, temp2Reg, resReg, iCursor);
             iCursor = generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, callLabel, condReg, iCursor);
             }
 
@@ -5847,53 +5776,6 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
          //branch to regular heapAlloc Snippet if we overflow (ie callLabel).
          iCursor = generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, condReg, temp2Reg, heapTopReg, iCursor);
          iCursor = generateConditionalBranchInstruction(cg, TR::InstOpCode::bgt, node, callLabel, condReg, iCursor);
-
-         //TODO: this code is never executed, check if we can remove this now.
-         if (!cg->isDualTLH())
-            {
-            //shouldAlignToCacheBoundary is false at definition at the top, and
-            //the only codepoint where its set to true is never executed
-            //so this looks like a candidate for deletion.
-            if (shouldAlignToCacheBoundary)
-               {
-               TR::LabelSymbol *doneAlignLabel = generateLabelSymbol(cg);
-               TR::LabelSymbol *multiSlotGapLabel = generateLabelSymbol(cg);
-               ;
-               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::subf, node, dataSizeReg, temp1Reg, resReg, iCursor);
-
-               if (sizeInReg)
-                  iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, sizeReg, dataSizeReg, sizeReg, iCursor);
-               else
-                  iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, sizeReg, dataSizeReg, allocSize, iCursor);
-
-               sizeInReg = true;
-
-               iCursor = generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, condReg, dataSizeReg, sizeof(uintptr_t), iCursor);
-               iCursor = generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, doneAlignLabel, condReg, iCursor);
-               iCursor = generateConditionalBranchInstruction(cg, TR::InstOpCode::bgt, node, multiSlotGapLabel, condReg, iCursor);
-               iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, dataSizeReg, J9_GC_SINGLE_SLOT_HOLE, iCursor);
-
-               if (comp->target().is64Bit() && fej9->generateCompressedLockWord())
-                  {
-                  iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(cg, temp1Reg, 0, 4), dataSizeReg, iCursor);
-                  iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(cg, temp1Reg, 4, 4), dataSizeReg, iCursor);
-                  }
-               else
-                  {
-                  iCursor = generateMemSrc1Instruction(cg,TR::InstOpCode::Op_st, node, TR::MemoryReference::createWithDisplacement(cg, temp1Reg, 0, TR::Compiler->om.sizeofReferenceAddress()), dataSizeReg,
-                        iCursor);
-                  }
-
-               iCursor = generateLabelInstruction(cg, TR::InstOpCode::b, node, doneAlignLabel, iCursor);
-               iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, multiSlotGapLabel, iCursor);
-               iCursor = generateMemSrc1Instruction(cg,TR::InstOpCode::Op_st, node, TR::MemoryReference::createWithDisplacement(cg, temp1Reg, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()),
-                     dataSizeReg, iCursor);
-               iCursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, dataSizeReg, J9_GC_MULTI_SLOT_HOLE, iCursor);
-               iCursor = generateMemSrc1Instruction(cg,TR::InstOpCode::Op_st, node, TR::MemoryReference::createWithDisplacement(cg, temp1Reg, 0, TR::Compiler->om.sizeofReferenceAddress()), dataSizeReg,
-                     iCursor);
-               iCursor = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneAlignLabel, iCursor);
-               }
-            }
 
          if (cg->enableTLHPrefetching())
             {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6079,34 +6079,6 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(
                                 eaxReal,
                                 generateX86MemoryReference(vmThreadReg,heapAlloc_offset, cg), cg);
 
-      if (comp->getOption(TR_EnableNewAllocationProfiling))
-         {
-         TR::LabelSymbol *doneProfilingLabel = generateLabelSymbol(cg);
-
-         uint32_t *globalAllocationDataPointer = fej9->getGlobalAllocationDataPointer();
-         if (globalAllocationDataPointer)
-            {
-            TR::MemoryReference *gmr = generateX86MemoryReference((uintptr_t)globalAllocationDataPointer, cg);
-
-            generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4,
-                                      node,
-                                      generateX86MemoryReference((uint32_t)(uintptr_t)globalAllocationDataPointer, cg),
-                                      0x07ffffff,
-                                      cg);
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, doneProfilingLabel, cg);
-
-            generateMemInstruction(TR::InstOpCode::INC4Mem, node, gmr, cg);
-            uint32_t *dataPointer = fej9->getAllocationProfilingDataPointer(node->getByteCodeInfo(), clazz, node->getOwningMethod(), comp);
-            if (dataPointer)
-               {
-               TR::MemoryReference *mr = generateX86MemoryReference((uint32_t)(uintptr_t)dataPointer, cg);
-               generateMemInstruction(TR::InstOpCode::INC4Mem, node, mr, cg);
-               }
-
-            generateLabelInstruction(TR::InstOpCode::label, node, doneProfilingLabel, cg);
-            }
-         }
-
       bool canSkipOverflowCheck = false;
 
       // If the array length is constant, check to see if the size of the array will fit in a single arraylet leaf.

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6256,7 +6256,7 @@ static void genHeapAlloc(
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
          if ((node->getOpCodeValue() == TR::New) &&
-             (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()) &&
+             (comp->getMethodHotness() >= hot) &&
              !disableAllocationAlignment)
             {
             TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();
@@ -6634,7 +6634,7 @@ static void genHeapAlloc2(
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
          if ((node->getOpCodeValue() == TR::New) &&
-             (comp->getMethodHotness() >= hot || node->shouldAlignTLHAlloc()) &&
+             (comp->getMethodHotness() >= hot) &&
              !disableAllocationAlignment)
             {
             TR_OpaqueMethodBlock *ownMethod = node->getOwningMethod();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7762,11 +7762,13 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    startLabel->setStartInternalControlFlow();
    fallThru->setEndInternalControlFlow();
 
+   bool enableTLHBatchClearing = fej9->tlhHasBeenCleared();
+
 #ifdef J9VM_GC_NON_ZERO_TLH
    // If we can skip zero init, and it is not outlined new, we use the new TLH
    // same logic also appears later, but we need to do this before generate the helper call
    //
-   if (node->canSkipZeroInitialization() && !comp->getOption(TR_DisableDualTLH) && !comp->getOptions()->realTimeGC())
+   if (node->canSkipZeroInitialization() && (enableTLHBatchClearing || !comp->getOption(TR_DisableDualTLH)) && !comp->getOptions()->realTimeGC())
       {
       // For value types, it should use jitNewValue helper call which is set up before code gen
       if ((node->getOpCodeValue() == TR::New)
@@ -7875,7 +7877,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    bool shouldInitZeroSizedArrayHeader = true;
 
 #ifdef J9VM_GC_NON_ZERO_TLH
-   if (comp->getOption(TR_DisableDualTLH) || comp->getOptions()->realTimeGC())
+   if (!enableTLHBatchClearing || comp->getOptions()->realTimeGC())
       {
 #endif
       if (!maxZeroInitWordsPerIteration)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6150,7 +6150,7 @@ static void genHeapAlloc(
             }
          else
             {
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
          // Must be an unsigned comparison on sizes.
@@ -6541,7 +6541,7 @@ static void genHeapAlloc2(
             }
          else
             {
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
          // Must be an unsigned comparison on sizes.

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6032,15 +6032,15 @@ static void genHeapAlloc(
       bool shouldAlignToCacheBoundary = false;
       bool isSmallAllocation = false;
 
-      size_t heapAlloc_offset=offsetof(J9VMThread, heapAlloc);
-      size_t heapTop_offset=offsetof(J9VMThread, heapTop);
-      size_t tlhPrefetchFTA_offset= offsetof(J9VMThread, tlhPrefetchFTA);
+      size_t heapAlloc_offset = offsetof(J9VMThread, heapAlloc);
+      size_t heapTop_offset = offsetof(J9VMThread, heapTop);
+      size_t tlhPrefetchFTA_offset = offsetof(J9VMThread, tlhPrefetchFTA);
 #ifdef J9VM_GC_NON_ZERO_TLH
       if (!comp->getOption(TR_DisableDualTLH) && node->canSkipZeroInitialization())
          {
-         heapAlloc_offset=offsetof(J9VMThread, nonZeroHeapAlloc);
-         heapTop_offset=offsetof(J9VMThread, nonZeroHeapTop);
-         tlhPrefetchFTA_offset= offsetof(J9VMThread, nonZeroTlhPrefetchFTA);
+         heapAlloc_offset = offsetof(J9VMThread, nonZeroHeapAlloc);
+         heapTop_offset = offsetof(J9VMThread, nonZeroHeapTop);
+         tlhPrefetchFTA_offset = offsetof(J9VMThread, nonZeroTlhPrefetchFTA);
          }
 #endif
       // Load the base of the next available heap storage.  This load is done speculatively on the assumption that the
@@ -7612,6 +7612,9 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    if (comp->suppressAllocationInlining())
       return NULL;
 
+   if (comp->getOption(TR_DisableAllocationInlining))
+      return NULL;
+
    // If the helper does not preserve all the registers there will not be
    // enough registers to do the inline allocation.
    // Also, don't do the inline allocation if optimizing for space
@@ -7631,11 +7634,10 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    bool realTimeGC = comp->getOptions()->realTimeGC();
    bool generateArraylets = comp->generateArraylets();
 
-   TR::Register *segmentReg      = NULL;
-   TR::Register *tempReg         = NULL;
-   TR::Register *targetReg       = NULL;
-   TR::Register *sizeReg         = NULL;
-
+   TR::Register *segmentReg = NULL;
+   TR::Register *tempReg    = NULL;
+   TR::Register *targetReg  = NULL;
+   TR::Register *sizeReg    = NULL;
 
    /**
     * Study of registers used in inline allocation.
@@ -7660,7 +7662,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
     *
     */
 
-   TR::RegisterDependencyConditions  *deps;
+   TR::RegisterDependencyConditions *deps;
 
    // --------------------------------------------------------------------------------
    //
@@ -7676,11 +7678,15 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    objectSize = comp->canAllocateInline(node, clazz);
    if (objectSize < 0)
       return NULL;
+
    // Currently dynamic allocation is only supported on reference array.
    // We are performing dynamic array allocation if both object size and
    // class block cannot be statically determined.
-   bool dynamicArrayAllocation = (node->getOpCodeValue() == TR::anewarray)
-         && (objectSize == 0) && (clazz == NULL);
+   bool dynamicArrayAllocation =
+      (node->getOpCodeValue() == TR::anewarray) &&
+      (objectSize == 0) &&
+      (clazz == NULL);
+
    allocationSize = objectSize;
 
    static long count = 0;
@@ -7689,11 +7695,8 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
 
    if (node->getOpCodeValue() == TR::New)
       {
-      if (comp->getOption(TR_DisableAllocationInlining))
-         return 0;
-
       // realtimeGC: cannot inline if object size is too big to get a size class
-      if (comp->getOptions()->realTimeGC())
+      if (realTimeGC)
          {
          if ((uint32_t) objectSize > fej9->getMaxObjectSizeForSizeClass())
             return NULL;
@@ -7722,24 +7725,18 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
       {
       if (node->getOpCodeValue() == TR::newarray)
          {
-         if (comp->getOption(TR_DisableAllocationInlining))
-            return 0;
-
          elementSize = TR::Compiler->om.getSizeOfArrayElement(node);
          }
       else
          {
          // Must be TR::anewarray
          //
-         if (comp->getOption(TR_DisableAllocationInlining))
-            return 0;
-
-         if (comp->useCompressedPointers())
-            elementSize = TR::Compiler->om.sizeofReferenceField();
-         else
-            elementSize = (int32_t)TR::Compiler->om.sizeofReferenceAddress();
+         elementSize = comp->useCompressedPointers() ?
+            TR::Compiler->om.sizeofReferenceField() :
+            (int32_t)TR::Compiler->om.sizeofReferenceAddress();
 
          classReg = node->getSecondChild()->getRegister();
+
          // For dynamic array allocation, need to evaluate second child
          if (!classReg && dynamicArrayAllocation)
             classReg = cg->evaluate(node->getSecondChild());
@@ -7747,14 +7744,9 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
 
       isArrayNew = true;
 
-      if (generateArraylets)
-         {
-         dataOffset = fej9->getArrayletFirstElementOffset(elementSize, comp);
-         }
-      else
-         {
-         dataOffset = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
-         }
+      dataOffset = generateArraylets ?
+         fej9->getArrayletFirstElementOffset(elementSize, comp) :
+         TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
       }
 
    TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
@@ -7768,7 +7760,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    // If we can skip zero init, and it is not outlined new, we use the new TLH
    // same logic also appears later, but we need to do this before generate the helper call
    //
-   if (node->canSkipZeroInitialization() && (enableTLHBatchClearing || !comp->getOption(TR_DisableDualTLH)) && !comp->getOptions()->realTimeGC())
+   if (node->canSkipZeroInitialization() && (enableTLHBatchClearing || !comp->getOption(TR_DisableDualTLH)) && !realTimeGC)
       {
       // For value types, it should use jitNewValue helper call which is set up before code gen
       if ((node->getOpCodeValue() == TR::New)
@@ -7776,6 +7768,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
          node->setSymbolReference(comp->getSymRefTab()->findOrCreateNewObjectNoZeroInitSymbolRef(comp->getMethodSymbol()));
       else if (node->getOpCodeValue() == TR::newarray)
          node->setSymbolReference(comp->getSymRefTab()->findOrCreateNewArrayNoZeroInitSymbolRef(comp->getMethodSymbol()));
+
       if (comp->getOption(TR_TraceCG))
          traceMsg(comp, "SKIPZEROINIT: for %p, change the symbol to %p ", node, node->getSymbolReference());
       }
@@ -7788,7 +7781,6 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    TR::LabelSymbol *failLabel = generateLabelSymbol(cg);
 
    segmentReg = cg->allocateRegister();
-
    tempReg = cg->allocateRegister();
 
    // If the size is variable, evaluate it into a register
@@ -7824,27 +7816,20 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    //
    // --------------------------------------------------------------------------------
 
-   bool canUseFastInlineAllocation =
-      (!comp->getOptions()->realTimeGC() &&
-       !comp->generateArraylets()) ? true : false;
+   bool canUseFastInlineAllocation = (!realTimeGC && !generateArraylets) ? true : false;
 
    bool useRepInstruction;
    bool monitorSlotIsInitialized;
    bool skipOutlineZeroInit = false;
    TR_ExtraInfoForNew *initInfo = node->getSymbolReference()->getExtraInfo();
+
    if (node->canSkipZeroInitialization())
       {
       skipOutlineZeroInit = true;
       }
    else if (initInfo)
       {
-      if (node->canSkipZeroInitialization())
-         {
-         initInfo->zeroInitSlots = NULL;
-         initInfo->numZeroInitSlots = 0;
-         skipOutlineZeroInit = true;
-         }
-      else if (initInfo->numZeroInitSlots <= 0)
+      if (initInfo->numZeroInitSlots <= 0)
          {
          skipOutlineZeroInit = true;
          }
@@ -7877,7 +7862,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    bool shouldInitZeroSizedArrayHeader = true;
 
 #ifdef J9VM_GC_NON_ZERO_TLH
-   if (!enableTLHBatchClearing || comp->getOptions()->realTimeGC())
+   if (!enableTLHBatchClearing || realTimeGC)
       {
 #endif
       if (!maxZeroInitWordsPerIteration)
@@ -7944,44 +7929,57 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
                   }
                else if (span > 3)
                   {
+                  TR::InstOpCode::Mnemonic storeOpCode;
                   if (lastSpan == 0)
                      {
-                     generateMemRegInstruction(TR::InstOpCode::MOVDMemReg, node, generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
+                     storeOpCode = TR::InstOpCode::MOVDMemReg;
                      }
                   else if (lastSpan == 1)
                      {
-                     generateMemRegInstruction(TR::InstOpCode::MOVQMemReg, node,generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
+                     storeOpCode = TR::InstOpCode::MOVQMemReg;
                      }
                   else
                      {
-                     generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node, generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
+                     storeOpCode = TR::InstOpCode::MOVDQUMemReg;
                      }
+
+                  generateMemRegInstruction(storeOpCode, node, generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
+
                   lastElementIndex = nextE;
                   lastSpan = 0;
                   }
                }
-            if (lastSpan == 0)
-               {
-               generateMemRegInstruction(TR::InstOpCode::MOVDMemReg, node, generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
+
+            int32_t adjustedDataOffset = dataOffset;
+            TR::InstOpCode::Mnemonic storeOpCode = TR::InstOpCode::bad;
+
+            switch (lastSpan)
+               {¬
+               case 0:¬
+                  storeOpCode = TR::InstOpCode::MOVDMemReg;
+                  break;
+               case 1:
+                  storeOpCode = TR::InstOpCode::MOVQMemReg;
+                  break;
+               case 2:
+                  TR_ASSERT(dataOffset >= 4, "dataOffset must be >= 4.");
+                  storeOpCode = TR::InstOpCode::MOVDQUMemReg;
+                  adjustedDataOffset -= 4;
+                  break;
+               default:
+                  break;
                }
-            else if (lastSpan == 1)
+
+            if (storeOpCode != TR::InstOpCode::bad)
                {
-               generateMemRegInstruction(TR::InstOpCode::MOVQMemReg, node,generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset, cg), scratchReg, cg);
-               }
-            else if (lastSpan == 2)
-               {
-               TR_ASSERT(dataOffset >= 4, "dataOffset must be >= 4.");
-               generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node, generateX86MemoryReference(targetReg, lastElementIndex*4 +dataOffset - 4, cg), scratchReg, cg);
+               generateMemRegInstruction(storeOpCode, node, generateX86MemoryReference(targetReg, lastElementIndex*4 + adjustedDataOffset, cg), scratchReg, cg);
                }
             }
 
          useRepInstruction = false;
 
          J9JavaVM * jvm = fej9->getJ9JITConfig()->javaVM;
-         if (jvm->lockwordMode == LOCKNURSERY_ALGORITHM_ALL_INHERIT)
-            monitorSlotIsInitialized = false;
-         else
-            monitorSlotIsInitialized = true;
+         monitorSlotIsInitialized = (jvm->lockwordMode != LOCKNURSERY_ALGORITHM_ALL_INHERIT);
          }
       else if ((!initInfo || initInfo->numZeroInitSlots > 0) &&
                !node->canSkipZeroInitialization())
@@ -7999,10 +7997,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
             }
 
          J9JavaVM * jvm = fej9->getJ9JITConfig()->javaVM;
-         if (jvm->lockwordMode == LOCKNURSERY_ALGORITHM_ALL_INHERIT)
-            monitorSlotIsInitialized = false;
-         else
-            monitorSlotIsInitialized = true;
+         monitorSlotIsInitialized = (jvm->lockwordMode != LOCKNURSERY_ALGORITHM_ALL_INHERIT);
          }
       else
          {
@@ -8150,8 +8145,8 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
       }
 #endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
 
-   if (fej9->inlinedAllocationsMustBeVerified() && (node->getOpCodeValue() == TR::New ||
-                                                        node->getOpCodeValue() == TR::anewarray) )
+   if (fej9->inlinedAllocationsMustBeVerified() &&
+       (node->getOpCodeValue() == TR::New || node->getOpCodeValue() == TR::anewarray))
       {
       startInstr = startInstr->getNext();
       TR_OpaqueClassBlock *classToValidate = clazz;


### PR DESCRIPTION
* Call NoZeroInit anewarray helper when appropriate on x86
* Misc. x86 allocation path improvements
* Remove obsolete TR_EnableNewAllocationProfiling code
* Misc. x86 allocation path improvements
* Cleanup x86 object initialization path
* Move x86 inlined allocation verification out of line
* Move off-heap dataAddr allocation into a separate function
* Use ScratchRegisterManager in x86 inline allocations
* Misc. code cleanup for readability
* Remove allocated object cache line alignment code on Power and x86
* Remove deprecated shouldAlignTLHAlloc() checks on TR::Nodes
* Compare variable array sizes as 32-bits for x86 inline allocations
* Add knobs to disable x86 object allocation features
* Misc. readability and formatting improvements to x86 inline allocation
* Do not perform zero initialization of TLH objects when batch clearing enabled