### PR TITLE
Remove redundant vlog newlines

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4139,7 +4139,7 @@ TR::CompilationInfoPerThread::processEntries()
       {
       TR_VerboseLog::writeLineLocked(
          TR_Vlog_DISPATCH,
-         "Starting to process queue entries. compThreadID=%d state=%d Q_SZ=%d Q_SZI=%d QW=%d\n",
+         "Starting to process queue entries. compThreadID=%d state=%d Q_SZ=%d Q_SZI=%d QW=%d",
          getCompThreadId(),
          getCompilationThreadState(),
          _compInfo.getMethodQueueSize(),
@@ -10472,7 +10472,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
                         {
                         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
-                                                          "Failure while relocating for %s, return code = %d [%s], relo error code = %s\n",
+                                                          "Failure while relocating for %s, return code = %d [%s], relo error code = %s",
                                                           comp->signature(),
                                                           returnCode,
                                                           (returnCode >= 0) && (returnCode < compilationMaxError) ? compilationErrorNames[returnCode] : "unknown error",

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -761,7 +761,7 @@ int TR_DataCacheManager::disclaimSegment(J9MemorySegment *segment, bool canDiscl
       int filePageCount = 0;
       int numPresentPages = countPresentPagesInSegment(segment, swappedCount, filePageCount);
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Will disclaim data cache segment %p of size %zu. Present pages =%d swapped=%d fileMapped=%d\n",
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Will disclaim data cache segment %p of size %zu. Present pages =%d swapped=%d fileMapped=%d",
               segment, segLength, numPresentPages, swappedCount, filePageCount);
 #endif // DEBUG_DISCLAIM
       int ret = madvise(segment->heapBase, segLength, MADV_PAGEOUT);
@@ -785,7 +785,7 @@ int TR_DataCacheManager::disclaimSegment(J9MemorySegment *segment, bool canDiscl
          filePageCount = 0;
          numPresentPages = countPresentPagesInSegment(segment, swappedCount, filePageCount);
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Disclaimed data cache segment %p of size %zu. Present pages =%d swapped=%d fileMapped=%d\n",
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Disclaimed data cache segment %p of size %zu. Present pages =%d swapped=%d fileMapped=%d",
                  segment, segLength, numPresentPages, swappedCount, filePageCount);
 #endif // DEBUG_DISCLAIM
          }

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -519,7 +519,7 @@ bool TR_HWProfiler::checkAndTurnBufferProcessingOn()
          if (TR::Options::isAnyVerboseOptionSet(TR_VerboseHWProfiler, TR_VerbosePerformance))
             {
             TR_VerboseLog::writeLineLocked(TR_Vlog_HWPROFILER,
-                                           "RI buffer processing re-enabled because we downgraded %d methods at cold since RI was turned off\n",
+                                           "RI buffer processing re-enabled because we downgraded %d methods at cold since RI was turned off",
                                            _numDowngradesSinceTurnedOff);
             }
          return true;

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -841,7 +841,7 @@ J9::CodeCache::disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap)
       size_t warm_size = _warmCodeAlloc - _segment->segmentBase() + sizeof(this);
       size_t cold_size = _coldCodeAllocBase - _coldCodeAlloc;
 
-      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Will disclaim cold code cache %p : coldStart=%p coldBase=%p warm_size=%zuB cold_size=%zuB cold_size/(cold_size + warm_size)=%5.2f%%\n",
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Will disclaim cold code cache %p : coldStart=%p coldBase=%p warm_size=%zuB cold_size=%zuB cold_size/(cold_size + warm_size)=%5.2f%%",
                                this, _coldCodeAlloc, _coldCodeAllocBase,
                                warm_size, cold_size, cold_size * 100.0/(cold_size + warm_size));
       }


### PR DESCRIPTION
Found using the command `grep -A 2 -rI -e 'TR_VerboseLog::writeLine' | grep -e '\\n"'` in `openj9/`.