### PR TITLE
UMA: fix references to flags j9vm_opt_criuSupport, j9vm_opt_jitserver

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -394,7 +394,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     omr/compiler/runtime/OMRCodeCacheMemorySegment.cpp \
     omr/compiler/runtime/OMRRuntimeAssumptions.cpp
 
-ifneq ($(J9VM_OPT_JITSERVER),)
+ifneq ($(j9vm_opt_jitserver),)
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/JITClientCompilationThread.cpp \
     compiler/control/JITServerCompilationThread.cpp \
@@ -422,7 +422,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/MetricsServer.cpp
 endif
 
-ifneq ($(J9VM_OPT_CRIU_SUPPORT),)
+ifneq ($(j9vm_opt_criuSupport),)
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/OptionsPostRestore.cpp \
     compiler/runtime/CRRuntime.cpp

--- a/runtime/compiler/compiler.mk
+++ b/runtime/compiler/compiler.mk
@@ -28,6 +28,10 @@ cleandeps: ; @echo SUCCESS - All dependencies are cleaned
 cleandll: ; @echo SUCCESS - All shared libraries are cleaned
 .PHONY: all clean cleanobjs cleandeps cleandll
 
+# Include build flags so names like j9vm_opt_jitserver can be used in places
+# like files/common.mk to conditionally include sources.
+include ../makelib/mkconstants.mk
+
 # This is the logic right now for locating Clang and LLVM-config
 # There's probably a nicer way to do all of this... it's pretty bad
 


### PR DESCRIPTION
Must include `mkconstants.mk` in order to use those build flags.

Otherwise, the LIT library has unresolved references and fails to load:
```
libj9jit29.so: undefined symbol: _ZN2TR9CRRuntime25purgeMemoizedCompilationsEv
```