### PR TITLE
cacheDirPerm should be set if -Xshareclasses is not specified

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -391,6 +391,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 				vm->sharedCacheAPI->verboseFlags = J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT;
 			}
 			vm->sharedCacheAPI->runtimeFlags = runtimeFlags;
+			vm->sharedCacheAPI->cacheDirPerm = J9SH_DIRPERM_ABSENT;
 		}
 	}
 


### PR DESCRIPTION
SCC is enabled by default when -Xshareclasses is not specified in the CML. cacheDirPerm should be set to J9SH_DIRPERM_ABSENT in this case.

Closes #19328