### PR TITLE
Add optimization to ROM class search for Anonymous classes unloading

### DIFF
--- a/runtime/gc_base/ClassLoaderManager.hpp
+++ b/runtime/gc_base/ClassLoaderManager.hpp
@@ -234,7 +234,24 @@ public:
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);
+
 private:
+	/**
+	 * Check is ROM class possible to unload.
+	 * There are might be multiple checks:
+	 * - ROM class should not be NULL
+	 * - ROM class for Indexable object can not be unloaded
+	 * @param clazz[in] class to check
+	 * @return true if class is possible to unload
+	 */
+	MMINLINE bool
+	isROMClassUnloadable(J9Class *clazz)
+	{
+		J9ROMClass *romClass = clazz->romClass;
+
+		return (NULL != romClass)
+				&& !_extensions->objectModel.isIndexable(clazz);
+	}
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	/**


### PR DESCRIPTION
Currently there is a N-square search behaviour during Anonymous classes unloading - search for the segment where ROM class for unloaded RAM class is stored. This general segments walk can introduce delays if there is a large number of Anonumous classes loaded. This PR introduces fast path can be attempted to find ROM class. There is a high possibility that the ROM segment we are looking for is the next one for RAM class segment. So, this segment can be checked first. If fast path search was not succesful an existed slow path is going to be used. Also can be a case when ROM class is not stored in Anonymous classloader, for example for Indexable, there is no reason to even search it.