### PR TITLE
JFR Writer fixes part1

### DIFF
--- a/runtime/vm/JFRChunkWriter.cpp
+++ b/runtime/vm/JFRChunkWriter.cpp
@@ -64,12 +64,11 @@ VM_JFRChunkWriter::writeJFRHeader()
 	/* pad */
 	_bufferWriter->writeU16(0); // 65
 
-	/* flags */
+	U_8 flags = JFR_HEADER_SPECIALFLAGS_COMPRESSED_INTS;
 	if (_finalWrite) {
-		_bufferWriter->writeU8(0x2); // 67 // final chunk bit?
-	} else {
-		_bufferWriter->writeU8(2);
+		flags |= JFR_HEADER_SPECIALFLAGS_LAST_CHUNK;
 	}
+	_bufferWriter->writeU8(flags);
 }
 
 U_8 *
@@ -597,7 +596,7 @@ VM_JFRChunkWriter::writeStacktraceCheckpointEvent()
 
 			/* number of stack frames */
 			UDATA framesCount = entry->numOfFrames;
-			_bufferWriter->writeU8(framesCount);
+			_bufferWriter->writeLEB128(framesCount);
 
 			for (UDATA i = 0; i < framesCount; i++) {
 				StackFrame *frame = entry->frames + i;

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1101,4 +1101,18 @@ VM_JFRConstantPoolTypes::freeUTF8Strings(void *entry, void *userData)
 	return FALSE;
 }
 
+UDATA
+VM_JFRConstantPoolTypes::freeStackStraceEntries(void *entry, void *userData)
+{
+	StackTraceEntry *tableEntry = (StackTraceEntry *) entry;
+	J9VMThread *currentThread = (J9VMThread *)userData;
+	PORT_ACCESS_FROM_VMC(currentThread);
+
+	j9mem_free_memory(tableEntry->frames);
+	tableEntry->frames = NULL;
+
+	return FALSE;
+}
+
+
 #endif /* defined(J9VM_OPT_JFR) */


### PR DESCRIPTION
- Add default entries for empty stack traces and unknown native methods.
- Add missing free for stackframe entries after writing chunk.
- Iterate the stack trace one before to get the real size.
- JFR readers do not accepts UDATA_MAX values for BCI and line numers, so use 0 instead if values are unknown.
- Add support for writing intermediate jfr files, currently we use this for debugging. But there are JFR modes that require this.
- Add compressedInts flag to chunk writer.

There is more work to be done for handling internal native functions as well as fixing the timestamps this will be addressed in a future PR.