### PR TITLE
Fix for tree verification error and block verification error

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -824,7 +824,7 @@ createArrayHeaderConst(TR::Compilation *comp, bool is64bit, TR::Node *baseNode)
 TR::Node*
 createArrayTopAddressTree(TR::Compilation *comp, bool is64bit, TR::Node *baseNode)
    {
-   TR::Node *top = TR::TransformUtil::generateFirstArrayElementAddressTrees(comp, baseNode);
+   TR::Node *top = TR::TransformUtil::generateFirstArrayElementAddressTrees(comp, createLoad(baseNode));
    return top;
    }
 
@@ -892,14 +892,15 @@ createArrayAddressTree(TR::Compilation *comp, bool is64bit, TR::Node *baseNode, 
    {
    TR::Node *top = NULL;
    TR::Node *c2 = NULL;
+   TR::Node *arrayObject = createLoad(baseNode);
    if (indexNode->getOpCodeValue() == TR::iconst && indexNode->getInt() == 0)
       {
-      top = TR::TransformUtil::generateFirstArrayElementAddressTrees(comp, baseNode);
+      top = TR::TransformUtil::generateFirstArrayElementAddressTrees(comp, arrayObject);
       }
    else
       {
       c2 = TR::TransformUtil::generateConvertArrayElementIndexToOffsetTrees(comp, indexNode, NULL, multiply);
-      top = TR::TransformUtil::generateArrayElementAddressTrees(comp, baseNode, c2);
+      top = TR::TransformUtil::generateArrayElementAddressTrees(comp, arrayObject, c2);
       }
 
    return top;


### PR DESCRIPTION
The tree and block verification errors were because the array object node was being reused for array access during idiom transformations. Using array object node duplicate fixes the errors.