### PR TITLE
[0.46.0] Change order of tests for inline Unsafe.{get|put}* calls

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -221,15 +221,15 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
        *           being inlined
        * \param comparisonTree A pointer to a \ref TR::TreeTop for a \c if node that will
        *           be the root of the diamond
-       * \param ifTree A pointer to a \ref TR::TreeTop representing the taken branch of
+       * \param branchTargetTree A pointer to a \ref TR::TreeTop representing the taken branch of
        *           \c comparisonTree
-       * \param elseTree A pointer to a \ref TR::TreeTop reprenting the fall-through branch
+       * \param fallThroughTree A pointer to a \ref TR::TreeTop reprenting the fall-through branch
        *           of \c comparisonTree
        *
        * \return A pointer to a \ref TR::Block representing the join point of the diamond
-       *         after executing either \c ifTree or \c elseTree
+       *         after executing either \c branchTargetTree or \c fallThroughTree
        */
-      TR::Block * createUnsafeGetPutCallDiamond(TR::TreeTop* callNodeTreeTop, TR::TreeTop* comparisonTree, TR::TreeTop* ifTree, TR::TreeTop* elseTree);
+      TR::Block * createUnsafeGetPutCallDiamond(TR::TreeTop* callNodeTreeTop, TR::TreeTop* comparisonTree, TR::TreeTop* branchTargetTree, TR::TreeTop* fallThroughTree);
       bool createUnsafePutWithOffset(TR::ResolvedMethodSymbol *, TR::ResolvedMethodSymbol *, TR::TreeTop *, TR::Node *, TR::DataType, bool, bool needNullCheck = false, bool isOrdered = false);
       TR::TreeTop* genDirectAccessCodeForUnsafeGetPut(TR::Node* callNode, bool conversionNeeded, bool isUnsafeGet);
       void createTempsForUnsafePutGet(TR::Node*& unsafeAddress, TR::Node* unsafeCall, TR::TreeTop* callNodeTreeTop, TR::Node*& offset, TR::SymbolReference*& newSymbolReferenceForAddress, bool isUnsafeGet);


### PR DESCRIPTION
If the J9Class for `java/lang/Class` is available to the compiler, the IL it generates inline for `Unsafe.{get|put}{int|long|Object}*` tests whether the Object being accessed is null (for native memory references), has the low-order bit set for the specified offset and whether its J9Class is that of `java/lang/Class`, in that order. Those tests are trying to distinguish whether a static field is being accessed, which requires different code to access the memory than all the other cases.

For both instance fields and static fields, the Object will be a non-null reference.  However, the low-order bit of the offset will never be set for instance fields.  Therefore, what is likely the most common usage would benefit from having the low-order offset bit tested first.

This commit changes the order of the tests accordingly for that case.

This opportunity was identified by @vijaysun-omr and @ymanton.

This is a port of pull request #19640 to the v0.46.0-release branch.