### PR TITLE
Skip jitCodeCache reclamation for scavenge backout case

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -7262,6 +7262,15 @@ static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum,
    {
    MM_GCCycleEndEvent *event = (MM_GCCycleEndEvent *)eventData;
    OMR_VMThread *omrVMThread = event->omrVMThread;
+
+   if (OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL == (event->cycleType & OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL))
+      {
+	   /**
+	    *  We skip the reclamation in the case of an unsuccessfully completed GC cycle
+	    *  (such as aborted Scavenge) since it does not have full object liveness info.
+	    */
+      return;
+      }
    condYieldFromGCFunctionPtr condYield = NULL;
    if (TR::Options::getCmdLineOptions()->realTimeGC())
       condYield = event->condYieldFromGCFunction;

--- a/runtime/gcchk/gcchk.cpp
+++ b/runtime/gcchk/gcchk.cpp
@@ -420,8 +420,10 @@ hookGcCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 
 	UDATA oldVMState = vmThread->omrVMThread->vmState;
 	vmThread->omrVMThread->vmState = OMRVMSTATE_GC_CHECK_AFTER_GC;
+	/* the OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL bit is set in the event->cycleType for cycleEnd in scavenge backout case, so mask off the bit to get the cycleType without it. */
+	uintptr_t cycleType = event->cycleType & (~OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL);
 
-	if (OMR_GC_CYCLE_TYPE_GLOBAL == event->cycleType) {
+	if (OMR_GC_CYCLE_TYPE_GLOBAL == cycleType) {
 		if (!excludeGlobalGc(vmThread)) {
 			if (cycle->getMiscFlags() & J9MODRON_GCCHK_VERBOSE) {
 				j9tty_printf(PORTLIB, "<gc check: start verifying slots after global gc (%zu)>\n", extensions->globalGcCount);
@@ -435,7 +437,7 @@ hookGcCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 		}
 	}
 #if defined(J9VM_GC_MODRON_SCAVENGER)
-	else if (OMR_GC_CYCLE_TYPE_SCAVENGE == event->cycleType) {
+	else if (OMR_GC_CYCLE_TYPE_SCAVENGE == cycleType) {
 		if (!excludeLocalGc(javaVM)) {
 			if (cycle->getMiscFlags() & J9MODRON_GCCHK_VERBOSE) {
 				j9tty_printf(PORTLIB, "<gc check: start verifying slots after local gc (%zu)>\n", extensions->localGcCount);


### PR DESCRIPTION
 jitCodeCache reclamation would be triggered by GC cycle end event,
 For scavenge backout case, at the end of cycle, heap would be rolled
 back to before scavenge cycle start, and another global GC would start
 right after the end of backout scavenge, so there is no need to do
 jitCodeCache reclamation at the end of backout scavenge.
 also from Java21 the partial reclamation(related with virtualThread)
processing has been split to move to clearable phase of GC in order to improve the processing performance
(PR:https://github.com/eclipse-openj9/openj9/pull/17527), but for scavenge backout case, the backout only could happen before the first part of reclamation processing(the processing would never get a chance to run for the case), without the first part  reclamation processing, the second part of reclamation processing, which triggered by GC cycle end, would be possible to reclaim the "live" stack jit frames, then cause the crash. so we need to skip jitCodeCache reclamation for scavenge backout case.

 - pass unsuccessful state via the cycleType of Cycle End event to the jitcodecache relamation hook for backout case.
 - check if unsuccessful state is set in the hook, if it is true, skip jitcodecache relamation processing(second part).

depends on:https://github.com/eclipse/omr/pull/7353

Signed-off-by: hulin <linhu@ca.ibm.com>