### PR TITLE
(0.46) Disclaim Cold Code Cache

### DIFF
--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -90,6 +90,8 @@ J9::OptionsPostRestore::OptionsPostRestore(J9VMThread *vmThread, J9JITConfig *ji
       = J9::Options::_xrsSync
         || options->getOption(TR_NoResumableTrapHandler)
         || options->getOption(TR_DisableTraps);
+
+   _enableCodeCacheDisclaimingPreCheckpoint = options->getOption(TR_EnableCodeCacheDisclaiming);
    }
 
 void
@@ -804,8 +806,19 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
          }
       }
 
+
+   if (!_enableCodeCacheDisclaimingPreCheckpoint &&
+       TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming))
+      {
+      TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+          TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "WARNING: Code Cache disclaiming disabled since it was disabled before checkpoint");
+      }
+
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming) ||
-       !TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming))
+       !TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming) ||
+       TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming))
       {
       TR::Options::disableMemoryDisclaimIfNeeded(_jitConfig);
       }

--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -164,6 +164,7 @@ class OptionsPostRestore
    bool _asyncCompilationPreCheckpoint;
    bool _disableTrapsPreCheckpoint;
    bool _disableAOTPostRestore;
+   bool _enableCodeCacheDisclaimingPreCheckpoint;
 
    int32_t _argIndexXjit;
    int32_t _argIndexXjitcolon;

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -62,7 +62,8 @@ TR_MHJ2IThunk::allocate(
    else
 #endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      result = (TR_MHJ2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
+      bool disclaim = TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming);
+      result = (TR_MHJ2IThunk*)cg->allocateCodeMemory(totalSize, !disclaim, false);
       }
    omrthread_jit_write_protect_disable();
    result->_codeSize  = codeSize;

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -654,9 +654,10 @@ TR::CRRuntime::prepareForCheckpoint()
 #endif
 
    // Make sure the limit for the ghost files is at least as big as the data cache size
-   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming))
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming) ||
+       TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming))
       {
-      U_32 ghostFileLimit = vm->jitConfig->dataCacheKB * 1024; // convert to bytes
+      U_32 ghostFileLimit = std::max(vm->jitConfig->dataCacheKB, vm->jitConfig->codeCacheTotalKB) * 1024; // convert to bytes
       vm->internalVMFunctions->setRequiredGhostFileLimit(vmThread, ghostFileLimit);
       }
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -103,6 +103,8 @@ public:
    */
    void resetCodeCache();
 
+   int32_t disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap);
+
    private:
    /**
     * @brief Restore trampoline pointers to their initial positions

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -427,6 +427,19 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
       }
 #endif
 
+#ifdef LINUX
+      if (_disclaimEnabled)
+         {
+         // If swap is enabled, we can allocate memory with mmap(MAP_ANOYNMOUS|MAP_PRIVATE) and disclaim to swap
+         // If swap is not enabled we can disclaim to a backing file
+         TR::CompilationInfo * compInfo = TR::CompilationInfo::get(_jitConfig);
+         if (!TR::Options::getCmdLineOptions()->getOption(TR_DisclaimMemoryOnSwap) || compInfo->isSwapMemoryDisabled())
+            {
+            segmentType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
+            }
+         }
+#endif
+
    mcc_printf("TR::CodeCache::allocate : requesting %d bytes\n", codeCacheSizeToAllocate);
    mcc_printf("TR::CodeCache::allocate : javaVM = %p\n", javaVM);
    mcc_printf("TR::CodeCache::allocate : codeCacheList = %p\n", jitConfig->codeCacheList);
@@ -487,6 +500,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
             }
          TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, verboseLogString, codeCacheSegment->baseAddress, codeCacheSegment->heapTop, alignment, largeCodePageSize);
          }
+
 #ifdef LINUX
       if (0 != madvise((void *)codeCacheSegment->baseAddress, (codeCacheSegment->heapTop - codeCacheSegment->baseAddress), MADV_HUGEPAGE))
          {
@@ -496,11 +510,21 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
             }
          }
 #endif // LINUX
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Allocated new code cache segment %p starting at address %p %d Kb",
+                                        codeCacheSegment,
+                                        codeCacheSegment->heapBase,
+                                        _jitConfig->codeCacheKB);
       }
    else
       {
       // TODO: we should generate a trace point
       mcc_printf("TR::CodeCache::allocate : codeCacheSegment is NULL, %p\n",codeCacheSegment);
+
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Failed to allocate new code cache segment of %d Kb", _jitConfig->codeCacheKB);
+
       return 0;
       }
 
@@ -787,4 +811,27 @@ J9::CodeCacheManager::printOccupancyStats()
       {
       codeCache->printOccupancyStats();
       }
+   }
+
+
+int32_t
+J9::CodeCacheManager::disclaimAllCodeCaches()
+   {
+   if (!_disclaimEnabled)
+      return 0;
+
+   int32_t numDisclaimed = 0;
+
+#ifdef LINUX
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_jitConfig);
+   bool canDisclaimOnSwap = TR::Options::getCmdLineOptions()->getOption(TR_DisclaimMemoryOnSwap) && !compInfo->isSwapMemoryDisabled();
+
+   CacheListCriticalSection scanCacheList(self());
+   for (TR::CodeCache *codeCache = self()->getFirstCodeCache(); codeCache; codeCache = codeCache->next())
+      {
+      numDisclaimed += codeCache->disclaim(self(), canDisclaimOnSwap);
+      }
+#endif // LINUX
+
+   return numDisclaimed;
    }

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -29,7 +29,7 @@ namespace J9 { class CodeCacheManager; }
 namespace J9 { typedef CodeCacheManager CodeCacheManagerConnector; }
 #endif
 
-
+#include "control/Options.hpp"
 #include "env/jittypes.h"
 //#include "runtime/CodeCacheMemorySegment.hpp"
 //#include "runtime/CodeCache.hpp"
@@ -56,6 +56,7 @@ public:
       _fe(fe)
       {
       _codeCacheManager = reinterpret_cast<TR::CodeCacheManager *>(this);
+      _disclaimEnabled = TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming);
       }
 
    void *operator new(size_t s, TR::CodeCacheManager *m) { return m; }
@@ -152,12 +153,16 @@ public:
     * @brief Print occupancy stats for each code cache
     */
    void printOccupancyStats();
+   bool isDisclaimEnabled() const { return _disclaimEnabled; }
+   void setDisclaimEnabled(bool value)  { _disclaimEnabled = value; }
+   int32_t disclaimAllCodeCaches();
 
 private :
    TR_FrontEnd *_fe;
    static TR::CodeCacheManager *_codeCacheManager;
    static J9JITConfig *_jitConfig;
    static J9JavaVM *_javaVM;
+   bool  _disclaimEnabled; // If true, code cache can be disclaimed to a file or swap
    };
 
 } // namespace J9

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -554,7 +554,9 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::generateVirtualIndirectThunk(TR::Node *
       }
    else
       {
-      thunk = (uint8_t *)cg()->allocateCodeMemory(codeSize, true);
+      // if disclaim enabled, put into warm
+      bool disclaim = TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming);
+      thunk = (uint8_t *)cg()->allocateCodeMemory(codeSize, !disclaim);
       cursor = thunkEntry = thunk;
       }
 


### PR DESCRIPTION
- use the same heuristcs for code cache disclaim as for data cache
- disclaim starting from the cold code
- move stack overflow outline instructions into the warm area to increase disclaim efficiency
- code is enabled with -Xjit:enableCodeCacheDisclaiming

Port of https://github.com/eclipse-openj9/openj9/pull/19397