### PR TITLE
Fixes to code cache disclaiming

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -119,8 +119,12 @@ public:
    */
    void resetAllocationPointers();
 
-   uint8_t * _warmCodeAllocBase; // used to reset the allocation pointers to initial values
-   uint8_t * _coldCodeAllocBase;
+   uint8_t *_warmCodeAllocBase; // used to reset the allocation pointers to initial values
+   uint8_t *_coldCodeAllocBase;
+#ifdef LINUX
+   uint8_t *_smallPageAreaStart; // used for code cache disclaiming to remember where the small page area starts/ends
+   uint8_t *_smallPageAreaEnd;
+#endif
    };
 
 


### PR DESCRIPTION
Existing code disclaims the cold code between
`coldCodeAlloc` and `coldCodeAllocBase`.
However, if the amount of cold code is larger than the amount of warm code, we will ask to disclaim some parts of the segment which was allocated with THP. This will disable the THP setting and lower throughput.
This commit also introduces two new code cache fields that are used to memorize the start and end of the section forced to use small pages and that should be subject to disclaiming.

Signe-off-by: Marius <mpirvu@ca.ibm.com>