### PR TITLE
Move anchored instanceof to the correct position

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2652,6 +2652,20 @@ void TR_J9ByteCodeIlGenerator::expandUnresolvedClassInstanceof(TR::TreeTop *tree
    TR_ASSERT(origClassNode->getSymbolReference()->isUnresolved(), "unresolved class instanceof n%un: expected symref of class child n%un to be unresolved\n", instanceofNode->getGlobalIndex(), origClassNode->getGlobalIndex());
 
    bool trace = comp()->getOption(TR_TraceILGen);
+
+   // If the receiver of the instanceof is non-null, there is no need of the null case
+   if(instanceofNode->isReferenceNonNull() || objNode->isNonNull())
+      {
+      TR::Node *resolveCheckNode = genResolveCheck(origClassNode);
+      resolveCheckNode->copyByteCodeInfo(instanceofNode);
+      tree->insertBefore(TR::TreeTop::create(comp(), resolveCheckNode));
+
+      if (trace)
+         traceMsg(comp(), "%s: emit ResolveCHK n%dn before the unresolved class instanceof n%un in block_%d\n", __FUNCTION__,
+            resolveCheckNode->getGlobalIndex(), instanceofNode->getGlobalIndex(), tree->getEnclosingBlock()->getNumber());
+      return;
+      }
+
    if (trace)
       traceMsg(comp(), "expanding unresolved class instanceof n%un in block_%d\n", instanceofNode->getGlobalIndex(), tree->getEnclosingBlock()->getNumber());
 


### PR DESCRIPTION
This commit includes the following two changes in ILGen:

1.
If the class is unresolved, `genInstanceof` anchors `instanceof` under a `treetop` node. Then the anchored `instanceof` treetop appears after the callTree and it commons with
the `instanceof` node under the `ZEROCHK` in `geninterface`.

This causes a problem because `expandUnresolvedClassInstanceof` does not expect the treetop that has the anchored `instanceof` to have already been evaluated when it appears under ZEROCHK. The transformation in `expandUnresolvedClassInstanceof` will not function correctly.

Therefore, the anchored `instanceof` treetop needs to be moved up before ZEROCHK.

2.
If the receiver of the `instanceof` is non-null, there is no need to transform the `instanceof` into two cases: the null case and the non-null cases in `expandUnresolvedClassInstanceof`.

Fixes: #18748