### PR TITLE
Accelerate Unsafe CAS Intrinsics on Power and X

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -655,13 +655,17 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       // Hiding compressedref logic from CodeGen doesn't seem a good practise, the evaluator always need the uncompressedref node for write barrier,
       // therefore, this part is deprecated. It'll be removed once P and Z update their corresponding evaluators.
       static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
-      if (self()->comp()->useCompressedPointers() && (UseOldCompareAndSwapObject || !(self()->comp()->target().cpu.isX86() || self()->comp()->target().cpu.isARM64())))
+      static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
+      if (self()->comp()->useCompressedPointers() && ((UseOldCompareAndSwapObject && (self()->comp()->target().cpu.isARM64() || !disableCASInlining)) || !(self()->comp()->target().cpu.isX86() || self()->comp()->target().cpu.isARM64())))
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
+         static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;
          // In Java9 Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,
          // while in Java8 it can only be the sun.misc package which will itself contain the JNI method.
          // Test for isNative to distinguish between them.
-         if ((methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z) &&
+         if (((methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z) ||
+              ((methodSymbol->getRecognizedMethod() == TR::jdk_internal_misc_Unsafe_compareAndExchangeObject) && !disableCAEIntrinsic) ||
+              ((methodSymbol->getRecognizedMethod() == TR::jdk_internal_misc_Unsafe_compareAndExchangeReference) && !disableCAEIntrinsic)) &&
                methodSymbol->isNative() &&
                (!TR::Compiler->om.canGenerateArraylets() || parent->isUnsafeGetPutCASCallOnNonArray()) && parent->isSafeForCGToFastPathUnsafeCall())
             {

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -362,9 +362,6 @@
    sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z,
    sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z,
    sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z,
-   sun_misc_Unsafe_compareAndExchangeInt_jlObjectJII_Z,
-   sun_misc_Unsafe_compareAndExchangeLong_jlObjectJJJ_Z,
-   sun_misc_Unsafe_compareAndExchangeObject_jlObjectJjlObjectjlObject_Z,
 
    sun_misc_Unsafe_putBoolean_jlObjectJZ_V,
    sun_misc_Unsafe_putByte_jlObjectJB_V,
@@ -458,6 +455,11 @@
    sun_misc_Unsafe_ensureClassInitialized,
    sun_misc_Unsafe_allocateInstance,
    sun_misc_Unsafe_allocateUninitializedArray0,
+
+   jdk_internal_misc_Unsafe_compareAndExchangeInt,
+   jdk_internal_misc_Unsafe_compareAndExchangeLong,
+   jdk_internal_misc_Unsafe_compareAndExchangeObject,
+   jdk_internal_misc_Unsafe_compareAndExchangeReference,
 
    jdk_internal_misc_Unsafe_copyMemory0,
    jdk_internal_loader_NativeLibraries_load,


### PR DESCRIPTION
Adds support for the following recognized methods:
```
CompareAndExchangeObject     //JDK11
CompareAndExchangeReference  //JDK17,21
CompareAndExchangeInt        //JDK11,17,21
CompareAndExchangeLong       //JDK11,17,21
```

Similar to their CompareAndSet counterparts, the JIT acceleration does not support CAE on static fields so the createUnsafeCASCallDiamond function was updated to also work on the CAE methods.

The accelerated CAE code was built on top of the existing accelerated CAS support on both Power and X.

Edit:
X changes are dependent on this OMR PR:
https://github.com/eclipse/omr/pull/7438
Behavior of `inlineCompareAndSwapNative` and `inlineCompareAndSwapObjectNative` in `J9TreeEvaluator.cpp` must match behavior in `willBeEvaluatedAsCallByCodeGen` in `OMRCodeGenerator.cpp`