### PR TITLE
Add support for aarch64 to j9vm.runner.Runner

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/javahome/JavaHomeTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/javahome/JavaHomeTestRunner.java
@@ -21,39 +21,39 @@
  */
 package j9vm.test.javahome;
 
-
 public class JavaHomeTestRunner extends j9vm.runner.Runner {
 
-public JavaHomeTestRunner(String className, String exeName, String bootClassPath, String userClassPath, String javaVersion) {
-	super(className, exeName, bootClassPath, userClassPath, javaVersion);
-}
+	public JavaHomeTestRunner(String className, String exeName, String bootClassPath, String userClassPath, String javaVersion) {
+		super(className, exeName, bootClassPath, userClassPath, javaVersion);
+	}
 
-public String getBootClassPathOption()  { return ""; }
+	public String getBootClassPathOption() {
+		return "";
+	}
 
-public boolean run()  {
-	boolean passed = true;
-	int rc = runCommandLine(getCommandLine() + "-Djava.home=" +
-			System.getProperty("java.home") + " " + className);
-	System.out.println("rc = " + rc + "\n");
-	if (0 != rc) {
-		passed = false;
+	public boolean run() {
+		boolean passed = true;
+		int rc = runCommandLine(getCommandLine() + " -Djava.home=" + System.getProperty("java.home") + " " + className);
+		System.out.println("rc = " + rc + "\n");
+		if (0 != rc) {
+			passed = false;
+		}
+
+		System.out.println("////// Failure starting VM expected here //////");
+		rc = runCommandLine(getCommandLine() + " -Djava.home=FooFooFoo! " + className);
+		System.out.println("rc = " + rc + "\n");
+		if (1 != rc) {
+			passed = false;
+		}
+
+		System.out.println("////// Failure starting VM expected here //////");
+		rc = runCommandLine(getCommandLine() + " -Djava.home= " + className);
+		System.out.println("rc = " + rc + "\n");
+		if (1 != rc) {
+			passed = false;
+		}
+
+		return passed;
 	}
-	
-	System.out.println("////// Failure starting VM expected here //////");
-	rc = runCommandLine(getCommandLine() + "-Djava.home=FooFooFoo! " + className);
-	System.out.println("rc = " + rc + "\n");
-	if (1 != rc) {
-		passed = false;
-	}
-	
-	System.out.println("////// Failure starting VM expected here //////");
-	rc = runCommandLine(getCommandLine() + "-Djava.home= " + className);
-	System.out.println("rc = " + rc + "\n");
-	if (1 != rc) {
-		passed = false;
-	}
-	
-	return passed;
-}
 
 }


### PR DESCRIPTION
Also reorganize and tidy up.

This was motivated by messages like
```
[2024-07-26T07:59:06.968Z] Runner couldn't determine underlying architecture. Got OS Arch:aarch64
```
A recent example can be seen in [a JDK acceptance build](https://openj9-jenkins.osuosl.org/job/Test_openjdk23_j9_sanity.functional_aarch64_linux_OpenJDK23_testList_0/5/consoleText).