### PR TITLE
CRIU adds NotCheckpointSafe at java/lang/ref/ReferenceQueue.poll

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -28,6 +28,10 @@ import jdk.internal.ref.Cleaner;
 import sun.misc.Cleaner;
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
+
 /**
  * ReferenceQueue is the container on which reference objects
  * are enqueued when their reachability type is detected for 
@@ -75,6 +79,9 @@ public class ReferenceQueue<T> extends Object {
  * @return		Reference
  *					next available Reference or NULL.
  */	
+/*[IF CRIU_SUPPORT]*/
+@NotCheckpointSafe
+/*[ENDIF] CRIU_SUPPORT */
 public Reference<? extends T> poll () {	
 	Reference ref;
 	


### PR DESCRIPTION
`CRIU` adds `NotCheckpointSafe` at `java/lang/ref/ReferenceQueue.poll`

Address `JVMCheckpointException: Blocking operation is not allowed in CRIU single thread mode`.

closes https://github.com/eclipse-openj9/openj9/issues/19653

Signed-off-by: Jason Feng <fengj@ca.ibm.com>