### PR TITLE
Profile in queue

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -7264,6 +7264,15 @@ static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum,
    {
    MM_GCCycleEndEvent *event = (MM_GCCycleEndEvent *)eventData;
    OMR_VMThread *omrVMThread = event->omrVMThread;
+
+   if (OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL == (event->cycleType & OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL))
+      {
+	   /**
+	    *  We skip the reclamation in the case of an unsuccessfully completed GC cycle
+	    *  (such as aborted Scavenge) since it does not have full object liveness info.
+	    */
+      return;
+      }
    condYieldFromGCFunctionPtr condYield = NULL;
    if (TR::Options::getCmdLineOptions()->realTimeGC())
       condYield = event->condYieldFromGCFunction;

--- a/runtime/gcchk/gcchk.cpp
+++ b/runtime/gcchk/gcchk.cpp
@@ -420,8 +420,10 @@ hookGcCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 
 	UDATA oldVMState = vmThread->omrVMThread->vmState;
 	vmThread->omrVMThread->vmState = OMRVMSTATE_GC_CHECK_AFTER_GC;
+	/* the OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL bit is set in the event->cycleType for cycleEnd in scavenge backout case, so mask off the bit to get the cycleType without it. */
+	uintptr_t cycleType = event->cycleType & (~OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL);
 
-	if (OMR_GC_CYCLE_TYPE_GLOBAL == event->cycleType) {
+	if (OMR_GC_CYCLE_TYPE_GLOBAL == cycleType) {
 		if (!excludeGlobalGc(vmThread)) {
 			if (cycle->getMiscFlags() & J9MODRON_GCCHK_VERBOSE) {
 				j9tty_printf(PORTLIB, "<gc check: start verifying slots after global gc (%zu)>\n", extensions->globalGcCount);
@@ -435,7 +437,7 @@ hookGcCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 		}
 	}
 #if defined(J9VM_GC_MODRON_SCAVENGER)
-	else if (OMR_GC_CYCLE_TYPE_SCAVENGE == event->cycleType) {
+	else if (OMR_GC_CYCLE_TYPE_SCAVENGE == cycleType) {
 		if (!excludeLocalGc(javaVM)) {
 			if (cycle->getMiscFlags() & J9MODRON_GCCHK_VERBOSE) {
 				j9tty_printf(PORTLIB, "<gc check: start verifying slots after local gc (%zu)>\n", extensions->localGcCount);

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -303,7 +303,8 @@ retry:
 		U_8 *profilingCursor = NULL;
 		if (J9_EVENT_IS_HOOKED(_vm->hookInterface, J9HOOK_VM_PROFILING_BYTECODE_BUFFER_FULL)) {
 			IDATA count = (IDATA)(UDATA)_literals->extra;
-			if ((count > 0) && (count <= (IDATA)_currentThread->maxProfilingCount)) {
+			if (((count > 0) && (count <= (IDATA)_currentThread->maxProfilingCount))
+				|| (count == J9_JIT_QUEUED_FOR_COMPILATION)) {
 #if defined(DEBUG_VERSION)
 				/* Do not profile breakpointed methods because the pc points to memory
 				 * which will go away when the breakpoint is removed.


### PR DESCRIPTION
Allow the IProfiler to run on methods while they are inside the compilation queues for better throughput