### PR TITLE
Fix vectorAPI address node helper after offheap changes

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1253,22 +1253,15 @@ TR_VectorAPIExpansion::generateAddressNode(TR::Compilation *comp, TR::Node *arra
    while ((elementSize = (elementSize >> 1)))
         ++shiftAmount;
 
-   TR::Node *laddNode = TR::Node::create(TR::ladd, 2);
-
    if (shiftAmount != 0)
       {
       TR::Node *lshlNode = TR::Node::create(TR::lshl, 2);
       lshlNode->setAndIncChild(0, arrayIndex);
       lshlNode->setAndIncChild(1, TR::Node::create(TR::iconst, 0, shiftAmount));
-
-      laddNode->setAndIncChild(0, lshlNode);
-      }
-   else
-      {
-      laddNode->setAndIncChild(0, arrayIndex);
+      arrayIndex = lshlNode;
       }
 
-   TR::Node *aladdNode = TR::TransformUtil::generateArrayElementAddressTrees(comp, array, laddNode);
+   TR::Node *aladdNode = TR::TransformUtil::generateArrayElementAddressTrees(comp, array, arrayIndex);
    aladdNode->setIsInternalPointer(true);
 
    return aladdNode;


### PR DESCRIPTION
Previous changes by to support offheap resulted in wrong generated trees, this fixes it.

Original changes:
https://github.com/eclipse-openj9/openj9/commit/566a656bece4538bcbc13a8d09c55e4cdbd8f37a

Tests: https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/22647/

Original trees:
```
aladd
    arrayRef
    ladd
        headerSize
        index (or shift)
```

After changes:
```
aladd
    arrayRef
    ladd
        headerSize
        ladd
            index (or shift)
            null
```

After this fix (non offheap case):
```
aladd
    arrayRef
    ladd
        headerSize
        index (or shift)
```

Issue was instead of passing the index/shift node to the helper we passed the `ladd` with one child being the index/shift.

Closes: https://github.com/eclipse-openj9/openj9/issues/19661