### PR TITLE
testDependency dir under C:/Users/jenkins/ should not be removed on windows

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
@@ -109,7 +109,7 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
                                  'testParentDir',
                                  'jni-*',
                                  'mauve',
-                                 'test*',
+                                 'test[^D]*',
                                  'blah-*.tmp',
                                  'lines*.tmp',
                                  'prefix*.json',


### PR DESCRIPTION
3rd party libs under C:/Users/jenkins/testDependency on Windows are pre-staged . However, this testDependency dir gets removed by this cleanup script since it removes patterns starting with test* in C:/Users/jenkins/ directory for windows machines.Due to missing pre-staged jars, the test jobs have to download the 3rd party jar at runtimes. The often cause test jobs failure because of unstable networks.

Helpful links:
https://github.ibm.com/runtimes/infrastructure/issues/9395