### PR TITLE
Do not update JVM CPU utilization too often

### DIFF
--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -100,6 +100,8 @@ private:
    int32_t _avgCpuUsage; // percentage of time each processor is used on average (0..100)
    int32_t _avgCpuIdle;  // percentage of time each processor is idle on average (0..100)
 
+   const int64_t _minIntervalLength; // Postpone the update until this many ns passed since the last update operation
+
    int64_t _prevIntervalLength; // the duration (in ns) of the last update interval
 
    // values recorded at start of this update interval


### PR DESCRIPTION
The JIT computes and displays in the verbose log the CPU consumed by the JVM process. It has been observed that when two readouts happen too close from one another, the values returned by the OS lose precision and the JVM may appear to use less CPU than in reality.

This commit prevents updating the JVM CPU values more frequently than every 100 ms.