### PR TITLE
Restore MemberName on stack for linkTo* methods after PopFrame

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -143,6 +143,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<classref name="java/lang/invoke/MemberName" flags="opt_openjdkMethodhandle"/>
 	<classref name="java/lang/invoke/MethodTypeForm" flags="opt_openjdkMethodhandle"/>
 	<classref name="java/lang/invoke/LambdaForm" flags="opt_openjdkMethodhandle"/>
+	<classref name="java/lang/invoke/DirectMethodHandle" flags="opt_openjdkMethodhandle"/>
 
 	<classref name="jdk/internal/loader/NativeLibraries" versions="15-"/>
 	<classref name="jdk/internal/loader/NativeLibraries$NativeLibraryImpl" versions="15-"/>
@@ -415,6 +416,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/invoke/MemberName" name="resolution" signature="Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/LambdaForm" name="vmentry" signature="Ljava/lang/invoke/MemberName;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodHandle" name="form" signature="Ljava/lang/invoke/LambdaForm;" flags="opt_openjdkMethodhandle"/>
+	<fieldref class="java/lang/invoke/DirectMethodHandle" name="member" signature="Ljava/lang/invoke/MemberName;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodType" name="form" signature="Ljava/lang/invoke/MethodTypeForm;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodTypeForm" name="argCounts" signature="J" flags="opt_openjdkMethodhandle" versions="8-13"/>
 	<fieldref class="java/lang/invoke/MethodTypeForm" name="parameterSlotCount" signature="S" flags="opt_openjdkMethodhandle" versions="14-"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1415,6 +1415,29 @@ obj:
 				memset(_sp, 0, sizeof(UDATA) * ((methodIndexAndArgCount & 0xFF) + 1));
 				break;
 			}
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			case JBinvokestatic: {
+				U_16 index = *(U_16*)(_pc + 1);
+				J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
+				J9RAMMethodRef *ramMethodRef = ((J9RAMMethodRef*)ramConstantPool) + index;
+				J9Method *method = ramMethodRef->method;
+				void *methodRunAddress = method->methodRunAddress;
+				if (((void *)J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOSTATICSPECIAL == methodRunAddress)
+				|| ((void *)J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOINTERFACE == methodRunAddress)
+				|| ((void *)J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOVIRTUAL == methodRunAddress)
+				) {
+					j9object_t dmhReceiver = *(j9object_t *)_arg0EA;
+					Assert_VM_true(0 != isSameOrSuperClassOf(
+						J9VMJAVALANGINVOKEDIRECTMETHODHANDLE_OR_NULL(_vm),
+						J9OBJECT_CLAZZ(_currentThread, dmhReceiver)));
+					j9object_t memberName = J9VMJAVALANGINVOKEDIRECTMETHODHANDLE_MEMBER(_currentThread, dmhReceiver);
+					*--_sp = (UDATA)memberName;
+				}
+				break;
+			}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+			default:
+				break;
 			}
 		} else {
 			/* ForceEarlyReturn */


### PR DESCRIPTION
OJDK MH INLs: `linkToStaticSpecial`, `linkToVirtual` and `linkToInterface`
pop the top element from the stack before executing the target method.
The top element is an instance of `MemberName`. These native INLs don't
show up on the stack, and when we pop a frame, we drop to the frame
which exists before these INLs. A crash happens if the element popped
by the OJDK MH INLs is not restored after a frame is popped. To
prevent the crash, the removed element is restored after a frame is
popped.

RTC Issue 151332
