### PR TITLE
Remove extra newlines in generated assembly files

### DIFF
--- a/runtime/compiler/z/runtime/Math.m4
+++ b/runtime/compiler/z/runtime/Math.m4
@@ -846,6 +846,6 @@ LCALLDESCDRM      DS    0D           * Dword Boundary
         DC    BL.3'000',BL.5'01001'  * XPLINK Linkage+Returns:double
         DC    BL.6'001000',BL.6'000000',BL.6'000000',BL.6'000000'
 ZZ                                   unprototyped call
-    END
 })dnl
+    END
 })dnl

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -2323,9 +2323,7 @@ ifdef({ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS},{dnl
 
 ifdef({J9ZOS390},{dnl
 ifdef({TR_HOST_64BIT},{dnl
-
 ZZ 64bit XPLINK doesn't need call descriptors
-
 },{dnl
 
 ZZ We will share this call descriptor for all calls to
@@ -2352,4 +2350,3 @@ ZZ                                     unprototyped call
 
     END
 })dnl
-

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -1146,4 +1146,3 @@ ZZ Restore our preserved registers.
 ifdef({J9ZOS390},{dnl
     END
 })dnl
-

--- a/runtime/compiler/z/runtime/ValueProf.m4
+++ b/runtime/compiler/z/runtime/ValueProf.m4
@@ -919,4 +919,3 @@ END_FUNC(_jitRIOFF,_jitRIOFF,11)
 ifdef({J9ZOS390},{dnl
     END
 })dnl
-


### PR DESCRIPTION
Similar to previously fixed Open XL errors, there were some more m4 files that generated extra newlines at the end of the generated assembly files. These changes make the tweaks to address this so as to only leave a single newline at the end of these generated assembly files.