### PR TITLE
Off heap changes

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -262,7 +262,7 @@ J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMetho
    if (method == TR::java_util_zip_CRC32C_updateBytes ||
        method == TR::java_util_zip_CRC32C_updateDirectByteBuffer)
       {
-      return (!TR::Compiler->om.canGenerateArraylets()) && comp->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32);
+      return (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled()) && comp->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32);
       }
    return false;
    }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -82,16 +82,16 @@ J9::ARM64::CodeGenerator::initialize()
       {
       cg->setSupportsInlineVectorizedMismatch();
       }
-   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableSIMDStringHashCode)))
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableSIMDStringHashCode)) && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringHashCode();
       }
-   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf)))
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf)) && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringIndexOf();
       }
    static bool disableInlineStringLatin1Inflate = feGetEnv("TR_disableInlineStringLatin1Inflate") != NULL;
-   if ((!TR::Compiler->om.canGenerateArraylets()) && (!disableInlineStringLatin1Inflate))
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!disableInlineStringLatin1Inflate) && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringLatin1Inflate();
       }

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6937,7 +6937,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          case TR::java_util_zip_CRC32_updateBytes:
 #endif
             {
-            if ((!TR::Compiler->om.canGenerateArraylets()) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
+            if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
                {
                resultReg = inlineCRC32CUpdateBytes(node, cg, false, false);
                return true;
@@ -6948,7 +6948,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
          case TR::java_util_zip_CRC32C_updateBytes:
             {
-            if ((!TR::Compiler->om.canGenerateArraylets()) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
+            if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
                {
                resultReg = inlineCRC32CUpdateBytes(node, cg, false, true);
                return true;
@@ -6963,7 +6963,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          case TR::java_util_zip_CRC32_updateByteBuffer:
 #endif
             {
-            if ((!TR::Compiler->om.canGenerateArraylets()) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
+            if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
                {
                resultReg = inlineCRC32CUpdateBytes(node, cg, true, false);
                return true;
@@ -6974,7 +6974,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
          case TR::java_util_zip_CRC32C_updateDirectByteBuffer:
             {
-            if ((!TR::Compiler->om.canGenerateArraylets()) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
+            if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_ARM64_CRC32) && (!disableCRC32))
                {
                resultReg = inlineCRC32CUpdateBytes(node, cg, true, true);
                return true;

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -353,7 +353,7 @@ J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol 
           ((methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateBytes0) ||
            (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateByteBuffer0)) &&
 #endif
-          (!TR::Compiler->om.canGenerateArraylets()))))
+          (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled()))))
       {
       return self();
       }
@@ -373,7 +373,8 @@ J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol 
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateBytes0) ||
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateByteBuffer0)) &&
 #endif
-       !comp->requiresSpineChecks()
+       !comp->requiresSpineChecks() &&
+       !TR::Compiler->om.isOffHeapAllocationEnabled()
       #ifdef J9VM_OPT_JITSERVER
          && !comp->isOutOfProcessCompilation()
       #endif

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4870,7 +4870,7 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
           * When Power gets a fast implementation of TR::java_lang_String_hashCodeImplCompressed, this case can be merged into the case
           * for java_lang_String_hashCodeImplCompressed instead of using a fallthrough.
           */
-         if (!TR::Compiler->om.canGenerateArraylets() &&
+         if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() &&
              comp->target().cpu.isPower() && comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) && !comp->compileRelocatableCode())
                {
                return true;

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -278,6 +278,7 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
    // Keep track of whether or not all constraints are global.
    bool isGlobal = true;
    bool isGlobalQuery;
+   int32_t headerAdjustment = TR::Compiler->om.isOffHeapAllocationEnabled() ? 0 : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 
    TR::VPConstraint *sourceConstraint = getConstraint(sourceStringNode, isGlobalQuery);
    isGlobal &= isGlobalQuery;
@@ -392,12 +393,12 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
             {
             if (is16Bit)
                {
-               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * i) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * i) + headerAdjustment);
                ch  = *((uint16_t*)element);
                }
             else
                {
-               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + headerAdjustment);
                ch  = *((uint8_t*)element);
                }
             }
@@ -437,12 +438,12 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
          {
          if (is16Bit)
             {
-            uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * start) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+            uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * start) + headerAdjustment);
             ch  = *((uint16_t*)element);
             }
          else
             {
-            uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, start + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+            uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, start + headerAdjustment);
             ch  = *((uint8_t*)element);
             }
          }
@@ -525,12 +526,12 @@ bool J9::ValuePropagation::transformIndexOfKnownString(
             {
             if (is16Bit)
                {
-               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * i) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, (2 * i) + headerAdjustment);
                ch  = *((uint16_t*)element);
                }
             else
                {
-               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+               uintptr_t element = TR::Compiler->om.getAddressOfElement(comp(), string, i + headerAdjustment);
                ch  = *((uint8_t*)element);
                }
             }

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -371,20 +371,8 @@ int32_t TR_UnsafeFastPath::perform()
             charArray->setIsNonNull(true);
 
             prepareToReplaceNode(node); // This will remove the usedef info, valueNumber info and all children of the node
-            TR::Node *addrCalc;
-            if (comp()->target().is64Bit())
-               {
-               addrCalc = TR::Node::create(TR::aladd, 2, charArray,
-                     TR::Node::create(TR::ladd, 2, TR::Node::create(TR::lmul, 2, TR::Node::create(TR::i2l, 1, index), TR::Node::lconst(index, 4)),
-                                       TR::Node::lconst(index, TR::Compiler->om.contiguousArrayHeaderSizeInBytes())));
-               }
-            else
-               {
-               addrCalc = TR::Node::create(TR::aiadd, 2, charArray,
-                     TR::Node::create(TR::iadd, 2, TR::Node::create(TR::imul, 2, index, TR::Node::iconst(index, 4)),
-                                       TR::Node::iconst(index, TR::Compiler->om.contiguousArrayHeaderSizeInBytes())));
-               }
-
+            TR::Node *offsetNode = TR::TransformUtil::generateConvertArrayElementIndexToOffsetTrees(comp(), index, NULL, 4, false);
+            TR::Node *addrCalc = TR::TransformUtil::generateArrayElementAddressTrees(comp(), charArray, offsetNode);
             TR::SymbolReference * unsafeSymRef = comp()->getSymRefTab()->findOrCreateUnsafeSymbolRef(TR::Int32, true, false);
             node = TR::Node::recreateWithoutProperties(node, TR::istorei, 2, addrCalc, value, unsafeSymRef);
 
@@ -913,10 +901,21 @@ int32_t TR_UnsafeFastPath::perform()
                TR::Node *addrCalc = NULL;
 
                // Calculate element address
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+               if (isArrayOperation && TR::Compiler->om.isOffHeapAllocationEnabled())
+                  {
+                  TR::Node *baseNodeForAdd = TR::TransformUtil::generateDataAddrLoadTrees(comp(), base);
+                  addrCalc = TR::Node::create(TR::aladd, 2, baseNodeForAdd, offset);
+                  }
+               else if (comp()->target().is64Bit())
+#else
                if (comp()->target().is64Bit())
+#endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
                   addrCalc = TR::Node::create(TR::aladd, 2, base, offset);
                else
                   addrCalc = TR::Node::create(TR::aiadd, 2, base, TR::Node::create(TR::l2i, 1, offset));
+
+               addrCalc->setIsInternalPointer(true);
 
                if (value)
                   {

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -94,7 +94,7 @@ J9::Power::CodeGenerator::initialize()
 
    if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) &&
       comp->target().is64Bit() && !comp->getOption(TR_DisableFastStringIndexOf) &&
-      !TR::Compiler->om.canGenerateArraylets())
+      !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       cg->setSupportsInlineStringIndexOf();
 
    static bool disableStringInflateIntrinsic = feGetEnv("TR_DisableStringInflateIntrinsic") != NULL;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12029,9 +12029,13 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          return true;
 
       case TR::java_lang_String_hashCodeImplDecompressed:
-         if (!TR::Compiler->om.canGenerateArraylets() && comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) && !comp->compileRelocatableCode()
+         if (!TR::Compiler->om.canGenerateArraylets()
+             && !TR::Compiler->om.isOffHeapAllocationEnabled()
+             && comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8)
+             && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX)
+             && !comp->compileRelocatableCode()
 #ifdef J9VM_OPT_JITSERVER
-               && !comp->isOutOfProcessCompilation()
+             && !comp->isOutOfProcessCompilation()
 #endif
             )
             {

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -134,7 +134,7 @@ TR::Register *J9::Power::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    // The specialCaseJNI shortcut will mangle register dependencies and use system/C dispatch.
    // The addresses of the optimized helpers in the server process will not necessarily
    // match the client-side addresses, so we can't take this shortcut in JITServer mode.
-   bool specialCaseJNI = (crc32m1 || crc32m2 || crc32m3) && !comp()->requiresSpineChecks();
+   bool specialCaseJNI = (crc32m1 || crc32m2 || crc32m3) && !comp()->requiresSpineChecks() && !TR::Compiler->om.isOffHeapAllocationEnabled();
 
 #ifdef J9VM_OPT_JITSERVER
    specialCaseJNI = specialCaseJNI && !comp()->isOutOfProcessCompilation();

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2916,7 +2916,8 @@ TR::Register *J9::Power::PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
          }
       }
 
-   if (!comp()->requiresSpineChecks() &&
+   if (!TR::Compiler->om.canGenerateArraylets() &&
+       !TR::Compiler->om.isOffHeapAllocationEnabled() &&
        comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
        comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) &&
        (callNode->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateBytes ||

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -73,7 +73,7 @@ J9::X86::CodeGenerator::initialize()
 
    cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
 
-   if (!TR::Compiler->om.canGenerateArraylets())
+   if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsReferenceArrayCopy();
       cg->setSupportsInlineStringLatin1Inflate();
@@ -104,19 +104,19 @@ J9::X86::CodeGenerator::initialize()
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&
-       !TR::Compiler->om.canGenerateArraylets())
+       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       cg->setSupportsInlineStringCaseConversion();
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) &&
        !comp->getOption(TR_DisableFastStringIndexOf) &&
-       !TR::Compiler->om.canGenerateArraylets())
+       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringIndexOf();
       }
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringHashCode) &&
-       !TR::Compiler->om.canGenerateArraylets())
+       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringHashCode();
       }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -88,13 +88,13 @@ J9::Z::CodeGenerator::initialize()
       cg->setSupportsInlineStringCaseConversion();
 
    if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableFastStringIndexOf) &&
-       !TR::Compiler->om.canGenerateArraylets())
+       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringIndexOf();
       }
 
    if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringHashCode) &&
-       !TR::Compiler->om.canGenerateArraylets())
+       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringHashCode();
       cg->setSupportsInlineVectorizedHashCode();
@@ -120,7 +120,7 @@ J9::Z::CodeGenerator::initialize()
       }
 
    static char *disableInlineEncodeASCII = feGetEnv("TR_disableInlineEncodeASCII");
-   if (comp->fej9()->isStringCompressionEnabledVM() && cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !disableInlineEncodeASCII)
+   if (comp->fej9()->isStringCompressionEnabledVM() && cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && !disableInlineEncodeASCII)
       {
       cg->setSupportsInlineEncodeASCII();
       }
@@ -221,7 +221,7 @@ J9::Z::CodeGenerator::initialize()
       }
 
    static bool disableIntegerToChars = (feGetEnv("TR_DisableIntegerToChars") != NULL);
-   if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !disableIntegerToChars && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z16))
+   if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && !disableIntegerToChars && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z16))
       {
       cg->setSupportsIntegerToChars();
       cg->setSupportsIntegerStringSize();

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3691,7 +3691,7 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
       }
 
    static bool disableCRC32CAcceleration = (feGetEnv("TR_DisableCRC32CAcceleration") != NULL);
-   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters())
+   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       if (method == TR::java_util_zip_CRC32C_updateBytes ||
          method == TR::java_util_zip_CRC32C_updateDirectByteBuffer)


### PR DESCRIPTION
Modifications to support offheap and disable some optimizations for offheap until its supported.

* Update getAddressOfElement to use dataAddr pointer
* Disable string caseConversion, inflate, hashcode, arrayCopy for offheap
* Disable CRC32 transformations for offheap
* Update unsafeFastPath to use dataAddr pointer for offheap
* Fix stackwalk internal-pointer displacement for off-heap
* ~~Use createLoadIfStore logic before calling helper~~ (included in another PR)