### PR TITLE
JDK17+ JVM_LoadLibrary() opens shared library via J9PORT_SLOPEN_DECORATE

### DIFF
--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -387,3 +387,7 @@ TraceExit=Trc_SC_VirtualThreadStart_Exit Overhead=1 Level=3 Template="thread = %
 
 TraceEntry=Trc_SC_VirtualThreadEnd_Entry Overhead=1 Level=3 Template="thread = %p"
 TraceExit=Trc_SC_VirtualThreadEnd_Exit Overhead=1 Level=3 Template="thread = %p"
+
+TraceEvent=Trc_SC_libName_no_prefix NoEnv Overhead=1 Level=3 Test Template="Skip JDK17+ libName(%s) without a lib prefix"
+TraceEvent=Trc_SC_libName_no_extension NoEnv Overhead=1 Level=3 Test Template="Skip JDK17+ libName(%s) without a file extension"
+TraceEvent=Trc_SC_allocate_memory_failed NoEnv Overhead=1 Level=2 Test Template="j9mem_allocate_memory(%zu) for libNameNotDecorated failed"


### PR DESCRIPTION
`JDK17+` `JVM_LoadLibrary()` opens shared library via `J9PORT_SLOPEN_DECORATE`

`j9sl_open_shared_library()` with the flag `J9PORT_SLOPEN_DECORATE` expects the incoming library name to be platform independent, i.e., it must not contain any prefix or file extension. A path to the library is supported.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/814
* https://github.com/ibmruntimes/openj9-openjdk-jdk23/pull/13

closes https://github.com/eclipse-openj9/openj9/issues/19344

Signed-off-by: Jason Feng <fengj@ca.ibm.com>