### PR TITLE
Send cached J9ROMClass hashes to JITServer

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -905,7 +905,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // If the client sent us the desired information in the compilation request, use that.
          if(!(std::get<0>(classInfoTuple).empty()))
             {
-            romClass = JITServerHelpers::romClassFromString(std::get<0>(classInfoTuple), clientSession->persistentMemory());
+            romClass = JITServerHelpers::romClassFromString(std::get<0>(classInfoTuple), std::get<25>(classInfoTuple), clientSession->persistentMemory());
             }
          else
             {

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -87,7 +87,8 @@ public:
       std::vector<J9ROMMethod *>,        // 21: _origROMMethods
       std::string,                       // 22: _classNameIdentifyingLoader
       int32_t,                           // 23: _arrayElementSize
-      j9object_t *                       // 24: _defaultValueSlotAddress
+      j9object_t *,                      // 24: _defaultValueSlotAddress
+      std::string                        // 25: optional hash of packedROMClass
       >;
 
    // Packs a ROMClass to be transferred to the server.
@@ -107,7 +108,7 @@ public:
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
    static J9ROMClass *getRemoteROMClass(J9Class *clazz, JITServer::ServerStream *stream,
                                         TR_PersistentMemory *persistentMemory, ClassInfoTuple &classInfoTuple);
-   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *persistentMemory);
+   static J9ROMClass *romClassFromString(const std::string &romClassStr, const std::string &romClassHashStr, TR_PersistentMemory *persistentMemory);
    static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData,
                                        JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data);
    static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData,

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 64; // ID: EbRgDu72oycJkc90HtnO
+   static const uint16_t MINOR_NUMBER = 65; // ID: YxVkiLqD7B1LhYMv58y8
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -93,6 +93,8 @@ public:
    // Find a runtime-generated class for given class loader, deterministic class name prefix, and ROMClass hash
    J9Class *findGeneratedClass(J9ClassLoader *loader, const uint8_t *namePrefix, size_t namePrefixLength,
                                const JITServerROMClassHash &hash, J9VMThread *vmThread);
+   // Find the stored hash for ramClass loaded by loader if it exists in the generated classes map.
+   std::string findGeneratedClassHash(J9ClassLoader *loader, J9Class *ramClass, TR_J9VM *fe, J9VMThread *vmThread);
    // Get the RAMClass for a previously deserialized ROMClass offset for a runtime-generated class
    virtual J9Class *getGeneratedClass(J9ClassLoader *loader, uintptr_t romClassSccOffset, TR::Compilation *comp) = 0;
 

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -205,9 +205,9 @@ JITServerSharedROMClassCache::shutdown(bool lastClient)
 
 
 J9ROMClass *
-JITServerSharedROMClassCache::getOrCreate(const J9ROMClass *packedROMClass)
+JITServerSharedROMClassCache::getOrCreate(const J9ROMClass *packedROMClass, const JITServerROMClassHash *packedROMClassHash)
    {
-   JITServerROMClassHash hash(packedROMClass);
+   JITServerROMClassHash hash = packedROMClassHash ? *packedROMClassHash : JITServerROMClassHash(packedROMClass);
    return getPartition(hash).getOrCreate(packedROMClass, hash);
    }
 

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
@@ -44,7 +44,9 @@ public:
    // Releases memory used by the cache. Must be called when the last client session is destroyed.
    void shutdown(bool lastClient = true);
 
-   J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass);
+   // Get an existing cache entry for packedROMClass or create one. The packedROMClassHash may be NULL; if not,
+   // it will be the cached deterministic hash of packedROMClass received from the client.
+   J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass, const JITServerROMClassHash *packedROMClassHash);
    void release(J9ROMClass *romClass);
 
    // Get precomputed hash of a shared ROMClass


### PR DESCRIPTION
If a JITServer client has a cached hash for a ROMClass, it may now send this hash to the server to avoid the server having to re-hash (and possibly re-pack) the ROMClass received from the client. The server will store this cached hash in its shared ROMClass cache. Currently, only the stored hashes of generated classes are sent to the server.