### PR TITLE
(0.46) Update sync logic between vthreadInspectorCount & internalSuspendState

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -169,7 +169,7 @@ getVMThread(J9VMThread *currentThread, jthread thread, J9VMThread **vmThreadPtr,
 		if (NULL != carrierThread) {
 			targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, carrierThread);
 		}
-		if (J9OBJECT_I64_LOAD(currentThread, threadObject, vm->virtualThreadInspectorCountOffset) < -1) {
+		if (J9OBJECT_I64_LOAD(currentThread, threadObject, vm->virtualThreadInspectorCountOffset) < -2) {
 			/* If the virtual thread is suspended in transition, check if the mounting process is already completed. */
 			J9VMThread *carrierVMThread = VM_VMHelpers::getCarrierVMThread(currentThread, threadObject);
 			if (NULL != carrierVMThread->currentContinuation) {

--- a/runtime/jvmti/suspendhelper.cpp
+++ b/runtime/jvmti/suspendhelper.cpp
@@ -96,7 +96,7 @@ suspendThread(J9VMThread *currentThread, jthread thread, BOOLEAN allowNull, BOOL
 		if (VM_VMHelpers::isThreadSuspended(currentThread, threadObject)) {
 			rc = JVMTI_ERROR_THREAD_SUSPENDED;
 		} else {
-			U_64 internalSuspendState = (U_64)VM_VMHelpers::getCarrierVMThread(currentThread, threadObject);
+			U_64 internalSuspendState = J9OBJECT_U64_LOAD(currentThread, threadObject, vm->internalSuspendStateOffset);
 			J9OBJECT_U64_STORE(currentThread, threadObject, vm->internalSuspendStateOffset, (internalSuspendState | J9_VIRTUALTHREAD_INTERNAL_STATE_SUSPENDED));
 		}
 #endif /* JAVA_SPEC_VERSION >= 19 */


### PR DESCRIPTION
- Add new state -2 when vthread suspends under transition
- Refactor state checks to match new design
- Add assertion on expected states for easier triaging

Note:
This design doesn't account for cases where a JVMTI agent tries to accesses a suspended vthread while resuming it simultaneously. This will lead to undefined behaviour of the JVM.

Backport of #19564 