### PR TITLE
JEP471 sets system property according to the command line option value

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2401,3 +2401,11 @@ J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.explanation=checkTran
 J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_CHECK_TRANSITION_TO_DEBUG_INTERPRETER_FAILED.user_response=View CRIU documentation to determine how to resolve the error.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_UNRECOGNISED_SUN_MISC_UNSAFE_MEMORY_ACCESS_VALUE=Value specified to --sun-misc-unsafe-memory-access not recognized: '%s'
+# START NON-TRANSLATABLE
+J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT.sample_input_1=allow
+J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT.explanation=The value specified is not known.
+J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT.system_action=The JVM will fail to start.
+J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT.user_response=Change the value to one of "allow", "warn", "debug" or "deny".
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -920,6 +920,7 @@ typedef struct J9VMCustomSpinOptions {
 #define J9SYSPROP_ERROR_INVALID_JCL  4
 #define J9SYSPROP_ERROR_UNSUPPORTED_PROP 5
 #define J9SYSPROP_ERROR_ARG_MISSING 6
+#define J9SYSPROP_ERROR_INVALID_VALUE  7
 
 typedef struct J9VMDllLoadInfo {
 	char dllName[32];

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -684,6 +684,9 @@ enum INIT_STAGE {
 /* JEP 421: Deprecate Finalization for Removal */
 #define VMOPT_DISABLE_FINALIZATION "--finalization="
 
+/* JEP 471: Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal */
+#define VMOPT_DISABLE_SUN_MISC_UNSAFE_MEMORY_ACCESS "--sun-misc-unsafe-memory-access="
+
 #define ENVVAR_IBM_MIXED_MODE_THRESHOLD "IBM_MIXED_MODE_THRESHOLD"
 #define ENVVAR_JAVA_COMPILER "JAVA_COMPILER"
 #define ENVVAR_JAVA_OPTIONS "_JAVA_OPTIONS"
@@ -713,6 +716,9 @@ enum INIT_STAGE {
 #define SYSPROP_JDK_MODULE_PATCH "jdk.module.patch."
 #define SYSPROP_JDK_MODULE_ILLEGALACCESS "jdk.module.illegalAccess"
 #define SYSPROP_JDK_MODULE_ENABLENATIVEACCESS "jdk.module.enable.native.access."
+#if JAVA_SPEC_VERSION >= 23
+#define SYSPROP_SUN_MISC_UNSAFE_MEMORY_ACCESS "sun.misc.unsafe.memory.access"
+#endif /* JAVA_SPEC_VERSION >= 23 */
 #define JAVA_BASE_MODULE "java.base"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1048,6 +1048,42 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if JAVA_SPEC_VERSION >= 23
+	{
+		/* JEP 471: Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal
+		 * --sun-misc-unsafe-memory-access=value which is expected to be "allow", "warn", "debug" or "deny".
+		 */
+		IDATA argIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_DISABLE_SUN_MISC_UNSAFE_MEMORY_ACCESS, NULL);
+		if (argIndex >= 0) {
+			PORT_ACCESS_FROM_JAVAVM(vm);
+			UDATA optionNameLen = LITERAL_STRLEN(VMOPT_DISABLE_SUN_MISC_UNSAFE_MEMORY_ACCESS);
+			/* option name includes the '=' so go back one to get the option arg */
+			char *optionArg = getOptionArg(vm, argIndex, optionNameLen - 1);
+
+			if (NULL != optionArg) {
+				if ((0 == strcmp(optionArg, "allow"))
+					|| (0 == strcmp(optionArg, "warn"))
+					|| (0 == strcmp(optionArg, "debug"))
+					|| (0 == strcmp(optionArg, "deny"))
+				) {
+					rc = addSystemProperty(vm, SYSPROP_SUN_MISC_UNSAFE_MEMORY_ACCESS, optionArg, J9SYSPROP_FLAG_VALUE_ALLOCATED);
+					if (J9SYSPROP_ERROR_NONE != rc) {
+						goto fail;
+					}
+				} else {
+					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNRECOGNISED_SUN_MISC_UNSAFE_MEMORY_ACCESS_VALUE, optionArg);
+					rc = J9SYSPROP_ERROR_INVALID_VALUE;
+					goto fail;
+				}
+			} else {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNRECOGNISED_SUN_MISC_UNSAFE_MEMORY_ACCESS_VALUE, "");
+				rc = J9SYSPROP_ERROR_ARG_MISSING;
+				goto fail;
+			}
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 23 */
+
 	/* If we get here all is good */
 	rc = J9SYSPROP_ERROR_NONE;
 


### PR DESCRIPTION
`JEP471` sets system property according to the command line option value

`--sun-misc-unsafe-memory-access=value` which is expected to be "allow", "warn", "debug" or "deny";
Set a system property `sun.misc.unsafe.memory.access` with the value specified via `--sun-misc-unsafe-memory-access=value`.

Verified locally that `sun/misc/UnsafeMemoryAccessWarnings.java` passes.

issue https://github.com/eclipse-openj9/openj9/issues/19583

Signed-off-by: Jason Feng <fengj@ca.ibm.com>