### PR TITLE
Extract Thread Test to JDK 22 and under

### DIFF
--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -286,11 +286,32 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 							<compilerarg line='${commonArgs}' />
 						</javac>
 					</then>
+					<elseif>
+						<matches string="${JDK_VERSION}" pattern="^(19|2[0-2])$$" />
+						<then>
+							<!-- Java 19 - 22 (SecurityManager removed) -->
+							<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+								<compilerarg line='${commonArgs}' />
+								<!-- exclude tests that depend on SecurityManager -->
+								<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
+								<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
+								<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_System_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_Thread_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_ThreadGroup_SM.java" />
+								<exclude name="org/openj9/test/java/lang/invoke/Test_MethodHandleInfo_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
+								<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
+								<exclude name="org/openj9/test/vm/Test_VM.java" />
+							</javac>
+						</then>
+					</elseif>
 					<else>
-						<!-- Java 19+ (SecurityManager removed) -->
+						<!-- Java 23+ (SecurityManage and Thread functions removed) -->
 						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
 							<compilerarg line='${commonArgs}' />
-							<!-- exclude tests that depend on SecurityManager -->
+							<!-- exclude tests that depend on SecurityManager or Thread functions -->
 							<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
 							<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
 							<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
@@ -301,6 +322,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 							<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
 							<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
 							<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
+							<exclude name="org/openj9/test/java/lang/Test_Thread.java" />
+							<exclude name="org/openj9/test/java/lang/Test_ThreadGroup.java" />
 							<exclude name="org/openj9/test/vm/Test_VM.java" />
 						</javac>
 					</else>

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1137,6 +1137,55 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</impls>
 	</test>
 	<test>
+		<testCaseName>JCL_Test_Thread</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-XX:RecreateClassfileOnload</variation>
+			<variation>-XX:+CompactStrings</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
+	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED $(ADD_EXPORTS_JDK_INTERNAL_REFLECT) \
+	--add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
+	--add-exports java.base/sun.net.www.protocol.jrt=ALL-UNNAMED \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.security=ALL-UNNAMED \
+	$(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(JAXB_API_JAR)$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng_thread.xml$(Q) \
+	-testnames \
+	JCL_TEST_Java-Lang_Tread \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>[11, 22]</version>
+		</versions>
+		<features>
+			<feature>AOT:nonapplicable</feature>
+		</features>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>JCL_Test_Native</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -197,9 +197,7 @@
 			<class name="org.openj9.test.java.lang.Test_StringBuffer"/>
 			<class name="org.openj9.test.java.lang.Test_StringBuilder"/>
 			<class name="org.openj9.test.java.lang.Test_System"/>
-			<class name="org.openj9.test.java.lang.Test_Thread"/>
 			<class name="org.openj9.test.java.lang.Test_Thread_Extra"/>			
-			<class name="org.openj9.test.java.lang.Test_ThreadGroup"/>
 			<class name="org.openj9.test.java.lang.Test_Throwable"/>
 			<class name="org.openj9.test.java.lang.Test_VMAccess"/>
 		</classes>

--- a/test/functional/Java8andUp/testng_thread.xml
+++ b/test/functional/Java8andUp/testng_thread.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright IBM Corp. and others 2024
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="GeneralTest suite" parallel="none" verbose="2">
+	<listeners>
+		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer"/>
+	</listeners>
+	<test name="JCL_TEST_Java-Lang_Tread">
+		<classes>
+			<class name="org.openj9.test.java.lang.Test_Thread"/>
+			<class name="org.openj9.test.java.lang.Test_ThreadGroup"/>
+		</classes>
+	</test>
+</suite>
+<!-- Suite -->

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -90,17 +90,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 						<property name="excludeFile" value="" />
 					</else>
 				</if>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${extraSrc}" />
-					<exclude name="${excludeFile}" />
-					<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
-					<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
-					<compilerarg line="${addExports}" />
-					<classpath>
-						<pathelement location="${asm.jar}" />
-					</classpath>
-				</javac>
+				<if>
+					<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
+					<then>
+						<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+							<src path="${src}" />
+							<src path="${extraSrc}" />
+							<exclude name="${excludeFile}" />
+							<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
+							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+							<compilerarg line="${addExports}" />
+							<classpath>
+								<pathelement location="${asm.jar}" />
+							</classpath>
+						</javac>
+					</then>
+					<else>
+						<!-- Java 23+ (SecurityManage and several Thread functions removed) -->
+						<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+							<src path="${src}" />
+							<src path="${extraSrc}" />
+							<exclude name="${excludeFile}" />
+							<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
+							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+							<compilerarg line="${addExports}" />
+							<exclude name="com/ibm/jvmti/tests/getThreadState/gts001.java" />
+							<classpath>
+								<pathelement location="${asm.jar}" />
+							</classpath>
+						</javac>
+					</else>
+				</if>
 			</else>
 		</if>
 


### PR DESCRIPTION
- Thread functions are removed for JDK 23, extract test to JDK 22 and under
Related Issue and PRs: https://github.com/eclipse-openj9/openj9/issues/18758 https://github.com/ibmruntimes/openj9-openjdk-jdk23/pull/16 and https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/818