### PR TITLE
Add override specifier to virtual declarations

### DIFF
--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -682,7 +682,7 @@ public:
 
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override;
 
-   virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
+   virtual J9SharedClassCacheDescriptor *getCacheDescriptorList() override;
 
    void setStream(JITServer::ServerStream *stream) { _stream = stream; }
    void setCompInfoPT(TR::CompilationInfoPerThread *compInfoPT) { _compInfoPT = compInfoPT; }
@@ -690,19 +690,19 @@ public:
 
 private:
 
-   virtual bool isPointerInMetadataSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr)
+   virtual bool isPointerInMetadataSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr) override
       {
       return isPointerInCache(cacheDesc, ptr);
       }
-   virtual bool isOffsetInMetadataSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, uintptr_t offset)
+   virtual bool isOffsetInMetadataSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, uintptr_t offset) override
       {
       return (isOffsetFromEnd(offset) && isOffsetInCache(cacheDesc, offset));
       }
-   virtual bool isPointerInROMClassesSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr)
+   virtual bool isPointerInROMClassesSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr) override
       {
       return isPointerInCache(cacheDesc, ptr);
       }
-   virtual bool isOffsetinROMClassesSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, uintptr_t offset)
+   virtual bool isOffsetinROMClassesSectionInCache(const J9SharedClassCacheDescriptor *cacheDesc, uintptr_t offset) override
       {
       return (isOffsetFromStart(offset) && isOffsetInCache(cacheDesc, offset));
       }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -197,7 +197,7 @@ public:
    virtual intptr_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptr_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
-   virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
+   virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) override { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
@@ -228,7 +228,7 @@ public:
    virtual UDATA getLowTenureAddress() override;
    virtual UDATA getHighTenureAddress() override;
 
-   virtual MethodOfHandle methodOfDirectOrVirtualHandle(uintptr_t *mh, bool isVirtual);
+   virtual MethodOfHandle methodOfDirectOrVirtualHandle(uintptr_t *mh, bool isVirtual) override;
 
    // Openjdk implementation
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -313,7 +313,7 @@ class TR_ResolvedRelocatableJ9JITServerMethod : public TR_ResolvedJ9JITServerMet
    virtual bool                  getUnresolvedVirtualMethodInCP(int32_t cpIndex) override;
    /* No need to override the stringConstant method as the parent method will be sufficient */
    virtual bool                  fieldAttributes(TR::Compilation * comp, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation) override;
-   virtual bool                  staticAttributes(TR::Compilation * comp, int32_t cpIndex, void * * address,TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation);
+   virtual bool                  staticAttributes(TR::Compilation * comp, int32_t cpIndex, void * * address,TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation) override;
    virtual TR_ResolvedMethod *   getResolvedImproperInterfaceMethod(TR::Compilation * comp, I_32 cpIndex) override;
 
    virtual TR_OpaqueMethodBlock *getNonPersistentIdentifier() override;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -522,9 +522,9 @@ public:
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 
 private:
-      virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize);
-      virtual uint8_t * allocateSpaceInDataCache(UDATA metaDataSize, UDATA type);
-      virtual void initializeCacheDeltas();
+      virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize) override;
+      virtual uint8_t * allocateSpaceInDataCache(UDATA metaDataSize, UDATA type) override;
+      virtual void initializeCacheDeltas() override;
       virtual void initializeAotRuntimeInfo() override { _classReloAmount = 1; }
 };
 #endif /* defined(J9VM_OPT_JITSERVER) */


### PR DESCRIPTION
Various virtual methods in derived classes override their base counterparts but are missing an override specifier. Clang warns about this, and so fails to compile with -Werror.