### PR TITLE
(0.46.0) Changes to the code cache repository allocation code

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -50,6 +50,12 @@
 #include "runtime/CodeCacheMemorySegment.hpp"
 #include "runtime/J9VMAccess.hpp"
 
+#if defined(LINUX)
+#if !defined(MADV_HUGEPAGE)
+#define MADV_HUGEPAGE 14
+#endif /* MADV_HUGEPAGE */
+#endif /* LINUX */
+
 TR::CodeCacheManager *J9::CodeCacheManager::_codeCacheManager = NULL;
 J9JavaVM *J9::CodeCacheManager::_javaVM = NULL;
 J9JITConfig *J9::CodeCacheManager::_jitConfig = NULL;


### PR DESCRIPTION
In order to eliminate helper trampolines, OpenJ9 tries to allocate the code cache in the vicinity of the JIT dll. This intention is signalled by using a preferredStartAddress when calling allocateCodeCacheSegment(). Currently, only x86-64 uses this approach.
This commit implements the following changes:
  - For Linux, we increase the search space to almost 2GB. Also, we prefer to start with an approach that uses the smaps pseudofile to find memory ranges where the code cache could be allocated.
  - For Windows, we keep a smaller memory search space because smaps are not available to speed up the search process.
  - We compute a preferred alignment and pass that to the VM. For x86-64 this alignment is 2 MB, i.e. the size of large pages used by the Transparent Huge Page (THP) mechanism. The alignment is relevant only when preferredStartAddress is provided.
  - For Linux we provide a hint to the OS (with madvise) that we prefer the usage of THP for the span of the code cache repository.

