### PR TITLE
Remove evaluators for String.compressNoCheck()

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -220,7 +220,6 @@
    java_lang_String_compareToIgnoreCase,
    java_lang_String_compress,
    java_lang_String_andOR,
-   java_lang_String_compressNoCheck,
    java_lang_String_unsafeCharAt,
    java_lang_String_split_str_int,
    java_lang_String_getChars_charArray,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2791,7 +2791,6 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_equalsIgnoreCase,    "equalsIgnoreCase",    "(Ljava/lang/String;)Z")},
       {x(TR::java_lang_String_compareToIgnoreCase, "compareToIgnoreCase", "(Ljava/lang/String;)I")},
       {x(TR::java_lang_String_compress,            "compress",            "([C[BII)I")},
-      {x(TR::java_lang_String_compressNoCheck,     "compressNoCheck",     "([C[BII)V")},
       {x(TR::java_lang_String_andOR,               "andOR",               "([CII)I")},
       {x(TR::java_lang_String_unsafeCharAt,        "unsafeCharAt",        "(I)C")},
       {x(TR::java_lang_String_split_str_int,       "split",               "(Ljava/lang/String;I)[Ljava/lang/String;")},

--- a/runtime/compiler/p/runtime/PPCCompressString.inc
+++ b/runtime/compiler/p/runtime/PPCCompressString.inc
@@ -34,13 +34,9 @@
 #ifdef AIXPPC
 	.globl    .__compressString
 	.globl    .__compressStringJ
-	.globl    .__compressStringNoCheck
-	.globl    .__compressStringNoCheckJ
 	.globl    .__andORString
 	.globl    __compressString{DS}
 	.globl    __compressStringJ{DS}
-	.globl    __compressStringNoCheck{DS}
-	.globl    __compressStringNoCheckJ{DS}
 	.globl    __andORString{DS}
 !	.globl    .__arrayCopy_dp
 !	.globl    __arrayCopy_dp{DS}
@@ -50,18 +46,12 @@
 	.type     FUNC_LABEL(__compressString),@function
 	.globl    FUNC_LABEL(__compressStringJ)
 	.type     FUNC_LABEL(__compressStringJ),@function
-	.globl    FUNC_LABEL(__compressStringNoCheck)
-	.type     FUNC_LABEL(__compressStringNoCheck),@function
-	.globl    FUNC_LABEL(__compressStringNoCheckJ)
-	.type     FUNC_LABEL(__compressStringNoCheckJ),@function
 	.globl    FUNC_LABEL(__andORString)
 	.type     FUNC_LABEL(__andOrString),@function
 
 #elif defined(LINUX)
 	.globl    __compressString
 	.globl    __compressStringJ
-	.globl    __compressStringNocheck
-	.globl    __compressStringNocheckJ
 	.globl    __andORString
 !	.globl    __arrayCopy_dp
 #endif
@@ -264,168 +254,6 @@ L.__finish:
 	bclr    BO_IF, CR0_EQ
 	endproc.__compressString:
 
-#ifdef AIXPPC
-	.csect	__compressStringNoCheck{PR}
-.__compressStringNoCheck:
-	.function .__compressStringNoCheck,startproc.__compressStringNoCheck,16,0,(endproc.__compressStringNoCheck-startproc.__compressStringNoCheck)
-#elif defined(LINUXPPC64)
-FUNC_LABEL(__compressStringNoCheck):
-#else
-__compressStringNoCheck:
-#endif
-
-	startproc.__compressStringNoCheck:
-L.__compressStringNoCheck:
-	add	r11, r7, r7
-	add	r9, r9, r11
-	srwi.	r0, r8, 4
-	bc	BO_IF, CR0_EQ, L.__residueNoCheck
-        mtctr   r0
-L.__loopNoCheck:
-	lwz     r0, 0(r9)
-	lwz     r11, 4(r9)
-	lwz     r6, 8(r9)
-	lwz     r3, 12(r9)
-	rlwinm	r4, r0, 8, 0xFF000000	!method 1
-	rlwinm	r7, r0, 16, 0xFF0000	!method 1
-	rlwinm	r5, r6, 8, 0xFF000000   !method 1
-	rlwinm	r12, r6, 16, 0xFF0000   !method 1
-	rlwimi	r4, r11, 24, 0xFF00	!method 1
-	rlwimi	r7, r11, 0, 0xFF	!method 1
-	rlwimi  r5, r3, 24, 0xFF00	!method 1
-	rlwimi  r12, r3, 0, 0xFF	!method 1
-	or	r4, r4, r7		!method 1
-	or	r5, r5, r12		!method 1
-	stw	r4, 0(r10)
-	stw     r5, 4(r10)
-
-	lwz     r0, 16(r9)
-	lwz     r11,20(r9)
-	lwz     r6, 24(r9)
-	lwz     r3, 28(r9)
-	addi	r9, r9, 32
-	rlwinm	r4, r0, 8, 0xFF000000	!method 1
-	rlwinm	r7, r0, 16, 0xFF0000	!method 1
-	rlwinm	r5, r6, 8, 0xFF000000	!method 1
-	rlwinm	r12, r6, 16, 0xFF0000	!method 1
-	rlwimi	r4, r11, 24, 0xFF00	!method 1
-	rlwimi	r7, r11, 0, 0xFF	!method 1
-	rlwimi  r5, r3, 24, 0xFF00	!method 1
-	rlwimi  r12, r3, 0, 0xFF	!method 1
-	or	r4, r4, r7		!method 1
-	or	r5, r5, r12		!method 1
-	stw	r4, 8(r10)
-	stw     r5, 12(r10)
-	addi	r10, r10, 16
-	subi    r8, r8, 16
-	bdnz	L.__loopNoCheck
-
-L.__residueNoCheck:
-	srwi.	r0, r8, 2
-	bc	BO_IF, CR0_EQ, L.__residue2NoCheck
-	mtctr	r0
-L.__residueLoopNoCheck:
-	lwz	r0, 0(r9)
-	lwz     r11, 4(r9)
-	addi	r9, r9, 8
-	rlwinm	r4, r0, 8, 0xFF000000
-	rlwinm	r7, r0, 16, 0xFF0000
-	rlwimi	r4, r11, 24, 0xFF00	!method 1
-	rlwimi	r7, r11, 0, 0xFF	!method 1
-	or	r4, r4, r7		!method 1
-	stw	r4, 0(r10)
-	addi    r10, r10, 4
-	subi	r8, r8, 4
-	bdnz	L.__residueLoopNoCheck
-
-L.__residue2NoCheck:
-	srwi.   r0, r8, 0
-	bc	BO_IF, CR0_EQ, L.__finishNoCheck
-	mtctr	r0
-L.__residueLoop2NoCheck:
-	lhz	r0, 0(r9)
-	addi    r9, r9, 2
-	stb	r0, 0(r10)
-	addi    r10, r10, 1
-	bdnz	L.__residueLoop2NoCheck
-
-L.__finishNoCheck:
-	bclr    BO_IF, CR0_EQ
-
-	endproc.__compressStringNoCheck:
-
-#ifdef AIXPPC
-	.csect	__compressStringNoCheckJ{PR}
-.__compressStringNoCheckJ:
-	.function .__compressStringNoCheckJ,startproc.__compressStringNoCheckJ,16,0,(endproc.__compressStringNoCheckJ-startproc.__compressStringNoCheckJ)
-#elif defined(LINUXPPC64)
-FUNC_LABEL(__compressStringNoCheckJ):
-#else
-__compressStringNoCheckJ:
-#endif
-	startproc.__compressStringNoCheckJ:
-L.__compressStringNoCheckJ:
-	add	r11, r7, r7
-	add	r9, r9, r11
-	srwi.    r0, r8, 4
-	bc	BO_IF, CR0_EQ, L.__residueNoCheckJ
-        mtctr   r0
-L.__loopNoCheckJ:
-	lwz     r0, 0(r9)
-	lwz     r11, 4(r9)
-	lwz     r6, 8(r9)
-	lwz     r3, 12(r9)
-	rlwinm  r4, r11, 8, 0xFFFFFFFF  !method 2
-	rlwinm  r5, r3, 8, 0xFFFFFFFF	!method 2
-	or      r4, r4, r0		!method 2
-	or	r5, r5, r6		!method 2
-	stw	r4, 0(r10)
-	stw     r5, 4(r10)
-
-	lwz     r0, 16(r9)
-	lwz     r11,20(r9)
-	lwz     r6, 24(r9)
-	lwz     r3, 28(r9)
-	addi	r9, r9, 32
-	rlwinm  r4, r11, 8, 0xFFFFFFFF	!method 2
-	rlwinm  r5, r3, 8, 0xFFFFFFFF	!method 2
-	or      r4, r4, r0		!method 2
-	or	r5, r5, r6		!method 2
-	stw	r4, 8(r10)
-	stw     r5, 12(r10)
-	addi	r10, r10, 16
-	subi    r8, r8, 16
-	bdnz	L.__loopNoCheckJ
-L.__residueNoCheckJ:
-	srwi.	r0, r8, 2
-	bc	BO_IF, CR0_EQ, L.__residue2NoCheckJ
-	mtctr	r0
-L.__residueLoopNoCheckJ:
-	lwz	r0, 0(r9)
-	lwz     r11, 4(r9)
-	addi	r9, r9, 8
-	rlwinm  r4, r11, 8, 0xFFFFFFFF	!method 2
-	or      r4, r4, r0		!method 2
-	stw	r4, 0(r10)
-	addi	r10, r10, 4
-	subi	r8, r8, 4
-	bdnz	L.__residueLoopNoCheckJ
-
-L.__residue2NoCheckJ:
-	srwi.   r0, r8, 0
-	bc	BO_IF, CR0_EQ, L.__finishNoCheckJ
-	mtctr	r0
-L.__residueLoop2NoCheckJ:
-	lhz	r0, 0(r9)
-	addi    r9, r9, 2
-	stb	r0, 0(r10)
-	addi    r10, r10, 1
-	bdnz	L.__residueLoop2NoCheckJ
-
-L.__finishNoCheckJ:
-	bclr    BO_IF, CR0_EQ
-	endproc.__compressStringNoCheckJ:
-
 
 #ifdef AIXPPC
 	.csect	__andORString{PR}
@@ -536,18 +364,6 @@ L.__finishandOR:
 	ADDR      0x00000000
 ! End   csect     __compressStringJ{DS}
 
-	.csect    __compressStringNoCheck{DS}
-	ADDR      .__compressStringNoCheck
-	ADDR      TOC{TC0}
-	ADDR      0x00000000
-! End   csect     __compressStringNoCheck{DS}
-
-	.csect    __compressStringNoCheckJ{DS}
-	ADDR      .__compressStringNoCheckJ
-	ADDR      TOC{TC0}
-	ADDR      0x00000000
-! End   csect     __compressStringNoCheckJ{DS}
-
 
 !	.csect    __arrayCopy_dp{DS}
 !	ADDR      .__arrayCopy_dp
@@ -574,22 +390,6 @@ __compressString:
 	.size     __compressStringJ,24
 __compressStringJ:
 	.quad     .__compressStringJ
-	.quad     .TOC.@tocbase
-	.long     0x00000000
-	.long     0x00000000
-
-	.globl    __compressStringNoCheck
-	.size     __compressStringNoCheck,24
-__compressStringNoCheck:
-	.quad     .__compressStringNoCheck
-	.quad     .TOC.@tocbase
-	.long     0x00000000
-	.long     0x00000000
-
-	.globl    __compressStringNoCheckJ
-	.size     __compressStringNoCheckJ,24
-__compressStringNoCheckJ:
-	.quad     .__compressStringNoCheckJ
 	.quad     .TOC.@tocbase
 	.long     0x00000000
 	.long     0x00000000

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -343,9 +343,7 @@ JIT_HELPER(icallVMprJavaSendVirtualF);
 JIT_HELPER(icallVMprJavaSendVirtualD);
 
 JIT_HELPER(compressString);
-JIT_HELPER(compressStringNoCheck);
 JIT_HELPER(compressStringJ);
-JIT_HELPER(compressStringNoCheckJ);
 JIT_HELPER(andORString);
 JIT_HELPER(encodeUTF16Big);
 JIT_HELPER(encodeUTF16Little);
@@ -375,9 +373,7 @@ JIT_HELPER(SSEdoubleRemainderIA32Thunk);
 JIT_HELPER(SSEdouble2LongIA32);
 
 JIT_HELPER(compressString);
-JIT_HELPER(compressStringNoCheck);
 JIT_HELPER(compressStringJ);
-JIT_HELPER(compressStringNoCheckJ);
 JIT_HELPER(andORString);
 JIT_HELPER(encodeUTF16Big);
 JIT_HELPER(encodeUTF16Little);
@@ -477,9 +473,7 @@ JIT_HELPER(ECP256subNoMod_PPC_compressed);
 
 #ifndef LINUX
 JIT_HELPER(__compressString);
-JIT_HELPER(__compressStringNoCheck);
 JIT_HELPER(__compressStringJ);
-JIT_HELPER(__compressStringNoCheckJ);
 JIT_HELPER(__andORString);
 #endif
 JIT_HELPER(__arrayTranslateTRTO);
@@ -521,9 +515,7 @@ JIT_HELPER(__long2Double);
 JIT_HELPER(__long2Float);
 JIT_HELPER(__arrayCopy);
 JIT_HELPER(__compressString);
-JIT_HELPER(__compressStringNoCheck);
 JIT_HELPER(__compressStringJ);
-JIT_HELPER(__compressStringNoCheckJ);
 JIT_HELPER(__andORString);
 JIT_HELPER(__multi64);
 JIT_HELPER(_interpreterUnresolvedStaticGlue);
@@ -1238,9 +1230,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 
    SET(TR_AMD64jitCollapseJNIReferenceFrame,          (void *)jitCollapseJNIReferenceFrame,   TR_Helper);
    SET(TR_AMD64compressString,                        (void *)compressString,            TR_Helper);
-   SET(TR_AMD64compressStringNoCheck,                 (void *)compressStringNoCheck,     TR_Helper);
    SET(TR_AMD64compressStringJ,                       (void *)compressStringJ,           TR_Helper);
-   SET(TR_AMD64compressStringNoCheckJ,                (void *)compressStringNoCheckJ,    TR_Helper);
    SET(TR_AMD64andORString,                           (void *)andORString,               TR_Helper);
    SET(TR_AMD64arrayTranslateTRTO,                    (void *)arrayTranslateTRTO,        TR_Helper);
    SET(TR_AMD64arrayTranslateTROTNoBreak,             (void *)arrayTranslateTROTNoBreak, TR_Helper);
@@ -1291,9 +1281,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_IA32floatToInt,                             (void *)floatToInt,   TR_Helper);
 
    SET(TR_IA32compressString,                         (void *)compressString,            TR_Helper);
-   SET(TR_IA32compressStringNoCheck,                  (void *)compressStringNoCheck,     TR_Helper);
    SET(TR_IA32compressStringJ,                        (void *)compressStringJ,           TR_Helper);
-   SET(TR_IA32compressStringNoCheckJ,                 (void *)compressStringNoCheckJ,    TR_Helper);
    SET(TR_IA32andORString,                            (void *)andORString,               TR_Helper);
    SET(TR_IA32arrayTranslateTRTO,                     (void *)arrayTranslateTRTO,        TR_Helper);
    SET(TR_IA32arrayTranslateTROTNoBreak,              (void *)arrayTranslateTROTNoBreak, TR_Helper);
@@ -1411,9 +1399,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 
 #ifndef LINUX
    SET(TR_PPCcompressString,               (void *) __compressString,               TR_Helper);
-   SET(TR_PPCcompressStringNoCheck,        (void *) __compressStringNoCheck,        TR_Helper);
    SET(TR_PPCcompressStringJ,              (void *) __compressStringJ,              TR_Helper);
-   SET(TR_PPCcompressStringNoCheckJ,       (void *) __compressStringNoCheckJ,       TR_Helper);
    SET(TR_PPCandORString,                  (void *) __andORString,                  TR_Helper);
 #endif
    SET(TR_PPCreferenceArrayCopy,           (void *) __referenceArrayCopy,           TR_Helper);

--- a/runtime/compiler/x/amd64/runtime/AMD64CompressString.inc
+++ b/runtime/compiler/x/amd64/runtime/AMD64CompressString.inc
@@ -22,8 +22,6 @@ segment .text
 
         DECLARE_GLOBAL  compressString
         DECLARE_GLOBAL  compressStringJ
-        DECLARE_GLOBAL  compressStringNoCheck
-        DECLARE_GLOBAL  compressStringNoCheckJ
         DECLARE_GLOBAL  andORString
 
         align 16
@@ -156,70 +154,4 @@ eightchars2:
         and  edx, ecx				            ; building the and
 
         mov  dx, bx
-ret
-
-
-compressStringNoCheckJ:
-        shr  rcx, 4
-        add  rsi, rax
-        add  rsi, rax
-eightcharsNoCheckJ:
-        mov  rax, QWORD  [rsi]  		        ; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, QWORD  [rsi+8]  		        ; load 4 bytes from the source array into EAX (2 chars)
-        shl  rbx, 8					            ; shift right by 8
-        or   rax, rbx					        ; or the 2 values
-        mov  QWORD  [rdi], rax			        ; write the low 2 bytes of the 4 byte value in the destination
-
-        mov  rax, QWORD  [rsi+16]  		        ; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, QWORD  [rsi+24]  		        ; load 4 bytes from the source array into EAX (2 chars)
-        shl  rbx, 8					            ; shift right by 8
-        or   rax, rbx					        ; or the 2 values
-        mov  QWORD  [rdi+8], rax			    ; write the low 2 bytes of the 4 byte value in the destination
-
-        add  rdi, 16
-        add  rsi, 32		
-        loop eightcharsNoCheckJ
-ret
-
-compressStringNoCheck:
-        shr  rcx, 4
-        add  rsi, rax
-        add  rsi, rax
-eightcharsNoCheck:
-        mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, rax					; copy the loaded value
-        shr  rbx, 8					    ; shift right by 8
-        or   rax, rbx					; or the 2 values
-        mov  WORD  [rdi], ax			; write the low 2 bytes of the 4 byte value in the destination
-        shr  rax, 32
-        mov  WORD  [rdi+2], ax			; write the low 2 bytes of the 4 byte value in the destination
-
-        mov  rax, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, rax					; copy the loaded value
-        shr  rbx, 8					    ; shift right by 8
-        or   rax, rbx					; or the 2 values
-        mov  WORD  [rdi+4], ax			; write the low 2 bytes of the 4 byte value in the destination
-        shr  rax, 32
-        mov  WORD  [rdi+6], ax			; write the low 2 bytes of the 4 byte value in the destination
-
-        mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, rax					; copy the loaded value
-        shr  rbx, 8					    ; shift right by 8
-        or   rax, rbx					; or the 2 values
-        mov  WORD  [rdi+8], ax			; write the low 2 bytes of the 4 byte value in the destination
-        shr  rax, 32
-        mov  WORD  [rdi+10], ax			; write the low 2 bytes of the 4 byte value in the destination
-
-
-        mov  rax, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
-        mov  rbx, rax					; copy the loaded value
-        shr  rbx, 8					    ; shift right by 8
-        or   rax, rbx					; or the 2 values
-        mov  WORD  [rdi+12], ax			; write the low 2 bytes of the 4 byte value in the destination
-        shr  rax, 32
-        mov  WORD  [rdi+14], ax			; write the low 2 bytes of the 4 byte value in the destination
-
-        add  rdi, 16
-        add  rsi, 32		
-        loop eightcharsNoCheck
 ret

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11672,9 +11672,6 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
       case TR::java_lang_String_compress:
          return TR::TreeEvaluator::compressStringEvaluator(node, cg, useJapaneseCompression);
 
-      case TR::java_lang_String_compressNoCheck:
-         return TR::TreeEvaluator::compressStringNoCheckEvaluator(node, cg, useJapaneseCompression);
-
       case TR::java_lang_String_andOR:
          return TR::TreeEvaluator::andORStringEvaluator(node, cg);
 
@@ -12392,65 +12389,6 @@ J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node, TR::CodeGener
    cg->decReferenceCount(node->getChild(2));
    cg->decReferenceCount(node->getChild(3));
    return result;
-   }
-
-TR::Register *
-J9::X86::TreeEvaluator::compressStringNoCheckEvaluator(
-      TR::Node *node,
-      TR::CodeGenerator *cg,
-      bool japaneseMethod)
-   {
-   TR::Node *srcObjNode, *dstObjNode, *startNode, *lengthNode;
-   TR::Register *srcObjReg, *dstObjReg, *lengthReg, *startReg;
-   bool stopUsingCopyReg1, stopUsingCopyReg2, stopUsingCopyReg3, stopUsingCopyReg4;
-
-   srcObjNode = node->getChild(0);
-   dstObjNode = node->getChild(1);
-   startNode = node->getChild(2);
-   lengthNode = node->getChild(3);
-
-   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
-   stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegAddr(dstObjNode, dstObjReg, cg);
-   stopUsingCopyReg3 = TR::TreeEvaluator::stopUsingCopyRegInteger(startNode, startReg, cg);
-   stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
-
-   uintptr_t hdrSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
-   generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, srcObjReg, hdrSize, cg);
-   generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, dstObjReg, hdrSize, cg);
-
-
-   // Now that we have all the registers, set up the dependencies
-   TR::RegisterDependencyConditions  *dependencies =
-      generateRegisterDependencyConditions((uint8_t)0, 5, cg);
-   dependencies->addPostCondition(srcObjReg, TR::RealRegister::esi, cg);
-   dependencies->addPostCondition(dstObjReg, TR::RealRegister::edi, cg);
-   dependencies->addPostCondition(lengthReg, TR::RealRegister::ecx, cg);
-   dependencies->addPostCondition(startReg, TR::RealRegister::eax, cg);
-   TR::Register *dummy = cg->allocateRegister();
-   dependencies->addPostCondition(dummy, TR::RealRegister::ebx, cg);
-   dependencies->stopAddingConditions();
-
-   TR_RuntimeHelper helper;
-   if (cg->comp()->target().is64Bit())
-      helper = japaneseMethod ? TR_AMD64compressStringNoCheckJ : TR_AMD64compressStringNoCheck;
-   else
-      helper = japaneseMethod ? TR_IA32compressStringNoCheckJ : TR_IA32compressStringNoCheck;
-
-   generateHelperCallInstruction(node, helper, dependencies, cg);
-   cg->stopUsingRegister(dummy);
-
-   for (uint16_t i = 0; i < node->getNumChildren(); i++)
-     cg->decReferenceCount(node->getChild(i));
-
-   if (stopUsingCopyReg1)
-      cg->getLiveRegisters(TR_GPR)->registerIsDead(srcObjReg);
-   if (stopUsingCopyReg2)
-      cg->getLiveRegisters(TR_GPR)->registerIsDead(dstObjReg);
-   if (stopUsingCopyReg3)
-      cg->getLiveRegisters(TR_GPR)->registerIsDead(startReg);
-   if (stopUsingCopyReg4)
-      cg->getLiveRegisters(TR_GPR)->registerIsDead(lengthReg);
-   return NULL;
    }
 
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -134,7 +134,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *encodeUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compressStringEvaluator(TR::Node *node, TR::CodeGenerator *cg, bool japaneseMethod);
-   static TR::Register *compressStringNoCheckEvaluator(TR::Node *node, TR::CodeGenerator *cg, bool japaneseMethod);
    static TR::Register *andORStringEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *toUpperIntrinsicUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *toLowerIntrinsicUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/compiler/x/i386/runtime/IA32CompressString.inc
+++ b/runtime/compiler/x/i386/runtime/IA32CompressString.inc
@@ -22,8 +22,6 @@ segment .text
 
                 DECLARE_GLOBAL  compressString
                 DECLARE_GLOBAL  compressStringJ
-                DECLARE_GLOBAL  compressStringNoCheck
-                DECLARE_GLOBAL  compressStringNoCheckJ
                 DECLARE_GLOBAL  andORString
                 align   16
 ;
@@ -168,79 +166,6 @@ eightchars2:
 
         OR   EAX, EBX		; AND is in the high word and OR is in the low word.
         MOV  EDX, EAX
-                ret
-;
-
-
-compressStringNoCheckJ:
-        SHR  ECX, 4
-        ADD  ESI, EAX
-        ADD  ESI, EAX
-eightcharsNoCheckJ:
-
-        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
-        SHL  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  DWORD  [EDI], EAX			; write the low 2 bytes of the 4 byte value in the destination
-        
-        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
-        SHL  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  DWORD  [EDI+4], EAX			; write the low 2 bytes of the 4 byte value in the destination
-        
-        MOV  EAX, DWORD  [ESI+16]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, DWORD  [ESI+20]  		; load 4 bytes from the source array into EAX (2 chars)
-        SHL  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  DWORD  [EDI+8], EAX			; write the low 2 bytes of the 4 byte value in the destination
-        
-        MOV  EAX, DWORD  [ESI+24]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, DWORD  [ESI+28]  		; load 4 bytes from the source array into EAX (2 chars)
-        SHL  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  DWORD  [EDI+12], EAX			; write the low 2 bytes of the 4 byte value in the destination
-
-        ADD  EDI, 16
-        ADD  ESI, 32		
-        LOOP eightcharsNoCheckJ
-                ret
-;
-
-
-compressStringNoCheck:
-        SHR  ECX, 3
-        ADD  ESI, EAX
-        ADD  ESI, EAX
-eightcharsNoCheck:
-        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, EAX					; copy the loaded value
-        SHR  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  WORD  [EDI], AX			; write the low 2 bytes of the 4 byte value in the destination
-
-        MOV  EAX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, EAX					; copy the loaded value
-        SHR  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  WORD  [EDI+2], AX			; write the low 2 bytes of the 4 byte value in the destination
-
-        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, EAX					; copy the loaded value
-        SHR  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  WORD  [EDI+4], AX			; write the low 2 bytes of the 4 byte value in the destination
-
-        MOV  EAX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
-        MOV  EBX, EAX					; copy the loaded value
-        SHR  EBX, 8					; shift right by 8
-        OR   EAX, EBX					; or the 2 values
-        MOV  WORD  [EDI+6], AX			; write the low 2 bytes of the 4 byte value in the destination
-
-        ADD  EDI, 8
-        ADD  ESI, 16		
-        LOOP eightcharsNoCheck
                 ret
 ;
 


### PR DESCRIPTION
This commit removes compressStringNoCheckEvaluator() for p and x platforms.  They are no longer used because there is no compressNoCheck() method in the String class.