### PR TITLE
Assembly fixes for Open XL compliance

### DIFF
--- a/runtime/oti/zhelpers.m4
+++ b/runtime/oti/zhelpers.m4
@@ -247,9 +247,7 @@ PPA2   DS    0D
         DC   XL3'000000'
 })
 
-define({FILE_END},{
-    END
-})
+define({FILE_END},{END})
 
 },{
 
@@ -297,8 +295,7 @@ LCALLDESC DS 0D
     DC BL.3'000',BL.5'00000'
     DC BL.6'001000',BL.6'000000',BL.6'000000',BL.6'000000'
 })
-    END
-})
+    END})
 
 })
 

--- a/runtime/port/zos390/j9gs_load_gscb.s
+++ b/runtime/port/zos390/j9gs_load_gscb.s
@@ -50,9 +50,6 @@ GSLDCB CELQPRLG BASEREG=6,DSASIZE=0
          LA    R3,1
          B     EXIT           Without this branch fails at runtime
 EXIT     DS    0F
-         DROP  R2
-         DROP  R1
-         DROP  R0
 
          AIF  ('&SYSPARM' EQ 'BIT64').JMP3
          EDCXEPLG

--- a/runtime/port/zos390/j9gs_store_gscb.s
+++ b/runtime/port/zos390/j9gs_store_gscb.s
@@ -50,9 +50,6 @@ GSSTCB CELQPRLG BASEREG=6,DSASIZE=0
          LA    R3,1
          B     EXIT           Without this branch fails at runtime
 EXIT     DS    0F
-         DROP  R2
-         DROP  R1
-         DROP  R0
 
          AIF  ('&SYSPARM' EQ 'BIT64').JMP3
          EDCXEPLG


### PR DESCRIPTION
Some errors were being seen while compiling some `.s` files for Open XL with z/OS. With some further investigation it was seen that some of these errors were also present with XLC, however the return code 4 was being ignored and continued building anyways. Open XL sees this return code and hard stops the compilation and reports it as an error, these changes address these problems.

---

Error information for more context: 
```bash
                                     74          DROP  R2
 ASMA045W Register or label not previously used - R2
 ASMA435I Record 53 in openj9/runtime/port/zos390/j9gs_load_gscb.s
       on volume:
                                      75          DROP  R1
 ASMA045W Register or label not previously used - R1
 ASMA435I Record 54 inopenj9/runtime/port/zos390/j9gs_load_gscb.s
       on volume:
                                      76          DROP  R0
 ASMA045W Register or label not previously used - R0
 ASMA435I Record 55 inopenj9/runtime/port/zos390/j9gs_load_gscb.s
       on volume:
FSUM3401 The assemble step ended with rc = 4.
ibm-clang: error: assembler command failed with exit code 4 (use -v to see invocation)
```

```bash

ASMA140W END record missing
 ASMA435I Record 51 in openj9/runtime/port/zos390/j9mprotect.s on
       volume:
FSUM3401 The assemble step ended with rc = 4.
ibm-clang: error: assembler command failed with exit code 4 (use -v to see invocation)
```
