### PR TITLE
Remove unused J9GCVMInfo and J9GCThreadInfo

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -103,11 +103,6 @@ MM_GCExtensions::initialize(MM_EnvironmentBase *env)
 	getJavaVM()->jniArrayCacheMaxSize = J9_GC_JNI_ARRAY_CACHE_SIZE;
 #endif /* J9VM_GC_JNI_ARRAY_CACHE */
 
-#if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-	getJavaVM()->gcInfo.tlhThreshold = J9_GC_TLH_THRESHOLD;
-	getJavaVM()->gcInfo.tlhSize = J9_GC_TLH_SIZE;
-#endif /* J9VM_GC_THREAD_LOCAL_HEAP */
-
 	/* if tuned for virtualized environment, we compromise a bit of performance for lower footprint */
 	if (getJavaVM()->runtimeFlags & J9_RUNTIME_TUNE_VIRTUALIZED) {
 		heapFreeMinimumRatioMultiplier = 20;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2972,15 +2972,6 @@ typedef struct J9VMGCSegregatedAllocationCacheEntry {
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 
-typedef struct J9GCVMInfo {
-	UDATA tlhSize;
-	UDATA tlhThreshold;
-} J9GCVMInfo;
-
-typedef struct J9GCThreadInfo {
-	UDATA foobar;
-} J9GCThreadInfo;
-
 typedef struct J9ModronThreadLocalHeap {
 	U_8* heapBase;
 	U_8* realHeapTop;
@@ -5838,7 +5829,6 @@ typedef struct J9JavaVM {
 	void* codertOldVMShutdown;
 	void* jitOldAboutToBootstrap;
 	void* jitOldVMShutdown;
-	struct J9GCVMInfo gcInfo;
 	void* gcExtensions;
 	UDATA gcAllocationType;
 	UDATA gcWriteBarrierType;


### PR DESCRIPTION
Looks like J9JavaVM->gcInfo field and J9GCVMInfo, J9GCThreadInfo structs are not used and can be deleted.