### PR TITLE
Open XL header includes and vm flag fixup

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
@@ -22,6 +22,7 @@
 
 #include "jvmti_test.h"
 #include <string.h>
+#include <strings.h>
 
 static agentEnv * env;
 static jmethodID catchMethod = NULL;

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
@@ -22,6 +22,7 @@
 
 #include "jvmti_test.h"
 #include <string.h>
+#include <strings.h>
 
 static agentEnv * env;
 static int imse = 0;

--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -271,6 +271,7 @@ isNewPageSize(UDATA pageSize, UDATA pageFlags)
  * On z/OS, 1M fixed and 2G fixed pages can be used only to allocate above 2G bar.
  * Only 4K and 1M pageable pages can be used to allocate memory below the bar.
  */
+BOOLEAN
 isPageSizeSupportedBelowBar(UDATA pageSize, UDATA pageFlags)
 {
 	if ((FOUR_KB == pageSize) ||

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -52,15 +52,23 @@ if(OMR_ARCH_POWER AND OMR_OS_AIX)
 		]]
 	endif()
 elseif(OMR_OS_ZOS)
-	# TODO need to handle optimized debug info
-	list(APPEND interp_flags_to_remove "-O3" "-g" "-qdebug=nohook")
+	if(OMR_TOOLCONFIG STREQUAL "openxl")
+		# Hooks are not implemented in Open XL. The default debug compiles in Open XL will be NOHOOK
+		# equivalent.
+		list(APPEND interp_flags_to_remove "-O3" "-g")
 
-	list(APPEND interp_new_flags
-		-O2
-		"\"-Wc,TBYDBG(-qdebug=MRABIG)\""
-		"\"-Wc,TBYDBG(-qdebug=lincomm:ptranl:tfbagg)\""
-		"\"-Wc,FEDBG(-qxflag=InlineDespiteVolatileInArgs)\""
-	)
+		list(APPEND interp_new_flags -O2)
+	else()
+		# TODO need to handle optimized debug info
+		list(APPEND interp_flags_to_remove "-O3" "-g" "-qdebug=nohook")
+
+		list(APPEND interp_new_flags
+			-O2
+			"\"-Wc,TBYDBG(-qdebug=MRABIG)\""
+			"\"-Wc,TBYDBG(-qdebug=lincomm:ptranl:tfbagg)\""
+			"\"-Wc,FEDBG(-qxflag=InlineDespiteVolatileInArgs)\""
+		)
+	endif()
 endif()
 
 if(interp_flags_to_remove)

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -54,6 +54,10 @@
 #include <signal.h>
 #endif
 
+#if defined(J9ZOS390)
+#include "atoe.h"
+#endif
+
 #include "omrcfg.h"
 #include "jvminitcommon.h"
 #include "j9user.h"


### PR DESCRIPTION
runtime/tests/jsig/main.c : dlfcn.h needs to be defined before defines for dllfree()/dllload() due to conflicting type definitions decomp003.c/decomp005.c : strcasecmp() implict function declaration needs strings.h j9vmemTest.c : -Wimplicit-int , missing type specifier that defaults to "int"
jvminit.c : atoe_enableFileTagging() implicit function declaration requires atoe.h
runtime/vm/CMakeLists.txt : Added appropriate conditionals to apply correct flags for Open XL suggested by compiler team. Hooks are not implemented for Open XL.