### PR TITLE
Fix various cast errors

### DIFF
--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2570,7 +2570,6 @@ TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes(TR::Compilation * comp
 
    if (!resolveField)
       {
-      *address = (U_32)NULL;
       fieldInfoCanBeUsed = false;
       }
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4021,7 +4021,7 @@ int32_t TR_MultipleCallTargetInliner::scaleSizeBasedOnBlockFrequency(int32_t byt
 
       float factor = (float)adjFrequency / (float)maxFrequency;
       float weight = (float)bytecodeSize / (factor*factor);
-      bytecodeSize = (weight > 0x7fffffff) ? 0x7fffffff : ((int32_t)weight);
+      bytecodeSize = (weight >= (float)0x7fffffff) ? 0x7fffffff : ((int32_t)weight);
 
       heuristicTrace(tracer(),"exceedsSizeThreshold: Scaled up size for call from %d to %d", oldSize, bytecodeSize);
       }


### PR DESCRIPTION
- This store of `NULL` in `address` in `TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes` is unnecessary, as the same store occurs later on in that function if `fieldInfoCanBeUsed` is false and `address` is not `NULL`. It has been removed, which also eliminates a clang error - it is wary of converting a `(U_32)0` value to a `void *` value.
- The `weight` check in `TR_MultipleCallTargetInliner::scaleSizeBasedOnBlockFrequency` is supposed to guard against the UB of casting a floating-point value outside the int32_t range to an int32_t. The value `0x7fffffff` (decimal 2147483647) is not exactly representable as a 32-bit float; both gcc and clang convert it to the float value 2147483648.0 (one more than the literal). The added explicit `(float)` cast eliminates a clang warning about the issue of inexact representation.

  The check is also changed to `>=`, as in light of the above the previous code would fail if `weight` were ever exactly the floating-point value 2147483648.0.