### PR TITLE
JDK24 bring up

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -242,6 +242,34 @@
 	</configuration>
 
 	<configuration
+		  label="JAVA24"
+		  outputpath="JAVA24/src"
+		  dependencies="JAVA23"
+		  jdkcompliance="22">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.criu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava23.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="JAVA_SPEC_VERSION=24"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
 		  label="OPENJ9-RAWBUILD"
 		  outputpath="OPENJ9-RAWBUILD/src"
 		  flags="OpenJ9-RawBuild"

--- a/test/TestConfig/resources/excludes/latest_exclude_24.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_24.txt
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright IBM Corp. and others 2024
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+##############################################################################
+
+# Exclude tests temporarily
+
+org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
+org.openj9.test.vmArguments.VmArgumentTests:testCrNocr 244 generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidMembers NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHostWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost2 NA generic-all
+
+# Exclude Java 19 Thread related failures
+
+org.openj9.test.java.lang.Test_ThreadGroup:test_activeCount NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_Constructor2 NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_destroy NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_destroy2 NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_destroy3 NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_list NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_remove NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_resume NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_setDaemon2 NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_stop NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_suspend NA generic-all
+org.openj9.test.java.lang.Test_ThreadGroup:test_uncaughtException NA generic-all
+org.openj9.test.java.lang.Test_Thread:test_start_WeakReference NA generic-all
+org.openj9.test.java.lang.Test_Thread:test_currentThread NA generic-all
+org.openj9.test.java.lang.Test_Thread:test_toString NA generic-all
+org.openj9.test.java.lang.management.TestManagementFactory:testGetPlatformMXBeans NA generic-all

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_24.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_excludes_24.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+Copyright IBM Corp. and others 2024
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl"?>
+
+<suite id="jvmtitest">
+
+	<!-- Define exclude configs here (all & platform names are parsed for free by harness) -->
+	<platform id="all"/>
+	<platform id="aix_ppc-64"/>
+	<platform id="win_x86_newrom"/>
+
+	<!-- AIX64 - The test creates thousands of threads without exhausting its available heap. Probably due to some sort of lazy stack mapping on the OS side -->
+	<exclude id="re002" platform="all" shouldFix="true">
+		<reason>No reliable cross-platform way of simulating this condition</reason>
+	</exclude>
+
+	<exclude id="gts001" platform="all" shouldFix="true">
+		<reason>Test is not very robust at the moment. Time dependency might cause it to fail</reason>
+	</exclude>
+
+	<exclude id="mt001" platform="latest" shouldFix="true">
+		<reason>Test doesn't work for b149 and later. Issue: </reason>
+	</exclude>
+
+	<exclude id="fer001" platform="all" shouldFix="true">
+		<reason>Testcase deadlocks due to bogus locking, replaced by fer003. keep fer001 for component debugging</reason>
+	</exclude>
+
+	<!-- Windows IA32 New ROMClass Builder - the test requires retransform support, which will be implemented under JAZZ 19331 -->
+	<exclude id="gpc002" platform="win_x86_newrom" shouldFix="true" expiry="Oct 8 2009">
+		<reason>Testcase requires retransform support, which will be implemented under JAZZ 19331</reason>
+	</exclude>
+
+	<exclude id="nmr001" platform="all">
+		<reason>Nestmates are not enabled on java10</reason>
+	</exclude>
+
+</suite>


### PR DESCRIPTION
`JDK24` bring up

Added `JPP flag JAVA24`;
Added `jvmtitests_excludes_24.xml`;
Added `latest_exclude_24.txt`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/806

Signed-off-by: Jason Feng <fengj@ca.ibm.com>