### PR TITLE
(0.46.0) Disable x86 TLH prefetch by default after Broadwell

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2178,7 +2178,7 @@ void J9::Options::preProcessTLHPrefetch(J9JavaVM *vm)
 #else // TR_HOST_X86
    preferTLHPrefetch =
       (TR::Compiler->target.cpu.isGenuineIntel() &&
-       TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_X86_INTEL_SKYLAKE)) ||
+       TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_X86_INTEL_BROADWELL)) ||
       !TR::Compiler->target.cpu.isGenuineIntel();
 
    // Disable TM on x86 because we cannot tell whether a Haswell chip supports


### PR DESCRIPTION
Performance analysis and measurement on multiple workloads suggests that enabling TLH prefetching by default on Skylake is suboptimal.  Only enable by default up until the Broadwell microarchitecture.