### PR TITLE
Optionally allow methods that generate IL to mask flags fields to yield zero or one as a result

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1309,12 +1309,6 @@ J9::SymbolReferenceTable::findOrCreateClassFlagsSymbolRef()
 
 
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateClassAndDepthFlagsSymbolRef()
-   {
-   return self()->findOrCreateClassDepthAndFlagsSymbolRef();
-   }
-
-TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateClassDepthAndFlagsSymbolRef()
    {
    if (!element(isClassDepthAndFlagsSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -243,7 +243,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateInstanceDescriptionSymbolRef();
    TR::SymbolReference * findOrCreateDescriptionWordFromPtrSymbolRef();
    TR::SymbolReference * findOrCreateClassFlagsSymbolRef();
-   TR::SymbolReference * findOrCreateClassAndDepthFlagsSymbolRef();
    TR::SymbolReference * findOrCreateClassDepthAndFlagsSymbolRef();
    TR::SymbolReference * findOrCreateArrayComponentTypeAsPrimitiveSymbolRef();
    TR::SymbolReference * findOrCreateMethodTypeCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1246,30 +1246,39 @@ public:
    /**
     * \brief Load class flags field of the specified class and test whether any of the
     *        specified flags is set.
-    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
-    * \param flagsToTest    The class field flags that are to be checked
+    * \param[in] j9ClassRefNode  A node representing a reference to a \ref J9Class
+    * \param[in] flagsToTest     The class field flags that are to be checked
+    * \param[in] zeroOrOneResult A \c bool flag specifying that the result of the
+    *                            test will be zero or one if the flag is true, or
+    *                            zero or non-zero if the flag is false
     * \return \ref TR::Node that evaluates to a non-zero integer if any of the specified
     *         flags is set; or evaluates to zero, otherwise.
     */
-   TR::Node * testAreSomeClassFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
+   TR::Node * testAreSomeClassFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest, bool zeroOrOneResult = false);
 
    /**
     * \brief Load class flags field of the specified class and test whether the value type
     *        flag is set.
-    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \param[in] j9ClassRefNode  A node representing a reference to a \ref J9Class
+    * \param[in] zeroOrOneResult A \c bool flag specifying that the result of the
+    *                            test will be zero or one if the flag is true, or
+    *                            zero or non-zero if the flag is false
     * \return \ref TR::Node that evaluates to a non-zero integer if the class is a value type,
     *         or zero if the class is an identity type
     */
-   TR::Node * testIsClassValueType(TR::Node *j9ClassRefNode);
+   TR::Node * testIsClassValueType(TR::Node *j9ClassRefNode, bool zeroOrOneResult = false);
 
    /**
     * \brief Load class flags field of the specified class and test whether the hasIdentity
     *        flag is set.
-    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \param[in] j9ClassRefNode  A node representing a reference to a \ref J9Class
+    * \param[in] zeroOrOneResult A \c bool flag specifying that the result of the
+    *                            test will be zero or one if the flag is true, or
+    *                            zero or non-zero if the flag is false
     * \return \ref TR::Node that evaluates to a non-zero integer if the class is an identity type,
     *         or zero otherwise
     */
-   TR::Node * testIsClassIdentityType(TR::Node *j9ClassRefNode);
+   TR::Node * testIsClassIdentityType(TR::Node *j9ClassRefNode, bool zeroOrOneResult = false);
 
    /**
     * \brief Generate IL to load the value of the \c componentType field of the specified
@@ -1292,22 +1301,28 @@ public:
    /**
     * \brief Generate IL to load the \c classDepthAndFlags field of the specified
     *        \ref J9Class, and apply the mask specified by \c flagsToTest.
-    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
-    * \param flagsToTest Flags to use as a mask for the \ref classAndFlags field
+    * \param[in] j9ClassRefNode  A node representing a reference to a \ref J9Class
+    * \param[in] flagsToTest     Flags to use as a mask for the \ref classAndFlags field
+    * \param[in] zeroOrOneResult A \c bool flag specifying that the result of the
+    *                            test will be zero or one if the flag is true, or
+    *                            zero or non-zero if the flag is false
     * \return A \ref TR::Node that produces the result of loading \c classDepthAndFlags
     *         and applying the \c flagsToTest mask to it.
     */
-   TR::Node * testAreSomeClassDepthAndFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
+   TR::Node * testAreSomeClassDepthAndFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest, bool zeroOrOneResult = false);
 
    /**
     * \brief Generate IL to test whether the specified \ref J9Class is an array class.
-    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \param[in] j9ClassRefNode  A node representing a reference to a \ref J9Class
+    * \param[in] zeroOrOneResult A \c bool flag specifying that the result of the
+    *                            test will be zero or one if the flag is true, or
+    *                            zero or non-zero if the flag is false
     * \return A \ref TR::Node that will evaluate to zero if the specified \ref J9Class
     *         is not an array class, or the value of
     *         \c TR::Compiler->cls.flagValueForArrayCheck (which is non-zero) if it is
     *         an array class.
     */
-   TR::Node * testIsClassArrayType(TR::Node *j9ClassRefNode);
+   TR::Node * testIsClassArrayType(TR::Node *j9ClassRefNode, bool zeroOrOneResult = false);
 
    /**
     * \brief Test whether any of the specified flags is set on the array's component class

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4712,11 +4712,7 @@ break
       TR::Node* obj = callNode->getChild(1);
       TR::Node* vftLoad = TR::Node::createWithSymRef(callNode, TR::aloadi, 1, obj, symRefTab()->findOrCreateVftSymbolRef());
 
-      int32_t andMask = comp()->fej9()->getFlagValueForArrayCheck();
-      resultNode = comp()->fej9()->testIsClassArrayType(vftLoad);
-
-      int32_t shiftAmount = trailingZeroes(andMask);
-      resultNode  = TR::Node::create(callNode, TR::iushr, 2, resultNode, TR::Node::iconst(callNode, shiftAmount));
+      resultNode = comp()->fej9()->testIsClassArrayType(vftLoad, /* zeroOrOneResult */ true);
 
       // Handle NullCHK
       if (callNodeTreeTop->getNode()->getOpCode().isNullCheck())

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -981,8 +981,8 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
       debugTrace(tracer(), "\t In genCodeForUnsafeGetPut, Block %d created for low tag comparison\n", lowTagCmpBlock->getNumber());
 
       TR::Node *testIsArrayFlag = comp()->fej9()->testIsClassArrayType(vftLoad);
-      TR::Node *flagConstNode = TR::Node::create(testIsArrayFlag, TR::iconst, 0, TR::Compiler->cls.flagValueForArrayCheck(comp()));
-      TR::Node *isArrayNode = TR::Node::createif(TR::ificmpeq, testIsArrayFlag, flagConstNode, NULL);
+      TR::Node *zeroNode = TR::Node::iconst(testIsArrayFlag, 0);
+      TR::Node *isArrayNode = TR::Node::createif(TR::ificmpne, testIsArrayFlag, zeroNode, NULL);
       isArrayTreeTop = TR::TreeTop::create(comp(), isArrayNode, NULL, NULL);
       isArrayBlock = TR::Block::createEmptyBlock(vftLoad, comp(), indirectAccessBlock->getFrequency());
       isArrayBlock->append(isArrayTreeTop);


### PR DESCRIPTION
Various utility methods that generate IL to mask the `flags` or `classDepthAndFlags` fields of j9Class produce IL that will yield a zero or non-zero result.  In some cases, code that uses those utility methods would prefer a result of zero or one.  This change adds an optional parameter to those methods to allow that result to be produced.  By default, the generated IL will yield a zero or non-zero result.

Also, all uses of `J9::SymbolReferenceTable::findOrCreateClassAndDepthFlagsSymbolRef` have been replaced with uses of `J9::SymbolReferenceTable::findOrCreateClassDepthAndFlagsSymbolRef`, so the old method can be removed.