### PR TITLE
(0.47) Add virtual thread support for JVMTI GetObjectMonitorUsage

### DIFF
--- a/runtime/jvmti/jvmtiObject.c
+++ b/runtime/jvmti/jvmtiObject.c
@@ -24,33 +24,33 @@
 #include "jvmti_internal.h"
 
 typedef struct J9JVMTIMonitorStats {
-	J9JavaVM * vm;
-	J9VMThread * currentThread;
+	J9JavaVM *vm;
+	J9VMThread *currentThread;
 	j9object_t lockObject;
 	UDATA numWaiting;
 	UDATA waitingCntr;
 	UDATA numBlocked;
 	UDATA blockedCntr;
-	jthread * waiting;
-	jthread * blocked;
+	jthread *waiting;
+	jthread *blocked;
 } J9JVMTIMonitorStats;
 
-static void findMonitorThreads(J9VMThread * vmThread, J9JVMTIMonitorStats * pStats);
+static void findMonitorThreads(J9VMThread *vmThread, J9JVMTIMonitorStats *pStats);
 
 jvmtiError JNICALL
-jvmtiGetObjectSize(jvmtiEnv* env,
+jvmtiGetObjectSize(jvmtiEnv *env,
 	jobject object,
-	jlong* size_ptr)
+	jlong *size_ptr)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
-	J9VMThread * currentThread;
+	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread = NULL;
 	jlong rv_size = 0;
 
 	Trc_JVMTI_jvmtiGetObjectSize2_Entry(env, object, size_ptr);
 
 	rc = getCurrentVMThread(vm, &currentThread);
-	if (rc == JVMTI_ERROR_NONE) {
+	if (JVMTI_ERROR_NONE == rc) {
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 		ENSURE_PHASE_START_OR_LIVE(env);
@@ -72,20 +72,20 @@ done:
 
 
 jvmtiError JNICALL
-jvmtiGetObjectHashCode(jvmtiEnv* env,
+jvmtiGetObjectHashCode(jvmtiEnv *env,
 	jobject object,
-	jint* hash_code_ptr)
+	jint *hash_code_ptr)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
-	J9VMThread * currentThread;
+	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread = NULL;
 	jint rv_hash_code = 0;
 
 	Trc_JVMTI_jvmtiGetObjectHashCode2_Entry(env, object, hash_code_ptr);
 
 	rc = getCurrentVMThread(vm, &currentThread);
-	if (rc == JVMTI_ERROR_NONE) {
-		j9object_t obj;
+	if (JVMTI_ERROR_NONE == rc) {
+		j9object_t obj = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -94,7 +94,7 @@ jvmtiGetObjectHashCode(jvmtiEnv* env,
 		ENSURE_JOBJECT_NON_NULL(object);
 		ENSURE_NON_NULL(hash_code_ptr);
 
-		obj = *((j9object_t*) object);
+		obj = *((j9object_t *)object);
 		rv_hash_code = (jint)objectHashCode(vm, obj);
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -106,15 +106,14 @@ done:
 	TRACE_ONE_JVMTI_RETURN(jvmtiGetObjectHashCode2, rv_hash_code);
 }
 
-
 jvmtiError JNICALL
-jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
+jvmtiGetObjectMonitorUsage(jvmtiEnv *env,
 	jobject object,
-	jvmtiMonitorUsage* info_ptr)
+	jvmtiMonitorUsage *info_ptr)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
-	J9VMThread * currentThread;
+	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	jthread rv_owner = NULL;
 	jint rv_entry_count = 0;
@@ -126,11 +125,11 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 	Trc_JVMTI_jvmtiGetObjectMonitorUsage2_Entry(env, object, info_ptr);
 
 	rc = getCurrentVMThread(vm, &currentThread);
-	if (rc == JVMTI_ERROR_NONE) {
-		J9VMThread * owner;
-		J9VMThread * walkThread;
+	if (JVMTI_ERROR_NONE == rc) {
+		J9VMThread *owner = NULL;
+		J9VMThread *walkThread = NULL;
 		UDATA count = 0;
-		J9JVMTIMonitorStats stats;
+		J9JVMTIMonitorStats stats = {0};
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -142,12 +141,16 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 
-		owner = getObjectMonitorOwner(vm, *((j9object_t*) object), &count);
+		owner = getObjectMonitorOwner(vm, *((j9object_t *)object), &count);
 		memset(info_ptr, 0, sizeof(jvmtiMonitorUsage));
 
-		if (owner && owner->threadObject) {
+		if ((NULL != owner) && (NULL != owner->threadObject)
+#if JAVA_SPEC_VERSION >= 23
+		&& !IS_JAVA_LANG_VIRTUALTHREAD(currentThread, owner->threadObject)
+#endif /* JAVA_SPEC_VERSION >= 23 */
+		) {
 			j9object_t target = (j9object_t)owner->threadObject;
-			rv_owner = (jthread) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, target);
+			rv_owner = (jthread)vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, target);
 			rv_entry_count = (jint)count;
 		}
 
@@ -155,21 +158,21 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 
 		stats.vm = vm;
 		stats.currentThread = currentThread;
-		stats.lockObject = *((j9object_t*) object);
+		stats.lockObject = *((j9object_t *)object);
 
 		/* Search for blocked/waiting threads (wind up counts) */
 		walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
-		while (walkThread != NULL) {
+		while (NULL != walkThread) {
 			findMonitorThreads(walkThread, &stats);
 			walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
 		}
 
 		stats.waiting = j9mem_allocate_memory(sizeof(jthread) * stats.numWaiting, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-		if (stats.waiting == NULL) {
+		if (NULL == stats.waiting) {
 			rc = JVMTI_ERROR_OUT_OF_MEMORY;
 		} else {
 			stats.blocked = j9mem_allocate_memory(sizeof(jthread) * stats.numBlocked, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-			if (stats.blocked == NULL) {
+			if (NULL == stats.blocked) {
 				j9mem_free_memory(stats.waiting);
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
@@ -178,7 +181,7 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 
 				/* Record blocked/waiting threads (wind down counts) */
 				walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
-				while (walkThread != NULL) {
+				while (NULL != walkThread) {
 					findMonitorThreads(walkThread, &stats);
 					walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
 				}
@@ -206,59 +209,71 @@ done:
 	TRACE_FOUR_JVMTI_RETURN(jvmtiGetObjectMonitorUsage2, rv_owner, rv_entry_count, rv_notify_waiter_count, rv_waiter_count);
 }
 
-
 static void
-findMonitorThreads(J9VMThread * vmThread, J9JVMTIMonitorStats * pStats)
+findMonitorThreads(J9VMThread *vmThread, J9JVMTIMonitorStats *pStats)
 {
-	j9object_t lockObject;
+	j9object_t lockObject = NULL;
+	J9VMThread *currentThread = (J9VMThread *)pStats->currentThread;
+	j9object_t target = (j9object_t)vmThread->threadObject;
+	UDATA threadState = 0;
 
-	UDATA threadState = getVMThreadObjectStatesAll(vmThread, &lockObject, NULL, NULL);
+	if (NULL == target) {
+		return;
+	}
+
+#if JAVA_SPEC_VERSION >= 23
+	if (IS_JAVA_LANG_VIRTUALTHREAD(currentThread, target)) {
+		return;
+	}
+#endif /* JAVA_SPEC_VERSION >= 23 */
+
+	threadState = getVMThreadObjectStatesAll(vmThread, &lockObject, NULL, NULL);
 
 	/* Stopped on the same monitor object? */
 	if (lockObject == pStats->lockObject) {
+		J9JavaVM *vm = pStats->vm;
+		JNIEnv *jniEnv = (JNIEnv *)currentThread;
 
-		j9object_t target = (j9object_t)vmThread->threadObject;
-
-		if (target) {
-
-			J9JavaVM * vm = pStats->vm;
-			JNIEnv * jniEnv = (JNIEnv *)pStats->currentThread;
+		threadState &= ~(J9VMTHREAD_STATE_SUSPENDED | J9VMTHREAD_STATE_INTERRUPTED);
+		switch (threadState) {
+		case J9VMTHREAD_STATE_WAITING:
+		case J9VMTHREAD_STATE_WAITING_TIMED:
+			if (NULL == pStats->waiting) {
+				pStats->numWaiting += 1;
+			} else {
+				if (pStats->waitingCntr < pStats->numWaiting) {
+					pStats->waiting[pStats->waitingCntr] =
+							(jthread)vm->internalVMFunctions->j9jni_createLocalRef(jniEnv, target);
+					pStats->waitingCntr += 1;
+				}
+			}
 
 			/* CMVC 87023 - the spec is unclear, but from experimentation it appears that 'waiting to be notified' threads
-			 * should appear in both lists
+			 * should appear in both lists.
+			 *
+			 * In JDK23+, these threads no longer appear in both lists. This behaviour will incrementally be backported to
+			 * JDK8/11/17/21 as the RI backports the fix and dependent test changes in their codebase. Backporting this
+			 * behaviour to older JDK versions before the RI will break existing third party tests.
 			 */
-			threadState &= ~(J9VMTHREAD_STATE_SUSPENDED | J9VMTHREAD_STATE_INTERRUPTED);
-			switch (threadState) {
-				case J9VMTHREAD_STATE_WAITING:
-				case J9VMTHREAD_STATE_WAITING_TIMED:
-					if (pStats->waiting == NULL) {
-						(pStats->numWaiting)++;
-					} else {
-						if (pStats->waitingCntr < pStats->numWaiting) {
-							pStats->waiting[pStats->waitingCntr] =
-									(jthread) vm->internalVMFunctions->j9jni_createLocalRef(jniEnv, target);
-							++(pStats->waitingCntr);
-						}
-					}
-					/* FALL THROUGH */
-
-				case J9VMTHREAD_STATE_BLOCKED:
-					if (pStats->blocked == NULL) {
-						(pStats->numBlocked)++;
-					} else {
-						if (pStats->blockedCntr < pStats->numBlocked) {
-							pStats->blocked[pStats->blockedCntr] =
-									(jthread) vm->internalVMFunctions->j9jni_createLocalRef(jniEnv, target);
-							++(pStats->blockedCntr);
-						}
-					}
-					break;
-
-				default:
-					break;
+#if JAVA_SPEC_VERSION >= 23
+			break;
+#else /* JAVA_SPEC_VERSION >= 23 */
+			/* FALL THROUGH */
+#endif /* JAVA_SPEC_VERSION >= 23 */
+		case J9VMTHREAD_STATE_BLOCKED:
+			if (NULL == pStats->blocked) {
+				pStats->numBlocked += 1;
+			} else {
+				if (pStats->blockedCntr < pStats->numBlocked) {
+					pStats->blocked[pStats->blockedCntr] =
+							(jthread)vm->internalVMFunctions->j9jni_createLocalRef(jniEnv, target);
+					pStats->blockedCntr += 1;
+				}
 			}
+			break;
+
+		default:
+			break;
 		}
 	}
 }
-
-


### PR DESCRIPTION
- RI has removed support for virtual threads if an object monitor is
owned by a virtual thread.
- Support has also been removed for virtual threads that are waiting
be notified or own a monitor.
- Also, new tests show that waiting to be notified threads do not
repeat and only appear in one list. This has been corrected in OpenJ9.
- Update formatting in jvmtiObject.c to follow coding standards.

Fixes: #19497

Backport of https://github.com/eclipse-openj9/openj9/pull/19871