### PR TITLE
Set spin-counts right

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -558,7 +558,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif /* J9VM_INTERP_CUSTOM_SPIN_OPTIONS */
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	cpus = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
+	cpus = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
 
 	/* initialize defaults, first */
 	vm->thrMaxYieldsBeforeBlocking = 45;


### PR DESCRIPTION
Currently, they are set according to how many CPUs there are online. However, it makes more senses to set them according to how many CPUs
 JVM is going to run. Such that, we can take advantages of single-CPU
 scenarios (be it numactl or container).