### PR TITLE
(0.46.0) Prefer to disable TLH allocation prefetching by default post-Skylake

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2176,8 +2176,13 @@ void J9::Options::preProcessTLHPrefetch(J9JavaVM *vm)
 #elif defined(TR_HOST_ARM64)
    preferTLHPrefetch = true;
 #else // TR_HOST_X86
-   preferTLHPrefetch = true;
-   // Disable TM on x86 because we cannot tell whether a Haswell chip supports TM or not, plus it's killing the performance on dayTrader3
+   preferTLHPrefetch =
+      (TR::Compiler->target.cpu.isGenuineIntel() &&
+       TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_X86_INTEL_SKYLAKE)) ||
+      !TR::Compiler->target.cpu.isGenuineIntel();
+
+   // Disable TM on x86 because we cannot tell whether a Haswell chip supports
+   // TM or not, plus it's killing the performance on dayTrader3
    self()->setOption(TR_DisableTM);
 #endif
 

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -236,7 +236,7 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
       prefetchSnippetBuffer[0] = 0x0F;
-      if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
+      if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMD_FAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;
       else
          prefetchSnippetBuffer[1] = 0x18;

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -214,35 +214,45 @@ J9::X86::CPU::is_test(OMRProcessorArchitecture p)
 
    switch(p)
       {
-      case OMR_PROCESSOR_X86_INTELWESTMERE:
+      case OMR_PROCESSOR_X86_INTEL_WESTMERE:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelWestmere() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELNEHALEM:
+      case OMR_PROCESSOR_X86_INTEL_NEHALEM:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelNehalem() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELPENTIUM:
+      case OMR_PROCESSOR_X86_INTEL_PENTIUM:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELP6:
+      case OMR_PROCESSOR_X86_INTEL_P6:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelP6() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+      case OMR_PROCESSOR_X86_INTEL_PENTIUM4:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium4() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELCORE2:
+      case OMR_PROCESSOR_X86_INTEL_CORE2:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelCore2() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELTULSA:
+      case OMR_PROCESSOR_X86_INTEL_TULSA:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelTulsa() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+      case OMR_PROCESSOR_X86_INTEL_SANDYBRIDGE:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelSandyBridge() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+      case OMR_PROCESSOR_X86_INTEL_IVYBRIDGE:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelIvyBridge() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELHASWELL:
+      case OMR_PROCESSOR_X86_INTEL_HASWELL:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelHaswell() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELBROADWELL:
+      case OMR_PROCESSOR_X86_INTEL_BROADWELL:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelBroadwell() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+      case OMR_PROCESSOR_X86_INTEL_SKYLAKE:
          return TR::CodeGenerator::getX86ProcessorInfo().isIntelSkylake() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+      case OMR_PROCESSOR_X86_INTEL_CASCADELAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelCascadeLake() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTEL_COOPERLAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelCooperLake() == (_processorDescription.processor == p);
+     case OMR_PROCESSOR_X86_INTEL_ICELAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelIceLake() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTEL_SAPPHIRERAPIDS:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSapphireRapids() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTEL_EMERALDRAPIDS:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelEmeraldRapids() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMD_ATHLONDURON:
          return TR::CodeGenerator::getX86ProcessorInfo().isAMDAthlonDuron() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_AMDOPTERON:
+      case OMR_PROCESSOR_X86_AMD_OPTERON:
          return TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron() == (_processorDescription.processor == p);
-      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+      case OMR_PROCESSOR_X86_AMD_FAMILY15H:
          return TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == (_processorDescription.processor == p);
       default:
          return false;


### PR DESCRIPTION
* Add support for new recognized processors to CPU inquiry check.  The code affected is a validation method that ensures the port library's determination of the CPU id matches the JIT's determination of the CPU.
* Prefer to disable TLH allocation prefetching by default post-Skylake