### PR TITLE
-XX:+EnableExtendedHCR TestRefreshGCSpecialClassesCache JIT_ON modes

### DIFF
--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -308,6 +308,7 @@
 			<variation>Mode107</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-XX:+EnableExtendedHCR \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)javaagenttest.jar$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames RefreshGCCache_NoBCI_Test \
@@ -361,6 +362,7 @@
 			<variation>Mode107</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-XX:+EnableExtendedHCR \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)javaagenttest.jar$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames RefreshGCCache_FastHCR_Test \


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19777

Tested on zlinux and Windows via https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3739/, which passed.

This may be reverted once the JIT fix https://github.com/eclipse-openj9/openj9/issues/19777#issuecomment-2209507409 is ready.