### PR TITLE
Remove duplicate exclude in jvmtitests

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -113,7 +113,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 							<exclude name="${excludeFile}" />
 							<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
 							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
-							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
 							<compilerarg line="${addExports}" />
 							<exclude name="com/ibm/jvmti/tests/getThreadState/gts001.java" />
 							<classpath>


### PR DESCRIPTION
Remove the duplicate exclude for GetThreadListStackTracesExtendedTest.

Issue: https://github.com/eclipse-openj9/openj9/pull/19918#discussion_r1697151877