### PR TITLE
Enforce maximum name size during class loading

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2416,3 +2416,10 @@ J9NLS_VM_OPENJ9_JFR_METADATA_FILE_NOT_FOUND.explanation=Couldn't find JFR metada
 J9NLS_VM_OPENJ9_JFR_METADATA_FILE_NOT_FOUND.system_action=The JVM will not generate a JFR file.
 J9NLS_VM_OPENJ9_JFR_METADATA_FILE_NOT_FOUND.user_response=Set the required environment variables.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_CLASS_NAME_EXCEEDS_MAX_LENGTH=Class name exceeds maximum length
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_NAME_EXCEEDS_MAX_LENGTH.explanation=Class name cannot be longer than 65535 characters.
+J9NLS_VM_CLASS_NAME_EXCEEDS_MAX_LENGTH.system_action=The JVM will throw a ClassNotFoundException.
+J9NLS_VM_CLASS_NAME_EXCEEDS_MAX_LENGTH.user_response=Shorten the class name.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -36,6 +36,10 @@
 #include "j9javaaccessflags.h"
 
 #define J9VM_MAX_HIDDEN_FIELDS_PER_CLASS 8
+/* Class names are stored in the VM as CONSTANT_Utf8_info which stores
+ * length in two bytes.
+ */
+#define J9VM_MAX_CLASS_NAME_LENGTH 0xFFFF
 
 #define J9VM_DLT_HISTORY_SIZE  16
 #define J9VM_OBJECT_MONITOR_CACHE_SIZE  32


### PR DESCRIPTION
Class names are stored as a UTF8 string and length is represented by
 two bytes

Port to 0.46: https://github.com/eclipse-openj9/openj9/pull/19898