### PR TITLE
Report live continuation Objects in verbosegc

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -110,6 +110,7 @@ public:
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	MM_ScavengerJavaStats scavengerJavaStats;
 #endif /* J9VM_GC_MODRON_SCAVENGER */
+	MM_ContinuationStats continuationStats;
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	enum DynamicClassUnloading {

--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -28,6 +28,7 @@
 
 #include "MarkJavaStats.hpp"
 #include "ScavengerJavaStats.hpp"
+#include "ContinuationStats.hpp"
 #include "GCExtensionsBase.hpp"
 #include "ObjectModel.hpp"
 
@@ -57,6 +58,7 @@ public:
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	MM_ScavengerJavaStats _scavengerJavaStats;
 #endif /* OMR_GC_MODRON_SCAVENGER */
+	MM_ContinuationStats _continuationStats;
 	MM_ReferenceObjectBuffer *_referenceObjectBuffer; /**< The thread-specific buffer of recently discovered reference objects */
 	MM_UnfinalizedObjectBuffer *_unfinalizedObjectBuffer; /**< The thread-specific buffer of recently allocated unfinalized objects */
 	MM_OwnableSynchronizerObjectBuffer *_ownableSynchronizerObjectBuffer; /**< The thread-specific buffer of recently allocated ownable synchronizer objects */

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -138,6 +138,7 @@ MM_MarkingDelegate::workerSetupForGC(MM_EnvironmentBase *env)
 		gcEnv->_scavengerJavaStats.clearContinuationCounts();
 	}
 #endif /* defined(J9VM_GC_MODRON_SCAVENGER) */
+	gcEnv->_continuationStats.clear();
 #if defined(OMR_GC_MODRON_STANDARD) || defined(OMR_GC_REALTIME)
 		/* record that this thread is participating in this cycle */
 		env->_markStats._gcCount = env->_workPacketStats._gcCount = _extensions->globalGCStats.gcCount;
@@ -168,6 +169,8 @@ MM_MarkingDelegate::workerCleanupAfterGC(MM_EnvironmentBase *env)
 	Assert_MM_true(gcEnv->_referenceObjectBuffer->isEmpty());
 
 	_extensions->markJavaStats.merge(&gcEnv->_markJavaStats);
+	_extensions->continuationStats.merge(&gcEnv->_continuationStats);
+
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	if (_extensions->scavengerEnabled) {
 		/* merge scavenger ownableSynchronizerObjects stats, only in generational gc */
@@ -187,6 +190,7 @@ MM_MarkingDelegate::mainSetupForGC(MM_EnvironmentBase *env)
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 	_collectStringConstantsEnabled = _extensions->collectStringConstants;
+	_extensions->continuationStats.clear();
 }
 
 void

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -53,6 +53,7 @@
 #include "ConcurrentSweepScheme.hpp"
 #endif /* J9VM_GC_CONCURRENT_SWEEP */
 #include "ConfigurationDelegate.hpp"
+#include "ContinuationStats.hpp"
 #include "EnvironmentStandard.hpp"
 #include "ExcessiveGCStats.hpp"
 #include "FinalizableObjectBuffer.hpp"
@@ -158,6 +159,7 @@ MM_ScavengerDelegate::tearDown(MM_EnvironmentBase *env)
 void
 MM_ScavengerDelegate::mainSetupForGC(MM_EnvironmentBase * envBase)
 {
+	_extensions->continuationStats.clear();
 	/* Remember the candidates of OwnableSynchronizerObject before
 	 * clearing scavenger statistics
 	 */
@@ -201,6 +203,7 @@ MM_ScavengerDelegate::workerSetupForGC_clearEnvironmentLangStats(MM_EnvironmentB
 {
 	/* clear thread-local java-only gc stats */
 	envBase->getGCEnvironment()->_scavengerJavaStats.clear();
+	envBase->getGCEnvironment()->_continuationStats.clear();
 }
 
 void
@@ -229,6 +232,8 @@ MM_ScavengerDelegate::mergeGCStats_mergeLangStats(MM_EnvironmentBase * envBase)
 
 	finalGCJavaStats->_unfinalizedCandidates += scavJavaStats->_unfinalizedCandidates;
 	finalGCJavaStats->_unfinalizedEnqueued += scavJavaStats->_unfinalizedEnqueued;
+
+	_extensions->continuationStats.merge(&env->getGCEnvironment()->_continuationStats);
 
 	finalGCJavaStats->_ownableSynchronizerCandidates += scavJavaStats->_ownableSynchronizerCandidates;
 	finalGCJavaStats->_ownableSynchronizerTotalSurvived += scavJavaStats->_ownableSynchronizerTotalSurvived;

--- a/runtime/gc_modron_standard/ContinuationObjectBufferStandard.cpp
+++ b/runtime/gc_modron_standard/ContinuationObjectBufferStandard.cpp
@@ -33,6 +33,9 @@
 #include "ContinuationObjectBufferStandard.hpp"
 #include "ContinuationObjectList.hpp"
 #include "ParallelTask.hpp"
+#if JAVA_SPEC_VERSION >= 19
+#include "ContinuationHelpers.hpp"
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 MM_ContinuationObjectBufferStandard::MM_ContinuationObjectBufferStandard(MM_GCExtensions *extensions, uintptr_t maxObjectCount)
 	: MM_ContinuationObjectBuffer(extensions, maxObjectCount)
@@ -113,6 +116,7 @@ MM_ContinuationObjectBufferStandard::iterateAllContinuationObjects(MM_Environmen
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
 	MM_HeapRegionDescriptorStandard *region = NULL;
 	GC_HeapRegionIteratorStandard regionIterator(extensions->heapRegionManager);
+	GC_Environment *gcEnv = env->getGCEnvironment();
 
 	/* to make sure that previous pruning phase of continuation list(scanContinuationObjects()) is complete */
 	env->_currentTask->synchronizeGCThreads(env, UNIQUE_ID);
@@ -126,9 +130,11 @@ MM_ContinuationObjectBufferStandard::iterateAllContinuationObjects(MM_Environmen
 
 					omrobjectptr_t object = list->getHeadOfList();
 					while (NULL != object) {
+						gcEnv->_continuationStats._total += 1;
 						omrobjectptr_t next = extensions->accessBarrier->getContinuationLink(object);
-						J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF((J9VMThread *)env->getLanguageVMThread(), object);
-						if (NULL != continuation) {
+						ContinuationState volatile *continuationStatePtr = VM_ContinuationHelpers::getContinuationStateAddress((J9VMThread *)env->getLanguageVMThread(), object);
+						if (VM_ContinuationHelpers::isActive(*continuationStatePtr)) {
+							gcEnv->_continuationStats._started += 1;
 							TRIGGER_J9HOOK_MM_WALKCONTINUATION(extensions->hookInterface, (J9VMThread *)env->getLanguageVMThread(), object);
 						}
 						object = next;

--- a/runtime/gc_stats/ContinuationStats.hpp
+++ b/runtime/gc_stats/ContinuationStats.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 1991
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+#if !defined(CONTINUATIONSTATS_HPP_)
+#define CONTINUATIONSTATS_HPP_
+#include "j9port.h"
+#include "modronopt.h"
+
+#include "Base.hpp"
+#include "AtomicOperations.hpp"
+
+/**
+ * Storage for statistics relevant to the continuation Objects
+ * @ingroup GC_Stats
+ */
+class MM_ContinuationStats : public MM_Base {
+private:
+protected:
+public:
+	uintptr_t _total;	/**< number of alive continuation objects on heap at the end of cycle */
+	uintptr_t _started;	/**< number of continuation objects has started at the end of cycle */
+
+	/* function members */
+private:
+protected:
+public:
+	void clear()
+	{
+		_total = 0;
+		_started = 0;
+	}
+
+	void merge(MM_ContinuationStats* statsToMerge)
+	{
+		_total += statsToMerge->_total;
+		_started += statsToMerge->_started;
+	}
+
+	MM_ContinuationStats() :
+		MM_Base()
+		, _total(0)
+		, _started(0)
+	{
+		clear();
+	}
+};
+#endif /* CONTINUATIONSTATS_HPP_ */

--- a/runtime/gc_stats/VLHGCIncrementStats.hpp
+++ b/runtime/gc_stats/VLHGCIncrementStats.hpp
@@ -43,6 +43,7 @@
 #include "CompactVLHGCStats.hpp"
 #endif /* J9VM_GC_MODRON_COMPACTION */
 #include "CopyForwardStats.hpp"
+#include "ContinuationStats.hpp"
 #include "InterRegionRememberedSetStats.hpp"
 #include "MarkVLHGCStats.hpp"
 #include "SweepVLHGCStats.hpp"
@@ -64,6 +65,7 @@ public:
 	class MM_CopyForwardStats _copyForwardStats;  /**< Stats for copy forward phase of increment */
 	class MM_ClassUnloadStats _classUnloadStats;  /**< Stats for class unload operations of the increment */
 	class MM_InterRegionRememberedSetStats _irrsStats; /**< Stats for Inter Region Remembered Set processing */
+	class MM_ContinuationStats _continuationStats;
 
 	enum GlobalMarkIncrementType {
 		mark_idle = 0, /**< No Global marking in progress */
@@ -81,8 +83,8 @@ public:
 #endif /* J9VM_GC_MODRON_COMPACTION */
 		,_workPacketStats()
 		,_copyForwardStats()
-		,_classUnloadStats()
 		,_irrsStats()
+		,_continuationStats()
 		,_globalMarkIncrementType(MM_VLHGCIncrementStats::mark_idle)
 		{};
 
@@ -100,6 +102,7 @@ public:
 		_copyForwardStats.clear();
 		_classUnloadStats.clear();
 		_irrsStats.clear();
+		_continuationStats.clear();
 		_globalMarkIncrementType = MM_VLHGCIncrementStats::mark_idle;
 	}
 
@@ -116,6 +119,7 @@ public:
 		_workPacketStats.merge(&stats->_workPacketStats);
 		_copyForwardStats.merge(&stats->_copyForwardStats);
 		_irrsStats.merge(&stats->_irrsStats);
+		_continuationStats.merge(&stats->_continuationStats);
 	}
 
 	/**

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
@@ -79,6 +79,7 @@ void
 MM_VerboseHandlerOutputStandardJava::outputMemoryInfoInnerStanzaInternal(MM_EnvironmentBase *env, uintptr_t indent, MM_CollectionStatistics *statsBase)
 {
 	MM_VerboseHandlerJava::outputFinalizableInfo(_manager, env, indent);
+	outputContinuationObjectInfo(env, indent);
 }
 
 void
@@ -138,6 +139,15 @@ MM_VerboseHandlerOutputStandardJava::outputContinuationInfo(MM_EnvironmentBase *
 {
 	if (0 != continuationCandidates) {
 		_manager->getWriterChain()->formatAndOutput(env, indent, "<continuations candidates=\"%zu\" cleared=\"%zu\" />", continuationCandidates, continuationCleared);
+	}
+}
+
+void
+MM_VerboseHandlerOutputStandardJava::outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent)
+{
+	MM_ContinuationStats *continuationStats = &MM_GCExtensions::getExtensions(env->getOmrVM())->continuationStats;
+	if (0 != continuationStats->_total) {
+		_manager->getWriterChain()->formatAndOutput(env, indent, "<continuation-objects total=\"%zu\" started=\"%zu\"/>", continuationStats->_total, continuationStats->_started);
 	}
 }
 

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
@@ -55,6 +55,7 @@ private:
 	 */
 	void outputOwnableSynchronizerInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t ownableSynchronizerCandidates, uintptr_t ownableSynchronizerCleared);
 	void outputContinuationInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t continuationCandidates, uintptr_t continuationCleared);
+	void outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent);
 
 	/**
 	 * Output reference processing summary.

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -24,6 +24,7 @@
 
 #include "CollectionStatisticsVLHGC.hpp"
 #include "ConcurrentPhaseStatsBase.hpp"
+#include "ContinuationStats.hpp"
 #include "CopyForwardStats.hpp"
 #include "CycleStateVLHGC.hpp"
 #include "EnvironmentBase.hpp"
@@ -282,6 +283,15 @@ MM_VerboseHandlerOutputVLHGC::outputContinuationInfo(MM_EnvironmentBase *env, UD
 }
 
 void
+MM_VerboseHandlerOutputVLHGC::outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent)
+{
+	MM_ContinuationStats *continuationStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._continuationStats;
+	if (0 != continuationStats->_total) {
+		_manager->getWriterChain()->formatAndOutput(env, indent, "<continuation-objects total=\"%zu\" started=\"%zu\" />", continuationStats->_total, continuationStats->_started);
+	}
+}
+
+void
 MM_VerboseHandlerOutputVLHGC::outputReferenceInfo(MM_EnvironmentBase *env, UDATA indent, const char *referenceType, MM_ReferenceStats *referenceStats, UDATA dynamicThreshold, UDATA maxThreshold)
 {
 	if(0 != referenceStats->_candidates) {
@@ -362,7 +372,7 @@ MM_VerboseHandlerOutputVLHGC::outputMemoryInfoInnerStanza(MM_EnvironmentBase *en
 	}
 
 	MM_VerboseHandlerJava::outputFinalizableInfo(_manager, env, indent);
-
+	outputContinuationObjectInfo(env, indent);
 	UDATA rememberedSetFreePercent = (UDATA)((100 * (U_64)stats->_rememberedSetBytesFree) / ((U_64)stats->_rememberedSetBytesTotal));
 
 	writer->formatAndOutput(env, indent, "<remembered-set count=\"%zu\" freebytes=\"%zu\" totalbytes=\"%zu\" percent=\"%zu\" regionsoverflowed=\"%zu\" regionsstable=\"%zu\" regionsrebuilding=\"%zu\"/>",

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -64,6 +64,7 @@ private:
 	 */
 	void outputOwnableSynchronizerInfo(MM_EnvironmentBase *env, UDATA indent, UDATA ownableSynchronizerCandidates, UDATA ownableSynchronizerCleared);
 	void outputContinuationInfo(MM_EnvironmentBase *env, UDATA indent, UDATA continuationCandidates, UDATA continuationCleared);
+	void outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent);
 
 	/**
 	 * Output reference processing summary.

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -416,6 +416,7 @@ MM_CopyForwardScheme::clearGCStats(MM_EnvironmentVLHGC *env)
 {
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats.clear();
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.clear();
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._continuationStats.clear();
 }
 
 void
@@ -1558,6 +1559,7 @@ MM_CopyForwardScheme::mergeGCStats(MM_EnvironmentVLHGC *env)
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats.merge(localStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.merge(&env->_workPacketStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._irrsStats.merge(&env->_irrsStats);
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._continuationStats.merge(&env->_continuationStats);
 	omrthread_monitor_exit(_extensions->gcStatsMutex);
 	
 	/* record the thread-specific parallelism stats in the trace buffer. This partially duplicates info in -Xtgc:parallel */ 

--- a/runtime/gc_vlhgc/CopyForwardSchemeTask.hpp
+++ b/runtime/gc_vlhgc/CopyForwardSchemeTask.hpp
@@ -64,6 +64,7 @@ public:
 		
 		env->_workPacketStats.clear();
 		env->_copyForwardStats.clear();
+		env->_continuationStats.clear();
 		
 		/* record that this thread is participating in this cycle */
 		env->_copyForwardStats._gcCount = MM_GCExtensions::getExtensions(env)->globalVLHGCStats.gcCount;

--- a/runtime/gc_vlhgc/EnvironmentVLHGC.hpp
+++ b/runtime/gc_vlhgc/EnvironmentVLHGC.hpp
@@ -84,6 +84,7 @@ public:
 	MM_CompactVLHGCStats _compactVLHGCStats;
 #endif /* J9VM_GC_MODRON_COMPACTION */
 	MM_InterRegionRememberedSetStats _irrsStats;
+	MM_ContinuationStats _continuationStats;
 
 protected:
 private:

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -162,6 +162,7 @@ MM_ParallelGlobalMarkTask::setup(MM_EnvironmentBase *envBase)
 	}
 	env->_markVLHGCStats.clear();
 	env->_workPacketStats.clear();
+	env->_continuationStats.clear();
 
 	/*
 	 * Get gc threads cpu time for when mark started, and add it to the stats structure.
@@ -194,6 +195,7 @@ MM_ParallelGlobalMarkTask::cleanup(MM_EnvironmentBase *envBase)
 
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats.merge(&env->_markVLHGCStats);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.merge(&env->_workPacketStats);
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._continuationStats.merge(&env->_continuationStats);
 
 	if (!env->isMainThread()) {
 		env->_cycleState = NULL;
@@ -376,6 +378,7 @@ MM_GlobalMarkingScheme::mainSetupForGC(MM_EnvironmentVLHGC *env)
 	/* Initialize the marking stack */
 	env->_cycleState->_workPackets->reset(env);
 	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._workPacketStats.clear();
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._continuationStats.clear();
 
 	_interRegionRememberedSet->prepareOverflowedRegionsForRebuilding(env);
 }


### PR DESCRIPTION
Report total alive and started continuation Objects in mem-info of verbosegc log.
- piggyback iterateAllContinuationObjects(), which is designed to help improving the performance of jit code cache reclamation, to collect total and started numbers of continuation at the end of GC.
- report tag continuationObjects in <mem-info> of verbase gc if total alive continuation Objects isn't 0.

limitation of this changes:
in case iterateAllContinuationObjects() helper is not run, no counts would be collected and reported, such as
case1: scavenger backout case
case2: disable jitcodecacheReclaim feature
case3: there is no need jitcodecachereclamation for the cycle case4: runtime GC (there is no iterateAllContinuationObjects() helper in runtime GC).

depends on: https://github.com/eclipse/omr/pull/7386

Signed-off-by: hulin [linhu@ca.ibm.com](mailto:linhu@ca.ibm.com)
