### PR TITLE
JVM_LoadLibrary: respect throwOnFailure in jdk11

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4074,7 +4074,7 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 	}
 #endif /* defined(WIN32) */
 
-#if JAVA_SPEC_VERSION >= 17
+#if JAVA_SPEC_VERSION >= 11
 	if ((NULL == result) && throwOnFailure) {
 		JNIEnv *env = NULL;
 		JavaVM *vm = (JavaVM *)javaVM;
@@ -4106,7 +4106,7 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 			}
 		}
 	}
-#endif /* JAVA_SPEC_VERSION >= 17 */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	Trc_SC_LoadLibrary_Exit(result);
 


### PR DESCRIPTION
This corrects an oversight in #14739 which changed the signature, but not the body of the function.