### PR TITLE
Improve JITServer stream incompatibility error

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -32,6 +32,8 @@
 
 namespace JITServer
 {
+// When adding another compatibility mask/flag, also add a new message in
+// CommunicationStream::showFullVersionIncompatibility that handles the new enum value.
 enum JITServerCompatibilityFlags
    {
    JITServerJavaVersionMask    = 0x00000FFF,
@@ -62,10 +64,18 @@ public:
       return (MAJOR_NUMBER << 24) | (MINOR_NUMBER << 8); // PATCH_NUMBER is ignored
       }
 
+   static std::string showJITServerVersion(uint32_t fullVersion)
+      {
+      uint8_t majorVersion = fullVersion >> 24;
+      uint16_t minorVersion = (fullVersion >> 8) & 0xFFFF;
+      return std::to_string(majorVersion) + "." + std::to_string(minorVersion);
+      }
+
    static uint64_t getJITServerFullVersion()
       {
       return Message::buildFullVersion(getJITServerVersion(), CONFIGURATION_FLAGS);
       }
+   static std::string showFullVersionIncompatibility(uint64_t serverFullVersion, uint64_t clientFullVersion);
 
    static void printJITServerVersion()
       {

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -161,7 +161,7 @@ public:
       readMessage(_cMsg);
       if (_cMsg.fullVersion() != 0 && _cMsg.fullVersion() != getJITServerFullVersion())
          {
-         throw StreamVersionIncompatible(getJITServerFullVersion(), _cMsg.fullVersion());
+         throw StreamVersionIncompatible(showFullVersionIncompatibility(getJITServerFullVersion(), _cMsg.fullVersion()));
          }
 
       switch (_cMsg.type())

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -116,10 +116,7 @@ class StreamVersionIncompatible: public virtual std::exception
    {
 public:
    StreamVersionIncompatible() : _message("JITServer/JITClient incompatibility detected") { }
-   StreamVersionIncompatible(uint64_t serverVersion, uint64_t clientVersion)
-      {
-      _message = "JITServer expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
-      }
+   StreamVersionIncompatible(const std::string &message) : _message(message) { }
    virtual const char* what() const throw()
       {
       return _message.c_str();


### PR DESCRIPTION
The error printed in the vlog at the server when an incompatible client tries to connect will now display the difference between the client and server in a human-readable format.