### PR TITLE
Clarify which branches should be compared

### DIFF
--- a/doc/GuideForCommitters.md
+++ b/doc/GuideForCommitters.md
@@ -138,9 +138,10 @@ possible between them.
     recently (generally within a day of a successful build).
 
     It is strongly recommended that you check that the tips of the
-    `eclipse-openj9/openj9-omr` [`master`](https://github.com/eclipse-openj9/openj9-omr/tree/master)
-    and [`openj9`](https://github.com/eclipse-openj9/openj9-omr/tree/openj9)
-    branches are the same before proceeding.  If they are different,
+    `eclipse-openj9/openj9-omr` [`master`](https://github.com/eclipse-openj9/openj9-omr/tree/master),
+    `eclipse-openj9/openj9-omr` [`openj9`](https://github.com/eclipse-openj9/openj9-omr/tree/openj9)
+    and `eclipse/omr` [`master`](https://github.com/eclipse/omr/tree/master)
+    branches are all the same before proceeding.  If they are different,
     be aware that you will be introducing other OMR changes that have
     not yet passed an OMR Acceptance build.  While not strictly
     required for the following steps to succeed, you should use your


### PR DESCRIPTION
The description of coordinated merges in the Guide for Committers indicates that the tips of the master and openj9 branches in the openj9-omr repository should be compared to avoid promoting changes that have not passed an OMR Acceptance build.  However, even if the tips of those branches are the same, it might be that the tip of the master branch in the omr repository does not match the tip of the master branch in the openj9-omr repository.  Performing a coordinated merge in that circumstance would also promote changes that have not passed an OMR acceptance build.

Added that case to the list of branches to compare.

[skip ci]