### PR TITLE
Improve JITServer AOT cache implementation portability

### DIFF
--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -122,11 +122,11 @@ public:
 protected:
    AOTCacheRecord() : _nextRecord(NULL) {}
 
-private:
    // Set the subrecord pointers in the variable-length portion of a record if necessary.
    // The subrecord pointers in the statically-sized portion of a record are set in the record constructors.
    virtual bool setSubrecordPointers(const JITServerAOTCacheReadContext &context) { return true; }
 
+private:
    AOTCacheRecord *_nextRecord;
    };
 

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -226,7 +226,7 @@ public:
 
 private:
    friend class AOTCacheRecord;
-   template<class D, class R, typename... Args> friend class AOTCacheListRecord;
+   friend class AOTCacheClassChainRecord;
 
    ClassChainSerializationRecord(uintptr_t id, size_t length);
    ClassChainSerializationRecord();
@@ -254,7 +254,7 @@ public:
 
 private:
    friend class AOTCacheRecord;
-   template<class D, class R, typename... Args> friend class AOTCacheListRecord;
+   friend class AOTCacheWellKnownClassesRecord;
 
    WellKnownClassesSerializationRecord(uintptr_t id, size_t length, uintptr_t includedClasses);
    WellKnownClassesSerializationRecord();


### PR DESCRIPTION
- The `AOTCacheRecord::setSubrecordPointers` method is now protected, instead of private. This works around a bug in clang. Without this, the invocation of `setSubrecordPointers` in the `AOTCacheRecord::readRecord<>` template method fails; clang complains that `setSubrecordPointers` is a private method of `AOTCacheRecord`. This shouldn't matter at all, as a method of `AOTCacheRecord` ought to be able to call the private methods of the `AOTCacheRecord` class itself, but clang issues an erroneous access error anyway.

- Instead of having an `AOTCacheListRecord` class from which the `AOTCacheClassChainRecord` and `AOTCacheWellKnownClassesRecord` classes are derived, those classes now derive from the base `AOTCacheRecord` class and declare their own methods separately. Some code duplication was avoided by adding static template functions for use in those classes' method implementations.

  The previous class inheritance structure was not portable; both clang and gcc support the non-standard flexible array member extension, but only gcc supports deriving from classes with a flexible array member (under certain circumstances).
