### PR TITLE
Use C++-style initialization for zeroed array type

### DIFF
--- a/runtime/vm/UpcallExceptionHandler.cpp
+++ b/runtime/vm/UpcallExceptionHandler.cpp
@@ -55,7 +55,7 @@ ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *functi
 ffiCallWithSetJmpForUpcall(J9VMThread *currentThread, ffi_cif *cif, void *function, UDATA *returnStorage, void **values)
 #endif /* FFI_NATIVE_RAW_API */
 {
-	jmp_buf jmpBufferEnv = {0};
+	jmp_buf jmpBufferEnv = {};
 	void *jmpBufEnvPtr = currentThread->jmpBufEnvPtr;
 
 	/* We only need to restore back to the latest call-out from the dispatcher


### PR DESCRIPTION
The `{}` initializer will zero-initialize a variable of the array type `jmp_buf`. Clang otherwise complains about the use of `0` to zero-initialize this array type.