### PR TITLE
Fix the references in continunation java stacks for scavenger backout

### DIFF
--- a/runtime/gc_glue_java/ScavengerBackOutScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerBackOutScanner.hpp
@@ -46,6 +46,7 @@ private:
 	void backoutUnfinalizedObjects(MM_EnvironmentStandard *env);
 	void backoutFinalizableObjects(MM_EnvironmentStandard *env);
 #endif
+	void backoutContinuationObjects(MM_EnvironmentStandard *env);
 
 public:
 	MM_ScavengerBackOutScanner(MM_EnvironmentBase *env, bool singleThread, MM_Scavenger *scavenger)
@@ -117,11 +118,12 @@ public:
 
 	/* empty, move ownable synchronizer backout processing in scanAllSlots() */
 	virtual void scanOwnableSynchronizerObjects(MM_EnvironmentBase *env) {}
-	/**
-	 * empty, move continuation backout processing in scanAllSlots(), scavenger abort would never happen after continuationObjectList processing
-	 * so only need to backout list._head from _priorHead
-	 */
-	virtual void scanContinuationObjects(MM_EnvironmentBase *env) {}
+	virtual void scanContinuationObjects(MM_EnvironmentBase *env)
+	{
+		reportScanningStarted(RootScannerEntity_ContinuationObjects);
+		backoutContinuationObjects(MM_EnvironmentStandard::getEnvironment(env));
+		reportScanningEnded(RootScannerEntity_ContinuationObjects);
+	}
 };
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -653,17 +653,6 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 		if (NULL != finalizeLinkAddress) {
 			barrier->setFinalizeLink(objectPtr, barrier->getFinalizeLink(fwdObjectPtr));
 		}
-
-		/* fixup the references in the continuation native StackSlots */
-		switch (_extensions->objectModel.getScanType(forwardedClass)) {
-
-		case GC_ObjectModel::SCAN_CONTINUATION_OBJECT:
-			scanContinuationNativeSlots(MM_EnvironmentStandard::getEnvironment(env), objectPtr, SCAN_REASON_BACKOUT);
-			break;
-		default:
-			break;
-		}
-
 	}
 }
 


### PR DESCRIPTION
In https://github.com/eclipse-openj9/openj9/pull/19388, we are fixing up stack references of unmounted continuation for scavenge backout during reverseForwardedObject(), but the fixup would depend on the related resverseForwardedPointer installed, so the scan for fix-up need to be done after all resverseForwardedPointer are installed, otherwise some fix-up would miss.

Using backoutContinuationObjects() to scan/fixup all of continuation stack references in evacuate region.