### PR TITLE
Recognize and handle Memory Segment View VarHandles in JDK21+

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1162,6 +1162,8 @@
    java_lang_invoke_VarHandleByteArrayAsX_ArrayHandle_method,
    java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method,
 
+   java_lang_invoke_VarHandleSegmentAsX_method,
+
    // Clone and Deep Copy
    java_lang_J9VMInternals_is32Bit,
    java_lang_J9VMInternals_isClassModifierPublic,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4765,8 +4765,20 @@ void TR_ResolvedJ9Method::construct()
                {
                setRecognizedMethodInfo(TR::java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method);
                }
+#if JAVA_SPEC_VERSION >= 21
+            else if ((classNameLen == 39 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsInts", 39))
+                  || (classNameLen == 40 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsBytes", 40))
+                  || (classNameLen == 40 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsChars", 40))
+                  || (classNameLen == 40 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsLongs", 40))
+                  || (classNameLen == 41 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsFloats", 41))
+                  || (classNameLen == 41 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsShorts", 41))
+                  || (classNameLen == 42 && !strncmp(className, "java/lang/invoke/VarHandleSegmentAsDoubles", 42)))
+               {
+               setRecognizedMethodInfo(TR::java_lang_invoke_VarHandleSegmentAsX_method);
+               }
+#endif // JAVA_SPEC_VERSION >= 21
             }
-#endif
+#endif // defined(J9VM_OPT_OPENJDK_METHODHANDLE)
          else if ((classNameLen >= 59 + 3 && classNameLen <= 59 + 7) && !strncmp(className, "java/lang/invoke/ArrayVarHandle$ArrayVarHandleOperations$Op", 59))
             {
             setRecognizedMethodInfo(TR::java_lang_invoke_ArrayVarHandle_ArrayVarHandleOperations_OpMethod);
@@ -5879,6 +5891,7 @@ TR_J9MethodBase::isVarHandleOperationMethod(TR::RecognizedMethod rm)
       case TR::java_lang_invoke_VarHandleX_FieldStaticReadOnlyOrReadWrite_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ArrayHandle_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method:
+      case TR::java_lang_invoke_VarHandleSegmentAsX_method:
 #else
       case TR::java_lang_invoke_ArrayVarHandle_ArrayVarHandleOperations_OpMethod:
       case TR::java_lang_invoke_StaticFieldVarHandle_StaticFieldVarHandleOperations_OpMethod:

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -151,6 +151,7 @@ static bool isVarHandleOperationMethodOnArray(TR::RecognizedMethod rm)
       case TR::java_lang_invoke_VarHandleX_Array_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ArrayHandle_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method:
+      case TR::java_lang_invoke_VarHandleSegmentAsX_method:
 #else
       case TR::java_lang_invoke_ArrayVarHandle_ArrayVarHandleOperations_OpMethod:
       case TR::java_lang_invoke_ByteArrayViewVarHandle_ByteArrayViewVarHandleOperations_OpMethod:
@@ -188,6 +189,7 @@ static bool isVarHandleOperationMethodOnNonStaticField(TR::RecognizedMethod rm)
       case TR::java_lang_invoke_VarHandleX_Array_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ArrayHandle_method:
       case TR::java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method:
+      case TR::java_lang_invoke_VarHandleSegmentAsX_method:
 #else
       case TR::java_lang_invoke_InstanceFieldVarHandle_InstanceFieldVarHandleOperations_OpMethod:
       case TR::java_lang_invoke_ArrayVarHandle_ArrayVarHandleOperations_OpMethod:


### PR DESCRIPTION
This PR enables UnsafeFastPath transformation to fast-path Unsafe operations that are part of Memory Segment View VarHandle usage in JDK 21 and above.

This PR depends on #19566, and will remain in draft state until it is merged.