### PR TITLE
Fix cmdLineTester_jfr

### DIFF
--- a/test/functional/cmdLineTests/jfr/build.xml
+++ b/test/functional/cmdLineTests/jfr/build.xml
@@ -69,9 +69,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../">
-				<filename name="metadata.blob" />
-				<filename name="*.mk" />
-				<filename name="*.xml" />
+				<include name="**/metadata.blob" />
+				<include name="**/*.xml" />
 			</fileset>
 		</copy>
 	</target>


### PR DESCRIPTION
Use include tag instead of filename tag.
Remove *.mk selector since it does not match any file.

Fix: https://github.com/eclipse-openj9/openj9/issues/19950