### PR TITLE
Mounts .ssh folder in docker and avoids git key error

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -821,7 +821,7 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     if ("${DOCKER_IMAGE}") {
                         prepare_docker_environment()
-                        docker.image(DOCKER_IMAGE_ID).inside("-v /home/jenkins/openjdk_cache:/home/jenkins/openjdk_cache:rw,z") {
+                        docker.image(DOCKER_IMAGE_ID).inside("-v /home/jenkins/openjdk_cache:/home/jenkins/openjdk_cache:rw,z -v /home/jenkins/.ssh:/home/jenkins/.ssh:rw,z") {
                             _build_all()
                         }
                     } else {


### PR DESCRIPTION
adds .ssh folder additionally and prevents public key error while cloning git repositories. In this way we can have needed key added to host machine and then run docker and having needed keys ready when it is not presented in the image related: infra 9291

Signed-off-by: mahdi@ibm.com