### PR TITLE
Reduce number of VM_getClassFromSignature messages for JITServer

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7358,6 +7358,10 @@ TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, TR_OpaqueMet
 TR_OpaqueClassBlock *
 TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool)
    {
+   // Primitive types don't have a class associated with them
+   if (isSignatureForPrimitiveType(sig, sigLength))
+      return NULL;
+
    TR::VMAccessCriticalSection getClassFromSignature(this);
    J9Class * j9class = NULL;
    TR_OpaqueClassBlock * returnValue = NULL;

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1505,6 +1505,10 @@ public:
    virtual bool isJ9VMThreadCurrentThreadImmutable();
 
 protected:
+   bool isSignatureForPrimitiveType(const char * sig, int32_t sigLength)
+      {
+      return sigLength == 1 && (*sig == 'I' || *sig == 'Z' || *sig == 'C' || *sig == 'B' || *sig == 'J' || *sig == 'F' || *sig == 'D' || *sig == 'S');
+      }
 
    enum // _flags
       {

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -350,6 +350,10 @@ TR_J9ServerVM::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayCl
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT)
    {
+   // Primitive types don't have a class associated with them
+   if (isSignatureForPrimitiveType(sig, length))
+      return NULL;
+
    TR_OpaqueClassBlock * clazz = NULL;
    J9ClassLoader * cl = ((TR_ResolvedJ9Method *)method)->getClassLoader();
    ClassLoaderStringPair key = {cl, std::string(sig, length)};
@@ -383,6 +387,10 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_Resolve
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT)
    {
+   // Primitive types don't have a class associated with them
+   if (isSignatureForPrimitiveType(sig, length))
+      return NULL;
+
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    std::string str(sig, length);
    stream->write(JITServer::MessageType::VM_getClassFromSignature, str, method, isVettedForAOT);
@@ -2683,6 +2691,10 @@ TR_J9SharedCacheServerVM::supportAllocationInlining(TR::Compilation *comp, TR::N
 TR_OpaqueClassBlock *
 TR_J9SharedCacheServerVM::getClassFromSignature(const char * sig, int32_t sigLength, TR_ResolvedMethod * method, bool isVettedForAOT)
    {
+   // Primitive types don't have a class associated with them
+   if (isSignatureForPrimitiveType(sig, sigLength))
+      return NULL;
+
    TR_ResolvedRelocatableJ9JITServerMethod* resolvedJITServerMethod = (TR_ResolvedRelocatableJ9JITServerMethod *)method;
    TR_OpaqueClassBlock* clazz = NULL;
    J9ClassLoader * cl = ((TR_ResolvedJ9Method *)method)->getClassLoader();


### PR DESCRIPTION
VM_getClassFromSignature messages account for 10-11% of all messages exchanged between client and server. Such messages are sent when the server calls getClassFromSignature() to obtain a j9class pointer starting from a class name. This commit is based on the observation that primitive types, like I, Z, B, etc., do not have an associate j9class, so the answer from the getClassFromSignature() query is always NULL. This change reduces the number of VM_getClassFromSignature messages by 33-35%