### PR TITLE
[0.46.0] Mark unlikely blocks as cold for Unsafe.{get|put}*

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1016,6 +1016,7 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
       nullComparisonNode->setBranchDestination(directAccessBlock->getEntry());
       nullComparisonBlock->append(nullComparisonTree);
       cfg->addNode(nullComparisonBlock);
+      nullComparisonBlock->setIsCold();
 
       debugTrace(tracer(), "\t In genCodeForUnsafeGetPut, Block %d created for null object comparison\n", nullComparisonBlock->getNumber());
 
@@ -1045,6 +1046,7 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
       isClassBlock->append(isClassTreeTop);
       isClassNode->setBranchDestination(directAccessBlock->getEntry());
       cfg->addNode(isClassBlock);
+      isClassBlock->setIsCold();
 
       indirectAccessBlock->getEntry()->insertTreeTopsBeforeMe(isClassBlock->getEntry(), isClassBlock->getExit());
 


### PR DESCRIPTION
In generating inline IL for `Unsafe.get*` and `Unsafe.put*` methods in the case where no conversion is needed, the blocks that test whether the object reference is null or whether the object's type is `java/lang/Class` had their frequencies set to `VERSIONED_COLD_BLOCK_COUNT`, copied from the indirect access block.  However, unlike the indirect access block, those two blocks were not marked explicitly as cold.  This change corrects that.

This is a port of pull request #19676 to the v0.46.0-release branch.