### PR TITLE
(0.46) Skip bounds checks in BigInteger bit{Count,Length}

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -839,6 +839,8 @@
    java_math_BigInteger_toByteArray,
    java_math_BigInteger_stripLeadingZeroBytes1,
    java_math_BigInteger_stripLeadingZeroBytes2,
+   java_math_BigInteger_bitCount,
+   java_math_BigInteger_bitLength,
 
    java_text_NumberFormat_format,
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2643,6 +2643,8 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_math_BigInteger_toByteArray,                     "toByteArray",           "()[B")},
       {x(TR::java_math_BigInteger_stripLeadingZeroBytes1,          "stripLeadingZeroBytes", "([BII)[I")},
       {x(TR::java_math_BigInteger_stripLeadingZeroBytes2,          "stripLeadingZeroBytes", "(I[BII)[I")},
+      {x(TR::java_math_BigInteger_bitCount,                        "bitCount",              "()I")},
+      {x(TR::java_math_BigInteger_bitLength,                       "bitLength",             "()I")},
       {    TR::unknownMethod}
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -303,6 +303,10 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
 #endif // OPENJ9_BUILD
    TR::java_math_BigInteger_stripLeadingZeroBytes1,
    TR::java_math_BigInteger_stripLeadingZeroBytes2,
+#ifdef OPENJ9_BUILD
+   TR::java_math_BigInteger_bitCount,
+   TR::java_math_BigInteger_bitLength,
+#endif // OPENJ9_BUILD
    TR::java_util_HashMap_get,
    TR::java_util_HashMap_findNonNullKeyEntry,
    TR::java_util_HashMap_putImpl,


### PR DESCRIPTION
These methods are currently safe to skip.

Picked from https://github.com/eclipse-openj9/openj9/pull/19688