### PR TITLE
Added a new Known limitation in 0.44.0 and 0.45.0 release note

### DIFF
--- a/doc/release-notes/0.44/0.44.md
+++ b/doc/release-notes/0.44/0.44.md
@@ -171,6 +171,14 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 <td valign="top">Avoid using the <tt>-XX:+ShowHiddenFrames</tt> option with OpenJDK 18 and later.</td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk22/issues/60">#60</a></td>
+<td valign="top">The <tt>-XX:+CompactStrings</tt> option is having an adverse impact on the <tt>indexOf()</tt> method results.</td>
+<td valign="top">All platforms</td>
+<td valign="top"><tt>String</tt> compression is enabled by default because of which the non-Latin-1 characters are not identified. If you use the <tt>split()</tt> method to create a <tt>string</tt> from a <tt>string</tt> that contains non-Latin-1 characters and you use that new <tt>string</tt> with the <tt>indexOf()</tt> method, the results might be wrong.</td>
+<td valign="top">Disable <tt>string</tt> compression with the <tt>-XX:-CompactStrings</tt> option or use OpenJDK 17 or later.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1341

The -XX:+CompactStrings option is having an adverse impact on the indexOf() method results

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com