### PR TITLE
Export JVM_IsContainerized() in UMA builds

### DIFF
--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -88,6 +88,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk23">
 				<include-if condition="spec.java23"/>
 			</group>
+			<group name="jdk24">
+				<include-if condition="spec.java24"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -89,6 +89,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<group name="jdk23">
 				<include-if condition="spec.java23"/>
 			</group>
+			<group name="jdk24">
+				<include-if condition="spec.java24"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
Group `jdk24` was defined, but not referenced in #19803.