### PR TITLE
Open XL implicit function declaration fixes

### DIFF
--- a/runtime/jcl/common/attach.c
+++ b/runtime/jcl/common/attach.c
@@ -204,7 +204,7 @@ Java_openj9_internal_tools_attach_target_IPC_isUsingDefaultUid(JNIEnv *env, jcla
 	/* all offsets are byte offsets */
 	U_32* PSATOLD_ADDR = (U_32 *)(UDATA) 0x21c;  /* z/OS Pointer to current TCB or zero if in SRB mode. Field fixed by architecture. */
 	U_32 tcbBase; /* base of the z/OS Task Control Block */
-	const TCBSENV_OFFSET = 0x154; /* offset of the TCBSENV field in the TCB.  This field contains a pointer to the ACEE. */
+	const U_32 TCBSENV_OFFSET = 0x154; /* offset of the TCBSENV field in the TCB.  This field contains a pointer to the ACEE. */
 	U_32 aceeBaseAddr; /* Address of a control block field which contains a pointer to the base of the RACF Accessor Environment Element (ACEE) */
 	U_32 aceeBase; /* absolute address of the start of the ACEE */
 	U_32 aceeflg3Addr; /* address of the "Miscellaneous flags" byte of the ACEE */

--- a/runtime/port/zos390/protect_helpers.c
+++ b/runtime/port/zos390/protect_helpers.c
@@ -25,6 +25,8 @@
 #include <sys/mman.h>
 #include <errno.h>
 
+extern intptr_t _MPROT(uintptr_t address, uintptr_t length); /* j9mprotect.s */
+extern intptr_t _MUNPROT(uintptr_t address, uintptr_t length); /* j9munprotect.s */
 
 /**
  * @internal @file
@@ -40,8 +42,6 @@ intptr_t
 protect_memory(struct J9PortLibrary *portLibrary, void *address, uintptr_t length, uintptr_t flags)
 {
 	OMRPORT_ACCESS_FROM_J9PORT(portLibrary);
-	uintptr_t index;
-	intptr_t unixFlags = 0;
 	intptr_t rc = -1;
 
 	if ((flags & OMRPORT_PAGE_PROTECT_WRITE) == 0) {

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -30,6 +30,7 @@
 #ifdef J9ZOS390
 #include <spawn.h>
 #include <errno.h>
+#include <sys/wait.h>
 #include "atoe.h"
 #endif
 #ifdef AIXPPC

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -60,6 +60,7 @@ char* dumpDirectoryPrefix = NULL;
 #if defined(J9ZOS390)
 #if defined(J9VM_ENV_DATA64)
 #include <__le_api.h>
+#include <ctest.h>
 #else
 #include <leawi.h>
 #include <ceeedcct.h>

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -30,8 +30,6 @@
 #include <malloc.h>
 #elif defined(LINUX) || defined(AIXPPC)
 #include <alloca.h>
-#elif defined(J9ZOS390)
-#include <stdlib.h>
 #endif
 #if defined(J9ZTPF)
 #include <sys/mman.h>

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -121,6 +121,7 @@ typedef enum gc_policy{
 #endif /* defined(AIXPPC) */
 
 #if defined(J9ZOS390)
+#include <dlfcn.h>
 #include <dll.h>
 #include "atoe.h"
 #include <stdlib.h>


### PR DESCRIPTION
Mostly a collection of missing function declaration fixes and other commonly seen errors/warnings from Open XL compilation.

runtime/jcl/common/attach.c : missing int specifier
runtime/rasdump/dmpagent.c : missing assembly func declarations
runtime/rasdump/dmpsup.c : implicit function declarations
runtime/rasdump/javadump.cpp : implicit function declarations
runtime/redirector/redirector.c : implicit function declarations