### PR TITLE
Fix and enable heavy/light value type tests

### DIFF
--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1019,9 +1019,6 @@ class RecordComponentIterator
 	U_16 getPermittedSubclassesClassCount() const { return _isSealed ? _permittedSubclassesAttribute->numberOfClasses : 0; }
 	bool isValueBased() const { return _isClassValueBased; }
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	bool needsIdentityFlag() const { return _isIdentityFlagNeeded; }
-	bool hasIdentityFlagSet() const { return _hasIdentityFlagSet; }
-	bool isValueType() const { return _isValueType; }
 	bool hasPreloadClasses() const { return NULL != _preloadAttribute; }
 	U_16 getPreloadClassCount() const { return  hasPreloadClasses() ? _preloadAttribute->numberOfClasses : 0; }
 
@@ -1150,12 +1147,7 @@ private:
 	bool _isSealed;
 	bool _isClassValueBased;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	bool _hasIdentityFlagSet;
-	bool _isIdentityFlagNeeded;
-	bool _isValueType;
 	bool _hasNonStaticSynchronizedMethod;
-	bool _hasNonStaticFields;
-	bool _hasNonEmptyConstructor;
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 	FieldInfo *_fieldsInfo;
@@ -1187,9 +1179,6 @@ private:
 	void walkAttributes();
 	void checkHiddenClass();
 	void walkInterfaces();
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	void checkAndRecordIsIdentityFlagNeeded();
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	void walkMethods();
 	void walkRecordComponents(J9CfrAttributeRecord *attrib);
 
@@ -1219,7 +1208,6 @@ private:
 	bool methodIsClinit(U_16 methodIndex);
 	bool methodIsNonStaticNonAbstract(U_16 methodIndex);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	bool methodIsConstructor(U_16 methodIndex);
 	bool methodIsNonStaticSynchronized(U_16 methodIndex);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 

--- a/runtime/bcutil/ROMClassCreationContext.cpp
+++ b/runtime/bcutil/ROMClassCreationContext.cpp
@@ -82,7 +82,6 @@ ROMClassCreationContext::verbosePrintPhase(ROMClassCreationPhase phase, bool *pr
 		"MethodIsVirtual",
 		"MethodIsObjectConstructor",
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		"MethodIsConstructor",
 		"MethodIsNonStaticSynchronized",
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		"ShouldConvertInvokeVirtualToInvokeSpecial",

--- a/runtime/bcutil/romphase.h
+++ b/runtime/bcutil/romphase.h
@@ -74,7 +74,6 @@ enum ROMClassCreationPhase {
 	MethodIsNonStaticNonAbstract,
 	MethodIsObjectConstructor,
 #if	defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	MethodIsConstructor,
 	MethodIsNonStaticSynchronized,
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	ShouldConvertInvokeVirtualToInvokeSpecial,

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2257,29 +2257,11 @@ nativeOOM:
 		if (NULL != superclass) {
 			/**
 			 * watched fields tag and exemption from validation are inherited from the superclass.
-			 * J9ClassHasIdentity is also inherited. If a class cannot be super class
-			 * of value types, its subclasses cannot be super of value types either.
 			 * J9ClassEnsureHashed inherited as subclasses of commonly hashed classes are likely
 			 * to be hashed as well.
 			 */
-			const U_32 inheritedFlags = J9ClassHasWatchedFields | J9ClassIsExemptFromValidation | J9ClassHasIdentity | J9ClassEnsureHashed;
+			const U_32 inheritedFlags = J9ClassHasWatchedFields | J9ClassIsExemptFromValidation| J9ClassEnsureHashed;
 			classFlags |= (superclass->classFlags & inheritedFlags);
-
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			if (J9_ARE_ALL_BITS_SET(classFlags, J9ClassHasIdentity)) {
-				if (J9ROMCLASS_IS_VALUE(romClass)) {
-					J9UTF8 *superclassName = J9ROMCLASS_SUPERCLASSNAME(romClass);
-					J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
-					setCurrentExceptionNLSWithArgs(vmThread, J9NLS_VM_VALUETYPE_HAS_WRONG_SUPERCLASS,
-							J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(className),
-							J9UTF8_DATA(className), J9UTF8_LENGTH(superclassName), J9UTF8_DATA(superclassName));
-				}
-			} else {
-				if (!J9ROMCLASS_IS_VALUE(romClass)) {
-					classFlags |= J9ClassHasIdentity;
-				}
-			}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		}
 		if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
 			/* if anonClass replace classLoader with hostClassLoader, no one can know about anonClassLoader */
@@ -2324,6 +2306,16 @@ nativeOOM:
 
 		if (J9ROMCLASS_IS_VALUE(romClass)) {
 			classFlags |= J9ClassIsValueType;
+			/* superclass can be NULL if primitive classes are changed to value typess in the future. */
+			if ((NULL != superclass) && J9_ARE_ALL_BITS_SET(superclass->classFlags, J9ClassHasIdentity)) {
+				J9UTF8 *superclassName = J9ROMCLASS_SUPERCLASSNAME(romClass);
+				if (!J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(superclassName), J9UTF8_LENGTH(superclassName), "java/lang/Object")) {
+					J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
+					setCurrentExceptionNLSWithArgs(vmThread, J9NLS_VM_VALUETYPE_HAS_WRONG_SUPERCLASS,
+							J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(className),
+							J9UTF8_DATA(className), J9UTF8_LENGTH(superclassName), J9UTF8_DATA(superclassName));
+				}
+			}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 			if (J9ROMCLASS_IS_PRIMITIVE_VALUE_TYPE(romClass)
 				|| J9_ARE_ALL_BITS_SET(classFlags, J9ClassAllowsInitialDefaultValue)
@@ -2351,6 +2343,8 @@ nativeOOM:
 				}
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+		} else {
+			classFlags |= J9ClassHasIdentity;
 		}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		if (J9_ARE_ALL_BITS_SET(state->valueTypeFlags, J9ClassContainsUnflattenedFlattenables)) {
@@ -3199,7 +3193,7 @@ fail:
 			 *                   + J9ClassHasReferences
 			 *                  + J9ClassRequiresPrePadding
 			 *                 + J9ClassIsValueBased
-			 *                + J9ClassHasIdentity (inherited)
+			 *                + J9ClassHasIdentity
 			 *
 			 *              + J9ClassEnsureHashed (inherited)
 			 *             + J9ClassHasOffloadAllowSubtasksNatives

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2264,6 +2264,22 @@ nativeOOM:
 			 */
 			const U_32 inheritedFlags = J9ClassHasWatchedFields | J9ClassIsExemptFromValidation | J9ClassHasIdentity | J9ClassEnsureHashed;
 			classFlags |= (superclass->classFlags & inheritedFlags);
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (J9_ARE_ALL_BITS_SET(classFlags, J9ClassHasIdentity)) {
+				if (J9ROMCLASS_IS_VALUE(romClass)) {
+					J9UTF8 *superclassName = J9ROMCLASS_SUPERCLASSNAME(romClass);
+					J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
+					setCurrentExceptionNLSWithArgs(vmThread, J9NLS_VM_VALUETYPE_HAS_WRONG_SUPERCLASS,
+							J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(className),
+							J9UTF8_DATA(className), J9UTF8_LENGTH(superclassName), J9UTF8_DATA(superclassName));
+				}
+			} else {
+				if (!J9ROMCLASS_IS_VALUE(romClass)) {
+					classFlags |= J9ClassHasIdentity;
+				}
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		}
 		if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
 			/* if anonClass replace classLoader with hostClassLoader, no one can know about anonClassLoader */
@@ -2294,10 +2310,6 @@ nativeOOM:
 		}
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9ROMCLASS_HAS_IDENTITY(romClass)) {
-			classFlags |= J9ClassHasIdentity;
-		}
-
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		if (J9_ARE_ALL_BITS_SET(romClass->optionalFlags, J9_ROMCLASS_OPTINFO_IMPLICITCREATION_ATTRIBUTE)) {
 			U_16 implicitCreationFlags = getImplicitCreationFlags(romClass);

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2942,11 +2942,11 @@ public class ValueTypeTests {
 	}
 
 	@Test(priority=1)
-	static public void testIdentityObjectOnHeavyAbstract() throws Throwable {
-		assertFalse(HeavyAbstractClass.class.isValue());
-		assertTrue(HeavyAbstractClass.class.isIdentity());
+	static public void testIdentityObjectOnAbstractClass() throws Throwable {
+		assertFalse(AbstractClass.class.isValue());
+		assertTrue(AbstractClass.class.isIdentity());
 	}
-	public static abstract class HeavyAbstractClass {
+	public static abstract class AbstractClass {
 		/* Abstract class that has fields */
 		private int x;
 		private int y;
@@ -2958,30 +2958,30 @@ public class ValueTypeTests {
 		}
 	}
 	
-	public static abstract class HeavyAbstractClass1 {
+	public static abstract class AbstractClass1 {
 		/* Abstract class that has non-empty constructors */
-		public HeavyAbstractClass1() {
-			System.out.println("This class is HeavyAbstractClass1");
+		public AbstractClass1() {
+			System.out.println("This class is AbstractClass1");
 		}
 	}
 	
-	public static abstract class HeavyAbstractClass2 {
+	public static abstract class AbstractClass2 {
 		/* Abstract class that has synchronized methods */
 		public synchronized void printClassName() {
-			System.out.println("This class is HeavyAbstractClass2");
+			System.out.println("This class is AbstractClass2");
 		}
 	}
 	
-	public static abstract class HeavyAbstractClass3 {
+	public static abstract class AbstractClass3 {
 		/* Abstract class that has initializer */
-		{ System.out.println("This class is HeavyAbstractClass3"); }
+		{ System.out.println("This class is AbstractClass3"); }
 	}
 	
-	public static abstract class LightAbstractClass {
+	public static abstract class AbstractClass4 {
 		
 	}
 
-	private static abstract class InvisibleLightAbstractClass {
+	private static abstract class InvisibleAbstractClass {
 		
 	}
 	
@@ -2994,38 +2994,34 @@ public class ValueTypeTests {
 		assertTrue(valueClass.isValue());
 	}
 
-	/* https://github.com/eclipse-openj9/openj9/issues/19692 tracks excluded tests */
-	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class, enabled = false)
-	static public void testValueTypeSubClassHeavyAbstract() throws Throwable {
-		String superClassName = HeavyAbstractClass.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassHeavyAbstract", superClassName, 0);
+	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
+	static public void testValueTypeSubClassAbstractClass() throws Throwable {
+		String superClassName = AbstractClass.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassAbstractClass", superClassName, 0);
 	}
 	
-	/* https://github.com/eclipse-openj9/openj9/issues/19692 tracks excluded tests */
-	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class, enabled = false)
-	static public void testValueTypeSubClassHeavyAbstract1() throws Throwable {
-		String superClassName = HeavyAbstractClass1.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassHeavyAbstract1", superClassName, 0);
+	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
+	static public void testValueTypeSubClassAbstractClass1() throws Throwable {
+		String superClassName = AbstractClass1.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassAbstractClass1", superClassName, 0);
 	}
 	
-	/* https://github.com/eclipse-openj9/openj9/issues/19692 tracks excluded tests */
-	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class, enabled = false)
-	static public void testValueTypeSubClassHeavyAbstract2() throws Throwable {
-		String superClassName = HeavyAbstractClass2.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassHeavyAbstract2", superClassName, 0);
+	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
+	static public void testValueTypeSubClassAbstractClass2() throws Throwable {
+		String superClassName = AbstractClass2.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassAbstractClass2", superClassName, 0);
 	}
 	
-	/* https://github.com/eclipse-openj9/openj9/issues/19692 tracks excluded tests */
-	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class, enabled = false)
-	static public void testValueTypeSubClassHeavyAbstract3() throws Throwable {
-		String superClassName = HeavyAbstractClass3.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassHeavyAbstract3", superClassName, 0);
+	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
+	static public void testValueTypeSubClassAbstractClass3() throws Throwable {
+		String superClassName = AbstractClass3.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassAbstractClass3", superClassName, 0);
 	}
 
-	@Test(priority=1)
-	static public void testValueTypeSubClassLightAbstract() throws Throwable {
-		String superClassName = LightAbstractClass.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassLightAbstract", superClassName, 0);
+	@Test(priority=1, expectedExceptions=IncompatibleClassChangeError.class)
+	static public void testValueTypeSubClassAbstractClass4() throws Throwable {
+		String superClassName = AbstractClass4.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassAbstractClass4", superClassName, 0);
 	}
 
 	@Test(priority=1, expectedExceptions=ClassFormatError.class)
@@ -3041,9 +3037,9 @@ public class ValueTypeTests {
 	}
 
 	@Test(priority=1, expectedExceptions=IllegalAccessError.class)
-	static public void testValueTypeSubClassInvisibleLightAbstractClass() throws Throwable {
-		String superClassName = InvisibleLightAbstractClass.class.getName().replace('.', '/');
-		valueTypeIdentityObjectTestHelper("testValueTypeSubClassInvisibleLightAbstractClass", superClassName, 0);
+	static public void testValueTypeSubClassInvisibleAbstractClass() throws Throwable {
+		String superClassName = InvisibleAbstractClass.class.getName().replace('.', '/');
+		valueTypeIdentityObjectTestHelper("testValueTypeSubClassInvisibleAbstractClass", superClassName, 0);
 	}
 
 	@Test(priority=1, expectedExceptions=ClassFormatError.class)
@@ -3077,7 +3073,7 @@ public class ValueTypeTests {
 
 	@Test(priority=1)
 	static public void testIsValueClassOnAbstractClass() throws Throwable {
-		assertFalse(HeavyAbstractClass.class.isValue());
+		assertFalse(AbstractClass.class.isValue());
 	}
 
 	@Test(priority=1)


### PR DESCRIPTION
- add back missing error handling for value type inheritance
- remove stale heavy/light abstract class logic
- re-enable tests and remove heavy/light naming

Related to https://github.com/eclipse-openj9/openj9/issues/19692