### PR TITLE
Re-enable IProfiler for JITServer

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -627,7 +627,6 @@ TR_IProfiler::TR_IProfiler(J9JITConfig *jitConfig)
 #endif
       _methodHashTable = NULL;
       _readSampleRequestsHistory = NULL;
-      _isIProfilingEnabled = false;
       }
    else
 #endif


### PR DESCRIPTION
IProfiler for JITServer was disabled by mistake by PR #19355 causing a severe performance degradation. This commit re-enables the usage of IProfiler.