### PR TITLE
Fix warnings in shared_common, libffi, tests/shared

### DIFF
--- a/runtime/libffi/closures.c
+++ b/runtime/libffi/closures.c
@@ -492,7 +492,9 @@ dlmmap_locked (void *start, size_t length, int prot, int flags, off_t offset)
 	  close (execfd);
 	  goto retry_open;
 	}
-      ftruncate (execfd, offset);
+      if (ftruncate (execfd, offset)) {
+        /* ignore any failure */
+      }
       return MFAIL;
     }
   else if (!offset
@@ -504,7 +506,9 @@ dlmmap_locked (void *start, size_t length, int prot, int flags, off_t offset)
   if (start == MFAIL)
     {
       munmap (ptr, length);
-      ftruncate (execfd, offset);
+      if (ftruncate (execfd, offset)) {
+        /* ignore any failure */
+      }
       return start;
     }
 

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -5935,6 +5935,7 @@ SH_CacheMap::startupLowerLayerForStats(J9VMThread* currentThread, const char* ct
 	IDATA rc = CC_STARTUP_OK;
 	SH_CompositeCacheImpl* ccToUse = _ccHead;
 	const char* cacheName = NULL;
+	char cacheNameBuf[USER_SPECIFIED_CACHE_NAME_MAXLEN];
 	U_32 cacheType = oscache->getCacheType();
 	char cacheUniqueID[J9SHR_UNIQUE_CACHE_ID_BUFSIZE];
 	J9JavaVM *vm = currentThread->javaVM;
@@ -5971,7 +5972,6 @@ SH_CacheMap::startupLowerLayerForStats(J9VMThread* currentThread, const char* ct
 				rc = CC_STARTUP_FAILED;
 				break;
 			}
-			char cacheNameBuf[USER_SPECIFIED_CACHE_NAME_MAXLEN];
 			Trc_SHR_Assert_True(idLen < sizeof(cacheUniqueID));
 			memcpy(cacheUniqueID, cacheUniqueIDPtr, idLen);
 			cacheUniqueID[idLen] = '\0';
@@ -6327,22 +6327,23 @@ SH_CacheMap::matchAotMethod(MethodSpecTable* specTable, IDATA numSpecs, J9UTF8* 
 		if (NULL == specTable[i].methodSig) {
 			/* Any signature */
 			sigMatch = true;
-		} else if (NULL == J9UTF8_DATA(romMethodSig)) {
-			/* Signature is missing */
-			sigMatch = false;
 		} else {
-			char* methodSig = (char *)J9UTF8_DATA(romMethodSig);
-			char* sigStart = strchr(methodSig, '(') + 1;
-			char* sigEnd = strchr(methodSig, ')');
-			IDATA sigLength = sigEnd - sigStart;
+			const char *methodSig = (const char *)J9UTF8_DATA(romMethodSig);
+			const char *sigStart = (const char *)memchr(methodSig, '(', J9UTF8_LENGTH(romMethodSig));
+			const char *sigEnd = (const char *)memchr(methodSig, ')', J9UTF8_LENGTH(romMethodSig));
 
-			/* Use string between '(' and ')' only */
-			if (sigLength < 0) {
+			if ((NULL == sigStart) || (NULL == sigEnd) || (sigEnd <= sigStart)) {
 				sigMatch = false;
 			} else {
-				sigMatch = (TRUE == wildcardMatch(specTable[i].methodSigMatchFlag,
-										(const char *)specTable[i].methodSig, specTable[i].methodSigLength,
-										(const char *)sigStart, sigLength));
+				/* Use string between '(' and ')' only. */
+				IDATA sigLength = sigEnd - sigStart - 1;
+
+				sigMatch = (TRUE == wildcardMatch(
+						specTable[i].methodSigMatchFlag,
+						(const char *)specTable[i].methodSig,
+						specTable[i].methodSigLength,
+						sigStart,
+						sigLength));
 			}
 		}
 

--- a/runtime/shared_common/ScopeManagerImpl.cpp
+++ b/runtime/shared_common/ScopeManagerImpl.cpp
@@ -87,21 +87,13 @@ SH_ScopeManagerImpl::scHashEqualFn(void* left, void* right, void *userData)
 	HashEntry* rightItem = (HashEntry*)right;
 	const J9UTF8* utf8left = leftItem->_value;
 	const J9UTF8* utf8right = rightItem->_value;
-	UDATA result;
 
 	Trc_SHR_SMI_scHashEqualFn_Entry(utf8left, utf8right);
 
-	/* PERFORMANCE: Compare key size first as this is the most likely cause for exit */
-	if (J9UTF8_LENGTH(utf8left) != J9UTF8_LENGTH(utf8right)) {
-		Trc_SHR_SMI_scHashEqualFn_Exit2();
-		return 0;
-	}
-	if (J9UTF8_DATA(utf8left)==NULL || J9UTF8_DATA(utf8right)==NULL) {
-		Trc_SHR_SMI_scHashEqualFn_Exit1();
-		return 0;
-	}
-	result = J9UTF8_EQUALS(utf8left, utf8right);
+	UDATA result = J9UTF8_EQUALS(utf8left, utf8right);
+
 	Trc_SHR_SMI_scHashEqualFn_Exit3(result);
+
 	return result;
 }
 

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -806,8 +806,8 @@ TraceEntry=Trc_SHR_SMI_scHashFn_Entry Noenv Overhead=1 Level=6 Template="SMI scH
 TraceExit=Trc_SHR_SMI_scHashFn_Exit Noenv Overhead=1 Level=6 Template="SMI scHashFn: Returning hashcode %u"
 
 TraceEntry=Trc_SHR_SMI_scHashEqualFn_Entry Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: Comparing 0x%p with 0x%p"
-TraceExit=Trc_SHR_SMI_scHashEqualFn_Exit1 Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: One key is null. Exiting with false."
-TraceExit=Trc_SHR_SMI_scHashEqualFn_Exit2 Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: Key lengths don't match. Exiting with false."
+TraceExit=Trc_SHR_SMI_scHashEqualFn_Exit1 Obsolete Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: One key is null. Exiting with false."
+TraceExit=Trc_SHR_SMI_scHashEqualFn_Exit2 Obsolete Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: Key lengths don't match. Exiting with false."
 TraceExit=Trc_SHR_SMI_scHashEqualFn_Exit3 Noenv Overhead=1 Level=6 Template="SMI scHashEqualFn: Called compareUTF8. Result=%d"
 
 TraceEntry=Trc_SHR_SMI_scTableAdd_Entry Overhead=1 Level=6 Template="SMI scTableAdd: Entering add with key %.*s for item 0x%p"

--- a/runtime/tests/shared/ByteDataTest.cpp
+++ b/runtime/tests/shared/ByteDataTest.cpp
@@ -104,6 +104,7 @@ IDATA testByteDataManager(J9JavaVM* vm)
 	UnitTest::unitTest = UnitTest::BYTE_DATA_TEST;
 
 	cachePointers.testCache1 = createTestCache(vm, SMALL_CACHE_SIZE, NULL, &existingCachePtr);
+	cachePointers.testCache2 = NULL;
 	if (cachePointers.testCache1 && existingCachePtr) {
 		cachePointers.config1 = vm->sharedClassConfig;
 		cachePointers.preConfig1 = vm->sharedClassPreinitConfig;


### PR DESCRIPTION
As part of the ongoing effort to enable warnings as errors, fix warnings in runtime/shared_common, runtime/libffi, and runtime/tests/shared, which appear on plinux builds on GCC 13