### PR TITLE
Add support for FFI_TYPE_STRUCT_FF/DD on z/OS

### DIFF
--- a/runtime/libffi/preconf/mz64/ffi.h
+++ b/runtime/libffi/preconf/mz64/ffi.h
@@ -466,18 +466,18 @@ void ffi_call(ffi_cif *cif,
 
 #if !defined(ZOS)
 /* If these change, update src/mips/ffitarget.h. */
-#define FFI_TYPE_VOID       0    
+#define FFI_TYPE_VOID       0
 #define FFI_TYPE_INT        1
-#define FFI_TYPE_FLOAT      2    
+#define FFI_TYPE_FLOAT      2
 #define FFI_TYPE_DOUBLE     3
 #if 1
 #define FFI_TYPE_LONGDOUBLE 4
 #else
 #define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
 #endif
-#define FFI_TYPE_UINT8      5   
+#define FFI_TYPE_UINT8      5
 #define FFI_TYPE_SINT8      6
-#define FFI_TYPE_UINT16     7 
+#define FFI_TYPE_UINT16     7
 #define FFI_TYPE_SINT16     8
 #define FFI_TYPE_UINT32     9
 #define FFI_TYPE_SINT32     10
@@ -495,23 +495,25 @@ void ffi_call(ffi_cif *cif,
 #else
 #define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
 #endif
-#define FFI_TYPE_UINT8      3   
+#define FFI_TYPE_UINT8      3
 #define FFI_TYPE_SINT8      4
-#define FFI_TYPE_UINT16     5 
+#define FFI_TYPE_UINT16     5
 #define FFI_TYPE_SINT16     6
 #define FFI_TYPE_UINT32     7
-#define FFI_TYPE_SINT64     8 
-#define FFI_TYPE_POINTER    9 
+#define FFI_TYPE_SINT64     8
+#define FFI_TYPE_POINTER    9
 #define FFI_TYPE_UINT64     10
-#define FFI_TYPE_FLOAT      11   
+#define FFI_TYPE_FLOAT      11
 #define FFI_TYPE_STRUCT     12
-#define FFI_TYPE_VOID       13    
+#define FFI_TYPE_VOID       13
 #define FFI_TYPE_SINT32     14
 #define FFI_TYPE_COMPLEX    15
+#define FFI_TYPE_STRUCT_FF  16
+#define FFI_TYPE_STRUCT_DD  17
 #endif
 
 /* This should always refer to the last type code (for sanity checks) */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
+#define FFI_TYPE_LAST       FFI_TYPE_STRUCT_DD
 
 #ifdef __cplusplus
 }

--- a/runtime/libffi/z/sysvz64.s
+++ b/runtime/libffi/z/sysvz64.s
@@ -35,16 +35,11 @@ FFISYS CELQPRLG DSASIZE=DSASZ,PSECT=ASP
 
          LGR 5,14              Copy of parameter types
 *Reset registers used in code gen
-*         SR  0,0              GPR counter
-          LA  0,0
-*         SR  14,14            FPR counter
-          LA  14,0
-*         SR  7,7              Offset in the arg area
-          LA  7,0
-*         SR  10,10            Offset in array of parm types
-          LA  10,0
-*         SR  6,6              Offset in stored parm values
-          LA  6,0
+         LA  0,0               GPR counter
+         LA  14,0              FPR counter
+         LA  7,0               Offset in the arg area
+         LA  10,0              Offset in array of parm types
+         LA  6,0               Offset in stored parm values
 
 *bytes, we need to allocate space for the dummy argument
 *that holds the return value pointer
@@ -52,8 +47,10 @@ FFISYS CELQPRLG DSASIZE=DSASZ,PSECT=ASP
          LG 15,0(,15)           ecif->cif
          LG 15,16(,15)          cif->rtype
          LG 15,0(,15)           rtype->size
-         CGIJNH 15,24,GETNARGS  size>24, means we need to use gpr1
+         CGIJNH 15,24,GETNARGS
 
+* return size is > 24, r1 should contain address in caller stack
+* to store the return value.
          LG 1,(2176+(((DSASZ+31)/32)*32)+24)(,4)
          AHI 0,1                One less gpr to work with
          AHI 7,8                reserve space in arg area
@@ -65,7 +62,7 @@ GETNARGS DS 0H
 
 *Place arguments passed to the foreign function based on type
 ARGLOOP  LG  11,0(10,5)       Get pointer to current ffi_type
-         LLGC 11,11(11)       ffi_type->type
+         LLGH 11,10(11)       ffi_type->type
          SLL 11,2             Find offset in branch tabel
          LA  15,ATABLE
          L   15,0(11,15)
@@ -479,62 +476,12 @@ DARGF    DS 0H                l_DOUBLE in arg area
          LA  14,4             We reached max fprs
          B CONT               Next parameter
 
-*If we have spare gprs, pass up to 24 bytes in GPRs.
-STRCT    DS 0H
-         LG  11,0(10,5)
-
-*check if first element is float or double
-STFPCHK  DS 0H
-         LG 15,16(,11)          type->elements
-         LG 15,0(,15)           type->elements[0]
-         LH 15,10(,15)          type->elements[0]->type
-         CFI 15,11              is it a float?
-         BE STFPCHKF
-         CFI 15,1               is it a double?
-         BE STFPCHKD
-         B STRCT2
-
-*first arg is a float
-STFPCHKF DS 0H
-         LG 15,16(,11)          type->elements
-         LA 15,8(,15)           type->elements[0]
-         LG 15,0(,15)
-         LH 15,10(,15)          type->elements[0]->type
-         CFI 15,11              is it a float?
-         BE STFPCHKF2
-         B STRCT2
-
-*first arg is a double
-STFPCHKD DS 0H
-         LG 15,16(,11)          type->elements
-         LA 15,8(,15)           type->elements[1]
-         LG 15,0(,15)
-         LH 15,10(,15)          type->elements[1]->type
-         CFI 15,1               is it a double?
-         BE STFPCHKD2
-         B STRCT2
-
-
-*check if there are more elements
-*if not we have a special case
-*this is to handle complex types
-*in languages that don't support
-*complex types natively
-*in this case we pass the struct
-*in the first 2 free FPRs, just check this
-*against r14 the free FPR counter
-STFPCHKF2 DS 0H
-         LG 15,16(,11)          type->elements
-         LA 15,16(,15)          type->elements[0]
-         LG 15,0(,15)
-         CFI 15,0
-         BNE STRCT2             if no, not special case
+CPXF     DS 0H
+         CFI 14,4               no FPRs are available
+         BNL STRCT              if yes, not special case
 
          LG  11,0(10,5)
          LG 15,0(,11)           type->size
-
-         CFI 14,4               no FPRs are available
-         BNL STRCT2             if yes, not special case
 
          CFI 14,3               1 FPR is available
          BNL STFPCHKF26         use fpr6 + memory
@@ -548,7 +495,6 @@ STFPCHKF2 DS 0H
          CFI 14,0               4 FPRs available
          BE STFPCHKF202         use fpr0 + fpr2
 
-
 STFPCHKF26 DS 0H
          LE 6,0(6,13)           first float will go in fpr
          AFI 0,1                one less GPR available
@@ -559,7 +505,6 @@ STFPCHKF26 DS 0H
          AFI 7,4                advance 4 bytes into argarea
 
          B STRCTLP              copy rest of struct
-
 
 STFPCHKF202 DS 0H
          LE 0,0(6,13)           first float
@@ -598,21 +543,11 @@ STFPCHKF246 DS 0H
 
          B STRCTLP
 
-
-
-*same as the float case (STFPCHKF2) above but for doubles
-STFPCHKD2 DS 0H
-         LG 15,16(,11)          type->elements
-         LA 15,16(,15)          type->elements + 1
-         LG 15,0(,15)           *(type->elements + 1)
-         CFI 15,0               is NULL?
-         BNE STRCT2             if no, not special case
-
+CPXD     DS 0H
+         CFI 14,4               no FPRs are available
+         BNL STRCT              if yes, not special case
          LG 11,0(10,5)          ensure we have size
          LG 15,0(,11)           ready for labels we branch to
-
-         CFI 14,4               no FPRs are available
-         BNL STRCT2             if yes, not special case
 
          CFI 14,3               1 FPR is available
          BNL STFPCHKD26         use fpr6+memory
@@ -679,16 +614,17 @@ STFPCHKD246 DS 0H
 *determine how to pass the struct based on size
 *at this point we've weeded out all the float/double
 *pair structs that get passed purely in FPRs
-STRCT2  DS 0H
-         LG 15,0(,11)          type->size
-         CFI 15,8              Struct <= 8 bytes?
+STRCT    DS 0H
+         LG  11,0(10,5)
+         LG  15,0(,11)          type->size
+         CFI 15,8               Struct <= 8 bytes?
          BNH  BYTE8
-         CFI 15,16             Struct <= 16 bytes?
+         CFI 15,16              Struct <= 16 bytes?
          BNH   BYTE16
-         CFI 15,24             Struct <= 24 bytes?
+         CFI 15,24              Struct <= 24 bytes?
          B BYTE24
 
-BYTE8    DS 0H               Struct <= 8 bytes
+BYTE8    DS 0H                  Struct <= 8 bytes
 
 *Since a struct here can be <8 bytes
 *we need to pad it to 8 bytes in the arg area
@@ -890,82 +826,29 @@ RS       DS 0H
 * r9 = cif->rtype
 * r7 = ecif->rvalue
 RSREG    DS 0H
-         LG 11,16(,9)         rtype->elements
-         LA 15,0              number of floats seen
-         LA 0,0               number of doubles seen
-         LA 6,0               number of elements in struct
-
-RSLOOP   DS 0H
-         LG 12,0(,11)         load the current element, we update
-*                             this register in NEXT so it's technically
-*                             actually rtype->elements + i
-         CGIJE 12,0,RSFPR     if we have NULL, we are done
-*                             this means we have all float types
-         LA 13,10(,12)        address of rtype->elements[i]->type
-         LLGH 10,0(,13)        load the type (halfword)
-         CFI 10,11            if type == FFI_TYPE_FLOAT
-         BE NEXTF             check next element
-         CFI 10,1             if type == FFI_TYPE_DOUBLE
-         BE NEXTD             check next element
-         B RSGPR              we have an integral type, use GPRs
-
-NEXTF    DS 0H
-         LA 11,8(,11)         increment the pointer to the next element
-         LA 15,1              we have seen a float
-         AFI 6,1
-         CGIJE 0,1,RSGPR      we have a mix of float/double use GPRs
-         B RSLOOP             loop back to the top
-
-NEXTD    DS 0H
-         LA 11,8(,11)         increment the pointer to the next element
-         LA 0,1               we have seen a double
-         AFI 6,1
-         CGIJE 15,1,RSGPR     we have a mix of float/double use GPRs
-         B RSLOOP             loop back to the top
-
-* label if we're using FPRs
-RSFPR    DS 0H
-         CFI 6,2
-         BNE RSGPR
-         LA 5,0
+         LLGH 11,10(,9)       rtype->type
          LA 15,SSTOR
-         LG 11,16(,9)
-         LG 12,0(,11)
-         CGIJE 12,0,RSCPY
-         LA 13,10(,12)        address of rtype->elements[i]->type
-         LLGH 10,0(,13)       load the type (halfword)
-         CFI 10,11            if type == FFI_TYPE_FLOAT
-         BE STOREF1           store the float in the return area
-         CFI 10,1             if type == FFI_TYPE_DOUBLE
+         CFI 11,16            rtype->type == FFI_TYPE_STRUCT_FF
+         BE STOREF1
+         CFI 11,17            rtype->type == FFI_TYPE_STRUCT_DD
          BE STORED1
-
-STOREF1  DS 0H
-         STE 0,0(5,15)
-         STE 2,4(5,15)
-         AGFI 5,4
-         B RSCPY
-
-STORED1  DS 0H
-         STD 0,0(5,15)
-         STD 2,8(5,15)
-         AGFI 5,8
-         B RSCPY
-
-* label if we're using GPRs
-RSGPR    DS 0H
-* so to save us from having to figure out
-* how many regs to save, we'll just save them all
-* into some local storage, then copy the right amount
-         LA 15,SSTOR
          STG  1,0(,15)
          STG  2,8(,15)
          STG  3,16(,15)
          B RSCPY
 
+STOREF1  DS 0H
+         STE 0,0(,15)
+         STE 2,4(,15)
+         B RSCPY
+
+STORED1  DS 0H
+         STD 0,0(,15)
+         STD 2,8(,15)
+
 * label to copy the struct to the return area
 * just move one byte at a time from r15 to r7
 * while r14 is non-zero
-
 RSCPY    DS 0H
          CGIJNH 14,0,RET
          LB 1,0(,15)
@@ -1001,6 +884,8 @@ ATABLE DC A(I)                Labels for parm types
  DC A(VOID)
  DC A(I)
  DC A(D)
+ DC A(CPXF)
+ DC A(CPXD)
 I32 DC A(IGPR1)               Labels for passing INT in gpr
  DC A(IGPR2)
  DC A(IGPR3)

--- a/runtime/vm/LayoutFFITypeHelpers.cpp
+++ b/runtime/vm/LayoutFFITypeHelpers.cpp
@@ -203,7 +203,13 @@ done:
 void
 LayoutFFITypeHelpers::freeStructFFIType(ffi_type *ffiType)
 {
-	if ((NULL != ffiType) && (FFI_TYPE_STRUCT == ffiType->type)) {
+	if ((NULL != ffiType)
+			&& ((FFI_TYPE_STRUCT == ffiType->type)
+#if defined(J9ZOS390) && defined(J9VM_ENV_DATA64)
+				|| (FFI_TYPE_STRUCT_FF == ffiType->type)
+				|| (FFI_TYPE_STRUCT_DD == ffiType->type)
+#endif /* defined(J9ZOS390) && defined(J9VM_ENV_DATA64) */
+	)) {
 		if (NULL != ffiType->elements) {
 			PORT_ACCESS_FROM_JAVAVM(_vm);
 			freeStructFFITypeElements(ffiType->elements);

--- a/runtime/vm/LayoutFFITypeHelpers.hpp
+++ b/runtime/vm/LayoutFFITypeHelpers.hpp
@@ -116,6 +116,10 @@ public:
 			typeCode = J9NtcPointer;
 			break;
 		case FFI_TYPE_STRUCT:
+#if defined(J9ZOS390) && defined(J9VM_ENV_DATA64)
+		case FFI_TYPE_STRUCT_FF:
+		case FFI_TYPE_STRUCT_DD:
+#endif /* defined(J9ZOS390) && defined(J9VM_ENV_DATA64) */
 			typeCode = J9NtcStruct;
 			break;
 		default:

--- a/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler.cpp
+++ b/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler.cpp
@@ -111,10 +111,15 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler_initCifNativeTh
 		rc = GOTO_THROW_CURRENT_EXCEPTION;
 		setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 		goto done;
-	/* Only intended for strut as the primitive's ffi_type is non-null */
+	/* Only intended for struct as the primitive's ffi_type is non-null. */
 	} else if ((NULL == returnType)
-	|| ((FFI_TYPE_STRUCT == returnType->type) && (NULL == returnType->elements))
-	) {
+				|| (((FFI_TYPE_STRUCT == returnType->type)
+#if defined(J9ZOS390) && defined(J9VM_ENV_DATA64)
+					|| (FFI_TYPE_STRUCT_FF == returnType->type)
+					|| (FFI_TYPE_STRUCT_DD == returnType->type)
+#endif /* defined(J9ZOS390) && defined(J9VM_ENV_DATA64) */
+				) && (NULL == returnType->elements)))
+	{
 		rc = GOTO_THROW_CURRENT_EXCEPTION;
 		setNativeOutOfMemoryError(currentThread, 0, 0);
 		goto done;
@@ -141,7 +146,12 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler_initCifNativeTh
 				goto freeAllMemoryThenExit;
 			/* Only intended for struct as the primitive's ffi_type is non-null */
 			} else if ((NULL == argTypes[argIndex])
-			|| ((FFI_TYPE_STRUCT == argTypes[argIndex]->type) && (NULL == argTypes[argIndex]->elements))
+						|| (((FFI_TYPE_STRUCT == argTypes[argIndex]->type)
+#if defined(J9ZOS390) && defined(J9VM_ENV_DATA64)
+							|| (FFI_TYPE_STRUCT_FF == argTypes[argIndex]->type)
+							|| (FFI_TYPE_STRUCT_DD == argTypes[argIndex]->type)
+#endif /* defined(J9ZOS390) && defined(J9VM_ENV_DATA64) */
+						) && (NULL == argTypes[argIndex]->elements))
 			) {
 				rc = GOTO_THROW_CURRENT_EXCEPTION;
 				setNativeOutOfMemoryError(currentThread, 0, 0);


### PR DESCRIPTION
XPLINK on z/OS requires a special treatment for structs which with two
members whose base type are same, either float or double. Such
parameters are passed to the function as complex type and available FPRs
will be used.
Changes in this PR adds support for two new types in libffi -
FFI_TYPE_STRUCT_FF and FFI_TYPE_STRUCT_DD and also uses it in J9 similar
to how FFI_TYPE_STRUCT is used as for J9 it shouldn't be different. It
is just that libffi needs to know if the argument type or return type
are considered complex on XPLINK to make sure that appropriate FPRs if
available are used to pass parameters or read return values from.

J9 does not need to do the analysis for complex types, that work is done
when platform dependant prep_cif is called when initializing the cif
object.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>