### PR TITLE
JDK24 removes JavaLangAccess.stringSize(long)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -556,16 +556,16 @@ final class Access implements JavaLangAccess {
 	public long stringConcatHelperPrepend(long indexCoder, byte[] buf, String value) {
 		return StringConcatHelper.prepend(indexCoder, buf, value);
 	}
+
+	@Override
+	public int stringSize(long x) {
+		return Long.stringSize(x);
+	}
 /*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	@Override
 	public long stringConcatMix(long lengthCoder, char value) {
 		return StringConcatHelper.mix(lengthCoder, value);
-	}
-
-	@Override
-	public int stringSize(long x) {
-		return Long.stringSize(x);
 	}
 
 	/*[IF !INLINE-TYPES]*/


### PR DESCRIPTION
`JDK24` removes `JavaLangAccess.stringSize(long x)`

Resolve jdk head stream abuild compilation error:
```
23:58:58  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:432: error: cannot find symbol
23:58:58  		return Long.stringSize(x);
23:58:58  		           ^
23:58:58    symbol:   method stringSize(long)
```

The openjdk change in question is https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/489b87654d9b6953227a951423d74cbfdc3c20d7

Signed-off-by: Jason Feng <fengj@ca.ibm.com>