### PR TITLE
Removed unused configuration flag 'build_openj9'

### DIFF
--- a/buildspecs/aix_ppc-64_cmprssptrs.spec
+++ b/buildspecs/aix_ppc-64_cmprssptrs.spec
@@ -128,7 +128,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_java9" value="false"/>
 		<flag id="build_product" value="true"/>
 		<flag id="build_stage_toronto_lab" value="true"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="env_dlpar" value="true"/>
 		<flag id="env_hasFPU" value="true"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -185,10 +185,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<description>BuildSpec represents a Java 9x configuration.</description>
 		<ifRemoved></ifRemoved>
 	</flag>
-	<flag id="build_openj9">
-		<description>Buildspec compiles sources with openjdk.</description>
-		<ifRemoved>Openj9 clone,make jobs longer run on this buildspec.</ifRemoved>
-	</flag>
 	<flag id="build_openj9JDK8">
 		<description>Buildspec compiles sources with openjdk-jdk8.</description>
 		<ifRemoved>OpenJ9 compile job, sanity and extended tests no longer run on this buildspec.</ifRemoved>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -128,7 +128,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="false"/>
 		<flag id="build_product" value="true"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="env_sharedLibsCalleeGlobalTableSetup" value="true"/>

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -121,7 +121,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="env_littleEndian" value="true"/>

--- a/buildspecs/linux_aarch64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs_cross.spec
@@ -121,7 +121,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>
 		<flag id="env_crossbuild" value="true"/>
 		<flag id="env_hasFPU" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le.spec
@@ -129,7 +129,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="false"/>
 		<flag id="build_product" value="true"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_stage_toronto_lab" value="true"/>
 		<flag id="env_gcc" value="true"/>

--- a/buildspecs/linux_riscv64.spec
+++ b/buildspecs/linux_riscv64.spec
@@ -125,7 +125,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="false"/>
 		<flag id="build_vmContinuous" value="true"/>

--- a/buildspecs/linux_riscv64_cmprssptrs.spec
+++ b/buildspecs/linux_riscv64_cmprssptrs.spec
@@ -126,7 +126,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="false"/>
 		<flag id="build_vmContinuous" value="true"/>

--- a/buildspecs/linux_riscv64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_riscv64_cmprssptrs_cross.spec
@@ -126,7 +126,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="false"/>
 		<flag id="build_vmContinuous" value="true"/>

--- a/buildspecs/linux_riscv64_cross.spec
+++ b/buildspecs/linux_riscv64_cross.spec
@@ -125,7 +125,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="false"/>
 		<flag id="build_vmContinuous" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -128,7 +128,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>

--- a/buildspecs/osx_x86-64_cmprssptrs.spec
+++ b/buildspecs/osx_x86-64_cmprssptrs.spec
@@ -127,7 +127,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>
 		<flag id="env_hasFPU" value="true"/>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -135,7 +135,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="false"/>
-		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_ouncemake" value="true"/>
 		<flag id="build_product" value="true"/>

--- a/debugtools/DDR_VM/data/superset-constants.dat
+++ b/debugtools/DDR_VM/data/superset-constants.dat
@@ -791,7 +791,6 @@ C|build_java8
 C|build_java8raw
 C|build_java9
 C|build_newCompiler
-C|build_openj9
 C|build_ouncemake
 C|build_product
 C|build_realtime

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -78,7 +78,6 @@ extern "C" {
 #cmakedefine J9VM_BUILD_JAVA8RAW
 #cmakedefine J9VM_BUILD_JAVA9
 #cmakedefine J9VM_BUILD_NEW_COMPILER
-#cmakedefine J9VM_BUILD_OPENJ9
 #cmakedefine J9VM_BUILD_OUNCEMAKE
 #cmakedefine J9VM_BUILD_PRODUCT
 #cmakedefine J9VM_BUILD_REALTIME


### PR DESCRIPTION
It could easily be confused with `OPENJ9_BUILD` which is used.