### PR TITLE
(0.46.0) Check file type for shared class cache jar files

### DIFF
--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -71,16 +71,17 @@ typedef struct URLElements {
 } URLElements;
 
 
-static J9ClassPathEntry* getCachedURL(JNIEnv* env, jint helperID, const char* pathChars, jsize pathLen, UDATA cpeType, U_16 cpeStatus);
+static J9ClassPathEntry *getCachedURL(JNIEnv *env, jint helperID, const char *pathChars, jsize pathLen, UDATA cpeType, U_16 cpeStatus, const char *correctedPath);
 static const char* copyString(J9PortLibrary* portlib, const char* toCopy, UDATA length, J9SharedStringFarm** farmRoot, const J9UTF8** makeUTF8);
 UDATA urlHashFn(void* item, void *userData);
-static jint createURLEntry(JNIEnv* env, jint helperID, J9ClassPathEntry** cpEntry_, char* correctedPathCopy, UDATA cpeType, U_16 cpeStatus);
+static jint createURLEntry(JNIEnv *env, jint helperID, J9ClassPathEntry **cpEntry_, const char *correctedPathCopy, UDATA cpeType, U_16 cpeStatus);
 UDATA utfHashEqualFn(void* left, void* right, void *userData);
 static jint createROMClassCookie(JNIEnv* env, J9JavaVM* vm, J9ROMClass* romClass, jbyteArray romClassCookieBuffer);
 static jint createToken(JNIEnv* env, jint helperID, J9ClassPathEntry** cpEntry_, const char* tokenChars, jsize tokenSize);
 static UDATA correctURLPath(JNIEnv* env, const char* pathChars, jsize pathLen, char** correctedPathPtr, J9SharedStringFarm** jclStringFarm);
 static const char* getCachedString(JNIEnv* env, const char* input, jsize length, J9SharedStringFarm** farmRoot, const J9UTF8** getUTF8);
-static UDATA getCpeTypeForProtocol(char* protocol, jsize protocolLen, const char* pathChars, jsize pathLen);
+static UDATA getCpeTypeForProtocol(JNIEnv *env, const char *protocol, jsize protocolLen, const char *urlPathChars, jsize urlPathLen, char **correctedPathPtr);
+static BOOLEAN isPathTypeJimage(const char *pathChars, jsize pathLen);
 static void getURLMethodIDs(JNIEnv* env);
 static J9Pool* getClasspathCache(JNIEnv* env);
 static J9Pool* getURLCache(JNIEnv* env);
@@ -122,14 +123,14 @@ correctURLPath(JNIEnv* env, const char* pathChars, jsize pathLen, char** correct
 	returnVal = 1;
 	startOffset = 0;
 
-#ifdef WIN32
+#if defined(WIN32)
 	for (;pathChars[startOffset]=='/'; startOffset++);
 
 	/* If Windows UNC (no path colon) do not remove leading spaces */
 	if (pathChars[startOffset+1] != ':') {
 		startOffset = 0;
 	}
-#endif
+#endif /* defined(WIN32) */
 
 	if (pathLen >= STACK_STRINGBUF_SIZE) {
 		if (!(bufPtr = (char*)j9mem_allocate_memory((pathLen + 1) * sizeof(char), J9MEM_CATEGORY_VM_JCL))) {
@@ -147,11 +148,11 @@ correctURLPath(JNIEnv* env, const char* pathChars, jsize pathLen, char** correct
 			if (i == (pathLen-1)) { 
 				current = '\0';		/* remove trailing slash */
 			} 
-#ifdef WIN32
+#if defined(WIN32)
 			else {
 				current = '\\';		/* convert / to \\ */
 			}
-#endif
+#endif /* defined(WIN32) */
 		}
 
 		/* Assumes escape sequence is %nn, where nn is hex value */
@@ -229,7 +230,6 @@ createROMClassCookie(JNIEnv* env, J9JavaVM* vm, J9ROMClass* romClass, jbyteArray
 static jint
 createCPEntries(JNIEnv* env, jint helperID, jint urlCount, J9ClassPathEntry*** cpEntries_, URLElements* urlArrayElements)
 {
-	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
 	J9ClassPathEntry* cpEntries = NULL;
 	struct J9ClasspathByID* newCacheItem = NULL;
 	J9ClassPathEntry** cpePtrArray = NULL;
@@ -251,23 +251,23 @@ createCPEntries(JNIEnv* env, jint helperID, jint urlCount, J9ClassPathEntry*** c
 	memset(cpePtrArray, 0, cpEntrySize);
 	cpEntries = (J9ClassPathEntry*)((char*)cpePtrArray + (urlCount * (sizeof(J9ClassPathEntry*))));
 
-	for (i=0; i<urlCount; i++) {
-		UDATA cpeType = 0;
-		char* correctPath = NULL;
-
-		cpeType = getCpeTypeForProtocol((char*)urlArrayElements[i].protocolChars, urlArrayElements[i].protocolLen, urlArrayElements[i].pathChars, urlArrayElements[i].pathLen);
+	for (i = 0; i < urlCount; i++) {
+		char *correctedPath = NULL;
+		UDATA cpeType = getCpeTypeForProtocol(
+				env,
+				urlArrayElements[i].protocolChars,
+				urlArrayElements[i].protocolLen,
+				urlArrayElements[i].pathChars,
+				urlArrayElements[i].pathLen,
+				&correctedPath);
 		if (CPE_TYPE_UNKNOWN == cpeType) {
 			Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse4(env);
 			goto _error;
 		}
-		if (!correctURLPath(env, urlArrayElements[i].pathChars, urlArrayElements[i].pathLen, &correctPath, &(vm->sharedClassConfig->jclStringFarm))) {
-			Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse5(env);
-			goto _error;
-		}
 
-		cpEntries[i].path = (U_8*)correctPath;
+		cpEntries[i].path = (U_8 *)correctedPath;
 		cpEntries[i].extraInfo = NULL;
-		cpEntries[i].pathLength = (U_32)strlen(correctPath);
+		cpEntries[i].pathLength = (U_32)strlen(correctedPath);
 		cpEntries[i].flags = 0;
 		cpEntries[i].type = (U_16)cpeType;
 		cpePtrArray[i] = &cpEntries[i];
@@ -455,11 +455,10 @@ _exit:
 	return;
 }
 
-
-/* Note:CorrectedPathCopy must be a copied string which will not disappear and partition must be also not disappear */
+/* Note: correctedPathCopy must not disappear. */
 /* THREADING: Must be protected by jclCacheMutex */
 static jint
-createURLEntry(JNIEnv* env, jint helperID, J9ClassPathEntry** cpEntry_, char* correctedPathCopy, UDATA cpeType, U_16 cpeStatus)
+createURLEntry(JNIEnv *env, jint helperID, J9ClassPathEntry **cpEntry_, const char *correctedPathCopy, UDATA cpeType, U_16 cpeStatus)
 {
 	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
 	J9ClassPathEntry* newEntry;
@@ -546,40 +545,67 @@ _end:
 	return rc;
 }
 
+static BOOLEAN
+isPathTypeJimage(const char *pathChars, jsize pathLen)
+{
+	char JimageEndsWith[] = DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "modules";
+	IDATA len = LITERAL_STRLEN(JimageEndsWith);
+
+	if (pathLen > len) {
+		const char *endsWith = pathChars + (pathLen - len);
+		if (0 == strncmp(endsWith, JimageEndsWith, len)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
 
 /* THREADING: Can be called multi-threaded */
 static UDATA
-getCpeTypeForProtocol(char* protocol, jsize protocolLen, const char* pathChars, jsize pathLen)
+getCpeTypeForProtocol(JNIEnv *env, const char *protocol, jsize protocolLen, const char *urlPathChars, jsize urlPathLen, char **correctedPathPtr)
 {
+	J9JavaVM *vm = ((J9VMThread *)env)->javaVM;
+	const char *pathChars = NULL;
+	jsize pathLen = 0;
+
 	Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_Entry();
 
-	if (!protocol) {
-		Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_Exit0();
-		return 0;
+	if (NULL == protocol) {
+		Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail1();
+		return CPE_TYPE_UNKNOWN;
 	}
-	if (strncmp(protocol, "jar", 4)==0) {
+	if (!correctURLPath(env, urlPathChars, urlPathLen, correctedPathPtr, &(vm->sharedClassConfig->jclStringFarm))) {
+		Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail2();
+		return CPE_TYPE_UNKNOWN;
+	}
+	if (0 == strncmp(protocol, "jar", 4)) {
 		Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR();
 		return CPE_TYPE_JAR;
 	}
-	if (strncmp(protocol, "file", 5)==0) {
-		char* endsWith = (char*)(pathChars + (pathLen-4));
-		if ((strncmp(endsWith, ".jar", 4)==0) || (strncmp(endsWith, ".zip", 4)==0) || strstr(pathChars,"!/") || strstr(pathChars,"!\\")) {
+	pathChars = *correctedPathPtr;
+	pathLen = (jsize)strlen(pathChars);
+	if (0 == strncmp(protocol, "file", 5)) {
+		if ((NULL != strstr(pathChars, "!/")) || (NULL != strstr(pathChars, "!\\"))) {
+			/* file is a fat jar */
 			Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR();
 			return CPE_TYPE_JAR;
+		} else if (isPathTypeJimage(pathChars, pathLen)) {
+			Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJIMAGE();
+			return CPE_TYPE_JIMAGE;
 		} else {
-			char JimageEndsWith[] = DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "modules";
-			IDATA len = LITERAL_STRLEN(JimageEndsWith);
-
-			if (pathLen >= len) {
-				endsWith = (char*)(pathChars + (pathLen - len));
-				if (strncmp(endsWith, JimageEndsWith, len) == 0) {
-					Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJIMAGE();
-					return CPE_TYPE_JIMAGE;
-				}
+			PORT_ACCESS_FROM_JAVAVM(vm);
+			I_32 result = j9file_attr(pathChars);
+			if (EsIsFile == result) {
+				Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR();
+				return CPE_TYPE_JAR;
+			} else if (EsIsDir == result) {
+				Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitDIR();
+				return CPE_TYPE_DIRECTORY;
+			} else {
+				Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail3(result);
+				return CPE_TYPE_UNKNOWN;
 			}
 		}
-		Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitDIR();
-		return CPE_TYPE_DIRECTORY;
 	}
 	Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_UnknownProtocol(protocolLen, protocol, pathLen, pathChars);
 	Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitUnknown();
@@ -588,8 +614,8 @@ getCpeTypeForProtocol(char* protocol, jsize protocolLen, const char* pathChars, 
 
 
 /* THREADING: Must be protected by jclCacheMutex */
-static J9ClassPathEntry* 
-getCachedURL(JNIEnv* env, jint helperID, const char* pathChars, jsize pathLen, UDATA cpeType, U_16 cpeStatus)
+static J9ClassPathEntry *
+getCachedURL(JNIEnv *env, jint helperID, const char *pathChars, jsize pathLen, UDATA cpeType, U_16 cpeStatus, const char *correctedPath)
 {
 	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
 	struct URLhtEntry* anElement = NULL;
@@ -617,7 +643,6 @@ getCachedURL(JNIEnv* env, jint helperID, const char* pathChars, jsize pathLen, U
 	} else {
 		URLhtEntry newEntry;
 		const char* origPathCopy;
-		char* correctedPathCopy;
 
 		/* We must make a copy of the path
 			This is kept in the URLhtEntry and must be valid for the lifetime of the JVM */
@@ -626,9 +651,7 @@ getCachedURL(JNIEnv* env, jint helperID, const char* pathChars, jsize pathLen, U
 			goto _error;
 		}
 
-		/* Function returns a corrected copy of pathChars into correctedPathCopy. */
-		correctURLPath(env, pathChars, pathLen, &correctedPathCopy, &(config->jclStringFarm));
-		if (!createURLEntry(env, helperID, &urlEntry, correctedPathCopy, cpeType, cpeStatus)) {
+		if (!createURLEntry(env, helperID, &urlEntry, correctedPath, cpeType, cpeStatus)) {
 			goto _error;
 		}
 
@@ -1230,6 +1253,7 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_findSharedClassImpl3(JNIEnv* en
 	U_16 cpeStatus = minimizeUpdateChecks ? CPE_STATUS_IGNORE_ZIP_LOAD_STATE : 0;
 	J9ClassLoader* classloader;
 	URLElements urlElements = {0};
+	char *correctedPath = NULL;
 	
 	Trc_JCL_com_ibm_oti_shared_SharedClassURLHelperImpl_findSharedClassImpl_Entry(env, helperID);
 
@@ -1261,13 +1285,21 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_findSharedClassImpl3(JNIEnv* en
 	if (!getStringPair(env, &nameChars, &nameLen, &partitionChars, &partitionLen, classNameObj, partitionObj)) {
 		goto _errorPostClassNamePartition;
 	}
-	if (!(cpeType = getCpeTypeForProtocol((char*)urlElements.protocolChars, urlElements.protocolLen, urlElements.pathChars, urlElements.pathLen))) {
+	cpeType = getCpeTypeForProtocol(
+			env,
+			urlElements.protocolChars,
+			urlElements.protocolLen,
+			urlElements.pathChars,
+			urlElements.pathLen,
+			&correctedPath);
+	if (CPE_TYPE_UNKNOWN == cpeType) {
 		goto _errorPostClassNamePartition;
 	}
 
 	omrthread_monitor_enter(jclCacheMutex);
 
-	if (!(urlEntry = getCachedURL(env, helperID, urlElements.pathChars, urlElements.pathLen, cpeType, cpeStatus))) {
+	urlEntry = getCachedURL(env, helperID, urlElements.pathChars, urlElements.pathLen, cpeType, cpeStatus, correctedPath);
+	if (NULL == urlEntry) {
 		omrthread_monitor_exit(jclCacheMutex);
 		goto _errorPostClassNamePartition;
 	}
@@ -1341,6 +1373,7 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_storeSharedClassImpl3(JNIEnv* e
 	SCAbstractAPI * sharedapi = (SCAbstractAPI *)(config->sharedAPIObject);
 	U_16 cpeStatus = minimizeUpdateChecks ? CPE_STATUS_IGNORE_ZIP_LOAD_STATE : 0;
 	URLElements urlElements = {0};
+	char *correctedPath = NULL;
 
 	Trc_JCL_com_ibm_oti_shared_SharedClassURLHelperImpl_storeSharedClassImpl_Entry(env, helperID);
 
@@ -1373,13 +1406,21 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_storeSharedClassImpl3(JNIEnv* e
 	if (!getStringChars(env, &partitionChars, &partitionLen, partitionObj)) {
 		goto _errorPostPathProtocol;
 	}
-	if (!(cpeType = getCpeTypeForProtocol((char*)urlElements.protocolChars, urlElements.protocolLen, urlElements.pathChars, urlElements.pathLen))) {
+	cpeType = getCpeTypeForProtocol(
+			env,
+			urlElements.protocolChars,
+			urlElements.protocolLen,
+			urlElements.pathChars,
+			urlElements.pathLen,
+			&correctedPath);
+	if (CPE_TYPE_UNKNOWN == cpeType) {
 		goto _errorPostPartition;
 	}
 
 	omrthread_monitor_enter(jclCacheMutex);
 
-	if (!(urlEntry = getCachedURL(env, helperID, urlElements.pathChars, urlElements.pathLen, cpeType, cpeStatus))) {
+	urlEntry = getCachedURL(env, helperID, urlElements.pathChars, urlElements.pathLen, cpeType, cpeStatus, correctedPath);
+	if (NULL == urlEntry) {
 		omrthread_monitor_exit(jclCacheMutex);
 		goto _errorPostPartition;
 	}
@@ -2526,7 +2567,7 @@ runCorrectURLUnitTests(JNIEnv* env)
 	testCorrectURLPath(env, "///C:/dir%201/dir%202/dir%20%203/", "C:\\dir 1\\dir 2\\dir  3");
 	testCorrectURLPath(env, "//UNCTest/subdir", "\\\\UNCTest\\subdir");
 	testCorrectURLPath(env, "//UNCTest/sub%20dir", "\\\\UNCTest\\sub dir");
-#else
+#else /* defined(WIN32) */
 	testCorrectURLPath(env, "/dir1", "/dir1");
 	testCorrectURLPath(env, "/dir1/", "/dir1");
 	testCorrectURLPath(env, "//dir1/", "//dir1");
@@ -2534,7 +2575,7 @@ runCorrectURLUnitTests(JNIEnv* env)
 	testCorrectURLPath(env, "/dir%251", "/dir%1");
 	testCorrectURLPath(env, "/dir%201/", "/dir 1");
 	testCorrectURLPath(env, "/dir%201/dir%202/dir%20%203/", "/dir 1/dir 2/dir  3");
-#endif 		/* WIN32 */
+#endif /* defined(WIN32) */
 }
 
 #endif /* J9SHR_UNIT_TEST */

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -181,7 +181,7 @@ TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse1 Overhead=1 Level
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse2 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE due to memory allocation failure"
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse3 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as getPathProtocolFromURL failed"
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse4 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as getCpeTypeForProtocol failed"
-TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse5 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as correctURLPath failed"
+TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse5 Obsolete Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as correctURLPath failed"
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse6 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as pool_newElement failed"
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitFalse7 Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting FALSE as copyString failed"
 TraceExit=Trc_JCL_com_ibm_oti_shared_createCPEntries_ExitTrue Overhead=1 Level=1 Template="JCL: com.ibm.oti.shared createCPEntries: Exiting with TRUE"
@@ -215,7 +215,7 @@ TraceExit=Trc_JCL_com_ibm_oti_shared_getCachedURL_ExitFound Overhead=1 Level=2 T
 TraceExit=Trc_JCL_com_ibm_oti_shared_getCachedURL_ExitNull Overhead=1 Level=2 Template="JCL: com.ibm.oti.shared getCachedURL: Exiting with NULL"
 
 TraceEntry=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_Entry Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Entering"
-TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_Exit0 Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with 0 as protocol is NULL"
+TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_Exit0 Obsolete Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with 0 as protocol is NULL"
 TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with JAR"
 TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitDIR Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with DIR"
 TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJXE Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with JXE"
@@ -707,3 +707,7 @@ TraceEvent=Trc_JCL_MXBean_getUptimeImpl Overhead=1 Level=3 Template="RuntimeMXBe
 
 TraceException=Trc_JCL_memoryManagement_verifyMemoryUsageAfterGC_memoryUsageError Test NoEnv Overhead=1 Level=1 Template="JCL: verifyMemoryUsageAfterGC memoryUsageError: GcName=%s, MemoryPool=%s, initialSize=%lld, preUsedSize=%llu, preCommittedSize==%llu, preMaxSize=%lld, postUsedSize=%llu, postCommittedSize==%llu, postMaxSize=%lld"
 TraceEvent=Trc_JCL_memoryManagement_verifyMemoryUsageAfterGC_memoryUsage Test NoEnv Overhead=1 Level=6 Template="JCL: verifyMemoryUsageAfterGC memoryUsage: GcName=%s, MemoryPool=%s, initialSize=%lld, preUsedSize=%llu, preCommittedSize==%llu, preMaxSize=%lld, postUsedSize=%llu, postCommittedSize==%llu, postMaxSize=%lld"
+
+TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail1 Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Protocol is NULL"
+TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail2 Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Call to correctURLPath failed"
+TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitFail3 Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Attempt to determine path type resulted in error code %d"

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-5.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-5.xml
@@ -39,6 +39,7 @@
 	<variable name="currentMode" value="$mode204$"/>
 	<variable name="XXShareClassesEnableBCI" value="-XX:ShareClassesEnableBCI"/>
 	
+	<variable name="UTILSJAR" value="$UTILSDIR$$PATHSEP$utils.jar" />
 	<variable name="CP_HANOI" value="-cp $UTILSJAR$" />
  	<variable name="BOOTCP_HANOI" value="-Xbootclasspath/a:$UTILSJAR$" />
  	<variable name="PROGRAM_HANOI" value="org.openj9.test.ivj.Hanoi 2" />
@@ -830,6 +831,35 @@
 	<test id="Test 199-c: Re-use the cache as read-only to load sample program with its classpath added to boot classpath" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $BOOTCP_HANOI$ $currentMode$,readonly -Xnolinenumbers $PROGRAM_HANOI$</command>
 		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<!-- Test fix for https://github.com/eclipse-openj9/openj9/issues/19378 -->
+	<test id="Test 200a: reset cache and run program with utils jar file that is missing the typical .jar ending">
+		<exec command="cp $UTILSJAR$ $UTILSDIR$$PATHSEP$utils"/>
+		<command>$JAVA_EXE$ $currentMode$,reset -cp $UTILSDIR$$PATHSEP$utils -Xnolinenumbers $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 200b: run program with utils jar file that is missing the typical .jar ending">
+		<command>$JAVA_EXE$ $currentMode$ -cp $UTILSDIR$$PATHSEP$utils -Xnolinenumbers $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 200c: verify that no classes are marked stale and classes from the utils jar file were reused">
+		<command>$JAVA_EXE$ $currentMode$,printStats -cp $UTILSDIR$$PATHSEP$utils -Xnolinenumbers $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Stale classes += 0</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -211,7 +211,7 @@
 	-DPATHSEP=$(Q)$(D)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DPROPS_DIR=$(PROPS_DIR) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) \
 	-DJAVA_EXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -DJAVA_HOME=$(SQ)$(TEST_JDK_HOME)$(SQ) -DSCMODE=204 -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
 	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DUTILSDIR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-5.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JDK_VERSION),$(JCL_VERSION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \


### PR DESCRIPTION
Port solution for https://github.com/eclipse-openj9/openj9/issues/19378 to 0.46
The change in the master branch is https://github.com/eclipse-openj9/openj9/pull/19380

Use the port library to check if path leads to a directory or file to support jar files that may not have the typical *.jar ending.