### PR TITLE
(0.46) Enabled AOT cache at server by default

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1419,7 +1419,12 @@ J9::Options::JITServerParseCommonOptions(J9VMInitArgs *vmArgsArray, J9JavaVM *vm
          return false;
       }
 
-   if (xxJITServerUseAOTCacheArgIndex > xxDisableJITServerUseAOTCacheArgIndex)
+   // If not explicitly set, AOT cache is disabled by default at the client and enabled by default at the server
+   if (xxDisableJITServerUseAOTCacheArgIndex > xxJITServerUseAOTCacheArgIndex)
+      compInfo->getPersistentInfo()->setJITServerUseAOTCache(false);
+   else if (xxJITServerUseAOTCacheArgIndex > xxDisableJITServerUseAOTCacheArgIndex)
+      compInfo->getPersistentInfo()->setJITServerUseAOTCache(true);
+   else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       compInfo->getPersistentInfo()->setJITServerUseAOTCache(true);
    else
       compInfo->getPersistentInfo()->setJITServerUseAOTCache(false);


### PR DESCRIPTION
This change makes the option -XX:+JITServerUseAOTCache unnecessary at the server; note that clients are still required to set that option to opt-in to the use of the AOT cache. The -XX:-JITServerUseAOTCache option may still be used at the server to disable the AOT cache as before.

This change also has the effect of making ROM class sharing at the server the default.