### PR TITLE
jdk11 always create compact Strings when possible

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -566,6 +566,19 @@ public final class JITHelpers {
 		}
 	}
 
+	public boolean canEncodeAsLatin1(byte[] array, int start, int length) {
+		int index = start << 1;
+		if (!IS_BIG_ENDIAN) {
+			index += 1;
+		}
+		for (int end = index + (length << 1); index < end; index += 2) {
+			if (array[index] != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * Returns the first index of the target character array within the source character array starting from the specified
 	 * offset.

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -937,6 +937,18 @@ public class Test_String {
 		String needle = "\u00b0\u00b1";
 		String hay = new StringBuilder("a").append(needle).toString();
 		AssertJUnit.assertEquals("Failed to find string 3", 1, hay.indexOf(needle));
+
+		String multi = "\u0100:abc";
+		String[] splits = multi.split(":");
+		AssertJUnit.assertEquals("Failed to find string 4", 3, "123abc".indexOf(splits[1]));
+		String sub = multi.substring(2);
+		AssertJUnit.assertEquals("Failed to find string 5", 3, "123abc".indexOf(sub));
+		String r1 = multi.replace('\u0100', '1');
+		AssertJUnit.assertEquals("Failed to find string 6", 0, "1:abc".indexOf(r1));
+		String r2 = multi.replaceAll("\u0100", "1");
+		AssertJUnit.assertEquals("Failed to find string 7", 0, "1:abc".indexOf(r2));
+		String r3 = multi.replaceAll("\u0100", "");
+		AssertJUnit.assertEquals("Failed to find string 8", 0, ":abc".indexOf(r3));
 	}
 
 	/**


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19543

Some testing at https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/529/
There was one unrelated failure, an old known issue https://github.com/eclipse-openj9/openj9/issues/16608#issuecomment-2134284248