### PR TITLE
[FFI/JDK22+] Remove the heap argument identifier in downcall

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6171,10 +6171,6 @@ typedef struct J9JavaVM {
 #define J9JAVAVM_DISCONTIGUOUS_INDEXABLE_HEADER_SIZE(vm) ((vm)->discontiguousIndexableHeaderSize)
 
 #if JAVA_SPEC_VERSION >= 16
-#if JAVA_SPEC_VERSION >= 22
-#define J9_FFI_DOWNCALL_HEAP_ARGUMENT_ID J9CONST_U64(0xFFFFFFFFFFFFFFFF)
-#endif /* JAVA_SPEC_VERSION >= 22 */
-
 /* The mask for the signature type identifier */
 #define J9_FFI_UPCALL_SIG_TYPE_MASK 0xF
 


### PR DESCRIPTION
The changes aim to avoid the conflicts of the native address
imposed by users by check the existence of the heap base to
determine whether a heap array rather than a native array
is passed down to native.

Fixes: #19005

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
