### PR TITLE
Stop predicting VH.asDirect()/directVarHandleTarget() during inlining

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1042,7 +1042,6 @@
    java_lang_invoke_Invokers_checkCustomized,
    java_lang_invoke_Invokers_checkExactType,
    java_lang_invoke_Invokers_getCallSiteTarget,
-   java_lang_invoke_Invokers_directVarHandleTarget,
    java_lang_invoke_Invokers_checkVarHandleGenericType,
    java_lang_invoke_MethodHandle_doCustomizationLogic,
    java_lang_invoke_MethodHandle_asType,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5161,21 +5161,6 @@ TR_J9VMBase::getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObje
    return result;
    }
 
-
-TR::KnownObjectTable::Index
-TR_J9VMBase::getDirectVarHandleTargetIndex(TR::Compilation* comp, TR::KnownObjectTable::Index vhIndex)
-   {
-   // Since IndirectVarHandle.asDirect can override VarHandle.asDirect, an exact type check here is necessary
-   const char * varHandleClassName = "java/lang/invoke/VarHandle";
-   TR_OpaqueClassBlock * varHandleClass =
-      getSystemClassFromClassName(varHandleClassName, strlen(varHandleClassName));
-   TR_OpaqueClassBlock * objectClass = getObjectClassFromKnownObjectIndex(comp, vhIndex);
-   if (NULL == varHandleClass || NULL == objectClass || varHandleClass != objectClass)
-      return TR::KnownObjectTable::UNKNOWN;
-
-   return vhIndex;
-   }
-
 bool
 TR_J9VMBase::isMethodHandleExpectedType(
    TR::Compilation *comp,

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -455,17 +455,6 @@ public:
     */
    virtual TR::KnownObjectTable::Index getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObjectTable::Index vhIndex, TR::KnownObjectTable::Index adIndex);
 
-   /**
-    * @brief Get the Direct VarHandle target object index. This function evaluates the result of
-    * java/lang/invoke/Invokers.directVarHandleTarget and java/lang/invoke/VarHandle.asDirect
-    * at compile time.
-    *
-    * @param comp the compilation
-    * @param vhIndex the VarHandle object
-    * @return TR::KnownObjectTable::Index the direct VH object index if success, TR::KnownObjectTable::UNKNOWN otherwise
-    */
-   TR::KnownObjectTable::Index getDirectVarHandleTargetIndex(TR::Compilation * comp, TR::KnownObjectTable::Index vhIndex);
-
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual TR_ResolvedMethod * createResolvedMethodWithVTableSlot(TR_Memory *, uint32_t vTableSlot, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod = 0, TR_OpaqueClassBlock * classForNewInstance = 0);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3720,7 +3720,6 @@ void TR_ResolvedJ9Method::construct()
       {  TR::java_lang_invoke_Invokers_checkCustomized,            15,     "checkCustomized",             (int16_t)-1, "*"},
       {  TR::java_lang_invoke_Invokers_checkExactType,             14,     "checkExactType",              (int16_t)-1, "*"},
       {  TR::java_lang_invoke_Invokers_getCallSiteTarget,          17,     "getCallSiteTarget",           (int16_t)-1, "*"},
-      {x(TR::java_lang_invoke_Invokers_directVarHandleTarget,              "directVarHandleTarget",       "(Ljava/lang/invoke/VarHandle;)Ljava/lang/invoke/VarHandle;")},
       {x(TR::java_lang_invoke_Invokers_checkVarHandleGenericType,          "checkVarHandleGenericType",   "(Ljava/lang/invoke/VarHandle;Ljava/lang/invoke/VarHandle$AccessDescriptor;)Ljava/lang/invoke/MethodHandle;")},
       {  TR::unknownMethod}
       };

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1073,22 +1073,6 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
             }
          break;
          }
-      case TR::java_lang_invoke_VarHandle_asDirect:
-      case TR::java_lang_invoke_Invokers_directVarHandleTarget:
-         {
-         Operand* varHandleOperand = top();
-         TR::KnownObjectTable::Index vhIndex = varHandleOperand->getKnownObjectIndex();
-         TR::KnownObjectTable *knot = comp()->getKnownObjectTable();
-         if (knot
-              && vhIndex != TR::KnownObjectTable::UNKNOWN
-              && !knot->isNull(vhIndex))
-            {
-            TR::KnownObjectTable::Index directVHIndex = comp()->fej9()->getDirectVarHandleTargetIndex(comp(), vhIndex);
-            if (directVHIndex != TR::KnownObjectTable::UNKNOWN)
-               result = new (trStackMemory()) KnownObjOperand(directVHIndex);
-            }
-         break;
-         }
       case TR::java_lang_invoke_Invokers_checkVarHandleGenericType:
          {
          Operand* varHandleOperand = topn(1);

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -406,26 +406,6 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
                comp(), dmhIndex, trace());
             }
 #endif
-         case TR::java_lang_invoke_Invokers_directVarHandleTarget:
-         case TR::java_lang_invoke_VarHandle_asDirect:
-            {
-            auto vhIndex = getObjectInfoOfNode(node->getLastChild());
-            if (knot && isKnownObject(vhIndex) && !knot->isNull(vhIndex))
-               {
-               auto directVHIndex = comp()->fej9()->getDirectVarHandleTargetIndex(comp(), vhIndex);
-               if (directVHIndex == TR::KnownObjectTable::UNKNOWN)
-                  break;
-               if (trace())
-                  {
-                  if (rm == TR::java_lang_invoke_Invokers_directVarHandleTarget)
-                     traceMsg(comp(), "Invokers_directVarHandleTarget with known VarHandle object %d, updating node n%dn with known object info\n", directVHIndex, node->getGlobalIndex());
-                  else traceMsg(comp(), "VarHandle_asDirect with known VarHandle object %d, updating node n%dn with known object info\n", directVHIndex, node->getGlobalIndex());
-                  }
-               node->setKnownObjectIndex(directVHIndex);
-               return directVHIndex;
-               }
-            break;
-            }
          case TR::java_lang_invoke_Invokers_checkVarHandleGenericType:
             {
             auto vhIndex = getObjectInfoOfNode(node->getFirstArgument());


### PR DESCRIPTION
The `MethodHandle` can be found without knowing the result of this call because it's looked up based on the original `VarHandle` reference, not the one from `directVarHandleTarget()`, and this is enough to allow the inliner to inline the entire access.

Additionally, the compiler has been failing to determine the result anyway. The logic deleted here would give up whenever the `VarHandle` was an instance of a subclass, which it seems is always the case.

Nothing looks for `directVarHandleTarget()` anymore, so it will no longer be recognized. But `asDirect()` will continue to be recognized for `isJSR292SmallGetterMethod()`.