### PR TITLE
JDK24 removes JavaLangAccess.executeOnCarrierThread()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -595,6 +595,7 @@ final class Access implements JavaLangAccess {
 		return Thread.currentCarrierThread();
 	}
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	public <V> V executeOnCarrierThread(Callable<V> task) throws Exception {
 		V result;
 		Thread currentThread = Thread.currentThread();
@@ -611,6 +612,7 @@ final class Access implements JavaLangAccess {
 		}
 		return result;
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	public Continuation getContinuation(Thread thread) {
 		return thread.getContinuation();


### PR DESCRIPTION
See [8336254: Virtual thread implementation + test updates](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/c9e87eb05f0703b880088d2eec1393d64aef078e).