### PR TITLE
[FFI/Test_JDK21+] Convert the native string for downcall on z/OS

### DIFF
--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/PrimitiveTypeTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/PrimitiveTypeTests2.java
@@ -263,7 +263,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment strlenSymbol = defaultLibLookup.find("strlen").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS);
 		MethodHandle mh = linker.downcallHandle(fd);
-		MemorySegment funcSegmt = arena.allocateUtf8String("JEP424 DOWNCALL TEST SUITES");
+		MemorySegment funcSegmt = PrimitiveTypeTests1.allocateString("JEP442 DOWNCALL TEST SUITES");
 		long strLength = (long)mh.invoke(strlenSymbol, funcSegmt);
 		Assert.assertEquals(strLength, 27);
 	}
@@ -289,7 +289,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(fd);
-		MemorySegment formatSegmt = arena.allocateUtf8String("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = PrimitiveTypeTests1.allocateString("\n%d + %d = %d\n");
 		mh.invoke(functionSymbol, formatSegmt, 15, 27, 42);
 	}
 
@@ -298,7 +298,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(fd, Linker.Option.firstVariadicArg(1));
-		MemorySegment formatSegmt = arena.allocateUtf8String("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = PrimitiveTypeTests1.allocateString("\n%d + %d = %d\n");
 		mh.invoke(functionSymbol, formatSegmt, 15, 27, 42);
 	}
 

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
@@ -25,7 +25,9 @@ import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandle;
+import java.nio.charset.Charset;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
@@ -44,6 +46,7 @@ import static java.lang.foreign.ValueLayout.*;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests1 {
+	private static final boolean isZos = "z/OS".equalsIgnoreCase(System.getProperty("os.name"));
 	private static Linker linker = Linker.nativeLinker();
 	private static Arena arena = Arena.ofAuto();
 
@@ -52,6 +55,12 @@ public class PrimitiveTypeTests1 {
 	}
 	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
 	private static final SymbolLookup defaultLibLookup = linker.defaultLookup();
+
+	static MemorySegment allocateString(String string) throws UnsupportedEncodingException {
+		return isZos
+				? arena.allocateFrom(string, Charset.forName("IBM1047"))
+				: arena.allocateFrom(string);
+	}
 
 	@Test
 	public void test_addTwoBoolsWithOr_1() throws Throwable {
@@ -263,7 +272,7 @@ public class PrimitiveTypeTests1 {
 		MemorySegment strlenSymbol = defaultLibLookup.find("strlen").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS);
 		MethodHandle mh = linker.downcallHandle(strlenSymbol, fd);
-		MemorySegment funcSegmt = arena.allocateFrom("JEP454 DOWNCALL TEST SUITES");
+		MemorySegment funcSegmt = allocateString("JEP454 DOWNCALL TEST SUITES");
 		long strLength = (long)mh.invoke(funcSegmt);
 		Assert.assertEquals(strLength, 27);
 	}
@@ -289,7 +298,7 @@ public class PrimitiveTypeTests1 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
-		MemorySegment formatSegmt = arena.allocateFrom("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = allocateString("\n%d + %d = %d\n");
 		mh.invoke(formatSegmt, 15, 27, 42);
 	}
 
@@ -298,7 +307,7 @@ public class PrimitiveTypeTests1 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(functionSymbol, fd, Linker.Option.firstVariadicArg(1));
-		MemorySegment formatSegmt = arena.allocateFrom("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = allocateString("\n%d + %d = %d\n");
 		mh.invoke(formatSegmt, 15, 27, 42);
 	}
 }

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests2.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests2.java
@@ -263,7 +263,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment strlenSymbol = defaultLibLookup.find("strlen").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_LONG, ADDRESS);
 		MethodHandle mh = linker.downcallHandle(fd);
-		MemorySegment funcSegmt = arena.allocateFrom("JEP454 DOWNCALL TEST SUITES");
+		MemorySegment funcSegmt = PrimitiveTypeTests1.allocateString("JEP454 DOWNCALL TEST SUITES");
 		long strLength = (long)mh.invoke(strlenSymbol, funcSegmt);
 		Assert.assertEquals(strLength, 27);
 	}
@@ -289,7 +289,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(fd);
-		MemorySegment formatSegmt = arena.allocateFrom("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = PrimitiveTypeTests1.allocateString("\n%d + %d = %d\n");
 		mh.invoke(functionSymbol, formatSegmt, 15, 27, 42);
 	}
 
@@ -298,7 +298,7 @@ public class PrimitiveTypeTests2 {
 		MemorySegment functionSymbol = defaultLibLookup.find("printf").get();
 		FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);
 		MethodHandle mh = linker.downcallHandle(fd, Linker.Option.firstVariadicArg(1));
-		MemorySegment formatSegmt = arena.allocateFrom("\n%d + %d = %d\n");
+		MemorySegment formatSegmt = PrimitiveTypeTests1.allocateString("\n%d + %d = %d\n");
 		mh.invoke(functionSymbol, formatSegmt, 15, 27, 42);
 	}
 }


### PR DESCRIPTION
The changes ensure the native strings are correctly converted by
leveraging the existing FFI methods with the encoding mode specified
prior to downcall on z/OS.

Related: [Internal 445](https://github.ibm.com/runtimes/javanext/issues/445)

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>