### PR TITLE
JIT: Detect in-place redefinition based on J9JITRedefinedClass

### DIFF
--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -308,7 +308,6 @@
 			<variation>Mode107</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-XX:+EnableExtendedHCR \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)javaagenttest.jar$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames RefreshGCCache_NoBCI_Test \
@@ -362,7 +361,6 @@
 			<variation>Mode107</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-XX:+EnableExtendedHCR \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)javaagenttest.jar$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames RefreshGCCache_FastHCR_Test \


### PR DESCRIPTION
Previously, the redefinition hook would determine the relationship between the old/new and stale/fresh status of redefined classes by checking for `TR_EnableHCR`. This was a proxy for debug mode, in which fast HCR is off because redefinition will OSR and discard the entire code cache. Until recently, this determination was accurate because in debug mode the VM would always redefine classes out-of-place to allow for "extended HCR." However, extended HCR is now being deprecated, and as of 704a781a1e6a, by default it's off and redefinition is in-place.

If a class was redefined in-place unexpectedly, the hook would mix up the old and the new class, which would result in an incorrect CH table state.

Rather than try to predict whether redefinition is supposed to be done in-place, the hook will now detect whether it was in fact done in-place.

Fixes #19777