### PR TITLE
(0.46) Update to openssl 3.0.14

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -133,7 +133,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.13+CVEs3'
+  extra_getsource_options: '-openssl-branch=openssl-3.0.14'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
This cherry-picks #19620 for the 0.46.0 release.