### PR TITLE
[FFI_test] Enable the excluded tests on z/OS in JDK21

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_21.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_21.txt
@@ -31,18 +31,6 @@ org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrong
 org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost NA generic-all
 org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost2 NA generic-all
 
-org.openj9.test.jep442.downcall.InvalidDownCallTests:test_heapSegmentForStructArgument javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.InvalidDownCallTests:test_invalidMemoryLayoutForMemAddr javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.InvalidDownCallTests:test_invalidMemoryLayoutForReturnType javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_memoryAllocFreeFromDefaultLib_1 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_printfFromDefaultLibWithMemAddr_1 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_printfFromDefaultLibWithMemAddr_LinkerOption_1 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests1:test_strlenFromDefaultLibWithMemAddr_1 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_memoryAllocFreeFromDefaultLib_2 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_printfFromDefaultLibWithMemAddr_2 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_printfFromDefaultLibWithMemAddr_LinkerOption_2 javanext/issues/441 zos_390-64
-org.openj9.test.jep442.downcall.PrimitiveTypeTests2:test_strlenFromDefaultLibWithMemAddr_2 javanext/issues/441 zos_390-64
-
 # Exclude Java 19 Thread related failures
 
 org.openj9.test.java.lang.Test_ThreadGroup:test_activeCount NA generic-all

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/MultiThreadingTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/MultiThreadingTests2.java
@@ -44,7 +44,7 @@ import static java.lang.foreign.ValueLayout.*;
  * verifies the downcalls with the shared downcall handlder (cached as soft reference in OpenJDK)
  * in multithreading.
  */
-@Test(groups = { "level.sanity", "disabled.os.zos" })
+@Test(groups = { "level.sanity" })
 public class MultiThreadingTests2 implements Thread.UncaughtExceptionHandler {
 	private volatile Throwable initException;
 

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
@@ -52,7 +52,7 @@ import static java.lang.foreign.ValueLayout.*;
  * [2] the test suite is mainly intended for the following Clinker API:
  * MethodHandle downcallHandle(MemorySegment symbol, FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity", "disabled.os.zos" })
+@Test(groups = { "level.sanity" })
 public class StructTests1 {
 	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
 	private static Linker linker = Linker.nativeLinker();

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
@@ -52,7 +52,7 @@ import static java.lang.foreign.ValueLayout.*;
  * [2] the test suite is mainly intended for the following Clinker API:
  * MethodHandle downcallHandle(FunctionDescriptor function)
  */
-@Test(groups = { "level.sanity", "disabled.os.zos" })
+@Test(groups = { "level.sanity" })
 public class StructTests2 {
 	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
 	private static Linker linker = Linker.nativeLinker();


### PR DESCRIPTION
The change enables the excluded tests specific to the default
library loading and struct given the related issues have been
resolved via https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/159 and https://github.com/eclipse-openj9/openj9/pull/19468.

Related: [Internal 441](https://github.ibm.com/runtimes/javanext/issues/441)

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>