### PR TITLE
Fix copyright notices to avoid Java compilation warnings

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/BuildVersionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/BuildVersionCommand.java
@@ -19,7 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
  *

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DSymtabCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DSymtabCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DyldInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DyldInfoCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylibCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylibCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylinkerCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylinkerCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EncryptionCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EncryptionCommand64.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EntryPointCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EntryPointCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkeditDataCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkeditDataCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkerOptionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkerOptionCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LoadCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LoadCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReader.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/NoteCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/NoteCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -49,7 +49,7 @@ public class NoteCommand extends LoadCommand
 	byte dataOwner[];
 	long offset;
 	long size;
-	
+
 	public NoteCommand() {}
 
 	public NoteCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/OSXProcessAddressSpace.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/OSXProcessAddressSpace.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -60,7 +60,7 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 {
 
 	private final MachoDumpReader reader;
-	
+
 	public OSXProcessAddressSpace(int pointerSizeBytes, ByteOrder byteOrder,
 			MachoDumpReader reader)
 	{
@@ -79,7 +79,7 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 	{
 		return reader.getCommandLine();
 	}
-	
+
 	@Override
 	public boolean equals(Object o)
 	{
@@ -100,7 +100,7 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 	{
 		throw new DataUnavailableException("Can't get environment from core dump");
 	}
-	
+
 	public IModule getExecutable() throws CorruptDataException
 	{
 		return reader.getExecutable();
@@ -126,7 +126,7 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 		return reader.getThreads();
 	}
 
-	
+
 	public int getSignalNumber() throws DataUnavailableException
 	{
 		return reader.getSignalNumber();
@@ -135,17 +135,17 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 	public String readStringAt(long nameAddress) throws MemoryFault
 	{
 		long ptr = nameAddress;
-		
+
 		while (getByteAt(ptr) != 0) {
 			ptr++;
 		}
-		
+
 		int stringLength = (int)(ptr - nameAddress);
-		
+
 		byte[] stringBuffer = new byte[stringLength];
-		
+
 		getBytesAt(nameAddress, stringBuffer);
-		
+
 		return new String(stringBuffer, StandardCharsets.US_ASCII);
 	}
 
@@ -158,5 +158,5 @@ public class OSXProcessAddressSpace extends ProcessAddressSpace
 	{
 		throw new DataUnavailableException("Not available on this platform");
 	}
-	
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PrebindChecksumCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PrebindChecksumCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PreboundDylibCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PreboundDylibCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RoutinesCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RoutinesCommand64.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RpathCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RpathCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SegmentCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SegmentCommand64.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -108,7 +108,7 @@ public class SegmentCommand64 extends LoadCommand
 		public int reserved1;
 		public int reserved2;
 		public int reserved3;
-		
+
 		public Section64()
 		{
 			sectionName = new byte[16];

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SourceVersionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SourceVersionCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SubCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SubCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SymtabCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SymtabCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/ThreadCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/ThreadCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/TwoLevelHintsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/TwoLevelHintsCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/UuidCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/UuidCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/VersionMinCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/VersionMinCommand.java
@@ -19,17 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-/*******************************************************************************
+/*
  * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
  * Reserved.
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -50,7 +50,7 @@ public class VersionMinCommand extends LoadCommand
 	int sdk;
 	BuildVersionCommand.Version osVersion;
 	BuildVersionCommand.Version sdkVersion;
-	
+
 	public VersionMinCommand() {}
 
 	public VersionMinCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -1490,7 +1490,7 @@ public class PointerGenerator {
 	}
 
 	private static void writeCopyright(PrintWriter writer) {
-		writer.println("/*******************************************************************************");
+		writer.println("/*");
 		writer.println(" * Copyright IBM Corp. and others 1991");
 		writer.println(" *");
 		writer.println(" * This program and the accompanying materials are made available under");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
@@ -416,7 +416,7 @@ public class StructureStubGenerator {
 	}
 
 	private static void writeCopyright(PrintWriter writer) {
-		writer.println("/*******************************************************************************");
+		writer.println("/*");
 		writer.println(" * Copyright IBM Corp. and others 1991");
 		writer.println(" *");
 		writer.println(" * This program and the accompanying materials are made available under");

--- a/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2011
  *
  * This program and the accompanying materials are made available under
@@ -30,28 +29,28 @@ public interface BufferPoolMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the name of the buffer pool.
-	 * 
+	 *
 	 * @return the name of the buffer pool.
 	 */
 	String getName();
 
 	/**
 	 * Returns the number of buffers of the pool.
-	 * 
+	 *
 	 * @return the number of buffers of the pool.
 	 */
 	long getCount();
 
 	/**
 	 * Returns the total capacity of the buffers in this pool.
-	 * 
+	 *
 	 * @return the total capacity of the buffers in this pool.
 	 */
 	long getTotalCapacity();
 
 	/**
 	 * Returns the count of used memory.
-	 * 
+	 *
 	 * @return the count of used memory.
 	 */
 	long getMemoryUsed();

--- a/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -41,7 +40,6 @@ package java.lang.management;
  * &quot;java.lang:type=ClassLoading&quot; for the value of the mxbeanName
  * parameter.</li>
  * </ol>
- * 
  */
 public interface ClassLoadingMXBean extends PlatformManagedObject {
 
@@ -53,28 +51,28 @@ public interface ClassLoadingMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns a figure for the total number of classes that have been
-	 * loaded by the virtual machine during its lifetime.  
+	 * loaded by the virtual machine during its lifetime.
 	 * @return the total number of classes that have been loaded
 	 */
 	public long getTotalLoadedClassCount();
 
 	/**
-	 * Returns a figure for the total number of classes that have 
+	 * Returns a figure for the total number of classes that have
 	 * been unloaded by the virtual machine over its lifetime.
 	 * @return the total number of unloaded classes
 	 */
 	public long getUnloadedClassCount();
 
 	/**
-	 * Returns a boolean indication of whether the virtual 
-	 * machine's class loading system is producing verbose output. 
+	 * Returns a boolean indication of whether the virtual
+	 * machine's class loading system is producing verbose output.
 	 * @return true if running in verbose mode
 	 */
 	public boolean isVerbose();
 
 	/**
-	 * Updates the virtual machine's class loading system to 
-	 * operate in verbose or non-verbose mode. 
+	 * Updates the virtual machine's class loading system to
+	 * operate in verbose or non-verbose mode.
 	 * @param value true to put the class loading system into verbose
 	 * mode, false to take the class loading system out of verbose mode.
 	 */

--- a/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -48,7 +47,7 @@ public interface CompilationMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the name of the virtual machine's Just In Time (JIT) compiler.
-	 * 
+	 *
 	 * @return the name of the JIT compiler
 	 */
 	public String getName();
@@ -58,7 +57,7 @@ public interface CompilationMXBean extends PlatformManagedObject {
 	 * returns the total number of <b>milliseconds </b> spent by the virtual
 	 * machine performing compilations. The figure is taken over the lifetime of
 	 * the virtual machine.
-	 * 
+	 *
 	 * @return the compilation time in milliseconds
 	 * @throws java.lang.UnsupportedOperationException
 	 *             if the virtual machine does not support compilation
@@ -70,7 +69,7 @@ public interface CompilationMXBean extends PlatformManagedObject {
 	/**
 	 * A boolean indication of whether or not the virtual machine supports the
 	 * timing of its compilation facilities.
-	 * 
+	 *
 	 * @return <code>true</code> if compilation timing is supported, otherwise
 	 *         <code>false</code>.
 	 */

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION > 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2016
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -44,7 +43,7 @@ package java.lang.management;
  * string &quot;java.lang:type=GarbageCollector,name= <i>unique collector's name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- *  
+ *
  * @since 1.5
  */
 public interface GarbageCollectorMXBean extends MemoryManagerMXBean {
@@ -52,7 +51,7 @@ public interface GarbageCollectorMXBean extends MemoryManagerMXBean {
 	/**
 	 * Returns in a long the number of garbage collections carried out by the
 	 * associated collector.
-	 * 
+	 *
 	 * @return the total number of garbage collections that have been carried
 	 *         out by the associated garbage collector.
 	 */
@@ -61,7 +60,7 @@ public interface GarbageCollectorMXBean extends MemoryManagerMXBean {
 	/**
 	 * For the associated garbage collector, returns the total amount of time in
 	 * milliseconds that it has spent carrying out garbage collection.
-	 * 
+	 *
 	 * @return the number of milliseconds that have been spent in performing
 	 *         garbage collection. This is a cumulative figure.
 	 */

--- a/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2008
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -46,11 +45,11 @@ public final class ManagementPermission extends BasicPermission {
 	private static final String MONITOR = "monitor";  //$NON-NLS-1$
 
 	/**
-	 * Creates a new instance of <code>ManagementPermission</code> with 
+	 * Creates a new instance of <code>ManagementPermission</code> with
 	 * the given name.
 	 * @param name the name of the permission. The only acceptable values
 	 * are the strings &quot;control&quot; or &quot;monitor&quot;.
-	 * @throws IllegalArgumentException if <code>name</code> is not one of 
+	 * @throws IllegalArgumentException if <code>name</code> is not one of
 	 * the string values &quot;control&quot; or &quot;monitor&quot;.
 	 * @throws NullPointerException if <code>name</code> is <code>null</code>.
 	 */
@@ -59,11 +58,11 @@ public final class ManagementPermission extends BasicPermission {
 	}
 
 	/**
-	 * Creates a new instance of <code>ManagementPermission</code> with 
+	 * Creates a new instance of <code>ManagementPermission</code> with
 	 * the given name and permitted actions.
 	 * @param name the name of the permission. The only acceptable values
 	 * are the strings &quot;control&quot; or &quot;monitor&quot;.
-	 * @param actions this argument must either be an empty string or 
+	 * @param actions this argument must either be an empty string or
 	 * <code>null</code>.
 	 * @throws NullPointerException if <code>name</code> is <code>null</code>.
 	 */

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -41,7 +40,6 @@ package java.lang.management;
  * string &quot;java.lang:type=ClassLoading&quot; for the value of the second
  * parameter.</li>
  * </ol>
- * 
  */
 public interface MemoryMXBean extends PlatformManagedObject {
 
@@ -53,7 +51,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the current memory usage of the heap for both live objects and
 	 * for objects no longer in use which are awaiting garbage collection.
-	 * 
+	 *
 	 * @return an instance of {@link MemoryUsage} which can be interrogated by
 	 *         the caller.
 	 */
@@ -61,7 +59,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the current non-heap memory usage for the virtual machine.
-	 * 
+	 *
 	 * @return an instance of {@link MemoryUsage} which can be interrogated by
 	 *         the caller.
 	 */
@@ -71,7 +69,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 	 * Returns the number of objects in the virtual machine that are awaiting
 	 * finalization. The returned value should only be used as an approximate
 	 * guide.
-	 * 
+	 *
 	 * @return the number of objects awaiting finalization.
 	 */
 	/*[IF JAVA_SPEC_VERSION >= 18]*/
@@ -82,7 +80,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the memory system is
 	 * producing verbose output.
-	 * 
+	 *
 	 * @return <code>true</code> if verbose output is being produced ;
 	 *         <code>false</code> otherwise.
 	 */
@@ -90,7 +88,7 @@ public interface MemoryMXBean extends PlatformManagedObject {
 
 	/**
 	 * Updates the verbose output setting of the memory system.
-	 * 
+	 *
 	 * @param value
 	 *            <code>true</code> enables verbose output ;
 	 *            <code>false</code> disables verbose output.

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -44,14 +43,13 @@ package java.lang.management;
  * string &quot;java.lang:type=MemoryManager,name= <i>unique manager's name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- * 
  */
 public interface MemoryManagerMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the names of all of the memory pools managed by this
 	 * <code>MXBean</code>.
-	 * 
+	 *
 	 * @return string array containing the names of all of the managed memory
 	 *         pools.
 	 */
@@ -59,7 +57,7 @@ public interface MemoryManagerMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the name of this particular memory manager.
-	 * 
+	 *
 	 * @return the name of this memory manager.
 	 */
 	public String getName();
@@ -68,7 +66,7 @@ public interface MemoryManagerMXBean extends PlatformManagedObject {
 	 * Returns <code>true</code> if this memory manager is still valid in the
 	 * virtual machine. That is, the memory manager has not been eliminated from
 	 * the virtual machine memory.
-	 * 
+	 *
 	 * @return <code>true</code> if the memory manager is still valid in the
 	 *         virtual machine ; otherwise <code>false</code>.
 	 */

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -76,7 +75,7 @@ public class MemoryNotificationInfo {
 
 	/**
 	 * Creates a new <code>MemoryNotificationInfo</code> instance.
-	 * 
+	 *
 	 * @param poolName
 	 *            the name of the memory pool that the notification relates to.
 	 * @param usage
@@ -117,7 +116,7 @@ public class MemoryNotificationInfo {
 	 * has been met or exceeded. For
 	 * {@link #MEMORY_COLLECTION_THRESHOLD_EXCEEDED} notifications, this will be
 	 * the number of times that the collection usage threshold was passed.
-	 * 
+	 *
 	 * @return the number of times the related memory usage was passed at the
 	 *         time of the notification construction.
 	 */
@@ -127,7 +126,7 @@ public class MemoryNotificationInfo {
 
 	/**
 	 * Returns the name of the memory pool that the notification relates to.
-	 * 
+	 *
 	 * @return the name of the associated memory pool.
 	 */
 	public String getPoolName() {
@@ -139,7 +138,7 @@ public class MemoryNotificationInfo {
 	 * usage of the memory pool that gave rise to this notification at the time
 	 * the notification was created. The <code>MemoryUsage</code> may be
 	 * interrogated by the caller to find out the details of the memory usage.
-	 * 
+	 *
 	 * @return the memory usage of the related memory pool at the point when
 	 *         this notification was created.
 	 */
@@ -151,16 +150,16 @@ public class MemoryNotificationInfo {
 	 * Receives a {@link CompositeData} representing a
 	 * <code>MemoryNotificationInfo</code> object and attempts to return
 	 * the root <code>MemoryNotificationInfo</code> instance.
-	 * 
+	 *
 	 * @param cd
 	 *            a <code>CompositeDate</code> that represents a
 	 *            <code>MemoryNotificationInfo</code>.
 	 * @return if <code>cd</code> is non- <code>null</code>, returns a new
-	 *         instance of <code>MemoryNotificationInfo</code>. 
+	 *         instance of <code>MemoryNotificationInfo</code>.
 	 *         If <code>cd</code> is <code>null</code>, returns <code>null</code>.
 	 * @throws IllegalArgumentException
 	 *             if argument <code>cd</code> does not correspond to a
-	 *             <code>MemoryNotificationInfo</code> with the following 
+	 *             <code>MemoryNotificationInfo</code> with the following
 	 *             attributes:
 	 *             <ul>
 	 *             <li><code>poolName</code>(<code>java.lang.String</code>)
@@ -172,7 +171,7 @@ public class MemoryNotificationInfo {
 	 * <p>
 	 * The <code>usage</code> attribute must represent a {@link MemoryUsage}
 	 * instance which encapsulates the memory usage of a memory pool.
-	 * </p>             
+	 * </p>
 	 */
 	public static MemoryNotificationInfo from(CompositeData cd) {
 		MemoryNotificationInfo result = null;
@@ -183,7 +182,7 @@ public class MemoryNotificationInfo {
 			// IllegalArgumentException
 
 			ManagementUtils.verifyFieldNumber(cd, 3);
-			String[] attributeNames = { "poolName", "usage", "count" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ 
+			String[] attributeNames = { "poolName", "usage", "count" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			ManagementUtils.verifyFieldNames(cd, attributeNames);
 			String[] attributeTypes = { "java.lang.String", CompositeData.class.getName(), "java.lang.Long" }; //$NON-NLS-1$ //$NON-NLS-2$
 			ManagementUtils.verifyFieldTypes(cd, attributeNames, attributeTypes);

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -45,7 +44,7 @@ package java.lang.management;
  * string &quot;java.lang:type=MemoryPool,name= <i>unique memory pool name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- *  
+ *
  * @since 1.5
  */
 public interface MemoryPoolMXBean extends PlatformManagedObject {
@@ -55,18 +54,18 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * encapsulates this memory pool's memory usage after the most recent run of
 	 * the garbage collector. No garbage collection will be actually occur as a
 	 * result of this method getting called.
-	 * 
+	 *
 	 * @return a {@link MemoryUsage} object that may be interrogated by the
 	 *         caller to determine the details of the memory usage. Returns
 	 *         <code>null</code> if the virtual machine does not support this
 	 *         method.
-	 * 
+	 *
 	 */
 	public MemoryUsage getCollectionUsage();
 
 	/**
 	 * Returns this memory pool's collection usage threshold.
-	 * 
+	 *
 	 * @return the collection usage threshold in bytes. The default value as set
 	 *         by the virtual machine will be zero.
 	 * @throws UnsupportedOperationException
@@ -79,7 +78,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the number of times that the memory usage for this memory pool
 	 * has grown to exceed the collection usage threshold.
-	 * 
+	 *
 	 * @return a count of the number of times that the collection usage
 	 *         threshold has been surpassed.
 	 * @throws UnsupportedOperationException
@@ -93,14 +92,14 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * Returns a string array containing the unique names of each memory manager
 	 * that manages this memory pool. A memory pool will always have at least
 	 * one memory manager associated with it.
-	 * 
+	 *
 	 * @return the names of all the memory managers for this memory pool.
 	 */
 	public String[] getMemoryManagerNames();
 
 	/**
 	 * Returns the name of this memory pool.
-	 * 
+	 *
 	 * @return the name of this memory pool.
 	 */
 	public String getName();
@@ -109,7 +108,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * Returns information on the peak usage of the memory pool. The scope of
 	 * this covers all elapsed time since either the start of the virtual
 	 * machine or the peak usage was reset.
-	 * 
+	 *
 	 * @return a {@link MemoryUsage} which can be interrogated by the caller to
 	 *         determine details of the peak memory usage. A <code>null</code>
 	 *         value will be returned if the memory pool no longer exists (and
@@ -121,7 +120,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the memory pool's type.
-	 * 
+	 *
 	 * @return a {@link MemoryType} value indicating the type of the memory pool
 	 *         (heap or non-heap).
 	 */
@@ -130,7 +129,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the current memory usage of this memory pool as estimated by the
 	 * virtual machine.
-	 * 
+	 *
 	 * @return an instance of {@link MemoryUsage} that can be interrogated by
 	 *         the caller to determine details on the pool's current memory
 	 *         usage. A <code>null</code> value will be returned if the memory
@@ -142,7 +141,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns this memory pool's usage threshold.
-	 * 
+	 *
 	 * @return the usage threshold in bytes. The default value as set by the
 	 *         virtual machine depends on the platform the virtual machine is
 	 *         running on. will be zero.
@@ -156,7 +155,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the number of times that the memory usage for this memory pool
 	 * has grown to exceed the current usage threshold.
-	 * 
+	 *
 	 * @return a count of the number of times that the usage threshold has been
 	 *         surpassed.
 	 * @throws UnsupportedOperationException
@@ -169,7 +168,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * Returns a boolean indication of whether or not this memory pool hit or
 	 * exceeded the current value of the collection usage threshold after the
 	 * latest garbage collection run.
-	 * 
+	 *
 	 * @return <code>true</code> if the collection usage threshold was
 	 *         surpassed after the latest garbage collection run, otherwise
 	 *         <code>false</code>.
@@ -183,7 +182,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not this memory pool supports
 	 * a collection usage threshold.
-	 * 
+	 *
 	 * @return <code>true</code> if supported, <code>false</code> otherwise.
 	 */
 	public boolean isCollectionUsageThresholdSupported();
@@ -191,7 +190,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not this memory pool has hit
 	 * or has exceeded the current value of the usage threshold.
-	 * 
+	 *
 	 * @return <code>true</code> if the usage threshold has been surpassed,
 	 *         otherwise <code>false</code>.
 	 * @throws UnsupportedOperationException
@@ -203,7 +202,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not this memory pool supports
 	 * a usage threshold.
-	 * 
+	 *
 	 * @return <code>true</code> if supported, <code>false</code> otherwise.
 	 */
 	public boolean isUsageThresholdSupported();
@@ -212,7 +211,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * Returns a boolean indication of whether or not this memory pool may still
 	 * be considered valid. A memory pool becomes invalid once it has been
 	 * removed by the virtual machine.
-	 * 
+	 *
 	 * @return <code>true</code> if the memory pool has not been removed by
 	 *         the virtual machine, <code>false</code> otherwise.
 	 */
@@ -221,7 +220,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	/**
 	 * Updates this memory pool's memory usage peak value to be whatever the
 	 * value of the current memory usage is.
-	 * 
+	 *
 	 * @throws SecurityException
 	 *             if there is a security manager active and the method caller
 	 *             does not have ManagementPermission "control".
@@ -236,7 +235,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * usage by the virtual machine. A value greater than zero establishes the
 	 * new threshold which the virtual machine will check against after each run
 	 * of the garbage collector in the memory pool.
-	 * 
+	 *
 	 * @param threshold
 	 *            the size of the new collection usage threshold expressed in
 	 *            bytes.
@@ -259,7 +258,7 @@ public interface MemoryPoolMXBean extends PlatformManagedObject {
 	 * effectively turns off any further checking of memory usage by the virtual
 	 * machine. A value greater than zero establishes the new threshold which
 	 * the virtual machine will check against.
-	 * 
+	 *
 	 * @param threshold
 	 *            the size of the new usage threshold expressed in bytes.
 	 * @throws UnsupportedOperationException

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -64,7 +63,7 @@ public class MemoryUsage {
 
 	/**
 	 * Constructs a new <code>MemoryUsage</code> instance.
-	 * 
+	 *
 	 * @param init
 	 *            if defined, the initial amount of memory that can be allocated
 	 *            by the virtual machine in bytes. If not defined, then
@@ -129,7 +128,7 @@ public class MemoryUsage {
 	/**
 	 * Returns the amount of memory that has been pledged by the operating
 	 * system for the virtual machine to use. This value is in bytes.
-	 * 
+	 *
 	 * @return the number of bytes committed to memory.
 	 */
 	public long getCommitted() {
@@ -144,7 +143,7 @@ public class MemoryUsage {
 	 * if the initial memory size was not defined, this method will return a
 	 * value of <code>-1</code>.
 	 * </p>
-	 * 
+	 *
 	 * @return the initial amount of memory requested at virtual machine start
 	 *         up. <code>-1</code> if not defined.
 	 */
@@ -156,7 +155,7 @@ public class MemoryUsage {
 	 * Returns the maximum amount of memory that is available to the virtual
 	 * machine which may change over the lifecycle of the virtual machine. The
 	 * value is in bytes.
-	 * 
+	 *
 	 * @return if defined, the maximum memory size in bytes. If not defined,
 	 *         <code>-1</code>.
 	 */
@@ -167,7 +166,7 @@ public class MemoryUsage {
 	/**
 	 * Returns the number of bytes currently used for memory management
 	 * purposes.
-	 * 
+	 *
 	 * @return the current number of bytes used for memory.
 	 */
 	public long getUsed() {
@@ -176,7 +175,7 @@ public class MemoryUsage {
 
 	/**
 	 * Returns a text description of this memory usage.
-	 * 
+	 *
 	 * @return a text description of this memory usage.
 	 */
 	@Override
@@ -213,7 +212,7 @@ public class MemoryUsage {
 	 * If <code>value</code> is <code>-1</code> then the appended text will
 	 * comprise of the word &quot;undefined&quot;.
 	 * </p>
-	 * 
+	 *
 	 * @param buff
 	 *            an existing <code>StringBuilder</code> that will be updated
 	 *            with <code>value</code> expressed in kilobytes.
@@ -221,7 +220,7 @@ public class MemoryUsage {
 	 *            a <code>long</code> value.
 	 */
 	private static void appendSizeInKBytes(StringBuilder buff, long value) {
-		// it would be better to write "undefined" for values of -1 but in 
+		// it would be better to write "undefined" for values of -1 but in
 		// order to do as the RI does...
 		if (value == -1) {
 			buff.append("(-1K) "); //$NON-NLS-1$
@@ -234,7 +233,7 @@ public class MemoryUsage {
 	 * Receives a {@link CompositeData} representing a <code>MemoryUsage</code>
 	 * object and attempts to return the root <code>MemoryUsage</code>
 	 * instance.
-	 * 
+	 *
 	 * @param cd
 	 *            a <code>CompositeDate</code> that represents a
 	 *            <code>MemoryUsage</code>.

--- a/jcl/src/java.management/share/classes/java/lang/management/MonitorInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MonitorInfo.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2007
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -41,7 +40,7 @@ package java.lang.management;
  * &quot;java.lang:type=OperatingSystem&quot; for the value of the second
  * parameter.</li>
  * </ol>
- *  
+ *
  * @since 1.5
  */
 public interface OperatingSystemMXBean extends PlatformManagedObject {
@@ -51,7 +50,7 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * operating system. The identifier value is identical to that which would
 	 * be obtained from a call to {@link System#getProperty(java.lang.String)}
 	 * supplying the value &quot;os.arch&quot; for the key.
-	 * 
+	 *
 	 * @return the identifier for the operating system architecture.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -65,7 +64,7 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * machine to run on. The information returned from this method is identical
 	 * to that which would be received from a call to
 	 * {@link Runtime#availableProcessors()}.
-	 * 
+	 *
 	 * @return the number of available processors.
 	 */
 	public int getAvailableProcessors();
@@ -75,7 +74,7 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;os.name&quot; for the key.
-	 * 
+	 *
 	 * @return the name of the operating system.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -89,7 +88,7 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * is identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;os.version&quot; for the key.
-	 * 
+	 *
 	 * @return the version of the operating system.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -107,12 +106,12 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * running on the available processors and the number of runnable entities
 	 * ready and queued to run on the available processors. The averaging
 	 * technique adopted can vary depending on the underlying operating system.
-	 * 
+	 *
 	 * @return normally, the system load average as a double. If the system load
 	 *         average is not obtainable (e.g. because the calculation may
 	 *         involve an unacceptable performance impact) then a negative value
 	 *         is returned.
-	 * @since 1.6        
+	 * @since 1.6
 	 */
 	public double getSystemLoadAverage();
 

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -26,7 +25,7 @@ package java.lang.management;
 import java.util.List;
 
 /**
- * The management interface for the logging facility. 
+ * The management interface for the logging facility.
  * <p>
  * Precisely one instance of this interface will be made available to management
  * clients.
@@ -42,7 +41,7 @@ import java.util.List;
  * &quot;java.util.logging:type=Logging&quot; for the value of the second parameter.
  * </li>
  * </ol>
- * 
+ *
  * @since 1.5
  */
 /*[IF JAVA_SPEC_VERSION >= 17]*/
@@ -58,7 +57,7 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * {@link java.util.logging.Logger}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17
 	 * instance's current log level.
-	 * 
+	 *
 	 * @param loggerName
 	 *            the name of a particular <code>Logger</code> instance
 	 * @return if <code>loggerName</code> resolves to an existing registered
@@ -73,7 +72,7 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	public String getLoggerLevel(String loggerName);
 
 	/**
-	 * Returns a list of the names of all of the currently registered 
+	 * Returns a list of the names of all of the currently registered
 	 * <code>Logger</code> instances.
 	 * @return a list of the names of all registered <code>Logger</code> objects.
 	 */
@@ -87,7 +86,7 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * {@link java.util.logging.Logger}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17
 	 * of the specified registered <code>Logger</code>,<code>loggerName</code>.
-	 * 
+	 *
 	 * @param loggerName
 	 *            the name of a particular <code>Logger</code> instance
 	 * @return if <code>loggerName</code> resolves to an existing registered
@@ -111,18 +110,18 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * with name <code>loggerName</code> to <code>levelName</code>.
 	 * <p>
 	 * If <code>levelName</code> is <code>null</code> then the <code>Logger</code>
-	 * instance's log level is set to be <code>null</code> with the result that 
+	 * instance's log level is set to be <code>null</code> with the result that
 	 * it will inherit its log level from its nearest parent which does not have
 	 * a <code>null</code> log level value.
 	 * </p>
 	 * @param loggerName the name of a registered <code>Logger</code>
-	 * @param levelName the name of the new log level. May be <code>null</code>, 
+	 * @param levelName the name of the new log level. May be <code>null</code>,
 	 * in which case <code>loggerName</code> will inherit the log level of its
 	 * closest parent with a non-<code>null</code> log level.
 	 * @throws IllegalArgumentException if there is no <code>Logger</code>
-	 * with the name <code>loggerName</code>. Also may be thrown if 
+	 * with the name <code>loggerName</code>. Also may be thrown if
 	 * <code>loggerName</code> is not a known log level name.
-	 * @throws SecurityException if there is a security manager active and 
+	 * @throws SecurityException if there is a security manager active and
 	 * the caller does not have
 	/*[IF JAVA_SPEC_VERSION >= 17]
 	 * {@link java.logging/java.util.logging.LoggingPermission}

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformManagedObject.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformManagedObject.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2012
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -45,7 +44,7 @@ import java.util.Map;
  * &quot;java.lang:type=Runtime&quot; for the value of the second parameter.
  * </li>
  * </ol>
- *  
+ *
  * @since 1.5
  */
 /*[IF JAVA_SPEC_VERSION >= 17]*/
@@ -62,7 +61,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * loader mechanism can be found from invoking the
 	 * {@link #isBootClassPathSupported()} method.
 	 * </p>
-	 * 
+	 *
 	 * @return the bootstrap classpath with each entry separated by the path
 	 *         separator character corresponding to the underlying operating
 	 *         system.
@@ -79,7 +78,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * and load class files. The value is identical to that which would be
 	 * obtained from a call to {@link System#getProperty(java.lang.String)}
 	 * supplying the value &quot;java.class.path&quot; for the key.
-	 * 
+	 *
 	 * @return the system classpath with each entry separated by the path
 	 *         separator character corresponding to the underlying operating
 	 *         system.
@@ -95,7 +94,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * machine on start-up. This will <i>not </i> include any input arguments
 	 * that are passed into the application's <code>main(String[] args)</code>
 	 * method.
-	 * 
+	 *
 	 * @return a list of strings, each one containing an argument to the virtual
 	 *         machine. If no virtual machine arguments were passed in at
 	 *         start-up time then this will be an empty list.
@@ -107,7 +106,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * locate and load libraries. The value is identical to that which would be
 	 * obtained from a call to {@link System#getProperty(java.lang.String)}
 	 * supplying the value &quot;java.library.path&quot; for the key.
-	 * 
+	 *
 	 * @return the Java library path with each entry separated by the path
 	 *         separator character corresponding to the underlying operating
 	 *         system.
@@ -121,7 +120,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a string containing the management interface specification
 	 * version that the virtual machine meets.
-	 * 
+	 *
 	 * @return the version of the management interface specification adhered to
 	 *         by the virtual machine.
 	 */
@@ -130,7 +129,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the string name of this virtual machine. This value may be
 	 * different for each particular running virtual machine.
-	 * 
+	 *
 	 * @return the name of this running virtual machine.
 	 */
 	public String getName();
@@ -138,9 +137,9 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * Returns the process ID (PID) of the current running Java virtual machine.
-	 * 
+	 *
 	 * @return the process ID of the current running JVM
-	 * 
+	 *
 	 * @since 10
 	 */
 	@SuppressWarnings("boxing")
@@ -158,7 +157,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * this virtual machine. The value is identical to that which would be
 	 * obtained from a call to {@link System#getProperty(java.lang.String)}
 	 * supplying the value &quot;java.vm.specification.name&quot; for the key.
-	 * 
+	 *
 	 * @return the name of the Java virtual machine specification.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -172,7 +171,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * value is identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;java.vm.specification.vendor&quot; for the key.
-	 * 
+	 *
 	 * @return the name of the Java virtual machine specification vendor.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -186,7 +185,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * value is identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;java.vm.specification.version&quot; for the key.
-	 * 
+	 *
 	 * @return the Java virtual machine specification version.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -197,7 +196,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the time, in milliseconds, when the virtual machine was started.
-	 * 
+	 *
 	 * @return the virtual machine start time in milliseconds.
 	 */
 	public long getStartTime();
@@ -205,7 +204,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a map of the names and values of every system property known to
 	 * the virtual machine.
-	 * 
+	 *
 	 * @return a map containing the names and values of every system property.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -215,7 +214,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 
 	/**
 	 * Returns the lifetime of the virtual machine in milliseconds.
-	 * 
+	 *
 	 * @return the number of milliseconds the virtual machine has been running.
 	 */
 	public long getUptime();
@@ -225,7 +224,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;java.vm.name&quot; for the key.
-	 * 
+	 *
 	 * @return the name of the Java virtual machine implementation.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -239,7 +238,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * value is identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;java.vm.vendor&quot; for the key.
-	 * 
+	 *
 	 * @return the name of the Java virtual machine implementation vendor.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -253,7 +252,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * is identical to that which would be obtained from a call to
 	 * {@link System#getProperty(java.lang.String)} supplying the value
 	 * &quot;java.vm.version&quot; for the key.
-	 * 
+	 *
 	 * @return the version of the Java virtual machine implementation.
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
@@ -265,7 +264,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the virtual machine
 	 * supports a bootstrap class loading mechanism.
-	 * 
+	 *
 	 * @return <code>true</code> if supported, <code>false</code> otherwise.
 	 */
 	public boolean isBootClassPathSupported();

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2007
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfoAccessImpl.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfoAccessImpl.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2017
  *
  * This program and the accompanying materials are made available under

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,6 +1,5 @@
 /*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
- *******************************************************************************
  * Copyright IBM Corp. and others 2005
  *
  * This program and the accompanying materials are made available under
@@ -41,7 +40,7 @@ package java.lang.management;
  * &quot;java.lang:type=Threading&quot; for the value of the second parameter.
  * </li>
  * </ol>
- *  
+ *
  * @since 1.5
  */
 public interface ThreadMXBean extends PlatformManagedObject {
@@ -60,7 +59,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * synchronization in a virtual machine. This is because the method may be
 	 * very expensive to run.
 	 * </p>
-	 * 
+	 *
 	 * @return an array of the identifiers of every thread in the virtual
 	 *         machine that has been detected as currently being in a deadlock
 	 *         situation over an object monitor. May be <code>null</code> if
@@ -76,7 +75,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * in the current virtual machine. When processing the return from this
 	 * method it should <i>not </i> be assumed that each identified thread is
 	 * still alive.
-	 * 
+	 *
 	 * @return the identifiers of all of the threads currently alive in the
 	 *         virtual machine.
 	 */
@@ -98,7 +97,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * {@link #getThreadCpuTime} with an argument
 	 * <code>Thread.currentThread().getId())</code>.
 	 * </p>
-	 * 
+	 *
 	 * @return on virtual machines where current thread CPU timing is supported
 	 *         and thread CPU timing is enabled, the number of nanoseconds CPU
 	 *         usage by the current thread. On virtual machines where current
@@ -107,7 +106,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * @throws UnsupportedOperationException
 	 *             if the virtual machine does not support current thread CPU
 	 *             timing.
-	 * 
+	 *
 	 */
 	public long getCurrentThreadCpuTime();
 
@@ -127,7 +126,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * {@link #getThreadUserTime} with an argument
 	 * <code>Thread.currentThread().getId())</code>.
 	 * </p>
-	 * 
+	 *
 	 * @return on virtual machines where current thread CPU timing is supported
 	 *         and thread CPU timing is enabled, the number of nanoseconds CPU
 	 *         time used by the current thread running in user mode. On virtual
@@ -136,14 +135,14 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * @throws UnsupportedOperationException
 	 *             if the virtual machine does not support current thread CPU
 	 *             timing.
-	 * 
+	 *
 	 */
 	public long getCurrentThreadUserTime();
 
 	/**
 	 * Returns the number of daemon threads currently alive in the virtual
 	 * machine.
-	 * 
+	 *
 	 * @return the number of currently alive daemon threads.
 	 */
 	public int getDaemonThreadCount();
@@ -152,7 +151,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * Returns the peak number of threads that have ever been alive in the
 	 * virtual machine at any one instant since either the virtual machine
 	 * start-up or the peak was reset.
-	 * 
+	 *
 	 * @return the peak number of live threads
 	 * @see #resetPeakThreadCount()
 	 */
@@ -161,7 +160,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the number of threads currently alive in the virtual machine.
 	 * This includes both daemon threads and non-daemon threads.
-	 * 
+	 *
 	 * @return the number of currently alive threads.
 	 */
 	public int getThreadCount();
@@ -177,7 +176,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * {@link #isThreadCpuTimeEnabled()} may be used to determine if thread CPU
 	 * timing is actually enabled.
 	 * </p>
-	 * 
+	 *
 	 * @param id
 	 *            the identifier for a thread. Must be a positive number greater
 	 *            than zero.
@@ -205,7 +204,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * will hold no details of locked synchronizers or locked object monitors
 	 * for the specified thread; calls to <code>getLockedMonitors()</code> and
 	 * <code>getLockedSynchronizers</code> will both return array values.
-	 * 
+	 *
 	 * @param id
 	 *            the identifier for a thread. Must be a positive number greater
 	 *            than zero.
@@ -230,7 +229,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * will hold no details of locked synchronizers or locked object monitors
 	 * for the specified thread; calls to <code>getLockedMonitors()</code> and
 	 * <code>getLockedSynchronizers</code> will both return array values.
-	 * 
+	 *
 	 * @param ids
 	 *            an array of thread identifiers. Each one must be a positive
 	 *            number greater than zero.
@@ -269,7 +268,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * <code>getLockedMonitors()</code> and
 	 * <code>getLockedSynchronizers</code> will both return array values.
 	 * </p>
-	 * 
+	 *
 	 * @param ids
 	 *            an array of thread identifiers. Each must be a positive number
 	 *            greater than zero.
@@ -315,7 +314,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * arguments should only be set to <code>true</code> if the virtual
 	 * machine supports the requested monitoring.
 	 * </p>
-	 * 
+	 *
 	 * @param ids
 	 *            an array of thread identifiers. Each one must be a positive
 	 *            number greater than zero.
@@ -379,7 +378,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * <code>getLockedMonitors()</code> and
 	 * <code>getLockedSynchronizers</code> will both return array values.
 	 * </p>
-	 * 
+	 *
 	 * @param id
 	 *            the identifier for a thread. Must be a positive number greater
 	 *            than zero.
@@ -414,7 +413,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * {@link #isThreadCpuTimeEnabled()} may be used to determine if thread CPU
 	 * timing is actually enabled.
 	 * </p>
-	 * 
+	 *
 	 * @param id
 	 *            the identifier for a thread. Must be a positive number greater
 	 *            than zero.
@@ -444,7 +443,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns the number of threads that have been started in this virtual
 	 * machine since it came into being.
-	 * 
+	 *
 	 * @return the total number of started threads.
 	 */
 	public long getTotalStartedThreadCount();
@@ -456,7 +455,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * Note that this method must return <code>true</code> if
 	 * {@link #isThreadCpuTimeSupported()} returns <code>true</code>.
 	 * </p>
-	 * 
+	 *
 	 * @return <code>true</code> if CPU timing of the current thread is
 	 *         supported, otherwise <code>false</code>.
 	 */
@@ -465,7 +464,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the monitoring of thread
 	 * contention situations is enabled on this virtual machine.
-	 * 
+	 *
 	 * @return <code>true</code> if thread contention monitoring is enabled,
 	 *         <code>false</code> otherwise.
 	 */
@@ -474,7 +473,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the monitoring of thread
 	 * contention situations is supported on this virtual machine.
-	 * 
+	 *
 	 * @return <code>true</code> if thread contention monitoring is supported,
 	 *         <code>false</code> otherwise.
 	 */
@@ -483,7 +482,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the CPU timing of threads
 	 * is enabled on this virtual machine.
-	 * 
+	 *
 	 * @return <code>true</code> if thread CPU timing is enabled,
 	 *         <code>false</code> otherwise.
 	 * @throws UnsupportedOperationException
@@ -495,7 +494,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the virtual machine
 	 * supports the CPU time measurement of any threads (current or otherwise).
-	 * 
+	 *
 	 * @return <code>true</code> if the virtual machine supports the CPU
 	 *         timing of threads, <code>false</code> otherwise.
 	 */
@@ -504,7 +503,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Resets the peak thread count to be the current number of threads alive in
 	 * the virtual machine when the call is made.
-	 * 
+	 *
 	 * @throws SecurityException
 	 *             if there is a security manager in effect and the caller does
 	 *             not have {@link ManagementPermission} of &quot;control&quot;.
@@ -518,7 +517,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * If it is supported, the virtual machine will initially not monitor thread
 	 * contention situations.
 	 * </p>
-	 * 
+	 *
 	 * @param enable
 	 *            enable thread contention monitoring if <code>true</code>,
 	 *            otherwise disable thread contention monitoring.
@@ -539,7 +538,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * The default value of this property depends on the underlying operating
 	 * system on which the virtual machine is running.
 	 * </p>
-	 * 
+	 *
 	 * @param enable
 	 *            enable thread CPU timing if <code>true</code>, otherwise
 	 *            disable thread CPU timing
@@ -555,7 +554,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns a boolean indication of whether or not the virtual machine
 	 * supports the monitoring of object monitor usage.
-	 * 
+	 *
 	 * @return <code>true</code> if object monitor usage is permitted,
 	 *         otherwise <code>false</code>
 	 * @since 1.6
@@ -567,7 +566,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * supports the monitoring of ownable synchronizers (synchronizers that make
 	 * use of the <code>AbstractOwnableSynchronizer</code> type and which are
 	 * completely owned by a single thread).
-	 * 
+	 *
 	 * @return <code>true</code> if synchronizer usage monitoring is
 	 *         permitted, otherwise <code>false</code>
 	 */
@@ -587,7 +586,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * synchronization in a virtual machine. This is because the method may be
 	 * very expensive to run.
 	 * </p>
-	 * 
+	 *
 	 * @return an array of the identifiers of every thread in the virtual
 	 *         machine that has been detected as currently being in a deadlock
 	 *         situation involving object monitors <i>and</i> ownable
@@ -600,14 +599,14 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 *             if the virtual machine does not support any monitoring of
 	 *             ownable synchronizers.
 	 * @see #isSynchronizerUsageSupported()
-	 * 
+	 *
 	 */
 	public long[] findDeadlockedThreads();
 
 	/**
 	 * Returns an array of {@link ThreadInfo} objects holding information on all
 	 * threads that were alive when the call was invoked.
-	 * 
+	 *
 	 * @param lockedMonitors
 	 *            boolean indication of whether or not information on all
 	 *            currently locked object monitors is to be included in the
@@ -638,7 +637,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	/**
 	 * Returns an array of {@link ThreadInfo} objects holding information on all
 	 * threads that were alive when the call was invoked.
-	 * 
+	 *
 	 * @param lockedMonitors
 	 *            boolean indication of whether or not information on all
 	 *            currently locked object monitors is to be included in the
@@ -690,7 +689,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * arguments should only be set to <code>true</code> if the virtual
 	 * machine supports the requested monitoring.
 	 * </p>
-	 * 
+	 *
 	 * @param ids
 	 *            an array of thread identifiers. Each one must be a positive
 	 *            number greater than zero.


### PR DESCRIPTION
Fix DDR generated copyright notices to avoid Java compilation warnings.
Also, fix some source files missed in #19427 to make copyright comment style more consistent.