### PR TITLE
Skip BigInteger zero-init & checks for OpenJ9 only

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -202,7 +202,9 @@ static TR::RecognizedMethod canSkipNullChecks[] =
    TR::java_math_BigDecimal_longString1C,
    TR::java_math_BigDecimal_longString2,
    TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
    TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
    TR::java_math_BigInteger_stripLeadingZeroBytes1,
    TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_util_EnumMap__nec_,
@@ -296,7 +298,9 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_math_BigDecimal_longString1C,
    TR::java_math_BigDecimal_longString2,
    TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
    TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
    TR::java_math_BigInteger_stripLeadingZeroBytes1,
    TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_util_HashMap_get,
@@ -716,7 +720,9 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    TR::java_lang_String_split_str_int,
    TR::java_math_BigDecimal_toString,
    TR::java_math_BigInteger_init_long,
+#ifdef OPENJ9_BUILD
    TR::java_math_BigInteger_toByteArray,
+#endif // OPENJ9_BUILD
    TR::java_math_BigInteger_stripLeadingZeroBytes1,
    TR::java_math_BigInteger_stripLeadingZeroBytes2,
    TR::java_lang_Integer_toString,


### PR DESCRIPTION
The BigInteger.toByteArray implementation in OpenJ9 doesn't depend on zero-initialization and it is currently safe to skip that operation in that context. The Apache Harmony BigInteger implementation relies on zero-init and returns the wrong result without it. This patch limits skipping of zero-init (and NULL and bounds checks, to be conservative) for BigInteger.toByteArray to OpenJ9 builds.

Follow-up to https://github.com/eclipse-openj9/openj9/pull/19556.