### PR TITLE
Fix romclass comparison and J9Class lookup given a romclass

### DIFF
--- a/runtime/bcutil/ComparingCursor.cpp
+++ b/runtime/bcutil/ComparingCursor.cpp
@@ -464,10 +464,6 @@ ComparingCursor::shouldCheckForEquality(DataType dataType, U_32 u32Value)
 	case INTERMEDIATE_CLASS_DATA_LENGTH:
 		return false;
 	case ROM_CLASS_MODIFIERS:
-		if (u32Value == (u32Value & _context->romMethodModifiers())) {
-			/*It's ok if the existing rom class has extra debug information and it is not required*/
-			return false;
-		}
 		break;
 	case OPTIONAL_FLAGS:
 		if (u32Value == (u32Value & _context->romClassOptionalFlags())) {


### PR DESCRIPTION
1. The romclass comparsion should include the ROM_CLASS_MODIFIERS.
2. For a ROMClass from SCC, its rom memory segment always belongs to the bootstrap class loader. But the class might not be actually loaded by the bootstrap loader. Search all live class loaders to find its defining class loader and the corresponding J9Class.

Fixes #19781