### PR TITLE
(0.46) Add required options to failing HCR tests

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
@@ -134,7 +134,7 @@
 	</test>
 
 	<test id="rc020">
-		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rc020 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rc020 -XX:+EnableExtendedHCR -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 


### PR DESCRIPTION
Resolves https://github.com/eclipse-openj9/openj9/issues/19778

Port of https://github.com/eclipse-openj9/openj9/pull/19792