### PR TITLE
UMA: fix references to flags opt_criuSupport, opt_jitserver (v2)

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -394,7 +394,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     omr/compiler/runtime/OMRCodeCacheMemorySegment.cpp \
     omr/compiler/runtime/OMRRuntimeAssumptions.cpp
 
-ifneq ($(j9vm_opt_jitserver),)
+<#if uma.spec.flags.opt_jitserver.enabled>
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/JITClientCompilationThread.cpp \
     compiler/control/JITServerCompilationThread.cpp \
@@ -420,13 +420,13 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/JITServerStatisticsThread.cpp \
     compiler/runtime/Listener.cpp \
     compiler/runtime/MetricsServer.cpp
-endif
+</#if>
 
-ifneq ($(j9vm_opt_criuSupport),)
+<#if uma.spec.flags.opt_criuSupport.enabled>
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/OptionsPostRestore.cpp \
     compiler/runtime/CRRuntime.cpp
-endif
+</#if>
 
 -include $(JIT_MAKE_DIR)/files/extra.mk
 include $(JIT_MAKE_DIR)/files/host/$(HOST_ARCH).mk

--- a/runtime/compiler/compiler.mk
+++ b/runtime/compiler/compiler.mk
@@ -28,10 +28,6 @@ cleandeps: ; @echo SUCCESS - All dependencies are cleaned
 cleandll: ; @echo SUCCESS - All shared libraries are cleaned
 .PHONY: all clean cleanobjs cleandeps cleandll
 
-# Include build flags so names like j9vm_opt_jitserver can be used in places
-# like files/common.mk to conditionally include sources.
-include ../makelib/mkconstants.mk
-
 # This is the logic right now for locating Clang and LLVM-config
 # There's probably a nicer way to do all of this... it's pretty bad
 


### PR DESCRIPTION
Including `mkconstants.mk` (in #19621) interferes with proper configuration on some platforms: convert `build/files/common.mk` to a freemarker template to apply those build flags.