### PR TITLE
j9vm31 Open XL support

### DIFF
--- a/runtime/j9vm31/CMakeLists.txt
+++ b/runtime/j9vm31/CMakeLists.txt
@@ -58,12 +58,27 @@ set(compile_flags_to_remove
 	"\"-Wa,SYSPARM(BIT64)\""
 	"-DJ9ZOS39064"
 	"-qxplink=noback"
+	"-m64"
 )
+
+if(OMR_TOOLCONFIG STREQUAL "openxl")
+	set(compile_flags_to_append
+		"-m32n"
+		"-mzos-float-kind=ieee"
+		"-Wno-c++11-narrowing"
+	)
+endif()
 
 foreach(flag IN LISTS compile_flags_to_remove)
 	omr_remove_flags(CMAKE_C_FLAGS "${flag}")
 	omr_remove_flags(CMAKE_CXX_FLAGS "${flag}")
 	omr_remove_flags(CMAKE_ASM_FLAGS "${flag}")
+endforeach()
+
+foreach(flag IN LISTS compile_flags_to_append)
+	omr_append_flags(CMAKE_C_FLAGS "${flag}")
+	omr_append_flags(CMAKE_CXX_FLAGS "${flag}")
+	omr_append_flags(CMAKE_ASM_FLAGS "${flag}")
 endforeach()
 
 # Flags to be removed when linking.

--- a/runtime/j9vm31/j9cel4ro64.c
+++ b/runtime/j9vm31/j9cel4ro64.c
@@ -22,6 +22,7 @@
 
 #include "j9cel4ro64.h"
 #include <assert.h> /* Required for __gtca() */
+#include <stdlib.h>
 
 /* Function descriptor of CEL4RO64 runtime call from GTCA control block */
 typedef void cel4ro64_cwi_func(void*);

--- a/runtime/j9vm31/j9vm31floatstubs.s
+++ b/runtime/j9vm31/j9vm31floatstubs.s
@@ -71,4 +71,3 @@ J9VM_LD RMODE ANY
 * to trick the compiler in doing it for us.
          EDCEPIL
          END
-


### PR DESCRIPTION
Makes the necessary changes to support compiling the j9vm31 module with Open XL. This includes tweaking the compiler flags to ensure it is built in 32 bit no-xp link mode.

tagging for reference: @joransiu 