### PR TITLE
Split IllegalAccessProtectedMethodTest to openj9 and hotspot variant

### DIFF
--- a/test/functional/IllegalAccessError_for_protected_method/playlist.xml
+++ b/test/functional/IllegalAccessError_for_protected_method/playlist.xml
@@ -22,7 +22,27 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
-		<testCaseName>IllegalAccessProtectedMethodTest</testCaseName>
+		<testCaseName>IllegalAccessProtectedMethodTest_hs</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-javaagent:$(Q)$(TEST_RESROOT)$(D)IllegalAccessProtectedMethod.jar$(Q) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(P)$(TEST_RESROOT)$(D)IllegalAccessProtectedMethod.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames IllegalAccessProtectedMethodTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>IllegalAccessProtectedMethodTest_j9</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-XX:+EnableExtendedHCR \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)IllegalAccessProtectedMethod.jar$(Q) \
@@ -38,5 +58,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
- Split IllegalAccessProtectedMethodTest due to extendedHCR setting
Fixes: https://github.com/adoptium/aqa-tests/issues/5393