### PR TITLE
(0.46.0) Skip zero-init, checks for some BigInteger methods

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -835,6 +835,10 @@
    java_math_BigInteger_add,
    java_math_BigInteger_subtract,
    java_math_BigInteger_multiply,
+   java_math_BigInteger_init_long,
+   java_math_BigInteger_toByteArray,
+   java_math_BigInteger_stripLeadingZeroBytes1,
+   java_math_BigInteger_stripLeadingZeroBytes2,
 
    java_text_NumberFormat_format,
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2636,9 +2636,13 @@ void TR_ResolvedJ9Method::construct()
 
    static X BigIntegerMethods[] =
       {
-      {x(TR::java_math_BigInteger_add,                   "add",                   "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
-      {x(TR::java_math_BigInteger_subtract,              "subtract",              "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
-      {x(TR::java_math_BigInteger_multiply,              "multiply",              "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
+      {x(TR::java_math_BigInteger_add,                             "add",                   "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
+      {x(TR::java_math_BigInteger_subtract,                        "subtract",              "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
+      {x(TR::java_math_BigInteger_multiply,                        "multiply",              "(Ljava/math/BigInteger;)Ljava/math/BigInteger;")},
+      {x(TR::java_math_BigInteger_init_long,                       "<init>",                "(J)V")},
+      {x(TR::java_math_BigInteger_toByteArray,                     "toByteArray",           "()[B")},
+      {x(TR::java_math_BigInteger_stripLeadingZeroBytes1,          "stripLeadingZeroBytes", "([BII)[I")},
+      {x(TR::java_math_BigInteger_stripLeadingZeroBytes2,          "stripLeadingZeroBytes", "(I[BII)[I")},
       {    TR::unknownMethod}
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -201,6 +201,12 @@ static TR::RecognizedMethod canSkipNullChecks[] =
    //TR::java_util_Vector_addElement,
    TR::java_math_BigDecimal_longString1C,
    TR::java_math_BigDecimal_longString2,
+   TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
+   TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
+   TR::java_math_BigInteger_stripLeadingZeroBytes1,
+   TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_util_EnumMap__nec_,
    TR::java_nio_Bits_getCharB,
    TR::java_nio_Bits_getCharL,
@@ -291,6 +297,12 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_util_TreeMap_all,
    TR::java_math_BigDecimal_longString1C,
    TR::java_math_BigDecimal_longString2,
+   TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
+   TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
+   TR::java_math_BigInteger_stripLeadingZeroBytes1,
+   TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_util_HashMap_get,
    TR::java_util_HashMap_findNonNullKeyEntry,
    TR::java_util_HashMap_putImpl,
@@ -707,6 +719,12 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    //TR::java_lang_String_toUpperCaseCore,
    TR::java_lang_String_split_str_int,
    TR::java_math_BigDecimal_toString,
+   TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
+   TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
+   TR::java_math_BigInteger_stripLeadingZeroBytes1,
+   TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_lang_Integer_toString,
    TR::java_lang_Long_toString,
    TR::java_lang_StringCoding_encode,


### PR DESCRIPTION
This patch recognizes the following BigInteger methods:

* BigInteger.BigInteger(long): void
* BigInteger.toByteArray(): byte[]
* BigInteger.stripLeadingZeroBytes(byte[], int, int): int[]
* BigInteger.stripLeadingZeroBytes(int, byte[], int, int): int[]

and skips array zero-initialization, NULL, and bounds checks in these methods.

Cherry-picked from https://github.com/eclipse-openj9/openj9/pull/19556