### PR TITLE
Continue using jdk21 as the boot jdk for jdk23+

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -163,8 +163,8 @@ boot_jdk_default:
       17: '17'
       21: '21'
       22: '21'
-      23: '22'
-      next: '22'
+      23: '21'
+      next: '21'
     dir_strip:
       all: '1'
     url:


### PR DESCRIPTION
Until https://github.com/eclipse-openj9/openj9/issues/19694 is resolved.
Related to https://github.com/eclipse-openj9/openj9/pull/19663