### PR TITLE
Walk segments in Anonymous classloader if there is something to unload

### DIFF
--- a/runtime/gc_base/ClassLoaderManager.cpp
+++ b/runtime/gc_base/ClassLoaderManager.cpp
@@ -560,7 +560,7 @@ MM_ClassLoaderManager::removeFromSubclassHierarchy(MM_EnvironmentBase *env, J9Cl
 }
 
 void
-MM_ClassLoaderManager::cleanUpClassLoaders(MM_EnvironmentBase *env, J9ClassLoader *classLoadersUnloadedList, J9MemorySegment **reclaimedSegments, J9ClassLoader **unloadLink, volatile bool *finalizationRequired)
+MM_ClassLoaderManager::cleanUpClassLoaders(MM_EnvironmentBase *env, J9ClassLoader *classLoadersUnloadedList, MM_ClassUnloadStats *classUnloadStats, J9MemorySegment **reclaimedSegments, J9ClassLoader **unloadLink, volatile bool *finalizationRequired)
 {
 	*reclaimedSegments = NULL;
 	*unloadLink = NULL;
@@ -568,7 +568,9 @@ MM_ClassLoaderManager::cleanUpClassLoaders(MM_EnvironmentBase *env, J9ClassLoade
 	/*
 	 * Cleanup segments in anonymous classloader
 	 */
-	cleanUpSegmentsInAnonymousClassLoader(env, reclaimedSegments);
+	if (0 < classUnloadStats->_anonymousClassesUnloadedCount) {
+		cleanUpSegmentsInAnonymousClassLoader(env, reclaimedSegments);
+	}
 	
 	/* For each classLoader that is not already unloading, not scanned and not enqueued for finalization:
 	 * perform classLoader-specific clean up, if it died on the current collection cycle; and either enqueue it for

--- a/runtime/gc_base/ClassLoaderManager.hpp
+++ b/runtime/gc_base/ClassLoaderManager.hpp
@@ -177,11 +177,12 @@ public:
 	 * Perform generic clean up for a list of class loaders to unload.
 	 * @param env[in] the current thread
 	 * @param classLoader[in] the list of class loaders to clean up
+	 * @param classUnloadStats[in] the Class Unloading Stats structure
 	 * @param reclaimedSegments[out] a linked list of memory segments to be reclaimed by cleanUpClassLoadersEnd
 	 * @param unloadLink[out] a linked list of class loaders to be reclaimed by cleanUpClassLoadersEnd
 	 * @param finalizationRequired[out] set to true if the finalize thread must be started, unmodified otherwise
 	 */
-	void cleanUpClassLoaders(MM_EnvironmentBase *env, J9ClassLoader *classLoadersUnloadedList, J9MemorySegment **reclaimedSegments, J9ClassLoader **unloadLink, volatile bool *finalizationRequired);
+	void cleanUpClassLoaders(MM_EnvironmentBase *env, J9ClassLoader *classLoadersUnloadedList, MM_ClassUnloadStats *classUnloadStats, J9MemorySegment **reclaimedSegments, J9ClassLoader **unloadLink, volatile bool *finalizationRequired);
 
 	/**
 	 * Attempt to enter the class unload mutex if it is uncontended.

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -462,7 +462,7 @@ MM_GlobalCollectorDelegate::unloadDeadClassLoaders(MM_EnvironmentBase *env)
 	/* The list of classLoaders to be unloaded by cleanUpClassLoadersEnd is rooted in unloadLink */
 	J9ClassLoader *unloadLink = NULL;
 	J9MemorySegment *reclaimedSegments = NULL;
-	_extensions->classLoaderManager->cleanUpClassLoaders(env, classLoadersUnloadedList, &reclaimedSegments, &unloadLink, &_finalizationRequired);
+	_extensions->classLoaderManager->cleanUpClassLoaders(env, classLoadersUnloadedList, classUnloadStats, &reclaimedSegments, &unloadLink, &_finalizationRequired);
 
 	/* Free the class memory segments associated with dead classLoaders, unload (free) the dead classLoaders that don't
 	 * require finalization, and perform any final clean up after the dead classLoaders are gone.

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -648,11 +648,13 @@ MM_MetronomeDelegate::unloadDeadClassLoaders(MM_EnvironmentBase *envModron)
 	
 	processDyingClasses(env, &classUnloadCount, &anonymousClassUnloadCount, &classLoaderUnloadCount, &classLoadersUnloadedList);
 
-	/* cleanup segments in anonymous classloader */
-	_extensions->classLoaderManager->cleanUpSegmentsInAnonymousClassLoader(env, &reclaimedSegments);
-	
-	/* enqueue all the segments we just salvaged from the dead class loaders for delayed free (this work was historically attributed in the unload end operation so it goes after the timer start) */
-	_extensions->classLoaderManager->enqueueUndeadClassSegments(reclaimedSegments);
+	if (0 < anonymousClassUnloadCount) {
+		/* cleanup segments in anonymous classloader */
+		_extensions->classLoaderManager->cleanUpSegmentsInAnonymousClassLoader(env, &reclaimedSegments);
+
+		/* enqueue all the segments we just salvaged from the anonymous classloader for delayed free */
+		_extensions->classLoaderManager->enqueueUndeadClassSegments(reclaimedSegments);
+	}
 
 	yieldFromClassUnloading(env);
 

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -2523,7 +2523,7 @@ MM_IncrementalGenerationalGC::unloadDeadClassLoaders(MM_EnvironmentVLHGC *env)
 		/* The list of classLoaders to be unloaded by cleanUpClassLoadersEnd is rooted in unloadLink */
 		J9ClassLoader *unloadLink = NULL;
 		J9MemorySegment *reclaimedSegments = NULL;
-		_extensions->classLoaderManager->cleanUpClassLoaders(env, classLoadersUnloadedList, &reclaimedSegments, &unloadLink, &env->_cycleState->_finalizationRequired);
+		_extensions->classLoaderManager->cleanUpClassLoaders(env, classLoadersUnloadedList, classUnloadStats, &reclaimedSegments, &unloadLink, &env->_cycleState->_finalizationRequired);
 
 		/* Free the class memory segments associated with dead classLoaders, unload (free) the dead classLoaders that don't
 		 * require finalization, and perform any final clean up after the dead classLoaders are gone.


### PR DESCRIPTION
Currently Anonymous classloader segments are walked regardless if there is something to unload or not. Skip walk if number of Anonymous classes to be unload is zero.