### PR TITLE
Remove redundant else in defineClassCommon

### DIFF
--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -187,11 +187,10 @@ retry:
 						NULL,
 						hostClass);
 				/* Done if a class was found or and exception is pending, otherwise try to define the bytes */
-				if ((clazz != NULL) || (currentThread->currentException != NULL)) {
+				if ((NULL != clazz) || (NULL != currentThread->currentException)) {
 					goto done;
-				} else {
-					loadedClass = NULL;
 				}
+				loadedClass = NULL;
 			} else {
 				tempClassBytes = J9ROMCLASS_INTERMEDIATECLASSDATA(loadedClass);
 				tempLength = loadedClass->intermediateClassDataLength;


### PR DESCRIPTION
This patch simply removes an else-after-goto and conforms the enclosing if-statement conditions to the coding standards.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>