### PR TITLE
Implement JVM_IsContainerized and fix JVM_IsUseContainerSupport

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -35,6 +35,8 @@
 #include "j9vmnls.h"
 #include "j9version.h"
 
+extern J9JavaVM *BFUjavaVM; /* from jvm.c */
+
 #if JAVA_SPEC_VERSION >= 11
 
 #define J9TIME_NANOSECONDS_PER_SECOND         ((jlong) 1000000000)
@@ -1730,12 +1732,18 @@ JVM_IsSharingEnabled(JNIEnv *env)
 #endif /* JAVA_SPEC_VERSION < 23 */
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
+/**
+ * @brief Determine if container support is enabled.
+ *
+ * @return JNI_FALSE if -XX:-UseContainerSupport is specified; otherwise, JNI_TRUE
+ */
 JNIEXPORT jboolean JNICALL
-JVM_IsUseContainerSupport(JNIEnv *env)
+JVM_IsUseContainerSupport(void)
 {
-	J9VMThread *const currentThread = (J9VMThread *)env;
-	J9JavaVM *vm = currentThread->javaVM;
+	J9JavaVM *vm = BFUjavaVM;
 	jboolean result = JNI_FALSE;
+
+	Assert_SC_true(NULL != vm);
 
 	if (J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_USE_CONTAINER_SUPPORT)) {
 		/* Return true if -XX:+UseContainerSupport is specified. This option is enabled by default. */

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -793,10 +793,25 @@ JVM_GetCDSConfigStatus()
 #endif /* JAVA_SPEC_VERSION >= 23 */
 
 #if JAVA_SPEC_VERSION >= 24
+/**
+ * @brief Determine if the JVM is running inside a container.
+ *
+ * @return JNI_TRUE if running inside a container; otherwise, JNI_FALSE
+ */
 JNIEXPORT jboolean JNICALL
 JVM_IsContainerized(void)
 {
-	return JNI_FALSE;
+	J9JavaVM *vm = BFUjavaVM;
+	jboolean isContainerized = JNI_FALSE;
+
+	Assert_SC_true(NULL != vm);
+
+	OMRPORT_ACCESS_FROM_J9PORT(vm->portLibrary);
+	if (omrsysinfo_is_running_in_container()) {
+		isContainerized = JNI_TRUE;
+	}
+
+	return isContainerized;
 }
 #endif /* JAVA_SPEC_VERSION >= 24 */
 

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -382,7 +382,7 @@ _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_DefineArchivedModules, JNICALL, false, void, JNIEnv *env, jobject obj1, jobject obj2)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_LogLambdaFormInvoker, JNICALL, false, void, JNIEnv *env, jstring str)])
-_X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)
+_X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, void)
 _X(AsyncGetCallTrace, JNICALL, false, void, void *trace, jint depth, void *ucontext)
 _IF([JAVA_SPEC_VERSION >= 17],
 	[_X(JVM_DumpClassListToFile, JNICALL, false, void, JNIEnv *env, jstring str)])


### PR DESCRIPTION
An implementation of `JVM_IsContainerized` has been added.

The signature of `JVM_IsUseContainerSupport` has been corrected.

Closes: #19801