### PR TITLE
Reduce modifications to zlib source code

### DIFF
--- a/runtime/include/zconf.h
+++ b/runtime/include/zconf.h
@@ -8,7 +8,11 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 
-/* Source is modified from the original zlib version in order to enable Z_PREFIX and so symbols exported from zlib are prefixed with j9zlib_ */
+/* Source is modified from the original zlib version in order to:
+ * - disable GZIP support
+ * - enable Z_PREFIX and so symbols exported from zlib are prefixed with "j9zlib_"
+ */
+#define NO_GZIP
 #define Z_PREFIX
 
 /*

--- a/runtime/zlib/deflate.h
+++ b/runtime/zlib/deflate.h
@@ -15,9 +15,6 @@
 
 #include "zutil.h"
 
-/* Source is modified from the original zlib version in order to enable NO_GZIP */
-#define NO_GZIP
-
 /* define NO_GZIP when compiling if you want to disable gzip header and
    trailer creation by deflate().  NO_GZIP would be used to avoid linking in
    the crc code when it is not needed.  For shared libraries, gzip encoding

--- a/runtime/zlib/inflate.h
+++ b/runtime/zlib/inflate.h
@@ -8,9 +8,6 @@
    subject to change. Applications should only use zlib.h.
  */
 
-/* Source is modified from the original zlib version in order to enable NO_GZIP */
-#define NO_GZIP
-
 /* define NO_GZIP when compiling if you want to disable gzip header and
    trailer decoding by inflate().  NO_GZIP would be used to avoid linking in
    the crc code when it is not needed.  For shared libraries, gzip decoding


### PR DESCRIPTION
Move the definition of `NO_GZIP` to `zconf.h` (see #14810).