### PR TITLE
Update Unsafe.copyMemory transformation to support offheap

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2625,3 +2625,189 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
    return false;
 #endif
    }
+
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+TR::TreeTop* J9::TransformUtil::convertUnsafeCopyMemoryCallToArrayCopyWithSymRefLoad(TR::Compilation *comp, TR::TreeTop *arrayCopyTT, TR::SymbolReference * srcRef, TR::SymbolReference * destRef)
+   {
+   // Convert call to arraycopy node
+   TR::Node *arrayCopyNode = arrayCopyTT->getNode()->getFirstChild();
+   arrayCopyNode->setNodeIsRecognizedArrayCopyCall(false);
+   TR::Node::recreate(arrayCopyNode, TR::arraycopy);
+
+   // Adjust src/dest
+   TR::Node* adjustedSrc = srcRef ? TR::Node::createLoad(arrayCopyNode, srcRef) : arrayCopyNode->getChild(1);
+   TR::Node* adjustedDest = destRef ? TR::Node::createLoad(arrayCopyNode, destRef) : arrayCopyNode->getChild(3);
+   adjustedSrc = TR::Node::create(TR::aladd, 2, adjustedSrc, arrayCopyNode->getChild(2));
+   adjustedDest = TR::Node::create(TR::aladd, 2, adjustedDest, arrayCopyNode->getChild(4));
+
+   TR::Node* newArrayCopyNode = TR::Node::createArraycopy(adjustedSrc, adjustedDest,  arrayCopyNode->getChild(5));
+   TR::TreeTop* newTT = TR::TreeTop::create(comp, newArrayCopyNode);
+   arrayCopyTT->insertAfter(newTT);
+   TR::TransformUtil::removeTree(comp, arrayCopyTT);
+
+   return newTT;
+
+   }
+
+TR::Block* J9::TransformUtil::insertUnsafeCopyMemoryArgumentChecksAndAdjustForOffHeap(TR::Compilation *comp, TR::Node* node, TR::SymbolReference* symRef, TR::Block* callBlock, bool insertArrayCheck, TR::CFG* cfg)
+   {
+   /**
+    *    Called if src/dest type is array (insertArrayCheck = false) or `java/lang/Object` (insertArrayCheck = true)
+    *    Inserts the following blocks:
+    *
+    *    BBStart nullCheckBlock
+    *    ifacmpeq --> newCallBlock
+    *      aload  src/dest
+    *      aconst NULL
+    *    BBEnd
+    *
+    *    ===== if (insertArrayCheck == true) =====
+    *    BBStart arrayCheckBlock
+    *    ificmpeq --> newCallBlock           // jumps if not an array
+    *      iand
+    *        l2i
+    *          lloadi  <isClassAndDepthFlags>
+    *            aloadi  <vft-symbol>
+    *              aload  src/dest
+    *        iconst 0x10000                  // array flag
+    *      iconst 0
+    *    BBEnd
+    *    =========================================
+    *
+    *    BBStart
+    *    astore  temp symRef
+    *      aloadi  <contiguousArrayDataAddrFieldSymbol>
+    *        aload  src/dest
+    *    BBEnd
+    */
+
+   TR::Block *nullCheckBlock = callBlock;
+   TR::Block *newCallBlock = nullCheckBlock->split(nullCheckBlock->getEntry()->getNextTreeTop(), cfg);
+   TR::Block *adjustBlock = nullCheckBlock->split(nullCheckBlock->getExit(), cfg);
+
+   // Insert null check trees
+   TR::Node* nullCheckNode = TR::Node::createif(TR::ifacmpeq, node->duplicateTree(), TR::Node::create(node, TR::aconst, 0, 0), newCallBlock->getEntry());
+   nullCheckBlock->append(TR::TreeTop::create(comp, nullCheckNode));
+   cfg->addEdge(nullCheckBlock, newCallBlock);
+
+   if (insertArrayCheck)
+      {
+      TR::Block* arrayCheckBlock = callBlock->split(callBlock->getExit(), cfg);
+
+      TR::Node *vftLoad = TR::Node::createWithSymRef(TR::aloadi, 1, 1, node->duplicateTree(), comp->getSymRefTab()->findOrCreateVftSymbolRef());
+      TR::Node *isArrayField = TR::Node::createWithSymRef(TR::lloadi, 1, 1, vftLoad, comp->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
+      isArrayField = TR::Node::create(TR::l2i, 1, isArrayField);
+      TR::Node *andConstNode = TR::Node::create(isArrayField, TR::iconst, 0, TR::Compiler->cls.flagValueForArrayCheck(comp));
+      TR::Node *andNode = TR::Node::create(TR::iand, 2, isArrayField, andConstNode);
+      TR::Node *arrayCheckNode = TR::Node::createif(TR::ificmpeq, andNode, TR::Node::create(node, TR::iconst, 0), newCallBlock->getEntry());
+
+      arrayCheckBlock->append(TR::TreeTop::create(comp, arrayCheckNode, NULL, NULL));
+      cfg->addEdge(callBlock, newCallBlock);
+      }
+
+   // Insert adjust trees
+   TR::Node* adjustedNode = TR::TransformUtil::generateDataAddrLoadTrees(comp, node->duplicateTree());
+   TR::Node *newStore = TR::Node::createStore(symRef, adjustedNode);
+   TR::TreeTop *newStoreTree = TR::TreeTop::create(comp, newStore);
+   adjustBlock->append(newStoreTree);
+
+   return newCallBlock;
+   }
+
+void J9::TransformUtil::transformUnsafeCopyMemorytoArrayCopyForOffHeap(TR::Compilation *comp, TR::TreeTop *arrayCopyTT, TR::Node *arraycopyNode)
+   {
+   // When using balanced GC policy with offheap allocation enabled, there are three possible for an argument type:
+   //
+   // 1.) The type is known to be a non-array object at compile time. In this scenario, the final address
+   //     can be calculated by simply adding ref and offset.
+   // 2.) The type is known to be an array at compile time. In this scenario, if the ref at runtime is `null` then
+   //     final address is calculated as in case 1. If not `null` then final address is the adjusted ref, by loading
+   //     the dataAddr pointer field then add it to the offset.
+   // 3.) The type of the object at dest is unknown at compile time (type is `java/lang/Object` or an interface).
+   //     In this scenario, a runtime null check and array check must be generated to determine whether it needs to
+   //     be handled such as case 1 or case 2.
+   //     Interface is included as valid bytecode can store an array into an interface type and then gets passed to
+   //     Unsafe.copyMemory().
+
+   TR::Node *src        = arraycopyNode->getChild(1);
+   TR::Node *dest       = arraycopyNode->getChild(3);
+
+   // Check src/dest type at compile time
+   int srcSigLen, destSigLen;
+   const char *srcObjTypeSig = src->getSymbolReference() ? src->getSymbolReference()->getTypeSignature(srcSigLen) : 0;
+   const char *destObjTypeSig = dest->getSymbolReference() ? dest->getSymbolReference()->getTypeSignature(destSigLen) : 0;
+
+   // Case 3
+   bool srcArrayCheckNeeded, destArrayCheckNeeded;
+   if (!srcObjTypeSig)
+      srcArrayCheckNeeded = true;
+   else
+      {
+      TR_OpaqueClassBlock *srcClass = comp->fej9()->getClassFromSignature(srcObjTypeSig, srcSigLen, src->getSymbolReference()->getOwningMethod(comp));
+      srcArrayCheckNeeded = srcClass == NULL ||
+                              srcClass == comp->getObjectClassPointer() ||
+                              TR::Compiler->cls.isInterfaceClass(comp, srcClass);
+      }
+
+   if (!destObjTypeSig)
+      destArrayCheckNeeded = true;
+   else
+      {
+      TR_OpaqueClassBlock *destClass = comp->fej9()->getClassFromSignature(destObjTypeSig, destSigLen, dest->getSymbolReference()->getOwningMethod(comp));
+      destArrayCheckNeeded = destClass == NULL ||
+                              destClass == comp->getObjectClassPointer() ||
+                              TR::Compiler->cls.isInterfaceClass(comp, destClass);
+      }
+
+   // Case 2 & 3
+   bool srcAdjustmentNeeded = srcArrayCheckNeeded || srcObjTypeSig[0] == '[';
+   bool destAdjustmentNeeded = destArrayCheckNeeded || destObjTypeSig[0] == '[';
+
+   TR::TransformUtil::separateNullCheck(comp, arrayCopyTT);
+
+   if (!(srcAdjustmentNeeded || destAdjustmentNeeded))
+      {
+      TR::TransformUtil::convertUnsafeCopyMemoryCallToArrayCopyWithSymRefLoad(comp, arrayCopyTT, NULL, NULL);
+      return;
+      }
+
+   // Anchor nodes
+   for (int32_t i=1; i < arraycopyNode->getNumChildren(); i++)
+      {
+      TR::Node* childNode = arraycopyNode->getChild(i);
+      if ( !(childNode->getOpCode().isLoadConst() ||
+            (childNode->getOpCode().isLoadVarDirect() && childNode->getSymbolReference()->getSymbol()->isAutoOrParm())) )
+         arrayCopyTT->insertBefore(TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, childNode)));
+      }
+
+   TR::CFG *cfg = comp->getFlowGraph();
+   TR::Block *currentBlock = arrayCopyTT->getEnclosingBlock();
+   TR::Block *callBlock = currentBlock->split(arrayCopyTT, cfg, true);
+   TR::Block *nextBlock = callBlock->split(arrayCopyTT->getNextTreeTop(), cfg, true);
+
+   TR::SymbolReference *adjustSrcTempRef = NULL;
+   TR::SymbolReference *adjustDestTempRef = NULL;
+   if (srcAdjustmentNeeded)
+      {
+      adjustSrcTempRef = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR::Address);
+      adjustSrcTempRef->getSymbol()->setNotCollected();
+      TR::Node* storeNode = TR::Node::createStore(adjustSrcTempRef, src);
+      TR::TreeTop* storeTree = TR::TreeTop::create(comp, storeNode);
+      currentBlock->getExit()->insertBefore(storeTree);
+      callBlock = TR::TransformUtil::insertUnsafeCopyMemoryArgumentChecksAndAdjustForOffHeap(comp, arraycopyNode->getChild(1), adjustSrcTempRef, callBlock, srcArrayCheckNeeded, cfg);
+      }
+   if (destAdjustmentNeeded)
+      {
+      adjustDestTempRef = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR::Address);
+      adjustDestTempRef->getSymbol()->setNotCollected();
+      TR::Node* storeNode = TR::Node::createStore(adjustDestTempRef, dest);
+      TR::TreeTop* storeTree = TR::TreeTop::create(comp, storeNode);
+      currentBlock->getExit()->insertBefore(storeTree);
+      callBlock = TR::TransformUtil::insertUnsafeCopyMemoryArgumentChecksAndAdjustForOffHeap(comp, arraycopyNode->getChild(3), adjustDestTempRef, callBlock, destArrayCheckNeeded, cfg);
+      }
+
+   TR::TransformUtil::convertUnsafeCopyMemoryCallToArrayCopyWithSymRefLoad(comp, arrayCopyTT, adjustSrcTempRef, adjustDestTempRef);
+
+   return;
+   }
+#endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -360,6 +360,36 @@ public:
       TR::Symbol::RecognizedField recField,
       TR::AnyConst *outValue);
 
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+   /**
+    * \brief
+    *    Converts Unsafe.copyMemory call into arraycopy node replacing
+    *    src and dest to loads if symbol reference is passed.
+    *
+    * \return
+    *    Return the TreeTop of the arrayCopy
+    */
+   static TR::TreeTop* convertUnsafeCopyMemoryCallToArrayCopyWithSymRefLoad(TR::Compilation *comp, TR::TreeTop *arrayCopyTT, TR::SymbolReference * srcRef, TR::SymbolReference * destRef);
+
+   /**
+    * \brief
+    *    Insert Unsafe.copyMemory src/dest argument checks and adjustments for offheap.
+    *
+    * \return
+    *    Return the new call block.
+    */
+   static TR::Block* insertUnsafeCopyMemoryArgumentChecksAndAdjustForOffHeap(TR::Compilation *comp, TR::Node* node, TR::SymbolReference* symRef, TR::Block* callBlock, bool insertArrayCheck, TR::CFG* cfg);
+
+   /**
+    * \brief
+    *    Convert Unsafe.copyMemory call to an arraycopy with all necessary checks for offheap
+    *
+    * \return
+    *    Return true if call is converted
+    */
+   static void transformUnsafeCopyMemorytoArrayCopyForOffHeap(TR::Compilation *comp, TR::TreeTop *arrayCopyTT, TR::Node *arraycopyNode);
+#endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
+
 protected:
    /**
     * \brief

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -370,6 +370,7 @@ class ValuePropagation : public OMR::ValuePropagation
 
    TR::VP_BCDSign **_bcdSignConstraints;
    List<TreeNodeResultPair> _callsToBeFoldedToNode;
+   List<TR_TreeTopNodePair> _offHeapCopyMemory;
 
    struct ValueTypesHelperCallTransform;
    struct ObjectComparisonHelperCallTransform;


### PR DESCRIPTION
TODO
- [x] Move implementation to J9TrnasformUtil
- [x] Call it from value propagation and codegen lowertrees ([LINK](https://github.com/rmnattas/openj9/blob/b656fc62f4288fe9fb0ff2a385985b296b5ed3ca/runtime/compiler/codegen/J9CodeGenerator.cpp#L875-L877))
- [x] Do transformation in VP's `doDelayedTransformations`

Depends on https://github.com/eclipse/omr/pull/7391

Example transformation trees
Before:
```
n816n     BBStart <block_50> (freq 18252)                                                     [    0x736558e0eec0] bci=[8,31,1293] rc=0 vc=214 vn=- li=- udi=- nc=0
n366n     treetop                                                                             [    0x736558e06220] bci=[8,28,1291] rc=0 vc=243 vn=- li=- udi=- nc=1
n365n       call  jdk/internal/misc/Unsafe.copyMemory0(Ljava/lang/Object;JLjava/lang/Object;JJ)V[#480  final native special Method] [flags 0x20500 0x0 ] ()  [    0x736558e061d0] bci=[8,28,1291] rc=1 vc=243 vn=- li=- udi=- n>
n359n         aload  <temp slot 10>[#532  Auto] [flags 0x20000007 0x0 ] (X!=0 )               [    0x736558e05ff0] bci=[8,19,1291] rc=1 vc=243 vn=- li=- udi=- nc=0 flg=0x4
n360n         aload  <parm 1 [I>[#404  Parm] [flags 0x40000107 0x0 ]                          [    0x736558e06040] bci=[8,20,1291] rc=1 vc=243 vn=- li=- udi=- nc=0
n890n         lconst 8 (highWordZero X!=0 X>=0 )                                              [    0x736558f205f0] bci=[-1,10,15] rc=1 vc=243 vn=- li=- udi=- nc=0 flg=0x4104
n362n         aload  <parm 2 Ljava/lang/Object;>[#405  Parm] [flags 0x40000107 0x0 ]          [    0x736558e060e0] bci=[8,22,1291] rc=1 vc=243 vn=- li=- udi=- nc=0
n363n         lload  <auto slot 3>[#409  Auto] [flags 0x4 0x0 ]                               [    0x736558e06130] bci=[8,24,1291] rc=1 vc=243 vn=- li=- udi=- nc=0
n891n         lconst 4 (highWordZero X!=0 X>=0 )                                              [    0x736558f20640] bci=[-1,15,15] rc=1 vc=243 vn=- li=- udi=- nc=0 flg=0x4104
n343n     BBEnd </block_50> =====                                                             [    0x736558e05af0] bci=[8,31,1293] rc=0 vc=243 vn=- li=- udi=- nc=0
```

After:
```
n816n     BBStart <block_50> (freq 18252)                                                     [    0x736558e0eec0] bci=[8,31,1293] rc=0 vc=275 vn=- li=- udi=- nc=0
n1071n    treetop                                                                             [    0x736558f23e80] bci=[8,20,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n360n       aload  <parm 1 [I>[#404  Parm] [flags 0x40000107 0x0 ]                            [    0x736558e06040] bci=[8,20,1291] rc=3 vc=275 vn=- li=- udi=- nc=0
n1078n    astore  <temp slot 8>[#537  Auto] [flags 0x7 0x0 ]                                  [    0x736558f240b0] bci=[8,20,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n360n       ==>aload
n1072n    treetop                                                                             [    0x736558f23ed0] bci=[8,22,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n362n       aload  <parm 2 Ljava/lang/Object;>[#405  Parm] [flags 0x40000107 0x0 ]            [    0x736558e060e0] bci=[8,22,1291] rc=3 vc=275 vn=- li=- udi=- nc=0
n1077n    astore  <temp slot 7>[#536  Auto] [flags 0x7 0x0 ]                                  [    0x736558f24060] bci=[8,22,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n362n       ==>aload
n1073n    treetop                                                                             [    0x736558f23f20] bci=[8,24,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n363n       lload  <auto slot 3>[#409  Auto] [flags 0x4 0x0 ] (cannotOverflow )               [    0x736558e06130] bci=[8,24,1291] rc=2 vc=275 vn=- li=- udi=- nc=0 flg=0x1000
n1076n    lstore  <temp slot 6>[#535  Auto] [flags 0x4 0x0 ]                                  [    0x736558f24010] bci=[8,24,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n363n       ==>lload
n1084n    astore  <temp slot 9>[#538  Auto] [flags 0x7 0x0 ]                                  [    0x736558f24290] bci=[8,20,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n360n       ==>aload
n1095n    astore  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                                 [    0x736558f24600] bci=[8,22,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n362n       ==>aload
n1075n    BBEnd </block_50> =====                                                             [    0x736558f23fc0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1074n    BBStart <block_135> (freq 18252)                                                    [    0x736558f23f70] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n1091n    ifacmpeq --> block_137 BBStart at n1085n ()                                         [    0x736558f244c0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=2 flg=0x20
n1089n      aload  <temp slot 9>[#538  Auto] [flags 0x7 0x0 ]                                 [    0x736558f24420] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1090n      aconst NULL (X==0 X>=0 X<=0 )                                                     [    0x736558f24470] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x302
n1088n    BBEnd </block_135> =====                                                            [    0x736558f243d0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1087n    BBStart <block_138> (freq 18252)                                                    [    0x736558f24380] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n1094n    astore  <temp slot 9>[#538  Auto] [flags 0x7 0x0 ]                                  [    0x736558f245b0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n1093n      aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x736558f24560] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8000
n1092n        aload  <temp slot 9>[#538  Auto] [flags 0x7 0x0 ]                               [    0x736558f24510] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1086n    BBEnd </block_138> =====                                                            [    0x736558f24330] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1085n    BBStart <block_137> (freq 18252)                                                    [    0x736558f242e0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n1102n    ifacmpeq --> block_139 BBStart at n1096n ()                                         [    0x736558f24830] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=2 flg=0x20
n1100n      aload  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                                [    0x736558f24790] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1101n      aconst NULL (X==0 X>=0 X<=0 )                                                     [    0x736558f247e0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x302
n1104n    BBEnd </block_137> =====                                                            [    0x736558f248d0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1103n    BBStart <block_141> (freq 18252)                                                    [    0x736558f24880] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n1112n    ificmpeq --> block_139 BBStart at n1096n ()                                         [    0x736558f24b50] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=2 flg=0x20
n1110n      iand                                                                              [    0x736558f24ab0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=2
n1108n        l2i                                                                             [    0x736558f24a10] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=1
n1107n          lloadi  <isClassAndDepthFlags>[#317  Shadow +24] [flags 0x603 0x0 ]           [    0x736558f249c0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=1
n1106n            aloadi  <vft-symbol>[#320  Shadow] [flags 0x18607 0x0 ]                     [    0x736558f24970] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=1
n1105n              aload  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                        [    0x736558f24920] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1109n        iconst 0x10000 (X!=0 X>=0 )                                                     [    0x736558f24a60] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x104
n1111n      iconst 0                                                                          [    0x736558f24b00] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1099n    BBEnd </block_141> =====                                                            [    0x736558f24740] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1098n    BBStart <block_140> (freq 18252)                                                    [    0x736558f246f0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n1115n    astore  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                                 [    0x736558f24c40] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=1
n1114n      aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x736558f24bf0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8000
n1113n        aload  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                              [    0x736558f24ba0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1097n    BBEnd </block_140> =====                                                            [    0x736558f246a0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0

n1096n    BBStart <block_139> (freq 18252)                                                    [    0x736558f24650] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=0
n366n     treetop                                                                             [    0x736558e06220] bci=[8,28,1291] rc=0 vc=275 vn=- li=- udi=- nc=1
n365n       arraycopy  jdk/internal/misc/Unsafe.copyMemory0(Ljava/lang/Object;JLjava/lang/Object;JJ)V[#480  final native special Method] [flags 0x20500 0x0 ] ()  [    0x736558e061d0] bci=[8,28,1291] rc=1 vc=275 vn=- li=- udi=- nc=3 flg=0x20
n1119n        aladd                                                                           [    0x736558f24d80] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=2
n1117n          aload  <temp slot 9>[#538  Auto] [flags 0x7 0x0 ]                             [    0x736558f24ce0] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n890n           lconst 8 (highWordZero X!=0 X>=0 )                                            [    0x736558f205f0] bci=[-1,10,15] rc=2 vc=275 vn=- li=- udi=- nc=0 flg=0x4104
n1120n        aladd                                                                           [    0x736558f24dd0] bci=[8,28,1291] rc=0 vc=0 vn=- li=- udi=- nc=2
n1118n          aload  <temp slot 10>[#539  Auto] [flags 0x7 0x0 ]                            [    0x736558f24d30] bci=[8,28,1291] rc=1 vc=0 vn=- li=- udi=- nc=0
n1081n          lload  <temp slot 6>[#535  Auto] [flags 0x4 0x0 ]                             [    0x736558f241a0] bci=[8,24,1291] rc=2 vc=0 vn=- li=- udi=- nc=0
n891n         lconst 4 (highWordZero X!=0 X>=0 )                                              [    0x736558f20640] bci=[-1,15,15] rc=1 vc=275 vn=- li=- udi=- nc=0 flg=0x4104
n1083n    BBEnd </block_139> =====                                                            [    0x736558f24240] bci=[8,31,1293] rc=0 vc=275 vn=- li=- udi=- nc=0

```