### PR TITLE
docker+cuda workaround for 86-64_linux and jdk17+

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -834,7 +834,7 @@ def create_docker_image_locally()
     dockerCredentialID = variableFile.get_user_credentials_id(dockerRegistry.replaceAll('https://','') ?: 'dockerhub')
     docker.withRegistry(dockerRegistry, "${dockerCredentialID}") {
             docker.build(new_image_name, "--build-arg image=${DOCKER_IMAGE} -f dockerFile .")
-    }    
+    }
     DOCKER_IMAGE = new_image_name
 }
 
@@ -845,9 +845,9 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     if ("${DOCKER_IMAGE}") {
                         // TODO: remove this workaround when https://github.com/adoptium/infrastructure/issues/3597 resolved. related: infra 9292
-                        if (SDK_VERSION.toInteger() >= 17 && PLATFORM ==~ /(x86-64_linux.*|ppc64le_linux.*)/ ) {
+                        if ((SDK_VERSION.toInteger() >= 17 && PLATFORM ==~ /x86-64_linux.*/) || (PLATFORM ==~ /ppc64le_linux.*/ )) {
                             create_docker_image_locally()
-                        }                        
+                        }
                         prepare_docker_environment()
                         docker.image(DOCKER_IMAGE_ID).inside("-v /home/jenkins/openjdk_cache:/home/jenkins/openjdk_cache:rw,z -v /home/jenkins/.ssh:/home/jenkins/.ssh:rw,z") {
                             _build_all()

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -226,10 +226,11 @@ ppc64le_linux:
     8: 'linux-ppc64le-normal-server-release'
     11: 'linux-ppc64le-normal-server-release'
   node_labels:
-    build: 'ci.role.build && hw.arch.ppc64le && sw.os.cent.7'
+    build: 'ci.role.build && hw.arch.ppc64le && sw.tool.docker'
+    docker_image: 'adoptopenjdk/centos7_build_image:latest'
   build_env:
-    cmd:
-      all: 'source /home/jenkins/set_gcc_11.2.0_env'
+    vars:
+      all: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
 #========================================#
 # Linux PPCLE 64bits /w JITSERVER
 #========================================#
@@ -304,9 +305,6 @@ x86-64_linux:
       11: 'eclipseopenj9/jenkins-agent-x86-centos6:29'
       all: 'adoptopenjdk/centos7_build_image:latest'
   build_env:
-    cmd:
-      # use env vars to configure gcc for 8, 11 (v11.2)
-      all: ''
     vars:
       all: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
   extra_test_labels:

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -298,22 +298,17 @@ x86-64_linux:
     11: 'linux-x86_64-normal-server-release'
   node_labels:
     build:
-      all: 'ci.role.build && hw.arch.x86 && sw.os.cent.7'
-      8: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
-      11: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
+      all: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
     docker_image:
       8: 'eclipseopenj9/jenkins-agent-x86-centos6:29'
       11: 'eclipseopenj9/jenkins-agent-x86-centos6:29'
+      all: 'adoptopenjdk/centos7_build_image:latest'
   build_env:
     cmd:
-      all: 'source /home/jenkins/set_gcc_11.2.0_env'
       # use env vars to configure gcc for 8, 11 (v11.2)
-      8: ''
-      11: ''
+      all: ''
     vars:
-      all: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
-      8: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
-      11: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
+      all: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
   extra_test_labels:
     11: '!sw.os.cent.6'
     17: '!sw.os.cent.6'


### PR DESCRIPTION
For 86-64_linux and jdk17+ builds adoptopenjdk/centos7_build_image do not have cuda headers and build fails. This will create an image on the fly based on adopt image and build wont fail. related infra 9292

Signed-off-by: mahdi@ibm.com