### PR TITLE
Remove internal qtype methods

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -513,22 +513,8 @@ static void addEntryForFieldImpl(TR_VMField *field, TR::TypeLayoutBuilder &tlb, 
    bool trace = comp->getOption(TR_TraceILGen);
    uint32_t mergedLength = 0;
    J9UTF8 *signature = J9ROMFIELDSHAPE_SIGNATURE(field->shape);
-
-   bool isFieldPrimitiveValueType = false;
-
-   if (TR::Compiler->om.areFlattenableValueTypesEnabled())
-      {
-      if (TR::Compiler->om.isQDescriptorForValueTypesSupported())
-         {
-         isFieldPrimitiveValueType = vm->internalVMFunctions->isNameOrSignatureQtype(signature);
-         }
-      else
-         {
-         isFieldPrimitiveValueType = vm->internalVMFunctions->isFieldNullRestricted(field->shape);
-         }
-      }
-
-   if (isFieldPrimitiveValueType &&
+   if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
+       vm->internalVMFunctions->isFieldNullRestricted(field->shape) &&
        vm->internalVMFunctions->isFlattenableFieldFlattened(definingClass, field->shape))
       {
       char *prefixForChild = buildTransitiveFieldNames(prefix, prefixLength, field->shape, comp->trMemory()->currentStackRegion(), mergedLength);
@@ -1033,14 +1019,7 @@ J9::ClassEnv::classNameToSignature(const char *name, int32_t &len, TR::Compilati
       {
       len += 2;
       sig = (char *)comp->trMemory()->allocateMemory(len+1, allocKind);
-      if (clazz &&
-         TR::Compiler->om.areFlattenableValueTypesEnabled() &&
-         TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
-         self()->isPrimitiveValueTypeClass(clazz)
-         )
-         sig[0] = 'Q';
-      else
-         sig[0] = 'L';
+      sig[0] = 'L';
       memcpy(sig+1,name,len-2);
       sig[len-1]=';';
       }

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -142,28 +142,6 @@ J9::ObjectModel::areFlattenableValueTypesEnabled()
    }
 
 bool
-J9::ObjectModel::isQDescriptorForValueTypesSupported()
-   {
-   // TODO: Implementation is required to determine under which case 'Q' descriptor is removed
-#if defined(J9VM_OPT_JITSERVER)
-   if (auto stream = TR::CompilationInfo::getStream())
-      {
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-      return true;
-#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-      return false;
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-      }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-
-   J9JavaVM * javaVM = TR::Compiler->javaVM;
-   if (javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM))
-     return true;
-
-   return false;
-   }
-
-bool
 J9::ObjectModel::areValueBasedMonitorChecksEnabled()
    {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -71,11 +71,6 @@ public:
    */
    bool areFlattenableValueTypesEnabled();
    /**
-   * @brief Whether or not `Q` signature is supported
-   */
-   bool isQDescriptorForValueTypesSupported();
-
-   /**
    * @brief Whether the check is enabled on monitor object being value based class type
    */
    bool areValueBasedMonitorChecksEnabled();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2562,14 +2562,7 @@ TR_J9VMBase::getClassSignature_DEPRECATED(TR_OpaqueClassBlock * clazz, int32_t &
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      {
-      if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
-          TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
-          TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
-         sig[i++] = 'Q';
-      else
-         sig[i++] = 'L';
-      }
+      sig[i++] = 'L';
    memcpy(sig+i, name, len);
    i += len;
    if (* name != '[')
@@ -2597,14 +2590,7 @@ TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock * clazz, TR_Memory * trMemory
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      {
-      if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
-          TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
-          TR::Compiler->cls.isPrimitiveValueTypeClass(myClass))
-         sig[i++] = 'Q';
-      else
-         sig[i++] = 'L';
-      }
+      sig[i++] = 'L';
    memcpy(sig+i, name, len);
    i += len;
    if (* name != '[')

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9643,28 +9643,11 @@ TR_J9ByteCodeIlGenerator::packReferenceChainOffsets(TR::Node *node, std::vector<
 #endif
 
 bool
-TR_ResolvedJ9Method::isFieldQType(int32_t cpIndex)
-   {
-   J9ROMFieldRef *ref = (J9ROMFieldRef *) (&romCPBase()[cpIndex]);
-   J9ROMNameAndSignature *nameAndSignature = J9ROMFIELDREF_NAMEANDSIGNATURE(ref);
-   J9UTF8 *signature = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature);
-
-   J9VMThread *vmThread = fej9()->vmThread();
-   return vmThread->javaVM->internalVMFunctions->isNameOrSignatureQtype(signature);
-   }
-
-bool
 TR_ResolvedJ9Method::isFieldNullRestricted(TR::Compilation *comp, int32_t cpIndex, bool isStatic, bool isStore)
    {
    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
-
-   if (TR::Compiler->om.isQDescriptorForValueTypesSupported())
-      {
-      if (isFieldQType(cpIndex)) // Temporary until javac supports NullRestricted attribute
-         return true;
-      }
 
    J9VMThread *vmThread = fej9()->vmThread();
    J9ROMFieldShape *fieldShape = NULL;

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -470,13 +470,6 @@ protected:
    TR_ResolvedMethod *             aotMaskResolvedPossiblyPrivateVirtualMethod(TR::Compilation *comp, TR_ResolvedMethod *method);
    TR_ResolvedMethod *             aotMaskResolvedImproperInterfaceMethod(TR::Compilation *comp, TR_ResolvedMethod *method);
 
-   /**
-    * @brief Check if a field is a QType or not.
-    *
-    * @param[in] cpIndex : the constant pool index of the field
-    */
-   virtual bool isFieldQType(int32_t cpIndex);
-
 public:
    virtual bool                    virtualMethodIsOverridden();
    virtual void                    setVirtualMethodIsOverridden();

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1845,28 +1845,11 @@ TR_ResolvedJ9JITServerMethod::archetypeArgPlaceholderSlot()
    }
 
 bool
-TR_ResolvedJ9JITServerMethod::isFieldQType(int32_t cpIndex)
-   {
-   auto comp = _fe->_compInfoPT->getCompilation();
-   int32_t sigLen;
-   char *sig = fieldOrStaticSignatureChars(cpIndex, sigLen);
-   J9UTF8 *utfWrapper = str2utf8(sig, sigLen, comp->trMemory(), heapAlloc);
-
-   J9VMThread *vmThread = comp->j9VMThread();
-   return vmThread->javaVM->internalVMFunctions->isNameOrSignatureQtype(utfWrapper);
-   }
-
-bool
 TR_ResolvedJ9JITServerMethod::isFieldNullRestricted(TR::Compilation *comp, int32_t cpIndex, bool isStatic, bool isStore)
    {
    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() ||
       (-1 == cpIndex))
       return false;
-
-   if (TR::Compiler->om.isQDescriptorForValueTypesSupported())
-      {
-      return isFieldQType(cpIndex);
-      }
 
    _stream->write(JITServer::MessageType::ResolvedMethod_isFieldNullRestricted, _remoteMirror, cpIndex, isStatic, isStore);
    return std::get<0>(_stream->read<bool>());

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -244,8 +244,6 @@ protected:
    virtual bool validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation);
    virtual bool canCacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic);
 
-   virtual bool isFieldQType(int32_t cpIndex) override;
-
 private:
 
    J9ROMClass *_romClass; // cached copy of ROM class from client

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6749,24 +6749,9 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
             case TR::Address:
                {
                const char *fieldSignature = entry._typeSignature;
-
-               // If the field's signature begins with a Q, it is a value type and should be initialized with a default value
-               // for that value type.  That's handled with a recursive call to genAconst_init.
-               // If the signature does not begin with a Q, the field is an identity type whose default value is a Java null
-               /// reference.
-               bool isNullRestricted = false;
                if (TR::Compiler->om.areFlattenableValueTypesEnabled())
                   {
-                  if (!TR::Compiler->om.isQDescriptorForValueTypesSupported())
-                     {
-                     isNullRestricted = entry._isNullRestricted;
-                     }
-                  else if (fieldSignature[0] == 'Q')
-                     {
-                     isNullRestricted = true;
-                     }
-
-                  if (isNullRestricted)
+                  if (entry._isNullRestricted)
                      {
                      // In non-SVM AOT compilation, cpIndex is required for AOT relocation.
                      // In this case, cpindex is unknown for the field.
@@ -6787,7 +6772,7 @@ TR_J9ByteCodeIlGenerator::genAconst_init(TR_OpaqueClassBlock *valueTypeClass, in
                      }
                   }
 
-               if (!isNullRestricted)
+               if (!entry._isNullRestricted)
                   {
                   if (comp()->target().is64Bit())
                      {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -201,12 +201,7 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
             }
          else
             {
-            if (TR::Compiler->om.areFlattenableValueTypesEnabled() &&
-                TR::Compiler->om.isQDescriptorForValueTypesSupported() &&
-                TR::Compiler->cls.isPrimitiveValueTypeClass(clazz))
-               sigStr[0] = 'Q';
-            else
-               sigStr[0] = 'L';
+            sigStr[0] = 'L';
             memcpy(&sigStr[1], className, sigLen - 2);
             sigStr[sigLen-1]=';';
             }

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -209,9 +209,7 @@ initImpl(J9VMThread *currentThread, j9object_t membernameObject, j9object_t refO
 			flags |= MN_TRUSTED_FINAL;
 		}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (vmFuncs->isNameOrSignatureQtype(J9ROMFIELDSHAPE_SIGNATURE(romField))
-			|| J9ROMFIELD_IS_NULL_RESTRICTED(romField)
-		) {
+		if (J9ROMFIELD_IS_NULL_RESTRICTED(romField)) {
 			if (vmFuncs->isFlattenableFieldFlattened(fieldID->declaringClass, fieldID->field)) {
 				flags |= MN_FLAT_FIELD;
 			}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5110,8 +5110,6 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_OPT_JITSERVER */
 	IDATA ( *createJoinableThreadWithCategory)(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend, omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category) ;
 	BOOLEAN ( *valueTypeCapableAcmp)(struct J9VMThread *currentThread, j9object_t lhs, j9object_t rhs) ;
-	BOOLEAN ( *isNameOrSignatureQtype)(J9UTF8 *utfWrapper) ;
-	BOOLEAN ( *isClassRefQtype)(struct J9Class *cpContextClass, U_16 cpIndex) ;
 	BOOLEAN ( *isFieldNullRestricted)(J9ROMFieldShape *field);
 	UDATA ( *getFlattenableFieldOffset)(struct J9Class *fieldOwner, J9ROMFieldShape *field);
 	BOOLEAN ( *isFlattenableFieldFlattened)(J9Class *fieldOwner, J9ROMFieldShape *field);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2686,29 +2686,6 @@ BOOLEAN
 valueTypeCapableAcmp(J9VMThread *currentThread, j9object_t lhs, j9object_t rhs);
 
 /**
- * Determines if a name or a signature pointed by a J9UTF8 pointer is a Qtype.
- *
- * @param[in] utfWrapper J9UTF8 pointer that points to the name or the signature
- *
- * @return TRUE if the name or the signature pointed by the J9UTF8 pointer is a Qtype, FALSE otherwise
- */
-BOOLEAN
-isNameOrSignatureQtype(J9UTF8 *utfWrapper);
-
-
-/**
- * Determines if the classref c=signature is a Qtype. There is no validation performed
- * to ensure that the cpIndex points at a classref.
- *
- * @param[in] cpContextClass ramClass that owns the constantpool being queried
- * @param[in] cpIndex the CP index
- *
- * @return TRUE if classref is a Qtype, FALSE otherwise
- */
-BOOLEAN
-isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex);
-
-/**
  * Determines if null restricted attribute is set on a field or not.
  *
  * @param[in] field The field to be checked

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4379,7 +4379,7 @@ done:
 				rc = GOTO_THROW_CURRENT_EXCEPTION;
 			} else {
 				I_32 result = false;
-				if (VM_ValueTypeHelpers::isNameOrSignatureQtype(J9ROMFIELDSHAPE_SIGNATURE(fieldID->field)) || J9ROMFIELD_IS_NULL_RESTRICTED(fieldID->field)) {
+				if (J9ROMFIELD_IS_NULL_RESTRICTED(fieldID->field)) {
 					result = (I_32)isFlattenableFieldFlattened(fieldID->declaringClass, fieldID->field);
 				}
 				restoreInternalNativeStackFrame(REGISTER_ARGS);
@@ -8551,9 +8551,6 @@ retry:
 					goto done;
 				}
 			} else {
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-resolve:
-#endif /* J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES */
 				/* Unresolved */
 				buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 				updateVMStruct(REGISTER_ARGS);
@@ -8570,23 +8567,12 @@ resolve:
 				goto retry;
 			}
 		}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		else if (VM_ValueTypeHelpers::isClassRefQtype(ramConstantPool, index)) {
-			/* Even though an NPE is going to be thrown the classref must still be resolved because
-			 * its a qtype.
-			 *
-			 * TODO in the future a different type of exception may thrown, spec for this behaviour
-			 * not currently known.
-			 */
-			if (NULL == castClass) {
-				/* Resolve the class and then check again whether it is a value type */
-				goto resolve;
-			}
 
-			rc = THROW_NPE;
-			goto done;
-		}
-#endif /* J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES */
+		/* In the future Valhalla checkcast needs to throw exception on
+		 * null restricted checkedType if obj is null,
+		 * see issue https://github.com/eclipse-openj9/openj9/issues/19764
+		 */
+
 		_pc += 3;
 done:
 		return rc;

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -110,18 +110,6 @@ valueTypeCapableAcmp(J9VMThread *currentThread, j9object_t lhs, j9object_t rhs)
 }
 
 BOOLEAN
-isNameOrSignatureQtype(J9UTF8 *utfWrapper)
-{
-	return VM_ValueTypeHelpers::isNameOrSignatureQtype(utfWrapper);
-}
-
-BOOLEAN
-isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex)
-{
-	return VM_ValueTypeHelpers::isClassRefQtype(cpContextClass->ramConstantPool, cpIndex);
-}
-
-BOOLEAN
 isFieldNullRestricted(J9ROMFieldShape *field)
 {
 	return VM_ValueTypeHelpers::isFieldNullRestricted(field);

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -190,48 +190,6 @@ public:
 	}
 
 	/**
-	* Determines if a name or a signature pointed by a J9UTF8 pointer is a Qtype.
-	*
-	* @param[in] utfWrapper J9UTF8 pointer that points to the name or the signature
-	*
-	* @return true if the name or the signature pointed by the J9UTF8 pointer is a Qtype, false otherwise
-	*/
-	static VMINLINE bool
-	isNameOrSignatureQtype(J9UTF8 *utfWrapper)
-	{
-		bool rc = false;
-		if (NULL != utfWrapper) {
-			U_8 *nameOrSignatureData = J9UTF8_DATA(utfWrapper);
-			U_16 nameOrSignatureLength = J9UTF8_LENGTH(utfWrapper);
-
-			if ((nameOrSignatureLength > 0)
-				&& (';' == nameOrSignatureData[nameOrSignatureLength - 1])
-				&& ('Q' == nameOrSignatureData[0])
-			) {
-				rc = true;
-			}
-		}
-		return rc;
-	}
-
-	/**
-	* Determines if the classref c=signature is a Qtype. There is no validation performed
-	* to ensure that the cpIndex points at a classref.
-	*
-	* @param[in] ramCP the constantpool that is being queried
-	* @param[in] cpIndex the CP index
-	*
-	* @return true if classref is a Qtype, false otherwise
-	*/
-	static VMINLINE bool
-	isClassRefQtype(J9ConstantPool *ramCP, U_16 cpIndex)
-	{
-		J9ROMStringRef *romStringRef = (J9ROMStringRef *)&ramCP->romConstantPool[cpIndex];
-		J9UTF8 *classNameWrapper = J9ROMSTRINGREF_UTF8DATA(romStringRef);
-		return isNameOrSignatureQtype(classNameWrapper);
-	}
-
-	/**
 	 * Determines if null restricted attribute is set on a field or not.
 	 *
 	 * @param[in] field The field to be checked

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -382,8 +382,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* J9VM_OPT_JITSERVER */
 	createJoinableThreadWithCategory,
 	valueTypeCapableAcmp,
-	isNameOrSignatureQtype,
-	isClassRefQtype,
 	isFieldNullRestricted,
 	getFlattenableFieldOffset,
 	isFlattenableFieldFlattened,

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -279,7 +279,7 @@ public class ValueTypeGenerator extends ClassLoader {
 			testWithFieldOnNonExistentClass(cw, className, fields);
 			testMonitorExitOnObject(cw, className, fields);
 			testMonitorEnterAndExitWithRefType(cw, className, fields);
-			testCheckCastRefClassOnNull(cw, className, fields);
+			testCheckCastNullableTypeOnNull(cw, className, fields);
 			if (valueUsedInCode != null) {
 				testUnresolvedValueTypeDefaultValue(cw, className, valueUsedInCode);
 				if (valueFields != null) {
@@ -293,14 +293,13 @@ public class ValueTypeGenerator extends ClassLoader {
 		} else {
 			makeValue(cw, className, makeValueSig, fields, makeMaxLocal);
 			makeValueTypeDefaultValue(cw, className, makeValueSig, fields, makeMaxLocal);
-			testCheckCastValueTypeOnNull(cw, className, fields);
-			testCheckCastValueTypeOnNonNullType(cw, className, fields);
+			testCheckCastNullRestrictedTypeOnNull(cw, className, fields);
+			testCheckCastNullRestrictedTypeOnNonNullType(cw, className, fields);
 			if (!isVerifiable) {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
 			}
 		}
 		test2DMultiANewArray(cw, className);
-		testCheckCastOnInvalidLtype(cw);
 		addStaticSynchronizedMethods(cw);
 		if (addSyncMethods) {
 			addSynchronizedMethods(cw);
@@ -496,8 +495,8 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitEnd();
 	}
 
-	private static void testCheckCastValueTypeOnNonNullType(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "testCheckCastValueTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
+	private static void testCheckCastNullRestrictedTypeOnNonNullType(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "testCheckCastNullRestrictedTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitTypeInsn(ValhallaUtils.ACONST_INIT, className);
 		mv.visitTypeInsn(CHECKCAST, className);
@@ -506,8 +505,8 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitEnd();
 	}
 
-	private static void testCheckCastValueTypeOnNull(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastValueTypeOnNull", "()Ljava/lang/Object;", null, null);
+	private static void testCheckCastNullRestrictedTypeOnNull(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastNullRestrictedTypeOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
 		mv.visitTypeInsn(CHECKCAST, className);
@@ -515,19 +514,9 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitMaxs(1, 2);
 		mv.visitEnd();
 	}
-	
-	private static void testCheckCastOnInvalidLtype(ClassWriter cw) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastOnInvalidLtype", "()Ljava/lang/Object;", null, null);
-		mv.visitCode();
-		mv.visitInsn(ACONST_NULL);
-		mv.visitTypeInsn(CHECKCAST, "ClassDoesNotExist");
-		mv.visitInsn(ARETURN);
-		mv.visitMaxs(1, 2);
-		mv.visitEnd();
-	}
 
-	private static void testCheckCastRefClassOnNull(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastRefClassOnNull", "()Ljava/lang/Object;", null, null);
+	private static void testCheckCastNullableTypeOnNull(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastNullableTypeOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
 		mv.visitTypeInsn(CHECKCAST, className);

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2441,19 +2441,6 @@ public class ValueTypeTests {
 	}
 
 	/*
-	 * Ensure that casting null to invalid Qtype class will throw a NoClassDef
-	 */
-	@Test(priority=1)
-	static public void testCheckCastValueTypeOnInvalidLtype() throws Throwable {
-		try {
-			String fields[] = {"longField:J"};
-			Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastOnInvalidLtype", fields);
-			MethodHandle checkCastOnInvalidLtype = lookup.findStatic(valueClass, "testCheckCastOnInvalidLtype", MethodType.methodType(Object.class));
-			checkCastOnInvalidLtype.invoke();
-		} catch (Exception e) {
-			Assert.fail("Should not throw exception");
-		}
-	}
 	
 	/*
 	 * Ensure that casting null to a value type class will throw a null pointer exception
@@ -2462,10 +2449,10 @@ public class ValueTypeTests {
 	 * no longer requires null check on the objectref for null restricted value type class
 	 */
 	@Test(enabled=false, priority=1, expectedExceptions=NullPointerException.class)
-	static public void testCheckCastValueTypeOnNull() throws Throwable {
+	static public void testCheckCastNullRestrictedTypeOnNull() throws Throwable {
 		String fields[] = {"longField:J"};
-		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNull", fields);
-		MethodHandle checkCastValueTypeOnNull = lookup.findStatic(valueClass, "testCheckCastValueTypeOnNull", MethodType.methodType(Object.class));
+		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastNullRestrictedTypeOnNull", fields);
+		MethodHandle checkCastValueTypeOnNull = lookup.findStatic(valueClass, "testCheckCastNullRestrictedTypeOnNull", MethodType.methodType(Object.class));
 		checkCastValueTypeOnNull.invoke();
 	}
 
@@ -2473,10 +2460,10 @@ public class ValueTypeTests {
 	 * Ensure that casting a non null value type to a valid value type will pass
 	 */
 	@Test(priority=1)
-	static public void testCheckCastValueTypeOnNonNullType() throws Throwable {
+	static public void testCheckCastNullRestrictedTypeOnNonNullType() throws Throwable {
 		String fields[] = {"longField:J"};
-		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNonNullType", fields);
-		MethodHandle checkCastValueTypeOnNonNullType = lookup.findStatic(valueClass, "testCheckCastValueTypeOnNonNullType", MethodType.methodType(Object.class));
+		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastNullRestrictedTypeOnNonNullType", fields);
+		MethodHandle checkCastValueTypeOnNonNullType = lookup.findStatic(valueClass, "testCheckCastNullRestrictedTypeOnNonNullType", MethodType.methodType(Object.class));
 		checkCastValueTypeOnNonNullType.invoke();
 	}
 
@@ -2484,10 +2471,10 @@ public class ValueTypeTests {
 	 * Ensure that casting null to a reference type class will pass
 	 */
 	@Test(priority=1)
-	static public void testCheckCastRefClassOnNull() throws Throwable {
+	static public void testCheckCastNullableTypeOnNull() throws Throwable {
 		String fields[] = {"longField:J"};
-		Class refClass = ValueTypeGenerator.generateRefClass("TestCheckCastRefClassOnNull", fields);
-		MethodHandle checkCastRefClassOnNull = lookup.findStatic(refClass, "testCheckCastRefClassOnNull", MethodType.methodType(Object.class));
+		Class refClass = ValueTypeGenerator.generateRefClass("TestCheckCastNullableTypeOnNull", fields);
+		MethodHandle checkCastRefClassOnNull = lookup.findStatic(refClass, "testCheckCastNullableTypeOnNull", MethodType.methodType(Object.class));
 		checkCastRefClassOnNull.invoke();
 	}
 


### PR DESCRIPTION
- isNameOrSignatureQType
- isClassRefQtype
- isFieldQType
- isQDescriptorForValueTypesSupported

Related to https://github.com/eclipse-openj9/openj9/issues/18157