### PR TITLE
Remove redundant comment line in header

### DIFF
--- a/runtime/compiler/net/Message.cpp
+++ b/runtime/compiler/net/Message.cpp
@@ -1,5 +1,4 @@
 /*******************************************************************************
-/*******************************************************************************
  * Copyright IBM Corp. and others 2020
  *
  * This program and the accompanying materials are made available under


### PR DESCRIPTION
The extra comment line in this file generates a clang warning, because two start-of-block-comment `/*` tokens are ended by a single end-of-block-comment `*/` token at the end of the copyright header.