### PR TITLE
Fix error when param SDK_VERSION is not numeric

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -845,7 +845,8 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     if ("${DOCKER_IMAGE}") {
                         // TODO: remove this workaround when https://github.com/adoptium/infrastructure/issues/3597 resolved. related: infra 9292
-                        if ((SDK_VERSION.toInteger() >= 17 && PLATFORM ==~ /x86-64_linux.*/) || (PLATFORM ==~ /ppc64le_linux.*/ )) {
+                        if ((PLATFORM ==~ /ppc64le_linux.*/) ||
+                            ((PLATFORM ==~ /x86-64_linux.*/) && ((SDK_VERSION.toLowerCase() == 'next') || (SDK_VERSION.toInteger() >= 17)))) {
                             create_docker_image_locally()
                         }
                         prepare_docker_environment()


### PR DESCRIPTION
When SDK_VERSION is non-numeric (e.g next) then cuda workaround fails as we are trying to compare it with 17 for xlinux. This change aims to solve that issue by taking care of `next` separately.

Signed-off-by: mahdi@ibm.com