### PR TITLE
Export jdk.management/jdk.crac.management only when CRaC is enabled

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -175,6 +175,13 @@ final class J9VMInternals {
 		if (openj9.internal.criu.InternalCRIUSupport.isCRaCSupportEnabled()) {
 			// export java.base/jdk.crac unconditionally
 			J9VMInternals.class.getModule().implAddExports("jdk.crac"); //$NON-NLS-1$
+
+			// export jdk.management/jdk.crac.management unconditionally
+			java.util.Optional<Module> om = ModuleLayer.boot().findModule("jdk.management");  //$NON-NLS-1$
+			if (om.isEmpty()) {
+				throw new InternalError("module jdk.management wasn't found"); //$NON-NLS-1$
+			}
+			om.get().implAddExports("jdk.crac.management"); //$NON-NLS-1$
 		}
 /*[ENDIF] CRAC_SUPPORT */
 	}

--- a/jcl/src/jdk.management/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.management/share/classes/module-info.java.extra
@@ -25,6 +25,3 @@ exports com.ibm.lang.management;
 exports openj9.lang.management;
 exports com.ibm.virtualization.management;
 provides sun.management.spi.PlatformMBeanProvider with com.ibm.lang.management.internal.PlatformMBeanProvider;
-/*[IF CRAC_SUPPORT]*/
-exports jdk.crac.management;
-/*[ENDIF] CRAC_SUPPORT*/

--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -73,15 +73,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 				</javac>
 			</then>
 			<else>
-				<if>
-					<equals arg1="${JCL_VERSION}" arg2="latest"/>
-					<then>
-						<property name="addExports" value="--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-exports java.management/javax.management=ALL-UNNAMED --add-exports java.base/java.security=ALL-UNNAMED" />
-					</then>
-					<else>
-						<property name="addExports" value="--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-exports java.management/javax.management=ALL-UNNAMED --add-exports java.base/java.security=ALL-UNNAMED" />
-					</else>
-				</if>
+				<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED
+					--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED
+					--add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
+					--add-exports java.management/javax.management=ALL-UNNAMED
+					--add-exports java.base/java.security=ALL-UNNAMED" />
 				<property name="TestUtilitiesExports" value="--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED" />
 				<property name="srcpath" location="${src}:${src_90}:${transformerListener}:${TestUtilities}" />
 				<path id="build.cp">

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1358,6 +1358,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng-crac.xml$(Q) \
 	-testnames testCRaCMXBean \

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -84,7 +84,8 @@
 				</javac>
 			</then>
 			<else>
-				<property name="addExports" value="--add-exports java.base/jdk.crac=ALL-UNNAMED --add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+				<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED --add-exports java.base/jdk.crac=ALL-UNNAMED
+					--add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
 				<echo>===addExports:        ${addExports}</echo>
 				<echo>===enablePreview:     ${enablePreview}</echo>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">


### PR DESCRIPTION
Export `jdk.management/jdk.crac.management` only when `CRaC` is enabled

Use reflection to get module `jdk.management`, export `jdk.crac.management` unconditionally, only when `CRaC` is enabled, assuming module `jdk.management` is to be loaded when `CRaC` is enabled;
Updated tests with `--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED`.

closes https://github.com/eclipse-openj9/openj9/issues/19534

Signed-off-by: Jason Feng <fengj@ca.ibm.com>