### PR TITLE
Update 0.46.0 release note

### DIFF
--- a/doc/release-notes/0.46/0.46.md
+++ b/doc/release-notes/0.46/0.46.md
@@ -1,0 +1,148 @@
+<!--
+* Copyright (c) 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# Eclipse OpenJ9 version 0.46.0 release notes
+
+These release notes support the [Eclipse OpenJ9&trade; 0.46.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.46.0/plan).
+
+## Supported environments
+
+OpenJ9 release 0.46.0 supports OpenJDK 8, 11, 17, 21, and 22.
+
+All releases are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests provided by Adoptium.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](https://eclipse.org/openj9/docs/openj9_support/index.html).
+
+## Notable changes in this release
+
+The following table covers notable changes in v0.46.0. Further information about these changes can be found in the [user documentation](https://www.eclipse.org/openj9/docs/version0.46/).
+
+<table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1"><thead align="left">
+<tr>
+<th valign="bottom">Issue number</th>
+<th valign="bottom">Description</th>
+<th valign="bottom">Version / Platform</th>
+<th valign="bottom">Impact</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/42">#42</a>, <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/140">#140</a>, <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/337">#337</a>, <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/743">#743</a>, <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/766">#766</a></td>
+<td valign="top">MD5 message digest algorithm support is added for OpenSSL.</td>
+<td valign="top">All versions</td>
+<td valign="top">OpenSSL native cryptographic support is added for the MD5 message digest algorithm, providing improved cryptographic performance. OpenSSL support is enabled by default. If you want to turn off support for the MD5 message digest algorithm, set the <tt>-Djdk.nativedigest</tt> system property to <tt>false</tt>.</td>
+</tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/19436">#19436</a></td>
+<td valign="top">Support is added for the <tt>com.sun.management.ThreadMXBean.getTotalThreadAllocatedBytes()</tt> API.</td>
+<td valign="top">All versions</td>
+<td valign="top">The OpenJ9 VM implementation supports measurement of the total memory allocation for all threads (<tt>com.sun.management.ThreadMXBean.getTotalThreadAllocatedBytes()</tt> API). The <tt>getTotalThreadAllocatedBytes()</tt> method now returns the total thread allocated bytes instead of <tt>-1</tt>.</td>
+</tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/19585">#19585</a>, <a href="https://github.com/eclipse-openj9/openj9/pull/19619">#19619</a></td>
+<td valign="top">The JITServer AOT caching feature is enabled by default at the JITServer server.</td>
+<td valign="top">All versions (Linux)</td>
+<td valign="top"><tt>-XX:+JITServerUseAOTCache</tt> is the default setting at the JITServer server now. That means that you don't have to specify the <tt>-XX:+JITServerUseAOTCache</tt> option at the server to enable the JITServer AOT caching feature.
+
+Although this option is by default enabled at the server, it is still disabled for the JITServer clients. The clients that want to use the JITServer AOT caching, must still specify the <tt>-XX:+JITServerUseAOTCache</tt> option on the command line. Also, now the clients don't have to enable the shared classes cache feature to use the <tt>-XX:+JITServerUseAOTCache</tt> option.
+</td>
+</tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/19554">#19554</a></td>
+<td valign="top">A new option <tt>-XX:[+|-]EnableExtendedHCR</tt> is added.</td>
+<td valign="top">All versions</td>
+<td valign="top">By default, the extended Hot Code Replace (HCR) capability in the VM is disabled for all OpenJDK versions. You can enable or disable the HCR capability by using the <tt>-XX:[+|-]EnableExtendedHCR</tt> option.
+
+The extended HCR feature is deprecated in this release and will be removed in a future release. From OpenJDK 25 onwards, extended HCR will not be supported. Following that, the extended HCR support will be removed from other earlier OpenJDK versions also.
+</td>
+</tr>
+</tbody>
+</table>
+
+## Known issues
+
+The v0.46.0 release contains the following known issues and limitations:
+
+<table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1">
+<thead align="left">
+<tr>
+<th valign="bottom">Issue number</th>
+<th valign="bottom">Description</th>
+<th valign="bottom">Version / Platform</th>
+<th valign="bottom">Impact</th>
+<th valign="bottom">Workaround</th>
+</tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/19833">#19833</a></td>
+<td valign="top">Class comparison for the shared cache might not not detect the removal of method access modifiers. For example, a change of a method from public to package-private.</td>
+<td valign="top">All</td>
+<td valign="top">If you ran your application with the <tt>-XX:+ShareOrphans</tt> option, then recompiled classes after removing the method access modifier and reran with the <tt>-XX:+ShareOrphans</tt> option, the old version of the class might still be used.</td>
+<td valign="top">Remove the <tt>-XX:+ShareOrphans</tt> option and rerun.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/19833">#19833</a></td>
+<td valign="top"><tt>java.lang.StackTraceElement.getClassLoaderName()</tt> might return null for classes that are stored in the shared cache.</td>
+<td valign="top">All</td>
+<td valign="top">When the <tt>-XX:+ShareOrphans</tt> option is specified, <tt>java.lang.StackTraceElement.getClassLoaderName()</tt> might incorrectly return null on a class loader that has a name. If a class loader has a name, the correct behaviour is to return the name.</td>
+<td valign="top">Remove the <tt>-XX:+ShareOrphans</tt> option and rerun.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/15011">#15011</a></td>
+<td valign="top">The default stack size for the main thread is a smaller platform-dependent value.</td>
+<td valign="top">All</td>
+<td valign="top">The main thread stack size was 1 MB in releases before 0.32. In the 0.32 release and later it was modified to a smaller
+platform-dependent value, the same value as the <tt>-Xmso</tt> setting. The 0.33 release increased the default <tt>-Xmso</tt> stack size
+on x64 platforms, but builds with OpenJDK 17 and later also require more stack space to run. These changes might result in a
+<tt>java.lang.StackOverflowError: operating system stack overflow</tt>.</td>
+<td valign="top">Use <tt>-Xmso</tt> to set the default stack size. See the default value by using <tt>-verbose:sizes</tt>.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/14803">#14803</a></td>
+<td valign="top">Using the <tt>-XX:+ShowHiddenFrames</tt> option in an OpenJ9 release that is built with OpenJDK 18 and later causes errors.</td>
+<td valign="top">All platforms</td>
+<td valign="top">Wrong exception might be thrown when using the Reflection API.</td>
+<td valign="top">Avoid using the <tt>-XX:+ShowHiddenFrames</tt> option with OpenJDK 18 and later.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/13767">#13767</a></td>
+<td valign="top">Compressed references mode is not available.</td>
+<td valign="top">Apple silicon macOS</td>
+<td valign="top">You can use only the large heap (non-compressed references) mode.</td>
+<td valign="top">None</td>
+</tr>
+
+</tbody>
+</table>
+
+## Other changes
+
+A full commit history for 0.46.0 release is available at [Eclipse OpenJ9 v0.46.0](https://github.com/eclipse-openj9/openj9/releases/tag/openj9-0.46.0).


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1330

Updated the draft release note that includes the known issues related to -XX:+ShareOrphans

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com