### PR TITLE
Make static final field folding more aggressive

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3517,6 +3517,7 @@ J9::Options::packOptions(const TR::Options *origOptions)
    addRegexStringSize(origOptions->_memUsage, totalSize);
    addRegexStringSize(origOptions->_classesWithFolableFinalFields, totalSize);
    addRegexStringSize(origOptions->_disabledIdiomPatterns, totalSize);
+   addRegexStringSize(origOptions->_dontFoldStaticFinalFields, totalSize);
 
    std::string optionsStr(totalSize, '\0');
    TR::Options * options = (TR::Options *)optionsStr.data();
@@ -3558,6 +3559,7 @@ J9::Options::packOptions(const TR::Options *origOptions)
    appendRegex(options->_memUsage, curPos);
    appendRegex(options->_classesWithFolableFinalFields, curPos);
    appendRegex(options->_disabledIdiomPatterns, curPos);
+   appendRegex(options->_dontFoldStaticFinalFields, curPos);
    options->_osVersionString = NULL;
    options->_logListForOtherCompThreads = NULL;
    options->_objectFileName = NULL;
@@ -3626,6 +3628,7 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    unpackRegex(options->_memUsage);
    unpackRegex(options->_classesWithFolableFinalFields);
    unpackRegex(options->_disabledIdiomPatterns);
+   unpackRegex(options->_dontFoldStaticFinalFields);
 
    return options;
    }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2124,6 +2124,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, TR::Compiler->cls.getDefaultValueSlotAddress(comp, clazz));
          }
          break;
+      case MessageType::ClassEnv_setClassHasIllegalStaticFinalFieldModification:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *>();
+         auto clazz = std::get<0>(recv);
+         TR::Compiler->cls.setClassHasIllegalStaticFinalFieldModification(clazz, comp);
+         client->write(response, JITServer::Void());
+         }
+         break;
       case MessageType::ClassEnv_enumerateFields:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *>();

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -87,6 +87,8 @@ public:
    bool isStringClass(TR_OpaqueClassBlock *clazz);
 
    bool classHasIllegalStaticFinalFieldModification(TR_OpaqueClassBlock * clazzPointer);
+   void setClassHasIllegalStaticFinalFieldModification(
+      TR_OpaqueClassBlock *clazz, TR::Compilation *comp);
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isConcreteClass(TR::Compilation *comp, TR_OpaqueClassBlock * clazzPointer);

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -620,6 +620,12 @@ void TR_JITClientPersistentClassInfo::clearShouldNotBeNewlyExtended()
    TR_PersistentClassInfo::clearShouldNotBeNewlyExtended();
    }
 
+void TR_JITClientPersistentClassInfo::setAlreadyScannedForFinalPutstatic()
+   {
+   TR_JITClientPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_PersistentClassInfo::setAlreadyScannedForFinalPutstatic();
+   }
+
 void TR_JITClientPersistentClassInfo::setHasRecognizedAnnotations(bool v)
    {
    TR_JITClientPersistentClassInfo::_chTable->markDirty(getClassId());

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -212,6 +212,7 @@ public:
    virtual void setShouldNotBeNewlyExtended(int32_t ID) override;
    virtual void resetShouldNotBeNewlyExtended(int32_t ID) override;
    virtual void clearShouldNotBeNewlyExtended() override;
+   virtual void setAlreadyScannedForFinalPutstatic() override;
    virtual void setHasRecognizedAnnotations(bool v = true) override;
    virtual void setAlreadyCheckedForAnnotations(bool v = true) override;
    virtual void setCannotTrustStaticFinal(bool v = true) override;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5343,7 +5343,7 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
 
    TR::SymbolReference * symRef = symRefTab()->findOrCreateStaticSymbol(_methodSymbol, cpIndex, false);
    if (comp()->getOption(TR_TraceILGen))
-      traceMsg(comp(), "load static symref %d created with knownObjectIndex %d", symRef->getReferenceNumber(), symRef->getKnownObjectIndex());
+      traceMsg(comp(), "load static symref %d created with knownObjectIndex %d\n", symRef->getReferenceNumber(), symRef->getKnownObjectIndex());
    TR::StaticSymbol *      symbol = symRef->getSymbol()->castToStaticSymbol();
    TR_ASSERT(symbol, "Didn't geta static symbol.");
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 63; // ID: Oemtun/nR/oBdrbdgkqE
+   static const uint16_t MINOR_NUMBER = 64; // ID: EbRgDu72oycJkc90HtnO
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -118,7 +118,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 62; // ID: TNff0n0QdLOhsH6CmQlT/
+   static const uint16_t MINOR_NUMBER = 63; // ID: Oemtun/nR/oBdrbdgkqE
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -212,6 +212,7 @@ const char *messageNames[] =
    "ClassEnv_enumerateFields",
    "ClassEnv_flattenedArrayElementSize",
    "ClassEnv_getDefaultValueSlotAddress",
+   "ClassEnv_setClassHasIllegalStaticFinalFieldModification",
    "SharedCache_getClassChainOffsetIdentifyingLoader",
    "SharedCache_rememberClass",
    "SharedCache_addHint",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -225,6 +225,7 @@ enum MessageType : uint16_t
    ClassEnv_enumerateFields,
    ClassEnv_flattenedArrayElementSize,
    ClassEnv_getDefaultValueSlotAddress,
+   ClassEnv_setClassHasIllegalStaticFinalFieldModification,
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetIdentifyingLoader,

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -994,11 +994,16 @@ J9::TransformUtil::canFoldStaticFinalField(
       {
       // Both putstatic and reflection have been ruled out, so fields declared
       // in declaringClass must not be modified. We do not support modifying
-      // them using Unsafe.
-      //
-      // For the time being, limit aggressive folding here to static final
-      // fields with declared type VarHandle.
-      //
+      // them using Unsafe. Go for it.
+      static const bool disableAggressiveSFFF =
+         feGetEnv("TR_disableAggressiveSFFF17") != NULL;
+
+      if (!disableAggressiveSFFF)
+         return TR_yes;
+
+      // General aggressive folding is disabled by environment variable. Still
+      // try to apply it to static final fields with declared type VarHandle,
+      // as before.
       static const bool disableAggressiveVarHandleSFFF =
          feGetEnv("TR_disableAggressiveVarHandleSFFF17") != NULL;
 

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -27,6 +27,8 @@
 #include "control/CompilationRuntime.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #include "env/CompilerEnv.hpp"
+#include "env/ClassTableCriticalSection.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "il/AnyConst.hpp"
 #include "il/Block.hpp"
 #include "il/Block_inlines.hpp"
@@ -39,6 +41,7 @@
 #include "il/StaticSymbol_inlines.hpp"
 #include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
+#include "ilgen/J9ByteCodeIterator.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
@@ -897,6 +900,104 @@ J9::TransformUtil::foldStaticFinalFieldAssumingProtection(TR::Compilation *comp,
    return false;
    }
 
+static bool
+classHasFinalPutstaticOutsideClinit(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
+   {
+   TR_J9VMBase *fej9 = comp->fej9();
+   J9VMThread *vmThread = fej9->vmThread();
+
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(clazz);
+   TR::Region &stackRegion = comp->trMemory()->currentStackRegion();
+
+   // Get all of the final fields declared by clazz from the VM.
+   J9Class *j9c = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+   uintptr_t numStaticFields =
+      fej9->_vmFunctionTable->getStaticFields(vmThread, romClass, NULL);
+
+   uintptr_t staticFieldsSize = numStaticFields * sizeof(J9ROMFieldShape*);
+   J9ROMFieldShape **staticFields =
+      (J9ROMFieldShape**)stackRegion.allocate(staticFieldsSize);
+
+   fej9->_vmFunctionTable->getStaticFields(vmThread, romClass, staticFields);
+
+   // Partition so that the final ones are at the beginning and the non-final
+   // ones follow.
+   uintptr_t numStaticFinalFields = 0;
+   for (uintptr_t i = 0; i < numStaticFields; i++)
+      {
+      if ((staticFields[i]->modifiers & J9AccFinal) != 0)
+         {
+         // Field i is final. Swap to add it to the end of the final prefix.
+         // Swapping is OK because we don't depend on the order of the fields.
+         TR_ASSERT_FATAL(numStaticFinalFields < numStaticFields, "out of bounds");
+         J9ROMFieldShape *tmp = staticFields[numStaticFinalFields];
+         staticFields[numStaticFinalFields] = staticFields[i];
+         staticFields[i] = tmp;
+         numStaticFinalFields++;
+         }
+      }
+
+   if (numStaticFinalFields == 0)
+      return false;
+
+   // Iterate the bytecode of all methods looking for a putstatic to a static
+   // field of clazz with a name and signature matching one in the final prefix
+   // of staticFields, i.e. staticFields[0..numStaticFinalFields].
+   J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+
+   TR_ScratchList<TR_ResolvedMethod> resolvedMethods(comp->trMemory());
+   fej9->getResolvedMethods(comp->trMemory(), clazz, &resolvedMethods);
+
+   ListIterator<TR_ResolvedMethod> mIt(&resolvedMethods);
+   for (auto *method = mIt.getFirst(); method != NULL; method = mIt.getNext())
+      {
+      if (method->isNative() || method->isAbstract())
+         continue; // method has no bytecode
+
+      if (method->nameLength() == 8 && !strncmp(method->nameChars(), "<clinit>", 8))
+         continue; // putstatic is always allowed in <clinit>
+
+      auto *methodJ9 = (TR_ResolvedJ9Method*)method;
+      TR_J9ByteCodeIterator bcIt(
+         TR::ResolvedMethodSymbol::create(comp->trHeapMemory(), method, comp),
+         methodJ9,
+         fej9,
+         comp);
+
+      for (TR_J9ByteCode bc = bcIt.first(); bc != J9BCunknown; bc = bcIt.next())
+         {
+         if (bc != J9BCputstatic)
+            continue;
+
+         int32_t cpIndex = bcIt.next2Bytes();
+         J9ROMConstantPoolItem *romCP = ((TR_ResolvedJ9Method*)method)->romLiterals();
+         J9ROMFieldRef *fieldRef = (J9ROMFieldRef*)&romCP[cpIndex];
+         J9ROMClassRef *classRef = (J9ROMClassRef*)&romCP[fieldRef->classRefCPIndex];
+         J9UTF8 *classRefName = J9ROMCLASSREF_NAME(classRef);
+         if (!J9UTF8_EQUALS(classRefName, className))
+            continue;
+
+         // putstatic to one of clazz's own static fields. Check whether it's
+         // one of the final ones.
+         J9ROMNameAndSignature *refNameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(fieldRef);
+         J9UTF8 *refName = J9ROMNAMEANDSIGNATURE_NAME(refNameAndSig);
+         J9UTF8 *refSig = J9ROMNAMEANDSIGNATURE_SIGNATURE(refNameAndSig);
+         for (uintptr_t i = 0; i < numStaticFinalFields; i++)
+            {
+            J9UTF8 *finalFieldName = J9ROMFIELDSHAPE_NAME(staticFields[i]);
+            J9UTF8 *finalFieldSig = J9ROMFIELDSHAPE_SIGNATURE(staticFields[i]);
+            if (J9UTF8_EQUALS(refName, finalFieldName)
+                && J9UTF8_EQUALS(refSig, finalFieldSig))
+               {
+               return true;
+               }
+            }
+         }
+      }
+
+   return false;
+   }
+
 TR_YesNoMaybe
 J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node)
    {
@@ -980,9 +1081,6 @@ J9::TransformUtil::canFoldStaticFinalField(
          return TR_no;
       }
 
-   // in Java 17 and above, it is not possible to remove the final attribute of a field
-   // to make it writable via reflection.
-#if JAVA_SPEC_VERSION >= 17
    // In classes with version 53 and later, putstatic can write to static final
    // fields only during class initialization.
    //
@@ -990,7 +1088,13 @@ J9::TransformUtil::canFoldStaticFinalField(
    // static final fields after initialization.
    //
    J9ROMClass *romClass = TR::Compiler->cls.romClassOf(declaringClass);
-   if (romClass->majorVersion >= 53 || fej9->isClassLibraryClass(declaringClass))
+   bool putstaticIsToSpec =
+      romClass->majorVersion >= 53 || fej9->isClassLibraryClass(declaringClass);
+
+   // in Java 17 and above, it is not possible to remove the final attribute of a field
+   // to make it writable via reflection.
+#if JAVA_SPEC_VERSION >= 17
+   if (putstaticIsToSpec)
       {
       // Both putstatic and reflection have been ruled out, so fields declared
       // in declaringClass must not be modified. We do not support modifying
@@ -1016,15 +1120,122 @@ J9::TransformUtil::canFoldStaticFinalField(
       }
 #endif
 
+   // Fold $assertionsDisabled and static final fields declared by allowlisted
+   // classes regardless of classHasIllegalStaticFinalFieldModification(). An
+   // allowlisted class (e.g. String) can have "illegal" stores occur during
+   // bootstrap that we want to ignore.
    if (!comp->getOption(TR_RestrictStaticFieldFolding) ||
        recField == TR::Symbol::assertionsDisabled ||
        J9::TransformUtil::foldFinalFieldsIn(
          declaringClass, className, classNameLen, true, comp))
       return TR_yes;
 
+   // Determine whether this class contains putstatic instructions outside of
+   // <clinit> that store to its static final fields. If it does, it can be
+   // considered to have an illegal modification, preventing all future folding
+   // of its static final fields.
+   bool putstaticScanDone = false;
+   if (putstaticIsToSpec)
+      {
+      // The problem can't occur. Such putstatic instructions would simply
+      // fail, so no scan is needed.
+      putstaticScanDone = true;
+      }
+   else
+      {
+      // Use the persistent class info to avoid repeated scanning.
+      TR_PersistentCHTable *cht = comp->getPersistentInfo()->getPersistentCHTable();
+      if (cht != NULL)
+         {
+         TR_PersistentClassInfo *classInfo =
+            cht->findClassInfoAfterLocking(declaringClass, comp);
+
+         if (classInfo != NULL)
+            {
+            putstaticScanDone = true;
+            if (!classInfo->alreadyScannedForFinalPutstatic())
+               {
+               if (classHasFinalPutstaticOutsideClinit(comp, declaringClass))
+                  {
+                  // There are no assumptions to invalidate when setting this
+                  // flag here. Any earlier attempts to fold static final fields
+                  // in this class have failed to scan, and therefore they have
+                  // refused to do even guarded folding.
+                  //
+                  // There could be a concurrent scan in another compilation
+                  // thread, but if so, it will also find the bad putstatic and
+                  // refuse to fold.
+                  //
+                  TR::Compiler->cls.setClassHasIllegalStaticFinalFieldModification(
+                     declaringClass, comp);
+                  }
+
+               TR::ClassTableCriticalSection chtCS(comp->fe());
+               classInfo->setAlreadyScannedForFinalPutstatic();
+               }
+            }
+         }
+      }
+
+   // If this class needs a scan that we failed to perform, then don't fold at
+   // all. Without the scan, we can't trust its static final fields. We could
+   // still do guarded folding, but if we did, there would be a possibility of
+   // successfully scanning later on and finding a bad putstatic. Then when
+   // setting the illegal write flag, there would be assumptions to invalidate.
+   if (!putstaticScanDone)
+      return TR_no;
+
+   // Reject fields belonging to classes in which illegal static final stores
+   // have been observed, and classes with old versions that have been found to
+   // contain a bad putstatic (even if no illegal store has occurred yet).
    if (TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
       return TR_no;
 
+   // The putstatic scan has been done (or ruled out), so we know that if
+   // declaringClass had a bad putstatic, it would have been flagged as having
+   // an illegal write. But it wasn't flagged, so there is no bad putstatic,
+   // and we can be very aggressive here.
+   //
+   // This applies in JDK 8 and 11, and it applies in JDK 17+ to static final
+   // fields declared by classes with !putstaticIsToSpec. We should be able to
+   // support references here in the future, at which point the path specific
+   // to JDK 17+ will be redundant.
+   //
+   switch (sig[0])
+      {
+      case 'B':
+      case 'Z':
+      case 'S':
+      case 'C':
+      case 'I':
+      case 'J':
+      case 'F':
+      case 'D':
+         {
+         static const bool disable =
+            feGetEnv("TR_disableAggressivePrimitiveSFFF") != NULL;
+
+         if (!disable)
+            return TR_yes;
+
+         break;
+         }
+
+      case 'L':
+      case '[':
+         {
+         // Ideally we should trust these as well, but current known
+         // object handling in the compiler is unable to deal with the
+         // possibility of a later store to the field, e.g. via the
+         // setAccessible modifiers hack. If we derive a known object at
+         // a particular point and then later reach that point after the
+         // field is modified, we get undefined behaviour, which is too
+         // steep a consequence.
+         break;
+         }
+      }
+
+   // Fall back to guarded folding.
    return TR_maybe;
    }
 

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -142,6 +142,9 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    bool shouldNotBeNewlyExtended(int32_t ID)         { return _shouldNotBeNewlyExtended.testAny(1 << ID); }
    flags16_t getShouldNotBeNewlyExtendedMask() const { return _shouldNotBeNewlyExtended; }
 
+   virtual void setAlreadyScannedForFinalPutstatic() { _flags.set(_alreadyScannedForFinalPutstatic, true); }
+   bool alreadyScannedForFinalPutstatic() { return _flags.testAny(_alreadyScannedForFinalPutstatic); }
+
    virtual void setHasRecognizedAnnotations(bool v = true){ _flags.set(_containsRecognizedAnnotations, v); }
    bool hasRecognizedAnnotations()                { return _flags.testAny(_containsRecognizedAnnotations); }
    virtual void setAlreadyCheckedForAnnotations(bool v = true){ _flags.set(_alreadyScannedForAnnotations, v); }
@@ -161,6 +164,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
 
    enum // flag bits
       {
+      _alreadyScannedForFinalPutstatic      = 0x01,
       _isReservable                         = 0x02,
       _containsRecognizedAnnotations        = 0x04,
       _alreadyScannedForAnnotations         = 0x08,

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4768,6 +4768,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *internalReleaseVMAccessSetStatus)(struct J9VMThread * vmThread, UDATA flags) ;
 	IDATA  ( *instanceFieldOffset)(struct J9VMThread *vmStruct, struct J9Class *clazz, U_8 *fieldName, UDATA fieldNameLength, U_8 *signature, UDATA signatureLength, struct J9Class **definingClass, UDATA *instanceField, UDATA options) ;
 	void*  ( *staticFieldAddress)(struct J9VMThread *vmStruct, struct J9Class *clazz, U_8 *fieldName, UDATA fieldNameLength, U_8 *signature, UDATA signatureLength, struct J9Class **definingClass, UDATA *staticField, UDATA options, struct J9Class *sourceClass) ;
+	UDATA  ( *getStaticFields)(struct J9VMThread *currentThread, struct J9ROMClass *romClass, J9ROMFieldShape **outFields);
 	struct J9Class*  ( *internalFindKnownClass)(struct J9VMThread *currentThread, UDATA index, UDATA flags) ;
 	struct J9Class*  ( *resolveKnownClass)(struct J9JavaVM * vm, UDATA index) ;
 	UDATA  ( *computeHashForUTF8)(const U_8 * string, UDATA size) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2924,6 +2924,19 @@ void *
 staticFieldAddress(J9VMThread *vmStruct, J9Class *clazz, U_8 *fieldName, UDATA fieldNameLength, U_8 *signature, UDATA signatureLength, J9Class **definingClass, UDATA *staticField, UDATA options, J9Class *sourceClass);
 
 /**
+* @brief Get the J9ROMFieldShape of all static fields of the given class.
+*
+* Count the static fields declared by romClass and collect their J9ROMFieldShapes into outFields if specified.
+*
+* @param *currentThread
+* @param *romClass The J9ROMClass whose static fields should be reported.
+* @param *outFields The resulting array of J9ROMFieldShape pointers. May be null.
+* @return The number of static fields declared by the class.
+*/
+UDATA
+getStaticFields(J9VMThread *currentThread, J9ROMClass *romClass, J9ROMFieldShape **outFields);
+
+/**
  *@brief find field in class
  *@param vmstruct vmthread token
  *@param clazz ramclass

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -69,6 +69,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	internalReleaseVMAccessSetStatus,
 	instanceFieldOffset,
 	staticFieldAddress,
+	getStaticFields,
 	internalFindKnownClass,
 	resolveKnownClass,
 	computeHashForUTF8,


### PR DESCRIPTION
- Add `dontFoldStaticFinalFields={}` JIT option
- Add missing newline to an IL generator log message
- Expand Java 17+ aggressive SFFF from `VarHandle` to all types
- Fold primitive-typed static final fields more aggressively

This depends on eclipse/omr#7376