### PR TITLE
Add Open XL equivalent for EXPORTALL in jvmtitests

### DIFF
--- a/runtime/tests/jvmtitests/agent/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/agent/CMakeLists.txt
@@ -42,7 +42,10 @@ target_link_libraries(jvmti_test_agent
 		jvmti_test_src
 )
 
-
 if(OMR_OS_ZOS)
-	target_compile_options(jvmti_test_agent PRIVATE -Wc,DLL,EXPORTALL)
+	if(OMR_TOOLCONFIG STREQUAL "openxl")
+		target_compile_options(jvmti_test_agent PRIVATE -fvisibility=default)
+	else()
+		target_compile_options(jvmti_test_agent PRIVATE -Wc,DLL,EXPORTALL)
+	endif()
 endif()

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -200,5 +200,9 @@ target_link_libraries(jvmti_test_src
 )
 
 if(OMR_OS_ZOS)
-	target_compile_options(jvmti_test_src PRIVATE -Wc,DLL,EXPORTALL)
+	if(OMR_TOOLCONFIG STREQUAL "openxl")
+		target_compile_options(jvmti_test_src PRIVATE -fvisibility=default)
+	else()
+		target_compile_options(jvmti_test_src PRIVATE -Wc,DLL,EXPORTALL)
+	endif()
 endif()


### PR DESCRIPTION
Having confirmed that exporting symbols is required for jvmtitests,
this change adds an Open XL conditional for the flag EXPORTALL
(-fvisibility=default).