### PR TITLE
Fix Internal Build Breaks caused by OMR 7349

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -392,6 +392,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     omr/compiler/runtime/OMRCodeCacheConfig.cpp \
     omr/compiler/runtime/OMRCodeCacheManager.cpp \
     omr/compiler/runtime/OMRCodeCacheMemorySegment.cpp \
+    omr/compiler/runtime/OMRRSSReport.cpp \
     omr/compiler/runtime/OMRRuntimeAssumptions.cpp
 
 <#if uma.spec.flags.opt_jitserver.enabled>


### PR DESCRIPTION
https://github.com/eclipse/omr/pull/7349 added a new file called OMRRSSRegion.cpp. Although this file was added to the CMakeLists.txt for OMR, there does not exist a common UMA config to add this file. As such, the OpenJ9 build when using UMA is broken.

This commit fixes this by adding this file to the UMA config.