### PR TITLE
Remove extra newline chars from j9mprotect/j9munprotect.s

### DIFF
--- a/runtime/port/zos390/j9mprotect.s
+++ b/runtime/port/zos390/j9mprotect.s
@@ -48,4 +48,3 @@ _MPROT   CELQPRLG BASEREG=8
          LTORG
  
          END
-

--- a/runtime/port/zos390/j9munprotect.s
+++ b/runtime/port/zos390/j9munprotect.s
@@ -48,4 +48,3 @@ _MUNPROT CELQPRLG BASEREG=8
          LTORG
  
          END
-


### PR DESCRIPTION
The two files `runtime/port/zos390/j9mprotect.s` and `runtime/port/zos390/j9munprotect.s` seems to have 2 newlines at the end of the file. This removes the extraneous one so that it only has the single newline, that should be in accordance with the typical guidelines.