### PR TITLE
Modify static assert to be C++11 conformant

### DIFF
--- a/runtime/compiler/runtime/MetricsServer.cpp
+++ b/runtime/compiler/runtime/MetricsServer.cpp
@@ -149,7 +149,7 @@ MetricsDatabase::MetricsDatabase(TR::CompilationInfo *compInfo) : _compInfo(comp
    _metrics[1] = new (PERSISTENT_NEW) AvailableMemoryMetric();
    _metrics[2] = new (PERSISTENT_NEW) ConnectedClientsMetric();
    _metrics[3] = new (PERSISTENT_NEW) ActiveThreadsMetric();
-   static_assert(3 == MAX_METRICS - 1);
+   static_assert(3 == MAX_METRICS - 1, "Unsupported number of metrics");
    }
 
 MetricsDatabase::~MetricsDatabase()


### PR DESCRIPTION
A static_assert declaration without a string literal message is only available in C++17. This causes a compilation error in clang, as the compiler is built with the C++11 standard.