### PR TITLE
Re-enable inlining unrecognized intrinsics

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2738,8 +2738,6 @@ J9::Options::fePreProcess(void * base)
    self()->setOption(TR_EnableSymbolValidationManager);
 #endif
 
-   // Forcing inlining of unrecognized intrinsics needs more performance investigation
-   self()->setOption(TR_DisableInliningUnrecognizedIntrinsics);
 
    // Memory disclaiming is available only on Linux
    if (!TR::Compiler->target.isLinux())


### PR DESCRIPTION
- the degradation caused by inlining can't be reproduced locally anymore
- re-enable for further performance testing