### PR TITLE
Don't throw an exception unnecessarily

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -177,11 +177,10 @@ final class J9VMInternals {
 			J9VMInternals.class.getModule().implAddExports("jdk.crac"); //$NON-NLS-1$
 
 			// export jdk.management/jdk.crac.management unconditionally
-			java.util.Optional<Module> om = ModuleLayer.boot().findModule("jdk.management");  //$NON-NLS-1$
-			if (om.isEmpty()) {
-				throw new InternalError("module jdk.management wasn't found"); //$NON-NLS-1$
+			java.util.Optional<Module> om = ModuleLayer.boot().findModule("jdk.management"); //$NON-NLS-1$
+			if (om.isPresent()) {
+				om.get().implAddExports("jdk.crac.management"); //$NON-NLS-1$
 			}
-			om.get().implAddExports("jdk.crac.management"); //$NON-NLS-1$
 		}
 /*[ENDIF] CRAC_SUPPORT */
 	}


### PR DESCRIPTION
The need for the `jdk.management` module should due to application requirements, not just that support for `CRaC` is enabled.