### PR TITLE
Fix docker+cuda workaround: handle "next" specifically

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -337,7 +337,7 @@ def build() {
 }
 
 def get_compile_command() {
-	return "make ${EXTRA_MAKE_OPTIONS} all"
+    return "make ${EXTRA_MAKE_OPTIONS} all"
 }
 
 def archive_sdk() {
@@ -845,7 +845,10 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     if ("${DOCKER_IMAGE}") {
                         // TODO: remove this workaround when https://github.com/adoptium/infrastructure/issues/3597 resolved. related: infra 9292
-                        if ((SDK_VERSION.toInteger() >= 17 && PLATFORM ==~ /x86-64_linux.*/) || (PLATFORM ==~ /ppc64le_linux.*/ )) {
+                        if ((PLATFORM ==~ /ppc64le_linux.*/)
+                        || ((PLATFORM ==~ /x86-64_linux.*/)
+                            && ((SDK_VERSION == "next") || (SDK_VERSION.toInteger() >= 17)))
+                        ) {
                             create_docker_image_locally()
                         }
                         prepare_docker_environment()


### PR DESCRIPTION
The acceptance job for the head stream is currently broken; see https://github.com/eclipse-openj9/openj9/pull/19811/files#r1681762242.