### PR TITLE
Remove JITHelpers.canEncodeAsLatin1() from Java 17+

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -566,6 +566,7 @@ public final class JITHelpers {
 		}
 	}
 
+/*[IF JAVA_SPEC_VERSION < 17]*/
 	public boolean canEncodeAsLatin1(byte[] array, int start, int length) {
 		int index = start << 1;
 		if (!IS_BIG_ENDIAN) {
@@ -578,6 +579,7 @@ public final class JITHelpers {
 		}
 		return true;
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 
 	/**
 	 * Returns the first index of the target character array within the source character array starting from the specified


### PR DESCRIPTION
The method JITHelpers.canEncodeAsLatin1() is used only by the String implementation before Java 17.