### PR TITLE
(0.47) Update VThread alive check to check continuation state

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -179,7 +179,14 @@ getVMThread(J9VMThread *currentThread, jthread thread, J9VMThread **vmThreadPtr,
 				targetThread = carrierVMThread;
 			}
 		}
-		isThreadAlive = (JVMTI_VTHREAD_STATE_NEW != vthreadState) && (JVMTI_VTHREAD_STATE_TERMINATED != vthreadState);
+		j9object_t continuationObj = J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
+		ContinuationState continuationState = *VM_ContinuationHelpers::getContinuationStateAddress(currentThread, continuationObj);
+		if ((JVMTI_VTHREAD_STATE_NEW != vthreadState)
+		&& (JVMTI_VTHREAD_STATE_TERMINATED != vthreadState)
+		&& !VM_ContinuationHelpers::isFinished(continuationState)
+		) {
+			isThreadAlive = TRUE;
+		}
 	} else
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	{


### PR DESCRIPTION
Check if the continuation is finished to determine more accurately if a virtual thread is alive.

Related: https://github.com/eclipse-openj9/openj9/issues/18738#issuecomment-2218824062

Backport of #19842 