### PR TITLE
DDR: Improve handling of processes with no JRE

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/VMDataFactory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/VMDataFactory.java
@@ -98,13 +98,7 @@ public abstract class VMDataFactory {
 	 * @throws IOException
 	 */
 	public static IVMData getVMData(IProcess process) throws IOException {
-		List<IVMData> cachedVMData = vmDataCache.get(process);
-
-		if ((cachedVMData != null) && (cachedVMData.size() > 0)) {
-			return cachedVMData.get(0); // return the first VM found
-		}
-
-		cachedVMData = getAllVMData(process);
+		List<IVMData> cachedVMData = getAllVMData(process);
 
 		if (cachedVMData.size() > 0) {
 			return cachedVMData.get(0); // return the first VM found

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageProcess.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageProcess.java
@@ -365,26 +365,29 @@ public class J9DDRImageProcess implements ImageProcess {
 
 		try {
 			IVMData data = VMDataFactory.getVMData(process);
-			version = data.getVersion();
 
-			Object[] passbackArray = new Object[1];
+			if (data != null) {
+				version = data.getVersion();
 
-			try {
-				// attempt to load a default bootstrap class which will allow different implementations to provide their own initializers
-				data.bootstrapRelative("view.dtfj.DTFJBootstrapShim", (Object) passbackArray, this);
-			} catch (ClassNotFoundException e) {
-				// no specific class was found, so use a generic native one instead
+				Object[] passbackArray = new Object[1];
+
 				try {
-					data.bootstrap("com.ibm.j9ddr.view.nativert.Bootstrap", (Object) passbackArray, this);
+					// attempt to load a default bootstrap class which will allow different implementations to provide their own initializers
+					data.bootstrapRelative("view.dtfj.DTFJBootstrapShim", (Object) passbackArray, this);
+				} catch (ClassNotFoundException e) {
+					// no specific class was found, so use a generic native one instead
+					try {
+						data.bootstrap("com.ibm.j9ddr.view.nativert.Bootstrap", (Object) passbackArray, this);
 
-				} catch (ClassNotFoundException e1) {
-					// this class should be packaged and without it we can't work, so abort
-					throw new Error(e1);
+					} catch (ClassNotFoundException e1) {
+						// this class should be packaged and without it we can't work, so abort
+						throw new Error(e1);
+					}
 				}
-			}
 
-			if (passbackArray[0] != null) {
-				toIterate.add(passbackArray[0]);
+				if (passbackArray[0] != null) {
+					toIterate.add(passbackArray[0]);
+				}
 			}
 		} catch (IOException e) {
 			// VMDataFactory may throw IOException for JVMs that this level of DDR does not support. Pass the

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9RASImageDataFactory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9RASImageDataFactory.java
@@ -45,61 +45,61 @@ public class J9RASImageDataFactory
 {
 
 	/**
-	 * 
+	 *
 	 * @return ProcessData or NULL if we can't find a J9DDR structure in p
 	 */
 	public static ProcessData getProcessData(IProcess p)
 	{
 		return (ProcessData)getRasData(p);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return MachineData or NULL if we can't find a J9DDR structure in c
 	 */
 	public static MachineData getMachineData(ICore c)
 	{
 		Collection<? extends IAddressSpace> addressSpaces = c.getAddressSpaces();
-		
+
 		for (IAddressSpace as : addressSpaces) {
 			MachineData data = getMachineData(as);
-			
+
 			if (data != null) {
 				return data;
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return MachineData or NULL if we can't find a J9DDR structure in a
 	 */
 	public static MachineData getMachineData(IAddressSpace a)
 	{
 		Collection<? extends IProcess> processes = a.getProcesses();
-		
+
 		for (IProcess p : processes) {
 			MachineData data = getMachineData(p);
-			
+
 			if (data != null) {
 				return data;
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return MachineData or NULL if we can't find a J9DDR structure in p
 	 */
 	public static MachineData getMachineData(IProcess p)
 	{
 		return (MachineData)getRasData(p);
 	}
-	
+
 	private static Object getRasData(IProcess p)
 	{
 		try {
@@ -132,36 +132,36 @@ public class J9RASImageDataFactory
 	public static interface MachineData
 	{
 		public long memoryBytes() throws CorruptDataException;
-		
+
 		public String osVersion() throws CorruptDataException;
-		
+
 		public String osArch() throws CorruptDataException;
-		
+
 		public String osName() throws CorruptDataException;
-		
+
 		public String hostName() throws DataUnavailableException, CorruptDataException;
-		
+
 		public Iterator<Object> ipaddresses() throws DataUnavailableException, CorruptDataException;
-		
+
 		public int cpus() throws CorruptDataException;
-		
+
 		public IProcess getProcess();
-		
+
 		public Properties systemInfo() throws DataUnavailableException, CorruptDataException;
-		
+
 		public long dumpTimeMillis() throws DataUnavailableException, CorruptDataException;
-		
+
 		public long dumpTimeNanos() throws DataUnavailableException, CorruptDataException;
 	}
-	
+
 	public static interface ProcessData
 	{
 		public int version() throws CorruptDataException;
-		
+
 		public long pid() throws CorruptDataException, DataUnavailable;
-		
+
 		public long tid() throws CorruptDataException, DataUnavailable;
-		
+
 		/**
 		 * Returns the information associated with a crash, such as the signal number
 		 * @return if the event of a crash, the string contains the data for this field. If there was not a crash
@@ -170,9 +170,9 @@ public class J9RASImageDataFactory
 		 * @throws CorruptDataException
 		 */
 		public String gpInfo() throws CorruptDataException;
-		
+
 		public IProcess getProcess();
-		
+
 		public long getEnvironment() throws CorruptDataException;
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9RASImageDataFactory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9RASImageDataFactory.java
@@ -104,26 +104,28 @@ public class J9RASImageDataFactory
 	{
 		try {
 			IVMData vmData = VMDataFactory.getVMData(p);
-			
-			Object[] passBackArray = new Object[1];
-			
-			try {
-				vmData.bootstrapRelative("view.dtfj.J9RASInfoBootstrapShim", (Object)passBackArray);
-			} catch (ClassNotFoundException e) {
-				// Need to return null here for IDDE as the class will not be found for Node.js cores
-				return null;
+
+			if (vmData != null) {
+				Object[] passBackArray = new Object[1];
+
+				try {
+					vmData.bootstrapRelative("view.dtfj.J9RASInfoBootstrapShim", (Object) passBackArray);
+				} catch (ClassNotFoundException e) {
+					// Need to return null here for IDDE as the class will not be found for Node.js cores.
+					return null;
+				}
+
+				return passBackArray[0];
 			}
-			
-			return passBackArray[0];
 		} catch (IOException e) {
 			//Ignore
 		} catch (UnsupportedOperationException e) {
 			// VMDataFactory may throw unsupported UnsupportedOperationException
-			// exceptions for JVM's DDR does not support.
+			// for JVMs DDR does not support.
 		} catch (Exception e) {
 			// Ignore
 		}
-		
+
 		return null;
 	}
 


### PR DESCRIPTION
On z/OS, a system dump may contain information about multiple processes in multiple address spaces: Not all of them need have Java runtimes. Those without a Java runtime were not being handled properly

`VMDataFactory.getVMData()` may return `null` (see [here](https://github.com/eclipse-openj9/openj9/blob/v0.45.0-release/debugtools/DDR_VM/src/com/ibm/j9ddr/VMDataFactory.java#L112)) which needs to be handled properly. Some places, (e.g. [`J9DDRImageProcess.getRuntimes()`](https://github.com/eclipse-openj9/openj9/blob/v0.45.0-release/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageProcess.java#L368)) would throw `NullPointerException` which then causes `J9DDRCorruptData` to be included in the resulting iterator.

Also:
* remove redundant checking for cached results
* remove trailing whitespace
