### PR TITLE
WIP: Subtract negative array header size from offset

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -907,7 +907,7 @@ createArrayAddressTree(TR::Compilation *comp, bool is64bit, TR::Node *baseNode, 
       {
       TR::Node *c2 = createIndexOffsetTree(comp, is64bit, indexNode, multiply);
       TR::Node *aload = createLoad(baseNode);
-      return TR::TransformUtil::generateArrayElementAddressTrees(comp, aload, c2);
+      return TR::TransformUtil::generateArrayElementAddressTrees(comp, aload, c2, true);
       }
    }
 


### PR DESCRIPTION
This restores the tree structure for non off-heap path. During refactoring for off-heap, the tree structure was accidentally changed to use addition instead of subtract. Reverting the change as there might be opts performing pattern matching against the original tree structure.