### PR TITLE
Sets cuda_default for p Linux and removes cuda_9

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -175,12 +175,6 @@ boot_jdk_default:
 cuda:
   extra_configure_options: '--enable-cuda'
 #========================================#
-# CUDA version 9
-#========================================#
-cuda_9:
-  extends: ['cuda']
-  extra_configure_options: '--with-cuda=/usr/local/cuda-9.0'
-#========================================#
 # CUDA default version
 #========================================#
 cuda_default:
@@ -217,7 +211,7 @@ ojdk292:
 # Linux PPCLE 64bits
 #========================================#
 ppc64le_linux:
-  extends: ['boot_jdk_default', 'cuda_9', 'debuginfo', 'openjdk_reference_repo', 'openssl']
+  extends: ['boot_jdk_default', 'cuda_default', 'debuginfo', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     arch: 'ppc64le'
     os: 'linux'


### PR DESCRIPTION
Now that plinux build moved to docker, we can set cuda level to `cuda_default` as we use for others like xlinux. With that we can also remove `cuda_9` which only plinux is using.

Signed-off-by: mahdi@ibm.com