### PR TITLE
Open XL Toolchain Changes

### DIFF
--- a/runtime/cmake/platform/toolcfg/openxl.cmake
+++ b/runtime/cmake/platform/toolcfg/openxl.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright IBM Corp. and others 2021
+# Copyright IBM Corp. and others 2024
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,13 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ################################################################################
 
-set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
+list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+	-O3
+	-fstack-protector
+)
 
-set(CMAKE_IMPORT_LIBRARY_PREFIX "lib")
+list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -fno-rtti)
+
+# OMR_PLATFORM_CXX_COMPILE_OPTIONS get applied to JIT code (which needs exceptions),
+# so we put these in the CMAKE_CXX_FLAGS instead.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fignore-exceptions")

--- a/runtime/cmake/platform/toolcfg/xlc.cmake
+++ b/runtime/cmake/platform/toolcfg/xlc.cmake
@@ -20,7 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ################################################################################
 
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3)
+list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+	-O3
+	"\"-Wc,inline(auto,noreport,600,5000)\""
+	"\"-Wc,list(),offset,gonumber\""
+)
 
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qnortti)
 


### PR DESCRIPTION
Contains all the initial required toolchain changes to start using Open XL compiler with z/OS builds.

---

Keeping as draft state until I have verified it does not interfere with z/OS XLC Builds.