### PR TITLE
Support lambdas and other generated classes in JITServer AOT cache

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -282,7 +282,7 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, ROMClassCreation
 	 * When there are a large number of such classes in the shared cache, they trigger a lot of class comparisons.
 	 * Performance can be much worse (compared to shared cache turned off).
 	 */
-	if (isLambdaFormClassName(originalStringBytes, originalStringLength)) {
+	if (isLambdaFormClassName(originalStringBytes, originalStringLength, NULL/*deterministicPrefixLength*/)) {
 		context->addFindClassFlags(J9_FINDCLASS_FLAG_DO_NOT_SHARE);
 		context->addFindClassFlags(J9_FINDCLASS_FLAG_LAMBDAFORM);
 	}
@@ -429,12 +429,15 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, ROMClassCreation
 	/* Mark if the class is a Lambda class. */
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	if (!context->isLambdaFormClass()
-		&& isLambdaClassName(reinterpret_cast<const char *>(_anonClassNameBuffer), newAnonClassNameLength - 1)
+		&& isLambdaClassName(reinterpret_cast<const char *>(_anonClassNameBuffer),
+		                     newAnonClassNameLength - 1, NULL/*deterministicPrefixLength*/)
 	) {
 		context->addFindClassFlags(J9_FINDCLASS_FLAG_LAMBDA);
 	}
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
-	if (isLambdaClassName(reinterpret_cast<const char *>(_anonClassNameBuffer), newAnonClassNameLength - 1)) {
+	if (isLambdaClassName(reinterpret_cast<const char *>(_anonClassNameBuffer),
+	                      newAnonClassNameLength - 1, NULL/*deterministicPrefixLength*/)
+	) {
 		context->addFindClassFlags(J9_FINDCLASS_FLAG_LAMBDA);
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -3827,6 +3827,11 @@ void jitHookClassLoadHelper(J9VMThread *vmThread,
 
    compInfo->getPersistentInfo()->getPersistentClassLoaderTable()->associateClassLoaderWithClass(vmThread, classLoader, clazz);
 
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto deserializer = compInfo->getJITServerAOTDeserializer())
+      deserializer->onClassLoad(cl, vmThread);
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    // Update the count for the newInstance
    //
    TR::Options * options = TR::Options::getCmdLineOptions();

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -141,6 +141,7 @@ int32_t J9::Options::_jitserverMallocTrimInterval = 1000 * 30; // 30000ms = 30s
 int32_t J9::Options::_lowCompDensityModeEnterThreshold = 4; // Maximum number of compilations per 10 min of CPU required to enter low compilation density mode. Use 0 to disable feature
 int32_t J9::Options::_lowCompDensityModeExitThreshold = 15; // Minimum number of compilations per 10 min of CPU required to exit low compilation density mode
 int32_t J9::Options::_lowCompDensityModeExitLPQSize = 120;  // Minimum number of compilations in LPQ to take us out of low compilation density mode
+bool J9::Options::_aotCacheDisableGeneratedClassSupport = false;
 TR::CompilationFilters *J9::Options::_JITServerAOTCacheStoreFilters = NULL;
 TR::CompilationFilters *J9::Options::_JITServerAOTCacheLoadFilters = NULL;
 TR::CompilationFilters *J9::Options::_JITServerRemoteExcludeFilters = NULL;
@@ -850,6 +851,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"activeThreadsThresholdForInterpreterSampling=", "M<nnn>\tSampling does not affect invocation count beyond this threshold",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_activeThreadsThreshold, 0, "F%d", NOT_IN_SUBSET },
 #if defined(J9VM_OPT_JITSERVER)
+   {"aotCacheDisableGeneratedClassSupport", " \tDisable support for generated classes such as lambdas in JITServer AOT cache",
+        TR::Options::setStaticBool, (intptr_t)&TR::Options::_aotCacheDisableGeneratedClassSupport, 1, "F%d", NOT_IN_SUBSET },
    {"aotCachePersistenceMinDeltaMethods=", "M<nnn>\tnumber of extra AOT methods that need to be added to the JITServer AOT cache before considering a save operation",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_aotCachePersistenceMinDeltaMethods, 0, "F%d", NOT_IN_SUBSET },
    {"aotCachePersistenceMinPeriodMs=", "M<nnn>\tmiminum time between two consecutive JITServer AOT cache save operations (ms)",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -380,6 +380,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _lowCompDensityModeEnterThreshold;
    static int32_t _lowCompDensityModeExitThreshold;
    static int32_t _lowCompDensityModeExitLPQSize;
+   static bool _aotCacheDisableGeneratedClassSupport;
    static TR::CompilationFilters *_JITServerAOTCacheStoreFilters;
    static TR::CompilationFilters *_JITServerAOTCacheLoadFilters;
    static TR::CompilationFilters *_JITServerRemoteExcludeFilters;

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -962,8 +962,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // Get defining class chain record to use as a part of the key to lookup or store the method in AOT cache
          JITServerHelpers::cacheRemoteROMClassBatch(clientSession, uncachedRAMClasses, uncachedClassInfos);
          bool missingLoaderInfo = false;
-         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChainOffset, ramClassChain,
-                                                                        stream, missingLoaderInfo);
+         _definingClassChainRecord = clientSession->getClassChainRecord(clazz, classChainOffset, ramClassChain, stream,
+                                                                        missingLoaderInfo, &scratchSegmentProvider);
          if (!_definingClassChainRecord)
             {
             if (TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -95,7 +95,8 @@ public:
    // structures used for packing). This function should be used with TR::StackMemoryRegion.
    // If passed non-zero expectedSize, and it doesn't match the resulting packedSize
    // (which is returned to the caller by reference), this function returns NULL.
-   static J9ROMClass *packROMClass(J9ROMClass *romClass, TR_Memory *trMemory, TR_J9VMBase *fej9, size_t &packedSize, size_t expectedSize = 0);
+   static J9ROMClass *packROMClass(const J9ROMClass *romClass, TR_Memory *trMemory, TR_J9VMBase *fej9,
+                                   size_t &packedSize, size_t expectedSize = 0, size_t generatedPrefixLength = 0);
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory, bool serializeClass);
    static void freeRemoteROMClass(J9ROMClass *romClass, TR_PersistentMemory *persistentMemory);
@@ -147,12 +148,21 @@ public:
    static uint64_t generateUID();
 
    static uint32_t getFullClassNameLength(const J9ROMClass *romClass, const J9ROMClass *baseComponent,
-                                          uint32_t numDimensions);
+                                          uint32_t numDimensions, bool checkGenerated = false);
    // Writes the full class name (array class signature for arrays, class name otherwise) into the result buffer.
    // The buffer length must be at least getFullClassNameLength(romClass, baseComponent, numDimensions).
    // The baseComponent ROMClass and numDimensions correspond to the result of TR_J9VM::getBaseComponentClass().
    static void getFullClassName(uint8_t *result, uint32_t length, const J9ROMClass *romClass,
-                                const J9ROMClass *baseComponent, uint32_t numDimensions);
+                                const J9ROMClass *baseComponent, uint32_t numDimensions, bool checkGenerated = false);
+
+   // If name matches one of the recognized runtime-generated class name patterns (where the name can vary across JVM
+   // instances, e.g., lambdas), returns the length of the deterministic class name prefix, otherwise returns 0.
+   static size_t getGeneratedClassNamePrefixLength(const J9UTF8 *name);
+
+   static size_t getGeneratedClassNamePrefixLength(const J9ROMClass *romClass)
+      {
+      return getGeneratedClassNamePrefixLength(J9ROMCLASS_CLASSNAME(romClass));
+      }
 
 private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2110,14 +2110,15 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
    // Create AOT deserializer at the client if using JITServer with AOT cache
    if ((persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT) && persistentInfo->getJITServerUseAOTCache())
       {
+      auto loaderTable = persistentInfo->getPersistentClassLoaderTable();
       JITServerAOTDeserializer *deserializer = NULL;
       if (persistentInfo->getJITServerAOTCacheIgnoreLocalSCC())
          {
-         deserializer = new (PERSISTENT_NEW) JITServerNoSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
+         deserializer = new (PERSISTENT_NEW) JITServerNoSCCAOTDeserializer(loaderTable, jitConfig);
          }
       else if (TR::Options::sharedClassCache())
          {
-         deserializer = new (PERSISTENT_NEW) JITServerLocalSCCAOTDeserializer(persistentInfo->getPersistentClassLoaderTable());
+         deserializer = new (PERSISTENT_NEW) JITServerLocalSCCAOTDeserializer(loaderTable, jitConfig);
          }
       else
          {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -212,7 +212,8 @@ public:
     * \return A pointer. Raises a fatal assertion before returning NULL if the pointer is invalid.
     */
    virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData);
-   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader);
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader,
+                                                              TR::Compilation *comp);
 
    /**
     * \brief Checks whether the specified pointer points into the metadata section
@@ -668,8 +669,11 @@ public:
 
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override { TR_ASSERT_FATAL(false, "called"); return false;}
 
-   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) override { TR_ASSERT_FATAL(false, "called"); return NULL; }
-   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader) override { TR_ASSERT_FATAL(false, "called"); return NULL;}
+   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) override
+      { TR_ASSERT_FATAL(false, "called"); return NULL; }
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader,
+                                                              TR::Compilation *comp) override
+      { TR_ASSERT_FATAL(false, "called"); return NULL;}
 
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { TR_ASSERT_FATAL(false, "called"); }
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { TR_ASSERT_FATAL(false, "called"); return TR_J9SharedCache::TR_J9SharedCacheDisabledReason::UNINITIALIZED;}
@@ -733,7 +737,8 @@ public:
    virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset) override;
    virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset) override;
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override;
-   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader) override;
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader,
+                                                              TR::Compilation *comp) override;
 
    virtual bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }
    virtual bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -68,7 +68,8 @@ public:
    virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) { return false; }
 
    virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) {return NULL; }
-   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *loader) { return NULL; }
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *loader,
+                                                              TR::Compilation *comp) { return NULL; }
 
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) { return 0; }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7285,23 +7285,21 @@ TR_J9VM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference * sym
    return tramp;
    }
 
+
 TR_OpaqueClassBlock *
-TR_J9VM::getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims)
+TR_J9VMBase::staticGetBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims)
    {
-   J9Class * myClass = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+   J9Class *myClass = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
    while (J9ROMCLASS_IS_ARRAY(myClass->romClass))
       {
-      J9Class * componentClass = (J9Class *)(((J9ArrayClass*)myClass)->componentType);
+      J9Class *componentClass = (J9Class *)(((J9ArrayClass *)myClass)->componentType);
       if (J9ROMCLASS_IS_PRIMITIVE_TYPE(componentClass->romClass))
          break;
       numDims++;
       myClass = componentClass;
       }
-   return convertClassPtrToClassOffset(myClass);
+   return TR::Compiler->cls.convertClassPtrToClassOffset(myClass);
    }
-
-
-
 
 
 TR_YesNoMaybe

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -561,7 +561,8 @@ public:
    uintptr_t                 getOffsetOfSuperclassesInClassObject();
    uintptr_t                 getOffsetOfBackfillOffsetField();
 
-   virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims) { return 0; }
+   static TR_OpaqueClassBlock *staticGetBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims);
+   virtual TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims) { return NULL; }
 
    bool vftFieldRequiresMask(){ return ~TR::Compiler->om.maskOfObjectVftField() != 0; }
 
@@ -1556,7 +1557,12 @@ public:
    virtual int32_t               getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT=false);
-   virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims);
+
+   virtual TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims)
+      {
+      return staticGetBaseComponentClass(clazz, numDims);
+      }
+
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT=false);
    virtual TR_YesNoMaybe      isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock *castClass, bool instanceIsFixed, bool castIsFixed = true, bool optimizeForAOT=false);
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3223,7 +3223,7 @@ TR_IPBCDataCallGraph::loadFromPersistentCopy(TR_IPBCDataStorageHeader * storage,
             J9ClassLoader *classLoader = (J9ClassLoader *)sharedCache->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
             if (classLoader)
                {
-               TR_OpaqueClassBlock *j9class = sharedCache->lookupClassFromChainAndLoader(classChain, classLoader);
+               TR_OpaqueClassBlock *j9class = sharedCache->lookupClassFromChainAndLoader(classChain, classLoader, comp);
                if (j9class)
                   {
                   // Optimizer and the codegen assume receiver classes of a call from profiling data are initialized,

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -475,14 +475,19 @@ public:
       }
 
    // If this function sets the missingLoaderInfo flag then a NULL result is due to missing class loader info;
-   // otherwise that result is due to reaching the AOT cache size limit.
-   const AOTCacheClassRecord *getClassRecord(J9Class *clazz, JITServer::ServerStream *stream, bool &missingLoaderInfo);
+   // otherwise that result is due to reaching the AOT cache size limit. If this function (or any other function
+   // in this class that takes a scratchSegmentProvider) is called outside of a compilation (e.g., at the start
+   // of processing a client compilation request), must pass a scratchSegmentProvider that will be used for
+   // scratch memory allocations when re-packing a runtime-generated ROMClass to compute its deterministic hash.
+   const AOTCacheClassRecord *getClassRecord(J9Class *clazz, JITServer::ServerStream *stream, bool &missingLoaderInfo,
+                                             J9::J9SegmentProvider *scratchSegmentProvider = NULL);
    const AOTCacheMethodRecord *getMethodRecord(J9Method *method, J9Class *definingClass, JITServer::ServerStream *stream);
    // If this function sets the missingLoaderInfo flag then a NULL result is due to missing class loader info;
    // otherwise that result is due to reaching the AOT cache size limit.
    const AOTCacheClassChainRecord *getClassChainRecord(J9Class *clazz, uintptr_t classChainOffset,
                                                        const std::vector<J9Class *> &ramClassChain,
-                                                       JITServer::ServerStream *stream, bool &missingLoaderInfo);
+                                                       JITServer::ServerStream *stream, bool &missingLoaderInfo,
+                                                       J9::J9SegmentProvider *scratchSegmentProvider = NULL);
    const AOTCacheWellKnownClassesRecord *getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
                                                                    size_t length, uintptr_t includedClasses);
 
@@ -498,11 +503,13 @@ private:
    // otherwise that result is due to either the base component (returned via non-NULL uncachedBaseComponent)
    // of the array class being uncached, or having reached the AOT cache size limit.
    const AOTCacheClassRecord *getClassRecord(ClassInfo &classInfo, bool &missingLoaderInfo,
-                                             J9Class *&uncachedBaseComponent);
+                                             J9Class *&uncachedBaseComponent,
+                                             J9::J9SegmentProvider *scratchSegmentProvider = NULL);
    // If this function sets one of the two boolean flags or uncachedBaseComponent then a NULL result is due to
    // one of those error conditions; otherwise that result is due to having reached the AOT cache size limit.
    const AOTCacheClassRecord *getClassRecord(J9Class *clazz, bool &missingLoaderInfo,
-                                             bool &uncachedClass, J9Class *&uncachedBaseComponent);
+                                             bool &uncachedClass, J9Class *&uncachedBaseComponent,
+                                             J9::J9SegmentProvider *scratchSegmentProvider = NULL);
 
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -147,7 +147,8 @@ struct ClassSerializationRecord : public AOTSerializationRecord
 public:
    uintptr_t classLoaderId() const { return _classLoaderId; }
    const JITServerROMClassHash &hash() const { return _hash; }
-   uint32_t romClassSize() const { return _romClassSize; }
+   uint32_t romClassSize() const { return _romClassSize & ~AOTCACHE_CLASS_RECORD_GENERATED; }
+   bool isGenerated() const { return _romClassSize & AOTCACHE_CLASS_RECORD_GENERATED; }
    uint32_t nameLength() const { return _nameLength; }
    const uint8_t *name() const { return _name; }
 
@@ -155,9 +156,12 @@ private:
    friend class AOTCacheRecord;
    friend class AOTCacheClassRecord;
 
+   static const uint32_t AOTCACHE_CLASS_RECORD_GENERATED = 1;
+
+   // The `generated` flag refers to runtime-generated classes such as lambdas
    ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId, const JITServerROMClassHash &hash,
-                            const J9ROMClass *romClass, const J9ROMClass *baseComponent,
-                            uint32_t numDimensions, uint32_t nameLength);
+                            uint32_t romClassSize, bool generated, const J9ROMClass *romClass,
+                            const J9ROMClass *baseComponent, uint32_t numDimensions, uint32_t nameLength);
    ClassSerializationRecord();
 
    static size_t size(uint32_t nameLength)
@@ -170,7 +174,7 @@ private:
    const uintptr_t _classLoaderId;
    const JITServerROMClassHash _hash;
    // Used to quickly detect class mismatches (without computing the hash) when ROMClass size is different
-   const uint32_t _romClassSize;
+   const uint32_t _romClassSize; // isGenerated flag is encoded in LSB
    // Class name string
    const uint32_t _nameLength;
    uint8_t _name[];

--- a/runtime/compiler/runtime/JITServerROMClassHash.cpp
+++ b/runtime/compiler/runtime/JITServerROMClassHash.cpp
@@ -30,8 +30,9 @@
 #include "runtime/JITServerAOTSerializationRecords.hpp"
 
 
-JITServerROMClassHash::JITServerROMClassHash(const JITServerROMClassHash &objectArrayHash,
-                                             const JITServerROMClassHash &baseComponentHash, size_t numDimensions)
+void
+JITServerROMClassHash::init(const JITServerROMClassHash &objectArrayHash,
+                            const JITServerROMClassHash &baseComponentHash, size_t numDimensions)
    {
    size_t data[ROMCLASS_HASH_WORDS * 2 + 1];
    memcpy(data, objectArrayHash._data, sizeof(_data));
@@ -62,11 +63,16 @@ JITServerROMClassHash::init(const void *data, size_t size)
    }
 
 void
-JITServerROMClassHash::init(const J9ROMClass *romClass, TR_Memory &trMemory, TR_J9VMBase *fej9)
+JITServerROMClassHash::init(const J9ROMClass *romClass, TR_Memory &trMemory,
+                            TR_J9VMBase *fej9, bool checkGenerated, size_t prefixLength)
    {
+   TR_ASSERT(!prefixLength || checkGenerated, "Invalid arguments");
+
    TR::StackMemoryRegion region(trMemory);
    size_t packedSize = 0;
-   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass((J9ROMClass *)romClass, &trMemory, fej9, packedSize, 0);
+   if (checkGenerated && !prefixLength)
+      prefixLength = JITServerHelpers::getGeneratedClassNamePrefixLength(romClass);
+   J9ROMClass *packedROMClass = JITServerHelpers::packROMClass(romClass, &trMemory, fej9, packedSize, 0, prefixLength);
 
    init(packedROMClass, packedSize);
    }
@@ -100,7 +106,7 @@ JITServerROMClassHash::getObjectArrayHash(const J9ROMClass *objectArrayROMClass,
    // There is no need to synchronize writes into _objectArrayHash since the only existing
    // call site of this function in JITServerAOTDeserializer::isClassMatching() is always
    // inside a critical section of the same monitor JITServerAOTDeserializer::_classMonitor.
-   _objectArrayHash.init(objectArrayROMClass, trMemory, fej9);
+   _objectArrayHash.init(objectArrayROMClass, trMemory, fej9, false, 0);
    VM_AtomicSupport::writeBarrier();
    _cachedObjectArrayHash = true;
    return _objectArrayHash;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1209,13 +1209,16 @@ TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_
    }
 
 bool
-TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated)
+TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader,
+                                                         void *classChainForClassBeingValidated)
    {
-   J9ClassLoader *classLoader = (J9ClassLoader *) _fej9->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+   J9ClassLoader *classLoader = (J9ClassLoader *)_fej9->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
    if (classLoader == NULL)
       return false;
 
-   TR_OpaqueClassBlock *clazz = _fej9->sharedCache()->lookupClassFromChainAndLoader(static_cast<uintptr_t *>(classChainForClassBeingValidated), classLoader);
+   TR_OpaqueClassBlock *clazz = _fej9->sharedCache()->lookupClassFromChainAndLoader(
+      static_cast<uintptr_t *>(classChainForClassBeingValidated), classLoader, _comp
+   );
    return validateSymbol(classID, clazz);
    }
 

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2476,23 +2476,25 @@ getLastDollarSignOfLambdaClassName(const char *className, UDATA classNameLength)
 /**
  * Checks if the given class name corresponds to a Lambda class.
  *
- * @param className The class name to check
- * @param classNameLength The length of the class name
+ * @param[in] className The class name to check
+ * @param[in] classNameLength The length of the class name
+ * @param[in,out] deterministicPrefixLength The length of the deterministic class name prefix (optional)
  * @return TRUE if the class name corresponds to a lambda class, otherwise FALSE
  */
 BOOLEAN
-isLambdaClassName(const char *className, UDATA classNameLength);
+isLambdaClassName(const char *className, UDATA classNameLength, UDATA *deterministicPrefixLength);
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 /**
  * Checks if the given class name corresponds to a LambdaForm class.
  *
- * @param className The class name to check
- * @param classNameLength The length of the class name
+ * @param[in] className The class name to check
+ * @param[in] classNameLength The length of the class name
+ * @param[in,out] deterministicPrefixLength The length of the deterministic class name prefix (optional)
  * @return TRUE if the class name corresponds to a lambdaForm class, otherwise FALSE
  */
 BOOLEAN
-isLambdaFormClassName(const char *className, UDATA classNameLength);
+isLambdaFormClassName(const char *className, UDATA classNameLength, UDATA *deterministicPrefixLength);
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 /* ---------------- cphelp.c ---------------- */


### PR DESCRIPTION
This PR implements support for correctly and reliably serializing and deserializing/loading JITServer AOT cache methods that are defined by or refer to classes generated at runtime.

The current list of recognized types of generated classes includes:
- Lambda classes;
- Dynamic proxy classes;
- Generated reflection accessors.

In each of these cases, the generated class name consists of a deterministic prefix followed by a suffix that can vary across JVMs.

Generated classes are identified across client JVMs using the combination of: the class loader ID (name of its first loaded class), the deterministic class name prefix, and the deterministic ROMClass hash. The latter is computed after re-packing the ROMClass to truncate all the instances of the class name string down to the deterministic class name prefix. In order to lookup generated classes at the client JVM during AOT deserialization and load, we maintain a mapping between <loader, prefix, hash> and the RAMClass, which is populated in the class load JIT hook, and invalidated in the class unload and redefinition hooks.

This mechanism can be disabled by passing the command line option `-Xjit:aotCacheDisableGeneratedClassSupport` to both the JITServer and the client JVMs.